### PR TITLE
Add quote marks to workdir in test shell script.

### DIFF
--- a/testclientserver.sh
+++ b/testclientserver.sh
@@ -13,7 +13,7 @@ cd ../NetCoreConsoleClient
 echo build client
 rm -r obj
 dotnet build NetCoreConsoleClient.csproj
-cd $workdir
+cd "$workdir"
 
 cd SampleApplications/Samples/NetCoreConsoleServer
 echo start server
@@ -23,7 +23,7 @@ serverpid="$!"
 echo wait for server started
 grep -m 1 "start" <(tail -f ./server.log --pid=$serverpid)
 tail -f ./server.log --pid=$serverpid &
-cd $workdir
+cd "$workdir"
 
 cd SampleApplications/Samples/NetCoreConsoleClient
 echo start client for tcp connection
@@ -32,7 +32,7 @@ clientpid="$!"
 echo start client for https connection
 dotnet run --no-restore --no-build --project NetCoreConsoleClient.csproj -t 20 -a https://localhost:51212 &
 httpsclientpid="$!"
-cd $workdir
+cd "$workdir"
 
 echo wait for opc.tcp client
 wait $clientpid
@@ -44,7 +44,7 @@ else
 fi
 
 cd SampleApplications/Samples/NetCoreConsoleClient
-cd $workdir
+cd "$workdir"
 
 echo wait for https client
 wait $httpsclientpid

--- a/testmonoclientserver.sh
+++ b/testmonoclientserver.sh
@@ -11,7 +11,7 @@ echo start server
 cd bin/Debug/net46
 mono MonoConsoleServer.exe -t 60 -a &
 serverpid="$!"
-cd $workdir
+cd "$workdir"
 
 cd SampleApplications/Samples/NetCoreConsoleClient
 echo build client
@@ -21,7 +21,7 @@ echo start client
 cd bin/Debug/net46
 mono MonoConsoleClient.exe -t 20 -a &
 clientpid="$!"
-cd $workdir
+cd "$workdir"
 
 echo wait for client
 wait $clientpid


### PR DESCRIPTION
Add quote marks. "cd" will fail without quote marks if the workdir has any blank spaces.