### PR TITLE
Added a constructor to ExtensionObject that takes byte[] specifically.

### DIFF
--- a/Stack/Opc.Ua.Core/Types/BuiltIn/ExtensionObject.cs
+++ b/Stack/Opc.Ua.Core/Types/BuiltIn/ExtensionObject.cs
@@ -314,6 +314,15 @@ namespace Opc.Ua
         }
 
         /// <summary>
+        /// Initializes the object with a body of Byte-array.
+        /// </summary>
+        /// <param name="body">The body of the object: Byte-array</param>
+        public ExtensionObject(Byte[] body)
+        {
+            Body = body;
+        }
+
+        /// <summary>
         /// Initializes the object with a body.
         /// </summary>
         /// <param name="body">The body of the object: IEncodeable, XmlElement or Byte-array</param>

--- a/Stack/Opc.Ua.Core/Types/Utils/Utils.cs
+++ b/Stack/Opc.Ua.Core/Types/Utils/Utils.cs
@@ -1845,6 +1845,17 @@ namespace Opc.Ua
                 }
             }
 
+            //try to find the Clone method by reflection.
+            MethodInfo cloneMethod = type.GetMethod("Clone", BindingFlags.Public | BindingFlags.Instance);
+            if (cloneMethod != null)
+            {
+                object clone = cloneMethod.Invoke(value, null);
+                if (clone != null)
+                {
+                    return clone;
+                }
+            }
+
             // don't know how to clone object.
             throw new NotSupportedException(Utils.Format("Don't know how to clone objects of type '{0}'", type.FullName));
         }


### PR DESCRIPTION
Adds a constructor specifically for Byte[]. This could be done with the `public ExtensionObject(object body)` constructor but if you use this the Byte[] is implicitly converted to a `ExpandedNodeId`. (see #535)

fixes #535 