### PR TITLE
Minor analyzer (roslynator) fixes

### DIFF
--- a/SampleApplications/SDK/Opc.Ua.Client.ComplexTypes/ComplexTypeSystem.cs
+++ b/SampleApplications/SDK/Opc.Ua.Client.ComplexTypes/ComplexTypeSystem.cs
@@ -525,7 +525,7 @@ namespace Opc.Ua.Client.ComplexTypes
 
             if (references.Count == 1)
             {
-                encodingId = references.First().NodeId;
+                encodingId = references[0].NodeId;
                 references = m_session.NodeCache.FindReferences(
                     encodingId,
                     ReferenceTypeIds.HasEncoding,
@@ -536,7 +536,7 @@ namespace Opc.Ua.Client.ComplexTypes
 
                 if (references.Count == 1)
                 {
-                    typeId = references.First().NodeId;
+                    typeId = references[0].NodeId;
                     dataTypeNode = m_session.NodeCache.Find(typeId) as DataTypeNode;
                     typeId = NormalizeExpandedNodeId(typeId);
                     return true;
@@ -795,7 +795,7 @@ namespace Opc.Ua.Client.ComplexTypes
             {
                 typeListEnumerator.MoveNext();
                 fieldBuilder.AddField(field, typeListEnumerator.Current, order);
-                order += 1;
+                order++;
             }
 
             return fieldBuilder.CreateType();
@@ -876,7 +876,7 @@ namespace Opc.Ua.Client.ComplexTypes
                 if (structuredObject != null)
                 {
                     var dependentFields = structuredObject.Field.Where(f => f.TypeName.Namespace == dictionary.TypeDictionary.TargetNamespace);
-                    if (dependentFields.Count() == 0)
+                    if (!dependentFields.Any())
                     {
                         structureList.Insert(0, structuredObject);
                     }

--- a/SampleApplications/SDK/Opc.Ua.Client.ComplexTypes/ComplexTypeSystem.cs
+++ b/SampleApplications/SDK/Opc.Ua.Client.ComplexTypes/ComplexTypeSystem.cs
@@ -121,7 +121,7 @@ namespace Opc.Ua.Client.ComplexTypes
                 Utils.Trace(sre, "Failed to load the custom type.");
                 if (throwOnError)
                 {
-                    throw sre;
+                    throw;
                 }
                 return null;
             }
@@ -161,7 +161,7 @@ namespace Opc.Ua.Client.ComplexTypes
                 Utils.Trace(sre, $"Failed to load the custom type dictionary.");
                 if (throwOnError)
                 {
-                    throw sre;
+                    throw;
                 }
                 return false;
             }
@@ -207,7 +207,7 @@ namespace Opc.Ua.Client.ComplexTypes
                 Utils.Trace(sre, $"Failed to load the custom type dictionary.");
                 if (throwOnError)
                 {
-                    throw sre;
+                    throw;
                 }
                 return false;
             }

--- a/SampleApplications/SDK/Opc.Ua.Client.ComplexTypes/ComplexTypeSystem.cs
+++ b/SampleApplications/SDK/Opc.Ua.Client.ComplexTypes/ComplexTypeSystem.cs
@@ -280,7 +280,7 @@ namespace Opc.Ua.Client.ComplexTypes
                             var structuredObject = item as Opc.Ua.Schema.Binary.StructuredType;
                             if (structuredObject != null)
                             {
-                                var nodeId = dictionary.DataTypes.Where(d => d.Value.DisplayName == item.Name).FirstOrDefault().Value;
+                                var nodeId = dictionary.DataTypes.FirstOrDefault(d => d.Value.DisplayName == item.Name).Value;
 
                                 // find the data type node and the binary encoding id
                                 ExpandedNodeId typeId;
@@ -653,10 +653,10 @@ namespace Opc.Ua.Client.ComplexTypes
             foreach (var item in enumList)
             {
                 Type newType = null;
-                DataTypeNode enumType = enumerationTypes.Where(node =>
+                DataTypeNode enumType = enumerationTypes.FirstOrDefault(node =>
                     node.BrowseName.Name == item.Name &&
                     (node.NodeId.NamespaceIndex == complexTypeBuilder.TargetNamespaceIndex ||
-                    complexTypeBuilder.TargetNamespaceIndex == -1)).FirstOrDefault()
+                    complexTypeBuilder.TargetNamespaceIndex == -1))
                     as DataTypeNode;
                 if (enumType != null)
                 {

--- a/SampleApplications/SDK/Opc.Ua.Client.ComplexTypes/ComplexTypeSystem.cs
+++ b/SampleApplications/SDK/Opc.Ua.Client.ComplexTypes/ComplexTypeSystem.cs
@@ -307,7 +307,7 @@ namespace Opc.Ua.Client.ComplexTypes
                         {
                             if (item is Opc.Ua.Schema.Binary.StructuredType structuredObject)
                             {   // note: the BrowseName contains the actual Value string of the DataType node.
-                                var nodeId = dictionary.DataTypes.FirstOrDefault(d => d.Value.BrowseName.Name == item.Name)?.Value;
+                                var nodeId = dictionary.DataTypes.FirstOrDefault(d => d.Value.BrowseName.Name == item.Name).Value;
                                 if (nodeId == null)
                                 {
                                     Utils.Trace(TraceMasks.Error, $"Skip the type definition of {item.Name} because the data type node was not found.");

--- a/SampleApplications/SDK/Opc.Ua.Client.ComplexTypes/DataTypeDefinitionExtension.cs
+++ b/SampleApplications/SDK/Opc.Ua.Client.ComplexTypes/DataTypeDefinitionExtension.cs
@@ -271,16 +271,16 @@ namespace Opc.Ua.Client.ComplexTypes
             }
             else
             {
-                var referenceId = typeCollection.Where(t =>
+                var referenceId = typeCollection.FirstOrDefault(t =>
                     t.DisplayName == typeName.Name &&
-                    t.NodeId.NamespaceUri == typeName.Namespace).FirstOrDefault();
+                    t.NodeId.NamespaceUri == typeName.Namespace);
                 if (referenceId == null)
                 {
                     // TODO: servers may have multiple dictionaries with different
                     // target namespace but types are stored for all in the same namespace.
                     // Find a way to find the right namespace here
-                    referenceId = typeCollection.Where(t =>
-                        t.DisplayName == typeName.Name).FirstOrDefault();
+                    referenceId = typeCollection.FirstOrDefault(t =>
+                        t.DisplayName == typeName.Name);
                     if (referenceId == null)
                     {
                         throw new ServiceResultException(StatusCodes.BadDataTypeIdUnknown,

--- a/SampleApplications/SDK/Opc.Ua.Client/MonitoredItemStatus.cs
+++ b/SampleApplications/SDK/Opc.Ua.Client/MonitoredItemStatus.cs
@@ -198,8 +198,8 @@ namespace Opc.Ua.Client
             MonitoredItemCreateResult  result,
             ServiceResult              error)
         {
-            if (request == null) throw new ArgumentNullException("request");
-            if (result == null)  throw new ArgumentNullException("result");
+            if (request == null) throw new ArgumentNullException(nameof(request));
+            if (result == null)  throw new ArgumentNullException(nameof(result));
             
             m_nodeId           = request.ItemToMonitor.NodeId;
             m_attributeId      = request.ItemToMonitor.AttributeId;
@@ -234,8 +234,8 @@ namespace Opc.Ua.Client
             MonitoredItemModifyResult  result,
             ServiceResult              error)
         {
-            if (request == null) throw new ArgumentNullException("request");
-            if (result == null)  throw new ArgumentNullException("result");
+            if (request == null) throw new ArgumentNullException(nameof(request));
+            if (result == null)  throw new ArgumentNullException(nameof(result));
             
             m_error = error;
 

--- a/SampleApplications/SDK/Opc.Ua.Client/NodeCache.cs
+++ b/SampleApplications/SDK/Opc.Ua.Client/NodeCache.cs
@@ -45,7 +45,7 @@ namespace Opc.Ua.Client
         /// </summary>
         public NodeCache(Session session)
         {
-            if (session == null) throw new ArgumentNullException("session");
+            if (session == null) throw new ArgumentNullException(nameof(session));
 
             m_session  = session;
             m_typeTree = new TypeTable(m_session.NamespaceUris);

--- a/SampleApplications/SDK/Opc.Ua.Client/Session.cs
+++ b/SampleApplications/SDK/Opc.Ua.Client/Session.cs
@@ -3139,7 +3139,7 @@ namespace Opc.Ua.Client
         /// <returns></returns>
         public bool AddSubscription(Subscription subscription)
         {
-            if (subscription == null) throw new ArgumentNullException("subscription");
+            if (subscription == null) throw new ArgumentNullException(nameof(subscription));
 
             lock (SyncRoot)
             {
@@ -3167,7 +3167,7 @@ namespace Opc.Ua.Client
         /// <returns></returns>
         public bool RemoveSubscription(Subscription subscription)
         {
-            if (subscription == null) throw new ArgumentNullException("subscription");
+            if (subscription == null) throw new ArgumentNullException(nameof(subscription));
 
             if (subscription.Created)
             {
@@ -3199,7 +3199,7 @@ namespace Opc.Ua.Client
         /// <returns></returns>
         public bool RemoveSubscriptions(IEnumerable<Subscription> subscriptions)
         {
-            if (subscriptions == null) throw new ArgumentNullException("subscriptions");
+            if (subscriptions == null) throw new ArgumentNullException(nameof(subscriptions));
 
             bool removed = false;
             List<Subscription> subscriptionsToDelete = new List<Subscription>();

--- a/SampleApplications/SDK/Opc.Ua.Client/Session.cs
+++ b/SampleApplications/SDK/Opc.Ua.Client/Session.cs
@@ -942,10 +942,10 @@ namespace Opc.Ua.Client
             {
                 session.Open(sessionName, sessionTimeout, identity, preferredLocales, checkDomain);
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 session.Dispose();
-                throw e;
+                throw;
             }
 
             return session;
@@ -2637,7 +2637,7 @@ namespace Opc.Ua.Client
                 // start keep alive thread.
                 StartKeepAliveTimer();
             }
-            catch (Exception ex)
+            catch (Exception)
             {
                 try
                 {
@@ -2653,7 +2653,7 @@ namespace Opc.Ua.Client
                     SessionCreated(null, null);
                 }
 
-                throw ex;
+                throw;
             }
         }
 

--- a/SampleApplications/SDK/Opc.Ua.Client/Subscription.cs
+++ b/SampleApplications/SDK/Opc.Ua.Client/Subscription.cs
@@ -1379,7 +1379,7 @@ namespace Opc.Ua.Client
             MonitoringMode       monitoringMode, 
             IList<MonitoredItem> monitoredItems)
         {
-            if (monitoredItems == null) throw new ArgumentNullException("monitoredItems");
+            if (monitoredItems == null) throw new ArgumentNullException(nameof(monitoredItems));
 
             VerifySubscriptionState(true);
 
@@ -1768,7 +1768,7 @@ namespace Opc.Ua.Client
         /// </summary>
         public void AddItem(MonitoredItem monitoredItem)
         {
-            if (monitoredItem == null) throw new ArgumentNullException("monitoredItem");
+            if (monitoredItem == null) throw new ArgumentNullException(nameof(monitoredItem));
 
             lock (m_cache)
             {
@@ -1790,7 +1790,7 @@ namespace Opc.Ua.Client
         /// </summary>
         public void AddItems(IEnumerable<MonitoredItem> monitoredItems)
         {
-            if (monitoredItems == null) throw new ArgumentNullException("monitoredItems");
+            if (monitoredItems == null) throw new ArgumentNullException(nameof(monitoredItems));
 
             bool added = false;
 
@@ -1819,7 +1819,7 @@ namespace Opc.Ua.Client
         /// </summary>
         public void RemoveItem(MonitoredItem monitoredItem)
         {
-            if (monitoredItem == null) throw new ArgumentNullException("monitoredItem");
+            if (monitoredItem == null) throw new ArgumentNullException(nameof(monitoredItem));
                         
             lock (m_cache)
             {
@@ -1845,7 +1845,7 @@ namespace Opc.Ua.Client
         /// </summary>
         public void RemoveItems(IEnumerable<MonitoredItem> monitoredItems)
         {
-            if (monitoredItems == null) throw new ArgumentNullException("monitoredItems");
+            if (monitoredItems == null) throw new ArgumentNullException(nameof(monitoredItems));
 
             bool changed = false;
             

--- a/SampleApplications/SDK/Opc.Ua.Configuration/ApplicationInstance.cs
+++ b/SampleApplications/SDK/Opc.Ua.Configuration/ApplicationInstance.cs
@@ -152,7 +152,7 @@ namespace Opc.Ua.Configuration
         /// </summary>
         public InstalledApplication LoadInstallConfigFromFile(string filePath)
         {
-            if (filePath == null) throw new ArgumentNullException("filePath");
+            if (filePath == null) throw new ArgumentNullException(nameof(filePath));
             
             Stream istrm = null;
 
@@ -173,7 +173,7 @@ namespace Opc.Ua.Configuration
         /// </summary>
         public InstalledApplication LoadInstallConfigFromResource(string resourcePath, Assembly assembly)
         {
-            if (resourcePath == null) throw new ArgumentNullException("resourcePath");
+            if (resourcePath == null) throw new ArgumentNullException(nameof(resourcePath));
 
             Stream istrm = assembly.GetManifestResourceStream(resourcePath);
 
@@ -1361,7 +1361,7 @@ namespace Opc.Ua.Configuration
         /// <param name="certificate">The certificate to register.</param>
         private static async Task AddToTrustedStore(ApplicationConfiguration configuration, X509Certificate2 certificate)
         {
-            if (certificate == null) throw new ArgumentNullException("certificate");
+            if (certificate == null) throw new ArgumentNullException(nameof(certificate));
 
             string storePath = null;
 

--- a/SampleApplications/SDK/Opc.Ua.Server/Aggregates/AggregateCalculator.cs
+++ b/SampleApplications/SDK/Opc.Ua.Server/Aggregates/AggregateCalculator.cs
@@ -101,7 +101,7 @@ namespace Opc.Ua.Server
             {
                 if (endTime == DateTime.MinValue || startTime == DateTime.MinValue)
                 {
-                    throw new ArgumentException("Non-zero processingInterval required.", "processingInterval");
+                    throw new ArgumentException("Non-zero processingInterval required.", nameof(processingInterval));
                 }
 
                 ProcessingInterval = Math.Abs((endTime - startTime).TotalMilliseconds);

--- a/SampleApplications/SDK/Opc.Ua.Server/Configuration/ConfigurationNodeManager.cs
+++ b/SampleApplications/SDK/Opc.Ua.Server/Configuration/ConfigurationNodeManager.cs
@@ -154,15 +154,15 @@ namespace Opc.Ua.Server
                                 activeNode.Create(context, passiveNode);
 
                                 // delete unsupported groups
-                                if (m_certificateGroups.FirstOrDefault(group => group.BrowseName == activeNode.DefaultHttpsGroup?.BrowseName) == null)
+                                if (m_certificateGroups.All(group => group.BrowseName != activeNode.DefaultHttpsGroup?.BrowseName))
                                 {
                                     activeNode.DefaultHttpsGroup = null;
                                 }
-                                if (m_certificateGroups.FirstOrDefault(group => group.BrowseName == activeNode.DefaultUserTokenGroup?.BrowseName) == null)
+                                if (m_certificateGroups.All(group => group.BrowseName != activeNode.DefaultUserTokenGroup?.BrowseName))
                                 {
                                     activeNode.DefaultUserTokenGroup = null;
                                 }
-                                if (m_certificateGroups.FirstOrDefault(group => group.BrowseName == activeNode.DefaultApplicationGroup?.BrowseName) == null)
+                                if (m_certificateGroups.All(group => group.BrowseName != activeNode.DefaultApplicationGroup?.BrowseName))
                                 {
                                     activeNode.DefaultApplicationGroup = null;
                                 }
@@ -544,7 +544,8 @@ namespace Opc.Ua.Server
             public NodeId SessionId;
             public X509Certificate2 CertificateWithPrivateKey;
             public X509Certificate2Collection IssuerCollection;
-        };
+        }
+
         private class ServerCertificateGroup
         {
             public string BrowseName;
@@ -555,7 +556,7 @@ namespace Opc.Ua.Server
             public string IssuerStorePath;
             public string TrustedStorePath;
             public UpdateCertificateData UpdateCertificate;
-        };
+        }
 
         private ServerConfigurationState m_serverConfigurationNode;
         private ApplicationConfiguration m_configuration;

--- a/SampleApplications/SDK/Opc.Ua.Server/Diagnostics/CustomNodeManager.cs
+++ b/SampleApplications/SDK/Opc.Ua.Server/Diagnostics/CustomNodeManager.cs
@@ -461,7 +461,7 @@ namespace Opc.Ua.Server
 
             protected set
             {
-                if (value == null) throw new ArgumentNullException("value");
+                if (value == null) throw new ArgumentNullException(nameof(value));
                 List<string> namespaceUris = new List<string>(value);
                 SetNamespaces(namespaceUris.ToArray());
             }
@@ -1123,8 +1123,8 @@ namespace Opc.Ua.Server
             ref ContinuationPoint       continuationPoint, 
             IList<ReferenceDescription> references)
         {            
-            if (continuationPoint == null) throw new ArgumentNullException("continuationPoint");
-            if (references == null) throw new ArgumentNullException("references");
+            if (continuationPoint == null) throw new ArgumentNullException(nameof(continuationPoint));
+            if (references == null) throw new ArgumentNullException(nameof(references));
             
             ServerSystemContext systemContext = m_systemContext.Copy(context);
 

--- a/SampleApplications/SDK/Opc.Ua.Server/Diagnostics/v10/CustomNodeManager.cs
+++ b/SampleApplications/SDK/Opc.Ua.Server/Diagnostics/v10/CustomNodeManager.cs
@@ -976,8 +976,8 @@ namespace Opc.Ua.Server
             ref ContinuationPoint       continuationPoint, 
             IList<ReferenceDescription> references)
         {
-            if (continuationPoint == null) throw new ArgumentNullException("continuationPoint");
-            if (references == null) throw new ArgumentNullException("references");
+            if (continuationPoint == null) throw new ArgumentNullException(nameof(continuationPoint));
+            if (references == null) throw new ArgumentNullException(nameof(references));
 
             // check for view.
             if (!ViewDescription.IsDefault(continuationPoint.View))

--- a/SampleApplications/SDK/Opc.Ua.Server/NodeManager/CoreNodeManager.cs
+++ b/SampleApplications/SDK/Opc.Ua.Server/NodeManager/CoreNodeManager.cs
@@ -61,8 +61,8 @@ namespace Opc.Ua.Server
             ApplicationConfiguration configuration,
             ushort                   dynamicNamespaceIndex)
         {
-            if (server == null)        throw new ArgumentNullException("server");
-            if (configuration == null) throw new ArgumentNullException("configuration");
+            if (server == null)        throw new ArgumentNullException(nameof(server));
+            if (configuration == null) throw new ArgumentNullException(nameof(configuration));
                   
             m_server                         = server;
             m_nodes                          = new NodeTable(server.NamespaceUris, server.ServerUris, server.TypeTree);
@@ -239,10 +239,10 @@ namespace Opc.Ua.Server
             IList<ExpandedNodeId> targetIds,
             IList<NodeId>         unresolvedTargetIds)
         {
-            if (sourceHandle == null) throw new ArgumentNullException("sourceHandle");
-            if (relativePath == null) throw new ArgumentNullException("relativePath");
-            if (targetIds == null) throw new ArgumentNullException("targetIds");
-            if (unresolvedTargetIds == null) throw new ArgumentNullException("unresolvedTargetIds");
+            if (sourceHandle == null) throw new ArgumentNullException(nameof(sourceHandle));
+            if (relativePath == null) throw new ArgumentNullException(nameof(relativePath));
+            if (targetIds == null) throw new ArgumentNullException(nameof(targetIds));
+            if (unresolvedTargetIds == null) throw new ArgumentNullException(nameof(unresolvedTargetIds));
 
             // check for valid handle.
             ILocalNode source = sourceHandle as ILocalNode;
@@ -302,9 +302,9 @@ namespace Opc.Ua.Server
             ref ContinuationPoint       continuationPoint,
             IList<ReferenceDescription> references)
         {              
-            if (context == null) throw new ArgumentNullException("context");
-            if (continuationPoint == null) throw new ArgumentNullException("continuationPoint");
-            if (references == null) throw new ArgumentNullException("references");
+            if (context == null) throw new ArgumentNullException(nameof(context));
+            if (continuationPoint == null) throw new ArgumentNullException(nameof(continuationPoint));
+            if (references == null) throw new ArgumentNullException(nameof(references));
             
             // check for valid handle.
             ILocalNode source = continuationPoint.NodeToBrowse as ILocalNode;
@@ -464,7 +464,7 @@ namespace Opc.Ua.Server
             object           targetHandle,
             BrowseResultMask resultMask)
         {
-            if (context == null) throw new ArgumentNullException("context");
+            if (context == null) throw new ArgumentNullException(nameof(context));
             
             // find target.
             ILocalNode target = targetHandle as ILocalNode;
@@ -620,7 +620,7 @@ namespace Opc.Ua.Server
         /// </remarks>
         public void AddReferences(IDictionary<NodeId,IList<IReference>> references)
         {
-            if (references == null) throw new ArgumentNullException("references");
+            if (references == null) throw new ArgumentNullException(nameof(references));
 
             lock (m_lock)
             {
@@ -649,10 +649,10 @@ namespace Opc.Ua.Server
             IList<DataValue>     values,
             IList<ServiceResult> errors)
         {
-            if (context == null)     throw new ArgumentNullException("context");
-            if (nodesToRead == null) throw new ArgumentNullException("nodesToRead");
-            if (values == null)      throw new ArgumentNullException("values");
-            if (errors == null)      throw new ArgumentNullException("errors");
+            if (context == null)     throw new ArgumentNullException(nameof(context));
+            if (nodesToRead == null) throw new ArgumentNullException(nameof(nodesToRead));
+            if (values == null)      throw new ArgumentNullException(nameof(values));
+            if (errors == null)      throw new ArgumentNullException(nameof(errors));
 
             lock (m_lock)
             {
@@ -763,11 +763,11 @@ namespace Opc.Ua.Server
             IList<HistoryReadResult>  results, 
             IList<ServiceResult>      errors) 
         {
-            if (context == null)     throw new ArgumentNullException("context");
-            if (details == null)     throw new ArgumentNullException("details");
-            if (nodesToRead == null) throw new ArgumentNullException("nodesToRead");
-            if (results == null)     throw new ArgumentNullException("results");
-            if (errors == null)      throw new ArgumentNullException("errors");
+            if (context == null)     throw new ArgumentNullException(nameof(context));
+            if (details == null)     throw new ArgumentNullException(nameof(details));
+            if (nodesToRead == null) throw new ArgumentNullException(nameof(nodesToRead));
+            if (results == null)     throw new ArgumentNullException(nameof(results));
+            if (errors == null)      throw new ArgumentNullException(nameof(errors));
 
             ReadRawModifiedDetails readRawModifiedDetails = details as ReadRawModifiedDetails;
             ReadAtTimeDetails readAtTimeDetails = details as ReadAtTimeDetails;
@@ -811,9 +811,9 @@ namespace Opc.Ua.Server
             IList<WriteValue>    nodesToWrite, 
             IList<ServiceResult> errors)
         {
-            if (context == null)      throw new ArgumentNullException("context");
-            if (nodesToWrite == null) throw new ArgumentNullException("nodesToWrite");
-            if (errors == null)       throw new ArgumentNullException("errors");
+            if (context == null)      throw new ArgumentNullException(nameof(context));
+            if (nodesToWrite == null) throw new ArgumentNullException(nameof(nodesToWrite));
+            if (errors == null)       throw new ArgumentNullException(nameof(errors));
 
             lock (m_lock)
             {
@@ -970,10 +970,10 @@ namespace Opc.Ua.Server
             IList<HistoryUpdateResult>  results, 
             IList<ServiceResult>        errors) 
         {
-            if (context == null)       throw new ArgumentNullException("context");
-            if (nodesToUpdate == null) throw new ArgumentNullException("nodesToUpdate");
-            if (results == null)       throw new ArgumentNullException("results");
-            if (errors == null)        throw new ArgumentNullException("errors");
+            if (context == null)       throw new ArgumentNullException(nameof(context));
+            if (nodesToUpdate == null) throw new ArgumentNullException(nameof(nodesToUpdate));
+            if (results == null)       throw new ArgumentNullException(nameof(results));
+            if (errors == null)        throw new ArgumentNullException(nameof(errors));
 
             lock (m_lock)
             {
@@ -1012,10 +1012,10 @@ namespace Opc.Ua.Server
             IList<CallMethodResult>  results,
             IList<ServiceResult>     errors)
         {
-            if (context == null)       throw new ArgumentNullException("context");
-            if (methodsToCall == null) throw new ArgumentNullException("methodsToCall");
-            if (results == null)       throw new ArgumentNullException("results");
-            if (errors == null)        throw new ArgumentNullException("errors");
+            if (context == null)       throw new ArgumentNullException(nameof(context));
+            if (methodsToCall == null) throw new ArgumentNullException(nameof(methodsToCall));
+            if (results == null)       throw new ArgumentNullException(nameof(results));
+            if (errors == null)        throw new ArgumentNullException(nameof(errors));
 
             lock (m_lock)
             {
@@ -1069,9 +1069,9 @@ namespace Opc.Ua.Server
             IEventMonitoredItem monitoredItem,
             bool                unsubscribe)
         {
-            if (context == null)  throw new ArgumentNullException("context");
-            if (sourceId == null) throw new ArgumentNullException("sourceId");
-            if (monitoredItem == null) throw new ArgumentNullException("monitoredItem");
+            if (context == null)  throw new ArgumentNullException(nameof(context));
+            if (sourceId == null) throw new ArgumentNullException(nameof(sourceId));
+            if (monitoredItem == null) throw new ArgumentNullException(nameof(monitoredItem));
 
             lock (m_lock)
             {
@@ -1106,8 +1106,8 @@ namespace Opc.Ua.Server
             IEventMonitoredItem monitoredItem,
             bool                unsubscribe)
         {  
-            if (context == null)  throw new ArgumentNullException("context");
-            if (monitoredItem == null)  throw new ArgumentNullException("monitoredItem");
+            if (context == null)  throw new ArgumentNullException(nameof(context));
+            if (monitoredItem == null)  throw new ArgumentNullException(nameof(monitoredItem));
             
             return ServiceResult.Good;
         }
@@ -1117,7 +1117,7 @@ namespace Opc.Ua.Server
             OperationContext           context,
             IList<IEventMonitoredItem> monitoredItems)
         {            
-            if (context == null)  throw new ArgumentNullException("context");
+            if (context == null)  throw new ArgumentNullException(nameof(context));
             
             return ServiceResult.Good;
         }
@@ -1136,10 +1136,10 @@ namespace Opc.Ua.Server
             IList<IMonitoredItem>             monitoredItems,
             ref long                          globalIdCounter)
         {
-            if (context == null)         throw new ArgumentNullException("context");
-            if (itemsToCreate == null)   throw new ArgumentNullException("itemsToCreate");
-            if (errors == null)          throw new ArgumentNullException("errors");
-            if (monitoredItems == null)  throw new ArgumentNullException("monitoredItems");
+            if (context == null)         throw new ArgumentNullException(nameof(context));
+            if (itemsToCreate == null)   throw new ArgumentNullException(nameof(itemsToCreate));
+            if (errors == null)          throw new ArgumentNullException(nameof(errors));
+            if (monitoredItems == null)  throw new ArgumentNullException(nameof(monitoredItems));
 
             lock (m_lock)
             {
@@ -1303,10 +1303,10 @@ namespace Opc.Ua.Server
             IList<ServiceResult>              errors,
             IList<MonitoringFilterResult>     filterErrors)
         { 
-            if (context == null)         throw new ArgumentNullException("context");
-            if (monitoredItems == null)  throw new ArgumentNullException("monitoredItems");
-            if (itemsToModify == null)   throw new ArgumentNullException("itemsToModify");
-            if (errors == null)          throw new ArgumentNullException("errors");
+            if (context == null)         throw new ArgumentNullException(nameof(context));
+            if (monitoredItems == null)  throw new ArgumentNullException(nameof(monitoredItems));
+            if (itemsToModify == null)   throw new ArgumentNullException(nameof(itemsToModify));
+            if (errors == null)          throw new ArgumentNullException(nameof(errors));
 
             lock (m_lock)
             {
@@ -1417,9 +1417,9 @@ namespace Opc.Ua.Server
             IList<bool>           processedItems,
             IList<ServiceResult>  errors)
         {
-            if (context == null)        throw new ArgumentNullException("context");
-            if (monitoredItems == null) throw new ArgumentNullException("monitoredItems");
-            if (errors == null)         throw new ArgumentNullException("errors");
+            if (context == null)        throw new ArgumentNullException(nameof(context));
+            if (monitoredItems == null) throw new ArgumentNullException(nameof(monitoredItems));
+            if (errors == null)         throw new ArgumentNullException(nameof(errors));
 
             lock (m_lock)
             {
@@ -1481,9 +1481,9 @@ namespace Opc.Ua.Server
             IList<ServiceResult>  errors)
         {
 
-            if (context == null)        throw new ArgumentNullException("context");
-            if (monitoredItems == null) throw new ArgumentNullException("monitoredItems");
-            if (errors == null)         throw new ArgumentNullException("errors");
+            if (context == null)        throw new ArgumentNullException(nameof(context));
+            if (monitoredItems == null) throw new ArgumentNullException(nameof(monitoredItems));
+            if (errors == null)         throw new ArgumentNullException(nameof(errors));
 
             lock (m_lock)
             {
@@ -1615,8 +1615,8 @@ namespace Opc.Ua.Server
         /// </summary>
         public NodeIdCollection FindLocalNodes(NodeId sourceId, NodeId referenceTypeId, bool isInverse)
         {
-            if (sourceId == null)        throw new ArgumentNullException("sourceId");
-            if (referenceTypeId == null) throw new ArgumentNullException("referenceTypeId");
+            if (sourceId == null)        throw new ArgumentNullException(nameof(sourceId));
+            if (referenceTypeId == null) throw new ArgumentNullException(nameof(referenceTypeId));
 
             lock (m_lock)
             {
@@ -1655,8 +1655,8 @@ namespace Opc.Ua.Server
         /// </summary>
         public NodeId FindTargetId(NodeId sourceId, NodeId referenceTypeId, bool isInverse, QualifiedName browseName)
         {
-            if (sourceId == null)        throw new ArgumentNullException("sourceId");
-            if (referenceTypeId == null) throw new ArgumentNullException("referenceTypeId");
+            if (sourceId == null)        throw new ArgumentNullException(nameof(sourceId));
+            if (referenceTypeId == null) throw new ArgumentNullException(nameof(referenceTypeId));
 
             lock (m_lock)
             {
@@ -1787,8 +1787,8 @@ namespace Opc.Ua.Server
         /// </remarks>
         public void RegisterSource(NodeId nodeId, object source, object handle, bool isEventSource)
         {
-            if (nodeId == null) throw new ArgumentNullException("nodeId");
-            if (source == null) throw new ArgumentNullException("source");
+            if (nodeId == null) throw new ArgumentNullException(nameof(nodeId));
+            if (source == null) throw new ArgumentNullException(nameof(source));
         }   
 
         /// <summary>
@@ -1817,8 +1817,8 @@ namespace Opc.Ua.Server
             ILocalNode templateDeclaration, 
             ushort     namespaceIndex)
         {
-            if (instance == null) throw new ArgumentNullException("instance");
-            if (typeDefinition == null) throw new ArgumentNullException("typeDefinition");
+            if (instance == null) throw new ArgumentNullException(nameof(instance));
+            if (typeDefinition == null) throw new ArgumentNullException(nameof(typeDefinition));
 
             // check existing type definition.
             UpdateTypeDefinition(instance, typeDefinition.NodeId);
@@ -2109,8 +2109,8 @@ namespace Opc.Ua.Server
         /// </summary>
         private void BuildDeclarationList(ILocalNode typeDefinition, List<DeclarationNode> declarations)
         {
-            if (typeDefinition == null) throw new ArgumentNullException("typeDefinition");
-            if (declarations == null) throw new ArgumentNullException("declarations");
+            if (typeDefinition == null) throw new ArgumentNullException(nameof(typeDefinition));
+            if (declarations == null) throw new ArgumentNullException(nameof(declarations));
 
             // guard against loops (i.e. common grandparents).
             for (int ii = 0; ii < declarations.Count; ii++)
@@ -2151,8 +2151,8 @@ namespace Opc.Ua.Server
         /// </summary>
         private void BuildDeclarationList(DeclarationNode parent, List<DeclarationNode> declarations)
         {            
-            if (parent == null) throw new ArgumentNullException("parent");
-            if (declarations == null) throw new ArgumentNullException("declarations");
+            if (parent == null) throw new ArgumentNullException(nameof(parent));
+            if (declarations == null) throw new ArgumentNullException(nameof(declarations));
 
             // get list of children.
             IList<IReference> references = parent.Node.References.Find(ReferenceTypeIds.HierarchicalReferences, false, true, m_nodes.TypeTree);
@@ -2196,8 +2196,8 @@ namespace Opc.Ua.Server
         /// </summary>
         private void BuildInstanceList(ILocalNode parent, string browsePath, IDictionary<string,ILocalNode> instances)
         { 
-            if (parent == null) throw new ArgumentNullException("parent");
-            if (instances == null) throw new ArgumentNullException("instances");
+            if (parent == null) throw new ArgumentNullException(nameof(parent));
+            if (instances == null) throw new ArgumentNullException(nameof(instances));
             
             // guard against loops.
             if (instances.ContainsKey(browsePath))
@@ -2430,7 +2430,7 @@ namespace Opc.Ua.Server
         /// </summary>
         public void DeleteNode(NodeId nodeId, bool deleteChildren, bool silent)
         {
-            if (nodeId == null) throw new ArgumentNullException("nodeId");
+            if (nodeId == null) throw new ArgumentNullException(nameof(nodeId));
             
             // find the node to delete.
             ILocalNode node = GetManagerHandle(nodeId) as ILocalNode;
@@ -2479,7 +2479,7 @@ namespace Opc.Ua.Server
         /// </summary>
         private void DeleteNode(ILocalNode node, bool deleteChildren, bool instance, Dictionary<NodeId,IList<IReference>> referencesToDelete)
         {
-            if (node == null) throw new ArgumentNullException("node");
+            if (node == null) throw new ArgumentNullException(nameof(node));
 
             List<ILocalNode> nodesToDelete = new List<ILocalNode>();
             List<IReference> referencesForNode = new List<IReference>();
@@ -2813,9 +2813,9 @@ namespace Opc.Ua.Server
             ExpandedNodeId targetId, 
             bool           deleteBidirectional)
         {
-            if (sourceHandle == null)    throw new ArgumentNullException("sourceHandle");
-            if (referenceTypeId == null) throw new ArgumentNullException("referenceTypeId");
-            if (targetId == null)        throw new ArgumentNullException("targetId");
+            if (sourceHandle == null)    throw new ArgumentNullException(nameof(sourceHandle));
+            if (referenceTypeId == null) throw new ArgumentNullException(nameof(referenceTypeId));
+            if (targetId == null)        throw new ArgumentNullException(nameof(targetId));
 
             lock (m_lock)
             {
@@ -3029,7 +3029,7 @@ namespace Opc.Ua.Server
         /// </summary>
         private void AttachNode(ILocalNode node, bool isInternal)
         {
-            if (node == null) throw new ArgumentNullException("node");
+            if (node == null) throw new ArgumentNullException(nameof(node));
 
             lock (m_lock)
             {

--- a/SampleApplications/SDK/Opc.Ua.Server/NodeManager/EventManager.cs
+++ b/SampleApplications/SDK/Opc.Ua.Server/NodeManager/EventManager.cs
@@ -46,7 +46,7 @@ namespace Opc.Ua.Server
         /// </summary>
         public EventManager(IServerInternal server, uint maxQueueSize)
         {
-            if (server == null) throw new ArgumentNullException("server");
+            if (server == null) throw new ArgumentNullException(nameof(server));
 
             m_server = server;
             m_monitoredItems = new Dictionary<uint,IEventMonitoredItem>();
@@ -92,7 +92,7 @@ namespace Opc.Ua.Server
         /// </summary>
         public static void ReportEvent(IFilterTarget e, IList<IEventMonitoredItem> monitoredItems)
         {
-            if (e == null) throw new ArgumentNullException("e");
+            if (e == null) throw new ArgumentNullException(nameof(e));
             
             foreach (IEventMonitoredItem monitoredItem in monitoredItems)
             {

--- a/SampleApplications/SDK/Opc.Ua.Server/NodeManager/MasterNodeManager.cs
+++ b/SampleApplications/SDK/Opc.Ua.Server/NodeManager/MasterNodeManager.cs
@@ -50,8 +50,8 @@ namespace Opc.Ua.Server
             string                   dynamicNamespaceUri,
             params INodeManager[]    additionalManagers)
         {
-            if (server == null) throw new ArgumentNullException("server");
-            if (configuration == null) throw new ArgumentNullException("configuration");
+            if (server == null) throw new ArgumentNullException(nameof(server));
+            if (configuration == null) throw new ArgumentNullException(nameof(configuration));
 
             m_server = server;
             m_nodeManagers = new List<INodeManager>();
@@ -342,8 +342,8 @@ namespace Opc.Ua.Server
         /// <exception cref="ArgumentNullException">Throw if the namespaceUri or the nodeManager are null.</exception>
         public void RegisterNamespaceManager(string namespaceUri, INodeManager nodeManager)
         {
-            if (String.IsNullOrEmpty(namespaceUri)) throw new ArgumentNullException("namespaceUri");
-            if (nodeManager == null) throw new ArgumentNullException("nodeManager");
+            if (String.IsNullOrEmpty(namespaceUri)) throw new ArgumentNullException(nameof(namespaceUri));
+            if (nodeManager == null) throw new ArgumentNullException(nameof(nodeManager));
 
             // look up the namespace uri.
             int index = m_server.NamespaceUris.GetIndex(namespaceUri);
@@ -520,7 +520,7 @@ namespace Opc.Ua.Server
             NodeIdCollection nodesToRegister,
             out NodeIdCollection registeredNodeIds)
         {
-            if (nodesToRegister == null) throw new ArgumentNullException("nodesToRegister");
+            if (nodesToRegister == null) throw new ArgumentNullException(nameof(nodesToRegister));
 
             // return the node id provided.
             registeredNodeIds = new NodeIdCollection(nodesToRegister.Count);
@@ -557,7 +557,7 @@ namespace Opc.Ua.Server
             OperationContext context,
             NodeIdCollection nodesToUnregister)
         {
-            if (nodesToUnregister == null) throw new ArgumentNullException("nodesToUnregister");
+            if (nodesToUnregister == null) throw new ArgumentNullException(nameof(nodesToUnregister));
 
             Utils.Trace(
                 (int)Utils.TraceMasks.ServiceDetail,
@@ -589,7 +589,7 @@ namespace Opc.Ua.Server
             out BrowsePathResultCollection results, 
             out DiagnosticInfoCollection   diagnosticInfos)
         {
-            if (browsePaths == null)throw new ArgumentNullException("browsePaths");
+            if (browsePaths == null)throw new ArgumentNullException(nameof(browsePaths));
             
             bool diagnosticsExist = false;
             results = new BrowsePathResultCollection(browsePaths.Count);
@@ -904,8 +904,8 @@ namespace Opc.Ua.Server
             out BrowseResultCollection   results,
             out DiagnosticInfoCollection diagnosticInfos)
         {
-            if (context == null) throw new ArgumentNullException("context");
-            if (nodesToBrowse == null) throw new ArgumentNullException("nodesToBrowse");
+            if (context == null) throw new ArgumentNullException(nameof(context));
+            if (nodesToBrowse == null) throw new ArgumentNullException(nameof(nodesToBrowse));
 
             if (view != null && !NodeId.IsNull(view.ViewId))
             {
@@ -1013,8 +1013,8 @@ namespace Opc.Ua.Server
             out BrowseResultCollection   results,
             out DiagnosticInfoCollection diagnosticInfos)
         {            
-            if (context == null) throw new ArgumentNullException("context");
-            if (continuationPoints == null) throw new ArgumentNullException("continuationPoints");
+            if (context == null) throw new ArgumentNullException(nameof(context));
+            if (continuationPoints == null) throw new ArgumentNullException(nameof(continuationPoints));
 
             bool diagnosticsExist = false;
             results = new BrowseResultCollection(continuationPoints.Count);
@@ -1288,8 +1288,8 @@ namespace Opc.Ua.Server
             BrowseResultMask     resultMask,
             ReferenceDescription description)
         {
-            if (targetId == null)    throw new ArgumentNullException("targetId");
-            if (description == null) throw new ArgumentNullException("description");
+            if (targetId == null)    throw new ArgumentNullException(nameof(targetId));
+            if (description == null) throw new ArgumentNullException(nameof(description));
                         
             // find node manager that owns the node.
             INodeManager nodeManager = null;                
@@ -1341,7 +1341,7 @@ namespace Opc.Ua.Server
             out DataValueCollection      values,
             out DiagnosticInfoCollection diagnosticInfos)
         {
-            if (nodesToRead == null) throw new ArgumentNullException("nodesToRead");
+            if (nodesToRead == null) throw new ArgumentNullException(nameof(nodesToRead));
             
             if (maxAge < 0)
             {
@@ -1598,8 +1598,8 @@ namespace Opc.Ua.Server
             out StatusCodeCollection     results, 
             out DiagnosticInfoCollection diagnosticInfos)
         {
-            if (context == null)      throw new ArgumentNullException("context");
-            if (nodesToWrite == null) throw new ArgumentNullException("nodesToWrite");
+            if (context == null)      throw new ArgumentNullException(nameof(context));
+            if (nodesToWrite == null) throw new ArgumentNullException(nameof(nodesToWrite));
 
             int count = nodesToWrite.Count;
 
@@ -1829,8 +1829,8 @@ namespace Opc.Ua.Server
             out CallMethodResultCollection results,
             out DiagnosticInfoCollection   diagnosticInfos)
         {
-            if (context == null)       throw new ArgumentNullException("context");
-            if (methodsToCall == null) throw new ArgumentNullException("methodsToCall");
+            if (context == null)       throw new ArgumentNullException(nameof(context));
+            if (methodsToCall == null) throw new ArgumentNullException(nameof(methodsToCall));
             
             bool diagnosticsExist = false;
             results = new CallMethodResultCollection(methodsToCall.Count);
@@ -1948,12 +1948,12 @@ namespace Opc.Ua.Server
             IList<MonitoringFilterResult>     filterResults,
             IList<IMonitoredItem>             monitoredItems)
         {
-            if (context == null)        throw new ArgumentNullException("context");
-            if (itemsToCreate == null)  throw new ArgumentNullException("itemsToCreate");
-            if (errors == null)         throw new ArgumentNullException("errors");
-            if (filterResults == null)   throw new ArgumentNullException("filterResults");
-            if (monitoredItems == null) throw new ArgumentNullException("monitoredItems");
-            if (publishingInterval < 0) throw new ArgumentOutOfRangeException("publishingInterval");
+            if (context == null)        throw new ArgumentNullException(nameof(context));
+            if (itemsToCreate == null)  throw new ArgumentNullException(nameof(itemsToCreate));
+            if (errors == null)         throw new ArgumentNullException(nameof(errors));
+            if (filterResults == null)   throw new ArgumentNullException(nameof(filterResults));
+            if (monitoredItems == null) throw new ArgumentNullException(nameof(monitoredItems));
+            if (publishingInterval < 0) throw new ArgumentOutOfRangeException(nameof(publishingInterval));
 
             if (timestampsToReturn < TimestampsToReturn.Source || timestampsToReturn > TimestampsToReturn.Neither)
             {
@@ -2155,11 +2155,11 @@ namespace Opc.Ua.Server
             IList<ServiceResult>              errors,
             IList<MonitoringFilterResult>     filterResults)
         {
-            if (context == null)        throw new ArgumentNullException("context");
-            if (itemsToModify == null)  throw new ArgumentNullException("itemsToModify");
-            if (monitoredItems == null) throw new ArgumentNullException("monitoredItems");
-            if (errors == null)         throw new ArgumentNullException("errors");
-            if (filterResults == null)   throw new ArgumentNullException("filterResults");
+            if (context == null)        throw new ArgumentNullException(nameof(context));
+            if (itemsToModify == null)  throw new ArgumentNullException(nameof(itemsToModify));
+            if (monitoredItems == null) throw new ArgumentNullException(nameof(monitoredItems));
+            if (errors == null)         throw new ArgumentNullException(nameof(errors));
+            if (filterResults == null)   throw new ArgumentNullException(nameof(filterResults));
 
             if (timestampsToReturn < TimestampsToReturn.Source || timestampsToReturn > TimestampsToReturn.Neither)
             {
@@ -2321,9 +2321,9 @@ namespace Opc.Ua.Server
             IList<IMonitoredItem> itemsToDelete, 
             IList<ServiceResult>  errors)
         {  
-            if (context == null)       throw new ArgumentNullException("context");
-            if (itemsToDelete == null) throw new ArgumentNullException("itemsToDelete");
-            if (errors == null)        throw new ArgumentNullException("errors");
+            if (context == null)       throw new ArgumentNullException(nameof(context));
+            if (itemsToDelete == null) throw new ArgumentNullException(nameof(itemsToDelete));
+            if (errors == null)        throw new ArgumentNullException(nameof(errors));
 
             List<bool> processedItems = new List<bool>(itemsToDelete.Count);
 
@@ -2414,9 +2414,9 @@ namespace Opc.Ua.Server
             IList<IMonitoredItem> itemsToModify, 
             IList<ServiceResult>  errors)
         {
-            if (context == null)       throw new ArgumentNullException("context");
-            if (itemsToModify == null) throw new ArgumentNullException("itemsToModify");
-            if (errors == null)        throw new ArgumentNullException("errors");
+            if (context == null)       throw new ArgumentNullException(nameof(context));
+            if (itemsToModify == null) throw new ArgumentNullException(nameof(itemsToModify));
+            if (errors == null)        throw new ArgumentNullException(nameof(errors));
 
             // call each node manager.
             List<bool> processedItems = new List<bool>(itemsToModify.Count);

--- a/SampleApplications/SDK/Opc.Ua.Server/NodeManager/ResourceManager.cs
+++ b/SampleApplications/SDK/Opc.Ua.Server/NodeManager/ResourceManager.cs
@@ -48,8 +48,8 @@ namespace Opc.Ua.Server
         /// </summary>
         public ResourceManager(IServerInternal server, ApplicationConfiguration configuration)
         {
-            if (server == null) throw new ArgumentNullException("server");    
-            if (configuration == null) throw new ArgumentNullException("configuration");
+            if (server == null) throw new ArgumentNullException(nameof(server));    
+            if (configuration == null) throw new ArgumentNullException(nameof(configuration));
            
             m_server = server;
             m_translationTables = new List<TranslationTable>();
@@ -192,15 +192,15 @@ namespace Opc.Ua.Server
         /// </summary>
         public void Add(string key, string locale, string text)
         {
-            if (key == null) throw new ArgumentNullException("key");
-            if (locale == null) throw new ArgumentNullException("locale");
-            if (text == null) throw new ArgumentNullException("text");
+            if (key == null) throw new ArgumentNullException(nameof(key));
+            if (locale == null) throw new ArgumentNullException(nameof(locale));
+            if (text == null) throw new ArgumentNullException(nameof(text));
 
             CultureInfo culture = new CultureInfo(locale);
             
             if (culture.IsNeutralCulture)
             {
-                throw new ArgumentException("Cannot specify neutral locales for translation tables.", "locale");
+                throw new ArgumentException("Cannot specify neutral locales for translation tables.", nameof(locale));
             }
 
             lock (m_lock)
@@ -215,14 +215,14 @@ namespace Opc.Ua.Server
         /// </summary>
         public void Add(string locale, IDictionary<string,string> translations)
         {
-            if (locale == null) throw new ArgumentNullException("locale");
-            if (translations == null) throw new ArgumentNullException("translations");
+            if (locale == null) throw new ArgumentNullException(nameof(locale));
+            if (translations == null) throw new ArgumentNullException(nameof(translations));
 
             CultureInfo culture = new CultureInfo(locale);
             
             if (culture.IsNeutralCulture)
             {
-                throw new ArgumentException("Cannot specify neutral locales for translation tables.", "locale");
+                throw new ArgumentException("Cannot specify neutral locales for translation tables.", nameof(locale));
             }
 
             lock (m_lock)

--- a/SampleApplications/SDK/Opc.Ua.Server/NodeManager/SamplingGroup.cs
+++ b/SampleApplications/SDK/Opc.Ua.Server/NodeManager/SamplingGroup.cs
@@ -53,9 +53,9 @@ namespace Opc.Ua.Server
             OperationContext        context,
             double                  samplingInterval)
         {
-            if (server == null)        throw new ArgumentNullException("server");
-            if (nodeManager == null)   throw new ArgumentNullException("nodeManager");
-            if (samplingRates == null) throw new ArgumentNullException("samplingRates");
+            if (server == null)        throw new ArgumentNullException(nameof(server));
+            if (nodeManager == null)   throw new ArgumentNullException(nameof(nodeManager));
+            if (samplingRates == null) throw new ArgumentNullException(nameof(samplingRates));
 
             m_server           = server;
             m_nodeManager      = nodeManager;

--- a/SampleApplications/SDK/Opc.Ua.Server/NodeManager/SamplingGroupManager.cs
+++ b/SampleApplications/SDK/Opc.Ua.Server/NodeManager/SamplingGroupManager.cs
@@ -50,8 +50,8 @@ namespace Opc.Ua.Server
             uint                           maxQueueSize,
             IEnumerable<SamplingRateGroup> samplingRates)
         {
-            if (server == null)      throw new ArgumentNullException("server");
-            if (nodeManager == null) throw new ArgumentNullException("nodeManager");
+            if (server == null)      throw new ArgumentNullException(nameof(server));
+            if (nodeManager == null) throw new ArgumentNullException(nameof(nodeManager));
 
             m_server          = server;
             m_nodeManager     = nodeManager;

--- a/SampleApplications/SDK/Opc.Ua.Server/Server/OperationContext.cs
+++ b/SampleApplications/SDK/Opc.Ua.Server/Server/OperationContext.cs
@@ -46,7 +46,7 @@ namespace Opc.Ua.Server
         /// <param name="requestType">Type of the request.</param>
         public OperationContext(RequestHeader requestHeader, RequestType requestType, IUserIdentity identity = null)
         {
-            if (requestHeader == null) throw new ArgumentNullException("requestHeader");
+            if (requestHeader == null) throw new ArgumentNullException(nameof(requestHeader));
             
             m_channelContext    = SecureChannelContext.Current;
             m_session           = null;
@@ -74,8 +74,8 @@ namespace Opc.Ua.Server
         /// <param name="session">The session.</param>
         public OperationContext(RequestHeader requestHeader, RequestType requestType, Session session)
         {
-            if (requestHeader == null) throw new ArgumentNullException("requestHeader");
-            if (session == null)       throw new ArgumentNullException("session");
+            if (requestHeader == null) throw new ArgumentNullException(nameof(requestHeader));
+            if (session == null)       throw new ArgumentNullException(nameof(session));
             
             m_channelContext     = SecureChannelContext.Current;
             m_session            = session;
@@ -102,7 +102,7 @@ namespace Opc.Ua.Server
         /// <param name="diagnosticsMasks">The diagnostics masks.</param>
         public OperationContext(Session session, DiagnosticsMasks diagnosticsMasks)
         {
-            if (session == null) throw new ArgumentNullException("session");
+            if (session == null) throw new ArgumentNullException(nameof(session));
             
             m_channelContext    = null;
             m_session           = session;
@@ -123,7 +123,7 @@ namespace Opc.Ua.Server
         /// <param name="monitoredItem">The monitored item.</param>
         public OperationContext(IMonitoredItem monitoredItem)
         {
-            if (monitoredItem == null) throw new ArgumentNullException("monitoredItem");
+            if (monitoredItem == null) throw new ArgumentNullException(nameof(monitoredItem));
             
             m_channelContext = null;
             m_session = monitoredItem.Session;

--- a/SampleApplications/SDK/Opc.Ua.Server/Server/RequestManager.cs
+++ b/SampleApplications/SDK/Opc.Ua.Server/Server/RequestManager.cs
@@ -47,7 +47,7 @@ namespace Opc.Ua.Server
         /// <param name="server"></param>
         public RequestManager(IServerInternal server)
         {
-            if (server == null) throw new ArgumentNullException("server");
+            if (server == null) throw new ArgumentNullException(nameof(server));
 
             m_server       = server;
             m_requests     = new Dictionary<uint,OperationContext>();
@@ -120,7 +120,7 @@ namespace Opc.Ua.Server
         /// <param name="context"></param>
         public void RequestReceived(OperationContext context)
         {
-            if (context == null) throw new ArgumentNullException("context");
+            if (context == null) throw new ArgumentNullException(nameof(context));
 
             lock (m_requests)
             {
@@ -138,7 +138,7 @@ namespace Opc.Ua.Server
         /// </summary>
         public void RequestCompleted(OperationContext context)
         {
-            if (context == null) throw new ArgumentNullException("context");
+            if (context == null) throw new ArgumentNullException(nameof(context));
 
             lock (m_requests)
             {      

--- a/SampleApplications/SDK/Opc.Ua.Server/Session/Session.cs
+++ b/SampleApplications/SDK/Opc.Ua.Server/Session/Session.cs
@@ -78,8 +78,8 @@ namespace Opc.Ua.Server
             int                     maxBrowseContinuationPoints,
             int                     maxHistoryContinuationPoints)
         {
-            if (context == null) throw new ArgumentNullException("context");
-            if (server == null)  throw new ArgumentNullException("server");
+            if (context == null) throw new ArgumentNullException(nameof(context));
+            if (server == null)  throw new ArgumentNullException(nameof(server));
             
             // verify that a secure channel was specified.
             if (context.ChannelContext == null)
@@ -435,7 +435,7 @@ namespace Opc.Ua.Server
         /// </summary>
         public virtual void ValidateRequest(RequestHeader requestHeader, RequestType requestType)
         {
-            if (requestHeader == null) throw new ArgumentNullException("requestHeader");
+            if (requestHeader == null) throw new ArgumentNullException(nameof(requestHeader));
             
             lock (m_lock)
             {
@@ -487,7 +487,7 @@ namespace Opc.Ua.Server
         /// <returns>true if the new locale ids are different from the old locale ids.</returns>
         public bool UpdateLocaleIds(StringCollection localeIds)
         {
-            if (localeIds == null) throw new ArgumentNullException("localeIds");
+            if (localeIds == null) throw new ArgumentNullException(nameof(localeIds));
                         
             lock (m_lock)
             {                
@@ -704,7 +704,7 @@ namespace Opc.Ua.Server
         /// </remarks>
         public void SaveContinuationPoint(ContinuationPoint continuationPoint)
         {
-            if (continuationPoint == null) throw new ArgumentNullException("continuationPoint");
+            if (continuationPoint == null) throw new ArgumentNullException(nameof(continuationPoint));
 
             lock (m_lock)
             {
@@ -773,7 +773,7 @@ namespace Opc.Ua.Server
         /// </remarks>
         public void SaveHistoryContinuationPoint(Guid id, object continuationPoint)
         {
-            if (continuationPoint == null) throw new ArgumentNullException("continuationPoint");
+            if (continuationPoint == null) throw new ArgumentNullException(nameof(continuationPoint));
 
             lock (m_lock)
             {
@@ -1095,7 +1095,7 @@ namespace Opc.Ua.Server
             IUserIdentity     identity, 
             IUserIdentity     effectiveIdentity)
         {
-            if (identityToken == null) throw new ArgumentNullException("identityToken");
+            if (identityToken == null) throw new ArgumentNullException(nameof(identityToken));
 
             lock (m_lock)
             {

--- a/SampleApplications/SDK/Opc.Ua.Server/Session/Session.cs
+++ b/SampleApplications/SDK/Opc.Ua.Server/Session/Session.cs
@@ -1040,7 +1040,7 @@ namespace Opc.Ua.Server
                 {
                     if (e is ServiceResultException)
                     {
-                        throw e;
+                        throw;
                     }
 
                     throw ServiceResultException.Create(StatusCodes.BadIdentityTokenInvalid, e, "Could not decrypt identity token.");

--- a/SampleApplications/SDK/Opc.Ua.Server/Session/SessionManager.cs
+++ b/SampleApplications/SDK/Opc.Ua.Server/Session/SessionManager.cs
@@ -49,8 +49,8 @@ namespace Opc.Ua.Server
             IServerInternal server,
             ApplicationConfiguration configuration)
         {
-            if (server == null) throw new ArgumentNullException("server");
-            if (configuration == null) throw new ArgumentNullException("configuration");
+            if (server == null) throw new ArgumentNullException(nameof(server));
+            if (configuration == null) throw new ArgumentNullException(nameof(configuration));
 
             m_server = server;
 
@@ -431,7 +431,7 @@ namespace Opc.Ua.Server
         /// </remarks>
         public virtual OperationContext ValidateRequest(RequestHeader requestHeader, RequestType requestType)
         {
-            if (requestHeader == null) throw new ArgumentNullException("requestHeader");
+            if (requestHeader == null) throw new ArgumentNullException(nameof(requestHeader));
 
             Session session = null;
 

--- a/SampleApplications/SDK/Opc.Ua.Server/Session/SessionManager.cs
+++ b/SampleApplications/SDK/Opc.Ua.Server/Session/SessionManager.cs
@@ -344,7 +344,7 @@ namespace Opc.Ua.Server
             {
                 if (e is ServiceResultException)
                 {
-                    throw e;
+                    throw;
                 }
 
                 throw ServiceResultException.Create(

--- a/SampleApplications/SDK/Opc.Ua.Server/Subscription/MonitoredItem.cs
+++ b/SampleApplications/SDK/Opc.Ua.Server/Subscription/MonitoredItem.cs
@@ -63,7 +63,7 @@ namespace Opc.Ua.Server
             bool                discardOldest,
             double              sourceSamplingInterval)
         {
-            if (itemToMonitor == null) throw new ArgumentNullException("itemToMonitor");
+            if (itemToMonitor == null) throw new ArgumentNullException(nameof(itemToMonitor));
             
             Initialize();
             
@@ -1006,7 +1006,7 @@ namespace Opc.Ua.Server
         /// </summary>
         public virtual void QueueEvent(IFilterTarget instance, bool bypassFilter)
         {
-            if (instance == null) throw new ArgumentNullException("instance");
+            if (instance == null) throw new ArgumentNullException(nameof(instance));
          
             lock (m_lock)
             {
@@ -1160,8 +1160,8 @@ namespace Opc.Ua.Server
         /// </summary>
         public virtual bool Publish(OperationContext context, Queue<EventFieldList> notifications)
         {
-            if (context == null)       throw new ArgumentNullException("context");
-            if (notifications == null) throw new ArgumentNullException("notifications");
+            if (context == null)       throw new ArgumentNullException(nameof(context));
+            if (notifications == null) throw new ArgumentNullException(nameof(notifications));
 
             lock (m_lock)
             {
@@ -1270,9 +1270,9 @@ namespace Opc.Ua.Server
             Queue<MonitoredItemNotification> notifications,
             Queue<DiagnosticInfo>            diagnostics)
         {
-            if (context == null)       throw new ArgumentNullException("context");
-            if (notifications == null) throw new ArgumentNullException("notifications");
-            if (diagnostics == null)   throw new ArgumentNullException("diagnostics");
+            if (context == null)       throw new ArgumentNullException(nameof(context));
+            if (notifications == null) throw new ArgumentNullException(nameof(notifications));
+            if (diagnostics == null)   throw new ArgumentNullException(nameof(diagnostics));
             
             lock (m_lock)
             {
@@ -1485,7 +1485,7 @@ namespace Opc.Ua.Server
         /// </summary>
         protected virtual bool ApplyFilter(DataValue value, ServiceResult error)
         {
-            if (value == null) throw new ArgumentNullException("value");
+            if (value == null) throw new ArgumentNullException(nameof(value));
 
             bool changed = ValueChanged(
                 value,
@@ -1509,7 +1509,7 @@ namespace Opc.Ua.Server
             DataChangeFilter filter,
             double range)
         {
-            if (value == null) throw new ArgumentNullException("value");
+            if (value == null) throw new ArgumentNullException(nameof(value));
 
             // select default data change filters.
             double deadband = 0.0;

--- a/SampleApplications/SDK/Opc.Ua.Server/Subscription/SessionPublishQueue.cs
+++ b/SampleApplications/SDK/Opc.Ua.Server/Subscription/SessionPublishQueue.cs
@@ -45,8 +45,8 @@ namespace Opc.Ua.Server
         /// </summary>
         public SessionPublishQueue(IServerInternal server, Session session, int maxPublishRequests)
         {
-            if (server == null)  throw new ArgumentNullException("server");
-            if (session == null) throw new ArgumentNullException("session");
+            if (server == null)  throw new ArgumentNullException(nameof(server));
+            if (session == null) throw new ArgumentNullException(nameof(session));
 
             m_server              = server;
             m_session             = session;
@@ -143,7 +143,7 @@ namespace Opc.Ua.Server
         /// </summary>
         public void Add(Subscription subscription)
         {
-            if (subscription == null) throw new ArgumentNullException("subscription");
+            if (subscription == null) throw new ArgumentNullException(nameof(subscription));
 
             lock (m_lock)
             {
@@ -164,7 +164,7 @@ namespace Opc.Ua.Server
         /// </summary>
         public void Remove(Subscription subscription)
         {
-            if (subscription == null) throw new ArgumentNullException("subscription");
+            if (subscription == null) throw new ArgumentNullException(nameof(subscription));
 
             lock (m_lock)
             {
@@ -203,8 +203,8 @@ namespace Opc.Ua.Server
             out StatusCodeCollection              acknowledgeResults, 
             out DiagnosticInfoCollection          acknowledgeDiagnosticInfos)
         {
-            if (context == null) throw new ArgumentNullException("context");
-            if (subscriptionAcknowledgements == null) throw new ArgumentNullException("subscriptionAcknowledgements");
+            if (context == null) throw new ArgumentNullException(nameof(context));
+            if (subscriptionAcknowledgements == null) throw new ArgumentNullException(nameof(subscriptionAcknowledgements));
 
             lock (m_lock)
             {                

--- a/SampleApplications/SDK/Opc.Ua.Server/Subscription/Subscription.cs
+++ b/SampleApplications/SDK/Opc.Ua.Server/Subscription/Subscription.cs
@@ -89,8 +89,8 @@ namespace Opc.Ua.Server
             bool             publishingEnabled,
             uint             maxMessageCount)
         {       
-            if (server == null)  throw new ArgumentNullException("server");
-            if (session == null) throw new ArgumentNullException("session");
+            if (server == null)  throw new ArgumentNullException(nameof(server));
+            if (session == null) throw new ArgumentNullException(nameof(session));
 
             m_server                      = server;
             m_session                     = session;
@@ -618,7 +618,7 @@ namespace Opc.Ua.Server
             out UInt32Collection  availableSequenceNumbers, 
             out bool              moreNotifications)
         {   
-            if (context == null) throw new ArgumentNullException("context");
+            if (context == null) throw new ArgumentNullException(nameof(context));
             
             NotificationMessage message = null;
 
@@ -987,7 +987,7 @@ namespace Opc.Ua.Server
             OperationContext context,
             uint             retransmitSequenceNumber)
         {            
-            if (context == null) throw new ArgumentNullException("context");
+            if (context == null) throw new ArgumentNullException(nameof(context));
 
             lock (DiagnosticsWriteLock)
             {
@@ -1135,9 +1135,9 @@ namespace Opc.Ua.Server
             out StatusCodeCollection removeResults,
             out DiagnosticInfoCollection removeDiagnosticInfos)
         {
-            if (context == null) throw new ArgumentNullException("context");
-            if (linksToAdd == null) throw new ArgumentNullException("linksToAdd");
-            if (linksToRemove == null) throw new ArgumentNullException("linksToRemove");
+            if (context == null) throw new ArgumentNullException(nameof(context));
+            if (linksToAdd == null) throw new ArgumentNullException(nameof(linksToAdd));
+            if (linksToRemove == null) throw new ArgumentNullException(nameof(linksToRemove));
 
             // allocate results.
             bool diagnosticsExist = false;
@@ -1305,8 +1305,8 @@ namespace Opc.Ua.Server
             out MonitoredItemCreateResultCollection results, 
             out DiagnosticInfoCollection            diagnosticInfos)
         {
-            if (context == null)       throw new ArgumentNullException("context");
-            if (itemsToCreate == null) throw new ArgumentNullException("itemsToCreate");
+            if (context == null)       throw new ArgumentNullException(nameof(context));
+            if (itemsToCreate == null) throw new ArgumentNullException(nameof(itemsToCreate));
             
             int count = itemsToCreate.Count;
             
@@ -1498,8 +1498,8 @@ namespace Opc.Ua.Server
             out MonitoredItemModifyResultCollection results,
             out DiagnosticInfoCollection            diagnosticInfos)
         {
-            if (context == null)       throw new ArgumentNullException("context");
-            if (itemsToModify == null) throw new ArgumentNullException("itemsToModify");
+            if (context == null)       throw new ArgumentNullException(nameof(context));
+            if (itemsToModify == null) throw new ArgumentNullException(nameof(itemsToModify));
 
             int count = itemsToModify.Count;
 
@@ -1661,8 +1661,8 @@ namespace Opc.Ua.Server
             out StatusCodeCollection     results,
             out DiagnosticInfoCollection diagnosticInfos)
         {
-            if (context == null)          throw new ArgumentNullException("context");
-            if (monitoredItemIds == null) throw new ArgumentNullException("monitoredItemIds");
+            if (context == null)          throw new ArgumentNullException(nameof(context));
+            if (monitoredItemIds == null) throw new ArgumentNullException(nameof(monitoredItemIds));
 
             int count = monitoredItemIds.Count;
 
@@ -1817,8 +1817,8 @@ namespace Opc.Ua.Server
             out StatusCodeCollection     results, 
             out DiagnosticInfoCollection diagnosticInfos)
         {  
-            if (context == null)          throw new ArgumentNullException("context");
-            if (monitoredItemIds == null) throw new ArgumentNullException("monitoredItemIds");
+            if (context == null)          throw new ArgumentNullException(nameof(context));
+            if (monitoredItemIds == null) throw new ArgumentNullException(nameof(monitoredItemIds));
 
             int count = monitoredItemIds.Count;
 

--- a/SampleApplications/SDK/Opc.Ua.Server/Subscription/SubscriptionManager.cs
+++ b/SampleApplications/SDK/Opc.Ua.Server/Subscription/SubscriptionManager.cs
@@ -49,8 +49,8 @@ namespace Opc.Ua.Server
             IServerInternal          server,
             ApplicationConfiguration configuration)
         {
-            if (server == null)        throw new ArgumentNullException("server");
-            if (configuration == null) throw new ArgumentNullException("configuration");
+            if (server == null)        throw new ArgumentNullException(nameof(server));
+            if (configuration == null) throw new ArgumentNullException(nameof(configuration));
             
             m_server = server;
             

--- a/SampleApplications/Samples/GDS/ClientCommon/GlobalDiscoveryServerClient.cs
+++ b/SampleApplications/Samples/GDS/ClientCommon/GlobalDiscoveryServerClient.cs
@@ -244,7 +244,7 @@ namespace Opc.Ua.Gds.Client
                     }
                     else
                     {
-                        throw e;
+                        throw;
                     }
                 }
             } while (serverHalted);

--- a/SampleApplications/Samples/GDS/ClientCommon/GlobalDiscoveryServerClient.cs
+++ b/SampleApplications/Samples/GDS/ClientCommon/GlobalDiscoveryServerClient.cs
@@ -1,4 +1,4 @@
-﻿/* ========================================================================
+/* ========================================================================
  * Copyright (c) 2005-2019 The OPC Foundation, Inc. All rights reserved.
  *
  * OPC Foundation MIT License 1.00
@@ -220,7 +220,7 @@ namespace Opc.Ua.Gds.Client
 
             if (!Uri.IsWellFormedUriString(endpointUrl, UriKind.Absolute))
             {
-                throw new ArgumentException(endpointUrl + " is not a valid URL.", "endpointUrl");
+                throw new ArgumentException(endpointUrl + " is not a valid URL.", nameof(endpointUrl));
             }
 
             bool serverHalted = false;
@@ -267,7 +267,7 @@ namespace Opc.Ua.Gds.Client
 
                 if (endpoint == null)
                 {
-                    throw new ArgumentNullException("endpoint");
+                    throw new ArgumentNullException(nameof(endpoint));
                 }
             }
 

--- a/SampleApplications/Samples/GDS/ClientCommon/LocalDiscoveryServerClient.cs
+++ b/SampleApplications/Samples/GDS/ClientCommon/LocalDiscoveryServerClient.cs
@@ -1,4 +1,4 @@
-﻿/* ========================================================================
+/* ========================================================================
  * Copyright (c) 2005-2019 The OPC Foundation, Inc. All rights reserved.
  *
  * OPC Foundation MIT License 1.00
@@ -409,7 +409,7 @@ namespace Opc.Ua.Gds.Client
 
             if (!Uri.IsWellFormedUriString(endpointUrl, UriKind.Absolute))
             {
-                throw new ArgumentException("Not a valid URL.", "endpointUrl");
+                throw new ArgumentException("Not a valid URL.", nameof(endpointUrl));
             }
 
             ServiceMessageContext context = ApplicationConfiguration.CreateMessageContext();

--- a/SampleApplications/Samples/GDS/ClientCommon/ServerPushConfigurationClient.cs
+++ b/SampleApplications/Samples/GDS/ClientCommon/ServerPushConfigurationClient.cs
@@ -491,7 +491,7 @@ namespace Opc.Ua.Gds.Client
 
                     return (bool)outputArguments[0];
                 }
-                catch (Exception e)
+                catch (Exception)
                 {
                     if (IsConnected)
                     {
@@ -501,7 +501,7 @@ namespace Opc.Ua.Gds.Client
                             fileHandle);
                     }
 
-                    throw e;
+                    throw;
                 }
             }
             finally

--- a/SampleApplications/Samples/GDS/ClientCommon/ServerPushConfigurationClient.cs
+++ b/SampleApplications/Samples/GDS/ClientCommon/ServerPushConfigurationClient.cs
@@ -298,7 +298,7 @@ namespace Opc.Ua.Gds.Client
             {
                 try
                 {
-                    Callback(this, new EventArgs());
+                    Callback(this, EventArgs.Empty);
                 }
                 catch (Exception exception)
                 {

--- a/SampleApplications/Samples/GDS/ClientCommon/ServerPushConfigurationClient.cs
+++ b/SampleApplications/Samples/GDS/ClientCommon/ServerPushConfigurationClient.cs
@@ -209,7 +209,7 @@ namespace Opc.Ua.Gds.Client
 
             if (!Uri.IsWellFormedUriString(endpointUrl, UriKind.Absolute))
             {
-                throw new ArgumentException(endpointUrl + " is not a valid URL.", "endpointUrl");
+                throw new ArgumentException(endpointUrl + " is not a valid URL.", nameof(endpointUrl));
             }
 
             EndpointDescription endpointDescription = CoreClientUtils.SelectEndpoint(endpointUrl, true);
@@ -236,7 +236,7 @@ namespace Opc.Ua.Gds.Client
 
                 if (endpoint == null)
                 {
-                    throw new ArgumentNullException("endpoint");
+                    throw new ArgumentNullException(nameof(endpoint));
                 }
             }
 

--- a/SampleApplications/Samples/GDS/ServerCommon/ApplicationsNodeManager.cs
+++ b/SampleApplications/Samples/GDS/ServerCommon/ApplicationsNodeManager.cs
@@ -341,7 +341,7 @@ namespace Opc.Ua.Gds.Server
                     {
                         Utils.Trace(e, "Unexpected error initializing certificateGroup: " + certificateGroupConfiguration.Id + "\r\n" + e.StackTrace);
                         // make sure gds server doesn't start without cert groups!
-                        throw e;
+                        throw;
                     }
                 }
 

--- a/Stack/Opc.Ua.Core/Schema/ApplicationConfiguration.cs
+++ b/Stack/Opc.Ua.Core/Schema/ApplicationConfiguration.cs
@@ -1246,10 +1246,10 @@ namespace Opc.Ua
                             SecurityMode = securityPolicy.SecurityMode,
                             SecurityPolicyUri = policyUri
                         };
-                        if (newPolicies.Where(s =>
+                        if (newPolicies.Find(s =>
                             s.SecurityMode == newPolicy.SecurityMode &&
                             String.Compare(s.SecurityPolicyUri, newPolicy.SecurityPolicyUri) == 0
-                            ).FirstOrDefault() == null)
+                            ) == null)
                         {
                             newPolicies.Add(newPolicy);
                         }
@@ -1261,10 +1261,10 @@ namespace Opc.Ua
                     {
                         if (securityPolicy.SecurityPolicyUri.Contains(supportedPolicies[i]))
                         {
-                            if (newPolicies.Where(s =>
+                            if (newPolicies.Find(s =>
                                 s.SecurityMode == securityPolicy.SecurityMode &&
                                 String.Compare(s.SecurityPolicyUri, securityPolicy.SecurityPolicyUri) == 0
-                                ).FirstOrDefault() == null)
+                                ) == null)
                             {
                                 newPolicies.Add(securityPolicy);
                             }

--- a/Stack/Opc.Ua.Core/Schema/UANodeSetHelpers.cs
+++ b/Stack/Opc.Ua.Core/Schema/UANodeSetHelpers.cs
@@ -125,7 +125,7 @@ namespace Opc.Ua.Export
         /// </summary>
         public void Export(ISystemContext context, NodeState node, bool outputRedundantNames =true)
         {
-            if (node == null) throw new ArgumentNullException("node");
+            if (node == null) throw new ArgumentNullException(nameof(node));
 
             if (Opc.Ua.NodeId.IsNull(node.NodeId))
             {

--- a/Stack/Opc.Ua.Core/Security/Certificates/CertificateFactory.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/CertificateFactory.cs
@@ -549,9 +549,9 @@ public class CertificateFactory
                 store.Close();
             }
         }
-        catch (Exception e)
+        catch (Exception)
         {
-            throw e;
+            throw;
         }
         return updatedCRL;
     }
@@ -933,11 +933,11 @@ public class CertificateFactory
                 throw new CryptographicException("Don't know how to verify the public/private key pair.");
             }
         }
-        catch (Exception e)
+        catch (Exception)
         {
             if (throwOnError)
             {
-                throw e;
+                throw;
             }
         }
         finally

--- a/Stack/Opc.Ua.Core/Security/Certificates/CertificateFactory.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/CertificateFactory.cs
@@ -973,7 +973,7 @@ public class CertificateFactory
 
         if (keySize % 1024 != 0)
         {
-            throw new ArgumentNullException("keySize", "KeySize must be a multiple of 1024.");
+            throw new ArgumentNullException(nameof(keySize), "KeySize must be a multiple of 1024.");
         }
 
         // enforce minimum lifetime.
@@ -995,7 +995,7 @@ public class CertificateFactory
         {
             if (subjectNameEntries == null)
             {
-                throw new ArgumentNullException("applicationName", "Must specify a applicationName or a subjectName.");
+                throw new ArgumentNullException(nameof(applicationName), "Must specify a applicationName or a subjectName.");
             }
 
             // use the common name as the application name.
@@ -1011,7 +1011,7 @@ public class CertificateFactory
 
         if (String.IsNullOrEmpty(applicationName))
         {
-            throw new ArgumentNullException("applicationName", "Must specify a applicationName or a subjectName.");
+            throw new ArgumentNullException(nameof(applicationName), "Must specify a applicationName or a subjectName.");
         }
 
         // remove special characters from name.

--- a/Stack/Opc.Ua.Core/Security/Certificates/CertificateIdentifier.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/CertificateIdentifier.cs
@@ -641,7 +641,7 @@ namespace Opc.Ua
         /// <param name="certificate">The certificate.</param>
         public async Task Add(X509Certificate2 certificate, string password = null)
         {
-            if (certificate == null) throw new ArgumentNullException("certificate");
+            if (certificate == null) throw new ArgumentNullException(nameof(certificate));
 
             for (int ii = 0; ii < this.Count; ii++)
             {

--- a/Stack/Opc.Ua.Core/Security/Certificates/CertificateValidator.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/CertificateValidator.cs
@@ -90,7 +90,7 @@ namespace Opc.Ua
         {
             if (configuration == null)
             {
-                throw new ArgumentNullException("configuration");
+                throw new ArgumentNullException(nameof(configuration));
             }
 
             await Update(configuration.SecurityConfiguration);
@@ -161,7 +161,7 @@ namespace Opc.Ua
         {
             if (configuration == null)
             {
-                throw new ArgumentNullException("configuration");
+                throw new ArgumentNullException(nameof(configuration));
             }
 
             lock (m_lock)

--- a/Stack/Opc.Ua.Core/Security/Certificates/DirectoryCertificateStore.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/DirectoryCertificateStore.cs
@@ -128,7 +128,7 @@ namespace Opc.Ua
         /// <summary cref="ICertificateStore.Add(X509Certificate2)" />
         public Task Add(X509Certificate2 certificate, string password = null)
         {
-            if (certificate == null) throw new ArgumentNullException("certificate");
+            if (certificate == null) throw new ArgumentNullException(nameof(certificate));
 
             lock (m_lock)
             {
@@ -356,12 +356,12 @@ namespace Opc.Ua
         {
             if (issuer == null)
             {
-                throw new ArgumentNullException("issuer");
+                throw new ArgumentNullException(nameof(issuer));
             }
 
             if (certificate == null)
             {
-                throw new ArgumentNullException("certificate");
+                throw new ArgumentNullException(nameof(certificate));
             }
 
             // check for CRL.
@@ -451,7 +451,7 @@ namespace Opc.Ua
         {
             if (issuer == null)
             {
-                throw new ArgumentNullException("issuer");
+                throw new ArgumentNullException(nameof(issuer));
             }
 
             List<X509CRL> crls = new List<X509CRL>();
@@ -485,7 +485,7 @@ namespace Opc.Ua
         {
             if (crl == null)
             {
-                throw new ArgumentNullException("crl");
+                throw new ArgumentNullException(nameof(crl));
             }
 
             X509Certificate2 issuer = null;
@@ -532,7 +532,7 @@ namespace Opc.Ua
         {
             if (crl == null)
             {
-                throw new ArgumentNullException("crl");
+                throw new ArgumentNullException(nameof(crl));
             }
 
             string filePath = m_directory.FullName;

--- a/Stack/Opc.Ua.Core/Security/Certificates/X509AuthorityKeyIdentifierExtension.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/X509AuthorityKeyIdentifierExtension.cs
@@ -138,7 +138,7 @@ namespace Opc.Ua
         /// </summary>
         public override void CopyFrom(AsnEncodedData asnEncodedData)
         {
-            if (asnEncodedData == null) throw new ArgumentNullException("asnEncodedData");
+            if (asnEncodedData == null) throw new ArgumentNullException(nameof(asnEncodedData));
             this.Oid = asnEncodedData.Oid;
             Parse(asnEncodedData.RawData);
         }

--- a/Stack/Opc.Ua.Core/Security/Certificates/X509CertificateStore.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/X509CertificateStore.cs
@@ -52,7 +52,7 @@ namespace Opc.Ua
         /// </remarks>
         public void Open(string path)
         {
-            if (path == null) throw new ArgumentNullException("path");
+            if (path == null) throw new ArgumentNullException(nameof(path));
 
             path = path.Trim();
 
@@ -112,7 +112,7 @@ namespace Opc.Ua
         /// <summary cref="ICertificateStore.Add(X509Certificate2)" />
         public Task Add(X509Certificate2 certificate, string password = null)
         {
-            if (certificate == null) throw new ArgumentNullException("certificate");
+            if (certificate == null) throw new ArgumentNullException(nameof(certificate));
 
             using (X509Store store = new X509Store(m_storeName, m_storeLocation))
             {

--- a/Stack/Opc.Ua.Core/Security/Certificates/X509SubjectAltNameExtension.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/X509SubjectAltNameExtension.cs
@@ -138,7 +138,7 @@ namespace Opc.Ua
         /// </summary>
         public override void CopyFrom(AsnEncodedData asnEncodedData)
         {
-            if (asnEncodedData == null) throw new ArgumentNullException("asnEncodedData");
+            if (asnEncodedData == null) throw new ArgumentNullException(nameof(asnEncodedData));
             this.Oid = asnEncodedData.Oid;
             Parse(asnEncodedData.RawData);
         }

--- a/Stack/Opc.Ua.Core/Stack/Bindings/BufferManager.cs
+++ b/Stack/Opc.Ua.Core/Stack/Bindings/BufferManager.cs
@@ -135,7 +135,7 @@ namespace Opc.Ua.Bindings
         {
             if (size > m_maxBufferSize)
             {
-                throw new ArgumentOutOfRangeException("size");
+                throw new ArgumentOutOfRangeException(nameof(size));
             }
 
             lock (m_lock)

--- a/Stack/Opc.Ua.Core/Stack/Client/ClientBase.cs
+++ b/Stack/Opc.Ua.Core/Stack/Client/ClientBase.cs
@@ -29,7 +29,7 @@ namespace Opc.Ua
         /// <param name="channel">The channel.</param>
         public ClientBase(ITransportChannel channel)
         {
-            if (channel == null) throw new ArgumentNullException("channel");
+            if (channel == null) throw new ArgumentNullException(nameof(channel));
             
             m_channel = channel;
             m_useTransportChannel = true;
@@ -498,7 +498,7 @@ namespace Opc.Ua
         {
             if (response is DiagnosticInfoCollection)
             {
-                throw new ArgumentException("Must call ValidateDiagnosticInfos() for DiagnosticInfoCollections.", "response");
+                throw new ArgumentException("Must call ValidateDiagnosticInfos() for DiagnosticInfoCollections.", nameof(response));
             }
 
             if (response == null || response.Count != request.Count)

--- a/Stack/Opc.Ua.Core/Stack/Client/RegistrationClient.cs
+++ b/Stack/Opc.Ua.Core/Stack/Client/RegistrationClient.cs
@@ -37,8 +37,8 @@ namespace Opc.Ua
             EndpointConfiguration    endpointConfiguration,
             X509Certificate2         instanceCertificate)
         {
-            if (configuration == null) throw new ArgumentNullException("configuration");
-            if (description == null) throw new ArgumentNullException("description");
+            if (configuration == null) throw new ArgumentNullException(nameof(configuration));
+            if (description == null) throw new ArgumentNullException(nameof(description));
 
             ITransportChannel channel = RegistrationChannel.Create(
                 configuration, 

--- a/Stack/Opc.Ua.Core/Stack/Client/UserIdentity.cs
+++ b/Stack/Opc.Ua.Core/Stack/Client/UserIdentity.cs
@@ -60,7 +60,7 @@ namespace Opc.Ua
         /// </summary>
         public UserIdentity(CertificateIdentifier certificateId)
         {
-            if (certificateId == null) throw new ArgumentNullException("certificateId");
+            if (certificateId == null) throw new ArgumentNullException(nameof(certificateId));
 
             X509Certificate2 certificate = certificateId.Find().Result;
             if (certificate != null)
@@ -74,7 +74,7 @@ namespace Opc.Ua
         /// </summary>
         public UserIdentity(X509Certificate2 certificate)
         {
-            if (certificate == null) throw new ArgumentNullException("certificate");
+            if (certificate == null) throw new ArgumentNullException(nameof(certificate));
             Initialize(certificate);
         }
 
@@ -151,7 +151,7 @@ namespace Opc.Ua
         /// </summary>
         private void Initialize(UserIdentityToken token)
         {
-            if (token == null) throw new ArgumentNullException("token");
+            if (token == null) throw new ArgumentNullException(nameof(token));
 
             m_token = token;
   
@@ -188,7 +188,7 @@ namespace Opc.Ua
                 {
                     if (issuedToken.DecryptedTokenData == null || issuedToken.DecryptedTokenData.Length == 0)
                     {
-                        throw new ArgumentException("JSON Web Token has no data associated with it.", "token");
+                        throw new ArgumentException("JSON Web Token has no data associated with it.", nameof(token));
                     }
 
                     m_tokenType = UserTokenType.IssuedToken;
@@ -211,7 +211,7 @@ namespace Opc.Ua
                 return;
             }
   
-            throw new ArgumentException("Unrecognized UA user identity token type.", "token");
+            throw new ArgumentException("Unrecognized UA user identity token type.", nameof(token));
         }
 
         /// <summary>

--- a/Stack/Opc.Ua.Core/Stack/Client/WcfChannelBase.cs
+++ b/Stack/Opc.Ua.Core/Stack/Client/WcfChannelBase.cs
@@ -1015,7 +1015,7 @@ namespace Opc.Ua
 
                 if (asyncResult == null)
                 {
-                    throw new ArgumentException("End called with an invalid IAsyncResult object.", "ar");
+                    throw new ArgumentException("End called with an invalid IAsyncResult object.", nameof(ar));
                 }
 
                 if (!asyncResult.WaitForComplete())

--- a/Stack/Opc.Ua.Core/Stack/Configuration/ApplicationConfiguration.cs
+++ b/Stack/Opc.Ua.Core/Stack/Configuration/ApplicationConfiguration.cs
@@ -37,7 +37,7 @@ namespace Opc.Ua
         {
             if (section == null)
             {
-                throw new ArgumentNullException("section");
+                throw new ArgumentNullException(nameof(section));
             }
 
             XmlNode element = section.FirstChild;

--- a/Stack/Opc.Ua.Core/Stack/Configuration/ConfigurationWatcher.cs
+++ b/Stack/Opc.Ua.Core/Stack/Configuration/ConfigurationWatcher.cs
@@ -26,7 +26,7 @@ namespace Opc.Ua
         /// </summary>
         public ConfigurationWatcher(ApplicationConfiguration configuration)
         {
-            if (configuration == null) throw new ArgumentNullException("configuration");
+            if (configuration == null) throw new ArgumentNullException(nameof(configuration));
 
             FileInfo fileInfo = new FileInfo(configuration.SourceFilePath);
 

--- a/Stack/Opc.Ua.Core/Stack/Configuration/ConfiguredEndpoints.cs
+++ b/Stack/Opc.Ua.Core/Stack/Configuration/ConfiguredEndpoints.cs
@@ -198,7 +198,7 @@ namespace Opc.Ua
             catch (Exception e)
             {
                 Utils.Trace(e, "Unexpected error loading ConfiguredEnpoints.");
-                throw e;
+                throw;
             }
         }
         

--- a/Stack/Opc.Ua.Core/Stack/Configuration/ConfiguredEndpoints.cs
+++ b/Stack/Opc.Ua.Core/Stack/Configuration/ConfiguredEndpoints.cs
@@ -295,7 +295,7 @@ namespace Opc.Ua
         /// <exception cref="T:System.NotSupportedException">The <see cref="T:System.Collections.Generic.IList`1"/> is read-only.</exception>
         public void RemoveAt(int index)
         {
-            if (index < 0 || index >= m_endpoints.Count) throw new ArgumentOutOfRangeException("index");
+            if (index < 0 || index >= m_endpoints.Count) throw new ArgumentOutOfRangeException(nameof(index));
             Remove(m_endpoints[index]);
         }
 
@@ -439,7 +439,7 @@ namespace Opc.Ua
         /// </summary>
         private void Insert(ConfiguredEndpoint endpoint, int index)
         {
-            if (endpoint == null) throw new ArgumentNullException("endpoint");
+            if (endpoint == null) throw new ArgumentNullException(nameof(endpoint));
 
             ValidateEndpoint(endpoint.Description);
 
@@ -476,7 +476,7 @@ namespace Opc.Ua
         /// </summary>
         public bool Remove(ConfiguredEndpoint item)
         {
-            if (item == null) throw new ArgumentNullException("item");
+            if (item == null) throw new ArgumentNullException(nameof(item));
             return m_endpoints.Remove(item);
         }
 
@@ -485,7 +485,7 @@ namespace Opc.Ua
         /// </summary>
         public void RemoveServer(string serverUri)
         {
-            if (serverUri == null) throw new ArgumentNullException("serverUri");
+            if (serverUri == null) throw new ArgumentNullException(nameof(serverUri));
 
             foreach (ConfiguredEndpoint endpointToRemove in GetEndpoints(serverUri))
             {
@@ -498,16 +498,16 @@ namespace Opc.Ua
         /// </summary>
         public void SetApplicationDescription(string serverUri, ApplicationDescription server)
         {
-            if (server == null) throw new ArgumentNullException("server");
+            if (server == null) throw new ArgumentNullException(nameof(server));
 
             if (String.IsNullOrEmpty(server.ApplicationUri))
             {
-                throw new ArgumentException("A ServerUri must provided.", "server");
+                throw new ArgumentException("A ServerUri must provided.", nameof(server));
             }
             
             if (server.DiscoveryUrls.Count == 0)
             {
-                throw new ArgumentException("At least one DiscoveryUrl must be provided.", "server");
+                throw new ArgumentException("At least one DiscoveryUrl must be provided.", nameof(server));
             }
 
             List<ConfiguredEndpoint> endpoints = GetEndpoints(server.ApplicationUri);
@@ -790,7 +790,7 @@ namespace Opc.Ua
             ApplicationDescription server, 
             EndpointConfiguration  configuration)
 	    {
-            if (server == null) throw new ArgumentNullException("server");
+            if (server == null) throw new ArgumentNullException(nameof(server));
 
             m_description = new EndpointDescription();
             m_updateBeforeConnect = true;
@@ -860,7 +860,7 @@ namespace Opc.Ua
             EndpointDescription          description, 
             EndpointConfiguration        configuration)
 	    {
-            if (description == null) throw new ArgumentNullException("description");
+            if (description == null) throw new ArgumentNullException(nameof(description));
 
             m_collection = collection;
 		    m_description = description;
@@ -933,7 +933,7 @@ namespace Opc.Ua
         /// </summary>
         public void Update(ConfiguredEndpoint endpoint)
         {
-            if (endpoint == null) throw new ArgumentNullException("endpoint");
+            if (endpoint == null) throw new ArgumentNullException(nameof(endpoint));
 
             m_description   = (EndpointDescription)endpoint.Description.MemberwiseClone();
             m_configuration = (EndpointConfiguration)endpoint.Configuration.MemberwiseClone();
@@ -964,7 +964,7 @@ namespace Opc.Ua
         /// </summary>
         public void Update(EndpointDescription description)
         {
-            if (description == null) throw new ArgumentNullException("description");
+            if (description == null) throw new ArgumentNullException(nameof(description));
 
             m_description = (EndpointDescription)description.MemberwiseClone();
 
@@ -989,7 +989,7 @@ namespace Opc.Ua
         /// </summary>
         public void Update(EndpointConfiguration configuration)
         {
-            if (configuration == null) throw new ArgumentNullException("configuration");
+            if (configuration == null) throw new ArgumentNullException(nameof(configuration));
             
             m_configuration = (EndpointConfiguration)configuration.MemberwiseClone();
             
@@ -1237,7 +1237,7 @@ namespace Opc.Ua
 
             internal set 
             { 
-                if (value == null) throw new ArgumentNullException("value");
+                if (value == null) throw new ArgumentNullException(nameof(value));
                 m_collection = value;
             }
 	    }

--- a/Stack/Opc.Ua.Core/Stack/Configuration/OAuth2Credential.cs
+++ b/Stack/Opc.Ua.Core/Stack/Configuration/OAuth2Credential.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.Serialization;
@@ -88,7 +88,7 @@ namespace Opc.Ua
         {
             if (configuration == null)
             {
-                throw new ArgumentNullException("configuration");
+                throw new ArgumentNullException(nameof(configuration));
             }
 
             OAuth2CredentialCollection list = null;

--- a/Stack/Opc.Ua.Core/Stack/Configuration/SecurityConfigurationManager.cs
+++ b/Stack/Opc.Ua.Core/Stack/Configuration/SecurityConfigurationManager.cs
@@ -31,7 +31,7 @@ namespace Opc.Ua.Security
         /// <returns>The security configuration.</returns>
         public SecuredApplication ReadConfiguration(string filePath)
         {
-            if (filePath == null) throw new ArgumentNullException("filePath");
+            if (filePath == null) throw new ArgumentNullException(nameof(filePath));
 
             string configFilePath = filePath;
             string exeFilePath = null;
@@ -232,7 +232,7 @@ namespace Opc.Ua.Security
         /// <param name="configuration">The configuration.</param>
         public void WriteConfiguration(string filePath, SecuredApplication configuration)
         {
-            if (configuration == null) throw new ArgumentNullException("configuration");
+            if (configuration == null) throw new ArgumentNullException(nameof(configuration));
 
             // check for valid file.
             if (String.IsNullOrEmpty(filePath) || !File.Exists(filePath))

--- a/Stack/Opc.Ua.Core/Stack/Generated/Opc.Ua.DataTypes.cs
+++ b/Stack/Opc.Ua.Core/Stack/Generated/Opc.Ua.DataTypes.cs
@@ -2803,6 +2803,7 @@ namespace Opc.Ua
     /// <exclude />
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Opc.Ua.ModelCompiler", "1.0.0.0")]
     [DataContract(Namespace = Opc.Ua.Namespaces.OpcUaXsd)]
+    [Flags]
     public enum OpenFileMode
     {
         /// <remarks />

--- a/Stack/Opc.Ua.Core/Stack/Generated/Opc.Ua.DataTypes.cs
+++ b/Stack/Opc.Ua.Core/Stack/Generated/Opc.Ua.DataTypes.cs
@@ -2803,7 +2803,6 @@ namespace Opc.Ua
     /// <exclude />
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Opc.Ua.ModelCompiler", "1.0.0.0")]
     [DataContract(Namespace = Opc.Ua.Namespaces.OpcUaXsd)]
-    [Flags]
     public enum OpenFileMode
     {
         /// <remarks />

--- a/Stack/Opc.Ua.Core/Stack/Generated/Opc.Ua.Endpoints.cs
+++ b/Stack/Opc.Ua.Core/Stack/Generated/Opc.Ua.Endpoints.cs
@@ -166,7 +166,7 @@ namespace Opc.Ua
                 OnRequestReceived(message.FindServersRequest);
 
                 // check for bad data.
-                if (message == null) throw new ArgumentNullException("message");
+                if (message == null) throw new ArgumentNullException(nameof(message));
 
                 // set the request context.
                 SetRequestContext(RequestEncoding.Xml);
@@ -279,7 +279,7 @@ namespace Opc.Ua
                 OnRequestReceived(message.FindServersOnNetworkRequest);
 
                 // check for bad data.
-                if (message == null) throw new ArgumentNullException("message");
+                if (message == null) throw new ArgumentNullException(nameof(message));
 
                 // set the request context.
                 SetRequestContext(RequestEncoding.Xml);
@@ -389,7 +389,7 @@ namespace Opc.Ua
                 OnRequestReceived(message.GetEndpointsRequest);
 
                 // check for bad data.
-                if (message == null) throw new ArgumentNullException("message");
+                if (message == null) throw new ArgumentNullException(nameof(message));
 
                 // set the request context.
                 SetRequestContext(RequestEncoding.Xml);
@@ -528,7 +528,7 @@ namespace Opc.Ua
                 OnRequestReceived(message.CreateSessionRequest);
 
                 // check for bad data.
-                if (message == null) throw new ArgumentNullException("message");
+                if (message == null) throw new ArgumentNullException(nameof(message));
 
                 // set the request context.
                 SetRequestContext(RequestEncoding.Xml);
@@ -646,7 +646,7 @@ namespace Opc.Ua
                 OnRequestReceived(message.ActivateSessionRequest);
 
                 // check for bad data.
-                if (message == null) throw new ArgumentNullException("message");
+                if (message == null) throw new ArgumentNullException(nameof(message));
 
                 // set the request context.
                 SetRequestContext(RequestEncoding.Xml);
@@ -751,7 +751,7 @@ namespace Opc.Ua
                 OnRequestReceived(message.CloseSessionRequest);
 
                 // check for bad data.
-                if (message == null) throw new ArgumentNullException("message");
+                if (message == null) throw new ArgumentNullException(nameof(message));
 
                 // set the request context.
                 SetRequestContext(RequestEncoding.Xml);
@@ -859,7 +859,7 @@ namespace Opc.Ua
                 OnRequestReceived(message.CancelRequest);
 
                 // check for bad data.
-                if (message == null) throw new ArgumentNullException("message");
+                if (message == null) throw new ArgumentNullException(nameof(message));
 
                 // set the request context.
                 SetRequestContext(RequestEncoding.Xml);
@@ -970,7 +970,7 @@ namespace Opc.Ua
                 OnRequestReceived(message.AddNodesRequest);
 
                 // check for bad data.
-                if (message == null) throw new ArgumentNullException("message");
+                if (message == null) throw new ArgumentNullException(nameof(message));
 
                 // set the request context.
                 SetRequestContext(RequestEncoding.Xml);
@@ -1081,7 +1081,7 @@ namespace Opc.Ua
                 OnRequestReceived(message.AddReferencesRequest);
 
                 // check for bad data.
-                if (message == null) throw new ArgumentNullException("message");
+                if (message == null) throw new ArgumentNullException(nameof(message));
 
                 // set the request context.
                 SetRequestContext(RequestEncoding.Xml);
@@ -1192,7 +1192,7 @@ namespace Opc.Ua
                 OnRequestReceived(message.DeleteNodesRequest);
 
                 // check for bad data.
-                if (message == null) throw new ArgumentNullException("message");
+                if (message == null) throw new ArgumentNullException(nameof(message));
 
                 // set the request context.
                 SetRequestContext(RequestEncoding.Xml);
@@ -1303,7 +1303,7 @@ namespace Opc.Ua
                 OnRequestReceived(message.DeleteReferencesRequest);
 
                 // check for bad data.
-                if (message == null) throw new ArgumentNullException("message");
+                if (message == null) throw new ArgumentNullException(nameof(message));
 
                 // set the request context.
                 SetRequestContext(RequestEncoding.Xml);
@@ -1416,7 +1416,7 @@ namespace Opc.Ua
                 OnRequestReceived(message.BrowseRequest);
 
                 // check for bad data.
-                if (message == null) throw new ArgumentNullException("message");
+                if (message == null) throw new ArgumentNullException(nameof(message));
 
                 // set the request context.
                 SetRequestContext(RequestEncoding.Xml);
@@ -1528,7 +1528,7 @@ namespace Opc.Ua
                 OnRequestReceived(message.BrowseNextRequest);
 
                 // check for bad data.
-                if (message == null) throw new ArgumentNullException("message");
+                if (message == null) throw new ArgumentNullException(nameof(message));
 
                 // set the request context.
                 SetRequestContext(RequestEncoding.Xml);
@@ -1639,7 +1639,7 @@ namespace Opc.Ua
                 OnRequestReceived(message.TranslateBrowsePathsToNodeIdsRequest);
 
                 // check for bad data.
-                if (message == null) throw new ArgumentNullException("message");
+                if (message == null) throw new ArgumentNullException(nameof(message));
 
                 // set the request context.
                 SetRequestContext(RequestEncoding.Xml);
@@ -1747,7 +1747,7 @@ namespace Opc.Ua
                 OnRequestReceived(message.RegisterNodesRequest);
 
                 // check for bad data.
-                if (message == null) throw new ArgumentNullException("message");
+                if (message == null) throw new ArgumentNullException(nameof(message));
 
                 // set the request context.
                 SetRequestContext(RequestEncoding.Xml);
@@ -1852,7 +1852,7 @@ namespace Opc.Ua
                 OnRequestReceived(message.UnregisterNodesRequest);
 
                 // check for bad data.
-                if (message == null) throw new ArgumentNullException("message");
+                if (message == null) throw new ArgumentNullException(nameof(message));
 
                 // set the request context.
                 SetRequestContext(RequestEncoding.Xml);
@@ -1976,7 +1976,7 @@ namespace Opc.Ua
                 OnRequestReceived(message.QueryFirstRequest);
 
                 // check for bad data.
-                if (message == null) throw new ArgumentNullException("message");
+                if (message == null) throw new ArgumentNullException(nameof(message));
 
                 // set the request context.
                 SetRequestContext(RequestEncoding.Xml);
@@ -2088,7 +2088,7 @@ namespace Opc.Ua
                 OnRequestReceived(message.QueryNextRequest);
 
                 // check for bad data.
-                if (message == null) throw new ArgumentNullException("message");
+                if (message == null) throw new ArgumentNullException(nameof(message));
 
                 // set the request context.
                 SetRequestContext(RequestEncoding.Xml);
@@ -2201,7 +2201,7 @@ namespace Opc.Ua
                 OnRequestReceived(message.ReadRequest);
 
                 // check for bad data.
-                if (message == null) throw new ArgumentNullException("message");
+                if (message == null) throw new ArgumentNullException(nameof(message));
 
                 // set the request context.
                 SetRequestContext(RequestEncoding.Xml);
@@ -2315,7 +2315,7 @@ namespace Opc.Ua
                 OnRequestReceived(message.HistoryReadRequest);
 
                 // check for bad data.
-                if (message == null) throw new ArgumentNullException("message");
+                if (message == null) throw new ArgumentNullException(nameof(message));
 
                 // set the request context.
                 SetRequestContext(RequestEncoding.Xml);
@@ -2426,7 +2426,7 @@ namespace Opc.Ua
                 OnRequestReceived(message.WriteRequest);
 
                 // check for bad data.
-                if (message == null) throw new ArgumentNullException("message");
+                if (message == null) throw new ArgumentNullException(nameof(message));
 
                 // set the request context.
                 SetRequestContext(RequestEncoding.Xml);
@@ -2537,7 +2537,7 @@ namespace Opc.Ua
                 OnRequestReceived(message.HistoryUpdateRequest);
 
                 // check for bad data.
-                if (message == null) throw new ArgumentNullException("message");
+                if (message == null) throw new ArgumentNullException(nameof(message));
 
                 // set the request context.
                 SetRequestContext(RequestEncoding.Xml);
@@ -2648,7 +2648,7 @@ namespace Opc.Ua
                 OnRequestReceived(message.CallRequest);
 
                 // check for bad data.
-                if (message == null) throw new ArgumentNullException("message");
+                if (message == null) throw new ArgumentNullException(nameof(message));
 
                 // set the request context.
                 SetRequestContext(RequestEncoding.Xml);
@@ -2761,7 +2761,7 @@ namespace Opc.Ua
                 OnRequestReceived(message.CreateMonitoredItemsRequest);
 
                 // check for bad data.
-                if (message == null) throw new ArgumentNullException("message");
+                if (message == null) throw new ArgumentNullException(nameof(message));
 
                 // set the request context.
                 SetRequestContext(RequestEncoding.Xml);
@@ -2874,7 +2874,7 @@ namespace Opc.Ua
                 OnRequestReceived(message.ModifyMonitoredItemsRequest);
 
                 // check for bad data.
-                if (message == null) throw new ArgumentNullException("message");
+                if (message == null) throw new ArgumentNullException(nameof(message));
 
                 // set the request context.
                 SetRequestContext(RequestEncoding.Xml);
@@ -2987,7 +2987,7 @@ namespace Opc.Ua
                 OnRequestReceived(message.SetMonitoringModeRequest);
 
                 // check for bad data.
-                if (message == null) throw new ArgumentNullException("message");
+                if (message == null) throw new ArgumentNullException(nameof(message));
 
                 // set the request context.
                 SetRequestContext(RequestEncoding.Xml);
@@ -3107,7 +3107,7 @@ namespace Opc.Ua
                 OnRequestReceived(message.SetTriggeringRequest);
 
                 // check for bad data.
-                if (message == null) throw new ArgumentNullException("message");
+                if (message == null) throw new ArgumentNullException(nameof(message));
 
                 // set the request context.
                 SetRequestContext(RequestEncoding.Xml);
@@ -3219,7 +3219,7 @@ namespace Opc.Ua
                 OnRequestReceived(message.DeleteMonitoredItemsRequest);
 
                 // check for bad data.
-                if (message == null) throw new ArgumentNullException("message");
+                if (message == null) throw new ArgumentNullException(nameof(message));
 
                 // set the request context.
                 SetRequestContext(RequestEncoding.Xml);
@@ -3341,7 +3341,7 @@ namespace Opc.Ua
                 OnRequestReceived(message.CreateSubscriptionRequest);
 
                 // check for bad data.
-                if (message == null) throw new ArgumentNullException("message");
+                if (message == null) throw new ArgumentNullException(nameof(message));
 
                 // set the request context.
                 SetRequestContext(RequestEncoding.Xml);
@@ -3460,7 +3460,7 @@ namespace Opc.Ua
                 OnRequestReceived(message.ModifySubscriptionRequest);
 
                 // check for bad data.
-                if (message == null) throw new ArgumentNullException("message");
+                if (message == null) throw new ArgumentNullException(nameof(message));
 
                 // set the request context.
                 SetRequestContext(RequestEncoding.Xml);
@@ -3572,7 +3572,7 @@ namespace Opc.Ua
                 OnRequestReceived(message.SetPublishingModeRequest);
 
                 // check for bad data.
-                if (message == null) throw new ArgumentNullException("message");
+                if (message == null) throw new ArgumentNullException(nameof(message));
 
                 // set the request context.
                 SetRequestContext(RequestEncoding.Xml);
@@ -3695,7 +3695,7 @@ namespace Opc.Ua
                 OnRequestReceived(message.PublishRequest);
 
                 // check for bad data.
-                if (message == null) throw new ArgumentNullException("message");
+                if (message == null) throw new ArgumentNullException(nameof(message));
 
                 // set the request context.
                 SetRequestContext(RequestEncoding.Xml);
@@ -3804,7 +3804,7 @@ namespace Opc.Ua
                 OnRequestReceived(message.RepublishRequest);
 
                 // check for bad data.
-                if (message == null) throw new ArgumentNullException("message");
+                if (message == null) throw new ArgumentNullException(nameof(message));
 
                 // set the request context.
                 SetRequestContext(RequestEncoding.Xml);
@@ -3916,7 +3916,7 @@ namespace Opc.Ua
                 OnRequestReceived(message.TransferSubscriptionsRequest);
 
                 // check for bad data.
-                if (message == null) throw new ArgumentNullException("message");
+                if (message == null) throw new ArgumentNullException(nameof(message));
 
                 // set the request context.
                 SetRequestContext(RequestEncoding.Xml);
@@ -4027,7 +4027,7 @@ namespace Opc.Ua
                 OnRequestReceived(message.DeleteSubscriptionsRequest);
 
                 // check for bad data.
-                if (message == null) throw new ArgumentNullException("message");
+                if (message == null) throw new ArgumentNullException(nameof(message));
 
                 // set the request context.
                 SetRequestContext(RequestEncoding.Xml);
@@ -4312,7 +4312,7 @@ namespace Opc.Ua
                 OnRequestReceived(message.FindServersRequest);
 
                 // check for bad data.
-                if (message == null) throw new ArgumentNullException("message");
+                if (message == null) throw new ArgumentNullException(nameof(message));
 
                 // set the request context.
                 SetRequestContext(RequestEncoding.Xml);
@@ -4425,7 +4425,7 @@ namespace Opc.Ua
                 OnRequestReceived(message.FindServersOnNetworkRequest);
 
                 // check for bad data.
-                if (message == null) throw new ArgumentNullException("message");
+                if (message == null) throw new ArgumentNullException(nameof(message));
 
                 // set the request context.
                 SetRequestContext(RequestEncoding.Xml);
@@ -4535,7 +4535,7 @@ namespace Opc.Ua
                 OnRequestReceived(message.GetEndpointsRequest);
 
                 // check for bad data.
-                if (message == null) throw new ArgumentNullException("message");
+                if (message == null) throw new ArgumentNullException(nameof(message));
 
                 // set the request context.
                 SetRequestContext(RequestEncoding.Xml);
@@ -4640,7 +4640,7 @@ namespace Opc.Ua
                 OnRequestReceived(message.RegisterServerRequest);
 
                 // check for bad data.
-                if (message == null) throw new ArgumentNullException("message");
+                if (message == null) throw new ArgumentNullException(nameof(message));
 
                 // set the request context.
                 SetRequestContext(RequestEncoding.Xml);
@@ -4752,7 +4752,7 @@ namespace Opc.Ua
                 OnRequestReceived(message.RegisterServer2Request);
 
                 // check for bad data.
-                if (message == null) throw new ArgumentNullException("message");
+                if (message == null) throw new ArgumentNullException(nameof(message));
 
                 // set the request context.
                 SetRequestContext(RequestEncoding.Xml);

--- a/Stack/Opc.Ua.Core/Stack/Generated/Opc.Ua.Endpoints.cs
+++ b/Stack/Opc.Ua.Core/Stack/Generated/Opc.Ua.Endpoints.cs
@@ -166,7 +166,7 @@ namespace Opc.Ua
                 OnRequestReceived(message.FindServersRequest);
 
                 // check for bad data.
-                if (message == null) throw new ArgumentNullException(nameof(message));
+                if (message == null) throw new ArgumentNullException("message");
 
                 // set the request context.
                 SetRequestContext(RequestEncoding.Xml);
@@ -279,7 +279,7 @@ namespace Opc.Ua
                 OnRequestReceived(message.FindServersOnNetworkRequest);
 
                 // check for bad data.
-                if (message == null) throw new ArgumentNullException(nameof(message));
+                if (message == null) throw new ArgumentNullException("message");
 
                 // set the request context.
                 SetRequestContext(RequestEncoding.Xml);
@@ -389,7 +389,7 @@ namespace Opc.Ua
                 OnRequestReceived(message.GetEndpointsRequest);
 
                 // check for bad data.
-                if (message == null) throw new ArgumentNullException(nameof(message));
+                if (message == null) throw new ArgumentNullException("message");
 
                 // set the request context.
                 SetRequestContext(RequestEncoding.Xml);
@@ -528,7 +528,7 @@ namespace Opc.Ua
                 OnRequestReceived(message.CreateSessionRequest);
 
                 // check for bad data.
-                if (message == null) throw new ArgumentNullException(nameof(message));
+                if (message == null) throw new ArgumentNullException("message");
 
                 // set the request context.
                 SetRequestContext(RequestEncoding.Xml);
@@ -646,7 +646,7 @@ namespace Opc.Ua
                 OnRequestReceived(message.ActivateSessionRequest);
 
                 // check for bad data.
-                if (message == null) throw new ArgumentNullException(nameof(message));
+                if (message == null) throw new ArgumentNullException("message");
 
                 // set the request context.
                 SetRequestContext(RequestEncoding.Xml);
@@ -751,7 +751,7 @@ namespace Opc.Ua
                 OnRequestReceived(message.CloseSessionRequest);
 
                 // check for bad data.
-                if (message == null) throw new ArgumentNullException(nameof(message));
+                if (message == null) throw new ArgumentNullException("message");
 
                 // set the request context.
                 SetRequestContext(RequestEncoding.Xml);
@@ -859,7 +859,7 @@ namespace Opc.Ua
                 OnRequestReceived(message.CancelRequest);
 
                 // check for bad data.
-                if (message == null) throw new ArgumentNullException(nameof(message));
+                if (message == null) throw new ArgumentNullException("message");
 
                 // set the request context.
                 SetRequestContext(RequestEncoding.Xml);
@@ -970,7 +970,7 @@ namespace Opc.Ua
                 OnRequestReceived(message.AddNodesRequest);
 
                 // check for bad data.
-                if (message == null) throw new ArgumentNullException(nameof(message));
+                if (message == null) throw new ArgumentNullException("message");
 
                 // set the request context.
                 SetRequestContext(RequestEncoding.Xml);
@@ -1081,7 +1081,7 @@ namespace Opc.Ua
                 OnRequestReceived(message.AddReferencesRequest);
 
                 // check for bad data.
-                if (message == null) throw new ArgumentNullException(nameof(message));
+                if (message == null) throw new ArgumentNullException("message");
 
                 // set the request context.
                 SetRequestContext(RequestEncoding.Xml);
@@ -1192,7 +1192,7 @@ namespace Opc.Ua
                 OnRequestReceived(message.DeleteNodesRequest);
 
                 // check for bad data.
-                if (message == null) throw new ArgumentNullException(nameof(message));
+                if (message == null) throw new ArgumentNullException("message");
 
                 // set the request context.
                 SetRequestContext(RequestEncoding.Xml);
@@ -1303,7 +1303,7 @@ namespace Opc.Ua
                 OnRequestReceived(message.DeleteReferencesRequest);
 
                 // check for bad data.
-                if (message == null) throw new ArgumentNullException(nameof(message));
+                if (message == null) throw new ArgumentNullException("message");
 
                 // set the request context.
                 SetRequestContext(RequestEncoding.Xml);
@@ -1416,7 +1416,7 @@ namespace Opc.Ua
                 OnRequestReceived(message.BrowseRequest);
 
                 // check for bad data.
-                if (message == null) throw new ArgumentNullException(nameof(message));
+                if (message == null) throw new ArgumentNullException("message");
 
                 // set the request context.
                 SetRequestContext(RequestEncoding.Xml);
@@ -1528,7 +1528,7 @@ namespace Opc.Ua
                 OnRequestReceived(message.BrowseNextRequest);
 
                 // check for bad data.
-                if (message == null) throw new ArgumentNullException(nameof(message));
+                if (message == null) throw new ArgumentNullException("message");
 
                 // set the request context.
                 SetRequestContext(RequestEncoding.Xml);
@@ -1639,7 +1639,7 @@ namespace Opc.Ua
                 OnRequestReceived(message.TranslateBrowsePathsToNodeIdsRequest);
 
                 // check for bad data.
-                if (message == null) throw new ArgumentNullException(nameof(message));
+                if (message == null) throw new ArgumentNullException("message");
 
                 // set the request context.
                 SetRequestContext(RequestEncoding.Xml);
@@ -1747,7 +1747,7 @@ namespace Opc.Ua
                 OnRequestReceived(message.RegisterNodesRequest);
 
                 // check for bad data.
-                if (message == null) throw new ArgumentNullException(nameof(message));
+                if (message == null) throw new ArgumentNullException("message");
 
                 // set the request context.
                 SetRequestContext(RequestEncoding.Xml);
@@ -1852,7 +1852,7 @@ namespace Opc.Ua
                 OnRequestReceived(message.UnregisterNodesRequest);
 
                 // check for bad data.
-                if (message == null) throw new ArgumentNullException(nameof(message));
+                if (message == null) throw new ArgumentNullException("message");
 
                 // set the request context.
                 SetRequestContext(RequestEncoding.Xml);
@@ -1976,7 +1976,7 @@ namespace Opc.Ua
                 OnRequestReceived(message.QueryFirstRequest);
 
                 // check for bad data.
-                if (message == null) throw new ArgumentNullException(nameof(message));
+                if (message == null) throw new ArgumentNullException("message");
 
                 // set the request context.
                 SetRequestContext(RequestEncoding.Xml);
@@ -2088,7 +2088,7 @@ namespace Opc.Ua
                 OnRequestReceived(message.QueryNextRequest);
 
                 // check for bad data.
-                if (message == null) throw new ArgumentNullException(nameof(message));
+                if (message == null) throw new ArgumentNullException("message");
 
                 // set the request context.
                 SetRequestContext(RequestEncoding.Xml);
@@ -2201,7 +2201,7 @@ namespace Opc.Ua
                 OnRequestReceived(message.ReadRequest);
 
                 // check for bad data.
-                if (message == null) throw new ArgumentNullException(nameof(message));
+                if (message == null) throw new ArgumentNullException("message");
 
                 // set the request context.
                 SetRequestContext(RequestEncoding.Xml);
@@ -2315,7 +2315,7 @@ namespace Opc.Ua
                 OnRequestReceived(message.HistoryReadRequest);
 
                 // check for bad data.
-                if (message == null) throw new ArgumentNullException(nameof(message));
+                if (message == null) throw new ArgumentNullException("message");
 
                 // set the request context.
                 SetRequestContext(RequestEncoding.Xml);
@@ -2426,7 +2426,7 @@ namespace Opc.Ua
                 OnRequestReceived(message.WriteRequest);
 
                 // check for bad data.
-                if (message == null) throw new ArgumentNullException(nameof(message));
+                if (message == null) throw new ArgumentNullException("message");
 
                 // set the request context.
                 SetRequestContext(RequestEncoding.Xml);
@@ -2537,7 +2537,7 @@ namespace Opc.Ua
                 OnRequestReceived(message.HistoryUpdateRequest);
 
                 // check for bad data.
-                if (message == null) throw new ArgumentNullException(nameof(message));
+                if (message == null) throw new ArgumentNullException("message");
 
                 // set the request context.
                 SetRequestContext(RequestEncoding.Xml);
@@ -2648,7 +2648,7 @@ namespace Opc.Ua
                 OnRequestReceived(message.CallRequest);
 
                 // check for bad data.
-                if (message == null) throw new ArgumentNullException(nameof(message));
+                if (message == null) throw new ArgumentNullException("message");
 
                 // set the request context.
                 SetRequestContext(RequestEncoding.Xml);
@@ -2761,7 +2761,7 @@ namespace Opc.Ua
                 OnRequestReceived(message.CreateMonitoredItemsRequest);
 
                 // check for bad data.
-                if (message == null) throw new ArgumentNullException(nameof(message));
+                if (message == null) throw new ArgumentNullException("message");
 
                 // set the request context.
                 SetRequestContext(RequestEncoding.Xml);
@@ -2874,7 +2874,7 @@ namespace Opc.Ua
                 OnRequestReceived(message.ModifyMonitoredItemsRequest);
 
                 // check for bad data.
-                if (message == null) throw new ArgumentNullException(nameof(message));
+                if (message == null) throw new ArgumentNullException("message");
 
                 // set the request context.
                 SetRequestContext(RequestEncoding.Xml);
@@ -2987,7 +2987,7 @@ namespace Opc.Ua
                 OnRequestReceived(message.SetMonitoringModeRequest);
 
                 // check for bad data.
-                if (message == null) throw new ArgumentNullException(nameof(message));
+                if (message == null) throw new ArgumentNullException("message");
 
                 // set the request context.
                 SetRequestContext(RequestEncoding.Xml);
@@ -3107,7 +3107,7 @@ namespace Opc.Ua
                 OnRequestReceived(message.SetTriggeringRequest);
 
                 // check for bad data.
-                if (message == null) throw new ArgumentNullException(nameof(message));
+                if (message == null) throw new ArgumentNullException("message");
 
                 // set the request context.
                 SetRequestContext(RequestEncoding.Xml);
@@ -3219,7 +3219,7 @@ namespace Opc.Ua
                 OnRequestReceived(message.DeleteMonitoredItemsRequest);
 
                 // check for bad data.
-                if (message == null) throw new ArgumentNullException(nameof(message));
+                if (message == null) throw new ArgumentNullException("message");
 
                 // set the request context.
                 SetRequestContext(RequestEncoding.Xml);
@@ -3341,7 +3341,7 @@ namespace Opc.Ua
                 OnRequestReceived(message.CreateSubscriptionRequest);
 
                 // check for bad data.
-                if (message == null) throw new ArgumentNullException(nameof(message));
+                if (message == null) throw new ArgumentNullException("message");
 
                 // set the request context.
                 SetRequestContext(RequestEncoding.Xml);
@@ -3460,7 +3460,7 @@ namespace Opc.Ua
                 OnRequestReceived(message.ModifySubscriptionRequest);
 
                 // check for bad data.
-                if (message == null) throw new ArgumentNullException(nameof(message));
+                if (message == null) throw new ArgumentNullException("message");
 
                 // set the request context.
                 SetRequestContext(RequestEncoding.Xml);
@@ -3572,7 +3572,7 @@ namespace Opc.Ua
                 OnRequestReceived(message.SetPublishingModeRequest);
 
                 // check for bad data.
-                if (message == null) throw new ArgumentNullException(nameof(message));
+                if (message == null) throw new ArgumentNullException("message");
 
                 // set the request context.
                 SetRequestContext(RequestEncoding.Xml);
@@ -3695,7 +3695,7 @@ namespace Opc.Ua
                 OnRequestReceived(message.PublishRequest);
 
                 // check for bad data.
-                if (message == null) throw new ArgumentNullException(nameof(message));
+                if (message == null) throw new ArgumentNullException("message");
 
                 // set the request context.
                 SetRequestContext(RequestEncoding.Xml);
@@ -3804,7 +3804,7 @@ namespace Opc.Ua
                 OnRequestReceived(message.RepublishRequest);
 
                 // check for bad data.
-                if (message == null) throw new ArgumentNullException(nameof(message));
+                if (message == null) throw new ArgumentNullException("message");
 
                 // set the request context.
                 SetRequestContext(RequestEncoding.Xml);
@@ -3916,7 +3916,7 @@ namespace Opc.Ua
                 OnRequestReceived(message.TransferSubscriptionsRequest);
 
                 // check for bad data.
-                if (message == null) throw new ArgumentNullException(nameof(message));
+                if (message == null) throw new ArgumentNullException("message");
 
                 // set the request context.
                 SetRequestContext(RequestEncoding.Xml);
@@ -4027,7 +4027,7 @@ namespace Opc.Ua
                 OnRequestReceived(message.DeleteSubscriptionsRequest);
 
                 // check for bad data.
-                if (message == null) throw new ArgumentNullException(nameof(message));
+                if (message == null) throw new ArgumentNullException("message");
 
                 // set the request context.
                 SetRequestContext(RequestEncoding.Xml);
@@ -4312,7 +4312,7 @@ namespace Opc.Ua
                 OnRequestReceived(message.FindServersRequest);
 
                 // check for bad data.
-                if (message == null) throw new ArgumentNullException(nameof(message));
+                if (message == null) throw new ArgumentNullException("message");
 
                 // set the request context.
                 SetRequestContext(RequestEncoding.Xml);
@@ -4425,7 +4425,7 @@ namespace Opc.Ua
                 OnRequestReceived(message.FindServersOnNetworkRequest);
 
                 // check for bad data.
-                if (message == null) throw new ArgumentNullException(nameof(message));
+                if (message == null) throw new ArgumentNullException("message");
 
                 // set the request context.
                 SetRequestContext(RequestEncoding.Xml);
@@ -4535,7 +4535,7 @@ namespace Opc.Ua
                 OnRequestReceived(message.GetEndpointsRequest);
 
                 // check for bad data.
-                if (message == null) throw new ArgumentNullException(nameof(message));
+                if (message == null) throw new ArgumentNullException("message");
 
                 // set the request context.
                 SetRequestContext(RequestEncoding.Xml);
@@ -4640,7 +4640,7 @@ namespace Opc.Ua
                 OnRequestReceived(message.RegisterServerRequest);
 
                 // check for bad data.
-                if (message == null) throw new ArgumentNullException(nameof(message));
+                if (message == null) throw new ArgumentNullException("message");
 
                 // set the request context.
                 SetRequestContext(RequestEncoding.Xml);
@@ -4752,7 +4752,7 @@ namespace Opc.Ua
                 OnRequestReceived(message.RegisterServer2Request);
 
                 // check for bad data.
-                if (message == null) throw new ArgumentNullException(nameof(message));
+                if (message == null) throw new ArgumentNullException("message");
 
                 // set the request context.
                 SetRequestContext(RequestEncoding.Xml);

--- a/Stack/Opc.Ua.Core/Stack/Https/HttpsTransportChannel.cs
+++ b/Stack/Opc.Ua.Core/Stack/Https/HttpsTransportChannel.cs
@@ -189,7 +189,7 @@ namespace Opc.Ua.Bindings
             AsyncResult result2 = result as AsyncResult;
             if (result2 == null)
             {
-                throw new ArgumentException("Invalid result object passed.", "result");
+                throw new ArgumentException("Invalid result object passed.", nameof(result));
             }
 
             try

--- a/Stack/Opc.Ua.Core/Stack/Https/HttpsTransportChannel.cs
+++ b/Stack/Opc.Ua.Core/Stack/Https/HttpsTransportChannel.cs
@@ -114,7 +114,7 @@ namespace Opc.Ua.Bindings
             catch (Exception ex)
             {
                 Utils.Trace("Exception creating HTTPS Client: " + ex.Message);
-                throw ex;
+                throw;
             }
         }
 

--- a/Stack/Opc.Ua.Core/Stack/Nodes/IFilterTarget.cs
+++ b/Stack/Opc.Ua.Core/Stack/Nodes/IFilterTarget.cs
@@ -129,8 +129,8 @@ namespace Opc.Ua
         /// <param name="context">The context.</param>
         public FilterContext(NamespaceTable namespaceUris, ITypeTable typeTree, IOperationContext context)
         {
-            if (namespaceUris == null) throw new ArgumentNullException("namespaceUris");
-            if (typeTree == null) throw new ArgumentNullException("typeTree");
+            if (namespaceUris == null) throw new ArgumentNullException(nameof(namespaceUris));
+            if (typeTree == null) throw new ArgumentNullException(nameof(typeTree));
 
             m_namespaceUris = namespaceUris;
             m_typeTree = typeTree;
@@ -156,8 +156,8 @@ namespace Opc.Ua
         /// <param name="preferredLocales">The preferred locales.</param>
         public FilterContext(NamespaceTable namespaceUris, ITypeTable typeTree, IList<string> preferredLocales)
         {
-            if (namespaceUris == null) throw new ArgumentNullException("namespaceUris");
-            if (typeTree == null) throw new ArgumentNullException("typeTree");
+            if (namespaceUris == null) throw new ArgumentNullException(nameof(namespaceUris));
+            if (typeTree == null) throw new ArgumentNullException(nameof(typeTree));
 
             m_namespaceUris = namespaceUris;
             m_typeTree = typeTree;

--- a/Stack/Opc.Ua.Core/Stack/Nodes/NodeSet.cs
+++ b/Stack/Opc.Ua.Core/Stack/Nodes/NodeSet.cs
@@ -124,7 +124,7 @@ namespace Opc.Ua
         /// </remarks>
         public void Add(Node node)
         {
-            if (node == null) throw new ArgumentNullException("node");
+            if (node == null) throw new ArgumentNullException(nameof(node));
 
             if (NodeId.IsNull(node.NodeId))
             {
@@ -386,8 +386,8 @@ namespace Opc.Ua
         /// </remarks>
         public Node Find(NodeId nodeId, NamespaceTable namespaceUris)
         {
-            if (nodeId == null) throw new ArgumentNullException("nodeId");
-            if (namespaceUris == null) throw new ArgumentNullException("namespaceUris");
+            if (nodeId == null) throw new ArgumentNullException(nameof(nodeId));
+            if (namespaceUris == null) throw new ArgumentNullException(nameof(namespaceUris));
 
             // check for unknown namespace index.
             string ns = namespaceUris.GetString(nodeId.NamespaceIndex);
@@ -670,8 +670,8 @@ namespace Opc.Ua
             NamespaceTable targetNamespaceUris, 
             NamespaceTable sourceNamespaceUris)
         {
-            if (targetNamespaceUris == null) throw new ArgumentNullException("targetNamespaceUris");
-            if (sourceNamespaceUris == null) throw new ArgumentNullException("sourceNamespaceUris");
+            if (targetNamespaceUris == null) throw new ArgumentNullException(nameof(targetNamespaceUris));
+            if (sourceNamespaceUris == null) throw new ArgumentNullException(nameof(sourceNamespaceUris));
 
             if (NodeId.IsNull(nodeId))
             {
@@ -709,8 +709,8 @@ namespace Opc.Ua
             NamespaceTable targetNamespaceUris, 
             NamespaceTable sourceNamespaceUris)
         {
-            if (targetNamespaceUris == null) throw new ArgumentNullException("targetNamespaceUris");
-            if (sourceNamespaceUris == null) throw new ArgumentNullException("sourceNamespaceUris");
+            if (targetNamespaceUris == null) throw new ArgumentNullException(nameof(targetNamespaceUris));
+            if (sourceNamespaceUris == null) throw new ArgumentNullException(nameof(sourceNamespaceUris));
 
             if (QualifiedName.IsNull(qname))
             {
@@ -757,13 +757,13 @@ namespace Opc.Ua
             NamespaceTable sourceNamespaceUris, 
             StringTable    sourceServerUris)
         {
-            if (targetNamespaceUris == null) throw new ArgumentNullException("targetNamespaceUris");
-            if (sourceNamespaceUris == null) throw new ArgumentNullException("sourceNamespaceUris");
+            if (targetNamespaceUris == null) throw new ArgumentNullException(nameof(targetNamespaceUris));
+            if (sourceNamespaceUris == null) throw new ArgumentNullException(nameof(sourceNamespaceUris));
         
             if (nodeId.ServerIndex > 0)
             {
-                if (targetServerUris == null) throw new ArgumentNullException("targetServerUris");
-                if (sourceServerUris == null) throw new ArgumentNullException("sourceServerUris");
+                if (targetServerUris == null) throw new ArgumentNullException(nameof(targetServerUris));
+                if (sourceServerUris == null) throw new ArgumentNullException(nameof(sourceServerUris));
             }
 
             if (NodeId.IsNull(nodeId))

--- a/Stack/Opc.Ua.Core/Stack/Nodes/ReferenceTable.cs
+++ b/Stack/Opc.Ua.Core/Stack/Nodes/ReferenceTable.cs
@@ -370,10 +370,10 @@ namespace Opc.Ua
         public void CopyTo(IReference[] array, int arrayIndex)
         {
             if (array == null) 
-                throw new ArgumentNullException("array");
+                throw new ArgumentNullException(nameof(array));
             
             if (arrayIndex < 0 || arrayIndex >= array.Length) 
-                throw new ArgumentOutOfRangeException("arrayIndex", "arrayIndex < 0 || arrayIndex >= array.Length");
+                throw new ArgumentOutOfRangeException(nameof(arrayIndex), "arrayIndex < 0 || arrayIndex >= array.Length");
 
             KeyValuePair<IReference,object>[] elements = new KeyValuePair<IReference,object>[array.Length-arrayIndex];
             m_references.CopyTo(elements, 0);
@@ -436,7 +436,7 @@ namespace Opc.Ua
             IReference reference,
             ITypeTable typeTree)
         {
-            if (typeTree == null) throw new ArgumentNullException("typeTree");
+            if (typeTree == null) throw new ArgumentNullException(nameof(typeTree));
 
             if (!ValidateReference(reference, false))
             {
@@ -501,7 +501,7 @@ namespace Opc.Ua
             bool       isInverse,
             ITypeTable typeTree)
         {
-            if (typeTree == null) throw new ArgumentNullException("typeTree");
+            if (typeTree == null) throw new ArgumentNullException(nameof(typeTree));
 
             List<IReference> hits = new List<IReference>();
             
@@ -953,7 +953,7 @@ namespace Opc.Ua
             {
                 if (throwOnError)
                 {
-                    throw new ArgumentNullException("key", "IReference must not be null.");
+                    throw new ArgumentNullException(nameof(key), "IReference must not be null.");
                 }
                 
                 return false;
@@ -963,7 +963,7 @@ namespace Opc.Ua
             {
                 if (throwOnError)
                 {
-                    throw new ArgumentNullException("key", "IReference does not have a valid ReferenceTypeId.");
+                    throw new ArgumentNullException(nameof(key), "IReference does not have a valid ReferenceTypeId.");
                 }
                 
                 return false;
@@ -973,7 +973,7 @@ namespace Opc.Ua
             {
                 if (throwOnError)
                 {
-                    throw new ArgumentNullException("key", "IReference does not have a valid TargetId.");
+                    throw new ArgumentNullException(nameof(key), "IReference does not have a valid TargetId.");
                 }
                 
                 return false;
@@ -1128,7 +1128,7 @@ namespace Opc.Ua
                 {
                     if (!replace)
                     {
-                        throw new ArgumentException("Key already exists in dictionary.", "key");
+                        throw new ArgumentException("Key already exists in dictionary.", nameof(key));
                     }
 
                     m_list.AddAfter(existingNode, node);
@@ -1181,7 +1181,7 @@ namespace Opc.Ua
                 {
                     if (!replace)
                     {
-                        throw new ArgumentException("Key already exists in dictionary.", "key");
+                        throw new ArgumentException("Key already exists in dictionary.", nameof(key));
                     }
 
                     m_list.AddAfter(existingNode, node);

--- a/Stack/Opc.Ua.Core/Stack/Nodes/ViewTable.cs
+++ b/Stack/Opc.Ua.Core/Stack/Nodes/ViewTable.cs
@@ -116,7 +116,7 @@ namespace Opc.Ua
         /// <param name="view">The view.</param>
         public void Add(ViewNode view)
         {
-            if (view == null) throw new ArgumentNullException("view");
+            if (view == null) throw new ArgumentNullException(nameof(view));
 
             if (NodeId.IsNull(view.NodeId))
             {
@@ -146,7 +146,7 @@ namespace Opc.Ua
         /// <param name="viewId">The view identifier.</param>
         public void Remove(NodeId viewId)
         {
-            if (NodeId.IsNull(viewId)) throw new ArgumentNullException("viewId");
+            if (NodeId.IsNull(viewId)) throw new ArgumentNullException(nameof(viewId));
                         
             lock (m_lock)
             {

--- a/Stack/Opc.Ua.Core/Stack/Server/EndpointBase.cs
+++ b/Stack/Opc.Ua.Core/Stack/Server/EndpointBase.cs
@@ -58,7 +58,7 @@ namespace Opc.Ua
         /// <param name="host">The host.</param>
         protected EndpointBase(IServiceHostBase host)
         {
-            if (host == null) throw new ArgumentNullException("host");
+            if (host == null) throw new ArgumentNullException(nameof(host));
 
             m_host = host;
             m_server = host.Server;
@@ -71,7 +71,7 @@ namespace Opc.Ua
         /// </summary>
         protected EndpointBase(ServerBase server)
         {
-            if (server == null) throw new ArgumentNullException("server");
+            if (server == null) throw new ArgumentNullException(nameof(server));
 
             m_host = null;
             m_server = server;
@@ -101,8 +101,8 @@ namespace Opc.Ua
             AsyncCallback callback,
             object callbackData)
         {
-            if (channeId == null) throw new ArgumentNullException("channeId");
-            if (request == null) throw new ArgumentNullException("request");
+            if (channeId == null) throw new ArgumentNullException(nameof(channeId));
+            if (request == null) throw new ArgumentNullException(nameof(request));
 
             // create operation.
             ProcessRequestAsyncResult result = new ProcessRequestAsyncResult(this, callback, callbackData, 0);
@@ -797,7 +797,7 @@ namespace Opc.Ua
 
                 if (result == null)
                 {
-                    throw new ArgumentException("End called with an invalid IAsyncResult object.", "ar");
+                    throw new ArgumentException("End called with an invalid IAsyncResult object.", nameof(ar));
                 }
 
                 if (result.m_response == null)

--- a/Stack/Opc.Ua.Core/Stack/Server/ServerBase.cs
+++ b/Stack/Opc.Ua.Core/Stack/Server/ServerBase.cs
@@ -156,7 +156,7 @@ namespace Opc.Ua
         /// <returns>Returns a host for a UA service.</returns>
         public Task Start(ApplicationConfiguration configuration, params Uri[] baseAddresses)
         {
-            if (configuration == null) throw new ArgumentNullException("configuration");
+            if (configuration == null) throw new ArgumentNullException(nameof(configuration));
 
             // do any pre-startup processing
             OnServerStarting(configuration);
@@ -214,7 +214,7 @@ namespace Opc.Ua
         /// </param>
         public void Start(ApplicationConfiguration configuration)
         {
-            if (configuration == null) throw new ArgumentNullException("configuration");
+            if (configuration == null) throw new ArgumentNullException(nameof(configuration));
 
             // do any pre-startup processing
             OnServerStarting(configuration);

--- a/Stack/Opc.Ua.Core/Stack/Server/ServerBase.cs
+++ b/Stack/Opc.Ua.Core/Stack/Server/ServerBase.cs
@@ -790,7 +790,7 @@ namespace Opc.Ua
                 catch (Exception e)
                 {
                     Utils.Trace(e, "Could not load UA-TCP Stack Listener.");
-                    throw e;
+                    throw;
                 }
             }
 

--- a/Stack/Opc.Ua.Core/Stack/State/NodeState.cs
+++ b/Stack/Opc.Ua.Core/Stack/State/NodeState.cs
@@ -4000,7 +4000,7 @@ namespace Opc.Ua
             IList<QualifiedName> browsePath,
             int index)
         {
-            if (index < 0 || index >= Int32.MaxValue) throw new ArgumentOutOfRangeException("index");
+            if (index < 0 || index >= Int32.MaxValue) throw new ArgumentOutOfRangeException(nameof(index));
 
             BaseInstanceState instance = FindChild(context, browsePath[index], false, null);
 
@@ -4331,8 +4331,8 @@ namespace Opc.Ua
             bool isInverse,
             ExpandedNodeId targetId)
         {
-            if (NodeId.IsNull(referenceTypeId)) throw new ArgumentNullException("referenceTypeId");
-            if (NodeId.IsNull(targetId)) throw new ArgumentNullException("targetId");
+            if (NodeId.IsNull(referenceTypeId)) throw new ArgumentNullException(nameof(referenceTypeId));
+            if (NodeId.IsNull(targetId)) throw new ArgumentNullException(nameof(targetId));
 
             if (m_references == null)
             {
@@ -4356,8 +4356,8 @@ namespace Opc.Ua
             bool isInverse,
             ExpandedNodeId targetId)
         {
-            if (NodeId.IsNull(referenceTypeId)) throw new ArgumentNullException("referenceTypeId");
-            if (NodeId.IsNull(targetId)) throw new ArgumentNullException("targetId");
+            if (NodeId.IsNull(referenceTypeId)) throw new ArgumentNullException(nameof(referenceTypeId));
+            if (NodeId.IsNull(targetId)) throw new ArgumentNullException(nameof(targetId));
 
             if (m_references == null)
             {
@@ -4380,7 +4380,7 @@ namespace Opc.Ua
         /// <param name="references">The list of references to add.</param>
         public void AddReferences(IList<IReference> references)
         {
-            if (references == null) throw new ArgumentNullException("references");
+            if (references == null) throw new ArgumentNullException(nameof(references));
 
             if (m_references == null)
             {
@@ -4408,7 +4408,7 @@ namespace Opc.Ua
             NodeId referenceTypeId,
             bool isInverse)
         {
-            if (NodeId.IsNull(referenceTypeId)) throw new ArgumentNullException("referenceTypeId");
+            if (NodeId.IsNull(referenceTypeId)) throw new ArgumentNullException(nameof(referenceTypeId));
 
             if (m_references == null)
             {

--- a/Stack/Opc.Ua.Core/Stack/State/NodeState.cs
+++ b/Stack/Opc.Ua.Core/Stack/State/NodeState.cs
@@ -1012,9 +1012,9 @@ namespace Opc.Ua
                 {
                     BaseInstanceState child = UpdateChild(context, decoder);
                 }
-                catch (Exception e)
+                catch (Exception)
                 {
-                    throw e;
+                    throw;
                 }
             }
         }

--- a/Stack/Opc.Ua.Core/Stack/State/NodeState.cs
+++ b/Stack/Opc.Ua.Core/Stack/State/NodeState.cs
@@ -4422,7 +4422,7 @@ namespace Opc.Ua
             
             refsToRemove.ForEach(r => RemoveReference(r.ReferenceTypeId, r.IsInverse, r.TargetId));
 
-            return refsToRemove.Any();
+            return refsToRemove.Count != 0;
         }
         #endregion
 

--- a/Stack/Opc.Ua.Core/Stack/State/NodeStateCollection.cs
+++ b/Stack/Opc.Ua.Core/Stack/State/NodeStateCollection.cs
@@ -403,9 +403,9 @@ namespace Opc.Ua
         /// <param name="updateTables">if set to <c>true</c> the namespace and server tables are updated with any new URIs.</param>
         public void LoadFromResource(ISystemContext context, string resourcePath, Assembly assembly, bool updateTables)
         {
-            if (resourcePath == null) throw new ArgumentNullException("resourcePath");
+            if (resourcePath == null) throw new ArgumentNullException(nameof(resourcePath));
 
-            if (assembly == null) throw new ArgumentNullException("assembly");
+            if (assembly == null) throw new ArgumentNullException(nameof(assembly));
             
             Stream istrm = assembly.GetManifestResourceStream(resourcePath);
             if (istrm == null)
@@ -431,9 +431,9 @@ namespace Opc.Ua
         /// <param name="updateTables">if set to <c>true</c> the namespace and server tables are updated with any new URIs.</param>
         public void LoadFromBinaryResource(ISystemContext context, string resourcePath, Assembly assembly, bool updateTables)
         {
-            if (resourcePath == null) throw new ArgumentNullException("resourcePath");
+            if (resourcePath == null) throw new ArgumentNullException(nameof(resourcePath));
 
-            if (assembly == null) throw new ArgumentNullException("assembly");
+            if (assembly == null) throw new ArgumentNullException(nameof(assembly));
             
             Stream istrm = assembly.GetManifestResourceStream(resourcePath);
             if (istrm == null)
@@ -560,8 +560,8 @@ namespace Opc.Ua
         /// <param name="type">The system type.</param>
         public void RegisterType(NodeId typeDefinitionId, Type type)
         {
-            if (NodeId.IsNull(typeDefinitionId)) throw new ArgumentNullException("typeDefinitionId");
-            if (type == null) throw new ArgumentNullException("type");
+            if (NodeId.IsNull(typeDefinitionId)) throw new ArgumentNullException(nameof(typeDefinitionId));
+            if (type == null) throw new ArgumentNullException(nameof(type));
             
             if (m_types == null)
             {
@@ -577,7 +577,7 @@ namespace Opc.Ua
         /// <param name="typeDefinitionId">The type definition.</param>
         public void UnRegisterType(NodeId typeDefinitionId)
         {
-            if (NodeId.IsNull(typeDefinitionId)) throw new ArgumentNullException("typeDefinitionId");
+            if (NodeId.IsNull(typeDefinitionId)) throw new ArgumentNullException(nameof(typeDefinitionId));
 
             if (m_types != null)
             {

--- a/Stack/Opc.Ua.Core/Stack/Tcp/TcpMessageSocket.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/TcpMessageSocket.cs
@@ -678,11 +678,11 @@ namespace Opc.Ua.Bindings
                     }
                 }
             }
-            catch (ServiceResultException sre)
+            catch (ServiceResultException)
             {
                 args.Dispose();
                 BufferManager.UnlockBuffer(m_receiveBuffer);
-                throw sre;
+                throw;
             }
             catch (Exception ex)
             {

--- a/Stack/Opc.Ua.Core/Stack/Tcp/UaSCBinaryClientChannel.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/UaSCBinaryClientChannel.cs
@@ -184,7 +184,7 @@ namespace Opc.Ua.Bindings
             catch (Exception e)
             {
                 Shutdown(ServiceResult.Create(e, StatusCodes.BadTcpInternalError, "Fatal error during connect."));
-                throw e;
+                throw;
             }
             finally
             {

--- a/Stack/Opc.Ua.Core/Types/BuiltIn/DataValue.cs
+++ b/Stack/Opc.Ua.Core/Types/BuiltIn/DataValue.cs
@@ -85,7 +85,7 @@ namespace Opc.Ua
         /// <exception cref="ArgumentNullException">Thrown when the value is null</exception>
         public DataValue(DataValue value)
         {            
-            if (value == null) throw new ArgumentNullException("value");
+            if (value == null) throw new ArgumentNullException(nameof(value));
 
             m_value.Value     = Utils.Clone(value.m_value.Value);
             m_statusCode      = value.m_statusCode;

--- a/Stack/Opc.Ua.Core/Types/BuiltIn/DiagnosticInfo.cs
+++ b/Stack/Opc.Ua.Core/Types/BuiltIn/DiagnosticInfo.cs
@@ -57,7 +57,7 @@ namespace Opc.Ua
         /// <exception cref="ArgumentNullException">Thrown when the value is null</exception>
         public DiagnosticInfo(DiagnosticInfo value)
         {            
-            if (value == null) throw new ArgumentNullException("value");
+            if (value == null) throw new ArgumentNullException(nameof(value));
 
             m_symbolicId      = value.m_symbolicId;
             m_namespaceUri    = value.m_namespaceUri;
@@ -198,7 +198,7 @@ namespace Opc.Ua
             DiagnosticsMasks diagnosticsMask, 
             StringTable      stringTable)
         {        
-            if (stringTable == null) throw new ArgumentNullException("stringTable");
+            if (stringTable == null) throw new ArgumentNullException(nameof(stringTable));
             
             m_symbolicId          = -1;
             m_namespaceUri        = -1;

--- a/Stack/Opc.Ua.Core/Types/BuiltIn/ExpandedNodeId.cs
+++ b/Stack/Opc.Ua.Core/Types/BuiltIn/ExpandedNodeId.cs
@@ -50,7 +50,7 @@ namespace Opc.Ua
         /// <exception cref="ArgumentNullException">Thrown when the parameter is null</exception>
         public ExpandedNodeId(ExpandedNodeId value)
         {
-            if (value == null) throw new ArgumentNullException("value");
+            if (value == null) throw new ArgumentNullException(nameof(value));
 
             m_namespaceUri = value.m_namespaceUri;
 

--- a/Stack/Opc.Ua.Core/Types/BuiltIn/ExtensionObject.cs
+++ b/Stack/Opc.Ua.Core/Types/BuiltIn/ExtensionObject.cs
@@ -299,7 +299,7 @@ namespace Opc.Ua
         {
             if (value == null)
             {
-                throw new ArgumentNullException("value");
+                throw new ArgumentNullException(nameof(value));
             }
 
             TypeId = value.TypeId;

--- a/Stack/Opc.Ua.Core/Types/BuiltIn/LocalizedText.cs
+++ b/Stack/Opc.Ua.Core/Types/BuiltIn/LocalizedText.cs
@@ -89,7 +89,7 @@ namespace Opc.Ua
         /// </summary>
         public LocalizedText(TranslationInfo translationInfo)
         {
-            if (translationInfo == null) throw new ArgumentNullException("translationInfo");
+            if (translationInfo == null) throw new ArgumentNullException(nameof(translationInfo));
 
             m_locale = translationInfo.Locale;
             m_text = translationInfo.Text;
@@ -134,7 +134,7 @@ namespace Opc.Ua
         /// <exception cref="ArgumentNullException">Thrown when the value is null</exception>
         public LocalizedText(LocalizedText value)
         {
-            if (value == null) throw new ArgumentNullException("value");
+            if (value == null) throw new ArgumentNullException(nameof(value));
 
             m_locale = value.m_locale;
             m_text = value.m_text;

--- a/Stack/Opc.Ua.Core/Types/BuiltIn/NodeId.cs
+++ b/Stack/Opc.Ua.Core/Types/BuiltIn/NodeId.cs
@@ -83,7 +83,7 @@ namespace Opc.Ua
         /// <exception cref="ArgumentNullException">Thrown when <i>value</i> is null</exception>
         public NodeId(NodeId value)
         {
-            if (value == null) throw new ArgumentNullException("value");
+            if (value == null) throw new ArgumentNullException(nameof(value));
 
             m_namespaceIndex = value.m_namespaceIndex;
             m_identifierType = value.m_identifierType;
@@ -281,7 +281,7 @@ namespace Opc.Ua
                 return;
             }
 
-            throw new ArgumentException("Identifier type not supported.", "value");
+            throw new ArgumentException("Identifier type not supported.", nameof(value));
         }
         #endregion
 
@@ -1712,7 +1712,7 @@ namespace Opc.Ua
         {
             if (key == null)
             {
-                throw new ArgumentNullException("key");
+                throw new ArgumentNullException(nameof(key));
             }
 
             m_version++;
@@ -1749,7 +1749,7 @@ namespace Opc.Ua
                 }
             }
           
-            throw new ArgumentOutOfRangeException("key", "key.IdType");
+            throw new ArgumentOutOfRangeException(nameof(key), "key.IdType");
         }
         
         /// <summary cref="IDictionary{TKey,TValue}.ContainsKey" />
@@ -2034,7 +2034,7 @@ namespace Opc.Ua
             {
                 if (key == null)
                 {
-                    throw new ArgumentNullException("key");
+                    throw new ArgumentNullException(nameof(key));
                 }
 
                 switch (key.IdType)
@@ -2090,7 +2090,7 @@ namespace Opc.Ua
             {
                 if (key == null)
                 {
-                    throw new ArgumentNullException("key");
+                    throw new ArgumentNullException(nameof(key));
                 }
 
                 m_version++;
@@ -2127,7 +2127,7 @@ namespace Opc.Ua
                     }
                 }
          
-                throw new ArgumentOutOfRangeException("key", "key.IdType");
+                throw new ArgumentOutOfRangeException(nameof(key), "key.IdType");
             }
         }
         #endregion
@@ -2165,12 +2165,12 @@ namespace Opc.Ua
         {
             if (array == null)
             {
-                throw new ArgumentNullException("array");
+                throw new ArgumentNullException(nameof(array));
             }
 
             if (arrayIndex < 0 || array.Length <= arrayIndex)
             {
-                throw new ArgumentOutOfRangeException("arrayIndex", "arrayIndex < 0 || array.Length <= arrayIndex");
+                throw new ArgumentOutOfRangeException(nameof(arrayIndex), "arrayIndex < 0 || array.Length <= arrayIndex");
             }
 
             foreach (KeyValuePair<ulong,T> entry in m_numericIds)
@@ -2232,7 +2232,7 @@ namespace Opc.Ua
         {
             if (arrayIndex >= array.Length)
             {
-                throw new ArgumentException("Not enough space in array.", "array");
+                throw new ArgumentException("Not enough space in array.", nameof(array));
             }
         }
         

--- a/Stack/Opc.Ua.Core/Types/BuiltIn/QualifiedName.cs
+++ b/Stack/Opc.Ua.Core/Types/BuiltIn/QualifiedName.cs
@@ -68,7 +68,7 @@ namespace Opc.Ua
         /// <exception cref="ArgumentNullException">Thrown if the provided value is null</exception>
         public QualifiedName(QualifiedName value)
         {            
-            if (value == null) throw new ArgumentNullException("value");
+            if (value == null) throw new ArgumentNullException(nameof(value));
 
             m_name = value.m_name;
             m_namespaceIndex = value.m_namespaceIndex;

--- a/Stack/Opc.Ua.Core/Types/BuiltIn/Variant.cs
+++ b/Stack/Opc.Ua.Core/Types/BuiltIn/Variant.cs
@@ -2578,7 +2578,7 @@ namespace Opc.Ua
         /// </summary>
         public Matrix(Array value, BuiltInType builtInType)
         {
-            if (value == null) throw new ArgumentNullException("value");
+            if (value == null) throw new ArgumentNullException(nameof(value));
 
             m_elements = value;
             m_dimensions = new int[value.Rank];
@@ -2602,7 +2602,7 @@ namespace Opc.Ua
         /// </summary>
         public Matrix(Array elements, BuiltInType builtInType, params int[] dimensions)
         {
-            if (elements == null) throw new ArgumentNullException("elements");
+            if (elements == null) throw new ArgumentNullException(nameof(elements));
 
             m_elements = elements;
             m_dimensions = dimensions;

--- a/Stack/Opc.Ua.Core/Types/Encoders/BinaryDecoder.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/BinaryDecoder.cs
@@ -48,7 +48,7 @@ namespace Opc.Ua
         /// </summary>
         public BinaryDecoder(Stream stream, ServiceMessageContext context)
         {
-            if (stream == null) throw new ArgumentNullException("stream");
+            if (stream == null) throw new ArgumentNullException(nameof(stream));
 
             m_istrm = stream;
             m_reader = new BinaryReader(m_istrm);
@@ -141,8 +141,8 @@ namespace Opc.Ua
         /// </summary>
         public static IEncodeable DecodeMessage(Stream stream, System.Type expectedType, ServiceMessageContext context)
         {
-            if (stream == null) throw new ArgumentNullException("stream");
-            if (context == null) throw new ArgumentNullException("context");
+            if (stream == null) throw new ArgumentNullException(nameof(stream));
+            if (context == null) throw new ArgumentNullException(nameof(context));
 
             BinaryDecoder decoder = new BinaryDecoder(stream, context);
 
@@ -161,8 +161,8 @@ namespace Opc.Ua
         /// </summary>
         public static IEncodeable DecodeSessionLessMessage(byte[] buffer, ServiceMessageContext context)
         {
-            if (buffer == null) throw new ArgumentNullException("buffer");
-            if (context == null) throw new ArgumentNullException("context");
+            if (buffer == null) throw new ArgumentNullException(nameof(buffer));
+            if (context == null) throw new ArgumentNullException(nameof(context));
 
             BinaryDecoder decoder = new BinaryDecoder(buffer, context);
 
@@ -200,8 +200,8 @@ namespace Opc.Ua
         /// </summary>
         public static IEncodeable DecodeMessage(byte[] buffer, System.Type expectedType, ServiceMessageContext context)
         {
-            if (buffer == null) throw new ArgumentNullException("buffer");
-            if (context == null) throw new ArgumentNullException("context");
+            if (buffer == null) throw new ArgumentNullException(nameof(buffer));
+            if (context == null) throw new ArgumentNullException(nameof(context));
 
             BinaryDecoder decoder = new BinaryDecoder(buffer, context);
 
@@ -792,7 +792,7 @@ namespace Opc.Ua
         /// </summary>
         public IEncodeable ReadEncodeable(string fieldName, System.Type systemType)
         {
-            if (systemType == null) throw new ArgumentNullException("systemType");
+            if (systemType == null) throw new ArgumentNullException(nameof(systemType));
 
             IEncodeable encodeable = Activator.CreateInstance(systemType) as IEncodeable;
 

--- a/Stack/Opc.Ua.Core/Types/Encoders/BinaryEncoder.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/BinaryEncoder.cs
@@ -41,7 +41,7 @@ namespace Opc.Ua
         /// </summary>
         public BinaryEncoder(byte[] buffer, int start, int count, ServiceMessageContext context)
         {
-            if (buffer == null) throw new ArgumentNullException("buffer");
+            if (buffer == null) throw new ArgumentNullException(nameof(buffer));
 
             m_ostrm = new MemoryStream(buffer, start, count);
             m_writer = new BinaryWriter(m_ostrm);
@@ -54,7 +54,7 @@ namespace Opc.Ua
         /// </summary>
         public BinaryEncoder(Stream stream, ServiceMessageContext context)
         {
-            if (stream == null) throw new ArgumentNullException("stream");
+            if (stream == null) throw new ArgumentNullException(nameof(stream));
 
             m_ostrm = stream;
             m_writer = new BinaryWriter(m_ostrm);
@@ -183,8 +183,8 @@ namespace Opc.Ua
         /// </summary>
         public static byte[] EncodeMessage(IEncodeable message, ServiceMessageContext context)
         {
-            if (message == null) throw new ArgumentNullException("message");
-            if (context == null) throw new ArgumentNullException("context");
+            if (message == null) throw new ArgumentNullException(nameof(message));
+            if (context == null) throw new ArgumentNullException(nameof(context));
 
             // create encoder.
             BinaryEncoder encoder = new BinaryEncoder(context);
@@ -201,8 +201,8 @@ namespace Opc.Ua
         /// </summary>
         public static void EncodeSessionLessMessage(IEncodeable message, Stream stream, ServiceMessageContext context, bool leaveOpen = false)
         {
-            if (message == null) throw new ArgumentNullException("message");
-            if (context == null) throw new ArgumentNullException("context");
+            if (message == null) throw new ArgumentNullException(nameof(message));
+            if (context == null) throw new ArgumentNullException(nameof(context));
 
             // create encoder.
             BinaryEncoder encoder = new BinaryEncoder(stream, context);
@@ -247,9 +247,9 @@ namespace Opc.Ua
         /// </summary>
         public static void EncodeMessage(IEncodeable message, Stream stream, ServiceMessageContext context, bool leaveOpen = false)
         {
-            if (message == null) throw new ArgumentNullException("message");
-            if (stream == null) throw new ArgumentNullException("stream");
-            if (context == null) throw new ArgumentNullException("context");
+            if (message == null) throw new ArgumentNullException(nameof(message));
+            if (stream == null) throw new ArgumentNullException(nameof(stream));
+            if (context == null) throw new ArgumentNullException(nameof(context));
 
             // create encoder.
             BinaryEncoder encoder = new BinaryEncoder(stream, context);
@@ -269,7 +269,7 @@ namespace Opc.Ua
         /// </summary>
         public void EncodeMessage(IEncodeable message)
         {
-            if (message == null) throw new ArgumentNullException("message");
+            if (message == null) throw new ArgumentNullException(nameof(message));
 
             long start = m_ostrm.Position;
 
@@ -1050,7 +1050,7 @@ namespace Opc.Ua
             // create a default object if a null object specified.
             if (value == null)
             {
-                if (systemType == null) throw new ArgumentNullException("systemType");
+                if (systemType == null) throw new ArgumentNullException(nameof(systemType));
                 value = Activator.CreateInstance(systemType) as IEncodeable;
             }
 
@@ -1070,7 +1070,7 @@ namespace Opc.Ua
         /// </summary>
         public void WriteEnumerated(string fieldName, Enum value)
         {
-            if (value == null) throw new ArgumentNullException("value");
+            if (value == null) throw new ArgumentNullException(nameof(value));
 
             WriteInt32(null, Convert.ToInt32(value, CultureInfo.InvariantCulture));
         }

--- a/Stack/Opc.Ua.Core/Types/Encoders/JsonDecoder.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/JsonDecoder.cs
@@ -38,7 +38,7 @@ namespace Opc.Ua
         #region Constructors
         public JsonDecoder(string json, ServiceMessageContext context)
         {
-            if (context == null) throw new ArgumentNullException("context");
+            if (context == null) throw new ArgumentNullException(nameof(context));
             Initialize();
 
             m_context = context;
@@ -76,8 +76,8 @@ namespace Opc.Ua
         /// </summary>
         public static IEncodeable DecodeSessionLessMessage(byte[] buffer, ServiceMessageContext context)
         {
-            if (buffer == null) throw new ArgumentNullException("buffer");
-            if (context == null) throw new ArgumentNullException("context");
+            if (buffer == null) throw new ArgumentNullException(nameof(buffer));
+            if (context == null) throw new ArgumentNullException(nameof(context));
 
             JsonDecoder decoder = new JsonDecoder(UTF8Encoding.UTF8.GetString(buffer), context);
 
@@ -109,7 +109,7 @@ namespace Opc.Ua
         /// </summary>
         public static IEncodeable DecodeMessage(ArraySegment<byte> buffer, System.Type expectedType, ServiceMessageContext context)
         {
-            if (context == null) throw new ArgumentNullException("context");
+            if (context == null) throw new ArgumentNullException(nameof(context));
 
             // check that the max message size was not exceeded.
             if (context.MaxMessageSize > 0 && context.MaxMessageSize < buffer.Count)
@@ -1369,7 +1369,7 @@ namespace Opc.Ua
             string fieldName,
             System.Type systemType)
         {
-            if (systemType == null) throw new ArgumentNullException("systemType");
+            if (systemType == null) throw new ArgumentNullException(nameof(systemType));
 
             object token = null;
 
@@ -1417,7 +1417,7 @@ namespace Opc.Ua
         /// </summary>
         public Enum ReadEnumerated(string fieldName, System.Type enumType)
         {
-            if (enumType == null) throw new ArgumentNullException("enumType");
+            if (enumType == null) throw new ArgumentNullException(nameof(enumType));
 
             return (Enum)Enum.ToObject(enumType, ReadInt32(fieldName));
         }
@@ -2213,7 +2213,7 @@ namespace Opc.Ua
         /// </summary>
         public Array ReadEncodeableArray(string fieldName, System.Type systemType)
         {
-            if (systemType == null) throw new ArgumentNullException("systemType");
+            if (systemType == null) throw new ArgumentNullException(nameof(systemType));
 
             List<object> token = null;
 
@@ -2246,7 +2246,7 @@ namespace Opc.Ua
         /// </summary>
         public Array ReadEnumeratedArray(string fieldName, System.Type enumType)
         {
-            if (enumType == null) throw new ArgumentNullException("enumType");
+            if (enumType == null) throw new ArgumentNullException(nameof(enumType));
 
             List<object> token = null;
 

--- a/Stack/Opc.Ua.Core/Types/Encoders/JsonEncoder.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/JsonEncoder.cs
@@ -84,8 +84,8 @@ namespace Opc.Ua
         /// </summary>
         public static void EncodeSessionLessMessage(IEncodeable message, Stream stream, ServiceMessageContext context, bool leaveOpen = false)
         {
-            if (message == null) throw new ArgumentNullException("message");
-            if (context == null) throw new ArgumentNullException("context");
+            if (message == null) throw new ArgumentNullException(nameof(message));
+            if (context == null) throw new ArgumentNullException(nameof(context));
 
             // create encoder.
             JsonEncoder encoder = new JsonEncoder(context, true, new StreamWriter(stream, new UTF8Encoding(false), 65535, leaveOpen));
@@ -129,9 +129,9 @@ namespace Opc.Ua
         /// </summary>
         public static ArraySegment<byte> EncodeMessage(IEncodeable message, byte[] buffer, ServiceMessageContext context)
         {
-            if (message == null) throw new ArgumentNullException("message");
-            if (buffer == null) throw new ArgumentNullException("buffer");
-            if (context == null) throw new ArgumentNullException("context");
+            if (message == null) throw new ArgumentNullException(nameof(message));
+            if (buffer == null) throw new ArgumentNullException(nameof(buffer));
+            if (context == null) throw new ArgumentNullException(nameof(context));
 
             using (MemoryStream stream = new MemoryStream(buffer, true))
             {
@@ -150,7 +150,7 @@ namespace Opc.Ua
         /// </summary>
         public void EncodeMessage(IEncodeable message)
         {
-            if (message == null) throw new ArgumentNullException("message");
+            if (message == null) throw new ArgumentNullException(nameof(message));
 
             // convert the namespace uri to an index.
             NodeId typeId = ExpandedNodeId.ToNodeId(message.TypeId, m_context.NamespaceUris);

--- a/Stack/Opc.Ua.Core/Types/Encoders/XmlDecoder.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/XmlDecoder.cs
@@ -30,7 +30,7 @@ namespace Opc.Ua
         /// </summary>
         public XmlDecoder(ServiceMessageContext context)
         {
-            if (context == null) throw new ArgumentNullException("context");
+            if (context == null) throw new ArgumentNullException(nameof(context));
             Initialize();
             m_context = context;
             m_nestingLevel = 0;
@@ -41,7 +41,7 @@ namespace Opc.Ua
         /// </summary>
         public XmlDecoder(XmlElement element, ServiceMessageContext context)
         {
-            if (context == null) throw new ArgumentNullException("context");
+            if (context == null) throw new ArgumentNullException(nameof(context));
             Initialize();
             m_reader = XmlReader.Create(new StringReader(element.OuterXml));
             m_context = context;
@@ -1476,7 +1476,7 @@ namespace Opc.Ua
             string      fieldName, 
             System.Type systemType)
         {
-            if (systemType == null) throw new ArgumentNullException("systemType");
+            if (systemType == null) throw new ArgumentNullException(nameof(systemType));
             
             IEncodeable value = Activator.CreateInstance(systemType) as IEncodeable;
             
@@ -2517,7 +2517,7 @@ namespace Opc.Ua
         /// </summary>
         public Array ReadEncodeableArray(string fieldName, System.Type systemType)
         {
-            if (systemType == null) throw new ArgumentNullException("systemType");
+            if (systemType == null) throw new ArgumentNullException(nameof(systemType));
             
             bool isNil = false;
 
@@ -2567,7 +2567,7 @@ namespace Opc.Ua
         /// </summary>
         public Array ReadEnumeratedArray(string fieldName, System.Type enumType)
         {
-            if (enumType == null) throw new ArgumentNullException("enumType");
+            if (enumType == null) throw new ArgumentNullException(nameof(enumType));
             
             bool isNil = false;
 

--- a/Stack/Opc.Ua.Core/Types/Utils/DataGenerator.cs
+++ b/Stack/Opc.Ua.Core/Types/Utils/DataGenerator.cs
@@ -70,17 +70,17 @@ namespace Opc.Ua.Test
         {
             if (bytes == null)
             {
-                throw new ArgumentNullException("bytes");
+                throw new ArgumentNullException(nameof(bytes));
             }
 
             if (offset < 0 || (offset != 0 && offset >= bytes.Length))
             {
-                throw new ArgumentOutOfRangeException("offset");
+                throw new ArgumentOutOfRangeException(nameof(offset));
             }
 
             if (count < 0 || offset + count > bytes.Length)
             {
-                throw new ArgumentOutOfRangeException("count");
+                throw new ArgumentOutOfRangeException(nameof(count));
             }
 
             if (bytes.Length == 0)
@@ -106,7 +106,7 @@ namespace Opc.Ua.Test
         {
             if (max < 0)
             {
-                throw new ArgumentOutOfRangeException("max");
+                throw new ArgumentOutOfRangeException(nameof(max));
             }
             
             if (max < Int32.MaxValue)

--- a/Stack/Opc.Ua.Core/Types/Utils/NamespaceTable.cs
+++ b/Stack/Opc.Ua.Core/Types/Utils/NamespaceTable.cs
@@ -90,7 +90,7 @@ namespace Opc.Ua
         /// </summary>
         public void Update(IEnumerable<string> strings)
         {
-            if (strings == null) throw new ArgumentNullException("strings");
+            if (strings == null) throw new ArgumentNullException(nameof(strings));
 
             lock (m_lock)
             {
@@ -115,7 +115,7 @@ namespace Opc.Ua
         {
             if (String.IsNullOrEmpty(value))
             {
-                throw new ArgumentNullException("value");
+                throw new ArgumentNullException(nameof(value));
             }
             
             #if DEBUG
@@ -171,7 +171,7 @@ namespace Opc.Ua
         {
             if (String.IsNullOrEmpty(value))
             {
-                throw new ArgumentNullException("value");
+                throw new ArgumentNullException(nameof(value));
             }
 
             lock (m_lock)
@@ -312,7 +312,7 @@ namespace Opc.Ua
         /// </summary>
         public new void Update(IEnumerable<string> namespaceUris)
         {
-            if (namespaceUris == null) throw new ArgumentNullException("namespaceUris");
+            if (namespaceUris == null) throw new ArgumentNullException(nameof(namespaceUris));
 
             // check that first entry is the UA namespace.
             int ii = 0;

--- a/Stack/Opc.Ua.Core/Types/Utils/NumericRange.cs
+++ b/Stack/Opc.Ua.Core/Types/Utils/NumericRange.cs
@@ -40,7 +40,7 @@ namespace Opc.Ua
         {
             if (begin < -1)
             {
-                throw new ArgumentOutOfRangeException("begin");
+                throw new ArgumentOutOfRangeException(nameof(begin));
             }
 
             m_begin = -1;
@@ -85,12 +85,12 @@ namespace Opc.Ua
             {
                 if (value < -1)
                 {
-                    throw new ArgumentOutOfRangeException("value", "Begin");
+                    throw new ArgumentOutOfRangeException(nameof(value), "Begin");
                 }                
                 
                 if (m_end != -1 && (m_begin > m_end || m_begin < 0))
                 {
-                    throw new ArgumentOutOfRangeException("value", "Begin > End");
+                    throw new ArgumentOutOfRangeException(nameof(value), "Begin > End");
                 }
 
                 m_begin = value; 
@@ -113,12 +113,12 @@ namespace Opc.Ua
             {
                 if (value < -1)
                 {
-                    throw new ArgumentOutOfRangeException("value", "End");
+                    throw new ArgumentOutOfRangeException(nameof(value), "End");
                 }
                 
                 if (m_end != -1 && (m_begin > m_end || m_begin < 0))
                 {
-                    throw new ArgumentOutOfRangeException("value", "Begin > End");
+                    throw new ArgumentOutOfRangeException(nameof(value), "Begin > End");
                 }
 
                 m_end = value; 

--- a/Stack/Opc.Ua.Core/Types/Utils/RelativePath.cs
+++ b/Stack/Opc.Ua.Core/Types/Utils/RelativePath.cs
@@ -85,7 +85,7 @@ namespace Opc.Ua
         /// </summary>
         public static RelativePath Parse(string browsePath, ITypeTable typeTree)
         {
-            if (typeTree == null) throw new ArgumentNullException("typeTree");
+            if (typeTree == null) throw new ArgumentNullException(nameof(typeTree));
 
             // parse the string.
             RelativePathFormatter formatter = RelativePathFormatter.Parse(browsePath);
@@ -498,8 +498,8 @@ namespace Opc.Ua
             /// </summary>
             public Element(RelativePathElement element, ITypeTable typeTree)
             {                
-                if (element == null) throw new ArgumentNullException("element");
-                if (typeTree == null) throw new ArgumentNullException("typeTree");
+                if (element == null) throw new ArgumentNullException(nameof(element));
+                if (typeTree == null) throw new ArgumentNullException(nameof(typeTree));
 
                 m_referenceTypeName = null;
                 m_targetName = element.TargetName;

--- a/Stack/Opc.Ua.Core/Types/Utils/Utils.cs
+++ b/Stack/Opc.Ua.Core/Types/Utils/Utils.cs
@@ -2703,7 +2703,7 @@ namespace Opc.Ua
         /// </summary>
         public static byte[] PSHA1(byte[] secret, string label, byte[] data, int offset, int length)
         {
-            if (secret == null) throw new ArgumentNullException("secret");
+            if (secret == null) throw new ArgumentNullException(nameof(secret));
             // create the hmac.
             HMACSHA1 hmac = new HMACSHA1(secret);
             return PSHA(hmac, label, data, offset, length);
@@ -2714,7 +2714,7 @@ namespace Opc.Ua
         /// </summary>
         public static byte[] PSHA256(byte[] secret, string label, byte[] data, int offset, int length)
         {
-            if (secret == null) throw new ArgumentNullException("secret");
+            if (secret == null) throw new ArgumentNullException(nameof(secret));
             // create the hmac.
             HMACSHA256 hmac = new HMACSHA256(secret);
             return PSHA(hmac, label, data, offset, length);
@@ -2725,9 +2725,9 @@ namespace Opc.Ua
         /// </summary>
         private static byte[] PSHA(HMAC hmac, string label, byte[] data, int offset, int length)
         {
-            if (hmac == null) throw new ArgumentNullException("hmac");
-            if (offset < 0) throw new ArgumentOutOfRangeException("offset");
-            if (length < 0) throw new ArgumentOutOfRangeException("length");
+            if (hmac == null) throw new ArgumentNullException(nameof(hmac));
+            if (offset < 0) throw new ArgumentOutOfRangeException(nameof(offset));
+            if (length < 0) throw new ArgumentOutOfRangeException(nameof(length));
 
             byte[] seed = null;
 

--- a/Stack/Opc.Ua.Core/Types/Utils/Utils.cs
+++ b/Stack/Opc.Ua.Core/Types/Utils/Utils.cs
@@ -713,7 +713,7 @@ namespace Opc.Ua
 
                 if (throwOnError)
                 {
-                    throw e;
+                    throw;
                 }
 
                 return filePath;
@@ -2321,7 +2321,7 @@ namespace Opc.Ua
                 catch (Exception ex)
                 {
                     Utils.Trace("Exception parsing extension: " + ex.Message);
-                    throw ex;
+                    throw;
                 }
                 finally
                 {


### PR DESCRIPTION
Minor simplification of some things, shouldn't change any functionality. In the individual commits I've included details for what changed/why.

Other things I noticed but did not change:
- Invalid comparison (type is unsigned, never less than zero):
https://github.com/OPCFoundation/UA-.NETStandard/blob/73d91d6e975eaf19cf971e7105ab5ea4dcec261e/Stack/Opc.Ua.Core/Stack/Nodes/ContentFilter.cs#L1194
- Duplicate null check:
https://github.com/OPCFoundation/UA-.NETStandard/blob/73d91d6e975eaf19cf971e7105ab5ea4dcec261e/Stack/Opc.Ua.Core/Types/Utils/ServiceResultException.cs#L146
- Unnecessary >= 0 comparison (type is unsigned, never less than zero):
https://github.com/OPCFoundation/UA-.NETStandard/blob/73d91d6e975eaf19cf971e7105ab5ea4dcec261e/Stack/Opc.Ua.Core/Types/Utils/NamespaceTable.cs#L142
- Unnecessary < 0 comparison (type is unsigned, never less than zero):
https://github.com/OPCFoundation/UA-.NETStandard/blob/73d91d6e975eaf19cf971e7105ab5ea4dcec261e/Stack/Opc.Ua.Core/Stack/Types/ContentFilter.Evaluate.cs#L2031