### PR TITLE
Nonce validation fix in Client Session

### DIFF
--- a/SampleApplications/SDK/Opc.Ua.Client/Session.cs
+++ b/SampleApplications/SDK/Opc.Ua.Client/Session.cs
@@ -316,7 +316,7 @@ namespace Opc.Ua.Client
             if (identity!= null && identity.TokenType != UserTokenType.Anonymous)
             {
                 // the server nonce should be validated if the token includes a secret.
-                if (!Utils.Nonce.ValidateNonce(serverNonce, MessageSecurityMode.SignAndEncrypt, securityPolicyUri))
+                if (!Utils.Nonce.ValidateNonce(serverNonce, MessageSecurityMode.SignAndEncrypt, (uint)m_configuration.SecurityConfiguration.NonceLength))
                 {
                     throw ServiceResultException.Create(StatusCodes.BadNonceInvalid, "Server nonce is not the correct length or not random enough.");
                 }

--- a/Stack/Opc.Ua.Core/Types/Utils/Utils.cs
+++ b/Stack/Opc.Ua.Core/Types/Utils/Utils.cs
@@ -2665,6 +2665,14 @@ namespace Opc.Ua
             /// </summary>
             public static bool ValidateNonce(byte[] nonce, MessageSecurityMode securityMode, string securityPolicyUri)
             {
+                return ValidateNonce(nonce, securityMode, GetNonceLength(securityPolicyUri));
+            }
+
+            /// <summary>
+            /// Validates the nonce for a message security mode and a minimum length.
+            /// </summary>
+            public static bool ValidateNonce(byte[] nonce, MessageSecurityMode securityMode, uint minNonceLength)
+            {
                 // no nonce needed for no security.
                 if (securityMode == MessageSecurityMode.None)
                 {
@@ -2672,7 +2680,7 @@ namespace Opc.Ua
                 }
 
                 // check the length.
-                if (nonce == null || nonce.Length < GetNonceLength(securityPolicyUri))
+                if (nonce == null || nonce.Length < minNonceLength)
                 {
                     return false;
                 }


### PR DESCRIPTION
Nonce validation fix in Client Session
The minimum nonce length should be 32 in CreateSession and ActivateSession responses.