### PR TITLE
Fixes the wrong DisplayName issue of a MonitoredItem after reconnect

### DIFF
--- a/SampleApplications/SDK/Opc.Ua.Client/Subscription.cs
+++ b/SampleApplications/SDK/Opc.Ua.Client/Subscription.cs
@@ -119,7 +119,8 @@ namespace Opc.Ua.Client
                 foreach (MonitoredItem monitoredItem in template.MonitoredItems)
                 {
                     MonitoredItem clone = new MonitoredItem(monitoredItem, copyEventHandlers);
-                    clone.Subscription = this; 
+                    clone.Subscription = this;
+                    clone.DisplayName = monitoredItem.DisplayName;
                     m_monitoredItems.Add(clone.ClientHandle, clone);
                 }      
             }


### PR DESCRIPTION
Fixes the wrong DisplayName issue (adds a random integer suffix to the DisplayName) of a MonitoredItem after reconnect