### PR TITLE
Return null for empty xml documents

### DIFF
--- a/Stack/Opc.Ua.Core/Types/Encoders/BinaryDecoder.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/BinaryDecoder.cs
@@ -498,8 +498,14 @@ namespace Opc.Ua
             }
 
             XmlDocument document = new XmlDocument();
-            document.InnerXml = new UTF8Encoding().GetString(bytes, 0, bytes.Length);
-
+            try
+            {
+                document.InnerXml = new UTF8Encoding().GetString(bytes, 0, bytes.Length);
+            }
+            catch (XmlException)
+            {
+                return null;
+            }
             return document.DocumentElement;
         }
 


### PR DESCRIPTION
If an empty XmlElement is parsed as member of an array, the exception makes the array disappear. Catching the exception the structure is maintained and an array with null items is returned.