### PR TITLE
Fix for self signed certs

### DIFF
--- a/Applications/ConsoleReferenceServer/Program.cs
+++ b/Applications/ConsoleReferenceServer/Program.cs
@@ -1,4 +1,4 @@
-﻿/* ========================================================================
+/* ========================================================================
  * Copyright (c) 2005-2019 The OPC Foundation, Inc. All rights reserved.
  *
  * OPC Foundation MIT License 1.00
@@ -230,7 +230,7 @@ namespace Quickstarts.ReferenceServer
             ApplicationConfiguration config = await application.LoadApplicationConfiguration(false);
 
             // check the application certificate.
-            bool haveAppCertificate = await application.CheckApplicationInstanceCertificate(false, CertificateFactory.defaultKeySize, CertificateFactory.defaultLifeTime);
+            bool haveAppCertificate = await application.CheckApplicationInstanceCertificate(false, CertificateFactory.DefaultKeySize, CertificateFactory.DefaultLifeTime);
             if (!haveAppCertificate)
             {
                 throw new Exception("Application instance certificate invalid!");

--- a/Libraries/Opc.Ua.Gds.Server.Common/GlobalDiscoveryServerConfiguration.cs
+++ b/Libraries/Opc.Ua.Gds.Server.Common/GlobalDiscoveryServerConfiguration.cs
@@ -121,12 +121,12 @@ namespace Opc.Ua.Gds.Server
         /// </summary>
         private void Initialize()
         {
-            DefaultCertificateLifetime = CertificateFactory.defaultLifeTime;
-            DefaultCertificateKeySize = CertificateFactory.defaultKeySize;
-            DefaultCertificateHashSize = CertificateFactory.defaultHashSize;
-            CACertificateLifetime = CertificateFactory.defaultLifeTime;
-            CACertificateKeySize = CertificateFactory.defaultKeySize;
-            CACertificateHashSize = CertificateFactory.defaultHashSize;
+            DefaultCertificateLifetime = CertificateFactory.DefaultLifeTime;
+            DefaultCertificateKeySize = CertificateFactory.DefaultKeySize;
+            DefaultCertificateHashSize = CertificateFactory.DefaultHashSize;
+            CACertificateLifetime = CertificateFactory.DefaultLifeTime;
+            CACertificateKeySize = CertificateFactory.DefaultKeySize;
+            CACertificateHashSize = CertificateFactory.DefaultHashSize;
         }
         #endregion
 

--- a/Stack/Opc.Ua.Core.Tests/Security/Certificates/CertificateFactoryTest.cs
+++ b/Stack/Opc.Ua.Core.Tests/Security/Certificates/CertificateFactoryTest.cs
@@ -1,0 +1,314 @@
+/* ========================================================================
+ * Copyright (c) 2005-2018 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ * 
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ * 
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography.X509Certificates;
+using NUnit.Framework;
+
+namespace Opc.Ua.Core.Tests.Security.Certificates
+{
+    /// <summary>
+    /// Tests for the CertificateFactory class.
+    /// </summary>
+    [TestFixture, Category("CertificateFactory")]
+    [Parallelizable]
+    [SetCulture("en-us")]
+    public class CertificateFactoryTest
+    {
+        #region DataPointSources
+        public class KeyHashPair : IFormattable
+        {
+            public KeyHashPair(ushort keySize, ushort hashSize)
+            {
+                KeySize = keySize;
+                HashSize = hashSize;
+            }
+
+            public ushort KeySize;
+            public ushort HashSize;
+
+            public string ToString(string format, IFormatProvider formatProvider)
+            {
+                return $"{KeySize}-{HashSize}";
+            }
+        }
+
+        public class KeyHashPairCollection : List<KeyHashPair>
+        {
+            public KeyHashPairCollection() { }
+            public KeyHashPairCollection(IEnumerable<KeyHashPair> collection) : base(collection) { }
+            public KeyHashPairCollection(int capacity) : base(capacity) { }
+            public static KeyHashPairCollection ToJsonValidationDataCollection(KeyHashPair[] values)
+            {
+                return values != null ? new KeyHashPairCollection(values) : new KeyHashPairCollection();
+            }
+
+            public void Add(ushort keySize, ushort hashSize)
+            {
+                Add(new KeyHashPair(keySize, hashSize));
+            }
+        }
+
+        [DatapointSource]
+        public KeyHashPair[] KeyHashPairs = new KeyHashPairCollection { { 1024, 160 }, { 2048, 256 }, { 3072, 384 }, { 4096, 512 } }.ToArray();
+        #endregion
+
+        #region Test Setup
+        /// <summary>
+        /// Set up a Global Discovery Server and Client instance and connect the session
+        /// </summary>
+        [OneTimeSetUp]
+        protected void OneTimeSetUp()
+        {
+        }
+
+        /// <summary>
+        /// Clean up the Test PKI folder
+        /// </summary>
+        [OneTimeTearDown]
+        protected void OneTimeTearDown()
+        {
+        }
+        #endregion
+
+        #region Test Methods
+        /// <summary>
+        /// Verify self signed app certs.
+        /// </summary>
+        [Theory]
+        public void VerifySelfSignedAppCerts(
+            KeyHashPair keyHashPair
+            )
+        {
+            var appTestGenerator = new ApplicationTestDataGenerator(keyHashPair.KeySize);
+            ApplicationTestData app = appTestGenerator.ApplicationTestSet(1).First();
+            var cert = CertificateFactory.CreateCertificate(null, null, null,
+                app.ApplicationUri, app.ApplicationName, app.Subject,
+                app.DomainNames, keyHashPair.KeySize, DateTime.UtcNow,
+                CertificateFactory.DefaultLifeTime, keyHashPair.HashSize);
+            Assert.NotNull(cert);
+            Assert.NotNull(cert.RawData);
+            Assert.True(cert.HasPrivateKey);
+            var plainCert = new X509Certificate2(cert.RawData);
+            Assert.NotNull(plainCert);
+            VerifySelfSignedApplicationCert(app, plainCert);
+            CertificateFactory.VerifySelfSigned(cert);
+            CertificateFactory.VerifyRSAKeyPair(cert, cert);
+        }
+
+        /// <summary>
+        /// Verify CA signed app certs.
+        /// </summary>
+        [Theory]
+        public void VerifyCACerts(
+            KeyHashPair keyHashPair
+            )
+        {
+            var subject = "CN=CA Test Cert";
+            var cert = CertificateFactory.CreateCertificate(
+                null, null, null,
+                null, null, subject,
+                null, keyHashPair.KeySize,
+                DateTime.UtcNow, 25 * 12,
+                keyHashPair.HashSize,
+                isCA: true,
+                pathLengthConstraint: -1);
+
+            Assert.NotNull(cert);
+            Assert.NotNull(cert.RawData);
+            Assert.True(cert.HasPrivateKey);
+            var plainCert = new X509Certificate2(cert.RawData);
+            Assert.NotNull(plainCert);
+            VerifyCACert(subject, plainCert);
+            CertificateFactory.VerifySelfSigned(cert);
+            CertificateFactory.VerifyRSAKeyPair(cert, cert);
+        }
+        #endregion
+
+        #region Private Methods
+        public static void VerifySelfSignedApplicationCert(ApplicationTestData testApp, X509Certificate2 cert)
+        {
+            Assert.NotNull(cert);
+            Assert.False(cert.HasPrivateKey);
+            Assert.True(Utils.CompareDistinguishedName(testApp.Subject, cert.Subject));
+            Assert.True(Utils.CompareDistinguishedName(testApp.Subject, cert.Issuer));
+
+            // test basic constraints
+            var constraints = FindExtension<X509BasicConstraintsExtension>(cert);
+            Assert.NotNull(constraints);
+            Assert.True(constraints.Critical);
+            Assert.True(constraints.CertificateAuthority);
+            Assert.True(constraints.HasPathLengthConstraint);
+            Assert.AreEqual(0, constraints.PathLengthConstraint);
+
+            // key usage
+            var keyUsage = FindExtension<X509KeyUsageExtension>(cert);
+            Assert.NotNull(keyUsage);
+            Assert.True(keyUsage.Critical);
+            Assert.True((keyUsage.KeyUsages & X509KeyUsageFlags.CrlSign) == 0);
+            Assert.True((keyUsage.KeyUsages & X509KeyUsageFlags.DataEncipherment) == X509KeyUsageFlags.DataEncipherment);
+            Assert.True((keyUsage.KeyUsages & X509KeyUsageFlags.DecipherOnly) == 0);
+            Assert.True((keyUsage.KeyUsages & X509KeyUsageFlags.DigitalSignature) == X509KeyUsageFlags.DigitalSignature);
+            Assert.True((keyUsage.KeyUsages & X509KeyUsageFlags.EncipherOnly) == 0);
+            Assert.True((keyUsage.KeyUsages & X509KeyUsageFlags.KeyAgreement) == 0);
+            Assert.True((keyUsage.KeyUsages & X509KeyUsageFlags.KeyCertSign) == X509KeyUsageFlags.KeyCertSign);
+            Assert.True((keyUsage.KeyUsages & X509KeyUsageFlags.KeyEncipherment) == X509KeyUsageFlags.KeyEncipherment);
+            Assert.True((keyUsage.KeyUsages & X509KeyUsageFlags.NonRepudiation) == X509KeyUsageFlags.NonRepudiation);
+
+            // enhanced key usage
+            X509EnhancedKeyUsageExtension enhancedKeyUsage = FindExtension<X509EnhancedKeyUsageExtension>(cert);
+            Assert.NotNull(enhancedKeyUsage);
+            Assert.True(enhancedKeyUsage.Critical);
+
+            // test for authority key
+            X509AuthorityKeyIdentifierExtension authority = FindAuthorityKeyIdentifier(cert);
+            Assert.NotNull(authority);
+            Assert.NotNull(authority.SerialNumber);
+            Assert.NotNull(authority.KeyId);
+            Assert.NotNull(authority.AuthorityNames);
+
+            // verify authority key in signed cert
+            X509SubjectKeyIdentifierExtension subjectKeyId = FindExtension<X509SubjectKeyIdentifierExtension>(cert);
+            Assert.AreEqual(subjectKeyId.SubjectKeyIdentifier, authority.KeyId);
+            Assert.AreEqual(cert.SerialNumber, authority.SerialNumber);
+
+            X509SubjectAltNameExtension subjectAlternateName = FindSubjectAltName(cert);
+            Assert.NotNull(subjectAlternateName);
+            Assert.False(subjectAlternateName.Critical);
+            var domainNames = Utils.GetDomainsFromCertficate(cert);
+            foreach (var domainName in testApp.DomainNames)
+            {
+                Assert.True(domainNames.Contains(domainName, StringComparer.OrdinalIgnoreCase));
+            }
+            Assert.True(subjectAlternateName.Uris.Count == 1);
+            var applicationUri = Utils.GetApplicationUriFromCertificate(cert);
+            Assert.AreEqual(testApp.ApplicationUri, applicationUri);
+        }
+
+        public static void VerifyCACert(string subject, X509Certificate2 cert)
+        {
+            Assert.NotNull(cert);
+            Assert.False(cert.HasPrivateKey);
+            Assert.True(Utils.CompareDistinguishedName(subject, cert.Subject));
+            Assert.True(Utils.CompareDistinguishedName(subject, cert.Issuer));
+
+            // test basic constraints
+            var constraints = FindExtension<X509BasicConstraintsExtension>(cert);
+            Assert.NotNull(constraints);
+            Assert.True(constraints.Critical);
+            Assert.True(constraints.CertificateAuthority);
+            Assert.True(constraints.HasPathLengthConstraint);
+
+            // key usage
+            var keyUsage = FindExtension<X509KeyUsageExtension>(cert);
+            Assert.NotNull(keyUsage);
+            Assert.True(keyUsage.Critical);
+            Assert.True((keyUsage.KeyUsages & X509KeyUsageFlags.CrlSign) == X509KeyUsageFlags.CrlSign);
+            Assert.True((keyUsage.KeyUsages & X509KeyUsageFlags.DataEncipherment) == 0);
+            Assert.True((keyUsage.KeyUsages & X509KeyUsageFlags.DecipherOnly) == 0);
+            Assert.True((keyUsage.KeyUsages & X509KeyUsageFlags.DigitalSignature) == X509KeyUsageFlags.DigitalSignature);
+            Assert.True((keyUsage.KeyUsages & X509KeyUsageFlags.EncipherOnly) == 0);
+            Assert.True((keyUsage.KeyUsages & X509KeyUsageFlags.KeyAgreement) == 0);
+            Assert.True((keyUsage.KeyUsages & X509KeyUsageFlags.KeyCertSign) == X509KeyUsageFlags.KeyCertSign);
+            Assert.True((keyUsage.KeyUsages & X509KeyUsageFlags.KeyEncipherment) == 0);
+            Assert.True((keyUsage.KeyUsages & X509KeyUsageFlags.NonRepudiation) == 0);
+
+            // enhanced key usage
+            X509EnhancedKeyUsageExtension enhancedKeyUsage = FindExtension<X509EnhancedKeyUsageExtension>(cert);
+            Assert.Null(enhancedKeyUsage);
+
+            // test for authority key
+            X509AuthorityKeyIdentifierExtension authority = FindAuthorityKeyIdentifier(cert);
+            Assert.NotNull(authority);
+            Assert.NotNull(authority.SerialNumber);
+            Assert.NotNull(authority.KeyId);
+            Assert.NotNull(authority.AuthorityNames);
+
+            // verify authority key in signed cert
+            X509SubjectKeyIdentifierExtension subjectKeyId = FindExtension<X509SubjectKeyIdentifierExtension>(cert);
+            Assert.AreEqual(subjectKeyId.SubjectKeyIdentifier, authority.KeyId);
+            Assert.AreEqual(cert.SerialNumber, authority.SerialNumber);
+
+            X509SubjectAltNameExtension subjectAlternateName = FindSubjectAltName(cert);
+            Assert.Null(subjectAlternateName);
+        }
+
+        private static T FindExtension<T>(X509Certificate2 certificate) where T : class
+        {
+            for (int ii = 0; ii < certificate.Extensions.Count; ii++)
+            {
+                T extension = certificate.Extensions[ii] as T;
+                if (extension != null)
+                {
+                    return extension;
+                }
+            }
+            return null;
+        }
+
+        private static X509AuthorityKeyIdentifierExtension FindAuthorityKeyIdentifier(X509Certificate2 certificate)
+        {
+            for (int ii = 0; ii < certificate.Extensions.Count; ii++)
+            {
+                X509Extension extension = certificate.Extensions[ii];
+
+                switch (extension.Oid.Value)
+                {
+                    case X509AuthorityKeyIdentifierExtension.AuthorityKeyIdentifierOid:
+                    case X509AuthorityKeyIdentifierExtension.AuthorityKeyIdentifier2Oid:
+                    {
+                        return new X509AuthorityKeyIdentifierExtension(extension, extension.Critical);
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        private static X509SubjectAltNameExtension FindSubjectAltName(X509Certificate2 certificate)
+        {
+            foreach (var extension in certificate.Extensions)
+            {
+                if (extension.Oid.Value == X509SubjectAltNameExtension.SubjectAltNameOid ||
+                    extension.Oid.Value == X509SubjectAltNameExtension.SubjectAltName2Oid)
+                {
+                    return new X509SubjectAltNameExtension(extension, extension.Critical);
+                }
+            }
+            return null;
+        }
+        #endregion
+
+        #region Private Fields
+        #endregion
+    }
+
+}

--- a/Stack/Opc.Ua.Core/Schema/ApplicationConfiguration.cs
+++ b/Stack/Opc.Ua.Core/Schema/ApplicationConfiguration.cs
@@ -736,7 +736,7 @@ namespace Opc.Ua
             m_autoAcceptUntrustedCertificates = false;
             m_rejectSHA1SignedCertificates = true;
             m_rejectUnknownRevocationStatus = false;
-            m_minCertificateKeySize = CertificateFactory.defaultKeySize;
+            m_minCertificateKeySize = CertificateFactory.DefaultKeySize;
             m_addAppCertToTrustedStore = true;
             m_sendCertificateChain = false;
         }

--- a/Stack/Opc.Ua.Core/Security/Certificates/CertificateFactory.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/CertificateFactory.cs
@@ -301,12 +301,12 @@ public class CertificateFactory
 
             // Basic constraints
             BasicConstraints basicConstraints = new BasicConstraints(isCA);
-            if (pathLengthConstraint >= 0 && isCA)
+            if (isCA && pathLengthConstraint >= 0)
             {
                 basicConstraints = new BasicConstraints(pathLengthConstraint);
             }
-            else if (issuerCAKeyCert == null)
-            {
+            else if (!isCA && issuerCAKeyCert == null)
+            {   // self-signed
                 basicConstraints = new BasicConstraints(0);
             }
             cg.AddExtension(X509Extensions.BasicConstraints.Id, true, basicConstraints);
@@ -1169,7 +1169,7 @@ public class CertificateFactory
     /// <summary>
     /// Get public key parameters from a X509Certificate2
     /// </summary>
-    private static RsaKeyParameters GetPublicKeyParameter(X509Certificate2 certificate)
+    internal static RsaKeyParameters GetPublicKeyParameter(X509Certificate2 certificate)
     {
         RSA rsa = null;
         try
@@ -1191,7 +1191,7 @@ public class CertificateFactory
     /// Get private key parameters from a X509Certificate2.
     /// The private key must be exportable.
     /// </summary>
-    private static RsaPrivateCrtKeyParameters GetPrivateKeyParameter(X509Certificate2 certificate)
+    internal static RsaPrivateCrtKeyParameters GetPrivateKeyParameter(X509Certificate2 certificate)
     {
         RSA rsa = null;
         try

--- a/Stack/Opc.Ua.Core/Security/Certificates/CertificateFactory.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/CertificateFactory.cs
@@ -1169,7 +1169,7 @@ public class CertificateFactory
     /// <summary>
     /// Get public key parameters from a X509Certificate2
     /// </summary>
-    internal static RsaKeyParameters GetPublicKeyParameter(X509Certificate2 certificate)
+    private static RsaKeyParameters GetPublicKeyParameter(X509Certificate2 certificate)
     {
         RSA rsa = null;
         try
@@ -1191,7 +1191,7 @@ public class CertificateFactory
     /// Get private key parameters from a X509Certificate2.
     /// The private key must be exportable.
     /// </summary>
-    internal static RsaPrivateCrtKeyParameters GetPrivateKeyParameter(X509Certificate2 certificate)
+    private static RsaPrivateCrtKeyParameters GetPrivateKeyParameter(X509Certificate2 certificate)
     {
         RSA rsa = null;
         try

--- a/Stack/Opc.Ua.Core/Security/Certificates/CertificateValidator.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/CertificateValidator.cs
@@ -30,9 +30,9 @@ namespace Opc.Ua
         public CertificateValidator()
         {
             m_validatedCertificates = new Dictionary<string, X509Certificate2>();
-            m_rejectSHA1SignedCertificates = CertificateFactory.defaultHashSize >= 256;
+            m_rejectSHA1SignedCertificates = CertificateFactory.DefaultHashSize >= 256;
             m_rejectUnknownRevocationStatus = false;
-            m_minimumCertificateKeySize = CertificateFactory.defaultKeySize;
+            m_minimumCertificateKeySize = CertificateFactory.DefaultKeySize;
         }
         #endregion
 
@@ -860,7 +860,8 @@ namespace Opc.Ua
                 throw new ServiceResultException(StatusCodes.BadCertificatePolicyCheckFailed, "SHA1 signed certificates are not trusted");
             }
 
-            if (certificate.GetRSAPublicKey().KeySize < m_minimumCertificateKeySize)
+            int keySize = CertificateFactory.GetRSAPublicKeySize(certificate);
+            if (keySize < m_minimumCertificateKeySize)
             {
                 throw new ServiceResultException(StatusCodes.BadCertificatePolicyCheckFailed, "Certificate doesn't meet minimum key length requirement");
             }

--- a/Stack/Opc.Ua.Core/Stack/Tcp/UaSCBinaryChannel.Asymmetric.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/UaSCBinaryChannel.Asymmetric.cs
@@ -594,7 +594,7 @@ namespace Opc.Ua.Bindings
 
                     if (SecurityMode != MessageSecurityMode.None)
                     {
-                        if (receiverCertificate.GetRSAPublicKey().KeySize <= TcpMessageLimits.KeySizeExtraPadding)
+                        if (CertificateFactory.GetRSAPublicKeySize(receiverCertificate) <= TcpMessageLimits.KeySizeExtraPadding)
                         {
                             // need to reserve one byte for the padding.
                             plainTextSize++;
@@ -978,7 +978,7 @@ namespace Opc.Ua.Bindings
             if (SecurityMode != MessageSecurityMode.None)
             {
                 int paddingEnd = -1;
-                if (receiverCertificate.GetRSAPublicKey().KeySize > TcpMessageLimits.KeySizeExtraPadding)
+                if (CertificateFactory.GetRSAPublicKeySize(receiverCertificate) > TcpMessageLimits.KeySizeExtraPadding)
                 {
                     paddingEnd = plainText.Offset + plainText.Count - signatureSize - 1;
                     paddingCount = plainText.Array[paddingEnd - 1] + plainText.Array[paddingEnd] * 256;

--- a/Stack/Opc.Ua.Core/Stack/Types/SoftwareCertficate.cs
+++ b/Stack/Opc.Ua.Core/Stack/Types/SoftwareCertficate.cs
@@ -11,26 +11,23 @@
 */
 
 using System;
