### PR TITLE
Fixes #703

### DIFF
--- a/SampleApplications/SDK/Opc.Ua.Client/MonitoredItem.cs
+++ b/SampleApplications/SDK/Opc.Ua.Client/MonitoredItem.cs
@@ -77,12 +77,22 @@ namespace Opc.Ua.Client
         /// </summary>
         /// <param name="template">The template used to specify the monitoring parameters.</param>
         /// <param name="copyEventHandlers">if set to <c>true</c> the event handlers are copied.</param>
-        public MonitoredItem(MonitoredItem template, bool copyEventHandlers)
+        public MonitoredItem(MonitoredItem template, bool copyEventHandlers) : this(template, copyEventHandlers, false)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MonitoredItem"/> class.
+        /// </summary>
+        /// <param name="template">The template used to specify the monitoring parameters.</param>
+        /// <param name="copyEventHandlers">if set to <c>true</c> the event handlers are copied.</param>
+        /// <param name="copyClientHandle">if set to <c>true</c> the clientHandle is of the template copied.</param>
+        public MonitoredItem(MonitoredItem template, bool copyEventHandlers, bool copyClientHandle)
         {
             Initialize();
-                       
+
             if (template != null)
-            {          
+            {
                 string displayName = template.DisplayName;
 
                 if (displayName != null)
@@ -103,7 +113,6 @@ namespace Opc.Ua.Client
                     }
                 }
 
-                m_clientHandle       = template.m_clientHandle; // keep the same clientHandle since it uniquely identifies the monitored item for the subscriber
                 m_handle             = template.m_handle;
                 m_displayName        = Utils.Format("{0} {1}", displayName, m_clientHandle);
                 m_startNodeId        = template.m_startNodeId;
@@ -121,6 +130,11 @@ namespace Opc.Ua.Client
                 if (copyEventHandlers)
                 {
                     m_Notification = template.m_Notification;
+                }
+
+                if (copyClientHandle)
+                {
+                    m_clientHandle = template.m_clientHandle;
                 }
 
                 // this ensures the state is consistent with the node class.

--- a/SampleApplications/SDK/Opc.Ua.Client/Subscription.cs
+++ b/SampleApplications/SDK/Opc.Ua.Client/Subscription.cs
@@ -68,7 +68,7 @@ namespace Opc.Ua.Client
             Initialize();
 
             if (template != null)
-            {                    
+            {
                 string displayName = template.DisplayName;
 
                 if (String.IsNullOrEmpty(displayName))
@@ -110,7 +110,7 @@ namespace Opc.Ua.Client
                 if (copyEventHandlers)
                 {
                     m_StateChanged               = template.m_StateChanged;
-                    m_PublishStatusChanged        = template.m_PublishStatusChanged;
+                    m_PublishStatusChanged       = template.m_PublishStatusChanged;
                     m_fastDataChangeCallback     = template.m_fastDataChangeCallback;
                     m_fastEventCallback          = template.m_fastEventCallback;
                 }
@@ -118,11 +118,10 @@ namespace Opc.Ua.Client
                 // copy the list of monitored items.
                 foreach (MonitoredItem monitoredItem in template.MonitoredItems)
                 {
-                    MonitoredItem clone = new MonitoredItem(monitoredItem, copyEventHandlers);
-                    clone.Subscription = this;
+                    MonitoredItem clone = new MonitoredItem(monitoredItem, copyEventHandlers, true);
                     clone.DisplayName = monitoredItem.DisplayName;
-                    m_monitoredItems.Add(clone.ClientHandle, clone);
-                }      
+                    AddItem(clone);
+                }
             }
         }
 


### PR DESCRIPTION
 Fix regression caused by #656. 
Add a MonitoredItem constructor to allow keeping the ClientHandle of the template.