### PR TITLE
Fix nesting level overflows when value is null

### DIFF
--- a/Stack/Opc.Ua.Core/Types/Encoders/JsonDecoder.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/JsonDecoder.cs
@@ -942,17 +942,16 @@ namespace Opc.Ua
                 return null;
             }
 
-            try
+            // check the nesting level for avoiding a stack overflow.
+            if (m_nestingLevel > m_context.MaxEncodingNestingLevels) 
             {
-                // check the nesting level for avoiding a stack overflow.
-                if (m_nestingLevel > m_context.MaxEncodingNestingLevels)
-                {
-                    throw ServiceResultException.Create(
-                        StatusCodes.BadEncodingLimitsExceeded,
-                        "Maximum nesting level of {0} was exceeded",
-                        m_context.MaxEncodingNestingLevels);
-                }
+                throw ServiceResultException.Create(
+                    StatusCodes.BadEncodingLimitsExceeded,
+                    "Maximum nesting level of {0} was exceeded",
+                    m_context.MaxEncodingNestingLevels);
+            }
 
+            try {
                 m_nestingLevel++;
                 m_stack.Push(value);
 
@@ -1161,17 +1160,15 @@ namespace Opc.Ua
                 return Variant.Null;
             }
 
-            try
+            // check the nesting level for avoiding a stack overflow.
+            if (m_nestingLevel > m_context.MaxEncodingNestingLevels) 
             {
-                // check the nesting level for avoiding a stack overflow.
-                if (m_nestingLevel > m_context.MaxEncodingNestingLevels)
-                {
-                    throw ServiceResultException.Create(
-                        StatusCodes.BadEncodingLimitsExceeded,
-                        "Maximum nesting level of {0} was exceeded",
-                        m_context.MaxEncodingNestingLevels);
-                }
-
+                throw ServiceResultException.Create(
+                    StatusCodes.BadEncodingLimitsExceeded,
+                    "Maximum nesting level of {0} was exceeded",
+                    m_context.MaxEncodingNestingLevels);
+            }
+            try {
                 m_nestingLevel++;
                 m_stack.Push(value);
 

--- a/Stack/Opc.Ua.Core/Types/Encoders/JsonEncoder.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/JsonEncoder.cs
@@ -740,13 +740,13 @@ namespace Opc.Ua
                     m_context.MaxEncodingNestingLevels);
             }
 
-            m_nestingLevel++;
-
             if (value == null)
             {
                 WriteSimpleField(fieldName, null, false);
                 return;
             }
+
+            m_nestingLevel++;
 
             PushStructure(fieldName);
 
@@ -865,13 +865,13 @@ namespace Opc.Ua
                     m_context.MaxEncodingNestingLevels);
             }
 
-            m_nestingLevel++;
-
             if (Variant.Null == value)
             {
                 WriteSimpleField(fieldName, null, false);
                 return;
             }
+
+            m_nestingLevel++;
 
             bool isNull = (value.TypeInfo == null || value.TypeInfo.BuiltInType == BuiltInType.Null || value.Value == null);
 
@@ -1024,13 +1024,14 @@ namespace Opc.Ua
                     m_context.MaxEncodingNestingLevels);
             }
 
-            m_nestingLevel++;
 
             if (value == null)
             {
                 WriteSimpleField(fieldName, null, false);
                 return;
             }
+
+            m_nestingLevel++;
 
             PushStructure(fieldName);
 


### PR DESCRIPTION
1.) Do not decrease nesting level when exception thrown because of level exceeded (decoder)
2.) Do not increase nesting level for simple field writes (i.e. null values), since they are not decreased on exit, nor are necessary.