### PR TITLE
Add nuspec file for NoHttps version

### DIFF
--- a/nuget/Opc.Ua.NoHttps.nuspec
+++ b/nuget/Opc.Ua.NoHttps.nuspec
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>OPCFoundation.NetStandard.Opc.Ua.NoHttps</id>
+    <version>1.04.354-preview180731</version>
+    <title>OPC UA .Net Standard Library</title>
+    <description>This package contains the OPC UA reference implementation and is targeting the .NET Standard Library without HTTPS support.</description>
+    <authors>OPC Foundation</authors>
+    <language>en-US</language>
+    <projectUrl>https://github.com/OPCFoundation/UA-.NETStandard</projectUrl>
+    <iconUrl>https://opcfoundation.org/wp-content/themes/opc/images/logo.jpg</iconUrl>
+    <licenseUrl>https://opcfoundation.org/license/redistributables/1.3/</licenseUrl>
+    <tags>OPCFoundation OPC-UA netstandard ios linux dotnet net netcore uwp</tags>
+    <dependencies>
+      <group targetFramework="net46" >
+        <dependency id="Newtonsoft.Json" version="10.0.3"/>
+        <dependency id="Portable.BouncyCastle" version="1.8.4"/>
+      </group>
+      <group targetFramework="netstandard1.3" >
+        <dependency id="Newtonsoft.Json" version="10.0.3"/>
+        <dependency id="Portable.BouncyCastle" version="1.8.4"/>
+        <dependency id="System.Data.Common" version="4.3.0"/>
+        <dependency id="System.ServiceModel.Primitives" version="4.5.3"/>
+        <dependency id="System.Net.NameResolution" version="4.3.0"/>
+        <dependency id="System.Collections.NonGeneric" version="4.3.0"/>
+        <dependency id="System.Xml.XmlSerializer" version="4.3.0"/>
+        <dependency id="System.Threading.Thread" version="4.3.0"/>
+        <dependency id="System.Reflection.TypeExtensions" version="4.4.0" />
+      </group>
+      <group targetFramework="netstandard2.0" >
+        <dependency id="Newtonsoft.Json" version="10.0.3"/>
+        <dependency id="Portable.BouncyCastle" version="1.8.4"/>
+        <dependency id="System.Data.Common" version="4.3.0"/>
+        <dependency id="System.ServiceModel.Primitives" version="4.5.3"/>
+        <dependency id="System.Reflection.TypeExtensions" version="4.4.0" />
+      </group>
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="..\Stack\Opc.Ua.Core\bin\Release\net46\Opc.Ua.Core.dll" target="lib\net46" />
+    <file src="..\SampleApplications\SDK\Opc.Ua.Client\bin\Release\net46\Opc.Ua.Client.dll" target="lib\net46" />
+    <file src="..\SampleApplications\SDK\Opc.Ua.Server\bin\Release\net46\Opc.Ua.Server.dll" target="lib\net46" />
+    <file src="..\SampleApplications\SDK\Opc.Ua.Configuration\bin\Release\net46\Opc.Ua.Configuration.dll" target="lib\net46" />
+    <file src="..\Stack\Opc.Ua.Core\bin\Release\netstandard1.3\Opc.Ua.Core.dll" target="lib\netstandard1.3" />
+    <file src="..\SampleApplications\SDK\Opc.Ua.Client\bin\Release\netstandard1.3\Opc.Ua.Client.dll" target="lib\netstandard1.3" />
+    <file src="..\SampleApplications\SDK\Opc.Ua.Server\bin\Release\netstandard1.3\Opc.Ua.Server.dll" target="lib\netstandard1.3" />
+    <file src="..\SampleApplications\SDK\Opc.Ua.Configuration\bin\Release\netstandard1.3\Opc.Ua.Configuration.dll" target="lib\netstandard1.3" />
+    <file src="..\Stack\Opc.Ua.Core\bin\Release\netstandard2.0\Opc.Ua.Core.dll" target="lib\netstandard2.0" />
+    <file src="..\SampleApplications\SDK\Opc.Ua.Client\bin\Release\netstandard2.0\Opc.Ua.Client.dll" target="lib\netstandard2.0" />
+    <file src="..\SampleApplications\SDK\Opc.Ua.Server\bin\Release\netstandard2.0\Opc.Ua.Server.dll" target="lib\netstandard2.0" />
+    <file src="..\SampleApplications\SDK\Opc.Ua.Configuration\bin\Release\netstandard2.0\Opc.Ua.Configuration.dll" target="lib\netstandard2.0" />
+    <file src="..\SampleApplications\Samples\GDS\ServerCommon\bin\Release\net46\Opc.Ua.Gds.Server.Common.dll" target="lib\net46" />
+    <file src="..\SampleApplications\Samples\GDS\ServerCommon\bin\Release\netstandard1.3\Opc.Ua.Gds.Server.Common.dll" target="lib\netstandard1.3" />
+    <file src="..\SampleApplications\Samples\GDS\ServerCommon\bin\Release\netstandard2.0\Opc.Ua.Gds.Server.Common.dll" target="lib\netstandard2.0" />
+    <file src="..\SampleApplications\Samples\GDS\ClientCommon\bin\Release\net46\Opc.Ua.Gds.Client.Common.dll" target="lib\net46" />
+    <file src="..\SampleApplications\Samples\GDS\ClientCommon\bin\Release\netstandard2.0\Opc.Ua.Gds.Client.Common.dll" target="lib\netstandard2.0" />
+  </files>
+</package>


### PR DESCRIPTION
Added a nuspec file for the NoHTTPS version of the OPC UA stack [Issue 600](https://github.com/OPCFoundation/UA-.NETStandard/issues/600)