### PR TITLE
Security: follow guidance of CVE-2018-8356 and Microsoft Security Advisory 4021279

### DIFF
--- a/Stack/Opc.Ua.Core/Opc.Ua.Core.csproj
+++ b/Stack/Opc.Ua.Core/Opc.Ua.Core.csproj
@@ -24,11 +24,12 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
     <PackageReference Include="System.Data.Common" Version="4.3.0" />
-    <PackageReference Include="System.ServiceModel.Primitives" Version="4.3.0" />
+    <PackageReference Include="System.ServiceModel.Primitives" Version="4.5.3" />
     <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
     <PackageReference Include="System.Xml.XmlSerializer" Version="4.3.0" />
     <PackageReference Include="System.Collections.NonGeneric" Version="4.3.0" />
-    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0" />
+    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.4.0" />
+    <PackageReference Include="System.Net.Websockets.Client" Version="4.3.2" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3' AND $(DefineConstants.Contains('NO_HTTPS'))=='false'">
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="1.1.3" />
@@ -37,11 +38,12 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.4'">
     <PackageReference Include="System.Data.Common" Version="4.3.0" />
-    <PackageReference Include="System.ServiceModel.Primitives" Version="4.3.0" />
+    <PackageReference Include="System.ServiceModel.Primitives" Version="4.5.3" />
     <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
     <PackageReference Include="System.Xml.XmlSerializer" Version="4.3.0" />
     <PackageReference Include="System.Collections.NonGeneric" Version="4.3.0" />
-    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0" />
+    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.4.0" />
+    <PackageReference Include="System.Net.Websockets.Client" Version="4.3.2" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.4' AND $(DefineConstants.Contains('NO_HTTPS'))=='false'">
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="1.1.3" />
@@ -72,9 +74,10 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Data.Common" Version="4.3.0" />
-    <PackageReference Include="System.ServiceModel.Primitives" Version="4.3.0" />
+    <PackageReference Include="System.ServiceModel.Primitives" Version="4.5.3" />
     <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
-    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0" />
+    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.4.0" />
+    <PackageReference Include="System.Net.Websockets.Client" Version="4.3.2" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' AND $(DefineConstants.Contains('NO_HTTPS'))=='false'">
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.0.1" />

--- a/nuget/Opc.Ua.Symbols.nuspec
+++ b/nuget/Opc.Ua.Symbols.nuspec
@@ -24,12 +24,13 @@
         <dependency id="Newtonsoft.Json" version="10.0.3"/>
         <dependency id="Portable.BouncyCastle" version="1.8.1.3"/>
         <dependency id="System.Data.Common" version="4.3.0"/>
-        <dependency id="System.ServiceModel.Primitives" version="4.3.0"/>
+        <dependency id="System.ServiceModel.Primitives" version="4.5.3"/>
         <dependency id="System.Net.NameResolution" version="4.3.0"/>
         <dependency id="System.Collections.NonGeneric" version="4.3.0"/>
         <dependency id="System.Xml.XmlSerializer" version="4.3.0"/>
         <dependency id="System.Threading.Thread" version="4.3.0"/>
-        <dependency id="System.Reflection.TypeExtensions" version="4.3.0" />
+        <dependency id="System.Reflection.TypeExtensions" version="4.4.0" />
+        <dependency id="System.Net.Websockets.Client" version="4.3.2" />
       </group>
       <group targetFramework="netstandard2.0" >
         <dependency id="Microsoft.AspNetCore.Server.Kestrel" version="2.0.1"/>
@@ -37,9 +38,10 @@
         <dependency id="Newtonsoft.Json" version="10.0.3"/>
         <dependency id="Portable.BouncyCastle" version="1.8.1.3"/>
         <dependency id="System.Data.Common" version="4.3.0"/>
-        <dependency id="System.ServiceModel.Primitives" version="4.3.0"/>
+        <dependency id="System.ServiceModel.Primitives" version="4.5.3"/>
         <dependency id="System.Net.NameResolution" version="4.3.0"/>
-        <dependency id="System.Reflection.TypeExtensions" version="4.3.0" />
+        <dependency id="System.Reflection.TypeExtensions" version="4.4.0" />
+        <dependency id="System.Net.Websockets.Client" version="4.3.2" />
       </group>
     </dependencies>
   </metadata>

--- a/nuget/Opc.Ua.nuspec
+++ b/nuget/Opc.Ua.nuspec
@@ -24,12 +24,13 @@
         <dependency id="Newtonsoft.Json" version="10.0.3"/>
         <dependency id="Portable.BouncyCastle" version="1.8.1.3"/>
         <dependency id="System.Data.Common" version="4.3.0"/>
-        <dependency id="System.ServiceModel.Primitives" version="4.3.0"/>
+        <dependency id="System.ServiceModel.Primitives" version="4.5.3"/>
         <dependency id="System.Net.NameResolution" version="4.3.0"/>
         <dependency id="System.Collections.NonGeneric" version="4.3.0"/>
         <dependency id="System.Xml.XmlSerializer" version="4.3.0"/>
         <dependency id="System.Threading.Thread" version="4.3.0"/>
-        <dependency id="System.Reflection.TypeExtensions" version="4.3.0" />
+        <dependency id="System.Reflection.TypeExtensions" version="4.4.0" />
+        <dependency id="System.Net.Websockets.Client" version="4.3.2" />
       </group>
       <group targetFramework="netstandard2.0" >
         <dependency id="Microsoft.AspNetCore.Server.Kestrel" version="2.0.1"/>
@@ -37,9 +38,10 @@
         <dependency id="Newtonsoft.Json" version="10.0.3"/>
         <dependency id="Portable.BouncyCastle" version="1.8.1.3"/>
         <dependency id="System.Data.Common" version="4.3.0"/>
-        <dependency id="System.ServiceModel.Primitives" version="4.3.0"/>
+        <dependency id="System.ServiceModel.Primitives" version="4.5.3"/>
         <dependency id="System.Net.NameResolution" version="4.3.0"/>
-        <dependency id="System.Reflection.TypeExtensions" version="4.3.0" />
+        <dependency id="System.Reflection.TypeExtensions" version="4.4.0" />
+        <dependency id="System.Net.Websockets.Client" version="4.3.2" />
       </group>
     </dependencies>
   </metadata>


### PR DESCRIPTION
https://github.com/dotnet/announcements/issues/73
https://github.com/aspnet/Announcements/issues/239

bumb up versions of affected assemblies:
"System.Net.WebSockets.Client" Version="4.3.2"
"System.ServiceModel.Primitives" Version="4.5.3"
