### PR TITLE
Fix for #796

### DIFF
--- a/SampleApplications/SDK/Opc.Ua.Client/Session.cs
+++ b/SampleApplications/SDK/Opc.Ua.Client/Session.cs
@@ -2770,7 +2770,7 @@ namespace Opc.Ua.Client
 
             ResponseHeader responseHeader = Read(
                 null,
-                Int32.MaxValue,
+                0,
                 TimestampsToReturn.Both,
                 valuesToRead,
                 out results,


### PR DESCRIPTION
User maxAge = 0 in Sesion.ReadValues()