### PR TITLE
Fixed GetServiceResult null checks

### DIFF
--- a/SampleApplications/SDK/Opc.Ua.Client/MonitoredItem.cs
+++ b/SampleApplications/SDK/Opc.Ua.Client/MonitoredItem.cs
@@ -929,7 +929,7 @@ namespace Opc.Ua.Client
 
             NotificationMessage message = datachange.Message;
 
-            if (message != null)
+            if (message == null)
             {
                 return null;
             }
@@ -951,7 +951,7 @@ namespace Opc.Ua.Client
 
             NotificationMessage message = eventFields.Message;
 
-            if (message != null)
+            if (message == null)
             {
                 return null;
             }


### PR DESCRIPTION
Fixed wrong null checks for Notification message in GetServiceResult(IEncodeable notification) and GetServiceResult(IEncodeable notification, int index)