### PR TITLE
Add support for netstandard2.1 in core libs and nuget packages

### DIFF
--- a/.azurepipelines/ci.yml
+++ b/.azurepipelines/ci.yml
@@ -8,7 +8,7 @@ jobs:
 - job: buildprep
   displayName: Prepare Build Jobs
   pool:
-    vmImage: 'vs2017-win2016'
+    vmImage: 'windows-2019'
   variables:
     DOTNET_CLI_TELEMETRY_OPTOUT: true
     DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
@@ -28,13 +28,6 @@ jobs:
   pool:
     vmImage: $(poolImage)
   steps:
-  - task: UseDotNet@2
-    displayName: 'Install .NET Core SDK'
-    inputs:
-      packageType: sdk
-      version: 2.1.x
-      includePreviewVersions: false
-      installationPath: $(Agent.ToolsDirectory)/dotnet
   - task: NuGetToolInstaller@1
     inputs:
       versionSpec: '>=5.4.x'

--- a/.azurepipelines/get-matrix.ps1
+++ b/.azurepipelines/get-matrix.ps1
@@ -43,7 +43,7 @@ if (![string]::IsNullOrEmpty($JobPrefix)) {
 if ($AgentTable -eq $null -or $AgentTable.Count -eq 0)
 {
     $agents = @{
-        windows = "vs2017-win2016"
+        windows = "windows-2019"
         linux = "ubuntu-18.04"
         mac = "macOS-10.15"
     }

--- a/.azurepipelines/preview.yml
+++ b/.azurepipelines/preview.yml
@@ -11,7 +11,7 @@ jobs:
   variables:
     msbuildversion: '/p:Version=$(NUGETVERSION) /p:AssemblyVersion=$(NUGETVERSION) /p:FileVersion=$(NUGETVERSION)'
     msbuildsign: '/p:AssemblyOriginatorKeyFile=$(strongnamefile.secureFilePath) /p:SignAssembly=true'
-    nugetpreviewversion: '$(NUGETVERSION)-$(Build.SourceBranchName)-$(Build.BuildNumber)-preview'
+    nugetpreviewversion: '$(NUGETVERSION)-$(Build.BuildNumber)-$(Build.SourceBranchName)-preview'
   steps:
   - task: NuGetToolInstaller@1
     inputs:

--- a/.azurepipelines/test.yml
+++ b/.azurepipelines/test.yml
@@ -5,8 +5,9 @@ parameters:
   configuration: 'Release'
   framework: netcoreapp2.1
   agents: '@{}'
+  jobnamesuffix: ''
 jobs:
-- job: testprep
+- job: testprep${{ parameters.jobnamesuffix }}
   displayName: Prepare Test Jobs ${{ parameters.configuration }} (${{ parameters.framework }})
   pool:
     vmImage: 'windows-2019'
@@ -21,11 +22,11 @@ jobs:
       targetType: filePath
       filePath: ./.azurepipelines/get-matrix.ps1
       arguments: -FileName azure-pipelines.yml -AgentTable ${{ parameters.agents }}
-- job: testall
+- job: testall${{ parameters.jobnamesuffix }}
   displayName: Run Tests for
-  dependsOn: testprep
+  dependsOn: testprep${{ parameters.jobnamesuffix }}
   strategy:
-    matrix: $[dependencies.testprep.outputs['testmatrix.jobMatrix'] ]
+    matrix: $[dependencies.testprep${{ parameters.jobnamesuffix }}.outputs['testmatrix.jobMatrix'] ]
   variables:
     DOTNET_CLI_TELEMETRY_OPTOUT: true
     DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true

--- a/.azurepipelines/test.yml
+++ b/.azurepipelines/test.yml
@@ -3,6 +3,7 @@
 #
 parameters:
   configuration: 'Release'
+  framework: netcoreapp2.1
   agents: '@{}'
 jobs:
 - job: testprep
@@ -46,4 +47,4 @@ jobs:
     inputs:
       command: test
       projects: '**/*.Tests.csproj'
-      arguments: '--no-restore --configuration ${{ parameters.configuration }}'
+      arguments: '--no-restore --framework ${{ parameters.framework }} --configuration ${{ parameters.configuration }}'

--- a/.azurepipelines/test.yml
+++ b/.azurepipelines/test.yml
@@ -8,7 +8,7 @@ jobs:
 - job: testprep
   displayName: Prepare Test Jobs ${{ parameters.configuration }}
   pool:
-    vmImage: 'vs2017-win2016'
+    vmImage: 'windows-2019'
   variables:
     DOTNET_CLI_TELEMETRY_OPTOUT: true
     DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
@@ -31,13 +31,6 @@ jobs:
   pool:
     vmImage: $(poolImage)
   steps:
-  - task: UseDotNet@2
-    displayName: 'Install .NET Core SDK'
-    inputs:
-      packageType: sdk
-      version: 2.1.x
-      includePreviewVersions: false
-      installationPath: $(Agent.ToolsDirectory)/dotnet
   - task: NuGetToolInstaller@1
     inputs:
       versionSpec: '>=5.4.x'

--- a/.azurepipelines/test.yml
+++ b/.azurepipelines/test.yml
@@ -23,7 +23,7 @@ jobs:
       filePath: ./.azurepipelines/get-matrix.ps1
       arguments: -FileName azure-pipelines.yml -AgentTable ${{ parameters.agents }}
 - job: testall${{ parameters.jobnamesuffix }}
-  displayName: Run Tests for
+  displayName: Run Tests for (${{ parameters.framework }})
   dependsOn: testprep${{ parameters.jobnamesuffix }}
   strategy:
     matrix: $[dependencies.testprep${{ parameters.jobnamesuffix }}.outputs['testmatrix.jobMatrix'] ]

--- a/.azurepipelines/test.yml
+++ b/.azurepipelines/test.yml
@@ -7,7 +7,7 @@ parameters:
   agents: '@{}'
 jobs:
 - job: testprep
-  displayName: Prepare Test Jobs ${{ parameters.configuration }}
+  displayName: Prepare Test Jobs ${{ parameters.configuration }} (${{ parameters.framework }})
   pool:
     vmImage: 'windows-2019'
   variables:

--- a/.azurepipelines/testcc.yml
+++ b/.azurepipelines/testcc.yml
@@ -44,7 +44,7 @@ jobs:
       arguments: install --tool-path tools dotnet-reportgenerator-globaltool 
     displayName: Install ReportGenerator tool
   - script: |
-      tools/reportgenerator -reports:$(Build.SourcesDirectory)/**/coverage.cobertura.xml -targetdir:$(Build.SourcesDirectory)/CodeCoverage "-reporttypes:Cobertura;HtmlSummary" "-title:UA .Net Standard Test Coverage" "-assemblyfilters:-*.Tests"
+      tools/reportgenerator -reports:$(Build.SourcesDirectory)/**/coverage.*.cobertura.xml -targetdir:$(Build.SourcesDirectory)/CodeCoverage "-reporttypes:Cobertura;HtmlSummary" "-title:UA .Net Standard Test Coverage" "-assemblyfilters:-*.Tests"
       mv $(Build.SourcesDirectory)/CodeCoverage/summary.htm $(Build.SourcesDirectory)/CodeCoverage/index.htm 
 
     displayName: Create Code Coverage Report

--- a/.azurepipelines/testcc.yml
+++ b/.azurepipelines/testcc.yml
@@ -22,6 +22,13 @@ jobs:
       version: 2.1.x
       includePreviewVersions: false
       installationPath: $(Agent.ToolsDirectory)/dotnet
+  - task: UseDotNet@2
+    displayName: 'Install .NET Core SDK'
+    inputs:
+      packageType: sdk
+      version: 3.1.x
+      includePreviewVersions: false
+      installationPath: $(Agent.ToolsDirectory)/dotnet
   - task: NuGetToolInstaller@1
     inputs:
       versionSpec: '>=5.4.x'

--- a/.azurepipelines/testcc.yml
+++ b/.azurepipelines/testcc.yml
@@ -3,12 +3,12 @@
 #
 parameters:
   configuration: 'Release'
-  framework: netcoreapp2.1
+  framework: 'netcoreapp2.1'
   agent: 'linux'
   poolImage: 'ubuntu-18.04'
 jobs:
 - job: testcc
-  displayName: Run Code Coverage for ${{ parameters.agent }}
+  displayName: Run Code Coverage for ${{ parameters.agent }} (${{ parameters.framework }})
   variables:
     DOTNET_CLI_TELEMETRY_OPTOUT: true
     DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true

--- a/.azurepipelines/testcc.yml
+++ b/.azurepipelines/testcc.yml
@@ -3,6 +3,7 @@
 #
 parameters:
   configuration: 'Release'
+  framework: netcoreapp2.1
   agent: 'linux'
   poolImage: 'ubuntu-18.04'
 jobs:
@@ -15,20 +16,6 @@ jobs:
   pool:
     vmImage: ${{ parameters.poolImage }}
   steps:
-  - task: UseDotNet@2
-    displayName: 'Install .NET Core SDK'
-    inputs:
-      packageType: sdk
-      version: 2.1.x
-      includePreviewVersions: false
-      installationPath: $(Agent.ToolsDirectory)/dotnet
-  - task: UseDotNet@2
-    displayName: 'Install .NET Core SDK'
-    inputs:
-      packageType: sdk
-      version: 3.1.x
-      includePreviewVersions: false
-      installationPath: $(Agent.ToolsDirectory)/dotnet
   - task: NuGetToolInstaller@1
     inputs:
       versionSpec: '>=5.4.x'
@@ -44,7 +31,7 @@ jobs:
     inputs:
       command: test
       projects: '**/*.Tests.csproj'
-      arguments: '--no-restore --configuration ${{ parameters.configuration }} /p:CollectCoverage=true /p:Exclude="[*.Tests]*" /p:CoverletOutputFormat=cobertura'
+      arguments: '--no-restore --framework ${{ parameters.framework }} --configuration ${{ parameters.configuration }} /p:CollectCoverage=true /p:Exclude="[*.Tests]*" /p:CoverletOutputFormat=cobertura'
   - script: |
       bash <(curl -s https://codecov.io/bash)
 

--- a/Applications/ConsoleReferenceServer/NetCoreReferenceServer.csproj
+++ b/Applications/ConsoleReferenceServer/NetCoreReferenceServer.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>$(AppTargetFrameWork)</TargetFramework>
     <AssemblyName>NetCoreReferenceServer</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>ConsoleReferenceServer</PackageId>
     <Company>OPC Foundation</Company>
     <Product>OPC UA SDK</Product>
-    <Description>.Net Core Reference Server</Description>
-    <Copyright>Copyright © 2004-2019 OPC Foundation, Inc</Copyright>
+    <Description>.NET Core Reference Server</Description>
+    <Copyright>Copyright © 2004-2020 OPC Foundation, Inc</Copyright>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Applications/ReferenceServer/ReferenceNodeManager.cs
+++ b/Applications/ReferenceServer/ReferenceNodeManager.cs
@@ -34,6 +34,7 @@ using System.Threading;
 using System.Numerics;
 using Opc.Ua;
 using Opc.Ua.Server;
+using Range = Opc.Ua.Range;
 
 namespace Quickstarts.ReferenceServer
 {
@@ -1699,12 +1700,12 @@ namespace Quickstarts.ReferenceServer
             return (CreateAnalogItemVariable(parent, path, name, dataType, valueRank, initialValues, null));
         }
 
-        private AnalogItemState CreateAnalogItemVariable(NodeState parent, string path, string name, BuiltInType dataType, int valueRank, object initialValues, Range customRange)
+        private AnalogItemState CreateAnalogItemVariable(NodeState parent, string path, string name, BuiltInType dataType, int valueRank, object initialValues, Opc.Ua.Range customRange)
         {
             return CreateAnalogItemVariable(parent, path, name, (uint)dataType, valueRank, initialValues, customRange);
         }
 
-        private AnalogItemState CreateAnalogItemVariable(NodeState parent, string path, string name, NodeId dataType, int valueRank, object initialValues, Range customRange)
+        private AnalogItemState CreateAnalogItemVariable(NodeState parent, string path, string name, NodeId dataType, int valueRank, object initialValues, Opc.Ua.Range customRange)
         {
             AnalogItemState variable = new AnalogItemState(parent);
             variable.BrowseName = new QualifiedName(path, NamespaceIndex);

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,3 +1,4 @@
 ﻿<Project>
+  <Import Project="targets.props" />
   <Import Project="version.props" />
 </Project>

--- a/Libraries/Opc.Ua.Client.ComplexTypes/Opc.Ua.Client.ComplexTypes.csproj
+++ b/Libraries/Opc.Ua.Client.ComplexTypes/Opc.Ua.Client.ComplexTypes.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;netcoreapp2.0</TargetFrameworks>
     <AssemblyName>Opc.Ua.Client.ComplexTypes</AssemblyName>
+    <TargetFrameworks>$(LibxTargetFrameworks)</TargetFrameworks>
     <LangVersion>7</LangVersion>
     <PackageId>Opc.Ua.Client.ComplexTypes</PackageId>
     <RootNameSpace>Opc.Ua.Client.ComplexTypes</RootNameSpace>
@@ -23,6 +23,10 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
+    <PackageReference Include="System.Reflection.Emit" Version="4.7.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
     <PackageReference Include="System.Reflection.Emit" Version="4.7.0" />
   </ItemGroup>
 

--- a/Libraries/Opc.Ua.Client/Opc.Ua.Client.csproj
+++ b/Libraries/Opc.Ua.Client/Opc.Ua.Client.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
     <AssemblyName>Opc.Ua.Client</AssemblyName>
+    <TargetFrameworks>$(LibTargetFrameworks)</TargetFrameworks>
     <LangVersion>6</LangVersion>
     <PackageId>Opc.Ua.Client</PackageId>
     <RootNamespace>Opc.Ua.Client</RootNamespace>

--- a/Libraries/Opc.Ua.Configuration/Opc.Ua.Configuration.csproj
+++ b/Libraries/Opc.Ua.Configuration/Opc.Ua.Configuration.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
     <AssemblyName>Opc.Ua.Configuration</AssemblyName>
+    <TargetFrameworks>$(LibTargetFrameworks)</TargetFrameworks>
     <LangVersion>6</LangVersion>
     <PackageId>Opc.Ua.Configuration</PackageId>
     <RootNamespace>Opc.Ua.Configuration</RootNamespace>

--- a/Libraries/Opc.Ua.Gds.Client.Common/Opc.Ua.Gds.Client.Common.csproj
+++ b/Libraries/Opc.Ua.Gds.Client.Common/Opc.Ua.Gds.Client.Common.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
     <DefineConstants>$(DefineConstants);NET_STANDARD</DefineConstants>
     <AssemblyName>Opc.Ua.Gds.Client.Common</AssemblyName>
+    <TargetFrameworks>$(LibTargetFrameworks)</TargetFrameworks>
     <PackageId>Opc.Ua.Gds.Client.Common</PackageId>
     <RootNamespace>Opc.Ua.Gds.Client</RootNamespace>
     <LangVersion>6</LangVersion>

--- a/Libraries/Opc.Ua.Gds.Server.Common/Opc.Ua.Gds.Server.Common.csproj
+++ b/Libraries/Opc.Ua.Gds.Server.Common/Opc.Ua.Gds.Server.Common.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
     <DefineConstants>$(DefineConstants);NET_STANDARD</DefineConstants>
     <AssemblyName>Opc.Ua.Gds.Server.Common</AssemblyName>
+    <TargetFrameworks>$(LibTargetFrameworks)</TargetFrameworks>
     <PackageId>Opc.Ua.Gds.Server.Common</PackageId>
     <RootNamespace>Opc.Ua.Gds.Server</RootNamespace>
     <LangVersion>6</LangVersion>

--- a/Libraries/Opc.Ua.Server/Opc.Ua.Server.csproj
+++ b/Libraries/Opc.Ua.Server/Opc.Ua.Server.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
     <AssemblyName>Opc.Ua.Server</AssemblyName>
+    <TargetFrameworks>$(LibTargetFrameworks)</TargetFrameworks>
     <LangVersion>6</LangVersion>
     <PackageId>Opc.Ua.Server</PackageId>
     <RootNamespace>Opc.Ua.Server</RootNamespace>

--- a/Stack/Opc.Ua.Core/Opc.Ua.Core.csproj
+++ b/Stack/Opc.Ua.Core/Opc.Ua.Core.csproj
@@ -1,8 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  
+  <!-- TODO: to be removed once finalized -->
+  <Target Name="VSVersion" BeforeTargets="Build">
+    <Message Text="Dotnet Version: '$(DotnetVersion)'" Importance="High" />
+    <Message Text="Visual Studio Version: '$(VisualStudioVersion)'" Importance="High" />
+    <Message Text="MS Build Version: '$(MSBuildVersion)'" Importance="High" />
+    <Message Text="MS Build Tools Version: '$(MSBuildToolsVersion)'" Importance="High" />
+    <Message Text="Tests Frameworks: '$(TestsTargetFrameworks)'" Importance="High" />
+    <Message Text="Lib Frameworks: '$(LibTargetFrameworks)'" Importance="High" />
+  </Target>
 
   <PropertyGroup>
-    <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
     <DefineConstants>$(DefineConstants);NET_STANDARD</DefineConstants>
+    <TargetFrameworks>$(LibTargetFrameworks)</TargetFrameworks>
     <LangVersion>6</LangVersion>
     <AssemblyName>Opc.Ua.Core</AssemblyName>
     <PackageId>Opc.Ua.Core</PackageId>
@@ -13,7 +23,7 @@
   <PropertyGroup>
     <DefineConstants Condition=" '$(NoHttps)' == 'true' ">$(DefineConstants);NO_HTTPS</DefineConstants>
   </PropertyGroup>
-  
+
   <PropertyGroup Condition="'$(SignAssembly)' == 'true'">
     <DefineConstants>$(DefineConstants);SIGNASSEMBLY</DefineConstants>
   </PropertyGroup>
@@ -28,7 +38,9 @@
   <ItemGroup>
     <EmbeddedResource Include="Schema\Opc.Ua.NodeSet2.xml" />
     <EmbeddedResource Include="Schema\Opc.Ua.Types.bsd" />
-    <EmbeddedResource Include="Stack\Generated\Opc.Ua.PredefinedNodes.uanodes;Types\Utils\LocalizedData.txt;Schema\ServerCapabilities.csv" />
+    <EmbeddedResource Include="Stack\Generated\Opc.Ua.PredefinedNodes.uanodes" />
+    <EmbeddedResource Include="Types\Utils\LocalizedData.txt" />
+    <EmbeddedResource Include="Schema\ServerCapabilities.csv" />
     <EmbeddedResource Include="Types\Schemas\BuiltInTypes.bsd" />
     <EmbeddedResource Include="Types\Schemas\StandardTypes.bsd" />
   </ItemGroup>
@@ -45,7 +57,7 @@
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.Net.Http" />
   </ItemGroup>
-  
+
   <ItemGroup Condition="$(DefineConstants.Contains('NO_HTTPS'))=='false'">
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets" Version="2.2.1" />
@@ -59,11 +71,19 @@
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.4.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
-    
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
+    <PackageReference Include="System.Data.Common" Version="4.3.0" />
+    <PackageReference Include="System.ServiceModel.Primitives" Version="4.7.0" />
+    <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
+    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.7.0" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+  </ItemGroup>
+
   <ItemGroup>
     <Folder Include="Properties\" />
   </ItemGroup>
-  
+
   <Target Name="GetPackagingOutputs" />
 
 </Project>

--- a/Stack/Opc.Ua.Core/Opc.Ua.Core.csproj
+++ b/Stack/Opc.Ua.Core/Opc.Ua.Core.csproj
@@ -1,15 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   
-  <!-- TODO: to be removed once finalized -->
-  <Target Name="VSVersion" BeforeTargets="Build">
-    <Message Text="Dotnet Version: '$(DotnetVersion)'" Importance="High" />
-    <Message Text="Visual Studio Version: '$(VisualStudioVersion)'" Importance="High" />
-    <Message Text="MS Build Version: '$(MSBuildVersion)'" Importance="High" />
-    <Message Text="MS Build Tools Version: '$(MSBuildToolsVersion)'" Importance="High" />
-    <Message Text="Tests Frameworks: '$(TestsTargetFrameworks)'" Importance="High" />
-    <Message Text="Lib Frameworks: '$(LibTargetFrameworks)'" Importance="High" />
-  </Target>
-
   <PropertyGroup>
     <DefineConstants>$(DefineConstants);NET_STANDARD</DefineConstants>
     <TargetFrameworks>$(LibTargetFrameworks)</TargetFrameworks>

--- a/Stack/Opc.Ua.Core/Security/Certificates/RsaUtils.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/RsaUtils.cs
@@ -388,7 +388,7 @@ namespace Opc.Ua
         /// Lazy helper to allow runtime to check for Pss support.
         /// </summary>
         internal static readonly Lazy<bool> IsSupportingRSAPssSign = new Lazy<bool>(() => {
-#if NET46 || NET461 || NET462 || NET47
+#if NETFRAMEWORK
             // The Pss check returns false on .Net4.6/4.7, although it is always supported with certs.
             // but not supported with Mono
             return !Utils.IsRunningOnMono();

--- a/Stack/Opc.Ua.Core/Types/Utils/Utils.cs
+++ b/Stack/Opc.Ua.Core/Types/Utils/Utils.cs
@@ -657,11 +657,24 @@ namespace Opc.Ua
                         if (!writable)
                         {
                             localFile = new FileInfo(Utils.Format("{0}{1}{2}", Directory.GetCurrentDirectory(), Path.DirectorySeparatorChar, filePath));
+#if NETFRAMEWORK
+                            if (!localFile.Exists)
+                            {
+                                var localFile2 = new FileInfo(Utils.Format("{0}{1}{2}",
+                                    Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location),
+                                    Path.DirectorySeparatorChar, filePath));
+                                if (localFile2.Exists)
+                                {
+                                    localFile = localFile2;
+                                }
+                            }
+#endif
                         }
                         else
                         {
                             localFile = new FileInfo(Utils.Format("{0}{1}{2}", Path.GetTempPath(), Path.DirectorySeparatorChar, filePath));
                         }
+
                         if (localFile.Exists)
                         {
                             return localFile.FullName;

--- a/Tests/Opc.Ua.Client.ComplexTypes.Tests/Main.cs
+++ b/Tests/Opc.Ua.Client.ComplexTypes.Tests/Main.cs
@@ -1,0 +1,43 @@
+/* ========================================================================
+ * Copyright (c) 2005-2018 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ * 
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ * 
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+
+#if NETFRAMEWORK
+namespace Opc.Ua.Client.ComplexTypes.Tests
+{
+    static class Program
+    {
+        // Main Method 
+        static public void Main(String[] args)
+        {
+        }
+    }
+}
+#endif

--- a/Tests/Opc.Ua.Client.ComplexTypes.Tests/Opc.Ua.Client.ComplexTypes.Tests.csproj
+++ b/Tests/Opc.Ua.Client.ComplexTypes.Tests/Opc.Ua.Client.ComplexTypes.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>$(TestsTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Tests/Opc.Ua.Core.Tests/Main.cs
+++ b/Tests/Opc.Ua.Core.Tests/Main.cs
@@ -1,0 +1,43 @@
+/* ========================================================================
+ * Copyright (c) 2005-2020 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ * 
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ * 
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+
+#if NETFRAMEWORK
+namespace Opc.Ua.Core.Tests
+{
+    static class Program
+    {
+        // Main Method 
+        static public void Main(String[] args)
+        {
+        }
+    }
+}
+#endif

--- a/Tests/Opc.Ua.Core.Tests/Opc.Ua.Core.Tests.csproj
+++ b/Tests/Opc.Ua.Core.Tests/Opc.Ua.Core.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>$(TestsTargetFrameworks)</TargetFrameworks>
     <RootNamespace>Opc.Ua.Core.Tests</RootNamespace>
   </PropertyGroup>
 

--- a/Tests/Opc.Ua.Gds.Tests/ClientTest.cs
+++ b/Tests/Opc.Ua.Gds.Tests/ClientTest.cs
@@ -830,7 +830,8 @@ namespace Opc.Ua.Gds.Tests
             var application = _goodApplicationTestSet[0];
             Assert.Null(application.CertificateRequestId);
             // load csr with invalid app URI
-            byte[] certificateRequest = File.ReadAllBytes("test.csr");
+            var testCSR = Utils.GetAbsoluteFilePath("test.csr", true, true, false);
+            byte[] certificateRequest = File.ReadAllBytes(testCSR);
             Assert.That(() => {
                 NodeId requestId = _gdsClient.GDSClient.StartSigningRequest(
                 application.ApplicationRecord.ApplicationId,

--- a/Tests/Opc.Ua.Gds.Tests/Main.cs
+++ b/Tests/Opc.Ua.Gds.Tests/Main.cs
@@ -1,0 +1,43 @@
+/* ========================================================================
+ * Copyright (c) 2005-2019 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ * 
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ * 
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+
+#if NETFRAMEWORK
+namespace Opc.Ua.Gds.Tests
+{
+    static class Program
+    {
+        // Main Method 
+        static public void Main(String[] args)
+        {
+        }
+    }
+}
+#endif

--- a/Tests/Opc.Ua.Gds.Tests/Opc.Ua.Gds.Tests.csproj
+++ b/Tests/Opc.Ua.Gds.Tests/Opc.Ua.Gds.Tests.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>$(TestsTargetFrameworks)</TargetFrameworks>
+    <RootNamespace>Opc.Ua.Gds.Tests</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/UA Core Library.sln
+++ b/UA Core Library.sln
@@ -23,6 +23,36 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Opc.Ua.Client.ComplexTypes.
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Opc.Ua.Gds.Tests", "Tests\Opc.Ua.Gds.Tests\Opc.Ua.Gds.Tests.csproj", "{7F726313-45CA-4571-AC8E-67DDBC196B21}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{0152A569-8287-4E49-9F02-E27FD700B719}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+		azure-pipelines-preview.yml = azure-pipelines-preview.yml
+		azure-pipelines.yml = azure-pipelines.yml
+		Directory.Build.props = Directory.Build.props
+		lgtm.yml = lgtm.yml
+		targets.props = targets.props
+		version.props = version.props
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "nuget", "nuget", "{F69ABCC3-ED93-446B-AC70-D6AA5F047781}"
+	ProjectSection(SolutionItems) = preProject
+		nuget\Opc.Ua.Client.ComplexTypes.nuspec = nuget\Opc.Ua.Client.ComplexTypes.nuspec
+		nuget\Opc.Ua.Client.ComplexTypes.Symbols.nuspec = nuget\Opc.Ua.Client.ComplexTypes.Symbols.nuspec
+		nuget\Opc.Ua.nuspec = nuget\Opc.Ua.nuspec
+		nuget\Opc.Ua.Symbols.nuspec = nuget\Opc.Ua.Symbols.nuspec
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "azurepipelines", "azurepipelines", "{1C25BE72-C337-42AE-9F7C-D6B45F7B7079}"
+	ProjectSection(SolutionItems) = preProject
+		.azurepipelines\ci.yml = .azurepipelines\ci.yml
+		.azurepipelines\get-matrix.ps1 = .azurepipelines\get-matrix.ps1
+		.azurepipelines\get-root.ps1 = .azurepipelines\get-root.ps1
+		.azurepipelines\preview.yml = .azurepipelines\preview.yml
+		.azurepipelines\sln.yml = .azurepipelines\sln.yml
+		.azurepipelines\test.yml = .azurepipelines\test.yml
+		.azurepipelines\testcc.yml = .azurepipelines\testcc.yml
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -72,6 +102,10 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{F69ABCC3-ED93-446B-AC70-D6AA5F047781} = {0152A569-8287-4E49-9F02-E27FD700B719}
+		{1C25BE72-C337-42AE-9F7C-D6B45F7B7079} = {0152A569-8287-4E49-9F02-E27FD700B719}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {EA3AA3AE-CE8A-4DF1-BED8-CA0BAFC87303}

--- a/UA Reference.sln
+++ b/UA Reference.sln
@@ -10,7 +10,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.editorconfig = .editorconfig
 		.gitattributes = .gitattributes
 		.gitignore = .gitignore
-		.travis.yml = .travis.yml
 		nuget\Opc.Ua.Client.ComplexTypes.nuspec = nuget\Opc.Ua.Client.ComplexTypes.nuspec
 		nuget\Opc.Ua.Client.ComplexTypes.Symbols.nuspec = nuget\Opc.Ua.Client.ComplexTypes.Symbols.nuspec
 		nuget\Opc.Ua.nuspec = nuget\Opc.Ua.nuspec

--- a/azure-pipelines-preview.yml
+++ b/azure-pipelines-preview.yml
@@ -2,15 +2,19 @@
 # Add steps that build, run tests, deploy, and more:
 # https://aka.ms/yaml
 
-pr:
-  autoCancel: true
+pr: none
+
+trigger:
   branches:
     include:
-    - '*'
+    - master
+  paths:
+    include:
+    - 'Stack/' 
+    - 'Libraries/' 
 
 stages:
 - stage: nugetpreview
-  condition: ne( variables['VSTSFEED'], '')
   displayName: 'Push Nuget Preview'
   jobs:
   - template: .azurepipelines/preview.yml

--- a/azure-pipelines-preview.yml
+++ b/azure-pipelines-preview.yml
@@ -10,7 +10,7 @@ pr:
 
 stages:
 - stage: nugetpreview
-  condition: ne( '$(VSTSFEED)', '')
+  condition: ne( variables['VSTSFEED'], '')
   displayName: 'Push Nuget Preview'
   jobs:
   - template: .azurepipelines/preview.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -45,3 +45,10 @@ stages:
   - template: .azurepipelines/test.yml
     parameters:
       configuration: Debug
+- stage: nugetpreview
+  condition: ne( variables['VSTSFEED'], '')
+  displayName: 'Push Nuget Preview'
+  jobs:
+  - template: .azurepipelines/preview.yml
+    parameters:
+      upload: ${{ startsWith(variables['Build.SourceBranch'], 'refs/heads/') }}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,11 +33,20 @@ stages:
   - template: .azurepipelines/test.yml
     parameters:
       configuration: Release
-      agents: '@{ windows = "vs2017-win2016"; mac = "macOS-10.15" }'
+      framework: net462
+      agents: '@{ windows = "windows-2019" }'
+  - template: .azurepipelines/test.yml
+    parameters:
+      configuration: Release
+      agents: '@{ windows = "windows-2019"; mac = "macOS-10.15" }'
   - template: .azurepipelines/testcc.yml
     parameters:
       configuration: Release
       poolImage: 'ubuntu-18.04'
+  - template: .azurepipelines/test.yml
+    parameters:
+      configuration: Release
+      framework: netcoreapp3.1
 - stage: testdebug
   dependsOn: []
   displayName: 'Test Core and SDK Debug'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,11 +2,17 @@
 # Add steps that build, run tests, deploy, and more:
 # https://aka.ms/yaml
 
-pr:
+pr: 
   autoCancel: true
   branches:
     include:
     - '*'
+  paths:
+    include:
+    - '*' 
+    exclude:
+    - 'Docs/*' 
+    - 'README.md' 
 
 stages:
 - stage: build

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,6 +35,7 @@ stages:
       configuration: Release
       framework: net462
       agents: '@{ windows = "windows-2019" }'
+      jobnamesuffix: net462
   - template: .azurepipelines/test.yml
     parameters:
       configuration: Release
@@ -47,6 +48,7 @@ stages:
     parameters:
       configuration: Release
       framework: netcoreapp3.1
+      jobnamesuffix: core3
 - stage: testdebug
   dependsOn: []
   displayName: 'Test Core and SDK Debug'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -45,10 +45,3 @@ stages:
   - template: .azurepipelines/test.yml
     parameters:
       configuration: Debug
-- stage: nugetpreview
-  condition: ne( variables['VSTSFEED'], '')
-  displayName: 'Push Nuget Preview'
-  jobs:
-  - template: .azurepipelines/preview.yml
-    parameters:
-      upload: ${{ startsWith(variables['Build.SourceBranch'], 'refs/heads/') }}

--- a/nuget/Opc.Ua.Client.ComplexTypes.Symbols.nuspec
+++ b/nuget/Opc.Ua.Client.ComplexTypes.Symbols.nuspec
@@ -19,6 +19,10 @@
         <dependency id="OPCFoundation.NetStandard.Opc.Ua.Symbols" version="$version$"/>
         <dependency id="System.Reflection.Emit" version="4.7.0" />
       </group>
+      <group targetFramework="netstandard2.1" >
+        <dependency id="OPCFoundation.NetStandard.Opc.Ua.Symbols" version="$version$"/>
+        <dependency id="System.Reflection.Emit" version="4.7.0" />
+      </group>
     </dependencies>
   </metadata>
   <files>
@@ -26,5 +30,7 @@
     <file src="..\Libraries\Opc.Ua.Client.ComplexTypes\bin\Debug\net462\Opc.Ua.Client.ComplexTypes.pdb" target="lib\net462" />
     <file src="..\Libraries\Opc.Ua.Client.ComplexTypes\bin\Debug\netcoreapp2.0\Opc.Ua.Client.ComplexTypes.dll" target="lib\netcoreapp2.0" />
     <file src="..\Libraries\Opc.Ua.Client.ComplexTypes\bin\Debug\netcoreapp2.0\Opc.Ua.Client.ComplexTypes.pdb" target="lib\netcoreapp2.0" />
+    <file src="..\Libraries\Opc.Ua.Client.ComplexTypes\bin\Debug\netstandard2.1\Opc.Ua.Client.ComplexTypes.dll" target="lib\netstandard2.1" />
+    <file src="..\Libraries\Opc.Ua.Client.ComplexTypes\bin\Debug\netstandard2.1\Opc.Ua.Client.ComplexTypes.pdb" target="lib\netstandard2.1" />
   </files>
 </package>

--- a/nuget/Opc.Ua.Client.ComplexTypes.nuspec
+++ b/nuget/Opc.Ua.Client.ComplexTypes.nuspec
@@ -19,10 +19,15 @@
         <dependency id="OPCFoundation.NetStandard.Opc.Ua" version="$version$"/>
         <dependency id="System.Reflection.Emit" version="4.7.0" />
       </group>
+      <group targetFramework="netstandard2.1" >
+        <dependency id="OPCFoundation.NetStandard.Opc.Ua" version="$version$"/>
+        <dependency id="System.Reflection.Emit" version="4.7.0" />
+      </group>
     </dependencies>
   </metadata>
   <files>
     <file src="..\Libraries\Opc.Ua.Client.ComplexTypes\bin\Release\net462\Opc.Ua.Client.ComplexTypes.dll" target="lib\net462" />
     <file src="..\Libraries\Opc.Ua.Client.ComplexTypes\bin\Release\netcoreapp2.0\Opc.Ua.Client.ComplexTypes.dll" target="lib\netcoreapp2.0" />
+    <file src="..\Libraries\Opc.Ua.Client.ComplexTypes\bin\Release\netstandard2.1\Opc.Ua.Client.ComplexTypes.dll" target="lib\netstandard2.1" />
   </files>
 </package>

--- a/nuget/Opc.Ua.Symbols.nuspec
+++ b/nuget/Opc.Ua.Symbols.nuspec
@@ -31,6 +31,18 @@
         <dependency id="System.Reflection.TypeExtensions" version="4.4.0" />
         <dependency id="System.Net.Http" version="4.3.4" />
       </group>
+      <group targetFramework="netstandard2.1" >
+        <dependency id="Microsoft.AspNetCore.Server.Kestrel" version="2.2.0"/>
+        <dependency id="Microsoft.AspNetCore.Server.Kestrel.Https" version= "2.2.0"/>
+        <dependency id="Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets" version="2.2.1"/>
+        <dependency id="Newtonsoft.Json" version="12.0.3"/>
+        <dependency id="Portable.BouncyCastle" version="1.8.6.7"/>
+        <dependency id="System.Data.Common" version="4.3.0"/>
+        <dependency id="System.ServiceModel.Primitives" version="4.7.0"/>
+        <dependency id="System.Net.NameResolution" version="4.3.0"/>
+        <dependency id="System.Reflection.TypeExtensions" version="4.7.0" />
+        <dependency id="System.Net.Http" version="4.3.4" />
+      </group>
     </dependencies>
   </metadata>
   <files>
@@ -42,6 +54,10 @@
     <file src="..\Libraries\Opc.Ua.Server\bin\Debug\net462\Opc.Ua.Server.pdb" target="lib\net462" />
     <file src="..\Libraries\Opc.Ua.Configuration\bin\Debug\net462\Opc.Ua.Configuration.dll" target="lib\net462" />
     <file src="..\Libraries\Opc.Ua.Configuration\bin\Debug\net462\Opc.Ua.Configuration.pdb" target="lib\net462" />
+    <file src="..\Libraries\Opc.Ua.Gds.Server.Common\bin\Debug\net462\Opc.Ua.Gds.Server.Common.dll" target="lib\net462" />
+    <file src="..\Libraries\Opc.Ua.Gds.Server.Common\bin\Debug\net462\Opc.Ua.Gds.Server.Common.pdb" target="lib\net462" />
+    <file src="..\Libraries\Opc.Ua.Gds.Client.Common\bin\Debug\net462\Opc.Ua.Gds.Client.Common.dll" target="lib\net462" />
+    <file src="..\Libraries\Opc.Ua.Gds.Client.Common\bin\Debug\net462\Opc.Ua.Gds.Client.Common.pdb" target="lib\net462" />
     <file src="..\Stack\Opc.Ua.Core\bin\Debug\netstandard2.0\Opc.Ua.Core.dll" target="lib\netstandard2.0" />
     <file src="..\Stack\Opc.Ua.Core\bin\Debug\netstandard2.0\Opc.Ua.Core.pdb" target="lib\netstandard2.0" />
     <file src="..\Libraries\Opc.Ua.Client\bin\Debug\netstandard2.0\Opc.Ua.Client.dll" target="lib\netstandard2.0" />
@@ -50,13 +66,21 @@
     <file src="..\Libraries\Opc.Ua.Server\bin\Debug\netstandard2.0\Opc.Ua.Server.pdb" target="lib\netstandard2.0" />
     <file src="..\Libraries\Opc.Ua.Configuration\bin\Debug\netstandard2.0\Opc.Ua.Configuration.dll" target="lib\netstandard2.0" />
     <file src="..\Libraries\Opc.Ua.Configuration\bin\Debug\netstandard2.0\Opc.Ua.Configuration.pdb" target="lib\netstandard2.0" />
-    <file src="..\Libraries\Opc.Ua.Gds.Server.Common\bin\Debug\net462\Opc.Ua.Gds.Server.Common.dll" target="lib\net462" />
-    <file src="..\Libraries\Opc.Ua.Gds.Server.Common\bin\Debug\net462\Opc.Ua.Gds.Server.Common.pdb" target="lib\net462" />
     <file src="..\Libraries\Opc.Ua.Gds.Server.Common\bin\Debug\netstandard2.0\Opc.Ua.Gds.Server.Common.dll" target="lib\netstandard2.0" />
     <file src="..\Libraries\Opc.Ua.Gds.Server.Common\bin\Debug\netstandard2.0\Opc.Ua.Gds.Server.Common.pdb" target="lib\netstandard2.0" />
-    <file src="..\Libraries\Opc.Ua.Gds.Client.Common\bin\Debug\net462\Opc.Ua.Gds.Client.Common.dll" target="lib\net462" />
-    <file src="..\Libraries\Opc.Ua.Gds.Client.Common\bin\Debug\net462\Opc.Ua.Gds.Client.Common.pdb" target="lib\net462" />
     <file src="..\Libraries\Opc.Ua.Gds.Client.Common\bin\Debug\netstandard2.0\Opc.Ua.Gds.Client.Common.dll" target="lib\netstandard2.0" />
     <file src="..\Libraries\Opc.Ua.Gds.Client.Common\bin\Debug\netstandard2.0\Opc.Ua.Gds.Client.Common.pdb" target="lib\netstandard2.0" />
+    <file src="..\Stack\Opc.Ua.Core\bin\Debug\netstandard2.1\Opc.Ua.Core.dll" target="lib\netstandard2.1" />
+    <file src="..\Stack\Opc.Ua.Core\bin\Debug\netstandard2.1\Opc.Ua.Core.pdb" target="lib\netstandard2.1" />
+    <file src="..\Libraries\Opc.Ua.Client\bin\Debug\netstandard2.1\Opc.Ua.Client.dll" target="lib\netstandard2.1" />
+    <file src="..\Libraries\Opc.Ua.Client\bin\Debug\netstandard2.1\Opc.Ua.Client.pdb" target="lib\netstandard2.1" />
+    <file src="..\Libraries\Opc.Ua.Server\bin\Debug\netstandard2.1\Opc.Ua.Server.dll" target="lib\netstandard2.1" />
+    <file src="..\Libraries\Opc.Ua.Server\bin\Debug\netstandard2.1\Opc.Ua.Server.pdb" target="lib\netstandard2.1" />
+    <file src="..\Libraries\Opc.Ua.Configuration\bin\Debug\netstandard2.1\Opc.Ua.Configuration.dll" target="lib\netstandard2.1" />
+    <file src="..\Libraries\Opc.Ua.Configuration\bin\Debug\netstandard2.1\Opc.Ua.Configuration.pdb" target="lib\netstandard2.1" />
+    <file src="..\Libraries\Opc.Ua.Gds.Server.Common\bin\Debug\netstandard2.1\Opc.Ua.Gds.Server.Common.dll" target="lib\netstandard2.1" />
+    <file src="..\Libraries\Opc.Ua.Gds.Server.Common\bin\Debug\netstandard2.1\Opc.Ua.Gds.Server.Common.pdb" target="lib\netstandard2.1" />
+    <file src="..\Libraries\Opc.Ua.Gds.Client.Common\bin\Debug\netstandard2.1\Opc.Ua.Gds.Client.Common.dll" target="lib\netstandard2.1" />
+    <file src="..\Libraries\Opc.Ua.Gds.Client.Common\bin\Debug\netstandard2.1\Opc.Ua.Gds.Client.Common.pdb" target="lib\netstandard2.1" />
   </files>
 </package>

--- a/nuget/Opc.Ua.nuspec
+++ b/nuget/Opc.Ua.nuspec
@@ -31,6 +31,18 @@
         <dependency id="System.Reflection.TypeExtensions" version="4.4.0" />
         <dependency id="System.Net.Http" version="4.3.4" />
       </group>
+      <group targetFramework="netstandard2.1" >
+        <dependency id="Microsoft.AspNetCore.Server.Kestrel" version="2.2.0"/>
+        <dependency id="Microsoft.AspNetCore.Server.Kestrel.Https" version= "2.2.0"/>
+        <dependency id="Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets" version="2.2.1"/>
+        <dependency id="Newtonsoft.Json" version="12.0.3"/>
+        <dependency id="Portable.BouncyCastle" version="1.8.6.7"/>
+        <dependency id="System.Data.Common" version="4.3.0"/>
+        <dependency id="System.ServiceModel.Primitives" version="4.7.0"/>
+        <dependency id="System.Net.NameResolution" version="4.3.0"/>
+        <dependency id="System.Reflection.TypeExtensions" version="4.7.0" />
+        <dependency id="System.Net.Http" version="4.3.4" />
+      </group>
     </dependencies>
   </metadata>
   <files>
@@ -38,13 +50,19 @@
     <file src="..\Libraries\Opc.Ua.Client\bin\Release\net462\Opc.Ua.Client.dll" target="lib\net462" />
     <file src="..\Libraries\Opc.Ua.Server\bin\Release\net462\Opc.Ua.Server.dll" target="lib\net462" />
     <file src="..\Libraries\Opc.Ua.Configuration\bin\Release\net462\Opc.Ua.Configuration.dll" target="lib\net462" />
+    <file src="..\Libraries\Opc.Ua.Gds.Server.Common\bin\Release\net462\Opc.Ua.Gds.Server.Common.dll" target="lib\net462" />
+    <file src="..\Libraries\Opc.Ua.Gds.Client.Common\bin\Release\net462\Opc.Ua.Gds.Client.Common.dll" target="lib\net462" />
     <file src="..\Stack\Opc.Ua.Core\bin\Release\netstandard2.0\Opc.Ua.Core.dll" target="lib\netstandard2.0" />
     <file src="..\Libraries\Opc.Ua.Client\bin\Release\netstandard2.0\Opc.Ua.Client.dll" target="lib\netstandard2.0" />
     <file src="..\Libraries\Opc.Ua.Server\bin\Release\netstandard2.0\Opc.Ua.Server.dll" target="lib\netstandard2.0" />
     <file src="..\Libraries\Opc.Ua.Configuration\bin\Release\netstandard2.0\Opc.Ua.Configuration.dll" target="lib\netstandard2.0" />
-    <file src="..\Libraries\Opc.Ua.Gds.Server.Common\bin\Release\net462\Opc.Ua.Gds.Server.Common.dll" target="lib\net462" />
     <file src="..\Libraries\Opc.Ua.Gds.Server.Common\bin\Release\netstandard2.0\Opc.Ua.Gds.Server.Common.dll" target="lib\netstandard2.0" />
-    <file src="..\Libraries\Opc.Ua.Gds.Client.Common\bin\Release\net462\Opc.Ua.Gds.Client.Common.dll" target="lib\net462" />
     <file src="..\Libraries\Opc.Ua.Gds.Client.Common\bin\Release\netstandard2.0\Opc.Ua.Gds.Client.Common.dll" target="lib\netstandard2.0" />
+    <file src="..\Stack\Opc.Ua.Core\bin\Release\netstandard2.1\Opc.Ua.Core.dll" target="lib\netstandard2.1" />
+    <file src="..\Libraries\Opc.Ua.Client\bin\Release\netstandard2.1\Opc.Ua.Client.dll" target="lib\netstandard2.1" />
+    <file src="..\Libraries\Opc.Ua.Server\bin\Release\netstandard2.1\Opc.Ua.Server.dll" target="lib\netstandard2.1" />
+    <file src="..\Libraries\Opc.Ua.Configuration\bin\Release\netstandard2.1\Opc.Ua.Configuration.dll" target="lib\netstandard2.1" />
+    <file src="..\Libraries\Opc.Ua.Gds.Server.Common\bin\Release\netstandard2.1\Opc.Ua.Gds.Server.Common.dll" target="lib\netstandard2.1" />
+    <file src="..\Libraries\Opc.Ua.Gds.Client.Common\bin\Release\netstandard2.1\Opc.Ua.Gds.Client.Common.dll" target="lib\netstandard2.1" />
   </files>
 </package>

--- a/targets.props
+++ b/targets.props
@@ -2,6 +2,7 @@
   <Choose>
     <When  Condition="'$(VisualStudioVersion)' == '16.0'">
       <PropertyGroup>
+        <AppTargetFramework>netcoreapp3.1</AppTargetFramework>
         <TestsTargetFrameworks>net462;netcoreapp2.1;netcoreapp3.1</TestsTargetFrameworks>
         <LibTargetFrameworks>net462;netstandard2.0;netstandard2.1</LibTargetFrameworks>
         <LibxTargetFrameworks>net462;netcoreapp2.0;netstandard2.1</LibxTargetFrameworks>
@@ -9,6 +10,7 @@
     </When>
     <Otherwise>
       <PropertyGroup>
+        <AppTargetFramework>netcoreapp2.1</AppTargetFramework>
         <TestsTargetFrameworks>netcoreapp2.1</TestsTargetFrameworks>
         <LibTargetFrameworks>net462;netstandard2.0</LibTargetFrameworks>
         <LibxTargetFrameworks>net462;netcoreapp2.0</LibxTargetFrameworks>

--- a/targets.props
+++ b/targets.props
@@ -1,0 +1,18 @@
+<Project>
+  <Choose>
+    <When  Condition="'$(VisualStudioVersion)' == '16.0'">
+      <PropertyGroup>
+        <TestsTargetFrameworks>net462;netcoreapp2.1;netcoreapp3.1</TestsTargetFrameworks>
+        <LibTargetFrameworks>net462;netstandard2.0;netstandard2.1</LibTargetFrameworks>
+        <LibxTargetFrameworks>net462;netcoreapp2.0;netstandard2.1</LibxTargetFrameworks>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <TestsTargetFrameworks>netcoreapp2.1</TestsTargetFrameworks>
+        <LibTargetFrameworks>net462;netstandard2.0</LibTargetFrameworks>
+        <LibxTargetFrameworks>net462;netcoreapp2.0</LibxTargetFrameworks>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+</Project>


### PR DESCRIPTION
- solutions support still VS2017 and VS 2019
- ci now also tests net462 & netcoreapp3.1
- next rev of nuget packages will have netstandard2.1 support