### PR TITLE
Improvement to enable UANodeSet to import/export AccessLevelEx as uint32

### DIFF
--- a/Stack/Opc.Ua.Core/Schema/UANodeSet.cs
+++ b/Stack/Opc.Ua.Core/Schema/UANodeSet.cs
@@ -1254,9 +1254,9 @@ namespace Opc.Ua.Export {
         
         private string arrayDimensionsField;
         
-        private byte accessLevelField;
+        private uint accessLevelField;
         
-        private byte userAccessLevelField;
+        private uint userAccessLevelField;
         
         private double minimumSamplingIntervalField;
         
@@ -1331,8 +1331,8 @@ namespace Opc.Ua.Export {
         
         /// <remarks/>
         [System.Xml.Serialization.XmlAttributeAttribute()]
-        [System.ComponentModel.DefaultValueAttribute(typeof(byte), "1")]
-        public byte AccessLevel {
+        [System.ComponentModel.DefaultValueAttribute(typeof(uint), "1")]
+        public uint AccessLevel {
             get {
                 return this.accessLevelField;
             }
@@ -1343,8 +1343,8 @@ namespace Opc.Ua.Export {
         
         /// <remarks/>
         [System.Xml.Serialization.XmlAttributeAttribute()]
-        [System.ComponentModel.DefaultValueAttribute(typeof(byte), "1")]
-        public byte UserAccessLevel {
+        [System.ComponentModel.DefaultValueAttribute(typeof(uint), "1")]
+        public uint UserAccessLevel {
             get {
                 return this.userAccessLevelField;
             }

--- a/Stack/Opc.Ua.Core/Schema/UANodeSetHelpers.cs
+++ b/Stack/Opc.Ua.Core/Schema/UANodeSetHelpers.cs
@@ -158,7 +158,7 @@ namespace Opc.Ua.Export
                     value.DataType = ExportAlias(o.DataType, context.NamespaceUris);
                     value.ValueRank = o.ValueRank;
                     value.ArrayDimensions = Export(o.ArrayDimensions);
-                    value.AccessLevel = o.AccessLevel;
+                    value.AccessLevel = o.AccessLevel < o.AccessLevelEx ? o.AccessLevelEx : o.AccessLevel;
                     value.UserAccessLevel = o.UserAccessLevel;
                     value.MinimumSamplingInterval = o.MinimumSamplingInterval;
                     value.Historizing = o.Historizing;
@@ -472,9 +472,10 @@ namespace Opc.Ua.Export
                     value.DataType = ImportNodeId(o.DataType, context.NamespaceUris, true);
                     value.ValueRank = o.ValueRank;
                     value.ArrayDimensions = ImportArrayDimensions(o.ArrayDimensions);
-                    value.AccessLevel = o.AccessLevel;
-                    value.UserAccessLevel = o.UserAccessLevel;
-                    //if UserAccessLevel is not specified but Access level is diferent from default use AccessLevel for UserAccessLevel
+                    value.AccessLevel = (byte)o.AccessLevel;
+                    value.AccessLevelEx = o.AccessLevel;
+                    value.UserAccessLevel = (byte)o.UserAccessLevel;
+                    //if UserAccessLevel is not specified but Access level is different from default use AccessLevel for UserAccessLevel
                     if (o.UserAccessLevel == AccessLevels.CurrentRead && o.AccessLevel > o.UserAccessLevel)
                     {
                         value.UserAccessLevel = (byte)o.AccessLevel;


### PR DESCRIPTION
These change is part of the issue [Datatype of (User)AccessLevel is now uint32 in NodeSet](https://github.com/OPCFoundation/UA-.NETStandard/issues/778).

if the AccessLevelEx is used in the XML NodeSet the import also fills the variable attribute AccessLevelEx. Viceversa in the Export method.