### PR TITLE
IOP workshop fixes for reference server

### DIFF
--- a/SampleApplications/Samples/Client.Net4/Opc.Ua.SampleClient.Endpoints.xml
+++ b/SampleApplications/Samples/Client.Net4/Opc.Ua.SampleClient.Endpoints.xml
@@ -12,7 +12,7 @@
       <ua:Endpoint>
         <EndpointUrl>opc.tcp://localhost:61210/UA/SampleClient</EndpointUrl>
         <SecurityMode>SignAndEncrypt_3</SecurityMode>
-        <SecurityPolicyUri>http://opcfoundation.org/UA/SecurityPolicy#Basic128Rsa15</SecurityPolicyUri>
+        <SecurityPolicyUri>http://opcfoundation.org/UA/SecurityPolicy#Basic256Sha256</SecurityPolicyUri>
         <UserIdentityTokens>
           <UserTokenPolicy>
             <TokenType>Anonymous_0</TokenType>
@@ -42,7 +42,7 @@
       <ua:Endpoint>
         <EndpointUrl>opc.tcp://localhost:51210/UA/SampleServer</EndpointUrl>
         <SecurityMode>SignAndEncrypt_3</SecurityMode>
-        <SecurityPolicyUri>http://opcfoundation.org/UA/SecurityPolicy#Basic128Rsa15</SecurityPolicyUri>
+        <SecurityPolicyUri>http://opcfoundation.org/UA/SecurityPolicy#Basic256Sha256</SecurityPolicyUri>
         <UserIdentityTokens>
           <UserTokenPolicy>
             <TokenType>Anonymous_0</TokenType>
@@ -72,7 +72,7 @@
       <ua:Endpoint>
         <EndpointUrl>opc.tcp://localhost:62541/UA/ReferenceServer</EndpointUrl>
         <SecurityMode>SignAndEncrypt_3</SecurityMode>
-        <SecurityPolicyUri>http://opcfoundation.org/UA/SecurityPolicy#Basic128Rsa15</SecurityPolicyUri>
+        <SecurityPolicyUri>http://opcfoundation.org/UA/SecurityPolicy#Basic256Sha256</SecurityPolicyUri>
         <UserIdentityTokens>
           <UserTokenPolicy>
             <TokenType>Anonymous_0</TokenType>
@@ -102,7 +102,7 @@
       <ua:Endpoint>
         <EndpointUrl>opc.tcp://localhost:62547/Quickstarts/DataAccessServer</EndpointUrl>
         <SecurityMode>SignAndEncrypt_3</SecurityMode>
-        <SecurityPolicyUri>http://opcfoundation.org/UA/SecurityPolicy#Basic128Rsa15</SecurityPolicyUri>
+        <SecurityPolicyUri>http://opcfoundation.org/UA/SecurityPolicy#Basic256Sha256</SecurityPolicyUri>
         <UserIdentityTokens>
           <UserTokenPolicy>
             <TokenType>Anonymous_0</TokenType>
@@ -132,7 +132,7 @@
       <ua:Endpoint>
         <EndpointUrl>opc.tcp://localhost:62544/Quickstarts/AlarmConditionServer</EndpointUrl>
         <SecurityMode>SignAndEncrypt_3</SecurityMode>
-        <SecurityPolicyUri>http://opcfoundation.org/UA/SecurityPolicy#Basic128Rsa15</SecurityPolicyUri>
+        <SecurityPolicyUri>http://opcfoundation.org/UA/SecurityPolicy#Basic256Sha256</SecurityPolicyUri>
         <UserIdentityTokens>
           <UserTokenPolicy>
             <TokenType>Anonymous_0</TokenType>
@@ -162,7 +162,7 @@
       <ua:Endpoint>
         <EndpointUrl>opc.tcp://localhost:62550/Quickstarts/HistoricalAccessServer</EndpointUrl>
         <SecurityMode>SignAndEncrypt_3</SecurityMode>
-        <SecurityPolicyUri>http://opcfoundation.org/UA/SecurityPolicy#Basic128Rsa15</SecurityPolicyUri>
+        <SecurityPolicyUri>http://opcfoundation.org/UA/SecurityPolicy#Basic256Sha256</SecurityPolicyUri>
         <UserIdentityTokens>
           <UserTokenPolicy>
             <TokenType>Anonymous_0</TokenType>
@@ -192,7 +192,7 @@
       <ua:Endpoint>
         <EndpointUrl>opc.tcp://localhost:62553/Quickstarts/HistoricalEventsServer</EndpointUrl>
         <SecurityMode>SignAndEncrypt_3</SecurityMode>
-        <SecurityPolicyUri>http://opcfoundation.org/UA/SecurityPolicy#Basic128Rsa15</SecurityPolicyUri>
+        <SecurityPolicyUri>http://opcfoundation.org/UA/SecurityPolicy#Basic256Sha256</SecurityPolicyUri>
         <UserIdentityTokens>
           <UserTokenPolicy>
             <TokenType>Anonymous_0</TokenType>

--- a/Stack/Opc.Ua.Core/Stack/Configuration/ConfiguredEndpoints.cs
+++ b/Stack/Opc.Ua.Core/Stack/Configuration/ConfiguredEndpoints.cs
@@ -569,7 +569,7 @@ namespace Opc.Ua
             }
 
             MessageSecurityMode securityMode = MessageSecurityMode.SignAndEncrypt;
-            string securityPolicyUri = SecurityPolicies.Basic128Rsa15;
+            string securityPolicyUri = SecurityPolicies.Basic256Sha256;
             bool useBinaryEncoding = true;
 
             if (!String.IsNullOrEmpty(parameters))

--- a/Stack/Opc.Ua.Core/Types/Utils/TypeInfo.cs
+++ b/Stack/Opc.Ua.Core/Types/Utils/TypeInfo.cs
@@ -1248,7 +1248,7 @@ namespace Opc.Ua
                 case BuiltInType.QualifiedName: { return QualifiedName.Null; }
                 case BuiltInType.LocalizedText: { return LocalizedText.Null; }
                 case BuiltInType.Variant: { return Variant.Null; }
-                case BuiltInType.DataValue: { return new DataValue(); }
+                case BuiltInType.DataValue: { return (int)0; }
                 case BuiltInType.Enumeration: { return (int)0; }
                 case BuiltInType.Number: { return (double)0; }
                 case BuiltInType.Integer: { return (long)0; }

--- a/Stack/Opc.Ua.Core/Types/Utils/TypeInfo.cs
+++ b/Stack/Opc.Ua.Core/Types/Utils/TypeInfo.cs
@@ -1248,7 +1248,7 @@ namespace Opc.Ua
                 case BuiltInType.QualifiedName: { return QualifiedName.Null; }
                 case BuiltInType.LocalizedText: { return LocalizedText.Null; }
                 case BuiltInType.Variant: { return Variant.Null; }
-                case BuiltInType.DataValue: { return (int)0; }
+                case BuiltInType.DataValue: { return null; }
                 case BuiltInType.Enumeration: { return (int)0; }
                 case BuiltInType.Number: { return (double)0; }
                 case BuiltInType.Integer: { return (long)0; }


### PR DESCRIPTION
- default to Basic256Sha256
- milo server couldn't read DataValue containing DataValue which is not allowed by spec. Default value of DataValue should be null.