### PR TITLE
Use [Flags] on NodeStateChangeMasks

### DIFF
--- a/Stack/Opc.Ua.Core/Stack/State/NodeState.cs
+++ b/Stack/Opc.Ua.Core/Stack/State/NodeState.cs
@@ -4557,6 +4557,7 @@ namespace Opc.Ua
         #endregion
     }
 
+    [Flags]
     /// <summary>
     /// Indicates what has changed in a node.
     /// </summary>


### PR DESCRIPTION
Tell the compiler that bitwise operators are allowed on NodeStateChangeMasks.