### PR TITLE
Update Ua Nodeset to support the new 1.04 Access Level attribute

### DIFF
--- a/SampleApplications/SDK/Opc.Ua.Client/Session.cs
+++ b/SampleApplications/SDK/Opc.Ua.Client/Session.cs
@@ -2198,7 +2198,15 @@ namespace Opc.Ua.Client
                 catch (Exception ex)
                 {
                     Utils.Trace("Create session failed with client certificate NULL. " + ex.Message);
-                    successCreateSession = false;
+                    if (ex.Message == "BadTooManySessions")
+                    {
+                        throw ServiceResultException.Create(StatusCodes.BadTooManySessions,
+                                        "BadTooManySessions");
+                    }
+                    else
+                    {
+                        successCreateSession = false;
+                    }
                 }
             }
 

--- a/Stack/Opc.Ua.Core/Schema/UANodeSet.cs
+++ b/Stack/Opc.Ua.Core/Schema/UANodeSet.cs
@@ -1343,13 +1343,13 @@ namespace Opc.Ua.Export {
         
         /// <remarks/>
         [System.Xml.Serialization.XmlAttributeAttribute()]
-        [System.ComponentModel.DefaultValueAttribute(typeof(byte), "1")]
-        public byte UserAccessLevel {
+        [System.ComponentModel.DefaultValueAttribute(typeof(uint), "1")]
+        public uint UserAccessLevel {
             get {
                 return this.userAccessLevelField;
             }
             set {
-                this.userAccessLevelField = value;
+                this.userAccessLevelField = (byte)value;
             }
         }
         

--- a/Stack/Opc.Ua.Core/Schema/UANodeSetHelpers.cs
+++ b/Stack/Opc.Ua.Core/Schema/UANodeSetHelpers.cs
@@ -472,7 +472,7 @@ namespace Opc.Ua.Export
                     value.DataType = ImportNodeId(o.DataType, context.NamespaceUris, true);
                     value.ValueRank = o.ValueRank;
                     value.ArrayDimensions = ImportArrayDimensions(o.ArrayDimensions);
-                    value.AccessLevel = o.AccessLevel;
+                    value.AccessLevel = (byte)o.AccessLevel;
                     value.UserAccessLevel = o.UserAccessLevel;
                     //if UserAccessLevel is not specified but Access level is diferent from default use AccessLevel for UserAccessLevel
                     if (o.UserAccessLevel == AccessLevels.CurrentRead && o.AccessLevel > o.UserAccessLevel)


### PR DESCRIPTION
In OPC UA V1.04, there were new access level bits defined. In the OPC UA information model, the attribute AccessLevel (byte) was not changed. Instead, a new optional attribute AccessLevelEx (Unsigned32) was added, whose lower 8 bits are identical to the the attribute AccessLevel.

In the XML NodeSet file, a different approach was chosen. Instead of adding another attribute, the existing attribute AccessLevel was changed from Byte to Unsigned32.
See https://opcfoundation.org/UA/schemas/1.04/UANodeSet.xsd.
