### PR TITLE
Fix for non reversible encoding of Unions/Structures

### DIFF
--- a/SampleApplications/SDK/Opc.Ua.Client.ComplexTypes.Tests/Types/JsonEncoderTests.cs
+++ b/SampleApplications/SDK/Opc.Ua.Client.ComplexTypes.Tests/Types/JsonEncoderTests.cs
@@ -276,6 +276,11 @@ namespace Opc.Ua.Client.ComplexTypes.Tests.Types
             var buffer = encoderStream.ToArray();
             TestContext.Out.WriteLine("Result:");
             var result = Encoding.UTF8.GetString(buffer);
+            if (data.Body is UnionComplexType && !useReversibleEncoding)
+            {
+                // helper to create testable JSON output for Unions
+                result = result.Replace("{", "{\"Union\" :");
+            }
             var formattedResult = PrettifyAndValidateJson(result);
             var jsonLoadSettings = new JsonLoadSettings() {
                 CommentHandling = CommentHandling.Ignore,
@@ -324,7 +329,7 @@ namespace Opc.Ua.Client.ComplexTypes.Tests.Types
                 }
                 else
                 {
-                    expected = $"{{\"Value\" :" + expected + "}";
+                    expected = "{\"Union\" :" + expected + "}";
                 }
             }
             else if (data.Body is OptionalFieldsComplexType)

--- a/SampleApplications/SDK/Opc.Ua.Client.ComplexTypes/ComplexTypeSystem.cs
+++ b/SampleApplications/SDK/Opc.Ua.Client.ComplexTypes/ComplexTypeSystem.cs
@@ -276,7 +276,7 @@ namespace Opc.Ua.Client.ComplexTypes
             var typeSystem = await m_session.LoadDataTypeSystem().ConfigureAwait(false);
 
             // sort dictionaries with import dependencies to the end of the list
-            var sortedTypeSystem = typeSystem.OrderBy(t => t.Value.TypeDictionary.Import?.Count()).ToList();
+            var sortedTypeSystem = typeSystem.OrderBy(t => t.Value.TypeDictionary?.Import?.Count()).ToList();
 
             bool allTypesLoaded = true;
 
@@ -286,6 +286,11 @@ namespace Opc.Ua.Client.ComplexTypes
                 try
                 {
                     var dictionary = dictionaryId.Value;
+                    if (dictionary.TypeDictionary == null ||
+                        dictionary.TypeDictionary.Items == null)
+                    {
+                        continue;
+                    }
                     var targetDictionaryNamespace = dictionary.TypeDictionary.TargetNamespace;
                     var targetNamespaceIndex = m_session.NamespaceUris.GetIndex(targetDictionaryNamespace);
                     var structureList = new List<Schema.Binary.TypeDescription>();

--- a/SampleApplications/SDK/Opc.Ua.Client.ComplexTypes/Types/BaseComplexType.cs
+++ b/SampleApplications/SDK/Opc.Ua.Client.ComplexTypes/Types/BaseComplexType.cs
@@ -42,7 +42,8 @@ namespace Opc.Ua.Client.ComplexTypes
 
     public class BaseComplexType :
         IEncodeable, IFormattable,
-        IComplexTypeProperties
+        IComplexTypeProperties,
+        IStructureTypeInfo
     {
         #region Constructors
         /// <summary>
@@ -92,6 +93,9 @@ namespace Opc.Ua.Client.ComplexTypes
 
         /// <summary cref="IEncodeable.XmlEncodingId" />
         public ExpandedNodeId XmlEncodingId { get; set; }
+
+        /// <summary cref="IStructureTypeInfo.StructureType" />
+        public StructureType StructureType => StructureType.Structure;
 
         /// <summary>
         /// Makes a deep copy of the object.

--- a/SampleApplications/SDK/Opc.Ua.Client.ComplexTypes/Types/OptionalFieldsComplexType.cs
+++ b/SampleApplications/SDK/Opc.Ua.Client.ComplexTypes/Types/OptionalFieldsComplexType.cs
@@ -58,6 +58,12 @@ namespace Opc.Ua.Client.ComplexTypes
 
         #region Public Properties
 
+        /// <summary cref="IStructureTypeInfo.StructureType" />
+        new public StructureType StructureType => StructureType.StructureWithOptionalFields;
+
+        /// <summary>
+        /// The encoding mask for the optional fields.
+        /// </summary>
         public UInt32 EncodingMask => m_encodingMask;
 
         /// <summary>

--- a/SampleApplications/SDK/Opc.Ua.Client.ComplexTypes/Types/UnionComplexType.cs
+++ b/SampleApplications/SDK/Opc.Ua.Client.ComplexTypes/Types/UnionComplexType.cs
@@ -64,6 +64,9 @@ namespace Opc.Ua.Client.ComplexTypes
         /// </summary>
         public UInt32 SwitchField => m_switchField;
 
+        /// <summary cref="IStructureTypeInfo.StructureType" />
+        new public StructureType StructureType => StructureType.Union;
+
         /// <summary>
         /// Makes a deep copy of the object.
         /// </summary>
@@ -82,9 +85,11 @@ namespace Opc.Ua.Client.ComplexTypes
         {
             encoder.PushNamespace(TypeId.NamespaceUri);
 
+            string fieldName = null;
             if (encoder.UseReversibleEncoding)
             {
                 encoder.WriteUInt32("SwitchField", m_switchField);
+                fieldName = "Value";
             }
 
             if (m_switchField != 0)
@@ -102,7 +107,11 @@ namespace Opc.Ua.Client.ComplexTypes
                     }
                     unionSelector++;
                 }
-                EncodeProperty(encoder, "Value", unionProperty, valueRank);
+                EncodeProperty(encoder, fieldName, unionProperty, valueRank);
+            }
+            else if (!encoder.UseReversibleEncoding)
+            {
+                encoder.WriteString(null, "null");
             }
 
             encoder.PopNamespace();

