### PR TITLE
race condition during connect, CTT client may hang on .Net Standard 2…

### DIFF
--- a/Stack/Opc.Ua.Core/Stack/Tcp/TcpListener.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/TcpListener.cs
@@ -324,16 +324,17 @@ namespace Opc.Ua.Bindings
                             m_serverCertificate,
                             m_descriptions);
 
+                        if (m_callback != null)
+                        {
+                            channel.SetRequestReceivedCallback(new TcpChannelRequestEventHandler(OnRequestReceived));
+                        }
+
                         // start accepting messages on the channel.
                         channel.Attach(++m_lastChannelId, e.AcceptSocket);
 
                         // save the channel for shutdown and reconnects.
                         m_channels.Add(m_lastChannelId, channel);
 
-                        if (m_callback != null)
-                        {
-                            channel.SetRequestReceivedCallback(new TcpChannelRequestEventHandler(OnRequestReceived));
-                        }
                     }
                     catch (Exception ex)
                     {


### PR DESCRIPTION
….0 server GetEndpoints call

to repro: run dotnet standard 2.0 reference server / connect from CTT 'open browser' would hang not getting a response.