### PR TITLE
Add build step to upload nuget packages to a preview feed

### DIFF
--- a/.azurepipelines/preview.yml
+++ b/.azurepipelines/preview.yml
@@ -10,7 +10,7 @@ jobs:
     vmImage: 'windows-2019'
   variables:
     msbuildversion: '/p:Version=$(NUGETVERSION) /p:AssemblyVersion=$(NUGETVERSION) /p:FileVersion=$(NUGETVERSION)'
-    nugetpreviewversion: '$(NUGETVERSION)-$(Build.SourceBranchName)-$(Year:yyyy)$(Month:mm)$(DayOfMonth:dd)$(Rev:.r)-preview'
+    nugetpreviewversion: '$(NUGETVERSION)-$(Build.SourceBranchName)$(Date:yyyyMMdd)$(Rev:.r)-preview'
   steps:
   - task: NuGetToolInstaller@1
     inputs:

--- a/.azurepipelines/preview.yml
+++ b/.azurepipelines/preview.yml
@@ -12,7 +12,7 @@ jobs:
   variables:
     strongnamekey: 'OPCFoundation.NetStandard.Key.snk'
     msbuildversion: '/p:Version=$(NUGETVERSION) /p:AssemblyVersion=$(NUGETVERSION) /p:FileVersion=$(NUGETVERSION)'
-    msbuildsign='/p:AssemblyOriginatorKeyFile=$(strongnamefile.secureFilePath) /p:SignAssembly=true'
+    msbuildsign: '/p:AssemblyOriginatorKeyFile=$(strongnamefile.secureFilePath) /p:SignAssembly=true'
     nugetpreviewversion: '$(NUGETVERSION)-$(Build.SourceBranchName)-$(Build.BuildNumber)-preview'
   steps:
   - task: NuGetToolInstaller@1

--- a/.azurepipelines/preview.yml
+++ b/.azurepipelines/preview.yml
@@ -1,5 +1,5 @@
 #
-# Build all .Net Core projects on all platforms
+# Build preview packages for internal feed
 #
 parameters:
   buildoption: ''
@@ -10,7 +10,7 @@ jobs:
     vmImage: 'windows-2019'
   variables:
     msbuildversion: '/p:Version=$(NUGETVERSION) /p:AssemblyVersion=$(NUGETVERSION) /p:FileVersion=$(NUGETVERSION)'
-    nugetpreviewversion: '$(NUGETVERSION)-$(Build.SourceBranchName)$(Date:yyyyMMdd)$(Rev:.r)-preview'
+    nugetpreviewversion: '$(NUGETVERSION)-$(Build.SourceBranchName)-$(Build.BuildNumber)-preview'
   steps:
   - task: NuGetToolInstaller@1
     inputs:
@@ -33,7 +33,6 @@ jobs:
       command: build
       projects: '**/Opc.Ua.*.csproj'
       arguments: '--no-restore --configuration Debug ${{ variables.msbuildversion }}'
-  # - script: echo '##vso[task.setvariable NUGETPREVIEW=$(nugetpreviewversion)]'
   - task: NuGetCommand@2
     displayName: Pack Nuget Preview
     inputs:

--- a/.azurepipelines/preview.yml
+++ b/.azurepipelines/preview.yml
@@ -10,7 +10,6 @@ jobs:
   pool:
     vmImage: 'windows-2019'
   variables:
-    strongnamekey: 'OPCFoundation.NetStandard.Key.snk'
     msbuildversion: '/p:Version=$(NUGETVERSION) /p:AssemblyVersion=$(NUGETVERSION) /p:FileVersion=$(NUGETVERSION)'
     msbuildsign: '/p:AssemblyOriginatorKeyFile=$(strongnamefile.secureFilePath) /p:SignAssembly=true'
     nugetpreviewversion: '$(NUGETVERSION)-$(Build.SourceBranchName)-$(Build.BuildNumber)-preview'
@@ -28,7 +27,7 @@ jobs:
     name: strongnamefile
     displayName: 'Download Strong Name Key'
     inputs:
-      secureFile: '$(strongnamekey)'
+      secureFile: 'OPCFoundation.NetStandard.Key.snk'
   - task: DotNetCoreCLI@2
     displayName: Release Build
     inputs:

