### PR TITLE
fix(CustomNodemanager): AddReferences method returns too early

### DIFF
--- a/SampleApplications/SDK/Opc.Ua.Server/Diagnostics/CustomNodeManager.cs
+++ b/SampleApplications/SDK/Opc.Ua.Server/Diagnostics/CustomNodeManager.cs
@@ -954,7 +954,7 @@ namespace Opc.Ua.Server
                     // only support external references to nodes that are stored in memory.
                     if (source == null || !source.Validated || source.Node == null)
                     {
-                        return;
+                        continue;
                     }
                     
                     // add reference to external target.

--- a/SampleApplications/SDK/Opc.Ua.Server/Diagnostics/v10/CustomNodeManager.cs
+++ b/SampleApplications/SDK/Opc.Ua.Server/Diagnostics/v10/CustomNodeManager.cs
@@ -818,7 +818,7 @@ namespace Opc.Ua.Server
 
                     if (source == null)
                     {
-                        return;
+                        continue;
                     }
 
                     // add reference to external target.

--- a/SampleApplications/Samples/Opc.Ua.Sample/Base/CustomNodeManager.cs
+++ b/SampleApplications/Samples/Opc.Ua.Sample/Base/CustomNodeManager.cs
@@ -824,7 +824,7 @@ namespace Opc.Ua.Sample
 
                     if (source == null)
                     {
-                        return;
+                        continue;
                     }
 
                     // add reference to external target.

--- a/SampleApplications/Samples/Opc.Ua.Sample/Base/SampleNodeManager.cs
+++ b/SampleApplications/Samples/Opc.Ua.Sample/Base/SampleNodeManager.cs
@@ -817,7 +817,7 @@ namespace Opc.Ua.Sample
 
                     if (source == null)
                     {
-                        return;
+                        continue;
                     }
 
                     // add reference to external target.

--- a/SampleApplications/Workshop/Common/QuickstartNodeManager.cs
+++ b/SampleApplications/Workshop/Common/QuickstartNodeManager.cs
@@ -928,7 +928,7 @@ namespace Quickstarts
                     // only support external references to nodes that are stored in memory.
                     if (source == null || !source.Validated || source.Node == null)
                     {
-                        return;
+                        continue;
                     }
                     
                     // add reference to external target.


### PR DESCRIPTION
The AddRefrences method loops through a list of (external) references and adds them to the designated objects. When obtaining node handles it also checks that the node belongs to one of the namspaces for the  current node manager. The problem was that it skipped the rest of  the nodes in the list as soon as it found one node that did not belong to one of the namespaces of the current node manager.