### PR TITLE
IOP 2020: Workshop fixes

### DIFF
--- a/SampleApplications/SDK/Opc.Ua.Client.ComplexTypes/ComplexTypeSystem.cs
+++ b/SampleApplications/SDK/Opc.Ua.Client.ComplexTypes/ComplexTypeSystem.cs
@@ -588,7 +588,7 @@ namespace Opc.Ua.Client.ComplexTypes
                                     var typeMatch = structTypesWorkList.Where(n => n.NodeId == dtnfex.nodeId).FirstOrDefault();
                                     if (typeMatch == null)
                                     {
-                                        throw dtnfex;
+                                        throw;
                                     }
                                     else
                                     {   // known missing type, retry on next round

--- a/SampleApplications/SDK/Opc.Ua.Client.ComplexTypes/ComplexTypeSystem.cs
+++ b/SampleApplications/SDK/Opc.Ua.Client.ComplexTypes/ComplexTypeSystem.cs
@@ -636,6 +636,21 @@ namespace Opc.Ua.Client.ComplexTypes
         {
             if (dataTypeNode.DataTypeDefinition?.Body is StructureDefinition structureDefinition)
             {
+                if (structureDefinition.Fields == null ||
+                    structureDefinition.BaseDataType.IsNullNodeId ||
+                    structureDefinition.BinaryEncodingId.IsNull)
+                {
+                    return null;
+                }
+                foreach (var field in structureDefinition.Fields)
+                {
+                    if (field.BinaryEncodingId.IsNull ||
+                        field.DataType.IsNullNodeId ||
+                        field.TypeId.IsNull)
+                    {
+                        return null;
+                    }
+                }
                 return structureDefinition;
             }
             return null;

--- a/SampleApplications/SDK/Opc.Ua.Client.ComplexTypes/DataTypeDefinitionExtension.cs
+++ b/SampleApplications/SDK/Opc.Ua.Client.ComplexTypes/DataTypeDefinitionExtension.cs
@@ -108,13 +108,13 @@ namespace Opc.Ua.Client.ComplexTypes
             // test forbidden combinations
             if (!isSupportedType)
             {
-                throw new ServiceResultException(StatusCodes.BadNotSupported,
+                throw new DataTypeNotSupportedException(
                     "The structure definition uses a Terminator or LengthInBytes, which are not supported.");
             }
 
             if (isUnionType && hasBitField)
             {
-                throw new ServiceResultException(StatusCodes.BadNotSupported,
+                throw new DataTypeNotSupportedException(
                     "The structure definition combines a Union and a bit filed, both of which are not supported in a single structure.");
             }
 
@@ -148,7 +148,7 @@ namespace Opc.Ua.Client.ComplexTypes
                     }
                     else
                     {
-                        throw new ServiceResultException(StatusCodes.BadNotSupported,
+                        throw new DataTypeNotSupportedException(
                             "Options for bit selectors must be 32 bit in size, use the Int32 datatype and must be the first element in the structure.");
                     }
                     continue;
@@ -157,7 +157,7 @@ namespace Opc.Ua.Client.ComplexTypes
                 if (switchFieldBitPosition != 0 &&
                     switchFieldBitPosition != 32)
                 {
-                    throw new ServiceResultException(StatusCodes.BadNotSupported,
+                    throw new DataTypeNotSupportedException(
                         "Bitwise option selectors must have 32 bits.");
                 }
 
@@ -177,7 +177,7 @@ namespace Opc.Ua.Client.ComplexTypes
                     var lastField = structureDefinition.Fields.Last();
                     if (lastField.Name != field.LengthField)
                     {
-                        throw new ServiceResultException(StatusCodes.BadNotSupported,
+                        throw new DataTypeNotSupportedException(
                             "The length field must precede the type field of an array.");
                     }
                     lastField.Name = field.Name;
@@ -193,14 +193,14 @@ namespace Opc.Ua.Client.ComplexTypes
                         {
                             if (structureDefinition.Fields.Count != 0)
                             {
-                                throw new ServiceResultException(StatusCodes.BadNotSupported,
+                                throw new DataTypeNotSupportedException(
                                     "The switch field of a union must be the first field in the complex type.");
                             }
                             continue;
                         }
                         if (structureDefinition.Fields.Count != dataTypeFieldPosition)
                         {
-                            throw new ServiceResultException(StatusCodes.BadNotSupported,
+                            throw new DataTypeNotSupportedException(
                                 "The count of the switch field of the union member is not matching the field position.");
                         }
                         dataTypeFieldPosition++;
@@ -213,7 +213,7 @@ namespace Opc.Ua.Client.ComplexTypes
                             byte value;
                             if (!switchFieldBits.TryGetValue(field.SwitchField, out value))
                             {
-                                throw new ServiceResultException(StatusCodes.BadNotSupported,
+                                throw new DataTypeNotSupportedException(
                                     $"The switch field for {field.SwitchField} does not exist.");
                             }
                         }
@@ -261,7 +261,7 @@ namespace Opc.Ua.Client.ComplexTypes
                 var internalField = typeof(DataTypeIds).GetField(typeName.Name);
                 if (internalField == null)
                 {
-                    throw new ServiceResultException(StatusCodes.BadDataTypeIdUnknown,
+                    throw new DataTypeNotFoundException(
                         $"The type {typeName.Name} was not found in the internal type factory.");
                 }
                 return (NodeId)internalField.GetValue(typeName.Name);
@@ -270,7 +270,7 @@ namespace Opc.Ua.Client.ComplexTypes
             {
                 if (!typeCollection.TryGetValue(typeName, out NodeId referenceId))
                 {
-                    throw new ComplexTypeSystem.DataTypeNotFoundException(
+                    throw new DataTypeNotFoundException(
                         typeName.Name,
                         $"The type {typeName.Name} in namespace {typeName.Namespace} was not found.");
                 }

--- a/SampleApplications/SDK/Opc.Ua.Client.ComplexTypes/DataTypeException.cs
+++ b/SampleApplications/SDK/Opc.Ua.Client.ComplexTypes/DataTypeException.cs
@@ -1,0 +1,101 @@
+/* ========================================================================
+ * Copyright (c) 2005-2019 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ * 
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ * 
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+
+namespace Opc.Ua.Client.ComplexTypes
+{
+
+    /// <summary>
+    /// Exception is thrown if data type is not found.
+    /// </summary>
+    public class DataTypeNotFoundException : Exception
+    {
+        public ExpandedNodeId nodeId;
+        public string typeName;
+
+        public DataTypeNotFoundException(ExpandedNodeId nodeId)
+        {
+            this.nodeId = nodeId;
+        }
+
+        public DataTypeNotFoundException(string typeName, string message)
+            : base(message)
+        {
+            this.nodeId = NodeId.Null;
+            this.typeName = typeName;
+        }
+
+        public DataTypeNotFoundException(ExpandedNodeId nodeId, string message)
+            : base(message)
+        {
+            this.nodeId = nodeId;
+        }
+
+        public DataTypeNotFoundException(ExpandedNodeId nodeId, string message, Exception inner)
+            : base(message, inner)
+        {
+            this.nodeId = nodeId;
+        }
+    }
+
+    /// <summary>
+    /// DataType is not supported due to structure or value rank.
+    /// </summary>
+    public class DataTypeNotSupportedException : Exception
+    {
+        public ExpandedNodeId nodeId;
+        public string typeName;
+
+        public DataTypeNotSupportedException(ExpandedNodeId nodeId)
+        {
+            this.nodeId = nodeId;
+        }
+
+        public DataTypeNotSupportedException(string typeName, string message)
+            : base(message)
+        {
+            this.nodeId = NodeId.Null;
+            this.typeName = typeName;
+        }
+
+        public DataTypeNotSupportedException(ExpandedNodeId nodeId, string message)
+            : base(message)
+        {
+            this.nodeId = nodeId;
+        }
+
+        public DataTypeNotSupportedException(ExpandedNodeId nodeId, string message, Exception inner)
+            : base(message, inner)
+        {
+            this.nodeId = nodeId;
+        }
+    }
+
+}//namespace

--- a/SampleApplications/SDK/Opc.Ua.Client.ComplexTypes/Types/BaseComplexType.cs
+++ b/SampleApplications/SDK/Opc.Ua.Client.ComplexTypes/Types/BaseComplexType.cs
@@ -663,7 +663,7 @@ namespace Opc.Ua.Client.ComplexTypes
             var propertyType = property.PropertyType;
             if (propertyType == typeof(Boolean))
             {
-                property.SetValue(this, decoder.ReadBoolean(property.Name));
+                property.SetValue(this, decoder.ReadBoolean(name));
             }
             else if (propertyType == typeof(SByte))
             {

--- a/SampleApplications/SDK/Opc.Ua.Client.ComplexTypes/Types/BaseComplexType.cs
+++ b/SampleApplications/SDK/Opc.Ua.Client.ComplexTypes/Types/BaseComplexType.cs
@@ -95,7 +95,7 @@ namespace Opc.Ua.Client.ComplexTypes
         public ExpandedNodeId XmlEncodingId { get; set; }
 
         /// <summary cref="IStructureTypeInfo.StructureType" />
-        public StructureType StructureType => StructureType.Structure;
+        public virtual StructureType StructureType => StructureType.Structure;
 
         /// <summary>
         /// Makes a deep copy of the object.

--- a/SampleApplications/SDK/Opc.Ua.Client.ComplexTypes/Types/OptionalFieldsComplexType.cs
+++ b/SampleApplications/SDK/Opc.Ua.Client.ComplexTypes/Types/OptionalFieldsComplexType.cs
@@ -59,7 +59,7 @@ namespace Opc.Ua.Client.ComplexTypes
         #region Public Properties
 
         /// <summary cref="IStructureTypeInfo.StructureType" />
-        new public StructureType StructureType => StructureType.StructureWithOptionalFields;
+        public override StructureType StructureType => StructureType.StructureWithOptionalFields;
 
         /// <summary>
         /// The encoding mask for the optional fields.

--- a/SampleApplications/SDK/Opc.Ua.Client.ComplexTypes/Types/UnionComplexType.cs
+++ b/SampleApplications/SDK/Opc.Ua.Client.ComplexTypes/Types/UnionComplexType.cs
@@ -65,7 +65,7 @@ namespace Opc.Ua.Client.ComplexTypes
         public UInt32 SwitchField => m_switchField;
 
         /// <summary cref="IStructureTypeInfo.StructureType" />
-        new public StructureType StructureType => StructureType.Union;
+        public override StructureType StructureType => StructureType.Union;
 
         /// <summary>
         /// Makes a deep copy of the object.

--- a/SampleApplications/Samples/GDS/ClientCommon/GlobalDiscoveryServerClient.cs
+++ b/SampleApplications/Samples/GDS/ClientCommon/GlobalDiscoveryServerClient.cs
@@ -944,7 +944,7 @@ namespace Opc.Ua.Gds.Client
         {
             try
             {
-                if (Object.ReferenceEquals(Session.Identity, AdminCredentials))
+                if (!Object.ReferenceEquals(Session.Identity, oldUser))
                 {
                     Session.UpdateSession(oldUser, PreferredLocales);
                 }

--- a/SampleApplications/Samples/GDS/ClientCommon/ServerPushConfigurationClient.cs
+++ b/SampleApplications/Samples/GDS/ClientCommon/ServerPushConfigurationClient.cs
@@ -30,11 +30,11 @@
 
 using System;
 using System.IO;
-using Opc.Ua.Client;
-using Opc.Ua.Configuration;
+using System.Reflection;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
-using System.Reflection;
+using Opc.Ua.Client;
+using Opc.Ua.Configuration;
 
 namespace Opc.Ua.Gds.Client
 {
@@ -59,7 +59,7 @@ namespace Opc.Ua.Gds.Client
         public NodeId DefaultHttpsGroup { get; private set; }
         public NodeId DefaultUserTokenGroup { get; private set; }
         // TODO: currently only sha256 cert is supported
-        public NodeId ApplicationCertificateType { get { return Opc.Ua.ObjectTypeIds.RsaSha256ApplicationCertificateType; } }
+        public NodeId ApplicationCertificateType => Opc.Ua.ObjectTypeIds.RsaSha256ApplicationCertificateType;
 
         /// <summary>
         /// Gets the application instance.
@@ -67,10 +67,7 @@ namespace Opc.Ua.Gds.Client
         /// <value>
         /// The application instance.
         /// </value>
-        public ApplicationInstance Application
-        {
-            get { return m_application; }
-        }
+        public ApplicationInstance Application => m_application;
 
         /// <summary>
         /// Gets or sets the admin credentials.
@@ -124,10 +121,7 @@ namespace Opc.Ua.Gds.Client
         /// <value>
         ///   <c>true</c> if the session is connected; otherwise, <c>false</c>.
         /// </value>
-        public bool IsConnected
-        {
-            get { return m_session != null && m_session.Connected; }
-        }
+        public bool IsConnected => m_session != null && m_session.Connected;
 
         /// <summary>
         /// Gets the session.
@@ -135,10 +129,7 @@ namespace Opc.Ua.Gds.Client
         /// <value>
         /// The session.
         /// </value>
-        public Session Session
-        {
-            get { return m_session; }
-        }
+        public Session Session => m_session;
 
         /// <summary>
         /// Gets the endpoint.
@@ -253,7 +244,7 @@ namespace Opc.Ua.Gds.Client
                 false,
                 m_application.ApplicationName,
                 60000,
-                null,
+                m_adminCredentials,
                 m_preferredLocales);
 
             m_endpoint = m_session.ConfiguredEndpoint;
@@ -782,7 +773,7 @@ namespace Opc.Ua.Gds.Client
         {
             try
             {
-                if (Object.ReferenceEquals(m_session.Identity, m_adminCredentials))
+                if (!Object.ReferenceEquals(m_session.Identity, oldUser))
                 {
                     m_session.UpdateSession(oldUser, m_preferredLocales);
                 }

--- a/Stack/Opc.Ua.Core/Security/Certificates/CertificateFactory.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/CertificateFactory.cs
@@ -536,7 +536,11 @@ public class CertificateFactory
 
                 List<X509CRL> certCACrl = store.EnumerateCRLs(certCA, false);
 
-                var certificateCollection = new X509Certificate2Collection() { certificate };
+                var certificateCollection = new X509Certificate2Collection() { };
+                if (!isCACert)
+                {
+                    certificateCollection.Add(certificate);
+                }
                 updatedCRL = RevokeCertificate(certCAWithPrivateKey, certCACrl, certificateCollection);
 
                 store.AddCRL(updatedCRL);

--- a/Stack/Opc.Ua.Core/Stack/Https/HttpsListener.cs
+++ b/Stack/Opc.Ua.Core/Stack/Https/HttpsListener.cs
@@ -177,7 +177,7 @@ namespace Opc.Ua.Bindings
         {
             Startup.Listener = this;
             m_hostBuilder = new WebHostBuilder();
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0 || NETSTANDARD2_1
             HttpsConnectionAdapterOptions httpsOptions = new HttpsConnectionAdapterOptions();
             httpsOptions.CheckCertificateRevocation = false;
             httpsOptions.ClientCertificateMode = ClientCertificateMode.NoCertificate;

--- a/Stack/Opc.Ua.Core/Types/Encoders/EncodableObject.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/EncodableObject.cs
@@ -67,9 +67,9 @@ namespace Opc.Ua
                 return StatusCodes.BadDataEncodingUnsupported;
             }
 
-            bool useXml = dataEncoding.Name == DefaultXml;
+            bool useXml = dataEncoding.Name == BrowseNames.DefaultXml;
 
-            if (!useXml && dataEncoding.Name != DefaultBinary)
+            if (!useXml && dataEncoding.Name != BrowseNames.DefaultBinary)
             {
                 return StatusCodes.BadDataEncodingInvalid;
             }
@@ -198,16 +198,6 @@ namespace Opc.Ua
             encoder.WriteEncodeable(null, encodeable, null);
             return encoder.CloseAndReturnBuffer();
         }
-        
-        /// <summary>
-        /// The BrowseName for the DefaultBinary component.
-        /// </summary>
-        private const string DefaultBinary = "Default Binary";
-
-        /// <summary>
-        /// The BrowseName for the DefaultXml component.
-        /// </summary>
-        private const string DefaultXml = "Default XML";
         #endregion
         
         /// <summary>

--- a/Stack/Opc.Ua.Core/Types/Schemas/BinarySchemaValidator.cs
+++ b/Stack/Opc.Ua.Core/Types/Schemas/BinarySchemaValidator.cs
@@ -339,7 +339,7 @@ namespace Opc.Ua.Schema.Binary
                 return false;
             }
 
-            if (!Char.IsLetter(name[0]) && name[0] != '_')
+            if (!Char.IsLetter(name[0]) && name[0] != '_' && name[0] != '"')
             {
                 return false;
             }
@@ -351,7 +351,7 @@ namespace Opc.Ua.Schema.Binary
                     continue;
                 }
 
-                if (name[ii] == '.' || name[ii] == '-' || name[ii] == '_')
+                if (name[ii] == '.' || name[ii] == '-' || name[ii] == '_' || name[ii] == '"')
                 {
                     continue;
                 }


### PR DESCRIPTION
- fix to validate structuredefinition if servers do not fill out the DataTypeDefinition correctly
- The GDS creates the CRL cert with its own CA serial number, invalidating the CA on some stacks
- complex structuretype must be virtual, non reversible encoding could not be detected 
- fix binary schema validation, allow the \" character in a qualified name
- support use of simple subtypes in a complex type. For custom and standard subtypes.
- only support structure objects with valuerank scalar or onedimension