### PR TITLE
Fix argTypes null pointer condition

### DIFF
--- a/Stack/Opc.Ua.Core/Types/Utils/TypeInfo.cs
+++ b/Stack/Opc.Ua.Core/Types/Utils/TypeInfo.cs
@@ -1181,7 +1181,7 @@ namespace Opc.Ua
                 {
                     Type[] argTypes = systemType.GetGenericArguments();
 
-                    if (argTypes != null || argTypes.Length == 1)
+                    if (argTypes != null && argTypes.Length == 1)
                     {
                         TypeInfo typeInfo = Construct(argTypes[0]);
 


### PR DESCRIPTION
I believe this was a typo:

```
if (argTypes != null || argTypes.Length == 1)
```

(If argTypes was null, then the first part would be false, and the second part of throw an exception. If argsType wasn't null, then the first part would be true and the second part wouldn't be evaluated.) I'm not sure whether the length check should be `== 1` or `>= 1`, nor do I know anything about how this is used, so apologies if I've misunderstood something.