### PR TITLE
Change to fix invalid certificates.

### DIFF
--- a/SampleApplications/SDK/Opc.Ua.Configuration/ApplicationInstance.cs
+++ b/SampleApplications/SDK/Opc.Ua.Configuration/ApplicationInstance.cs
@@ -1070,8 +1070,29 @@ namespace Opc.Ua.Configuration
 
             Utils.Trace(Utils.TraceMasks.Information, "Checking application instance certificate. {0}", certificate.Subject);
 
-            // validate certificate.
-            configuration.CertificateValidator.Validate(certificate);
+            try
+            {
+                // validate certificate.
+                configuration.CertificateValidator.Validate(certificate);
+            }
+            catch (Exception ex)
+            {
+                string message = Utils.Format(
+                    "Error validating certificate. Exception: {0}. Use certificate anyway?", ex.Message);
+                if (!silent && MessageDlg != null)
+                {
+                    MessageDlg.Message(message, true);
+                    if (!await MessageDlg.ShowAsync())
+                    {
+                        return false;
+                    }
+                }
+                else
+                {
+                    Utils.Trace(message);
+                    return false;
+                }
+            }
 
             // check key size.
             if (minimumKeySize > certificate.GetRSAPublicKey().KeySize)


### PR DESCRIPTION
#710 and #678 both are errors caused by expired certificates. There is a work around, but everyone who will be using this library will be required to implement a fix. I propose a try/catch around the Validate call in the CheckApplicationInstanceCertificate call, where if it fails, to return a false. This will allow the code that comes after the call to receive the false from the call to reissue the certificate.