--- a/.azurepipelines/preview.yml
+++ b/.azurepipelines/preview.yml
@@ -2,7 +2,6 @@
 # Build preview packages for internal feed
 #
 parameters:
-  buildoption: ''
   upload: false
 jobs:
 - job: buildnuget
@@ -33,7 +32,7 @@ jobs:
     inputs:
       command: build
       projects: '**/Opc.Ua.*.csproj'
-      arguments: '--no-restore --configuration Release ${{ variables.msbuildversion }} $(msbuildsign)'
+      arguments: '--no-restore --configuration Release ${{ variables.msbuildversion }} ${{ variables.msbuildsign }}'
   - task: DotNetCoreCLI@2
     displayName: Debug Build
     inputs:

--- a/.azurepipelines/preview.yml
+++ b/.azurepipelines/preview.yml
@@ -1,0 +1,48 @@
+#
+# Build all .Net Core projects on all platforms
+#
+parameters:
+  buildoption: ''
+jobs:
+- job: buildnuget
+  displayName: Build Nuget Packages
+  pool:
+    vmImage: 'windows-2019'
+  variables:
+    msbuildversion: '/p:Version=$(NUGETVERSION) /p:AssemblyVersion=$(NUGETVERSION) /p:FileVersion=$(NUGETVERSION)'
+  steps:
+  - task: NuGetToolInstaller@1
+    inputs:
+      versionSpec: '>=5.4.x'
+  - task: DotNetCoreCLI@2
+    displayName: Release Restore
+    inputs:
+      command: restore
+      projects: '**/Opc.Ua.*.csproj'
+      arguments: '--configuration Release'
+  - task: DotNetCoreCLI@2
+    displayName: Release Build
+    inputs:
+      command: build
+      projects: '**/Opc.Ua.*.csproj'
+      arguments: '--no-restore --configuration Release ${{ variables.msbuildversion }}'
+  - task: DotNetCoreCLI@2
+    displayName: Debug Build
+    inputs:
+      command: build
+      projects: '**/Opc.Ua.*.csproj'
+      arguments: '--no-restore --configuration Debug ${{ variables.msbuildversion }}'
+  - task: NuGetCommand@2
+    inputs:
+      command: 'pack'
+      packagesToPack: '**/*.nuspec'
+      versioningScheme: 'byEnvVar'
+      versionEnvVar: 'NUGETVERSION'
+      includeSymbols: true
+  - task: NuGetCommand@2
+    inputs:
+      command: 'push'
+      packagesToPush: '$(Build.ArtifactStagingDirectory)/**/*.nupkg;!$(Build.ArtifactStagingDirectory)/**/*.symbols.nupkg'
+      nuGetFeedType: 'internal'
+      publishVstsFeed: '865bd736-d0a6-4260-a336-d09d3eb39375/986181c2-3f3f-4a1c-9a70-3ead6139a294'
+      allowPackageConflicts: true

--- a/.azurepipelines/preview.yml
+++ b/.azurepipelines/preview.yml
@@ -33,14 +33,14 @@ jobs:
       command: build
       projects: '**/Opc.Ua.*.csproj'
       arguments: '--no-restore --configuration Debug ${{ variables.msbuildversion }}'
-  - script: echo '##vso[task.setvariable NUGETPREVIEW=nugetpreviewversion]nugetpreviewversion'
+  # - script: echo '##vso[task.setvariable NUGETPREVIEW=$(nugetpreviewversion)]'
   - task: NuGetCommand@2
     displayName: Pack Nuget Preview
     inputs:
       command: 'pack'
       packagesToPack: '**/*.nuspec'
       versioningScheme: 'byEnvVar'
-      versionEnvVar: 'NUGETPREVIEW'
+      versionEnvVar: 'nugetpreviewversion'
       includeSymbols: true
   - task: NuGetCommand@2
     displayName: Upload Nuget Preview

--- a/.azurepipelines/preview.yml
+++ b/.azurepipelines/preview.yml
@@ -10,7 +10,9 @@ jobs:
   pool:
     vmImage: 'windows-2019'
   variables:
