### PR TITLE
Update in CertificateValidator.Validate() to require the complete chain.

### DIFF
--- a/Stack/Opc.Ua.Core/Stack/Tcp/TcpServerChannel.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/TcpServerChannel.cs
@@ -813,6 +813,7 @@ namespace Opc.Ua.Bindings
                         return false;
                     }
                     else if (innerException.StatusCode == StatusCodes.BadCertificateUntrusted ||
+                        innerException.StatusCode == StatusCodes.BadCertificateChainIncomplete ||
                         innerException.StatusCode == StatusCodes.BadCertificateRevoked)
                     {
                         ForceChannelFault(StatusCodes.BadSecurityChecksFailed, e.Message);


### PR DESCRIPTION
Update in CertificateValidator.Validate() to require the complete chain.