### PR TITLE
fix "Cannot add a object with type 'Opc.Ua.ExtensionObject' to an extension object"

### DIFF
--- a/SampleApplications/SDK/Opc.Ua.Client/Session.cs
+++ b/SampleApplications/SDK/Opc.Ua.Client/Session.cs
@@ -1719,7 +1719,14 @@ namespace Opc.Ua.Client
 
                         if (value != null)
                         {
-                            dataTypeNode.DataTypeDefinition = new ExtensionObject(attributes[Attributes.DataTypeDefinition].Value);
+                            ExtensionObject extensionObject = value.Value as ExtensionObject;
+
+                            if(extensionObject == null)
+                            {
+                                extensionObject = new ExtensionObject(value.Value);
+                            }
+                            
+                            dataTypeNode.DataTypeDefinition = extensionObject;
                         }
 
                         node = dataTypeNode;


### PR DESCRIPTION
Calling Session.ReadNode on an DataType Node causes this exception.
I am not sure if this is the right way, but this commit fixed the problem for me.

![grafik](https://user-images.githubusercontent.com/55235322/65132842-ded78700-da01-11e9-8f2a-fac4dfe9ba0e.png)