+    strongnamekey: 'OPCFoundation.NetStandard.Key.snk'
     msbuildversion: '/p:Version=$(NUGETVERSION) /p:AssemblyVersion=$(NUGETVERSION) /p:FileVersion=$(NUGETVERSION)'
+    msbuildsign='/p:AssemblyOriginatorKeyFile=$(strongnamefile.secureFilePath) /p:SignAssembly=true'
     nugetpreviewversion: '$(NUGETVERSION)-$(Build.SourceBranchName)-$(Build.BuildNumber)-preview'
   steps:
   - task: NuGetToolInstaller@1
@@ -22,18 +24,23 @@ jobs:
       command: restore
       projects: '**/Opc.Ua.*.csproj'
       arguments: '--configuration Release'
+  - task: DownloadSecureFile@1
+    name: strongnamefile
+    displayName: 'Download Strong Name Key'
+    inputs:
+      secureFile: '$(strongnamekey)'
   - task: DotNetCoreCLI@2
     displayName: Release Build
     inputs:
       command: build
       projects: '**/Opc.Ua.*.csproj'
-      arguments: '--no-restore --configuration Release ${{ variables.msbuildversion }}'
+      arguments: '--no-restore --configuration Release ${{ variables.msbuildversion }} $(msbuildsign)'
   - task: DotNetCoreCLI@2
     displayName: Debug Build
     inputs:
       command: build
       projects: '**/Opc.Ua.*.csproj'
-      arguments: '--no-restore --configuration Debug ${{ variables.msbuildversion }}'
+      arguments: '--no-restore --configuration Debug ${{ variables.msbuildversion }} ${{ variables.msbuildsign }}'
   - task: NuGetCommand@2
     displayName: Pack Nuget Preview
     inputs:

--- a/.azurepipelines/preview.yml
+++ b/.azurepipelines/preview.yml
@@ -3,6 +3,7 @@
 #
 parameters:
   buildoption: ''
+  upload: false
 jobs:
 - job: buildnuget
   displayName: Build Nuget Preview Packages
@@ -43,9 +44,10 @@ jobs:
       includeSymbols: true
   - task: NuGetCommand@2
     displayName: Upload Nuget Preview
+    condition: ${{ variables.upload }}
     inputs:
       command: 'push'
       packagesToPush: '$(Build.ArtifactStagingDirectory)/**/*.nupkg;!$(Build.ArtifactStagingDirectory)/**/*.symbols.nupkg'
       nuGetFeedType: 'internal'
-      publishVstsFeed: '865bd736-d0a6-4260-a336-d09d3eb39375/986181c2-3f3f-4a1c-9a70-3ead6139a294'
+      publishVstsFeed: '$(VSTSFEED)'
       allowPackageConflicts: true

--- a/.azurepipelines/preview.yml
+++ b/.azurepipelines/preview.yml
@@ -5,11 +5,12 @@ parameters:
   buildoption: ''
 jobs:
 - job: buildnuget
-  displayName: Build Nuget Packages
+  displayName: Build Nuget Preview Packages
   pool:
     vmImage: 'windows-2019'
   variables:
     msbuildversion: '/p:Version=$(NUGETVERSION) /p:AssemblyVersion=$(NUGETVERSION) /p:FileVersion=$(NUGETVERSION)'
+    nugetpreviewversion: '$(NUGETVERSION)-$(Build.SourceBranchName)-$(Year:yyyy)$(Month:mm)$(DayOfMonth:dd)$(Rev:.r)-preview'
   steps:
   - task: NuGetToolInstaller@1
     inputs:
@@ -32,14 +33,17 @@ jobs:
       command: build
       projects: '**/Opc.Ua.*.csproj'
       arguments: '--no-restore --configuration Debug ${{ variables.msbuildversion }}'
+  - script: echo '##vso[task.setvariable NUGETPREVIEW=nugetpreviewversion]nugetpreviewversion'
   - task: NuGetCommand@2
+    displayName: Pack Nuget Preview
     inputs:
       command: 'pack'
       packagesToPack: '**/*.nuspec'
       versioningScheme: 'byEnvVar'
-      versionEnvVar: 'NUGETVERSION'
+      versionEnvVar: 'NUGETPREVIEW'
       includeSymbols: true
   - task: NuGetCommand@2
