### PR TITLE
Certificate stores renamed according to specs

### DIFF
--- a/ComIOP/Wrapper/ServerWrapper/Opc.Ua.ComServerWrapper.Config.xml
+++ b/ComIOP/Wrapper/ServerWrapper/Opc.Ua.ComServerWrapper.Config.xml
@@ -14,26 +14,26 @@
     <!-- Where the application instance certificate is stored (MachineDefault) -->
     <ApplicationCertificate>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\MachineDefault</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\own</StorePath>
       <SubjectName>CN=UA COM Server Wrapper, C=US, S=Arizona, O=OPC Foundation, DC=localhost</SubjectName>
     </ApplicationCertificate>
 
     <!-- Where the issuer certificate are stored (certificate authorities) -->
     <TrustedIssuerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\UA Certificate Authorities</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\issuer</StorePath>
     </TrustedIssuerCertificates>
 
     <!-- Where the trust list is stored (UA Applications) -->
     <TrustedPeerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\UA Applications</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\trusted</StorePath>
     </TrustedPeerCertificates>
 
     <!-- The directory used to store invalid certficates for later review by the administrator. -->
     <RejectedCertificateStore>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\RejectedCertificates</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\rejected</StorePath>
     </RejectedCertificateStore>
 
     <!-- WARNING: The following setting (to automatically accept untrusted certificates) should be used

--- a/SampleApplications/Samples/Client.Net4/Opc.Ua.SampleClient.Config.xml
+++ b/SampleApplications/Samples/Client.Net4/Opc.Ua.SampleClient.Config.xml
@@ -53,7 +53,7 @@
          specify the certificate for each trusted certification authority. -->
     <TrustedIssuerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\UA Certificate Authorities</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\issuer</StorePath>
     </TrustedIssuerCertificates>
     
     <!-- The list of trusted certificates. 
@@ -72,7 +72,7 @@
          -->
     <TrustedPeerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\UA Applications</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\trusted</StorePath>
     </TrustedPeerCertificates>
     
     <!-- Applications exchange Nonces during the CreateSession. This value specifies the length. Must be >= 32 -->
@@ -81,7 +81,7 @@
     <!-- The directory used to store invalid certficates for later review by the administrator. -->
     <RejectedCertificateStore>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\RejectedCertificates</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\rejected</StorePath>
     </RejectedCertificateStore>
 
     <!-- Specifies whether the complete certificate chain should be sent for CA signed certificates. -->

--- a/SampleApplications/Samples/Client.Net4/Opc.Ua.SampleClient.Config.xml
+++ b/SampleApplications/Samples/Client.Net4/Opc.Ua.SampleClient.Config.xml
@@ -86,7 +86,30 @@
 
     <!-- Specifies whether the complete certificate chain should be sent for CA signed certificates. -->
     <SendCertificateChain>false</SendCertificateChain>
-  
+
+    <!-- Where the User issuer certificates are stored -->
+    <UserIssuerCertificates>
+      <StoreType>Directory</StoreType>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\issuerUser</StorePath>
+    </UserIssuerCertificates>
+
+    <!-- Where the User trust list is stored-->
+    <TrustedUserCertificates>
+      <StoreType>Directory</StoreType>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\trustedUser</StorePath>
+    </TrustedUserCertificates>
+
+    <!-- Where the Https issuer certificates are stored -->
+    <HttpsIssuerCertificates>
+      <StoreType>Directory</StoreType>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\issuerHttps</StorePath>
+    </HttpsIssuerCertificates>
+
+    <!-- Where the Https trust list is stored-->
+    <TrustedHttpsCertificates>
+      <StoreType>Directory</StoreType>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\trustedHttps</StorePath>
+    </TrustedHttpsCertificates>
 </SecurityConfiguration>
 
   <TransportConfigurations></TransportConfigurations>
@@ -169,11 +192,11 @@
          
          The first policy in the list is assigned to base address. -->
     <SecurityPolicies>
-      <!--Removing no secuirty option from the configuration as this is a security risk
+      <!--Removing no secuirty option from the configuration as this is a security risk-->
         <ServerSecurityPolicy>
         <SecurityMode>None_1</SecurityMode>
         <SecurityPolicyUri>http://opcfoundation.org/UA/SecurityPolicy#None</SecurityPolicyUri>
-      </ServerSecurityPolicy>-->
+      </ServerSecurityPolicy>
       <ServerSecurityPolicy>
         <SecurityMode>Sign_2</SecurityMode>
         <SecurityPolicyUri>http://opcfoundation.org/UA/SecurityPolicy#Basic256Sha256</SecurityPolicyUri>
@@ -293,7 +316,7 @@
     </RegistrationEndpoint>
 
     <!-- The maximum interval between registration. 0 disables periodic registration -->
-    <MaxRegistrationInterval>30000</MaxRegistrationInterval>
+    <MaxRegistrationInterval>0</MaxRegistrationInterval>
 
     <!-- The file used to save nodes added to the CoreNodeManager. If missing the CoreNodeManger will discard nodes when it stops. -->
     <NodeManagerSaveFile>Opc.Ua.Server.nodes.xml</NodeManagerSaveFile>

--- a/SampleApplications/Samples/Client.Net4/Opc.Ua.SampleClient.Config.xml
+++ b/SampleApplications/Samples/Client.Net4/Opc.Ua.SampleClient.Config.xml
@@ -98,18 +98,6 @@
       <StoreType>Directory</StoreType>
       <StorePath>%CommonApplicationData%\OPC Foundation\pki\trustedUser</StorePath>
     </TrustedUserCertificates>
-
-    <!-- Where the Https issuer certificates are stored -->
-    <HttpsIssuerCertificates>
-      <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\pki\issuerHttps</StorePath>
-    </HttpsIssuerCertificates>
-
-    <!-- Where the Https trust list is stored-->
-    <TrustedHttpsCertificates>
-      <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\pki\trustedHttps</StorePath>
-    </TrustedHttpsCertificates>
 </SecurityConfiguration>
 
   <TransportConfigurations></TransportConfigurations>

--- a/SampleApplications/Samples/Client/Opc.Ua.SampleClient.Config.xml
+++ b/SampleApplications/Samples/Client/Opc.Ua.SampleClient.Config.xml
@@ -53,7 +53,7 @@
          specify the certificate for each trusted certification authority. -->
     <TrustedIssuerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>%LocalFolder%\OPC Foundation\CertificateStores\UA Certificate Authorities</StorePath>
+      <StorePath>%LocalFolder%\OPC Foundation\pki\issuer</StorePath>
     </TrustedIssuerCertificates>
     
     <!-- The list of trusted certificates. 
@@ -72,7 +72,7 @@
          -->
     <TrustedPeerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>%LocalFolder%\OPC Foundation\CertificateStores\UA Applications</StorePath>
+      <StorePath>%LocalFolder%\OPC Foundation\pki\trusted</StorePath>
     </TrustedPeerCertificates>
     
     <!-- Applications exchange Nonces during the CreateSession. This value specifies the length. Must be >= 32 -->
@@ -81,7 +81,7 @@
     <!-- The directory used to store invalid certficates for later review by the administrator. -->
     <RejectedCertificateStore>
       <StoreType>Directory</StoreType>
-      <StorePath>%LocalFolder%\OPC Foundation\CertificateStores\RejectedCertificates</StorePath>
+      <StorePath>%LocalFolder%\OPC Foundation\pki\rejected</StorePath>
     </RejectedCertificateStore>
   
 </SecurityConfiguration>

--- a/SampleApplications/Samples/GDS/Client/Opc.Ua.GdsClient.Config.xml
+++ b/SampleApplications/Samples/GDS/Client/Opc.Ua.GdsClient.Config.xml
@@ -21,19 +21,19 @@
     <!-- Where the issuer certificate are stored (certificate authorities) -->
     <TrustedIssuerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\UA Certificate Authorities</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\issuer</StorePath>
     </TrustedIssuerCertificates>
 
     <!-- Where the trust list is stored (UA Applications) -->
     <TrustedPeerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\UA Applications</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\trusted</StorePath>
     </TrustedPeerCertificates>
 
     <!-- The directory used to store invalid certficates for later review by the administrator. -->
     <RejectedCertificateStore>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\RejectedCertificates</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\rejected</StorePath>
     </RejectedCertificateStore>
 
     <!-- WARNING: SHA1 signed certficates are by default rejected and should be phased out. -->

--- a/SampleApplications/Samples/GDS/ClientTest/Opc.Ua.GlobalDiscoveryTestClient.Config.xml
+++ b/SampleApplications/Samples/GDS/ClientTest/Opc.Ua.GlobalDiscoveryTestClient.Config.xml
@@ -12,23 +12,23 @@
   <SecurityConfiguration>
     <ApplicationCertificate>
       <StoreType>Directory</StoreType>
-      <StorePath>%LocalApplicationData%/OPC/PKI/own</StorePath>
+      <StorePath>%LocalApplicationData%/OPC/pki/own</StorePath>
       <SubjectName>CN=Global Discovery Test Client, O=OPC Foundation, DC=localhost</SubjectName>
     </ApplicationCertificate>
 
     <TrustedIssuerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>%LocalApplicationData%/OPC/PKI/issuers</StorePath>
+      <StorePath>%LocalApplicationData%/OPC/pki/issuers</StorePath>
     </TrustedIssuerCertificates>
 
     <TrustedPeerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>%LocalApplicationData%/OPC/PKI/trusted</StorePath>
+      <StorePath>%LocalApplicationData%/OPC/pki/trusted</StorePath>
     </TrustedPeerCertificates>
 
     <RejectedCertificateStore>
       <StoreType>Directory</StoreType>
-      <StorePath>%LocalApplicationData%/OPC/PKI/rejected</StorePath>
+      <StorePath>%LocalApplicationData%/OPC/pki/rejected</StorePath>
     </RejectedCertificateStore>
 
     <!-- WARNING: The following setting (to automatically accept untrusted certificates) should be used

--- a/SampleApplications/Samples/GDS/ClientTest/Opc.Ua.GlobalDiscoveryTestServer.Config.xml
+++ b/SampleApplications/Samples/GDS/ClientTest/Opc.Ua.GlobalDiscoveryTestServer.Config.xml
@@ -12,23 +12,23 @@
   <SecurityConfiguration>
     <ApplicationCertificate>
       <StoreType>Directory</StoreType>
