### PR TITLE
Allow relative URI as module name

### DIFF
--- a/SampleApplications/SDK/Opc.Ua.Client.ComplexTypes/ComplexTypeSystem.cs
+++ b/SampleApplications/SDK/Opc.Ua.Client.ComplexTypes/ComplexTypeSystem.cs
@@ -56,9 +56,18 @@ namespace Opc.Ua.Client.ComplexTypes
         public class DataTypeNotFoundException : Exception
         {
             public ExpandedNodeId nodeId;
+            public string typeName;
+
             public DataTypeNotFoundException(ExpandedNodeId nodeId)
             {
                 this.nodeId = nodeId;
+            }
+
+            public DataTypeNotFoundException(string typeName, string message)
+                : base(message)
+            {
+                this.nodeId = NodeId.Null;
+                this.typeName = typeName;
             }
 
             public DataTypeNotFoundException(ExpandedNodeId nodeId, string message)
@@ -349,6 +358,13 @@ namespace Opc.Ua.Client.ComplexTypes
                                             binaryEncodingId,
                                             typeDictionary,
                                             m_session.NamespaceUris);
+                                    }
+                                    catch (DataTypeNotFoundException typeNotFoundException)
+                                    {
+                                        Utils.Trace(typeNotFoundException,
+                                            $"Skipped the type definition of {item.Name}. Retry in next round.");
+                                        retryStructureList.Add(item);
+                                        continue;
                                     }
                                     catch (ServiceResultException sre)
                                     {

--- a/SampleApplications/SDK/Opc.Ua.Client.ComplexTypes/DataTypeDefinitionExtension.cs
+++ b/SampleApplications/SDK/Opc.Ua.Client.ComplexTypes/DataTypeDefinitionExtension.cs
@@ -270,7 +270,8 @@ namespace Opc.Ua.Client.ComplexTypes
             {
                 if (!typeCollection.TryGetValue(typeName, out NodeId referenceId))
                 {
-                    throw new ServiceResultException(StatusCodes.BadDataTypeIdUnknown,
+                    throw new ComplexTypeSystem.DataTypeNotFoundException(
+                        typeName.Name,
                         $"The type {typeName.Name} in namespace {typeName.Namespace} was not found.");
                 }
                 return referenceId;

--- a/SampleApplications/SDK/Opc.Ua.Client.ComplexTypes/TypeBuilder/ComplexTypeBuilder.cs
+++ b/SampleApplications/SDK/Opc.Ua.Client.ComplexTypes/TypeBuilder/ComplexTypeBuilder.cs
@@ -202,8 +202,9 @@ namespace Opc.Ua.Client.ComplexTypes
         {
             if (String.IsNullOrWhiteSpace(moduleName))
             {
-                Uri uri = new Uri(targetNamespace);
-                string tempName = uri.AbsolutePath;
+                Uri uri = new Uri(targetNamespace, UriKind.RelativeOrAbsolute);
+                var tempName = uri.IsAbsoluteUri ? uri.AbsolutePath : uri.ToString();
+
                 tempName = tempName.Replace("/", "");
                 var splitName = tempName.Split(':');
                 moduleName = splitName.Last();


### PR DESCRIPTION
I am working with codesys opc ua server. Method `ComplexTypeBuilder.FindModuleName()` crashes because the `targetNamespace` parameter is set to `"CODESYSSPV3/3S/IecVarAccess"` which the currently used `Uri` constuctor can't handle.  The `uri.AbsolutePath` can be used only if the uri is absolute (will throw if relative).