### PR TITLE
IOP GDS cert related fixes

### DIFF
--- a/SampleApplications/Samples/GDS/ClientTest/X509TestUtils.cs
+++ b/SampleApplications/Samples/GDS/ClientTest/X509TestUtils.cs
@@ -110,8 +110,7 @@ namespace Opc.Ua.Gds.Test
             Assert.True((keyUsage.KeyUsages & X509KeyUsageFlags.DigitalSignature) == X509KeyUsageFlags.DigitalSignature);
             Assert.True((keyUsage.KeyUsages & X509KeyUsageFlags.EncipherOnly) == 0);
             Assert.True((keyUsage.KeyUsages & X509KeyUsageFlags.KeyAgreement) == 0);
-            // TODO: check for key cert sign once GDS is fixed
-            //Assert.True((keyUsage.KeyUsages & X509KeyUsageFlags.KeyCertSign) == X509KeyUsageFlags.KeyCertSign);
+            Assert.True((keyUsage.KeyUsages & X509KeyUsageFlags.KeyCertSign) == 0);
             Assert.True((keyUsage.KeyUsages & X509KeyUsageFlags.KeyEncipherment) == X509KeyUsageFlags.KeyEncipherment);
             Assert.True((keyUsage.KeyUsages & X509KeyUsageFlags.NonRepudiation) == X509KeyUsageFlags.NonRepudiation);
 

--- a/SampleApplications/Samples/GDS/ClientTest/X509TestUtils.cs
+++ b/SampleApplications/Samples/GDS/ClientTest/X509TestUtils.cs
@@ -110,7 +110,8 @@ namespace Opc.Ua.Gds.Test
             Assert.True((keyUsage.KeyUsages & X509KeyUsageFlags.DigitalSignature) == X509KeyUsageFlags.DigitalSignature);
             Assert.True((keyUsage.KeyUsages & X509KeyUsageFlags.EncipherOnly) == 0);
             Assert.True((keyUsage.KeyUsages & X509KeyUsageFlags.KeyAgreement) == 0);
-            Assert.True((keyUsage.KeyUsages & X509KeyUsageFlags.KeyCertSign) == X509KeyUsageFlags.KeyCertSign);
+            // TODO: check for key cert sign once GDS is fixed
+            //Assert.True((keyUsage.KeyUsages & X509KeyUsageFlags.KeyCertSign) == X509KeyUsageFlags.KeyCertSign);
             Assert.True((keyUsage.KeyUsages & X509KeyUsageFlags.KeyEncipherment) == X509KeyUsageFlags.KeyEncipherment);
             Assert.True((keyUsage.KeyUsages & X509KeyUsageFlags.NonRepudiation) == X509KeyUsageFlags.NonRepudiation);
 

--- a/SampleApplications/Samples/GDS/ServerCommon/ApplicationsDatabaseBase.cs
+++ b/SampleApplications/Samples/GDS/ServerCommon/ApplicationsDatabaseBase.cs
@@ -110,7 +110,7 @@ namespace Opc.Ua.Gds.Server.Database
 
                 if (application.ServerCapabilities == null || application.ServerCapabilities.Count == 0)
                 {
-                    throw new ArgumentException("At least one Server Capability must be provided.", "ServerCapabilities");
+                    application.ServerCapabilities = new StringCollection() { "NA" };
                 }
             }
             else

--- a/Stack/Opc.Ua.Core/Security/Certificates/CertificateValidator.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/CertificateValidator.cs
@@ -789,6 +789,21 @@ namespace Opc.Ua
                 }
             }
 
+            bool issuedByCA = !Utils.CompareDistinguishedName(certificate.Subject, certificate.Issuer);
+
+            // check if certificate issuer is trusted.
+            if (issuedByCA && !isIssuerTrusted)
+            {
+                if (m_applicationCertificate == null || !Utils.IsEqual(m_applicationCertificate.RawData, certificate.RawData))
+                {
+                    throw ServiceResultException.Create(
+                        StatusCodes.BadCertificateUntrusted,
+                        "Certificate issuer is not trusted.\r\nSubjectName: {0}\r\nIssuerName: {1}",
+                        certificate.SubjectName.Name,
+                        certificate.IssuerName.Name);
+                }
+            }
+
             // check if certificate is trusted.
             if (trustedCertificate == null && !isIssuerTrusted)
             {

--- a/Stack/Opc.Ua.Core/Security/Certificates/CertificateValidator.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/CertificateValidator.cs
@@ -789,21 +789,6 @@ namespace Opc.Ua
                 }
             }
 
-            bool issuedByCA = !Utils.CompareDistinguishedName(certificate.Subject, certificate.Issuer);
-
-            // check if certificate issuer is trusted.
-            if (issuedByCA && !isIssuerTrusted)
-            {
-                if (m_applicationCertificate == null || !Utils.IsEqual(m_applicationCertificate.RawData, certificate.RawData))
-                {
-                    throw ServiceResultException.Create(
-                        StatusCodes.BadCertificateUntrusted,
-                        "Certificate issuer is not trusted.\r\nSubjectName: {0}\r\nIssuerName: {1}",
-                        certificate.SubjectName.Name,
-                        certificate.IssuerName.Name);
-                }
-            }
-
             // check if certificate is trusted.
             if (trustedCertificate == null && !isIssuerTrusted)
             {


### PR DESCRIPTION
PR for fixes found during IOP 2019 in Phoenix

- fix a few issues found related to cert creation, e.g. signed cert should not have KeyCertSign set
- root ca should set the basic constraint path length
- do not mandate the server caps