-using System.Collections.Generic;
-using System.ServiceModel;
+using System.IO;
 using System.Runtime.Serialization;
 using System.Security.Cryptography.X509Certificates;
-using System.IO;
-using System.Threading.Tasks;
 
 namespace Opc.Ua
 {
-	/// <summary>
-	/// The SoftwareCertificate class.
-	/// </summary>
-	public partial class SoftwareCertificate
-	{
+    /// <summary>
+    /// The SoftwareCertificate class.
+    /// </summary>
+    public partial class SoftwareCertificate
+    {
         /// <summary>
         /// The SignedSoftwareCertificate that contains the SoftwareCertificate
         /// </summary>
         public X509Certificate2 SignedCertificate
         {
-            get { return m_signedCertificate;  } 
+            get { return m_signedCertificate; }
             set { m_signedCertificate = value; }
         }
 

--- a/Tests/Opc.Ua.Core.Tests/Security/Certificates/CertificateValidatorTest.cs
+++ b/Tests/Opc.Ua.Core.Tests/Security/Certificates/CertificateValidatorTest.cs
@@ -71,7 +71,6 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
 
             // create all certs and CRL
             m_caChain = new X509Certificate2[kCaChainCount];
-            m_constraintChain = new X509Certificate2[kCaChainCount];
             m_caDupeChain = new X509Certificate2[kCaChainCount];
             m_caAllSameIssuerChain = new X509Certificate2[kCaChainCount];
             m_crlChain = new X509CRL[kCaChainCount];

--- a/Tests/Opc.Ua.Core.Tests/Security/Certificates/Common.cs
+++ b/Tests/Opc.Ua.Core.Tests/Security/Certificates/Common.cs
@@ -29,16 +29,13 @@
 
 using System;
 using System.Collections.Generic;
+using System.Security.Cryptography.X509Certificates;
 using System.Text.RegularExpressions;
 using Opc.Ua.Test;
 
 
 namespace Opc.Ua.Core.Tests
 {
-    public class ApplicationRecordDataType
-    {
-    }
-
     public class ApplicationTestDataGenerator
     {
         private int m_randomStart = 1;
@@ -149,7 +146,6 @@ namespace Opc.Ua.Core.Tests
             }
             return result;
         }
-
     }
 
     public class ApplicationTestData
@@ -202,6 +198,5 @@ namespace Opc.Ua.Core.Tests
                 store.Dispose();
             }
         }
