### PR TITLE
Fix treatment of trusted issuers

### DIFF
--- a/SampleApplications/Samples/GDS/ClientTest/Common.cs
+++ b/SampleApplications/Samples/GDS/ClientTest/Common.cs
@@ -168,7 +168,7 @@ namespace Opc.Ua.Gds.Test
             CertificateValidator certValidator = new CertificateValidator();
             CertificateTrustList issuerStore = new CertificateTrustList();
             CertificateTrustList trustedStore = new CertificateTrustList();
-            trustedStore.TrustedCertificates = issuerCertIdCollection;
+            issuerStore.TrustedCertificates = issuerCertIdCollection;
             certValidator.Update(trustedStore, issuerStore, null);
             Assert.That(() =>
             {

--- a/Stack/Opc.Ua.Core/Security/Certificates/CertificateValidator.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/CertificateValidator.cs
@@ -509,11 +509,11 @@ namespace Opc.Ua
 
             do
             {
-                issuer = await GetIssuer(certificate, m_trustedCertificateList, m_trustedCertificateStore, true);
+                issuer = await GetIssuer(certificate, m_issuerCertificateList, m_issuerCertificateStore, true);
 
                 if (issuer == null)
                 {
-                    issuer = await GetIssuer(certificate, m_issuerCertificateList, m_issuerCertificateStore, true);
+                    issuer = await GetIssuer(certificate, m_trustedCertificateList, m_trustedCertificateStore, true);
 
                     if (issuer == null)
                     {
@@ -555,11 +555,11 @@ namespace Opc.Ua
 
             do
             {
-                issuer = await GetIssuer(certificate, m_trustedCertificateList, m_trustedCertificateStore, true);
+                issuer = await GetIssuer(certificate, m_issuerCertificateList, m_issuerCertificateStore, true);
 
                 if (issuer == null)
                 {
-                    issuer = await GetIssuer(certificate, m_issuerCertificateList, m_issuerCertificateStore, true);
+                    issuer = await GetIssuer(certificate, m_trustedCertificateList, m_trustedCertificateStore, true);
                 }
                 else
                 {


### PR DESCRIPTION
The current `GetIssuers()`-methods of the `CertificateValidator` only set the `isTrusted` boolean to true if the issuer certificate is in the trusted peer store (since the boolean is only set to true in the else-clauses in the methods when the certificate is found in the peer trust list).

In my opinion, the methods should only return true if the issuer certificates are stored in the issuer trust list. If certificates are (only) stored in the peer trust list, false should be returned. So the specific lines must be swapped to separate trusted issuers and trusted peers.

Otherwise, the trusted issuer store is practically unfunctional and trusted peers are more than just trusted communication partners due to the given right to issue certificates (in case the `IsIssuerAllowed()`-method returns true).