### PR TITLE
Compliance fixes in CertificateValidator

### DIFF
--- a/SampleApplications/Workshop/Reference/Server/Quickstarts.ReferenceServer.Config.xml
+++ b/SampleApplications/Workshop/Reference/Server/Quickstarts.ReferenceServer.Config.xml
@@ -43,6 +43,7 @@
     <!-- WARNING: SHA1 signed certficates are by default rejected and should be phased out. 
     The setting below to allow them is only required for UACTT (1.02.336.244) which uses SHA-1 signed certs. -->
     <RejectSHA1SignedCertificates>false</RejectSHA1SignedCertificates>
+    <RejectUnknownRevocationStatus>true</RejectUnknownRevocationStatus>
     <MinimumCertificateKeySize>2048</MinimumCertificateKeySize>
     <AddAppCertToTrustedStore>false</AddAppCertToTrustedStore>
     <SendCertificateChain>true</SendCertificateChain>

--- a/Stack/Opc.Ua.Core/Schema/ApplicationConfiguration.cs
+++ b/Stack/Opc.Ua.Core/Schema/ApplicationConfiguration.cs
@@ -759,6 +759,7 @@ namespace Opc.Ua
             m_nonceLength = 32;
             m_autoAcceptUntrustedCertificates = false;
             m_rejectSHA1SignedCertificates = true;
+            m_rejectUnknownRevocationStatus = false;
             m_minCertificateKeySize = CertificateFactory.defaultKeySize;
             m_addAppCertToTrustedStore = true;
             m_sendCertificateChain = false;
@@ -898,12 +899,25 @@ namespace Opc.Ua
         }
 
         /// <summary>
+        /// Gets or sets a value indicating whether certificates with unavailable revocation lists are not accepted.
+        /// </summary>
+        /// <remarks>
+        /// This flag can be set to true by servers that must have a revocation list for each CA (even if empty).
+        /// </remarks>
+        [DataMember(IsRequired = false, EmitDefaultValue = false, Order = 11)]
+        public bool RejectUnknownRevocationStatus
+        {
+            get { return m_rejectUnknownRevocationStatus; }
+            set { m_rejectUnknownRevocationStatus = value; }
+        }
+
+        /// <summary>
         /// Gets or sets a value indicating which minimum certificate key strength is accepted.
         /// </summary>
         /// <remarks>
         /// This value can be set to 1024, 2048 or 4096 by servers
         /// </remarks>
