### PR TITLE
Added .NetStandard2.1 targetframework

### DIFF
--- a/Libraries/Opc.Ua.Client.ComplexTypes/Opc.Ua.Client.ComplexTypes.csproj
+++ b/Libraries/Opc.Ua.Client.ComplexTypes/Opc.Ua.Client.ComplexTypes.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net462;netcoreapp2.0;netstandard2.1</TargetFrameworks>
     <AssemblyName>Opc.Ua.Client.ComplexTypes</AssemblyName>
     <LangVersion>7</LangVersion>
     <PackageId>Opc.Ua.Client.ComplexTypes</PackageId>
@@ -23,6 +23,10 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
+    <PackageReference Include="System.Reflection.Emit" Version="4.7.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
     <PackageReference Include="System.Reflection.Emit" Version="4.7.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Hello,

I had extended the ComplexTypes Library to target DotNetStandard2.1.
To use the CompleyTypes Libraray in a DotNetStandard project it was needed to also add the Targetframework NetStandard.

NetStandard2.0 could not be used, because System.Reflection.Emit did not support needed TypeBuilder functions.
So it was necessary to use NetStandard2.1.