### PR TITLE
Write qualified name strings with quotation marks

### DIFF
--- a/Stack/Opc.Ua.Core/Types/Encoders/JsonEncoder.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/JsonEncoder.cs
@@ -805,7 +805,7 @@ namespace Opc.Ua
 
             if (UseReversibleEncoding)
             {
-                WriteSimpleField("Name", value.Name.ToString(), false);
+                WriteString("Name", value.Name);
 
                 if (value.NamespaceIndex > 0)
                 {
@@ -814,7 +814,7 @@ namespace Opc.Ua
             }
             else
             {
-                WriteSimpleField("Name", value.Name.ToString(), false);
+                WriteString("Name", value.Name);
                 WriteNamespaceIndex(value.NamespaceIndex);
             }
 
@@ -836,18 +836,18 @@ namespace Opc.Ua
             {
                 PushStructure(fieldName);
 
-                WriteSimpleField("Text", value.Text.ToString(), true);
+                WriteString("Text", value.Text);
 
                 if (!String.IsNullOrEmpty(value.Locale))
                 {
-                    WriteSimpleField("Locale", value.Locale.ToString(), true);
+                    WriteString("Locale", value.Locale);
                 }
 
                 PopStructure();
             }
             else
             {
-                WriteSimpleField(fieldName, value.Text, true);
+                WriteString(fieldName, value.Text);
             }
         }
 


### PR DESCRIPTION
- QualifiedName "Name" field's value string was not enclosed in quotes resulting in json parser exceptions on deserialization using Json.net.  This is the main issue addressed here.  
- Replaced some other obvious string writes with WriteString and removed ToString().