-
     }
 }

--- a/Tests/Opc.Ua.Core.Tests/Security/Certificates/Common.cs
+++ b/Tests/Opc.Ua.Core.Tests/Security/Certificates/Common.cs
@@ -29,7 +29,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Security.Cryptography.X509Certificates;
 using System.Text.RegularExpressions;
 using Opc.Ua.Test;
 

--- a/Tests/Opc.Ua.Gds.Tests/Common.cs
+++ b/Tests/Opc.Ua.Gds.Tests/Common.cs
@@ -284,7 +284,7 @@ namespace Opc.Ua.Gds.Tests
         }
     }
 
-    public class TestUtils
+    public static class TestUtils
     {
         public static void CleanupTrustList(ICertificateStore store, bool dispose = true)
         {

--- a/Tests/Opc.Ua.Gds.Tests/PushTest.cs
+++ b/Tests/Opc.Ua.Gds.Tests/PushTest.cs
@@ -433,10 +433,10 @@ namespace Opc.Ua.Gds.Tests
                 _applicationRecord.ApplicationNames[0].Text,
                 _selfSignedServerCert.Subject,
                 null,
-                CertificateFactory.defaultKeySize,
+                CertificateFactory.DefaultKeySize,
                 DateTime.UtcNow,
-                CertificateFactory.defaultLifeTime,
-                CertificateFactory.defaultHashSize);
+                CertificateFactory.DefaultLifeTime,
+                CertificateFactory.DefaultHashSize);
 
             byte[] privateKey = null;
             if (keyFormat == "PFX")
