### PR TITLE
Fixes in UaSCUaBinaryTransportChannel and Client.Subscription

### DIFF
--- a/SampleApplications/SDK/Opc.Ua.Client/Subscription.cs
+++ b/SampleApplications/SDK/Opc.Ua.Client/Subscription.cs
@@ -700,8 +700,8 @@ namespace Opc.Ua.Client
             {
                 lock (m_cache)
                 {
-                    int keepAliveInterval = (int)(m_currentPublishingInterval*m_currentKeepAliveCount);   
-                                        
+                    int keepAliveInterval = (int)(Math.Min(m_currentPublishingInterval * m_currentKeepAliveCount, Int32.MaxValue - 500));
+
                     if (m_lastNotificationTime.AddMilliseconds(keepAliveInterval+500) < DateTime.UtcNow)
                     {
                         return true;
@@ -846,13 +846,13 @@ namespace Opc.Ua.Client
                 m_lastNotificationTime = DateTime.MinValue;
             }
 
-            int keepAliveInterval = (int)(m_currentPublishingInterval*m_currentKeepAliveCount);       
-            
+            int keepAliveInterval = (int)(Math.Min(m_currentPublishingInterval * m_currentKeepAliveCount, Int32.MaxValue));
+
             m_lastNotificationTime = DateTime.UtcNow;
             m_publishTimer = new Timer(OnKeepAlive, keepAliveInterval, keepAliveInterval, keepAliveInterval);
 
             // send initial publish.
-            m_session.BeginPublish(keepAliveInterval*3);
+            m_session.BeginPublish(Math.Min(keepAliveInterval, Int32.MaxValue /3)*3);
         }
 
         /// <summary>

--- a/Stack/Opc.Ua.Core/Stack/Tcp/UaSCBinaryTransportChannel.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/UaSCBinaryTransportChannel.cs
@@ -172,27 +172,32 @@ namespace Opc.Ua.Bindings
                 UaSCUaBinaryClientChannel channel = m_channel;
                 m_channel = null;
 
-                // reconnect.
-                OpenOnDemand();
-
-                // begin connect operation.
-                IAsyncResult result = m_channel.BeginConnect(m_url, m_operationTimeout, null, null);
-                m_channel.EndConnect(result);
-
-                // close existing channel.
-                if (channel != null)
+                try
                 {
-                    try
+                    // reconnect.
+                    OpenOnDemand();
+
+                    // begin connect operation.
+                    IAsyncResult result = m_channel.BeginConnect(m_url, m_operationTimeout, null, null);
+                    m_channel.EndConnect(result);
+                }
+                finally
+                {
+                    // close existing channel.
+                    if (channel != null)
                     {
-                        channel.Close(1000);
-                    }
-                    catch (Exception)
-                    {
-                        // do nothing.
-                    }
-                    finally
-                    {
-                        channel.Dispose();
+                        try
+                        {
+                            channel.Close(1000);
+                        }
+                        catch (Exception)
+                        {
+                            // do nothing.
+                        }
+                        finally
+                        {
+                            channel.Dispose();
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Fix for abandoned socket connection in UaSCUaBinaryTransportChannel.Reconnect()
Fix to avoid timer interval higher than Int32.MaxValue in ClientSubscription.StartKeepAliveTimer()