-      <StorePath>%LocalApplicationData%/OPC/GDS/own</StorePath>
+      <StorePath>%LocalApplicationData%/OPC/pki/own</StorePath>
       <SubjectName>CN=Global Discovery Test Server, O=OPC Foundation, DC=localhost</SubjectName>
     </ApplicationCertificate>
 
     <TrustedIssuerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>%LocalApplicationData%/OPC/GDS/issuers</StorePath>
+      <StorePath>%LocalApplicationData%/OPC/pki/issuers</StorePath>
     </TrustedIssuerCertificates>
 
     <TrustedPeerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>%LocalApplicationData%/OPC/GDS/trusted</StorePath>
+      <StorePath>%LocalApplicationData%/OPC/pki/trusted</StorePath>
     </TrustedPeerCertificates>
 
     <RejectedCertificateStore>
       <StoreType>Directory</StoreType>
-      <StorePath>%LocalApplicationData%/OPC/GDS/rejected</StorePath>
+      <StorePath>%LocalApplicationData%/OPC/pki/rejected</StorePath>
     </RejectedCertificateStore>
 
     <!-- WARNING: The following setting (to automatically accept untrusted certificates) should be used

--- a/SampleApplications/Samples/GDS/ClientTest/Opc.Ua.GlobalDiscoveryTestServer.Config.xml
+++ b/SampleApplications/Samples/GDS/ClientTest/Opc.Ua.GlobalDiscoveryTestServer.Config.xml
@@ -12,7 +12,7 @@
   <SecurityConfiguration>
     <ApplicationCertificate>
       <StoreType>Directory</StoreType>
-      <StorePath>%LocalApplicationData%/OPC/pki/own</StorePath>
+      <StorePath>%LocalApplicationData%/OPC/GDS/own</StorePath>
       <SubjectName>CN=Global Discovery Test Server, O=OPC Foundation, DC=localhost</SubjectName>
     </ApplicationCertificate>
 

--- a/SampleApplications/Samples/GDS/ClientTest/Opc.Ua.GlobalDiscoveryTestServer.Config.xml
+++ b/SampleApplications/Samples/GDS/ClientTest/Opc.Ua.GlobalDiscoveryTestServer.Config.xml
@@ -18,17 +18,17 @@
 
     <TrustedIssuerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>%LocalApplicationData%/OPC/pki/issuers</StorePath>
+      <StorePath>%LocalApplicationData%/OPC/GDS/issuers</StorePath>
     </TrustedIssuerCertificates>
 
     <TrustedPeerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>%LocalApplicationData%/OPC/pki/trusted</StorePath>
+      <StorePath>%LocalApplicationData%/OPC/GDS/trusted</StorePath>
     </TrustedPeerCertificates>
 
     <RejectedCertificateStore>
       <StoreType>Directory</StoreType>
-      <StorePath>%LocalApplicationData%/OPC/pki/rejected</StorePath>
+      <StorePath>%LocalApplicationData%/OPC/GDS/rejected</StorePath>
     </RejectedCertificateStore>
 
     <!-- WARNING: The following setting (to automatically accept untrusted certificates) should be used

--- a/SampleApplications/Samples/GDS/ClientTest/Opc.Ua.ServerConfigurationPushTestClient.Config.xml
+++ b/SampleApplications/Samples/GDS/ClientTest/Opc.Ua.ServerConfigurationPushTestClient.Config.xml
@@ -12,23 +12,23 @@
   <SecurityConfiguration>
     <ApplicationCertificate>
       <StoreType>Directory</StoreType>
-      <StorePath>%LocalApplicationData%/OPC/PKI/own</StorePath>
+      <StorePath>%LocalApplicationData%/OPC/pki/own</StorePath>
       <SubjectName>CN=Server Configuration Push Test Client, O=OPC Foundation</SubjectName>
     </ApplicationCertificate>
 
     <TrustedIssuerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>%LocalApplicationData%/OPC/PKI/issuers</StorePath>
+      <StorePath>%LocalApplicationData%/OPC/pki/issuers</StorePath>
     </TrustedIssuerCertificates>
 
     <TrustedPeerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>%LocalApplicationData%/OPC/PKI/trusted</StorePath>
+      <StorePath>%LocalApplicationData%/OPC/pki/trusted</StorePath>
     </TrustedPeerCertificates>
 
     <RejectedCertificateStore>
       <StoreType>Directory</StoreType>
-      <StorePath>%LocalApplicationData%/OPC/PKI/rejected</StorePath>
+      <StorePath>%LocalApplicationData%/OPC/pki/rejected</StorePath>
     </RejectedCertificateStore>
 
     <!-- WARNING: The following setting (to automatically accept untrusted certificates) should be used

--- a/SampleApplications/Samples/GDS/ConsoleServer/Opc.Ua.GlobalDiscoveryServer.Config.xml
+++ b/SampleApplications/Samples/GDS/ConsoleServer/Opc.Ua.GlobalDiscoveryServer.Config.xml
@@ -12,23 +12,23 @@
   <SecurityConfiguration>
     <ApplicationCertificate>
       <StoreType>Directory</StoreType>
-      <StorePath>%LocalApplicationData%/OPC Foundation/GDS/PKI/own</StorePath>
+      <StorePath>%LocalApplicationData%/OPC Foundation/GDS/pki/own</StorePath>
       <SubjectName>CN=Global Discovery Server, O=somecompany, DC=localhost</SubjectName>
     </ApplicationCertificate>
 
     <TrustedIssuerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>%LocalApplicationData%/OPC Foundation/GDS/PKI/issuers</StorePath>
+      <StorePath>%LocalApplicationData%/OPC Foundation/GDS/pki/issuers</StorePath>
     </TrustedIssuerCertificates>
 
     <TrustedPeerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>%LocalApplicationData%/OPC Foundation/GDS/PKI/trusted</StorePath>
+      <StorePath>%LocalApplicationData%/OPC Foundation/GDS/pki/trusted</StorePath>
     </TrustedPeerCertificates>
 
     <RejectedCertificateStore>
       <StoreType>Directory</StoreType>
-      <StorePath>%LocalApplicationData%/OPC Foundation/GDS/PKI/rejected</StorePath>
+      <StorePath>%LocalApplicationData%/OPC Foundation/GDS/pki/rejected</StorePath>
     </RejectedCertificateStore>
 
     <!-- The GDS server must accept connections from any client -->

--- a/SampleApplications/Samples/GDS/Server/Opc.Ua.GlobalDiscoveryServer.Config.xml
+++ b/SampleApplications/Samples/GDS/Server/Opc.Ua.GlobalDiscoveryServer.Config.xml
@@ -12,23 +12,23 @@
   <SecurityConfiguration>
     <ApplicationCertificate>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%/OPC Foundation/GDS/PKI/own</StorePath>
+      <StorePath>%CommonApplicationData%/OPC Foundation/GDS/pki/own</StorePath>
       <SubjectName>CN=Global Discovery Server, O=somecompany, DC=localhost</SubjectName>
     </ApplicationCertificate>
 
     <TrustedIssuerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%/OPC Foundation/GDS/PKI/issuers</StorePath>
+      <StorePath>%CommonApplicationData%/OPC Foundation/GDS/pki/issuers</StorePath>
     </TrustedIssuerCertificates>
 
     <TrustedPeerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%/OPC Foundation/GDS/PKI/trusted</StorePath>
+      <StorePath>%CommonApplicationData%/OPC Foundation/GDS/pki/trusted</StorePath>
     </TrustedPeerCertificates>
 
     <RejectedCertificateStore>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%/OPC Foundation/GDS/PKI/rejected</StorePath>
+      <StorePath>%CommonApplicationData%/OPC Foundation/GDS/pki/rejected</StorePath>
     </RejectedCertificateStore>
 
     <!-- The GDS server must accept connections from any client -->

--- a/SampleApplications/Samples/NetCoreConsoleClient/Opc.Ua.MonoSampleClient.Config.xml
+++ b/SampleApplications/Samples/NetCoreConsoleClient/Opc.Ua.MonoSampleClient.Config.xml
@@ -14,26 +14,26 @@
     <!-- Where the application instance certificate is stored (MachineDefault) -->
     <ApplicationCertificate>
       <StoreType>Directory</StoreType>
-      <StorePath>./OPC Foundation/PKI/own</StorePath>
+      <StorePath>./OPC Foundation/pki/own</StorePath>
       <SubjectName>CN=UA Mono Sample Client, C=US, S=Arizona, O=OPC Foundation, DC=localhost</SubjectName>
     </ApplicationCertificate>
 
     <!-- Where the issuer certificate are stored (certificate authorities) -->
     <TrustedIssuerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>./OPC Foundation/PKI/issuer</StorePath>
+      <StorePath>./OPC Foundation/pki/issuer</StorePath>
     </TrustedIssuerCertificates>
 
     <!-- Where the trust list is stored (UA Applications) -->
     <TrustedPeerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>./OPC Foundation/PKI/trusted</StorePath>
+      <StorePath>./OPC Foundation/pki/trusted</StorePath>
     </TrustedPeerCertificates>
 
     <!-- The directory used to store invalid certficates for later review by the administrator. -->
     <RejectedCertificateStore>
       <StoreType>Directory</StoreType>
-      <StorePath>./OPC Foundation/PKI/rejected</StorePath>
+      <StorePath>./OPC Foundation/pki/rejected</StorePath>
     </RejectedCertificateStore>
 
     <!-- WARNING: The following setting (to automatically accept untrusted certificates) should be used

--- a/SampleApplications/Samples/NetCoreConsoleClient/Opc.Ua.SampleClient.Config.xml
+++ b/SampleApplications/Samples/NetCoreConsoleClient/Opc.Ua.SampleClient.Config.xml
@@ -21,19 +21,19 @@
     <!-- Where the issuer certificate are stored (certificate authorities) -->
     <TrustedIssuerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>%LocalApplicationData%/OPC Foundation/CertificateStores/UA Certificate Authorities</StorePath>
+      <StorePath>%LocalApplicationData%/OPC Foundation/pki/issuer</StorePath>
     </TrustedIssuerCertificates>
 
     <!-- Where the trust list is stored (UA Applications) -->
     <TrustedPeerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>%LocalApplicationData%/OPC Foundation/CertificateStores/UA Applications</StorePath>
