### PR TITLE
Prototyping complextypeclient improvements

### DIFF
--- a/SampleApplications/SDK/Opc.Ua.Client.ComplexTypes/AssemblyModuleFactory.cs
+++ b/SampleApplications/SDK/Opc.Ua.Client.ComplexTypes/AssemblyModuleFactory.cs
@@ -1,0 +1,80 @@
+/* ========================================================================
+ * Copyright (c) 2005-2019 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ * 
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ * 
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+
+using System;
+using System.Reflection;
+using System.Reflection.Emit;
+
+namespace Opc.Ua.Client.ComplexTypes
+{
+    /// <summary>
+    /// Use a single assembly and module builder instance to build the type system.
+    /// </summary>
+    public class AssemblyModuleFactory
+    {
+        #region Constructors
+        /// <summary>
+        /// Initializes the object with default values.
+        /// </summary>
+        public AssemblyModuleFactory(string assemblyName = null)
+        {
+            m_assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(
+                new AssemblyName(assemblyName ?? Guid.NewGuid().ToString()),
+                AssemblyBuilderAccess.Run);
+            m_moduleBuilder = m_assemblyBuilder.DefineDynamicModule(m_opcTypesModuleName);
+        }
+        #endregion
+
+        #region Public Members
+        /// <summary>
+        /// Get the module builder instance.
+        /// </summary>
+        public ModuleBuilder GetModuleBuilder()
+        {
+            return m_moduleBuilder;
+        }
+
+        /// <summary>
+        /// Get the types defined in this assembly.
+        /// </summary>
+        public Type[] GetTypes()
+        {
+            return m_assemblyBuilder.GetTypes();
+        }
+        #endregion
+
+        #region Private Fields
+        AssemblyBuilder m_assemblyBuilder;
+        ModuleBuilder m_moduleBuilder;
+        private const string m_opcTypesModuleName = "Opc.Ua.ComplexTypes.Module";
+        #endregion
+    }
+
+}//namespace

--- a/SampleApplications/SDK/Opc.Ua.Client.ComplexTypes/AssemblyModuleFactory.cs
+++ b/SampleApplications/SDK/Opc.Ua.Client.ComplexTypes/AssemblyModuleFactory.cs
@@ -29,6 +29,7 @@
 
 
 using System;
+using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
 
@@ -65,6 +66,14 @@ namespace Opc.Ua.Client.ComplexTypes
         /// Get the types defined in this assembly.
         /// </summary>
         public Type[] GetTypes()
+        {
+            return m_assemblyBuilder.GetTypes();
+        }
+
+        /// <summary>
+        /// Get the types defined in this assembly.
+        /// </summary>
+        public Type[] GetDefinedTypes()
         {
             return m_assemblyBuilder.GetTypes();
         }

--- a/SampleApplications/SDK/Opc.Ua.Client.ComplexTypes/ComplexTypeSystem.cs
+++ b/SampleApplications/SDK/Opc.Ua.Client.ComplexTypes/ComplexTypeSystem.cs
@@ -112,6 +112,14 @@ namespace Opc.Ua.Client.ComplexTypes
                 Utils.TraceDebug($"Failed to load the custom type dictionary: {sre.Message}.");
             }
         }
+
+        /// <summary>
+        /// Get the types defined in this type system.
+        /// </summary>
+        public Type[] GetDefinedTypes()
+        {
+            return m_assemblyModuleFactory.GetTypes();
+        }
         #endregion
 
         #region Private Members

--- a/SampleApplications/SDK/Opc.Ua.Client.ComplexTypes/ComplexTypeSystem.cs
+++ b/SampleApplications/SDK/Opc.Ua.Client.ComplexTypes/ComplexTypeSystem.cs
@@ -100,10 +100,12 @@ namespace Opc.Ua.Client.ComplexTypes
         {
             try
             {
+                // ensure the types loaded by the session are using a cloned type factory
+                m_session.CloneFactory();
+
                 // load server types
                 var serverEnumTypes = LoadDataTypes(DataTypeIds.Enumeration);
                 var serverStructTypes = LoadDataTypes(DataTypeIds.Structure, true);
-
                 LoadBaseDataTypes(serverEnumTypes, serverStructTypes);
                 await LoadDictionaryDataTypes(serverEnumTypes, serverStructTypes);
             }
@@ -240,7 +242,8 @@ namespace Opc.Ua.Client.ComplexTypes
                             }
                         }
                     }
-                } catch (ServiceResultException sre)
+                }
+                catch (ServiceResultException sre)
                 {
                     Utils.TraceDebug(
                         $"Warning: Unexpected error processing {dictionaryId.Value.Name}: {sre.Message}.");
@@ -276,7 +279,7 @@ namespace Opc.Ua.Client.ComplexTypes
                         string targetNamespace = m_session.NamespaceUris.GetString(i);
                         complexTypeBuilder = new ComplexTypeBuilder(
                             m_assemblyModuleFactory,
-                            targetNamespace, 
+                            targetNamespace,
                             (int)i);
                     }
                     foreach (var enumType in enumTypes)
@@ -671,6 +674,10 @@ namespace Opc.Ua.Client.ComplexTypes
                     if (fieldType == typeof(Byte[]))
                     {
                         collectionType = typeof(ByteStringCollection);
+                    }
+                    else if (fieldType == typeof(Single))
+                    {
+                        collectionType = typeof(FloatCollection);
                     }
                     else
                     {

--- a/SampleApplications/Samples/NetCoreComplexClient/Program.cs
+++ b/SampleApplications/Samples/NetCoreComplexClient/Program.cs
@@ -238,6 +238,12 @@ namespace NetCoreConsoleClient
             var complexTypeSystem = new ComplexTypeSystem(session);
             await complexTypeSystem.Load();
 
+            Console.WriteLine($"Defined types:");
+            foreach (var type in complexTypeSystem.GetDefinedTypes())
+            {
+                Console.WriteLine($"{type.Namespace}.{type.Name}");
+            }
+
             Console.WriteLine($"Loaded {session.DataTypeSystem.Count} dictionaries:");
             foreach (var dictionary in session.DataTypeSystem)
             {

--- a/SampleApplications/Samples/NetCoreComplexClient/Program.cs
+++ b/SampleApplications/Samples/NetCoreComplexClient/Program.cs
@@ -35,6 +35,7 @@ using Opc.Ua.Client.ComplexTypes;
 using Opc.Ua.Configuration;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -142,9 +143,11 @@ namespace NetCoreConsoleClient
 
         public void Run()
         {
+            Session session;
+
             try
             {
-                ConsoleSampleClient().Wait();
+                session = ConsoleSampleClient().Result;
             }
             catch (Exception ex)
             {
@@ -166,6 +169,14 @@ namespace NetCoreConsoleClient
             {
             }
 
+            bool eventResult = quitEvent.WaitOne(5000);
+            if (!eventResult)
+            {
+                Console.WriteLine(" --- Start simulated reconnect... --- ");
+                reconnectHandler = new SessionReconnectHandler();
+                reconnectHandler.BeginReconnect(session, 1000, Client_ReconnectComplete);
+            }
+
             // wait for timeout or Ctrl-C
             quitEvent.WaitOne(clientRunTime);
 
@@ -181,7 +192,7 @@ namespace NetCoreConsoleClient
 
         public static ExitCode ExitCode => exitCode;
 
-        private async Task ConsoleSampleClient()
+        private async Task<Session> ConsoleSampleClient()
         {
             Console.WriteLine("1 - Create an Application Configuration.");
             exitCode = ExitCode.ErrorCreateApplication;
@@ -238,7 +249,7 @@ namespace NetCoreConsoleClient
             var complexTypeSystem = new ComplexTypeSystem(session);
             await complexTypeSystem.Load();
 
-            Console.WriteLine($"Defined types:");
+            Console.WriteLine($"Custom types defined for this session:");
             foreach (var type in complexTypeSystem.GetDefinedTypes())
             {
                 Console.WriteLine($"{type.Namespace}.{type.Name}");
@@ -254,52 +265,22 @@ namespace NetCoreConsoleClient
                 }
             }
 
-            ReferenceDescriptionCollection references;
-            Byte[] continuationPoint;
-            Console.WriteLine("5 - Browse the OPC UA server namespace.");
-            exitCode = ExitCode.ErrorBrowseNamespace;
+            Console.WriteLine("5 - Read all custom type values.");
+            var allVariableNodes = BrowseAllVariables(session);
+            var allStructures = allVariableNodes.Where(n => ((VariableNode)n).DataType == DataTypeIds.Structure).ToList();
+            var allCustomTypeVariables = allVariableNodes.Where(n => ((VariableNode)n).DataType.NamespaceIndex != 0).ToList();
 
-            session.Browse(
-                null,
-                null,
-                ObjectIds.ObjectsFolder,
-                0u,
-                BrowseDirection.Forward,
-                ReferenceTypeIds.HierarchicalReferences,
-                true,
-                (uint)NodeClass.Variable | (uint)NodeClass.Object | (uint)NodeClass.Method,
-                out continuationPoint,
-                out references);
-
-            Console.WriteLine(" DisplayName, BrowseName, NodeClass");
-            foreach (var rd in references)
+            foreach (VariableNode variableNode in allCustomTypeVariables)
             {
-                Console.WriteLine(" {0}, {1}, {2}", rd.DisplayName, rd.BrowseName, rd.NodeClass);
-                ReferenceDescriptionCollection nextRefs;
-                byte[] nextCp;
-                session.Browse(
-                    null,
-                    null,
-                    ExpandedNodeId.ToNodeId(rd.NodeId, session.NamespaceUris),
-                    0u,
-                    BrowseDirection.Forward,
-                    ReferenceTypeIds.HierarchicalReferences,
-                    true,
-                    (uint)NodeClass.Variable | (uint)NodeClass.Object | (uint)NodeClass.Method,
-                    out nextCp,
-                    out nextRefs);
-
-                foreach (var nextRd in nextRefs)
-                {
-                    Console.WriteLine("   + {0}, {1}, {2}", nextRd.DisplayName, nextRd.BrowseName, nextRd.NodeClass);
-                }
+                var value = session.ReadValue(variableNode.NodeId);
+                Console.WriteLine($" -- {variableNode}:{value}");
             }
 
             Console.WriteLine("6 - Create a subscription with publishing interval of 1 second.");
             exitCode = ExitCode.ErrorCreateSubscription;
             var subscription = new Subscription(session.DefaultSubscription) { PublishingInterval = 1000 };
 
-            Console.WriteLine("7 - Add a list of items (server current time and status) to the subscription.");
+            Console.WriteLine("7 - Add all custom values and the server time to the subscription.");
             exitCode = ExitCode.ErrorMonitoredItem;
             var list = new List<MonitoredItem> {
                 new MonitoredItem(subscription.DefaultItem)
@@ -308,6 +289,18 @@ namespace NetCoreConsoleClient
                 }
             };
             list.ForEach(i => i.Notification += OnNotification);
+
+            foreach (var customVariable in allCustomTypeVariables)
+            {
+                var newItem = new MonitoredItem(subscription.DefaultItem)
+                {
+                    DisplayName = customVariable.DisplayName.Text,
+                    StartNodeId = ExpandedNodeId.ToNodeId(customVariable.NodeId, session.NamespaceUris)
+                };
+                newItem.Notification += OnComplexTypeNotification;
+                list.Add(newItem);
+            }
+
             subscription.AddItems(list);
 
             Console.WriteLine("8 - Add the subscription to the session.");
@@ -317,6 +310,40 @@ namespace NetCoreConsoleClient
 
             Console.WriteLine("9 - Running...Press Ctrl-C to exit...");
             exitCode = ExitCode.ErrorRunning;
+
+            return session;
+        }
+
+        private IList<INode> BrowseAllVariables(Session session)
+        {
+            var result = new List<INode>();
+            var nodesToBrowse = new ExpandedNodeIdCollection();
+            nodesToBrowse.Add(ObjectIds.ObjectsFolder);
+
+            while (nodesToBrowse.Count > 0)
+            {
+                var nextNodesToBrowse = new ExpandedNodeIdCollection();
+                foreach (var node in nodesToBrowse)
+                {
+                    var response = session.NodeCache.FindReferences(
+                        node,
+                        ReferenceTypeIds.Organizes,
+                        false,
+                        false);
+                    var components = session.NodeCache.FindReferences(
+                        node,
+                        ReferenceTypeIds.HasComponent,
+                        false,
+                        false);
+                    nextNodesToBrowse.AddRange(response
+                        .Where(n => n is ObjectNode)
+                        .Select(n => n.NodeId).ToList());
+                    result.AddRange(response.Where(n => n is VariableNode));
+                    result.AddRange(components.Where(n => n is VariableNode));
+                }
+                nodesToBrowse = nextNodesToBrowse;
+            }
+            return result;
         }
 
         private bool TestNodeId(NodeId nodeId)
@@ -367,6 +394,15 @@ namespace NetCoreConsoleClient
             foreach (var value in item.DequeueValues())
             {
                 Console.WriteLine("{0}: {1}, {2}, {3}", item.DisplayName, value.Value, value.SourceTimestamp, value.StatusCode);
+            }
+        }
+
+        private static void OnComplexTypeNotification(MonitoredItem item, MonitoredItemNotificationEventArgs e)
+        {
+            foreach (var value in item.DequeueValues())
+            {
+                Console.WriteLine("{0}: {1}, {2}", item.DisplayName, value.SourceTimestamp, value.StatusCode);
+                Console.WriteLine(value.Value);
             }
         }
 

--- a/Stack/Opc.Ua.Core/Types/BuiltIn/ExtensionObject.cs
+++ b/Stack/Opc.Ua.Core/Types/BuiltIn/ExtensionObject.cs
@@ -12,14 +12,14 @@
 
 using System;
 using System.Collections.Generic;
-using System.Text;
-using System.Xml;
+using System.Linq;
 using System.Reflection;
 using System.Runtime.Serialization;
-using System.Linq;
+using System.Text;
+using System.Xml;
 
 namespace Opc.Ua
-{    
+{
     /// <summary>
     /// An object used to wrap data types that the receiver may not understand.
     /// </summary>
@@ -271,7 +271,7 @@ namespace Opc.Ua
     /// </example>
     [DataContract(Namespace = Namespaces.OpcUaXsd)]
     public class ExtensionObject : IFormattable
-    {                     
+    {
         #region Constructors
         /// <summary>
         /// Initializes the object with default values.
@@ -280,11 +280,11 @@ namespace Opc.Ua
         /// Initializes the object with default values.
         /// </remarks>
         public ExtensionObject()
-        {           
-            m_typeId   = ExpandedNodeId.Null;
-            m_encoding = ExtensionObjectEncoding.None;   
-            m_body     = null;
-            m_context  = MessageContextExtension.CurrentContext;
+        {
+            m_typeId = ExpandedNodeId.Null;
+            m_encoding = ExtensionObjectEncoding.None;
+            m_body = null;
+            m_context = MessageContextExtension.CurrentContext;
         }
 
         /// <summary>
@@ -296,11 +296,14 @@ namespace Opc.Ua
         /// </remarks>
         /// <exception cref="ArgumentNullException">Thrown when the value is null</exception>
         public ExtensionObject(ExtensionObject value)
-        {            
-            if (value == null) throw new ArgumentNullException("value");
+        {
+            if (value == null)
+            {
+                throw new ArgumentNullException("value");
+            }
 
             TypeId = value.TypeId;
-            Body   = Utils.Clone(value.Body);
+            Body = Utils.Clone(value.Body);
         }
 
         /// <summary>
@@ -310,7 +313,7 @@ namespace Opc.Ua
         public ExtensionObject(ExpandedNodeId typeId)
         {
             TypeId = typeId;
-            Body   = null;
+            Body = null;
         }
 
         /// <summary>
@@ -323,9 +326,9 @@ namespace Opc.Ua
 
             if (encodeable != null)
             {
-                m_typeId   = null;
+                m_typeId = null;
                 m_encoding = ExtensionObjectEncoding.EncodeableObject;
-                m_body     = encodeable;
+                m_body = encodeable;
             }
             else
             {
@@ -342,14 +345,14 @@ namespace Opc.Ua
         /// Initializes the object with an encodeable object.
         /// </remarks>
         public ExtensionObject(ExpandedNodeId typeId, object body)
-        {            
+        {
             TypeId = typeId;
-            Body   = body;
+            Body = body;
         }
 
         [OnSerializing()]
         private void UpdateContext(StreamingContext context)
-        {      
+        {
             m_context = MessageContextExtension.CurrentContext;
         }
 
@@ -359,13 +362,13 @@ namespace Opc.Ua
         [OnDeserializing()]
         private void Initialize(StreamingContext context)
         {
-            m_typeId   = ExpandedNodeId.Null;
-            m_encoding = ExtensionObjectEncoding.None;   
-            m_body     = null;
-            m_context  = MessageContextExtension.CurrentContext;
+            m_typeId = ExpandedNodeId.Null;
+            m_encoding = ExtensionObjectEncoding.None;
+            m_body = null;
+            m_context = MessageContextExtension.CurrentContext;
         }
         #endregion
-             
+
         #region Public Properties
         /// <summary>
         /// The data type node id for the extension object.
@@ -373,7 +376,7 @@ namespace Opc.Ua
         /// <value>The type id.</value>
         public ExpandedNodeId TypeId
         {
-            get { return m_typeId;  }
+            get { return m_typeId; }
             set { m_typeId = value; }
         }
 
@@ -381,11 +384,11 @@ namespace Opc.Ua
         /// The encoding to use when the deserializing/serializing the body.
         /// </summary>
         /// <value>The encoding for the embedd object.</value>
-        public ExtensionObjectEncoding Encoding 
+        public ExtensionObjectEncoding Encoding
         {
-            get 
-            { 
-                return m_encoding;  
+            get
+            {
+                return m_encoding;
             }
         }
 
@@ -405,17 +408,17 @@ namespace Opc.Ua
         /// <exception cref="ServiceResultException">Thrown when the body is not one of the types listed above</exception>
         public object Body
         {
-            get { return m_body;  }
-            
-            set 
-            { 
+            get { return m_body; }
+
+            set
+            {
                 m_body = value;
 
                 if (m_body == null)
                 {
                     m_encoding = ExtensionObjectEncoding.None;
                 }
-                
+
                 else if (m_body is IEncodeable)
                 {
                     m_encoding = ExtensionObjectEncoding.EncodeableObject;
@@ -440,7 +443,7 @@ namespace Opc.Ua
             }
         }
         #endregion
-       
+
         #region Overridden Methods
         /// <summary>
         /// Determines if the specified object is equal to the <paramref name="obj"/>.
@@ -450,7 +453,7 @@ namespace Opc.Ua
         /// true if the specified <see cref="T:System.Object"/> is equal to the current embeded object; otherwise, false.
         /// </returns>
         public override bool Equals(object obj)
-		    {
+        {
             if (Object.ReferenceEquals(obj, null))
             {
                 return IsNull(this);
@@ -469,12 +472,12 @@ namespace Opc.Ua
                 {
                     return false;
                 }
-                
+
                 return Utils.IsEqual(this.m_body, value.m_body);
             }
-            
+
             return false;
-		    }
+        }
 
         /// <summary>
         /// Returns a unique hashcode for the embeded object.
@@ -482,20 +485,20 @@ namespace Opc.Ua
         /// <returns>
         /// A hash code for the current embeded object.
         /// </returns>
-		    public override int GetHashCode()
-		    {
-          if (this.m_body != null)
-          {
-              return this.m_body.GetHashCode();
-          }
-          
-          if (this.m_typeId != null)
-          {
-              return this.m_typeId.GetHashCode();
-          }
+        public override int GetHashCode()
+        {
+            if (this.m_body != null)
+            {
+                return this.m_body.GetHashCode();
+            }
 
-          return 0;
-		    }
+            if (this.m_typeId != null)
+            {
+                return this.m_typeId.GetHashCode();
+            }
+
+            return 0;
+        }
 
         /// <summary>
         /// Converts the value to a human readable string.
@@ -527,14 +530,19 @@ namespace Opc.Ua
                 {
                     return String.Format(formatProvider, "Byte[{0}]", ((byte[])m_body).Length);
                 }
-                
+
                 if (m_body is XmlElement)
                 {
                     return String.Format(formatProvider, "<{0}>", ((XmlElement)m_body).Name);
                 }
-                
+
+                if (m_body is IFormattable)
+                {
+                    return String.Format(formatProvider, "{0}", ((IFormattable)m_body).ToString(null, formatProvider));
+                }
+
                 if (m_body is IEncodeable)
-                {            
+                {
                     StringBuilder body = new StringBuilder();
 
                     PropertyInfo[] properties = m_body.GetType().GetProperties(BindingFlags.Public | BindingFlags.FlattenHierarchy | BindingFlags.Instance);
@@ -570,7 +578,7 @@ namespace Opc.Ua
 
                     return String.Format(formatProvider, "{0}", body);
                 }
-                
+
                 if (!NodeId.IsNull(this.m_typeId))
                 {
                     return String.Format(formatProvider, "{{{0}}}", this.m_typeId);
@@ -578,11 +586,11 @@ namespace Opc.Ua
 
                 return "(null)";
             }
-        
+
             throw new FormatException(Utils.Format("Invalid format string: '{0}'.", format));
         }
         #endregion
-        
+
         #region ICloneable Members
         /// <summary>
         /// Makes a deep copy of the object.
@@ -610,7 +618,7 @@ namespace Opc.Ua
         public static bool IsNull(ExtensionObject extension)
         {
             if (extension != null && extension.m_body != null)
-            {                
+            {
                 return false;
             }
 
@@ -664,31 +672,31 @@ namespace Opc.Ua
                     output.SetValue(element, ii);
                 }
             }
-            
+
             return output;
         }
         #endregion
-        
+
         #region Private Members
         [DataMember(Name = "TypeId", Order = 1, IsRequired = false, EmitDefaultValue = true)]
         private NodeId XmlEncodedTypeId
         {
-            get 
-            { 
+            get
+            {
                 // must use the XML encoding id if encoding in an XML stream.
                 IEncodeable encodeable = m_body as IEncodeable;
 
                 if (encodeable != null)
                 {
-                    return ExpandedNodeId.ToNodeId(encodeable.XmlEncodingId, m_context.NamespaceUris);  
+                    return ExpandedNodeId.ToNodeId(encodeable.XmlEncodingId, m_context.NamespaceUris);
                 }
 
-                return ExpandedNodeId.ToNodeId(m_typeId, m_context.NamespaceUris);  
+                return ExpandedNodeId.ToNodeId(m_typeId, m_context.NamespaceUris);
             }
 
-            set 
-            { 
-                m_typeId = NodeId.ToExpandedNodeId(value, m_context.NamespaceUris);  
+            set
+            {
+                m_typeId = NodeId.ToExpandedNodeId(value, m_context.NamespaceUris);
             }
         }
 
@@ -702,10 +710,10 @@ namespace Opc.Ua
                 {
                     return null;
                 }
-         
+
                 // create encoder.
                 XmlEncoder encoder = new XmlEncoder(m_context);
-                
+
                 // write body.
                 encoder.WriteExtensionObjectBody(m_body);
 
@@ -728,10 +736,10 @@ namespace Opc.Ua
 
                 // create decoder.
                 XmlDecoder decoder = new XmlDecoder(value, m_context);
-              
+
                 // read body.
                 Body = decoder.ReadExtensionObjectBody(m_typeId);
-                                
+
                 // clear the type id for encodeables.
                 IEncodeable encodeable = m_body as IEncodeable;
 
@@ -739,7 +747,7 @@ namespace Opc.Ua
                 {
                     m_typeId = null;
                 }
-                                
+
                 // close decoder.
                 try
                 {
@@ -755,7 +763,7 @@ namespace Opc.Ua
             }
         }
         #endregion
-        
+
         #region Private Fields
         private ExpandedNodeId m_typeId;
         private ExtensionObjectEncoding m_encoding;
@@ -799,7 +807,7 @@ namespace Opc.Ua
         Json = 4
     }
     #endregion
-    
+
     #region ExtensionObjectCollection Class
     /// <summary>
     /// A collection of ExtensionObjects.
@@ -817,7 +825,7 @@ namespace Opc.Ua
         /// <remarks>
         /// Initializes an empty collection.
         /// </remarks>
-        public ExtensionObjectCollection() {}
+        public ExtensionObjectCollection() { }
 
         /// <summary>
         /// Initializes the collection from another collection.
@@ -826,8 +834,8 @@ namespace Opc.Ua
         /// Initializes the collection from another collection.
         /// </remarks>
         /// <param name="collection">The collection containing the objects to copy into this new instance</param>
-        public ExtensionObjectCollection(IEnumerable<ExtensionObject> collection) : base(collection) {}
-        
+        public ExtensionObjectCollection(IEnumerable<ExtensionObject> collection) : base(collection) { }
+
         /// <summary>
         /// Initializes the collection with the specified capacity.
         /// </summary>
@@ -835,9 +843,9 @@ namespace Opc.Ua
         /// Initializes the collection with the specified capacity.
         /// </remarks>
         /// <param name="capacity">Max capacity of the collection</param>
-        public ExtensionObjectCollection(int capacity) : base(capacity) {}
+        public ExtensionObjectCollection(int capacity) : base(capacity) { }
         #endregion
-                       
+
         #region Static Members
         /// <summary>
         /// Converts an array of ExtensionObjects to a collection.


### PR DESCRIPTION
- use single assembly per session
- use namespace for custom types
- create the custom types per session in a local factory only, not in the global factory
- implement IFormattable, to improve .ToString of ExtensionObjects
- improve consol test to auto find, read and subscribe to all custom types of a server
