### PR TITLE
Possible bug in QuickstartNodeManager.cs

### DIFF
--- a/SampleApplications/Workshop/Common/QuickstartNodeManager.cs
+++ b/SampleApplications/Workshop/Common/QuickstartNodeManager.cs
@@ -548,7 +548,7 @@ namespace Quickstarts
                 return predefinedNode;
             }
 
-            return predefinedNode;
+            return passiveNode;
         }
 
         /// <summary>


### PR DESCRIPTION
On `protected virtual NodeState AddBehaviourToPredefinedNode`, always return `predefinedNode`.
Maybe it's an error? If `passiveNode `is not null we should return instead of `predefinedNode`?