### PR TITLE
Fix Wrong clientHandle when reconnecting a session

### DIFF
--- a/SampleApplications/SDK/Opc.Ua.Client/MonitoredItem.cs
+++ b/SampleApplications/SDK/Opc.Ua.Client/MonitoredItem.cs
@@ -103,6 +103,7 @@ namespace Opc.Ua.Client
                     }
                 }
 
+                m_clientHandle       = template.m_clientHandle; // keep the same clientHandle since it uniquely identifies the monitored item for the subscriber
                 m_handle             = template.m_handle;
                 m_displayName        = Utils.Format("{0} {1}", displayName, m_clientHandle);
                 m_startNodeId        = template.m_startNodeId;


### PR DESCRIPTION
The "template constructors" where not keeping this precious _ClientHandle_ unique identifier.

So subscriptions were screwed-up when using reconnect.