### PR TITLE
EventFilter now considers BrowseName, NodeClass and NodeId of Variabl…

### DIFF
--- a/Stack/Opc.Ua.Core/Stack/State/BaseInstanceStateSnapshot.cs
+++ b/Stack/Opc.Ua.Core/Stack/State/BaseInstanceStateSnapshot.cs
@@ -266,7 +266,7 @@ namespace Opc.Ua
         {
             if (index >= relativePath.Count)
             {
-                if (node.NodeClass == NodeClass.Object && attributeId == Attributes.NodeId)
+                if (attributeId == Attributes.NodeId)
                 {
                     return node.Value;
                 }
@@ -274,6 +274,16 @@ namespace Opc.Ua
                 if (node.NodeClass == NodeClass.Variable && attributeId == Attributes.Value)
                 {
                     return node.Value;
+                }
+
+                if (attributeId == Attributes.NodeClass)
+                {
+                    return node.NodeClass;
+                }
+
+                if (attributeId == Attributes.BrowseName)
+                {
+                    return node.BrowseName;
                 }
 
                 return null;


### PR DESCRIPTION
…es when filtering an event

Fixes: [https://github.com/OPCFoundation/UA-.NETStandard/issues/618](https://github.com/OPCFoundation/UA-.NETStandard/issues/618)
