### PR TITLE
change LGTM extraction behaviour

### DIFF
--- a/lgtm.yml
+++ b/lgtm.yml
@@ -1,7 +1,5 @@
 extraction:
   csharp:
     index:
-      solution: "UA Core Library.sln"
-      msbuild:
-        configuration: "release"
-        platform: "Any CPU"
+      buildless: true
+      nuget_restore: false


### PR DESCRIPTION
**Background**
Method of Http Client isn't available (based on documentation) in 4.6.2, but without using it HTTPS isn't working anymore.

**Problem**
LGTM build are failing because they didn't find method mentioned above.

**Solution**
Change LGTM behaviour from building the solution before analysis to just analyze all *.cs files independent, expectation:
* LGTM analysis are more robust
* LGTM may report errors within files that are not part of product (increase number of violations)