### PR TITLE
Save server certificate in ClientSession if no encryption is required.

### DIFF
--- a/SampleApplications/SDK/Opc.Ua.Client/Session.cs
+++ b/SampleApplications/SDK/Opc.Ua.Client/Session.cs
@@ -2110,7 +2110,7 @@ namespace Opc.Ua.Client
             X509Certificate2 serverCertificate = null;
             byte[] certificateData = m_endpoint.Description.ServerCertificate;
 
-            if (certificateData != null && certificateData.Length > 0 && requireEncryption)
+            if (certificateData != null && certificateData.Length > 0)
             {
                 X509Certificate2Collection serverCertificateChain = Utils.ParseCertificateChainBlob(certificateData);
 
@@ -2119,14 +2119,17 @@ namespace Opc.Ua.Client
                     serverCertificate = serverCertificateChain[0];
                 }
 
-                m_configuration.CertificateValidator.Validate(serverCertificateChain);
-
-                if (checkDomain)
+                if (requireEncryption)
                 {
-                    CheckCertificateDomain(m_endpoint);
+                    m_configuration.CertificateValidator.Validate(serverCertificateChain);
+
+                    if (checkDomain)
+                    {
+                        CheckCertificateDomain(m_endpoint);
+                    }
+                    // save for reconnect
+                    m_checkDomain = checkDomain;
                 }
-                // save for reconnect
-                m_checkDomain = checkDomain;
             }
 
             // create a nonce.

--- a/UA Quickstart Applications.sln
+++ b/UA Quickstart Applications.sln
@@ -54,6 +54,9 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DataTypes Server", "SampleApplications\Workshop\DataTypes\Server\DataTypes Server.csproj", "{2E23571F-9987-4EBD-A9FD-5D5DD639E071}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DataTypes Library", "SampleApplications\Workshop\DataTypes\Common\DataTypes Library.csproj", "{A5F4C543-387E-41C6-94A3-B2F1C866D17C}"
+	ProjectSection(ProjectDependencies) = postProject
+		{17B6F98C-B58C-419F-AE58-63B9883F211A} = {17B6F98C-B58C-419F-AE58-63B9883F211A}
+	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Empty Client", "SampleApplications\Workshop\Empty\Client\Empty Client.csproj", "{00FE42A0-219C-4FC7-9EC5-B3F8F1FA058F}"
 EndProject


### PR DESCRIPTION
Save server certificate in ClientSession evenif no encryption is required.
Sometimes the encryption is required at a later time for user identity tokens. i.e. at UpdateSession. And the server certificate is needed.