+      <StorePath>%LocalApplicationData%/OPC Foundation/pki/trusted</StorePath>
     </TrustedPeerCertificates>
 
     <!-- The directory used to store invalid certficates for later review by the administrator. -->
     <RejectedCertificateStore>
       <StoreType>Directory</StoreType>
-      <StorePath>%LocalApplicationData%/OPC Foundation/CertificateStores/RejectedCertificates</StorePath>
+      <StorePath>%LocalApplicationData%/OPC Foundation/pki/rejected</StorePath>
     </RejectedCertificateStore>
 
     <!-- WARNING: The following setting (to automatically accept untrusted certificates) should be used

--- a/SampleApplications/Samples/NetCoreConsoleServer/Opc.Ua.MonoSampleServer.Config.xml
+++ b/SampleApplications/Samples/NetCoreConsoleServer/Opc.Ua.MonoSampleServer.Config.xml
@@ -14,26 +14,26 @@
     <!-- Where the application instance certificate is stored (MachineDefault) -->
     <ApplicationCertificate>
       <StoreType>Directory</StoreType>
-      <StorePath>./OPC Foundation/PKI/own</StorePath>
+      <StorePath>./OPC Foundation/pki/own</StorePath>
       <SubjectName>CN=UA Mono Sample Server, C=US, S=Arizona, O=OPC Foundation, DC=localhost</SubjectName>
     </ApplicationCertificate>
 
     <!-- Where the issuer certificate are stored (certificate authorities) -->
     <TrustedIssuerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>./OPC Foundation/PKI/issuer</StorePath>
+      <StorePath>./OPC Foundation/pki/issuer</StorePath>
     </TrustedIssuerCertificates>
     
     <!-- Where the trust list is stored (UA Applications) -->
     <TrustedPeerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>./OPC Foundation/PKI/trusted</StorePath>
+      <StorePath>./OPC Foundation/pki/trusted</StorePath>
     </TrustedPeerCertificates>
     
     <!-- The directory used to store invalid certficates for later review by the administrator. -->
     <RejectedCertificateStore>
       <StoreType>Directory</StoreType>
-      <StorePath>./OPC Foundation/PKI/rejected</StorePath>
+      <StorePath>./OPC Foundation/pki/rejected</StorePath>
     </RejectedCertificateStore>
 
     <!-- WARNING: The following setting (to automatically accept untrusted certificates) should be used

--- a/SampleApplications/Samples/NetCoreConsoleServer/Opc.Ua.SampleServer.Config.xml
+++ b/SampleApplications/Samples/NetCoreConsoleServer/Opc.Ua.SampleServer.Config.xml
@@ -21,19 +21,19 @@
     <!-- Where the issuer certificate are stored (certificate authorities) -->
     <TrustedIssuerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>%LocalApplicationData%/OPC Foundation/CertificateStores/UA Certificate Authorities</StorePath>
+      <StorePath>%LocalApplicationData%/OPC Foundation/pki/issuer</StorePath>
     </TrustedIssuerCertificates>
 
     <!-- Where the trust list is stored (UA Applications) -->
     <TrustedPeerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>%LocalApplicationData%/OPC Foundation/CertificateStores/UA Applications</StorePath>
+      <StorePath>%LocalApplicationData%/OPC Foundation/pki/trusted</StorePath>
     </TrustedPeerCertificates>
 
     <!-- The directory used to store invalid certficates for later review by the administrator. -->
     <RejectedCertificateStore>
       <StoreType>Directory</StoreType>
-      <StorePath>%LocalApplicationData%/OPC Foundation/CertificateStores/RejectedCertificates</StorePath>
+      <StorePath>%LocalApplicationData%/OPC Foundation/pki/rejected</StorePath>
     </RejectedCertificateStore>
 
     <!-- WARNING: The following setting (to automatically accept untrusted certificates) should be used

--- a/SampleApplications/Samples/Opc.Ua.Sample/SampleServer.UserAuthentication.cs
+++ b/SampleApplications/Samples/Opc.Ua.Sample/SampleServer.UserAuthentication.cs
@@ -136,15 +136,6 @@ namespace Opc.Ua.Sample
                 {
                     CertificateValidator.Validate(certificate);
                 }
