### PR TITLE
catch an exception which may occur in rare cases

### DIFF
--- a/Stack/Opc.Ua.Core/Stack/Tcp/TcpMessageSocket.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/TcpMessageSocket.cs
@@ -760,6 +760,10 @@ namespace Opc.Ua.Bindings
                         socket.Shutdown(SocketShutdown.Both);
                     }
                 }
+                catch
+                {
+                    // socket.Shutdown may throw but can be ignored
+                }
                 finally
                 {
                     socket.Dispose();


### PR DESCRIPTION
Fix a rare case when socket.Shutdown throws exception connecting to a specific server, causing the app to crash.

fix for #426 