### PR TITLE
Test cases fail in US timezone

### DIFF
--- a/Stack/Opc.Ua.Core.Tests/Types/Encoders/EncoderCommon.cs
+++ b/Stack/Opc.Ua.Core.Tests/Types/Encoders/EncoderCommon.cs
@@ -31,7 +31,6 @@ using System;
 using System.Collections;
 using System.IO;
 using System.Linq;
-using System.Security.Cryptography;
 using System.Text;
 using System.Xml;
 using Newtonsoft.Json;
@@ -218,10 +217,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
             expected = AdjustExpectedBoundaryValues(encoderType, builtInType, expected);
             if (BuiltInType.DateTime == builtInType)
             {
-                if (((DateTime)expected).Kind == DateTimeKind.Unspecified)
-                {
-                    expected = ((DateTime)expected).ToUniversalTime();
-                }
+                expected = Utils.NormalizeToUniversalTime((DateTime)expected);
             }
             Assert.AreEqual(expected, result, encodeInfo);
             Assert.IsTrue(Opc.Ua.Utils.IsEqual(expected, result), "Opc.Ua.Utils.IsEqual failed to compare expected and result. " + encodeInfo);
@@ -574,10 +570,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
             {
                 return dateTime;
             }
-            if (dateTime.Kind != DateTimeKind.Utc)
-            {
-                dateTime = dateTime.ToUniversalTime();
-            }
+            dateTime = Utils.NormalizeToUniversalTime(dateTime);
             return dateTime <= Utils.TimeBase ? DateTime.MinValue : dateTime;
         }
 

--- a/Stack/Opc.Ua.Core/Types/Encoders/BinaryEncoder.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/BinaryEncoder.cs
@@ -454,10 +454,7 @@ namespace Opc.Ua
         /// </summary>
         public void WriteDateTime(string fieldName, DateTime value)
         {
-            if (value.Kind != DateTimeKind.Utc)
-            {
-                value = value.ToUniversalTime();
-            }
+            value = Utils.NormalizeToUniversalTime(value);
 
             long ticks = value.Ticks;
 

--- a/Stack/Opc.Ua.Core/Types/Encoders/XmlEncoder.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/XmlEncoder.cs
@@ -462,7 +462,8 @@ namespace Opc.Ua
         {       
             if (BeginField(fieldName, false, false))
             {
-                m_writer.WriteValue(value.ToUniversalTime());
+                value = Utils.NormalizeToUniversalTime(value);
+                m_writer.WriteValue(value);
                 EndField(fieldName);
             }
         }

--- a/Stack/Opc.Ua.Core/Types/Utils/DataComparer.cs
+++ b/Stack/Opc.Ua.Core/Types/Utils/DataComparer.cs
@@ -300,15 +300,8 @@ namespace Opc.Ua.Test
         {
             if (value1.Kind != value2.Kind)
             {
-                if (value1.Kind != DateTimeKind.Utc)
-                {
-                    value1 = value1.ToUniversalTime();
-                }
-
-                if (value2.Kind != DateTimeKind.Utc)
-                {
-                    value2 = value2.ToUniversalTime();
-                }
+                value1 = Utils.NormalizeToUniversalTime(value1);
+                value2 = Utils.NormalizeToUniversalTime(value2);
             }
 
             if (value1 < Utils.TimeBase)
@@ -328,7 +321,6 @@ namespace Opc.Ua.Test
 
             // allow milliseconds to be truncated.
             return Math.Abs((value1 - value2).Ticks) < 10000;
-
         }
         #endregion
 

--- a/Stack/Opc.Ua.Core/Types/Utils/Utils.cs
+++ b/Stack/Opc.Ua.Core/Types/Utils/Utils.cs
@@ -880,6 +880,26 @@ namespace Opc.Ua
         private static readonly DateTime s_TimeBase = new DateTime(1601, 1, 1, 0, 0, 0, DateTimeKind.Utc);
 
         /// <summary>
+        /// Normalize a DateTime to UniversalTime.
+        /// </summary>
+        public static DateTime NormalizeToUniversalTime(DateTime value)
+        {
+            if (value <= DateTime.MinValue)
+            {
+                return DateTime.MinValue;
+            }
+            if (value >= DateTime.MaxValue)
+            {
+                return DateTime.MaxValue;
+            }
+            if (value.Kind != DateTimeKind.Utc)
+            {
+                return value.ToUniversalTime();
+            }
+            return value;
+        }
+
+        /// <summary>
         /// Returns an absolute deadline for a timeout.
         /// </summary>
         public static DateTime GetDeadline(TimeSpan timeSpan)
@@ -1905,7 +1925,7 @@ namespace Opc.Ua
             // check for DateTime objects
             if (value1 is DateTime)
             {
-                return ((DateTime)value1).ToUniversalTime().CompareTo(((DateTime)value2).ToUniversalTime()) == 0;
+                return (Utils.NormalizeToUniversalTime((DateTime)value1).CompareTo(Utils.NormalizeToUniversalTime((DateTime)value2))) == 0;
             }
 
             // check for compareable objects.


### PR DESCRIPTION
-A few tests with DateTime fail in US timezones, boundary conversions need to be handled in a unified way