-
-                // determine if self-signed.
-                bool isSelfSigned = Utils.CompareDistinguishedName(certificate.Subject, certificate.Issuer);
-
-                // do not allow self signed application certs as user token
-                if (isSelfSigned && Utils.HasApplicationURN(certificate))
-                {
-                    throw new ServiceResultException(StatusCodes.BadCertificateUseNotAllowed);
-                }
             }
             catch (Exception e)
             {

--- a/SampleApplications/Samples/Opc.Ua.Sample/SampleServer.cs
+++ b/SampleApplications/Samples/Opc.Ua.Sample/SampleServer.cs
@@ -52,10 +52,10 @@ namespace Opc.Ua.Sample
         {
             Utils.Trace("The server is starting.");
 
-            base.OnServerStarting(configuration);     
+            base.OnServerStarting(configuration);
             
             // it is up to the application to decide how to validate user identity tokens.
-            // this function creates validators for SAML and X509 identity tokens.
+            // this function creates validator for X509 identity tokens.
             CreateUserIdentityValidators(configuration);
         }
 

--- a/SampleApplications/Samples/Server.Net4/Opc.Ua.SampleServer.Config.xml
+++ b/SampleApplications/Samples/Server.Net4/Opc.Ua.SampleServer.Config.xml
@@ -29,13 +29,24 @@
       <StoreType>Directory</StoreType>
       <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\UA Applications</StorePath>
     </TrustedPeerCertificates>
-    
+
     <!-- The directory used to store invalid certficates for later review by the administrator. -->
     <RejectedCertificateStore>
       <StoreType>Directory</StoreType>
       <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\RejectedCertificates</StorePath>
     </RejectedCertificateStore>
 
+    <!-- Where the User issuer certificates are stored -->
+    <UserIssuerCertificates>
+      <StoreType>Directory</StoreType>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\issuerUser</StorePath>
+    </UserIssuerCertificates>
+
+    <!-- Where the User trust list is stored-->
+    <TrustedUserCertificates>
+      <StoreType>Directory</StoreType>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\trustedUser</StorePath>
+    </TrustedUserCertificates>
   </SecurityConfiguration>
 
 

--- a/SampleApplications/Samples/Server.Net4/Opc.Ua.SampleServer.Config.xml
+++ b/SampleApplications/Samples/Server.Net4/Opc.Ua.SampleServer.Config.xml
@@ -21,19 +21,19 @@
     <!-- Where the issuer certificate are stored (certificate authorities) -->
     <TrustedIssuerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\UA Certificate Authorities</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\issuer</StorePath>
     </TrustedIssuerCertificates>
     
     <!-- Where the trust list is stored (UA Applications) -->
     <TrustedPeerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\UA Applications</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\trusted</StorePath>
     </TrustedPeerCertificates>
 
     <!-- The directory used to store invalid certficates for later review by the administrator. -->
     <RejectedCertificateStore>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\RejectedCertificates</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\rejected</StorePath>
     </RejectedCertificateStore>
 
     <!-- Where the User issuer certificates are stored -->

--- a/SampleApplications/Samples/Server/Opc.Ua.SampleServer.Config.xml
+++ b/SampleApplications/Samples/Server/Opc.Ua.SampleServer.Config.xml
@@ -21,19 +21,19 @@
     <!-- Where the issuer certificate are stored (certificate authorities) -->
     <TrustedIssuerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>%LocalFolder%\OPC Foundation\CertificateStores\UA Certificate Authorities</StorePath>
+      <StorePath>%LocalFolder%\OPC Foundation\pki\issuer</StorePath>
     </TrustedIssuerCertificates>
     
     <!-- Where the trust list is stored (UA Applications) -->
     <TrustedPeerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>%LocalFolder%\OPC Foundation\CertificateStores\UA Applications</StorePath>
+      <StorePath>%LocalFolder%\OPC Foundation\pki\trusted</StorePath>
     </TrustedPeerCertificates>
     
     <!-- The directory used to store invalid certficates for later review by the administrator. -->
     <RejectedCertificateStore>
       <StoreType>Directory</StoreType>
-      <StorePath>%LocalFolder%\OPC Foundation\CertificateStores\RejectedCertificates</StorePath>
+      <StorePath>%LocalFolder%\OPC Foundation\pki\rejected</StorePath>
     </RejectedCertificateStore>
 
   </SecurityConfiguration>

--- a/SampleApplications/Samples/XamarinClient/XamarinClient.Android/Assets/Opc.Ua.SampleClient.Config.xml
+++ b/SampleApplications/Samples/XamarinClient/XamarinClient.Android/Assets/Opc.Ua.SampleClient.Config.xml
@@ -14,26 +14,26 @@
     <!-- Where the application instance certificate is stored (MachineDefault) -->
     <ApplicationCertificate>
       <StoreType>Directory</StoreType>
-      <StorePath>/storage/emulated/0/OPC Foundation/PKI/own</StorePath>
+      <StorePath>/storage/emulated/0/OPC Foundation/pki/own</StorePath>
       <SubjectName>CN=UA Xamarin Sample Client, C=US, S=Arizona, O=OPC Foundation, DC=localhost</SubjectName>
     </ApplicationCertificate>
 
     <!-- Where the issuer certificate are stored (certificate authorities) -->
     <TrustedIssuerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>/storage/emulated/0/OPC Foundation/PKI/issuer</StorePath>
+      <StorePath>/storage/emulated/0/OPC Foundation/pki/issuer</StorePath>
     </TrustedIssuerCertificates>
 
     <!-- Where the trust list is stored (UA Applications) -->
     <TrustedPeerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>/storage/emulated/0/OPC Foundation/PKI/trusted</StorePath>
+      <StorePath>/storage/emulated/0/OPC Foundation/pki/trusted</StorePath>
     </TrustedPeerCertificates>
 
     <!-- The directory used to store invalid certficates for later review by the administrator. -->
     <RejectedCertificateStore>
       <StoreType>Directory</StoreType>
-      <StorePath>/storage/emulated/0/OPC Foundation/PKI/rejected</StorePath>
+      <StorePath>/storage/emulated/0/OPC Foundation/pki/rejected</StorePath>
     </RejectedCertificateStore>
 
     <!-- WARNING: The following setting (to automatically accept untrusted certificates) should be used

--- a/SampleApplications/Samples/XamarinClient/XamarinClient.UWP/Opc.Ua.SampleClient.Config.xml
+++ b/SampleApplications/Samples/XamarinClient/XamarinClient.UWP/Opc.Ua.SampleClient.Config.xml
@@ -21,19 +21,19 @@
     <!-- Where the issuer certificate are stored (certificate authorities) -->
     <TrustedIssuerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>%LocalApplicationData%/OPC Foundation/PKI/issuer</StorePath>
+      <StorePath>%LocalApplicationData%/OPC Foundation/pki/issuer</StorePath>
     </TrustedIssuerCertificates>
 
     <!-- Where the trust list is stored (UA Applications) -->
     <TrustedPeerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>%LocalApplicationData%/OPC Foundation/PKI/trusted</StorePath>
+      <StorePath>%LocalApplicationData%/OPC Foundation/pki/trusted</StorePath>
     </TrustedPeerCertificates>
 
     <!-- The directory used to store invalid certficates for later review by the administrator. -->
     <RejectedCertificateStore>
       <StoreType>Directory</StoreType>
-      <StorePath>%LocalApplicationData%/OPC Foundation/PKI/rejected</StorePath>
+      <StorePath>%LocalApplicationData%/OPC Foundation/pki/rejected</StorePath>
     </RejectedCertificateStore>
 
     <!-- WARNING: The following setting (to automatically accept untrusted certificates) should be used

--- a/SampleApplications/Samples/XamarinClient/XamarinClient.iOS/Opc.Ua.SampleClient.Config.xml
+++ b/SampleApplications/Samples/XamarinClient/XamarinClient.iOS/Opc.Ua.SampleClient.Config.xml
@@ -14,26 +14,26 @@
     <!-- Where the application instance certificate is stored (MachineDefault) -->
     <ApplicationCertificate>
       <StoreType>Directory</StoreType>
-      <StorePath>./OPC Foundation/PKI/own</StorePath>
+      <StorePath>./OPC Foundation/pki/own</StorePath>
       <SubjectName>CN=UA Xamarin Sample Client, C=US, S=Arizona, O=OPC Foundation, DC=localhost</SubjectName>
     </ApplicationCertificate>
 
     <!-- Where the issuer certificate are stored (certificate authorities) -->
     <TrustedIssuerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>./OPC Foundation/PKI/issuer</StorePath>
+      <StorePath>./OPC Foundation/pki/issuer</StorePath>
     </TrustedIssuerCertificates>
 
     <!-- Where the trust list is stored (UA Applications) -->
     <TrustedPeerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>./OPC Foundation/PKI/trusted</StorePath>
+      <StorePath>./OPC Foundation/pki/trusted</StorePath>
     </TrustedPeerCertificates>
 
     <!-- The directory used to store invalid certficates for later review by the administrator. -->
     <RejectedCertificateStore>
       <StoreType>Directory</StoreType>
-      <StorePath>./OPC Foundation/PKI/rejected</StorePath>
+      <StorePath>./OPC Foundation/pki/rejected</StorePath>
     </RejectedCertificateStore>
 
     <!-- WARNING: The following setting (to automatically accept untrusted certificates) should be used

--- a/SampleApplications/Workshop/Aggregation/Client/Quickstarts.AggregationClient.Config.xml
+++ b/SampleApplications/Workshop/Aggregation/Client/Quickstarts.AggregationClient.Config.xml
@@ -14,26 +14,26 @@
     <!-- Where the application instance certificate is stored (MachineDefault) -->
     <ApplicationCertificate>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\MachineDefault</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\own</StorePath>
       <SubjectName>CN=Quickstart Aggregation Client, C=US, S=Arizona, O=OPC Foundation, DC=localhost</SubjectName>
     </ApplicationCertificate>
 
-    <!-- Where the issuer certificate are stored (certificate authorities) -->
+   <!-- Where the issuer certificate are stored (certificate authorities) -->
     <TrustedIssuerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\UA Certificate Authorities</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\issuer</StorePath>
     </TrustedIssuerCertificates>
 
-    <!-- Where the trust list is stored (UA Applications) -->
+    <!-- Where the trust list is stored -->
     <TrustedPeerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\UA Applications</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\trusted</StorePath>
     </TrustedPeerCertificates>
 
-        <!-- The directory used to store invalid certficates for later review by the administrator. -->
+    <!-- The directory used to store invalid certficates for later review by the administrator. -->
     <RejectedCertificateStore>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\RejectedCertificates</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\rejected</StorePath>
     </RejectedCertificateStore>
   </SecurityConfiguration>
   

--- a/SampleApplications/Workshop/Aggregation/ConsoleAggregationServer/Quickstarts.AggregationServer.Config.xml
+++ b/SampleApplications/Workshop/Aggregation/ConsoleAggregationServer/Quickstarts.AggregationServer.Config.xml
@@ -14,26 +14,26 @@
     <!-- Where the application instance certificate is stored (MachineDefault) -->
     <ApplicationCertificate>
       <StoreType>Directory</StoreType>
-      <StorePath>OPC Foundation/CertificateStores/MachineDefault</StorePath>
+      <StorePath>OPC Foundation/pki/own</StorePath>
       <SubjectName>CN=Quickstart Aggregation Server, C=US, S=Arizona, O=OPC Foundation, DC=localhost</SubjectName>
     </ApplicationCertificate>
 
     <!-- Where the issuer certificate are stored (certificate authorities) -->
     <TrustedIssuerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>OPC Foundation/CertificateStores/UA Certificate Authorities</StorePath>
+      <StorePath>OPC Foundation/pki/issuer</StorePath>
     </TrustedIssuerCertificates>
 
     <!-- Where the trust list is stored (UA Applications) -->
     <TrustedPeerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>OPC Foundation/CertificateStores/UA Applications</StorePath>
+      <StorePath>OPC Foundation/pki/trusted</StorePath>
     </TrustedPeerCertificates>
 
     <!-- The directory used to store invalid certficates for later review by the administrator. -->
     <RejectedCertificateStore>
       <StoreType>Directory</StoreType>
-      <StorePath>OPC Foundation/CertificateStores/RejectedCertificates</StorePath>
+      <StorePath>OPC Foundation/pki/rejected</StorePath>
     </RejectedCertificateStore>
 
     <!-- WARNING: The following setting (to automatically accept untrusted certificates) should be used

--- a/SampleApplications/Workshop/Aggregation/Server/Quickstarts.AggregationServer.Config.xml
+++ b/SampleApplications/Workshop/Aggregation/Server/Quickstarts.AggregationServer.Config.xml
@@ -14,26 +14,26 @@
     <!-- Where the application instance certificate is stored (MachineDefault) -->
     <ApplicationCertificate>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\MachineDefault</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\own</StorePath>
       <SubjectName>CN=Quickstart Aggregation Server, C=US, S=Arizona, O=OPC Foundation, DC=localhost</SubjectName>
     </ApplicationCertificate>
 
     <!-- Where the issuer certificate are stored (certificate authorities) -->
     <TrustedIssuerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\UA Certificate Authorities</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\issuer</StorePath>
     </TrustedIssuerCertificates>
 
     <!-- Where the trust list is stored (UA Applications) -->
     <TrustedPeerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\UA Applications</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\trusted</StorePath>
     </TrustedPeerCertificates>
 
     <!-- The directory used to store invalid certficates for later review by the administrator. -->
     <RejectedCertificateStore>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\RejectedCertificates</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\rejected</StorePath>
     </RejectedCertificateStore>
 
   </SecurityConfiguration>

--- a/SampleApplications/Workshop/AlarmCondition/Client/AlarmConditionClient.Config.xml
+++ b/SampleApplications/Workshop/AlarmCondition/Client/AlarmConditionClient.Config.xml
@@ -14,26 +14,26 @@
     <!-- Where the application instance certificate is stored (MachineDefault) -->
     <ApplicationCertificate>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\MachineDefault</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\own</StorePath>
       <SubjectName>CN=Quickstart AlarmCondition Client, C=US, S=Arizona, O=OPC Foundation, DC=localhost</SubjectName>
     </ApplicationCertificate>
 
     <!-- Where the issuer certificate are stored (certificate authorities) -->
     <TrustedIssuerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\UA Certificate Authorities</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\issuer</StorePath>
     </TrustedIssuerCertificates>
 
     <!-- Where the trust list is stored (UA Applications) -->
     <TrustedPeerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\UA Applications</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\trusted</StorePath>
     </TrustedPeerCertificates>
 
     <!-- The directory used to store invalid certficates for later review by the administrator. -->
     <RejectedCertificateStore>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\RejectedCertificates</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\rejected</StorePath>
     </RejectedCertificateStore>
   </SecurityConfiguration>
   

--- a/SampleApplications/Workshop/AlarmCondition/Server/AlarmConditionServer.Config.xml
+++ b/SampleApplications/Workshop/AlarmCondition/Server/AlarmConditionServer.Config.xml
@@ -14,26 +14,26 @@
     <!-- Where the application instance certificate is stored (MachineDefault) -->
     <ApplicationCertificate>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\MachineDefault</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\own</StorePath>
       <SubjectName>CN=Quickstart AlarmCondition Server, C=US, S=Arizona, O=OPC Foundation, DC=localhost</SubjectName>
     </ApplicationCertificate>
 
     <!-- Where the issuer certificate are stored (certificate authorities) -->
     <TrustedIssuerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\UA Certificate Authorities</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\issuer</StorePath>
     </TrustedIssuerCertificates>
 
     <!-- Where the trust list is stored (UA Applications) -->
     <TrustedPeerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\UA Applications</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\trusted</StorePath>
     </TrustedPeerCertificates>
 
     <!-- The directory used to store invalid certficates for later review by the administrator. -->
     <RejectedCertificateStore>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\RejectedCertificates</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\rejected</StorePath>
     </RejectedCertificateStore>
   </SecurityConfiguration>
 

--- a/SampleApplications/Workshop/Boiler/Client/BoilerClient.Config.xml
+++ b/SampleApplications/Workshop/Boiler/Client/BoilerClient.Config.xml
@@ -14,26 +14,26 @@
     <!-- Where the application instance certificate is stored (MachineDefault) -->
     <ApplicationCertificate>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\MachineDefault</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\own</StorePath>
       <SubjectName>CN=Quickstart InformationModel Client, C=US, S=Arizona, O=OPC Foundation, DC=localhost</SubjectName>
     </ApplicationCertificate>
 
     <!-- Where the issuer certificate are stored (certificate authorities) -->
     <TrustedIssuerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\UA Certificate Authorities</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\issuer</StorePath>
     </TrustedIssuerCertificates>
 
     <!-- Where the trust list is stored (UA Applications) -->
     <TrustedPeerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\UA Applications</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\trusted</StorePath>
     </TrustedPeerCertificates>
 
     <!-- The directory used to store invalid certficates for later review by the administrator. -->
     <RejectedCertificateStore>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\RejectedCertificates</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\rejected</StorePath>
     </RejectedCertificateStore>
   </SecurityConfiguration>
   

--- a/SampleApplications/Workshop/Boiler/Server/BoilerServer.Config.xml
+++ b/SampleApplications/Workshop/Boiler/Server/BoilerServer.Config.xml
@@ -14,26 +14,26 @@
     <!-- Where the application instance certificate is stored (MachineDefault) -->
     <ApplicationCertificate>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\MachineDefault</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\own</StorePath>
       <SubjectName>CN=Quickstart InformationModel Server, C=US, S=Arizona, O=OPC Foundation, DC=localhost</SubjectName>
     </ApplicationCertificate>
 
     <!-- Where the issuer certificate are stored (certificate authorities) -->
     <TrustedIssuerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\UA Certificate Authorities</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\issuer</StorePath>
     </TrustedIssuerCertificates>
 
     <!-- Where the trust list is stored (UA Applications) -->
     <TrustedPeerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\UA Applications</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\trusted</StorePath>
     </TrustedPeerCertificates>
 
     <!-- The directory used to store invalid certficates for later review by the administrator. -->
     <RejectedCertificateStore>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\RejectedCertificates</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\rejected</StorePath>
     </RejectedCertificateStore>
   </SecurityConfiguration>
   

--- a/SampleApplications/Workshop/DataAccess/Client/DataAccessClient.Config.xml
+++ b/SampleApplications/Workshop/DataAccess/Client/DataAccessClient.Config.xml
@@ -14,26 +14,26 @@
     <!-- Where the application instance certificate is stored (MachineDefault) -->
     <ApplicationCertificate>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\MachineDefault</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\own</StorePath>
       <SubjectName>CN=Quickstart DataAccess Client, C=US, S=Arizona, O=OPC Foundation, DC=localhost</SubjectName>
     </ApplicationCertificate>
 
     <!-- Where the issuer certificate are stored (certificate authorities) -->
     <TrustedIssuerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\UA Certificate Authorities</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\issuer</StorePath>
     </TrustedIssuerCertificates>
 
     <!-- Where the trust list is stored (UA Applications) -->
     <TrustedPeerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\UA Applications</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\trusted</StorePath>
     </TrustedPeerCertificates>
 
     <!-- The directory used to store invalid certficates for later review by the administrator. -->
     <RejectedCertificateStore>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\RejectedCertificates</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\rejected</StorePath>
     </RejectedCertificateStore>
   </SecurityConfiguration>
   

--- a/SampleApplications/Workshop/DataAccess/Server/DataAccessServer.Config.xml
+++ b/SampleApplications/Workshop/DataAccess/Server/DataAccessServer.Config.xml
@@ -14,26 +14,26 @@
     <!-- Where the application instance certificate is stored (MachineDefault) -->
     <ApplicationCertificate>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\MachineDefault</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\own</StorePath>
       <SubjectName>CN=Quickstart DataAccess Server, C=US, S=Arizona, O=OPC Foundation, DC=localhost</SubjectName>
     </ApplicationCertificate>
 
     <!-- Where the issuer certificate are stored (certificate authorities) -->
     <TrustedIssuerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\UA Certificate Authorities</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\issuer</StorePath>
     </TrustedIssuerCertificates>
 
     <!-- Where the trust list is stored (UA Applications) -->
     <TrustedPeerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\UA Applications</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\trusted</StorePath>
     </TrustedPeerCertificates>
 
     <!-- The directory used to store invalid certficates for later review by the administrator. -->
     <RejectedCertificateStore>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\RejectedCertificates</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\rejected</StorePath>
     </RejectedCertificateStore>
   </SecurityConfiguration>
   

--- a/SampleApplications/Workshop/DataTypes/Client/DataTypesClient.Config.xml
+++ b/SampleApplications/Workshop/DataTypes/Client/DataTypesClient.Config.xml
@@ -14,26 +14,26 @@
     <!-- Where the application instance certificate is stored (MachineDefault) -->
     <ApplicationCertificate>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\MachineDefault</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\own</StorePath>
       <SubjectName>CN=Quickstart DataTypes Client, C=US, S=Arizona, O=SomeCompany, DC=localhost</SubjectName>
     </ApplicationCertificate>
 
-    <!-- Where the issuer certificate are stored (certificate authorities) -->
+   <!-- Where the issuer certificate are stored (certificate authorities) -->
     <TrustedIssuerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\UA Certificate Authorities</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\issuer</StorePath>
     </TrustedIssuerCertificates>
 
-    <!-- Where the trust list is stored (UA Applications) -->
+    <!-- Where the trust list is stored -->
     <TrustedPeerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\UA Applications</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\trusted</StorePath>
     </TrustedPeerCertificates>
 
     <!-- The directory used to store invalid certficates for later review by the administrator. -->
     <RejectedCertificateStore>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\RejectedCertificates</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\rejected</StorePath>
     </RejectedCertificateStore>
   </SecurityConfiguration>
   

--- a/SampleApplications/Workshop/DataTypes/Server/DataTypesServer.Config.xml
+++ b/SampleApplications/Workshop/DataTypes/Server/DataTypesServer.Config.xml
@@ -14,26 +14,26 @@
     <!-- Where the application instance certificate is stored (MachineDefault) -->
     <ApplicationCertificate>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\MachineDefault</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\own</StorePath>
       <SubjectName>CN=Quickstart DataTypes Server, C=US, S=Arizona, O=SomeCompany, DC=localhost</SubjectName>
     </ApplicationCertificate>
 
     <!-- Where the issuer certificate are stored (certificate authorities) -->
     <TrustedIssuerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\UA Certificate Authorities</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\issuer</StorePath>
     </TrustedIssuerCertificates>
 
-    <!-- Where the trust list is stored (UA Applications) -->
+    <!-- Where the trust list is stored -->
     <TrustedPeerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\UA Applications</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\trusted</StorePath>
     </TrustedPeerCertificates>
 
     <!-- The directory used to store invalid certficates for later review by the administrator. -->
     <RejectedCertificateStore>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\RejectedCertificates</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\rejected</StorePath>
     </RejectedCertificateStore>
   </SecurityConfiguration>
   

--- a/SampleApplications/Workshop/Empty/Client/Quickstarts.EmptyClient.Config.xml
+++ b/SampleApplications/Workshop/Empty/Client/Quickstarts.EmptyClient.Config.xml
@@ -14,26 +14,26 @@
     <!-- Where the application instance certificate is stored (MachineDefault) -->
     <ApplicationCertificate>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\MachineDefault</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\own</StorePath>
       <SubjectName>CN=Quickstart Empty Client, C=US, S=Arizona, O=SomeCompany, DC=localhost</SubjectName>
     </ApplicationCertificate>
 
-    <!-- Where the issuer certificate are stored (certificate authorities) -->
+   <!-- Where the issuer certificate are stored (certificate authorities) -->
     <TrustedIssuerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\UA Certificate Authorities</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\issuer</StorePath>
     </TrustedIssuerCertificates>
 
-    <!-- Where the trust list is stored (UA Applications) -->
+    <!-- Where the trust list is stored -->
     <TrustedPeerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\UA Applications</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\trusted</StorePath>
     </TrustedPeerCertificates>
 
     <!-- The directory used to store invalid certficates for later review by the administrator. -->
     <RejectedCertificateStore>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\RejectedCertificates</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\rejected</StorePath>
     </RejectedCertificateStore>
   </SecurityConfiguration>
   

--- a/SampleApplications/Workshop/Empty/Server/Quickstarts.EmptyServer.Config.xml
+++ b/SampleApplications/Workshop/Empty/Server/Quickstarts.EmptyServer.Config.xml
@@ -14,26 +14,26 @@
     <!-- Where the application instance certificate is stored (MachineDefault) -->
     <ApplicationCertificate>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\MachineDefault</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\own</StorePath>
       <SubjectName>CN=Quickstart Empty Server, C=US, S=Arizona, O=SomeCompany, DC=localhost</SubjectName>
     </ApplicationCertificate>
 
     <!-- Where the issuer certificate are stored (certificate authorities) -->
     <TrustedIssuerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\UA Certificate Authorities</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\issuer</StorePath>
     </TrustedIssuerCertificates>
 
-    <!-- Where the trust list is stored (UA Applications) -->
+    <!-- Where the trust list is stored -->
     <TrustedPeerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\UA Applications</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\trusted</StorePath>
     </TrustedPeerCertificates>
 
     <!-- The directory used to store invalid certficates for later review by the administrator. -->
     <RejectedCertificateStore>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\RejectedCertificates</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\rejected</StorePath>
     </RejectedCertificateStore>
   </SecurityConfiguration>
   

--- a/SampleApplications/Workshop/HistoricalAccess/Client/HistoricalAccessClient.Config.xml
+++ b/SampleApplications/Workshop/HistoricalAccess/Client/HistoricalAccessClient.Config.xml
@@ -14,26 +14,26 @@
     <!-- Where the application instance certificate is stored (MachineDefault) -->
     <ApplicationCertificate>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\MachineDefault</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\own</StorePath>
       <SubjectName>CN=Quickstart HistoricalAccess Client, C=US, S=Arizona, O=OPC Foundation, DC=localhost</SubjectName>
     </ApplicationCertificate>
 
     <!-- Where the issuer certificate are stored (certificate authorities) -->
     <TrustedIssuerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\UA Certificate Authorities</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\issuer</StorePath>
     </TrustedIssuerCertificates>
 
-    <!-- Where the trust list is stored (UA Applications) -->
+    <!-- Where the trust list is stored -->
     <TrustedPeerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\UA Applications</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\trusted</StorePath>
     </TrustedPeerCertificates>
 
     <!-- The directory used to store invalid certficates for later review by the administrator. -->
     <RejectedCertificateStore>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\RejectedCertificates</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\rejected</StorePath>
     </RejectedCertificateStore>
   </SecurityConfiguration>
   

--- a/SampleApplications/Workshop/HistoricalAccess/Server/HistoricalAccessServer.Config.xml
+++ b/SampleApplications/Workshop/HistoricalAccess/Server/HistoricalAccessServer.Config.xml
@@ -14,28 +14,27 @@
     <!-- Where the application instance certificate is stored (MachineDefault) -->
     <ApplicationCertificate>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\MachineDefault</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\own</StorePath>
       <SubjectName>CN=Quickstart HistoricalAccess Server, C=US, S=Arizona, O=OPC Foundation, DC=localhost</SubjectName>
     </ApplicationCertificate>
 
     <!-- Where the issuer certificate are stored (certificate authorities) -->
     <TrustedIssuerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\UA Certificate Authorities</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\issuer</StorePath>
     </TrustedIssuerCertificates>
 
-    <!-- Where the trust list is stored (UA Applications) -->
+    <!-- Where the trust list is stored -->
     <TrustedPeerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\UA Applications</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\trusted</StorePath>
     </TrustedPeerCertificates>
 
     <!-- The directory used to store invalid certficates for later review by the administrator. -->
     <RejectedCertificateStore>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\RejectedCertificates</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\rejected</StorePath>
     </RejectedCertificateStore>
-
   </SecurityConfiguration>
   
   <TransportConfigurations></TransportConfigurations>

--- a/SampleApplications/Workshop/HistoricalEvents/Client/HistoricalEventsClient.Config.xml
+++ b/SampleApplications/Workshop/HistoricalEvents/Client/HistoricalEventsClient.Config.xml
@@ -14,28 +14,27 @@
     <!-- Where the application instance certificate is stored (MachineDefault) -->
     <ApplicationCertificate>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\MachineDefault</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\own</StorePath>
       <SubjectName>CN=Quickstart HistoricalEvents Client, C=US, S=Arizona, O=OPC Foundation, DC=localhost</SubjectName>
     </ApplicationCertificate>
 
     <!-- Where the issuer certificate are stored (certificate authorities) -->
     <TrustedIssuerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\UA Certificate Authorities</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\issuer</StorePath>
     </TrustedIssuerCertificates>
 
-    <!-- Where the trust list is stored (UA Applications) -->
+    <!-- Where the trust list is stored -->
     <TrustedPeerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\UA Applications</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\trusted</StorePath>
     </TrustedPeerCertificates>
 
     <!-- The directory used to store invalid certficates for later review by the administrator. -->
     <RejectedCertificateStore>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\RejectedCertificates</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\rejected</StorePath>
     </RejectedCertificateStore>
-
   </SecurityConfiguration>
   
   <TransportConfigurations></TransportConfigurations>

--- a/SampleApplications/Workshop/HistoricalEvents/Server/HistoricalEventsServer.Config.xml
+++ b/SampleApplications/Workshop/HistoricalEvents/Server/HistoricalEventsServer.Config.xml
@@ -14,28 +14,27 @@
     <!-- Where the application instance certificate is stored (MachineDefault) -->
     <ApplicationCertificate>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\MachineDefault</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\own</StorePath>
       <SubjectName>CN=Quickstart HistoricalEvents Server, C=US, S=Arizona, O=OPC Foundation, DC=localhost</SubjectName>
     </ApplicationCertificate>
 
     <!-- Where the issuer certificate are stored (certificate authorities) -->
     <TrustedIssuerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\UA Certificate Authorities</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\issuer</StorePath>
     </TrustedIssuerCertificates>
 
-    <!-- Where the trust list is stored (UA Applications) -->
+    <!-- Where the trust list is stored -->
     <TrustedPeerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\UA Applications</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\trusted</StorePath>
     </TrustedPeerCertificates>
 
     <!-- The directory used to store invalid certficates for later review by the administrator. -->
     <RejectedCertificateStore>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\RejectedCertificates</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\rejected</StorePath>
     </RejectedCertificateStore>
-
   </SecurityConfiguration>
   
   <TransportConfigurations></TransportConfigurations>

--- a/SampleApplications/Workshop/Methods/Client/Quickstarts.MethodsClient.Config.xml
+++ b/SampleApplications/Workshop/Methods/Client/Quickstarts.MethodsClient.Config.xml
@@ -14,26 +14,26 @@
     <!-- Where the application instance certificate is stored (MachineDefault) -->
     <ApplicationCertificate>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\MachineDefault</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\own</StorePath>
       <SubjectName>CN=Quickstart Methods Client, C=US, S=Arizona, O=OPC Foundation, DC=localhost</SubjectName>
     </ApplicationCertificate>
 
-    <!-- Where the issuer certificate are stored (certificate authorities) -->
+   <!-- Where the issuer certificate are stored (certificate authorities) -->
     <TrustedIssuerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\UA Certificate Authorities</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\issuer</StorePath>
     </TrustedIssuerCertificates>
 
-    <!-- Where the trust list is stored (UA Applications) -->
+    <!-- Where the trust list is stored -->
     <TrustedPeerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\UA Applications</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\trusted</StorePath>
     </TrustedPeerCertificates>
 
     <!-- The directory used to store invalid certficates for later review by the administrator. -->
     <RejectedCertificateStore>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\RejectedCertificates</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\rejected</StorePath>
     </RejectedCertificateStore>
   </SecurityConfiguration>
   

--- a/SampleApplications/Workshop/Methods/Server/Quickstarts.MethodsServer.Config.xml
+++ b/SampleApplications/Workshop/Methods/Server/Quickstarts.MethodsServer.Config.xml
@@ -14,26 +14,26 @@
     <!-- Where the application instance certificate is stored (MachineDefault) -->
     <ApplicationCertificate>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\MachineDefault</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\own</StorePath>
       <SubjectName>CN=Quickstart Methods Server, C=US, S=Arizona, O=OPC Foundation, DC=localhost</SubjectName>
     </ApplicationCertificate>
 
     <!-- Where the issuer certificate are stored (certificate authorities) -->
     <TrustedIssuerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\UA Certificate Authorities</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\issuer</StorePath>
     </TrustedIssuerCertificates>
 
-    <!-- Where the trust list is stored (UA Applications) -->
+    <!-- Where the trust list is stored -->
     <TrustedPeerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\UA Applications</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\trusted</StorePath>
     </TrustedPeerCertificates>
 
     <!-- The directory used to store invalid certficates for later review by the administrator. -->
     <RejectedCertificateStore>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\RejectedCertificates</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\rejected</StorePath>
     </RejectedCertificateStore>
   </SecurityConfiguration>
   

--- a/SampleApplications/Workshop/PerfTest/Client/PerfTestClient.Config.xml
+++ b/SampleApplications/Workshop/PerfTest/Client/PerfTestClient.Config.xml
@@ -12,26 +12,26 @@
   <SecurityConfiguration>
     <ApplicationCertificate>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\MachineDefault</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\own</StorePath>
       <SubjectName>CN=Quickstart PerfTest Client, C=US, S=Arizona, O=OPC Foundation, DC=localhost</SubjectName>
     </ApplicationCertificate>
 
     <!-- Where the issuer certificate are stored (certificate authorities) -->
     <TrustedIssuerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\UA Certificate Authorities</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\issuer</StorePath>
     </TrustedIssuerCertificates>
-    
-    <!-- Where the trust list is stored (UA Applications) -->
+
+    <!-- Where the trust list is stored -->
     <TrustedPeerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\UA Applications</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\trusted</StorePath>
     </TrustedPeerCertificates>
 
     <!-- The directory used to store invalid certficates for later review by the administrator. -->
     <RejectedCertificateStore>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\RejectedCertificates</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\rejected</StorePath>
     </RejectedCertificateStore>
   </SecurityConfiguration>
   

--- a/SampleApplications/Workshop/PerfTest/Server/PerfTestServer.Config.xml
+++ b/SampleApplications/Workshop/PerfTest/Server/PerfTestServer.Config.xml
@@ -12,28 +12,27 @@
   <SecurityConfiguration>
     <ApplicationCertificate>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\MachineDefault</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\own</StorePath>
       <SubjectName>CN=Quickstart PerfTest Server, C=US, S=Arizona, O=OPC Foundation, DC=localhost</SubjectName>
     </ApplicationCertificate>
 
     <!-- Where the issuer certificate are stored (certificate authorities) -->
     <TrustedIssuerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\UA Certificate Authorities</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\issuer</StorePath>
     </TrustedIssuerCertificates>
 
-    <!-- Where the trust list is stored (UA Applications) -->
+    <!-- Where the trust list is stored -->
     <TrustedPeerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\UA Applications</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\trusted</StorePath>
     </TrustedPeerCertificates>
 
     <!-- The directory used to store invalid certficates for later review by the administrator. -->
     <RejectedCertificateStore>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\RejectedCertificates</StorePath>
-    </RejectedCertificateStore>
-    
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\rejected</StorePath>
+    </RejectedCertificateStore>    
   </SecurityConfiguration>
  
   <TransportConfigurations></TransportConfigurations>

--- a/SampleApplications/Workshop/Reference/Client/Quickstarts.ReferenceClient.Config.xml
+++ b/SampleApplications/Workshop/Reference/Client/Quickstarts.ReferenceClient.Config.xml
@@ -14,26 +14,26 @@
     <!-- Where the application instance certificate is stored (MachineDefault) -->
     <ApplicationCertificate>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\MachineDefault</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\own</StorePath>
       <SubjectName>CN=Quickstart Reference Client, C=US, S=Arizona, O=OPC Foundation, DC=localhost</SubjectName>
     </ApplicationCertificate>
 
-    <!-- Where the issuer certificate are stored (certificate authorities) -->
+   <!-- Where the issuer certificate are stored (certificate authorities) -->
     <TrustedIssuerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\UA Certificate Authorities</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\issuer</StorePath>
     </TrustedIssuerCertificates>
 
-    <!-- Where the trust list is stored (UA Applications) -->
+    <!-- Where the trust list is stored -->
     <TrustedPeerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\UA Applications</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\trusted</StorePath>
     </TrustedPeerCertificates>
 
     <!-- The directory used to store invalid certficates for later review by the administrator. -->
     <RejectedCertificateStore>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\RejectedCertificates</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\rejected</StorePath>
     </RejectedCertificateStore>
 
     <!-- WARNING: The following setting (to automatically accept untrusted certificates) should be used

--- a/SampleApplications/Workshop/Reference/ConsoleReferenceServer/Quickstarts.MonoReferenceServer.Config.xml
+++ b/SampleApplications/Workshop/Reference/ConsoleReferenceServer/Quickstarts.MonoReferenceServer.Config.xml
@@ -14,26 +14,26 @@
     <!-- Where the application instance certificate is stored (MachineDefault) -->
     <ApplicationCertificate>
       <StoreType>Directory</StoreType>
-      <StorePath>./OPC Foundation/PKI/own</StorePath>
+      <StorePath>./OPC Foundation/pki/own</StorePath>
       <SubjectName>CN=Quickstart Mono Reference Server, C=US, S=Arizona, O=OPC Foundation, DC=localhost</SubjectName>
     </ApplicationCertificate>
 
     <!-- Where the issuer certificate are stored (certificate authorities) -->
     <TrustedIssuerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>./OPC Foundation/PKI/issuer</StorePath>
+      <StorePath>./OPC Foundation/pki/issuer</StorePath>
     </TrustedIssuerCertificates>
 
     <!-- Where the trust list is stored (UA Applications) -->
     <TrustedPeerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>./OPC Foundation/PKI/trusted</StorePath>
+      <StorePath>./OPC Foundation/pki/trusted</StorePath>
     </TrustedPeerCertificates>
 
     <!-- The directory used to store invalid certficates for later review by the administrator. -->
     <RejectedCertificateStore>
       <StoreType>Directory</StoreType>
-      <StorePath>./OPC Foundation/PKI/rejected</StorePath>
+      <StorePath>./OPC Foundation/pki/rejected</StorePath>
     </RejectedCertificateStore>
 
     <!-- WARNING: The following setting (to automatically accept untrusted certificates) should be used

--- a/SampleApplications/Workshop/Reference/ConsoleReferenceServer/Quickstarts.ReferenceServer.Config.xml
+++ b/SampleApplications/Workshop/Reference/ConsoleReferenceServer/Quickstarts.ReferenceServer.Config.xml
@@ -14,26 +14,26 @@
     <!-- Where the application instance certificate is stored (MachineDefault) -->
     <ApplicationCertificate>
       <StoreType>Directory</StoreType>
-      <StorePath>%LocalApplicationData%/OPC Foundation/CertificateStores/MachineDefault</StorePath>
+      <StorePath>%LocalApplicationData%/OPC Foundation/pki/own</StorePath>
       <SubjectName>CN=Quickstart Reference Server, C=US, S=Arizona, O=OPC Foundation, DC=localhost</SubjectName>
     </ApplicationCertificate>
 
     <!-- Where the issuer certificate are stored (certificate authorities) -->
     <TrustedIssuerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>%LocalApplicationData%/OPC Foundation/CertificateStores/UA Certificate Authorities</StorePath>
+      <StorePath>%LocalApplicationData%/OPC Foundation/pki/issuer</StorePath>
     </TrustedIssuerCertificates>
 
     <!-- Where the trust list is stored (UA Applications) -->
     <TrustedPeerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>%LocalApplicationData%/OPC Foundation/CertificateStores/UA Applications</StorePath>
+      <StorePath>%LocalApplicationData%/OPC Foundation/pki/trusted</StorePath>
     </TrustedPeerCertificates>
 
     <!-- The directory used to store invalid certficates for later review by the administrator. -->
     <RejectedCertificateStore>
       <StoreType>Directory</StoreType>
-      <StorePath>%LocalApplicationData%/OPC Foundation/CertificateStores/RejectedCertificates</StorePath>
+      <StorePath>%LocalApplicationData%/OPC Foundation/pki/rejected</StorePath>
     </RejectedCertificateStore>
 
     <!-- WARNING: The following setting (to automatically accept untrusted certificates) should be used

--- a/SampleApplications/Workshop/Reference/Server/Quickstarts.ReferenceServer.Config.xml
+++ b/SampleApplications/Workshop/Reference/Server/Quickstarts.ReferenceServer.Config.xml
@@ -45,6 +45,17 @@
     <RejectSHA1SignedCertificates>false</RejectSHA1SignedCertificates>
     <MinimumCertificateKeySize>2048</MinimumCertificateKeySize>
 
+    <!-- Where the User issuer certificates are stored -->
+    <UserIssuerCertificates>
+      <StoreType>Directory</StoreType>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\issuerUser</StorePath>
+    </UserIssuerCertificates>
+
+    <!-- Where the User trust list is stored-->
+    <TrustedUserCertificates>
+      <StoreType>Directory</StoreType>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\trustedUser</StorePath>
+    </TrustedUserCertificates>
   </SecurityConfiguration>
   
   <TransportConfigurations></TransportConfigurations>

--- a/SampleApplications/Workshop/Reference/Server/Quickstarts.ReferenceServer.Config.xml
+++ b/SampleApplications/Workshop/Reference/Server/Quickstarts.ReferenceServer.Config.xml
@@ -11,29 +11,29 @@
   
   <SecurityConfiguration>
 
-    <!-- Where the application instance certificate is stored (MachineDefault) -->
+    <!-- Where the application instance certificate is stored-->
     <ApplicationCertificate>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\MachineDefault</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\own</StorePath>
       <SubjectName>CN=Quickstart Reference Server, C=US, S=Arizona, O=OPC Foundation, DC=localhost</SubjectName>
     </ApplicationCertificate>
 
     <!-- Where the issuer certificate are stored (certificate authorities) -->
     <TrustedIssuerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\UA Certificate Authorities</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\issuer</StorePath>
     </TrustedIssuerCertificates>
 
-    <!-- Where the trust list is stored (UA Applications) -->
+    <!-- Where the trust list is stored -->
     <TrustedPeerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\UA Applications</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\trusted</StorePath>
     </TrustedPeerCertificates>
 
     <!-- The directory used to store invalid certficates for later review by the administrator. -->
     <RejectedCertificateStore>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\RejectedCertificates</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\rejected</StorePath>
     </RejectedCertificateStore>
 
     <!-- WARNING: The following setting (to automatically accept untrusted certificates) should be used

--- a/SampleApplications/Workshop/Reference/Server/ReferenceServer.cs
+++ b/SampleApplications/Workshop/Reference/Server/ReferenceServer.cs
@@ -265,15 +265,6 @@ namespace Quickstarts.ReferenceServer
                 {
                     CertificateValidator.Validate(certificate);
                 }
-
-                // determine if self-signed.
-                bool isSelfSigned = Utils.CompareDistinguishedName(certificate.Subject, certificate.Issuer);
-
-                // do not allow self signed application certs as user token
-                if (isSelfSigned && Utils.HasApplicationURN(certificate))
-                {
-                    throw new ServiceResultException(StatusCodes.BadCertificateUseNotAllowed);
-                }
             }
             catch (Exception e)
             {

--- a/SampleApplications/Workshop/SimpleEvents/Client/SimpleEventsClient.Config.xml
+++ b/SampleApplications/Workshop/SimpleEvents/Client/SimpleEventsClient.Config.xml
@@ -14,26 +14,26 @@
     <!-- Where the application instance certificate is stored (MachineDefault) -->
     <ApplicationCertificate>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\MachineDefault</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\own</StorePath>
       <SubjectName>CN=Quickstart SimpleEvents Client, C=US, S=Arizona, O=OPC Foundation, DC=localhost</SubjectName>
     </ApplicationCertificate>
 
     <!-- Where the issuer certificate are stored (certificate authorities) -->
     <TrustedIssuerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\UA Certificate Authorities</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\issuer</StorePath>
     </TrustedIssuerCertificates>
 
-    <!-- Where the trust list is stored (UA Applications) -->
+    <!-- Where the trust list is stored -->
     <TrustedPeerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\UA Applications</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\trusted</StorePath>
     </TrustedPeerCertificates>
 
     <!-- The directory used to store invalid certficates for later review by the administrator. -->
     <RejectedCertificateStore>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\RejectedCertificates</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\rejected</StorePath>
     </RejectedCertificateStore>
   </SecurityConfiguration>
   

--- a/SampleApplications/Workshop/SimpleEvents/Server/SimpleEventsServer.Config.xml
+++ b/SampleApplications/Workshop/SimpleEvents/Server/SimpleEventsServer.Config.xml
@@ -14,26 +14,26 @@
     <!-- Where the application instance certificate is stored (MachineDefault) -->
     <ApplicationCertificate>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\MachineDefault</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\own</StorePath>
       <SubjectName>CN=Quickstart SimpleEvents Server, C=US, S=Arizona, O=OPC Foundation, DC=localhost</SubjectName>
     </ApplicationCertificate>
 
-    <!-- Where the issuer certificate are stored (certificate authorities) -->
+   <!-- Where the issuer certificate are stored (certificate authorities) -->
     <TrustedIssuerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\UA Certificate Authorities</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\issuer</StorePath>
     </TrustedIssuerCertificates>
 
-    <!-- Where the trust list is stored (UA Applications) -->
+    <!-- Where the trust list is stored -->
     <TrustedPeerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\UA Applications</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\trusted</StorePath>
     </TrustedPeerCertificates>
 
     <!-- The directory used to store invalid certficates for later review by the administrator. -->
     <RejectedCertificateStore>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\RejectedCertificates</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\rejected</StorePath>
     </RejectedCertificateStore>
   </SecurityConfiguration>
   

--- a/SampleApplications/Workshop/UserAuthentication/Client/Quickstarts.UserAuthenticationClient.Config.xml
+++ b/SampleApplications/Workshop/UserAuthentication/Client/Quickstarts.UserAuthenticationClient.Config.xml
@@ -14,26 +14,26 @@
     <!-- Where the application instance certificate is stored (MachineDefault) -->
     <ApplicationCertificate>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\MachineDefault</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\own</StorePath>
       <SubjectName>CN=Quickstart UserAuthentication Client, C=US, S=Arizona, O=OPC Foundation, DC=localhost</SubjectName>
     </ApplicationCertificate>
 
     <!-- Where the issuer certificate are stored (certificate authorities) -->
     <TrustedIssuerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\UA Certificate Authorities</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\issuer</StorePath>
     </TrustedIssuerCertificates>
 
-    <!-- Where the trust list is stored (UA Applications) -->
+    <!-- Where the trust list is stored -->
     <TrustedPeerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\UA Applications</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\trusted</StorePath>
     </TrustedPeerCertificates>
 
     <!-- The directory used to store invalid certficates for later review by the administrator. -->
     <RejectedCertificateStore>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\RejectedCertificates</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\rejected</StorePath>
     </RejectedCertificateStore>
   </SecurityConfiguration>
   

--- a/SampleApplications/Workshop/UserAuthentication/Server/Quickstarts.UserAuthenticationServer.Config.xml
+++ b/SampleApplications/Workshop/UserAuthentication/Server/Quickstarts.UserAuthenticationServer.Config.xml
@@ -14,26 +14,26 @@
     <!-- Where the application instance certificate is stored (MachineDefault) -->
     <ApplicationCertificate>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\MachineDefault</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\own</StorePath>
       <SubjectName>CN=Quickstart UserAuthentication Server, C=US, S=Arizona, O=OPC Foundation, DC=localhost</SubjectName>
     </ApplicationCertificate>
 
     <!-- Where the issuer certificate are stored (certificate authorities) -->
     <TrustedIssuerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\UA Certificate Authorities</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\issuer</StorePath>
     </TrustedIssuerCertificates>
 
-    <!-- Where the trust list is stored (UA Applications) -->
+    <!-- Where the trust list is stored -->
     <TrustedPeerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\UA Applications</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\trusted</StorePath>
     </TrustedPeerCertificates>
 
     <!-- The directory used to store invalid certficates for later review by the administrator. -->
     <RejectedCertificateStore>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\RejectedCertificates</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\rejected</StorePath>
     </RejectedCertificateStore>
   </SecurityConfiguration>
   

--- a/SampleApplications/Workshop/Views/Client/Quickstarts.ViewsClient.Config.xml
+++ b/SampleApplications/Workshop/Views/Client/Quickstarts.ViewsClient.Config.xml
@@ -14,28 +14,27 @@
     <!-- Where the application instance certificate is stored (MachineDefault) -->
     <ApplicationCertificate>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\MachineDefault</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\own</StorePath>
       <SubjectName>CN=Quickstart Views Client, C=US, S=Arizona, O=OPC Foundation, DC=localhost</SubjectName>
     </ApplicationCertificate>
 
     <!-- Where the issuer certificate are stored (certificate authorities) -->
     <TrustedIssuerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\UA Certificate Authorities</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\issuer</StorePath>
     </TrustedIssuerCertificates>
 
-    <!-- Where the trust list is stored (UA Applications) -->
+    <!-- Where the trust list is stored -->
     <TrustedPeerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\UA Applications</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\trusted</StorePath>
     </TrustedPeerCertificates>
 
     <!-- The directory used to store invalid certficates for later review by the administrator. -->
     <RejectedCertificateStore>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\RejectedCertificates</StorePath>
-    </RejectedCertificateStore>
-  
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\rejected</StorePath>
+    </RejectedCertificateStore>  
   </SecurityConfiguration>
   
   <TransportConfigurations></TransportConfigurations>

--- a/SampleApplications/Workshop/Views/Server/Quickstarts.ViewsServer.Config.xml
+++ b/SampleApplications/Workshop/Views/Server/Quickstarts.ViewsServer.Config.xml
@@ -14,26 +14,26 @@
     <!-- Where the application instance certificate is stored (MachineDefault) -->
     <ApplicationCertificate>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\MachineDefault</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\own</StorePath>
       <SubjectName>CN=Quickstart Views Server, C=US, S=Arizona, O=OPC Foundation, DC=localhost</SubjectName>
     </ApplicationCertificate>
 
     <!-- Where the issuer certificate are stored (certificate authorities) -->
     <TrustedIssuerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\UA Certificate Authorities</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\issuer</StorePath>
     </TrustedIssuerCertificates>
 
-    <!-- Where the trust list is stored (UA Applications) -->
+    <!-- Where the trust list is stored -->
     <TrustedPeerCertificates>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\UA Applications</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\trusted</StorePath>
     </TrustedPeerCertificates>
 
     <!-- The directory used to store invalid certficates for later review by the administrator. -->
     <RejectedCertificateStore>
       <StoreType>Directory</StoreType>
-      <StorePath>%CommonApplicationData%\OPC Foundation\CertificateStores\RejectedCertificates</StorePath>
+      <StorePath>%CommonApplicationData%\OPC Foundation\pki\rejected</StorePath>
     </RejectedCertificateStore>
   </SecurityConfiguration>
   

--- a/Stack/Opc.Ua.Core/Schema/ApplicationConfiguration.cs
+++ b/Stack/Opc.Ua.Core/Schema/ApplicationConfiguration.cs
@@ -826,7 +826,7 @@ namespace Opc.Ua
         }
 
         /// <summary>