-        [DataMember(IsRequired = false, EmitDefaultValue = false, Order = 11)]
+        [DataMember(IsRequired = false, EmitDefaultValue = false, Order = 12)]
         public ushort MinimumCertificateKeySize
         {
             get { return m_minCertificateKeySize; }
@@ -916,7 +930,7 @@ namespace Opc.Ua
         /// <remarks>
         /// It is useful for client/server applications running on the same host  and sharing the cert store to autotrust.
         /// </remarks>
-        [DataMember(IsRequired = false, EmitDefaultValue = false, Order = 12)]
+        [DataMember(IsRequired = false, EmitDefaultValue = false, Order = 13)]
         public bool AddAppCertToTrustedStore
         {
             get { return m_addAppCertToTrustedStore; }
@@ -929,7 +943,7 @@ namespace Opc.Ua
         /// <remarks>
         /// If set to true the complete certificate chain will be sent for CA signed certificates.
         /// </remarks>
-        [DataMember(IsRequired = false, EmitDefaultValue = false, Order = 13)]
+        [DataMember(IsRequired = false, EmitDefaultValue = false, Order = 14)]
         public bool SendCertificateChain
         {
             get { return m_sendCertificateChain; }
@@ -939,7 +953,7 @@ namespace Opc.Ua
         /// <summary>
         /// The store containing additional user issuer certificates.
         /// </summary>
-        [DataMember(IsRequired = false, EmitDefaultValue = false, Order = 14)]
+        [DataMember(IsRequired = false, EmitDefaultValue = false, Order = 15)]
         public CertificateTrustList UserIssuerCertificates
         {
             get
@@ -961,7 +975,7 @@ namespace Opc.Ua
         /// <summary>
         /// The store containing trusted user certificates.
         /// </summary>
-        [DataMember(IsRequired = false, EmitDefaultValue = false, Order = 15)]
+        [DataMember(IsRequired = false, EmitDefaultValue = false, Order = 16)]
         public CertificateTrustList TrustedUserCertificates
         {
             get
@@ -983,7 +997,7 @@ namespace Opc.Ua
         /// <summary>
         /// The store containing additional Https issuer certificates.
         /// </summary>
-        [DataMember(IsRequired = false, EmitDefaultValue = false, Order = 16)]
+        [DataMember(IsRequired = false, EmitDefaultValue = false, Order = 17)]
         public CertificateTrustList HttpsIssuerCertificates
         {
             get
@@ -1005,7 +1019,7 @@ namespace Opc.Ua
         /// <summary>
         /// The store containing trusted Https certificates.
         /// </summary>
-        [DataMember(IsRequired = false, EmitDefaultValue = false, Order = 17)]
+        [DataMember(IsRequired = false, EmitDefaultValue = false, Order = 18)]
         public CertificateTrustList TrustedHttpsCertificates
         {
             get
@@ -1038,6 +1052,7 @@ namespace Opc.Ua
         private bool m_autoAcceptUntrustedCertificates;
         private string m_userRoleDirectory;
         private bool m_rejectSHA1SignedCertificates;
+        private bool m_rejectUnknownRevocationStatus;
         private ushort m_minCertificateKeySize;
         private bool m_addAppCertToTrustedStore;
         private bool m_sendCertificateChain;

--- a/Stack/Opc.Ua.Core/Schema/ApplicationConfiguration.xsd
+++ b/Stack/Opc.Ua.Core/Schema/ApplicationConfiguration.xsd
@@ -49,6 +49,7 @@
       <xs:element name="AutoAcceptUntrustedCertificates" type="xs:boolean" minOccurs="0" />
       <xs:element name="UserRoleDirectory" type="xs:string"  minOccurs="0" nillable="true" />
       <xs:element name="RejectSHA1SignedCertificates" type="xs:boolean" minOccurs="0" />
+      <xs:element name="RejectUnknownRevocationStatus" type="xs:boolean" minOccurs="0" />
       <xs:element name="MinimumCertificateKeySize" type="xs:unsignedShort" minOccurs="0" />
       <xs:element name="AddAppCertToTrustedStore" type="xs:boolean" minOccurs="0" />
       <xs:element name="SendCertificateChain" type="xs:boolean" minOccurs="0" />

--- a/Stack/Opc.Ua.Core/Security/Certificates/CertificateFactory.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/CertificateFactory.cs
@@ -1231,7 +1231,7 @@ public class CertificateFactory
     /// <summary>
     /// Determines whether the certificate is issued by a Certificate Authority.
     /// </summary>
-    private static bool IsCertificateAuthority(X509Certificate2 certificate)
+    public static bool IsCertificateAuthority(X509Certificate2 certificate)
     {
         X509BasicConstraintsExtension constraints = null;
 

--- a/Stack/Opc.Ua.Core/Security/Certificates/CertificateValidator.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/CertificateValidator.cs
@@ -32,6 +32,7 @@ namespace Opc.Ua
         {
             m_validatedCertificates = new Dictionary<string, X509Certificate2>();
             m_rejectSHA1SignedCertificates = CertificateFactory.defaultHashSize >= 256;
+            m_rejectUnknownRevocationStatus = false;
             m_minimumCertificateKeySize = CertificateFactory.defaultKeySize;
         }
         #endregion
@@ -170,6 +171,7 @@ namespace Opc.Ua
                     configuration.TrustedPeerCertificates,
                     configuration.RejectedCertificateStore);
                 m_rejectSHA1SignedCertificates = configuration.RejectSHA1SignedCertificates;
+                m_rejectUnknownRevocationStatus = configuration.RejectUnknownRevocationStatus;
                 m_minimumCertificateKeySize = configuration.MinimumCertificateKeySize;
             }
 
@@ -305,7 +307,7 @@ namespace Opc.Ua
                 // add to list of peers.
                 lock (m_lock)
                 {
-                    m_validatedCertificates[certificate.Thumbprint] = certificate;
+                    m_validatedCertificates[certificate.Thumbprint] = new X509Certificate2(certificate.RawData);
                 }
             }
         }
@@ -631,9 +633,21 @@ namespace Opc.Ua
                                 {
                                     StatusCode status = store.IsRevoked(issuer, certificate);
 
-                                    if (StatusCode.IsBad(status))
+                                    if (StatusCode.IsBad(status) && status != StatusCodes.BadNotSupported)
                                     {
-                                        if (status != StatusCodes.BadNotSupported && status != StatusCodes.BadCertificateRevocationUnknown)
+                                        if (status == StatusCodes.BadCertificateRevocationUnknown)
+                                        {
+                                            if (CertificateFactory.IsCertificateAuthority(certificate))
+                                            {
+                                                status.Code = StatusCodes.BadCertificateIssuerRevocationUnknown;
+                                            }
+
+                                            if(m_rejectUnknownRevocationStatus)
+                                            {
+                                                throw new ServiceResultException(status);
+                                            }
+                                        }
+                                        else
                                         {
                                             throw new ServiceResultException(status);
                                         }
@@ -806,12 +820,13 @@ namespace Opc.Ua
                 }
             }
 
-#if TODO    // test if cert is valid for use as app/sw or user cert
-            if ()
+            // check if certificate is valid for use as app/sw or user cert
+            X509KeyUsageFlags certificateKeyUsage = CertificateFactory.GetKeyUsage(certificate);
+
+            if ((certificateKeyUsage & X509KeyUsageFlags.DataEncipherment) == 0)
             {
                 throw new ServiceResultException(StatusCodes.BadCertificateUseNotAllowed, "Usage of certificate is not allowed.");
             }
-#endif
 
             // check if minimum requirements are met
             if (m_rejectSHA1SignedCertificates && IsSHA1SignatureAlgorithm(certificate.SignatureAlgorithm))
@@ -823,7 +838,6 @@ namespace Opc.Ua
             {
                 throw new ServiceResultException(StatusCodes.BadCertificatePolicyCheckFailed, "Certificate doesn't meet minimum key length requirement");
             }
-
         }
 
         /// <summary>
@@ -995,6 +1009,7 @@ namespace Opc.Ua
         private event CertificateUpdateEventHandler m_CertificateUpdate;
         private X509Certificate2 m_applicationCertificate;
         private bool m_rejectSHA1SignedCertificates;
+        private bool m_rejectUnknownRevocationStatus;
         private ushort m_minimumCertificateKeySize;
 #endregion
     }

--- a/Stack/Opc.Ua.Core/Security/Certificates/X509CertificateStore.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/X509CertificateStore.cs
@@ -169,7 +169,7 @@ namespace Opc.Ua
 
         public StatusCode IsRevoked(X509Certificate2 issuer, X509Certificate2 certificate)
         {
-            throw new ServiceResultException(StatusCodes.BadNotSupported);
+            return StatusCodes.BadNotSupported;
         }
 
         public List<X509CRL> EnumerateCRLs()


### PR DESCRIPTION
Compliance fixes in CertificateValidator
Added setting in SecurityConfiguration to require revocation lists for all CAs