### PR TITLE
Fixes #822 - Certificate Validation fix.

### DIFF
--- a/SampleApplications/Samples/ClientControls.Net4/Configuration/Common (OLD)/GuiUtils.cs
+++ b/SampleApplications/Samples/ClientControls.Net4/Configuration/Common (OLD)/GuiUtils.cs
@@ -253,8 +253,14 @@ namespace Opc.Ua.Client.Controls
         {       
             StringBuilder buffer = new StringBuilder();
 
-            buffer.AppendFormat("Certificate could not be validated: {0}\r\n\r\n", e.Error.StatusCode);
-            buffer.AppendFormat("Subject: {0}\r\n", e.Certificate.Subject);
+            buffer.AppendFormat("Certificate could not be validated!\r\n");
+            buffer.AppendFormat("Validation error(s): \r\n");
+            buffer.AppendFormat("\t{0}\r\n", e.Error.StatusCode);
+            if (e.Error.InnerResult != null)
+            {
+                buffer.AppendFormat("\t{0}\r\n", e.Error.InnerResult.StatusCode);
+            }
+            buffer.AppendFormat("\r\nSubject: {0}\r\n", e.Certificate.Subject);
             buffer.AppendFormat("Issuer: {0}\r\n", (e.Certificate.Subject == e.Certificate.Issuer)?"Self-signed":e.Certificate.Issuer);
             buffer.AppendFormat("Valid From: {0}\r\n", e.Certificate.NotBefore);
             buffer.AppendFormat("Valid To: {0}\r\n", e.Certificate.NotAfter);

--- a/Stack/Opc.Ua.Core/Security/Certificates/CertificateValidator.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/CertificateValidator.cs
@@ -264,7 +264,7 @@ namespace Opc.Ua
                     case StatusCodes.BadCertificateUseNotAllowed:
                     case StatusCodes.BadCertificateUntrusted:
                         {
-                            Utils.Trace("Cert Validate failed: {0}", (StatusCode)se.StatusCode);
+                            Utils.Trace("Certificate Vaildation failed for '{0}'. Reason={1}", certificate.Subject, (StatusCode)se.StatusCode);
                             break;
                         }
 
@@ -304,6 +304,7 @@ namespace Opc.Ua
                 // add to list of peers.
                 lock (m_lock)
                 {
+                    Utils.Trace("Validation error suppressed for '{0}'.", certificate.Subject);
                     m_validatedCertificates[certificate.Thumbprint] = new X509Certificate2(certificate.RawData);
                 }
             }
@@ -761,7 +762,15 @@ namespace Opc.Ua
                         // check untrusted certificates.
                         if (trustedCertificate == null)
                         {
-                            throw new ServiceResultException(StatusCodes.BadSecurityChecksFailed);
+                            ServiceResult errorResult = new ServiceResult(
+                                result.StatusCode,
+                                result.SymbolicId,
+                                result.NamespaceUri,
+                                result.LocalizedText,
+                                result.AdditionalInfo,
+                                StatusCodes.BadCertificateUntrusted);
+
+                            throw new ServiceResultException(errorResult);
                         }
 
                         throw new ServiceResultException(result);

--- a/Stack/Opc.Ua.Core/Security/Certificates/CertificateValidator.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/CertificateValidator.cs
@@ -259,7 +259,6 @@ namespace Opc.Ua
                     case StatusCodes.BadCertificateIssuerUseNotAllowed:
                     case StatusCodes.BadCertificateRevocationUnknown:
                     case StatusCodes.BadCertificateTimeInvalid:
-                    case StatusCodes.BadCertificateUriInvalid:
                     case StatusCodes.BadCertificatePolicyCheckFailed:
                     case StatusCodes.BadCertificateUseNotAllowed:
                     case StatusCodes.BadCertificateUntrusted:


### PR DESCRIPTION
- Allow validation event to suppress validation errors for expired or not yet valid certificates that are also untrusted.
- The validation error can also contain an extra inner error (like BadCertificateUntrusted).
- The user can see both validation errors when accepting the certificate

![image](https://user-images.githubusercontent.com/13765819/68195607-d04c2b80-ffbf-11e9-89fe-f4c352564bf8.png)