-        /// The trusted certificate store.
+        /// The store containing any additional issuer certificates.
         /// </summary>
         [DataMember(IsRequired = false, EmitDefaultValue = false, Order = 2)]
         public CertificateTrustList TrustedIssuerCertificates
@@ -848,7 +848,7 @@ namespace Opc.Ua
         }
 
         /// <summary>
-        /// The store containing any additional issuer certificates.
+        /// The trusted certificate store.
         /// </summary>
         [DataMember(IsRequired = false, EmitDefaultValue = false, Order = 4)]
         public CertificateTrustList TrustedPeerCertificates
@@ -951,7 +951,7 @@ namespace Opc.Ua
         /// <remarks>
         /// It is useful for client/server applications running on the same host  and sharing the cert store to autotrust.
         /// </remarks>
-        [DataMember(IsRequired = false, EmitDefaultValue = false, Order = 8)]
+        [DataMember(IsRequired = false, EmitDefaultValue = false, Order = 12)]
         public bool AddAppCertToTrustedStore
         {
             get { return m_addAppCertToTrustedStore; }
@@ -964,11 +964,99 @@ namespace Opc.Ua
         /// <remarks>
         /// If set to true the complete certificate chain will be sent for CA signed certificates.
         /// </remarks>
-        [DataMember(IsRequired = false, EmitDefaultValue = false, Order = 9)]
+        [DataMember(IsRequired = false, EmitDefaultValue = false, Order = 13)]
         public bool SendCertificateChain
         {
             get { return m_sendCertificateChain; }
             set { m_sendCertificateChain = value; }
+        }
+
+        /// <summary>
+        /// The store containing additional user issuer certificates.
+        /// </summary>
+        [DataMember(IsRequired = false, EmitDefaultValue = false, Order = 14)]
+        public CertificateTrustList UserIssuerCertificates
+        {
+            get
+            {
+                return m_userIssuerCertificates;
+            }
+
+            set
+            {
+                m_userIssuerCertificates = value;
+
+                if (m_userIssuerCertificates == null)
+                {
+                    m_userIssuerCertificates = new CertificateTrustList();
+                }
+            }
+        }
+
+        /// <summary>
+        /// The store containing trusted user certificates.
+        /// </summary>
+        [DataMember(IsRequired = false, EmitDefaultValue = false, Order = 15)]
+        public CertificateTrustList TrustedUserCertificates
+        {
+            get
+            {
+                return m_trustedUserCertificates;
+            }
+
+            set
+            {
+                m_trustedUserCertificates = value;
+
+                if (m_trustedUserCertificates == null)
+                {
+                    m_trustedUserCertificates = new CertificateTrustList();
+                }
+            }
+        }
+
+        /// <summary>
+        /// The store containing additional Https issuer certificates.
+        /// </summary>
+        [DataMember(IsRequired = false, EmitDefaultValue = false, Order = 16)]
+        public CertificateTrustList HttpsIssuerCertificates
+        {
+            get
+            {
+                return m_httpsIssuerCertificates;
+            }
+
+            set
+            {
+                m_httpsIssuerCertificates = value;
+
+                if (m_httpsIssuerCertificates == null)
+                {
+                    m_httpsIssuerCertificates = new CertificateTrustList();
+                }
+            }
+        }
+
+        /// <summary>
+        /// The store containing trusted Https certificates.
+        /// </summary>
+        [DataMember(IsRequired = false, EmitDefaultValue = false, Order = 17)]
+        public CertificateTrustList TrustedHttpsCertificates
+        {
+            get
+            {
+                return m_trustedHttpsCertificates;
+            }
+
+            set
+            {
+                m_trustedHttpsCertificates = value;
+
+                if (m_trustedHttpsCertificates == null)
+                {
+                    m_trustedHttpsCertificates = new CertificateTrustList();
+                }
+            }
         }
         #endregion
 
@@ -976,6 +1064,10 @@ namespace Opc.Ua
         private CertificateIdentifier m_applicationCertificate;
         private CertificateTrustList m_trustedIssuerCertificates;
         private CertificateTrustList m_trustedPeerCertificates;
+        private CertificateTrustList m_httpsIssuerCertificates;
+        private CertificateTrustList m_trustedHttpsCertificates;
+        private CertificateTrustList m_userIssuerCertificates;
+        private CertificateTrustList m_trustedUserCertificates;
         private int m_nonceLength;
         private CertificateStoreIdentifier m_rejectedCertificateStore;
         private bool m_autoAcceptUntrustedCertificates;
@@ -2249,7 +2341,6 @@ namespace Opc.Ua
         private void Initialize()
         {
             m_trustedCertificates = new CertificateIdentifierCollection();
-
         }
 
         /// <summary>

--- a/Stack/Opc.Ua.Core/Schema/ApplicationConfiguration.xsd
+++ b/Stack/Opc.Ua.Core/Schema/ApplicationConfiguration.xsd
@@ -52,6 +52,10 @@
       <xs:element name="MinimumCertificateKeySize" type="xs:unsignedShort" minOccurs="0" />
       <xs:element name="AddAppCertToTrustedStore" type="xs:boolean" minOccurs="0" />
       <xs:element name="SendCertificateChain" type="xs:boolean" minOccurs="0" />
+      <xs:element name="UserIssuerCertificates" type="CertificateTrustList" minOccurs="0" />
+      <xs:element name="TrustedUserCertificates" type="CertificateTrustList" minOccurs="0" />
+      <xs:element name="HttpsIssuerCertificates" type="CertificateTrustList" minOccurs="0" />
+      <xs:element name="TrustedHttpsCertificates" type="CertificateTrustList" minOccurs="0" />
     </xs:sequence>
   </xs:complexType>
   


### PR DESCRIPTION
- Certificate stores renamed according to spec recommendation.
- Configuration settings for user and https certificates.
- Custom validators for user certificates in sample applications.