+    displayName: Upload Nuget Preview
     inputs:
       command: 'push'
       packagesToPush: '$(Build.ArtifactStagingDirectory)/**/*.nupkg;!$(Build.ArtifactStagingDirectory)/**/*.symbols.nupkg'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,7 +47,8 @@ stages:
       configuration: Debug
 - stage: nugetpreview
   condition: ne( variables['NUGETVERSION'], '')
-#  dependsOn: [testdebug,testrelease,solutions,build,buildnohttps]
+  dependsOn: [] 
+  #[testdebug,testrelease,solutions,build,buildnohttps]
   displayName: 'Push Nuget Preview'
   jobs:
   - template: .azurepipelines/preview.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -45,3 +45,12 @@ stages:
   - template: .azurepipelines/test.yml
     parameters:
       configuration: Debug
+- stage: nugetpreview
+  condition: ne( variables['NUGETVERSION'], '')
+  continueOnError: true
+#  dependsOn: [testdebug,testrelease,solutions,build,buildnohttps]
+  displayName: 'Push Nuget Preview'
+  jobs:
+  - template: .azurepipelines/preview.yml
+    parameters:
+      configuration: Debug

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -46,11 +46,10 @@ stages:
     parameters:
       configuration: Debug
 - stage: nugetpreview
-  condition: ne( variables['NUGETVERSION'], '')
-  dependsOn: [] 
-  #[testdebug,testrelease,solutions,build,buildnohttps]
+  condition: ne( variables['VSTSFEED'], '')
+  dependsOn: [testdebug,testrelease,solutions,build,buildnohttps]
   displayName: 'Push Nuget Preview'
   jobs:
   - template: .azurepipelines/preview.yml
     parameters:
-      configuration: Debug
+      upload: ${{ startsWith(variables['Build.SourceBranch'], 'refs/heads/') }}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -46,7 +46,7 @@ stages:
     parameters:
       configuration: Debug
 - stage: nugetpreview
-  condition: ne( variables['VSTSFEED'], '')
+  condition: ne( $(VSTSFEED), '')
   dependsOn: [testdebug,testrelease,solutions,build,buildnohttps]
   displayName: 'Push Nuget Preview'
   jobs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -46,7 +46,7 @@ stages:
     parameters:
       configuration: Debug
 - stage: nugetpreview
-  condition: ne( $(VSTSFEED), '')
+  condition: ne( '$(VSTSFEED)', '')
   dependsOn: [testdebug,testrelease,solutions,build,buildnohttps]
   displayName: 'Push Nuget Preview'
   jobs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,8 +47,7 @@ stages:
       configuration: Debug
 - stage: nugetpreview
   condition: ne( '$(VSTSFEED)', '')
-  dependsOn: []
-  #dependsOn: [testdebug,testrelease,solutions,build,buildnohttps]
+  dependsOn: [testdebug,testrelease,solutions,build,buildnohttps]
   displayName: 'Push Nuget Preview'
   jobs:
   - template: .azurepipelines/preview.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,7 +47,8 @@ stages:
       configuration: Debug
 - stage: nugetpreview
   condition: ne( '$(VSTSFEED)', '')
-  dependsOn: [testdebug,testrelease,solutions,build,buildnohttps]
+  dependsOn: []
+  #dependsOn: [testdebug,testrelease,solutions,build,buildnohttps]
   displayName: 'Push Nuget Preview'
   jobs:
   - template: .azurepipelines/preview.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,7 +47,6 @@ stages:
       configuration: Debug
 - stage: nugetpreview
   condition: ne( variables['NUGETVERSION'], '')
-  continueOnError: true
 #  dependsOn: [testdebug,testrelease,solutions,build,buildnohttps]
   displayName: 'Push Nuget Preview'
   jobs:


### PR DESCRIPTION
- add the preview build step to allow the samples repo to consume latest and greatest preview packages

preview feed for Nuget.Config:
```
<configuration>
  <packageSources>
    <add key="opcua-preview" value="https://opcfoundation.pkgs.visualstudio.com/opcua-netstandard/_packaging/opcua-preview/nuget/v3/index.json" />
  </packageSources>
</configuration>
```