@@ -819,10 +819,10 @@ namespace Opc.Ua.Gds.Tests
                 null,
                 subjectName,
                 null,
-                CertificateFactory.defaultKeySize,
+                CertificateFactory.DefaultKeySize,
                 DateTime.UtcNow,
-                CertificateFactory.defaultLifeTime,
-                CertificateFactory.defaultHashSize,
+                CertificateFactory.DefaultLifeTime,
+                CertificateFactory.DefaultHashSize,
                 true,
                 null,
                 null);

--- a/lgtm.yml
+++ b/lgtm.yml
@@ -1,5 +1,7 @@
 extraction:
   csharp:
     index:
-      dotnet:
-        version: 2.1.301
+      solution: "UA Core Library.sln"
+      msbuild:
+        configuration: "release"
+        platform: "Any CPU"

--- a/lgtm.yml
+++ b/lgtm.yml
@@ -1,7 +1,5 @@
 extraction:
   csharp:
     index:
-      solution: "UA Core Library.sln"
-      msbuild:
-        configuration: "release"
-        platform: "Any CPU"
+      dotnet:
+        version: 2.1.301


### PR DESCRIPTION
- The self signed certs should have the CA flag set
- small cleanup fixes for cert code
- make sure public key is always disposed
- breaking change: defaults for certs naming convention was not quite right and it should be a readonly, to make sure policy changes are reflected in calling code