--- a/SampleApplications/SDK/Opc.Ua.Client/DataDictionary.cs
+++ b/SampleApplications/SDK/Opc.Ua.Client/DataDictionary.cs
@@ -131,6 +131,13 @@ namespace Opc.Ua.Client
                 throw ServiceResultException.Create(StatusCodes.BadUnexpectedError, "Cannot parse empty data dictionary.");
             }
 
+            // Interoperability: some server may return a null terminated dictionary string, adjust length
+            int zeroTerminator = Array.IndexOf<byte>(schema, (byte)0);
+            if (zeroTerminator >= 0)
+            {
+                Array.Resize(ref schema, zeroTerminator);
+            }
+
             await Validate(schema);
 
             ReadDataTypes(dictionaryId);

--- a/Stack/Opc.Ua.Core/Types/Encoders/IStructureTypeInfo.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/IStructureTypeInfo.cs
@@ -1,0 +1,25 @@
+/* Copyright (c) 1996-2019 The OPC Foundation. All rights reserved.
+   The source code in this file is covered under a dual-license scenario:
+     - RCL: for OPC Foundation members in good-standing
+     - GPL V2: everybody else
+   RCL license terms accompanied with this source code. See http://opcfoundation.org/License/RCL/1.00/
+   GNU General Public License as published by the Free Software Foundation;
+   version 2 of the License are accompanied with this source code. See http://opcfoundation.org/License/GPLv2
+   This source code is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+*/
+
+namespace Opc.Ua
+{
+    /// <summary>
+    /// Interface implemented by structured type instances.
+    /// </summary>
+    public interface IStructureTypeInfo
+    {
+        /// <summary>
+        /// Gets the structure type.
+        /// </summary>
+        StructureType StructureType { get; }
+    }
+}

--- a/Stack/Opc.Ua.Core/Types/Schemas/BinarySchemaValidator.cs
+++ b/Stack/Opc.Ua.Core/Types/Schemas/BinarySchemaValidator.cs
@@ -159,17 +159,20 @@ namespace Opc.Ua.Schema.Binary
             }
 
             // import types from target dictionary.
-            foreach (TypeDescription description in Dictionary.Items)
+            if (Dictionary.Items != null)
             {
-                ImportDescription(description, Dictionary.TargetNamespace);
-                m_validatedDescriptions.Add(description);
-            }
+                foreach (TypeDescription description in Dictionary.Items)
+                {
+                    ImportDescription(description, Dictionary.TargetNamespace);
+                    m_validatedDescriptions.Add(description);
+                }
 
-            // validate types from target dictionary.
-            foreach (TypeDescription description in m_validatedDescriptions)
-            {
-                ValidateDescription(description);
-                m_warnings.Add(String.Format(CultureInfo.InvariantCulture, "{0} '{1}' validated.", description.GetType().Name, description.Name));
+                // validate types from target dictionary.
+                foreach (TypeDescription description in m_validatedDescriptions)
+                {
+                    ValidateDescription(description);
+                    m_warnings.Add(String.Format(CultureInfo.InvariantCulture, "{0} '{1}' validated.", description.GetType().Name, description.Name));
+                }
             }
         }
 


### PR DESCRIPTION
- NetCoreComplexClient ran into JSON output exceptions with Structures and Unions
- Structures need a {}
- Unions don't need a {}