### PR TITLE
Use monotonic timer for Window

### DIFF
--- a/Libraries/Opc.Ua.Server/Diagnostics/MonitoredItemQueue.cs
+++ b/Libraries/Opc.Ua.Server/Diagnostics/MonitoredItemQueue.cs
@@ -110,7 +110,7 @@ namespace Opc.Ua.Server
             }
 
             // calculate the next sampling interval.
-            m_samplingInterval = (long)(samplingInterval * TimeSpan.TicksPerMillisecond);
+            m_samplingInterval = (long)samplingInterval;
 
             if (m_samplingInterval > 0)
             {
@@ -193,7 +193,7 @@ namespace Opc.Ua.Server
         /// <param name="error">The error to queue.</param>
         public void QueueValue(DataValue value, ServiceResult error)
         {
-            long now = DateTime.UtcNow.Ticks;
+            long now = HiResClock.TickCount64;
 
             if (m_start >= 0)
             {

--- a/Libraries/Opc.Ua.Server/Subscription/MonitoredItem.cs
+++ b/Libraries/Opc.Ua.Server/Subscription/MonitoredItem.cs
@@ -30,6 +30,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Runtime.InteropServices;
 using System.Xml;
 using static Opc.Ua.Utils;
 
@@ -45,55 +46,55 @@ namespace Opc.Ua.Server
         /// Initializes the object with its node type.
         /// </summary>
         public MonitoredItem(
-            IServerInternal     server,
-            INodeManager        nodeManager,
-            object              mangerHandle,
-            uint                subscriptionId,
-            uint                id,
-            Session             session,
-            ReadValueId         itemToMonitor,
-            DiagnosticsMasks    diagnosticsMasks,
-            TimestampsToReturn  timestampsToReturn,
-            MonitoringMode      monitoringMode,
-            uint                clientHandle,
-            MonitoringFilter    originalFilter,
-            MonitoringFilter    filterToUse,
-            Range               range,
-            double              samplingInterval,
-            uint                queueSize,
-            bool                discardOldest,
-            double              sourceSamplingInterval)
+            IServerInternal server,
+            INodeManager nodeManager,
+            object mangerHandle,
+            uint subscriptionId,
+            uint id,
+            Session session,
+            ReadValueId itemToMonitor,
+            DiagnosticsMasks diagnosticsMasks,
+            TimestampsToReturn timestampsToReturn,
+            MonitoringMode monitoringMode,
+            uint clientHandle,
+            MonitoringFilter originalFilter,
+            MonitoringFilter filterToUse,
+            Range range,
+            double samplingInterval,
+            uint queueSize,
+            bool discardOldest,
+            double sourceSamplingInterval)
         {
             if (itemToMonitor == null) throw new ArgumentNullException(nameof(itemToMonitor));
-            
+
             Initialize();
-            
-            m_server                  = server;
-            m_nodeManager             = nodeManager;
-            m_managerHandle           = mangerHandle;
-            m_subscriptionId          = subscriptionId;
-            m_id                      = id;
-            m_session                 = session;
-            m_nodeId                  = itemToMonitor.NodeId;
-            m_attributeId             = itemToMonitor.AttributeId;
-            m_indexRange              = itemToMonitor.IndexRange;
-            m_parsedIndexRange        = itemToMonitor.ParsedIndexRange;
-            m_encoding                = itemToMonitor.DataEncoding;
-            m_diagnosticsMasks        = diagnosticsMasks;
-            m_timestampsToReturn      = timestampsToReturn;
-            m_monitoringMode          = monitoringMode;
-            m_clientHandle            = clientHandle;
-            m_originalFilter          = originalFilter;
-            m_filterToUse             = filterToUse;
-            m_range                   = 0;
-            m_samplingInterval        = samplingInterval;
-            m_queueSize               = queueSize;
-            m_discardOldest           = discardOldest;
-            m_sourceSamplingInterval  = (int)sourceSamplingInterval;
-            m_calculator              = null;
-            m_nextSamplingTime        = DateTime.UtcNow.Ticks;
-            m_alwaysReportUpdates     = false;
-            
+
+            m_server = server;
+            m_nodeManager = nodeManager;
+            m_managerHandle = mangerHandle;
+            m_subscriptionId = subscriptionId;
+            m_id = id;
+            m_session = session;
+            m_nodeId = itemToMonitor.NodeId;
+            m_attributeId = itemToMonitor.AttributeId;
+            m_indexRange = itemToMonitor.IndexRange;
+            m_parsedIndexRange = itemToMonitor.ParsedIndexRange;
+            m_encoding = itemToMonitor.DataEncoding;
+            m_diagnosticsMasks = diagnosticsMasks;
+            m_timestampsToReturn = timestampsToReturn;
+            m_monitoringMode = monitoringMode;
+            m_clientHandle = clientHandle;
+            m_originalFilter = originalFilter;
+            m_filterToUse = filterToUse;
+            m_range = 0;
+            m_samplingInterval = samplingInterval;
+            m_queueSize = queueSize;
+            m_discardOldest = discardOldest;
+            m_sourceSamplingInterval = (int)sourceSamplingInterval;
+            m_calculator = null;
+            m_nextSamplingTime = HiResClock.TickCount64;
+            m_alwaysReportUpdates = false;
+
             m_typeMask = MonitoredItemTypeMask.DataChange;
 
             if (originalFilter is EventFilter)
@@ -143,31 +144,31 @@ namespace Opc.Ua.Server
         /// </summary>
         private void Initialize()
         {
-            m_server                  = null;
-            m_nodeManager             = null;
-            m_managerHandle           = null;
-            m_subscriptionId          = 0;
-            m_id                      = 0;
-            m_session                 = null;
-            m_nodeId                  = null;
-            m_attributeId             = 0;
-            m_indexRange              = null;
-            m_parsedIndexRange        = NumericRange.Empty;
-            m_encoding                = null;
-            m_clientHandle            = 0;
-            m_monitoringMode          = MonitoringMode.Disabled;
-            m_samplingInterval        = 0;
-            m_queueSize               = 0;
-            m_discardOldest           = true;
-            m_originalFilter          = null;
-            m_lastValue               = null;
-            m_lastError               = null;
-            m_events                  = null;
-            m_overflow                = false;
-            m_readyToPublish          = false;
-            m_readyToTrigger          = false;
-            m_sourceSamplingInterval  = 0;
-            m_samplingError           = ServiceResult.Good;
+            m_server = null;
+            m_nodeManager = null;
+            m_managerHandle = null;
+            m_subscriptionId = 0;
+            m_id = 0;
+            m_session = null;
+            m_nodeId = null;
+            m_attributeId = 0;
+            m_indexRange = null;
+            m_parsedIndexRange = NumericRange.Empty;
+            m_encoding = null;
+            m_clientHandle = 0;
+            m_monitoringMode = MonitoringMode.Disabled;
+            m_samplingInterval = 0;
+            m_queueSize = 0;
+            m_discardOldest = true;
+            m_originalFilter = null;
+            m_lastValue = null;
+            m_lastError = null;
+            m_events = null;
+            m_overflow = false;
+            m_readyToPublish = false;
+            m_readyToTrigger = false;
+            m_sourceSamplingInterval = 0;
+            m_samplingError = ServiceResult.Good;
         }
         #endregion
 
@@ -236,7 +237,7 @@ namespace Opc.Ua.Server
                 if (m_sourceSamplingInterval == 0)
                 {
                     // re-queue if too little time has passed since the last publish.
-                    long now = DateTime.UtcNow.Ticks;
+                    long now = HiResClock.TickCount64;
 
                     if (m_nextSamplingTime > now)
                     {
@@ -294,8 +295,8 @@ namespace Opc.Ua.Server
             }
 
             return false;
-        }        
-                
+        }
+
         /// <summary>
         /// Sets a flag indicating that the semantics for the monitored node have changed.
         /// </summary>
@@ -305,8 +306,8 @@ namespace Opc.Ua.Server
         public void SetSemanticsChanged()
         {
             m_semanticsChanged = true;
-        }        
-                
+        }
+
         /// <summary>
         /// Sets a flag indicating that the structure of the monitored node has changed.
         /// </summary>
@@ -316,18 +317,18 @@ namespace Opc.Ua.Server
         public void SetStructureChanged()
         {
             m_structureChanged = true;
-        }    
-                
+        }
+
         /// <summary>
         /// The filter used by the monitored item.
         /// </summary>
         public MonitoringFilter Filter => m_originalFilter;
-        
+
         /// <summary>
         /// The event filter used by the monitored item.
         /// </summary>
         public EventFilter EventFilter => m_originalFilter as EventFilter;
-        
+
         /// <summary>
         /// The data change filter used by the monitored item.
         /// </summary>
@@ -338,15 +339,15 @@ namespace Opc.Ua.Server
         /// </summary>
         public Session Session
         {
-            get 
-            { 
-                lock (m_lock) 
-                { 
-                    return m_session; 
-                } 
+            get
+            {
+                lock (m_lock)
+                {
+                    return m_session;
+                }
             }
         }
-        
+
         /// <summary>
         /// The identifier for the item that is unique within the server.
         /// </summary>
@@ -361,12 +362,12 @@ namespace Opc.Ua.Server
         /// The node id being monitored.
         /// </summary>
         public NodeId NodeId => m_nodeId;
-        
+
         /// <summary>
         /// The attribute being monitored.
         /// </summary>
         public uint AttributeId => m_attributeId;
- 
+
         /// <summary>
         /// The current monitoring mode for the item
         /// </summary>
@@ -377,12 +378,12 @@ namespace Opc.Ua.Server
         /// </summary>
         public double SamplingInterval
         {
-            get 
-            { 
-                lock (m_lock) 
+            get
+            {
+                lock (m_lock)
                 {
-                    return m_samplingInterval; 
-                } 
+                    return m_samplingInterval;
+                }
             }
         }
 
@@ -395,7 +396,7 @@ namespace Opc.Ua.Server
         /// The queue size for the item.
         /// </summary>
         public uint QueueSize => m_queueSize;
-              
+
         /// <summary>
         /// Gets number of elements actually contained in value queue.
         /// </summary>
@@ -443,7 +444,7 @@ namespace Opc.Ua.Server
             get { return m_alwaysReportUpdates; }
             set { m_alwaysReportUpdates = value; }
         }
-        
+
         /// <summary>
         /// Returns a description of the item being monitored. 
         /// </summary>
@@ -453,17 +454,17 @@ namespace Opc.Ua.Server
             {
                 ReadValueId valueId = new ReadValueId();
 
-                valueId.NodeId           = m_nodeId;
-                valueId.AttributeId      = m_attributeId;
-                valueId.IndexRange       = m_indexRange;
+                valueId.NodeId = m_nodeId;
+                valueId.AttributeId = m_attributeId;
+                valueId.IndexRange = m_indexRange;
                 valueId.ParsedIndexRange = m_parsedIndexRange;
-                valueId.DataEncoding     = m_encoding;
-                valueId.Handle           = m_managerHandle;
+                valueId.DataEncoding = m_encoding;
+                valueId.Handle = m_managerHandle;
 
                 return valueId;
             }
         }
-        
+
         /// <summary>
         /// Sets an error that occured in the sampling group.
         /// </summary>
@@ -494,10 +495,10 @@ namespace Opc.Ua.Server
             {
                 result = new MonitoredItemCreateResult();
 
-                result.MonitoredItemId         = m_id;
+                result.MonitoredItemId = m_id;
                 result.RevisedSamplingInterval = m_samplingInterval;
-                result.RevisedQueueSize        = m_queueSize;
-                result.StatusCode              = StatusCodes.Good;
+                result.RevisedQueueSize = m_queueSize;
+                result.StatusCode = StatusCodes.Good;
 
                 if (ServiceResult.IsBad(m_samplingError))
                 {
@@ -518,8 +519,8 @@ namespace Opc.Ua.Server
                 result = new MonitoredItemModifyResult();
 
                 result.RevisedSamplingInterval = m_samplingInterval;
-                result.RevisedQueueSize        = m_queueSize;
-                result.StatusCode              = StatusCodes.Good;
+                result.RevisedQueueSize = m_queueSize;
+                result.StatusCode = StatusCodes.Good;
 
                 if (ServiceResult.IsBad(m_samplingError))
                 {
@@ -534,26 +535,26 @@ namespace Opc.Ua.Server
         /// Modifies the attributes for monitored item.
         /// </summary>
         public ServiceResult ModifyAttributes(
-            DiagnosticsMasks   diagnosticsMasks,
+            DiagnosticsMasks diagnosticsMasks,
             TimestampsToReturn timestampsToReturn,
-            uint               clientHandle,
-            MonitoringFilter   originalFilter,
-            MonitoringFilter   filterToUse,
-            Range              range,
-            double             samplingInterval,
-            uint               queueSize,
-            bool               discardOldest)
+            uint clientHandle,
+            MonitoringFilter originalFilter,
+            MonitoringFilter filterToUse,
+            Range range,
+            double samplingInterval,
+            uint queueSize,
+            bool discardOldest)
         {
             lock (m_lock)
             {
-                m_diagnosticsMasks   = diagnosticsMasks;
+                m_diagnosticsMasks = diagnosticsMasks;
                 m_timestampsToReturn = timestampsToReturn;
-                m_clientHandle       = clientHandle;
-                m_discardOldest      = discardOldest;
+                m_clientHandle = clientHandle;
+                m_discardOldest = discardOldest;
 
                 m_originalFilter = originalFilter;
-                m_filterToUse    = filterToUse;
-                                    
+                m_filterToUse = filterToUse;
+
                 if (range != null)
                 {
                     m_range = range.High - range.Low;
@@ -617,17 +618,17 @@ namespace Opc.Ua.Server
                 }
 
                 // subtract the previous sampling interval.
-                long oldSamplingInterval = (long)(m_samplingInterval*TimeSpan.TicksPerMillisecond);
+                long oldSamplingInterval = (long)m_samplingInterval;
 
                 if (oldSamplingInterval < m_nextSamplingTime)
                 {
                     m_nextSamplingTime -= oldSamplingInterval;
                 }
-                
+
                 m_samplingInterval = samplingInterval;
 
                 // calculate the next sampling interval.                
-                long newSamplingInterval = (long)(m_samplingInterval*TimeSpan.TicksPerMillisecond);
+                long newSamplingInterval = (long)m_samplingInterval;
 
                 if (m_samplingInterval > 0)
                 {
@@ -639,21 +640,21 @@ namespace Opc.Ua.Server
                 }
             }
         }
-        
+
         /// <summary>
         /// Changes the monitoring mode for the item.
         /// </summary>
         void ISampledDataChangeMonitoredItem.SetMonitoringMode(MonitoringMode monitoringMode)
         {
-            SetMonitoringMode(monitoringMode);            
+            SetMonitoringMode(monitoringMode);
         }
-        
+
         /// <summary>
         /// Changes the monitoring mode for the item.
         /// </summary>
         void IEventMonitoredItem.SetMonitoringMode(MonitoringMode monitoringMode)
         {
-            SetMonitoringMode(monitoringMode);            
+            SetMonitoringMode(monitoringMode);
         }
 
         /// <summary>
@@ -674,13 +675,13 @@ namespace Opc.Ua.Server
 
                 if (previousMode == MonitoringMode.Disabled)
                 {
-                    m_nextSamplingTime = DateTime.UtcNow.Ticks;
+                    m_nextSamplingTime = HiResClock.TickCount64;
                     m_lastError = null;
                     m_lastValue = null;
                 }
 
                 m_monitoringMode = monitoringMode;
-                
+
                 if (monitoringMode == MonitoringMode.Disabled)
                 {
                     m_readyToPublish = false;
@@ -697,7 +698,7 @@ namespace Opc.Ua.Server
                     m_discardOldest,
                     m_filterToUse,
                     m_monitoringMode);
-                    
+
                 InitializeQueue();
 
                 return previousMode;
@@ -730,7 +731,7 @@ namespace Opc.Ua.Server
                 {
                     return;
                 }
-                
+
                 // make a shallow copy of the value.
                 if (value != null)
                 {
@@ -744,7 +745,7 @@ namespace Opc.Ua.Server
                     copy.SourcePicoseconds = value.SourcePicoseconds;
                     copy.ServerTimestamp = value.ServerTimestamp;
                     copy.ServerPicoseconds = value.ServerPicoseconds;
-                    
+
                     value = copy;
 
                     // ensure the data value matches the error status code.
@@ -771,7 +772,7 @@ namespace Opc.Ua.Server
                 {
                     return;
                 }
-                                
+
                 // apply aggregate filter.
                 if (m_calculator != null)
                 {
@@ -790,7 +791,7 @@ namespace Opc.Ua.Server
 
                     return;
                 }
-                
+
                 // apply filter to incoming item.
                 if (!m_alwaysReportUpdates && !bypassFilter)
                 {
@@ -800,19 +801,19 @@ namespace Opc.Ua.Server
                         return;
                     }
                 }
-                
+
                 ServerUtils.ReportQueuedValue(m_nodeId, m_id, value);
 
                 // add the value to the queue.
                 AddValueToQueue(value, error);
             }
         }
-        
+
         /// <summary>
         /// Sets the overflow bit.
         /// </summary>
         private ServiceResult SetOverflowBit(
-            object value, 
+            object value,
             ServiceResult error)
         {
             DataValue dataValue = value as DataValue;
@@ -825,7 +826,7 @@ namespace Opc.Ua.Server
             if (error != null)
             {
                 error = new ServiceResult(
-                    error.StatusCode.SetOverflow(true), 
+                    error.StatusCode.SetOverflow(true),
                     error.SymbolicId,
                     error.NamespaceUri,
                     error.LocalizedText,
@@ -840,7 +841,7 @@ namespace Opc.Ua.Server
         /// Adds a value to the queue.
         /// </summary>
         private void AddValueToQueue(DataValue value, ServiceResult error)
-        {            
+        {
             if (m_queueSize > 1)
             {
                 m_queue.QueueValue(value, error);
@@ -858,7 +859,7 @@ namespace Opc.Ua.Server
 
             Utils.Trace("QUEUE VALUE[{0}]: Value={1} CODE={2}<{2:X8}> OVERFLOW={3}", m_id, m_lastValue.WrappedValue, m_lastValue.StatusCode.Code, m_lastValue.StatusCode.Overflow);
         }
-        
+
         /// <summary>
         /// Whether the item is monitoring all events produced by the server.
         /// </summary>
@@ -879,10 +880,10 @@ namespace Opc.Ua.Server
             {
                 // get the value of the attribute (apply localization).
                 object value = instance.GetAttributeValue(
-                    context, 
-                    clause.TypeDefinitionId, 
-                    clause.BrowsePath, 
-                    clause.AttributeId, 
+                    context,
+                    clause.TypeDefinitionId,
+                    clause.BrowsePath,
+                    clause.AttributeId,
                     clause.ParsedIndexRange);
 
                 // add the value to the list of event fields.
@@ -924,7 +925,7 @@ namespace Opc.Ua.Server
         public virtual void QueueEvent(IFilterTarget instance, bool bypassFilter)
         {
             if (instance == null) throw new ArgumentNullException(nameof(instance));
-         
+
             lock (m_lock)
             {
                 // this method should only be called for objects or views. 
@@ -932,7 +933,7 @@ namespace Opc.Ua.Server
                 {
                     throw new ServiceResultException(StatusCodes.BadInternalError);
                 }
-                
+
                 // can't do anything if queuing is disabled.
                 if (m_events == null)
                 {
@@ -962,7 +963,7 @@ namespace Opc.Ua.Server
                         return;
                     }
                 }
-                
+
                 // construct the context to use for the event filter.
                 FilterContext context = new FilterContext(m_server.NamespaceUris, m_server.TypeTree, m_session.PreferredLocales);
 
@@ -973,7 +974,7 @@ namespace Opc.Ua.Server
                 {
                     throw new ServiceResultException(StatusCodes.BadInternalError);
                 }
-                
+
                 // apply filter.
                 if (!bypassFilter)
                 {
@@ -982,7 +983,7 @@ namespace Opc.Ua.Server
                         return;
                     }
                 }
-                
+
                 // fetch the event fields.
                 EventFieldList fields = GetEventFields(context, filter, instance);
                 QueueEvent(fields);
@@ -1029,12 +1030,12 @@ namespace Opc.Ua.Server
                     {
                         return false;
                     }
-    
+
                     return m_readyToPublish;
                 }
             }
         }
-        
+
         /// <summary>
         /// Used to check whether the item is ready to sample.
         /// </summary>
@@ -1052,8 +1053,8 @@ namespace Opc.Ua.Server
         private void IncrementSampleTime()
         {
             // update next sample time.
-            long now = DateTime.UtcNow.Ticks;            
-            long samplingInterval = (long)(m_samplingInterval*TimeSpan.TicksPerMillisecond);
+            long now = HiResClock.TickCount64;
+            long samplingInterval = (long)m_samplingInterval;
 
             if (m_nextSamplingTime > 0)
             {
@@ -1061,7 +1062,7 @@ namespace Opc.Ua.Server
 
                 if (samplingInterval > 0 && delta >= 0)
                 {
-                    m_nextSamplingTime += ((delta/samplingInterval)+1)*samplingInterval;                 
+                    m_nextSamplingTime += ((delta / samplingInterval) + 1) * samplingInterval;
                 }
             }
 
@@ -1071,13 +1072,13 @@ namespace Opc.Ua.Server
                 m_nextSamplingTime = now + samplingInterval;
             }
         }
-        
+
         /// <summary>
         /// Publishes all available event notifications.
         /// </summary>
         public virtual bool Publish(OperationContext context, Queue<EventFieldList> notifications)
         {
-            if (context == null)       throw new ArgumentNullException(nameof(context));
+            if (context == null) throw new ArgumentNullException(nameof(context));
             if (notifications == null) throw new ArgumentNullException(nameof(notifications));
 
             lock (m_lock)
@@ -1108,7 +1109,7 @@ namespace Opc.Ua.Server
                     {
                         // construct event.
                         EventQueueOverflowEventState e = new EventQueueOverflowEventState(null);
-                                
+
                         TranslationInfo message = new TranslationInfo(
                             "EventQueueOverflowEventState",
                             "en-US",
@@ -1178,19 +1179,19 @@ namespace Opc.Ua.Server
                 return false;
             }
         }
-                    
+
         /// <summary>
         /// Publishes all available data change notifications.
         /// </summary>
         public virtual bool Publish(
-            OperationContext                 context, 
+            OperationContext context,
             Queue<MonitoredItemNotification> notifications,
-            Queue<DiagnosticInfo>            diagnostics)
+            Queue<DiagnosticInfo> diagnostics)
         {
-            if (context == null)       throw new ArgumentNullException(nameof(context));
+            if (context == null) throw new ArgumentNullException(nameof(context));
             if (notifications == null) throw new ArgumentNullException(nameof(notifications));
-            if (diagnostics == null)   throw new ArgumentNullException(nameof(diagnostics));
-            
+            if (diagnostics == null) throw new ArgumentNullException(nameof(diagnostics));
+
             lock (m_lock)
             {
                 // check if the item reports data changes.
@@ -1224,7 +1225,7 @@ namespace Opc.Ua.Server
 
                 // go to the next sampling interval.
                 IncrementSampleTime();
-                
+
                 // check if queueing enabled.
                 if (m_queue != null)
                 {
@@ -1243,7 +1244,7 @@ namespace Opc.Ua.Server
                     Utils.Trace("DEQUEUE VALUE: Value={0} CODE={1}<{1:X8}> OVERFLOW={2}", m_lastValue.WrappedValue, m_lastValue.StatusCode.Code, m_lastValue.StatusCode.Overflow);
                     Publish(context, notifications, diagnostics, m_lastValue, m_lastError);
                 }
-                
+
                 // reset state variables.
                 m_overflow = false;
                 m_readyToPublish = false;
@@ -1253,17 +1254,17 @@ namespace Opc.Ua.Server
                 return false;
             }
         }
-        
+
         /// <summary>
         /// Publishes a single data change notifications.
         /// </summary>
         protected virtual bool Publish(
-            OperationContext                 context,
+            OperationContext context,
             Queue<MonitoredItemNotification> notifications,
-            Queue<DiagnosticInfo>            diagnostics,
-            DataValue                        value, 
-            ServiceResult                    error)
-        {            
+            Queue<DiagnosticInfo> diagnostics,
+            DataValue value,
+            ServiceResult error)
+        {
             // set semantics changed bit.
             if (m_semanticsChanged)
             {
@@ -1275,7 +1276,7 @@ namespace Opc.Ua.Server
                 if (error != null)
                 {
                     error = new ServiceResult(
-                        error.StatusCode.SetSemanticsChanged(true), 
+                        error.StatusCode.SetSemanticsChanged(true),
                         error.SymbolicId,
                         error.NamespaceUri,
                         error.LocalizedText,
@@ -1285,7 +1286,7 @@ namespace Opc.Ua.Server
 
                 m_semanticsChanged = false;
             }
-            
+
             // set structure changed bit.
             if (m_structureChanged)
             {
@@ -1297,7 +1298,7 @@ namespace Opc.Ua.Server
                 if (error != null)
                 {
                     error = new ServiceResult(
-                        error.StatusCode.SetStructureChanged(true), 
+                        error.StatusCode.SetStructureChanged(true),
                         error.SymbolicId,
                         error.NamespaceUri,
                         error.LocalizedText,
@@ -1312,8 +1313,8 @@ namespace Opc.Ua.Server
             MonitoredItemNotification item = new MonitoredItemNotification();
 
             item.ClientHandle = m_clientHandle;
-            item.Value        = value;
-            
+            item.Value = value;
+
             // apply timestamp filter.
             if (m_timestampsToReturn != TimestampsToReturn.Server && m_timestampsToReturn != TimestampsToReturn.Both)
             {
@@ -1330,7 +1331,7 @@ namespace Opc.Ua.Server
 
             // update diagnostic info.
             DiagnosticInfo diagnosticInfo = null;
-            
+
             if ((m_diagnosticsMasks & DiagnosticsMasks.OperationAll) != 0)
             {
                 diagnosticInfo = ServerUtils.CreateDiagnosticInfo(m_server, context, error);
@@ -1350,7 +1351,7 @@ namespace Opc.Ua.Server
             {
                 lock (m_lock)
                 {
-                    return m_subscription;                    
+                    return m_subscription;
                 }
             }
 
@@ -1383,14 +1384,14 @@ namespace Opc.Ua.Server
                         return 0;
                     }
 
-                    DateTime now = DateTime.UtcNow;
+                    var now = HiResClock.TickCount64;
 
-                    if (m_nextSamplingTime <= now.Ticks)
+                    if (m_nextSamplingTime <= now)
                     {
                         return 0;
                     }
 
-                    return (int)((m_nextSamplingTime - now.Ticks)/TimeSpan.TicksPerMillisecond); 
+                    return (int)(m_nextSamplingTime - now);
                 }
             }
         }
@@ -1422,7 +1423,7 @@ namespace Opc.Ua.Server
             DataValue value,
             ServiceResult error,
             DataValue lastValue,
-            ServiceResult lastError, 
+            ServiceResult lastError,
             DataChangeFilter filter,
             double range)
         {
@@ -1446,10 +1447,10 @@ namespace Opc.Ua.Server
                     trigger = DataChangeTrigger.StatusValue;
                 }
             }
-            
+
             // get the current status.
             uint status = StatusCodes.Good;
-            
+
             if (error != null)
             {
                 status = error.StatusCode.Code;
@@ -1518,13 +1519,13 @@ namespace Opc.Ua.Server
             {
                 return true;
             }
-            
+
             // check for invalid values.
             if (value1 == null || value2 == null)
             {
                 return value1 == value2;
             }
-            
+
             // check for type change.
             if (value1.GetType() != value2.GetType())
             {
@@ -1532,9 +1533,9 @@ namespace Opc.Ua.Server
             }
 
             // special case NaN is always not equal
-            if (value1.Equals(float.NaN) || 
+            if (value1.Equals(float.NaN) ||
                 value1.Equals(double.NaN) ||
-                value2.Equals(float.NaN) || 
+                value2.Equals(float.NaN) ||
                 value2.Equals(double.NaN))
             {
                 return false;
@@ -1570,7 +1571,7 @@ namespace Opc.Ua.Server
                 // check deadband.
                 return !ExceedsDeadband(value1, value2, deadbandType, deadband, range);
             }
-            
+
             // compare lengths.
             if (array1.Length != array2.Length)
             {
@@ -1625,7 +1626,7 @@ namespace Opc.Ua.Server
 
                 if (baseline > 0)
                 {
-                    if (Math.Abs((decimal1 - decimal2)/baseline) <= (decimal)deadband)
+                    if (Math.Abs((decimal1 - decimal2) / baseline) <= (decimal)deadband)
                     {
                         return false;
                     }
@@ -1635,10 +1636,10 @@ namespace Opc.Ua.Server
             {
                 // treat all conversion errors as evidence that the deadband was exceeded.
             }
-                
+
             return true;
         }
-        
+
         /// <summary>
         /// Returns true if the deadband was exceeded.
         /// </summary>
@@ -1653,14 +1654,14 @@ namespace Opc.Ua.Server
 
             if (baseline > 0)
             {
-                if (Math.Abs((value1 - value2)/baseline) <= deadband)
+                if (Math.Abs((value1 - value2) / baseline) <= deadband)
                 {
                     return false;
                 }
             }
 
             return true;
-        }        
+        }
 
         /// <summary>
         /// Clears and re-initializes the queue if the monitoring parameters changed.
@@ -1679,51 +1680,51 @@ namespace Opc.Ua.Server
 
                 case MonitoringMode.Reporting:
                 case MonitoringMode.Sampling:
+                {
+                    // check if queuing is disabled.
+                    if (m_queueSize == 0)
                     {
-                        // check if queuing is disabled.
-                        if (m_queueSize == 0)
-                        {
-                            if (m_typeMask == MonitoredItemTypeMask.DataChange)
-                            {
-                                m_queueSize = 1;
-                            }
-
-                            if ((m_typeMask & MonitoredItemTypeMask.Events) != 0)
-                            {
-                                m_queueSize = 1000;
-                            }
-                        }
-
-                        // create data queue.
                         if (m_typeMask == MonitoredItemTypeMask.DataChange)
                         {
-                            if (m_queueSize <= 1)
-                            {
-                                m_queue = null;
-                                break; // queueing is disabled
-                            }
-
-                            bool queueLastValue = false;
-
-                            if (m_queue == null)
-                            {
-                                m_queue = new MonitoredItemQueue(m_id, QueueOverflowHandler);
-                                queueLastValue = true;
-                            }
-
-                            m_queue.SetQueueSize(m_queueSize, m_discardOldest, m_diagnosticsMasks);
-                            m_queue.SetSamplingInterval(m_samplingInterval);
-
-                            if (queueLastValue && m_lastValue != null)
-                            {
-                                m_queue.QueueValue(m_lastValue, m_lastError);
-                            }
+                            m_queueSize = 1;
                         }
-                        else // create event queue.
+
+                        if ((m_typeMask & MonitoredItemTypeMask.Events) != 0)
                         {
-                            if (m_events == null)
-                            {
-                                m_events = new List<EventFieldList>();
+                            m_queueSize = 1000;
+                        }
+                    }
+
+                    // create data queue.
+                    if (m_typeMask == MonitoredItemTypeMask.DataChange)
+                    {
+                        if (m_queueSize <= 1)
+                        {
+                            m_queue = null;
+                            break; // queueing is disabled
+                        }
+
+                        bool queueLastValue = false;
+
+                        if (m_queue == null)
+                        {
+                            m_queue = new MonitoredItemQueue(m_id, QueueOverflowHandler);
+                            queueLastValue = true;
+                        }
+
+                        m_queue.SetQueueSize(m_queueSize, m_discardOldest, m_diagnosticsMasks);
+                        m_queue.SetSamplingInterval(m_samplingInterval);
+
+                        if (queueLastValue && m_lastValue != null)
+                        {
+                            m_queue.QueueValue(m_lastValue, m_lastError);
+                        }
+                    }
+                    else // create event queue.
+                    {
+                        if (m_events == null)
+                        {
+                            m_events = new List<EventFieldList>();
                         }
 
                         // check if existing queue entries must be discarded;
@@ -1741,7 +1742,7 @@ namespace Opc.Ua.Server
                             }
                         }
                     }
-                    
+
                     break;
                 }
             }
@@ -1782,7 +1783,7 @@ namespace Opc.Ua.Server
         private bool m_discardOldest;
         private int m_sourceSamplingInterval;
         private bool m_alwaysReportUpdates;
-        
+
         private DataValue m_lastValue;
         private ServiceResult m_lastError;
         private long m_nextSamplingTime;

--- a/Libraries/Opc.Ua.Server/Subscription/Subscription.cs
+++ b/Libraries/Opc.Ua.Server/Subscription/Subscription.cs
@@ -35,7 +35,7 @@ using System.Threading;
 using System.Runtime.Serialization;
 using System.Text;
 
-namespace Opc.Ua.Server 
+namespace Opc.Ua.Server
 {
     /// <summary>
     /// An interface used by the monitored items to signal the subscription.
@@ -50,7 +50,7 @@ namespace Opc.Ua.Server
         /// <summary>
         /// The identifier for the item that is unique within the server.
         /// </summary>
-        uint Id { get; } 
+        uint Id { get; }
 
         /// <summary>
         /// Called when a monitored item is ready to publish.
@@ -78,45 +78,45 @@ namespace Opc.Ua.Server
         /// Initializes the object.
         /// </summary>
         public Subscription(
-            IServerInternal  server,
-            Session          session,
-            uint             subscriptionId,
-            double           publishingInterval,
-            uint             maxLifetimeCount,
-            uint             maxKeepAliveCount,
-            uint             maxNotificationsPerPublish,
-            byte             priority,
-            bool             publishingEnabled,
-            uint             maxMessageCount)
-        {       
-            if (server == null)  throw new ArgumentNullException(nameof(server));
+            IServerInternal server,
+            Session session,
+            uint subscriptionId,
+            double publishingInterval,
+            uint maxLifetimeCount,
+            uint maxKeepAliveCount,
+            uint maxNotificationsPerPublish,
+            byte priority,
+            bool publishingEnabled,
+            uint maxMessageCount)
+        {
+            if (server == null) throw new ArgumentNullException(nameof(server));
             if (session == null) throw new ArgumentNullException(nameof(session));
 
-            m_server                      = server;
-            m_session                     = session;
-            m_id                          = subscriptionId;
-            m_publishingInterval          = publishingInterval;
-            m_maxLifetimeCount            = maxLifetimeCount;
-            m_maxKeepAliveCount           = maxKeepAliveCount;
-            m_maxNotificationsPerPublish  = maxNotificationsPerPublish;
-            m_publishingEnabled           = publishingEnabled;
-            m_priority                    = priority;
-            m_publishTimerExpiry          = HiResClock.UtcNow.Ticks/TimeSpan.TicksPerMillisecond + (long)publishingInterval;
-            m_keepAliveCounter            = maxKeepAliveCount;
-            m_lifetimeCounter             = 0;
-            m_waitingForPublish           = false;
-            m_maxMessageCount             = maxMessageCount;
-            m_sentMessages                = new List<NotificationMessage>();
-            
-            m_monitoredItems              = new Dictionary<uint,LinkedListNode<IMonitoredItem>>();
-            m_itemsToCheck                = new LinkedList<IMonitoredItem>();
-            m_itemsToPublish              = new LinkedList<IMonitoredItem>();
-            m_itemsToTrigger              = new Dictionary<uint,List<ITriggeredMonitoredItem>>();
+            m_server = server;
+            m_session = session;
+            m_id = subscriptionId;
+            m_publishingInterval = publishingInterval;
+            m_maxLifetimeCount = maxLifetimeCount;
+            m_maxKeepAliveCount = maxKeepAliveCount;
+            m_maxNotificationsPerPublish = maxNotificationsPerPublish;
+            m_publishingEnabled = publishingEnabled;
+            m_priority = priority;
+            m_publishTimerExpiry = HiResClock.TickCount64 + (long)publishingInterval;
+            m_keepAliveCounter = maxKeepAliveCount;
+            m_lifetimeCounter = 0;
+            m_waitingForPublish = false;
+            m_maxMessageCount = maxMessageCount;
+            m_sentMessages = new List<NotificationMessage>();
+
+            m_monitoredItems = new Dictionary<uint, LinkedListNode<IMonitoredItem>>();
+            m_itemsToCheck = new LinkedList<IMonitoredItem>();
+            m_itemsToPublish = new LinkedList<IMonitoredItem>();
+            m_itemsToTrigger = new Dictionary<uint, List<ITriggeredMonitoredItem>>();
 
             // m_itemsReadyToPublish         = new Queue<IMonitoredItem>();
             // m_itemsNotificationsAvailable = new LinkedList<IMonitoredItem>();
-            m_sequenceNumber              = 1;
-            
+            m_sequenceNumber = 1;
+
             // initialize diagnostics.
             m_diagnostics = new SubscriptionDiagnosticsDataType();
 
@@ -156,17 +156,17 @@ namespace Opc.Ua.Server
                 systemContext,
                 m_diagnostics,
                 OnUpdateDiagnostics);
-            
+
             // TraceState("CREATED");
         }
         #endregion
-        
+
         #region IDisposable Members
         /// <summary>
         /// Frees any unmanaged resources.
         /// </summary>
         public void Dispose()
-        {   
+        {
             Dispose(true);
         }
 
@@ -192,8 +192,8 @@ namespace Opc.Ua.Server
         /// <summary>
         /// The session that owns the monitored item.
         /// </summary>
-        public Session Session 
-        { 
+        public Session Session
+        {
             get { return m_session; }
         }
 
@@ -204,7 +204,7 @@ namespace Opc.Ua.Server
         {
             get { return m_id; }
         }
-        
+
         /// <summary>
         /// Queues an item that is ready to publish.
         /// </summary>
@@ -238,7 +238,7 @@ namespace Opc.Ua.Server
         /// </summary>
         public NodeId SessionId
         {
-            get 
+            get
             {
                 lock (m_lock)
                 {
@@ -316,8 +316,8 @@ namespace Opc.Ua.Server
                     return m_monitoredItems.Count;
                 }
             }
-        }    
-        
+        }
+
         /// <summary>
         /// The priority assigned to the subscription.
         /// </summary>
@@ -327,7 +327,7 @@ namespace Opc.Ua.Server
             {
                 return m_priority;
             }
-        }        
+        }
 
         /// <summary>
         /// Deletes the subscription.
@@ -342,9 +342,9 @@ namespace Opc.Ua.Server
             }
 
             lock (m_lock)
-            {   
+            {
                 try
-                {        
+                {
                     // TraceState("DELETED");
 
                     // the context may be null if the server is cleaning up expired subscriptions.
@@ -380,20 +380,20 @@ namespace Opc.Ua.Server
         {
             lock (m_lock)
             {
-                long currentTime = HiResClock.UtcNow.Ticks/TimeSpan.TicksPerMillisecond;
-                
+                long currentTime = HiResClock.TickCount64;
+
                 // check if publish interval has elapsed.
                 if (m_publishTimerExpiry >= currentTime)
                 {
                     // check if waiting for publish.
                     if (m_waitingForPublish)
-                    {                      
+                    {
                         return PublishingState.WaitingForPublish;
                     }
 
                     return PublishingState.Idle;
                 }
-                
+
                 // set next expiry time.
                 while (m_publishTimerExpiry < currentTime)
                 {
@@ -410,9 +410,9 @@ namespace Opc.Ua.Server
                         m_diagnostics.LatePublishRequestCount++;
                         m_diagnostics.CurrentLifetimeCount = m_lifetimeCounter;
                     }
-                    
+
                     if (m_lifetimeCounter >= m_maxLifetimeCount)
-                    {                        
+                    {
                         TraceState("EXPIRED");
                         return PublishingState.Expired;
                     }
@@ -420,7 +420,7 @@ namespace Opc.Ua.Server
 
                 // increment keep alive counter.
                 m_keepAliveCounter++;
-                
+
                 lock (DiagnosticsWriteLock)
                 {
                     m_diagnostics.CurrentKeepAliveCount = m_keepAliveCounter;
@@ -428,7 +428,7 @@ namespace Opc.Ua.Server
 
                 // check for monitored items.
                 if (m_publishingEnabled && m_session != null)
-                {                  
+                {
                     // check for monitored items that are ready to publish.
                     LinkedListNode<IMonitoredItem> current = m_itemsToCheck.First;
                     bool itemsTriggered = false;
@@ -498,8 +498,8 @@ namespace Opc.Ua.Server
                         m_waitingForPublish = true;
                         return PublishingState.NotificationsAvailable;
                     }
-                }                
-                
+                }
+
                 // check if keep alive expired.
                 if (m_keepAliveCounter >= m_maxKeepAliveCount)
                 {
@@ -511,7 +511,7 @@ namespace Opc.Ua.Server
                     m_waitingForPublish = true;
                     return PublishingState.NotificationsAvailable;
                 }
-                
+
                 // do nothing.
                 return PublishingState.Idle;
             }
@@ -532,7 +532,7 @@ namespace Opc.Ua.Server
                 m_diagnostics.SessionId = null;
             }
         }
-        
+
         /// <summary>
         /// Resets the keepalive counter.
         /// </summary>
@@ -566,7 +566,7 @@ namespace Opc.Ua.Server
         {
             lock (DiagnosticsWriteLock)
             {
-                m_diagnostics.MonitoringQueueOverflowCount ++;
+                m_diagnostics.MonitoringQueueOverflowCount++;
             }
         }
 
@@ -609,17 +609,17 @@ namespace Opc.Ua.Server
                 return StatusCodes.BadSequenceNumberUnknown;
             }
         }
-        
+
         /// <summary>
         /// Returns all available notifications.
         /// </summary>
         public NotificationMessage Publish(
-            OperationContext      context, 
-            out UInt32Collection  availableSequenceNumbers, 
-            out bool              moreNotifications)
-        {   
+            OperationContext context,
+            out UInt32Collection availableSequenceNumbers,
+            out bool moreNotifications)
+        {
             if (context == null) throw new ArgumentNullException(nameof(context));
-            
+
             NotificationMessage message = null;
 
             lock (m_lock)
@@ -642,7 +642,7 @@ namespace Opc.Ua.Server
                     }
 
                     message = InnerPublish(context, out availableSequenceNumbers, out moreNotifications);
-                    
+
                     lock (DiagnosticsWriteLock)
                     {
                         m_diagnostics.UnacknowledgedMessageCount = (uint)availableSequenceNumbers.Count;
@@ -699,10 +699,10 @@ namespace Opc.Ua.Server
         /// Returns all available notifications.
         /// </summary>
         private NotificationMessage InnerPublish(
-            OperationContext      context, 
-            out UInt32Collection  availableSequenceNumbers, 
-            out bool              moreNotifications)
-        {   
+            OperationContext context,
+            out UInt32Collection availableSequenceNumbers,
+            out bool moreNotifications)
+        {
             // check session.
             VerifySession(context);
 
@@ -722,24 +722,24 @@ namespace Opc.Ua.Server
                 {
                     availableSequenceNumbers.Add(m_sentMessages[ii].SequenceNumber);
                 }
-                
-                moreNotifications = m_waitingForPublish = m_lastSentMessage < m_sentMessages.Count-1;
+
+                moreNotifications = m_waitingForPublish = m_lastSentMessage < m_sentMessages.Count - 1;
 
                 // TraceState("PUBLISH QUEUED MESSAGE");
                 return m_sentMessages[m_lastSentMessage++];
             }
-            
+
             List<NotificationMessage> messages = new List<NotificationMessage>();
 
             if (m_publishingEnabled)
-            {                
+            {
                 DateTime start1 = DateTime.UtcNow;
 
                 // collect notifications to publish.
                 Queue<EventFieldList> events = new Queue<EventFieldList>();
                 Queue<MonitoredItemNotification> datachanges = new Queue<MonitoredItemNotification>();
                 Queue<DiagnosticInfo> datachangeDiagnostics = new Queue<DiagnosticInfo>();
-                
+
                 // check for monitored items that are ready to publish.
                 LinkedListNode<IMonitoredItem> current = m_itemsToPublish.First;
 
@@ -754,13 +754,13 @@ namespace Opc.Ua.Server
                     }
                     else
                     {
-                        ((IEventMonitoredItem)monitoredItem).Publish(context, events);                        
+                        ((IEventMonitoredItem)monitoredItem).Publish(context, events);
                     }
 
                     // add back to list to check.
                     m_itemsToPublish.Remove(current);
                     m_itemsToCheck.AddLast(current);
-                                    
+
                     // check there are enough notifications for a message.
                     if (m_maxNotificationsPerPublish > 0 && events.Count + datachanges.Count > m_maxNotificationsPerPublish)
                     {
@@ -768,11 +768,11 @@ namespace Opc.Ua.Server
                         int notificationCount;
                         int eventCount = events.Count;
                         int dataChangeCount = datachanges.Count;
-                                           
+
                         NotificationMessage message = ConstructMessage(
-                             events, 
-                             datachanges, 
-                             datachangeDiagnostics, 
+                             events,
+                             datachanges,
+                             datachangeDiagnostics,
                              out notificationCount);
 
                         // add to list of messages to send.
@@ -795,13 +795,13 @@ namespace Opc.Ua.Server
                     // construct message.
                     int notificationCount;
                     int eventCount = events.Count;
-                    int dataChangeCount = datachanges.Count;   
-                                       
-                     NotificationMessage message = ConstructMessage(
-                         events, 
-                         datachanges, 
-                         datachangeDiagnostics, 
-                         out notificationCount);
+                    int dataChangeCount = datachanges.Count;
+
+                    NotificationMessage message = ConstructMessage(
+                        events,
+                        datachanges,
+                        datachangeDiagnostics,
+                        out notificationCount);
 
                     // add to list of messages to send.
                     messages.Add(message);
@@ -820,15 +820,15 @@ namespace Opc.Ua.Server
                     Utils.Trace(
                         (int)Utils.TraceMasks.Error,
                         "Oops! MonitoredItems queued but no notifications availabled.");
-               
+
                     m_waitingForPublish = false;
 
                     return null;
                 }
-                
+
                 DateTime end1 = DateTime.UtcNow;
-                
-                double delta1 = ((double)(end1.Ticks-start1.Ticks))/TimeSpan.TicksPerMillisecond;
+
+                double delta1 = ((double)(end1.Ticks - start1.Ticks)) / TimeSpan.TicksPerMillisecond;
 
                 if (delta1 > 200)
                 {
@@ -842,8 +842,8 @@ namespace Opc.Ua.Server
                 NotificationMessage message = new NotificationMessage();
 
                 // use the sequence number for the next message.                    
-                message.SequenceNumber = (uint)m_sequenceNumber; 
-                message.PublishTime    = DateTime.UtcNow;
+                message.SequenceNumber = (uint)m_sequenceNumber;
+                message.PublishTime = DateTime.UtcNow;
 
                 // return the available sequence numbers.
                 for (int ii = 0; ii <= m_lastSentMessage && ii < m_sentMessages.Count; ii++)
@@ -859,9 +859,9 @@ namespace Opc.Ua.Server
             int overflowCount = messages.Count - (int)m_maxMessageCount;
             if (overflowCount > 0)
             {
-                
+
                 Utils.Trace(
-                    "WARNING: QUEUE OVERFLOW. Dropping {2} Messages. Increase MaxMessageQueueSize. SubId={0}, MaxMessageQueueSize={1}", 
+                    "WARNING: QUEUE OVERFLOW. Dropping {2} Messages. Increase MaxMessageQueueSize. SubId={0}, MaxMessageQueueSize={1}",
                     m_id,
                     m_maxMessageCount,
                     overflowCount);
@@ -891,7 +891,7 @@ namespace Opc.Ua.Server
             // save new message
             m_lastSentMessage = m_sentMessages.Count;
             m_sentMessages.AddRange(messages);
-            
+
             // check if there are more notifications to send.
             moreNotifications = m_waitingForPublish = messages.Count > 1;
 
@@ -918,8 +918,8 @@ namespace Opc.Ua.Server
 
             NotificationMessage message = new NotificationMessage();
 
-            message.SequenceNumber = (uint)m_sequenceNumber; 
-            message.PublishTime    = DateTime.UtcNow;
+            message.SequenceNumber = (uint)m_sequenceNumber;
+            message.PublishTime = DateTime.UtcNow;
 
             Utils.IncrementIdentifier(ref m_sequenceNumber);
 
@@ -927,7 +927,7 @@ namespace Opc.Ua.Server
             {
                 m_diagnostics.NextSequenceNumber = (uint)m_sequenceNumber;
             }
-             
+
             // add events.
             if (events.Count > 0 && notificationCount < m_maxNotificationsPerPublish)
             {
@@ -948,7 +948,7 @@ namespace Opc.Ua.Server
                 bool diagnosticsExist = false;
                 DataChangeNotification notification = new DataChangeNotification();
 
-                notification.MonitoredItems  = new MonitoredItemNotificationCollection(datachanges.Count);
+                notification.MonitoredItems = new MonitoredItemNotificationCollection(datachanges.Count);
                 notification.DiagnosticInfos = new DiagnosticInfoCollection(datachanges.Count);
 
                 while (datachanges.Count > 0 && notificationCount < m_maxNotificationsPerPublish)
@@ -962,7 +962,7 @@ namespace Opc.Ua.Server
                     {
                         diagnosticsExist = true;
                     }
-                    
+
                     notification.DiagnosticInfos.Add(diagnosticInfo);
 
                     notificationCount++;
@@ -985,8 +985,8 @@ namespace Opc.Ua.Server
         /// </summary>
         public NotificationMessage Republish(
             OperationContext context,
-            uint             retransmitSequenceNumber)
-        {            
+            uint retransmitSequenceNumber)
+        {
             if (context == null) throw new ArgumentNullException(nameof(context));
 
             lock (DiagnosticsWriteLock)
@@ -1001,7 +1001,7 @@ namespace Opc.Ua.Server
 
                 // clear lifetime counter.
                 ResetLifetimeCount();
-                
+
                 lock (DiagnosticsWriteLock)
                 {
                     m_diagnostics.RepublishRequestCount++;
@@ -1032,11 +1032,11 @@ namespace Opc.Ua.Server
         /// </summary>
         public void Modify(
             OperationContext context,
-            double           publishingInterval,
-            uint             maxLifetimeCount,
-            uint             maxKeepAliveCount,
-            uint             maxNotificationsPerPublish,
-            byte             priority)
+            double publishingInterval,
+            uint maxLifetimeCount,
+            uint maxKeepAliveCount,
+            uint maxNotificationsPerPublish,
+            byte priority)
         {
             lock (m_lock)
             {
@@ -1052,10 +1052,10 @@ namespace Opc.Ua.Server
                 if (publishingInterval != m_publishingInterval)
                 {
                     m_publishingInterval = publishingInterval;
-                    m_publishTimerExpiry = (HiResClock.UtcNow.Ticks/TimeSpan.TicksPerMillisecond) + (long)publishingInterval;
+                    m_publishTimerExpiry = (HiResClock.TickCount64) + (long)publishingInterval;
                     ResetKeepaliveCount();
                 }
-                
+
                 // update keep alive count.
                 if (maxKeepAliveCount != m_maxKeepAliveCount)
                 {
@@ -1069,7 +1069,7 @@ namespace Opc.Ua.Server
 
                 // update diagnostics
                 lock (DiagnosticsWriteLock)
-                {   
+                {
                     m_diagnostics.ModifyCount++;
                     m_diagnostics.PublishingInterval = m_publishingInterval;
                     m_diagnostics.MaxKeepAliveCount = m_maxKeepAliveCount;
@@ -1077,17 +1077,17 @@ namespace Opc.Ua.Server
                     m_diagnostics.Priority = m_priority;
                     m_diagnostics.MaxNotificationsPerPublish = m_maxNotificationsPerPublish;
                 }
-                
+
                 // TraceState("MODIFIED");
             }
         }
-                
+
         /// <summary>
         /// Enables/disables publishing for the subscription.
         /// </summary>
         public void SetPublishingMode(
             OperationContext context,
-            bool             publishingEnabled)
+            bool publishingEnabled)
         {
             lock (m_lock)
             {
@@ -1116,12 +1116,12 @@ namespace Opc.Ua.Server
                             m_diagnostics.DisableCount++;
                         }
                     }
-                }     
-           
+                }
+
                 // TraceState((publishingEnabled)?"ENABLED":"DISABLED");
             }
         }
-        
+
         /// <summary>
         /// Updates the triggers for the monitored item.
         /// </summary>
@@ -1294,22 +1294,22 @@ namespace Opc.Ua.Server
                 }
             }
         }
-        
+
         /// <summary>
         /// Adds monitored items to a subscription.
         /// </summary>
         public void CreateMonitoredItems(
-            OperationContext                        context,
-            TimestampsToReturn                      timestampsToReturn,
-            MonitoredItemCreateRequestCollection    itemsToCreate, 
-            out MonitoredItemCreateResultCollection results, 
-            out DiagnosticInfoCollection            diagnosticInfos)
+            OperationContext context,
+            TimestampsToReturn timestampsToReturn,
+            MonitoredItemCreateRequestCollection itemsToCreate,
+            out MonitoredItemCreateResultCollection results,
+            out DiagnosticInfoCollection diagnosticInfos)
         {
-            if (context == null)       throw new ArgumentNullException(nameof(context));
+            if (context == null) throw new ArgumentNullException(nameof(context));
             if (itemsToCreate == null) throw new ArgumentNullException(nameof(itemsToCreate));
-            
+
             int count = itemsToCreate.Count;
-            
+
             lock (m_lock)
             {
                 // check session.
@@ -1318,7 +1318,7 @@ namespace Opc.Ua.Server
                 // clear lifetime counter.
                 ResetLifetimeCount();
             }
-             
+
             // create the monitored items.
             List<IMonitoredItem> monitoredItems = new List<IMonitoredItem>(count);
             List<ServiceResult> errors = new List<ServiceResult>(count);
@@ -1330,7 +1330,7 @@ namespace Opc.Ua.Server
                 errors.Add(null);
                 filterResults.Add(null);
             }
-            
+
             m_server.NodeManager.CreateMonitoredItems(
                 context,
                 this.m_id,
@@ -1340,7 +1340,7 @@ namespace Opc.Ua.Server
                 errors,
                 filterResults,
                 monitoredItems);
-                
+
             // allocate results.
             bool diagnosticsExist = false;
             results = new MonitoredItemCreateResultCollection(count);
@@ -1360,7 +1360,7 @@ namespace Opc.Ua.Server
                 {
                     // update results.
                     MonitoredItemCreateResult result = null;
-                    
+
                     if (ServiceResult.IsBad(errors[ii]))
                     {
                         result = new MonitoredItemCreateResult();
@@ -1378,7 +1378,7 @@ namespace Opc.Ua.Server
                         if (monitoredItem != null)
                         {
                             monitoredItem.SubscriptionCallback = this;
-                            
+
                             LinkedListNode<IMonitoredItem> node = m_itemsToCheck.AddLast(monitoredItem);
                             m_monitoredItems.Add(monitoredItem.Id, node);
 
@@ -1387,7 +1387,7 @@ namespace Opc.Ua.Server
                             // update sampling interval diagnostics.
                             AddItemToSamplingInterval(result.RevisedSamplingInterval, itemsToCreate[ii].MonitoringMode);
                         }
-                    }                   
+                    }
 
                     results.Add(result);
 
@@ -1395,7 +1395,7 @@ namespace Opc.Ua.Server
                     if ((context.DiagnosticsMask & DiagnosticsMasks.OperationAll) != 0)
                     {
                         DiagnosticInfo diagnosticInfo = null;
-                        
+
                         if (errors[ii] != null && errors[ii].Code != StatusCodes.Good)
                         {
                             diagnosticInfo = ServerUtils.CreateDiagnosticInfo(m_server, context, errors[ii]);
@@ -1444,7 +1444,7 @@ namespace Opc.Ua.Server
         {
             // TBD
         }
-        
+
         /// <summary>
         /// Removes an item from the sampling interval.
         /// </summary>
@@ -1492,13 +1492,13 @@ namespace Opc.Ua.Server
         /// Modifies monitored items in a subscription.
         /// </summary>
         public void ModifyMonitoredItems(
-            OperationContext                        context,
-            TimestampsToReturn                      timestampsToReturn,
-            MonitoredItemModifyRequestCollection    itemsToModify,
+            OperationContext context,
+            TimestampsToReturn timestampsToReturn,
+            MonitoredItemModifyRequestCollection itemsToModify,
             out MonitoredItemModifyResultCollection results,
-            out DiagnosticInfoCollection            diagnosticInfos)
+            out DiagnosticInfoCollection diagnosticInfos)
         {
-            if (context == null)       throw new ArgumentNullException(nameof(context));
+            if (context == null) throw new ArgumentNullException(nameof(context));
             if (itemsToModify == null) throw new ArgumentNullException(nameof(itemsToModify));
 
             int count = itemsToModify.Count;
@@ -1507,12 +1507,12 @@ namespace Opc.Ua.Server
             bool diagnosticsExist = false;
             results = new MonitoredItemModifyResultCollection(count);
             diagnosticInfos = null;
-            
+
             if ((context.DiagnosticsMask & DiagnosticsMasks.OperationAll) != 0)
             {
                 diagnosticInfos = new DiagnosticInfoCollection(count);
             }
-            
+
             // build list of items to modify.
             List<IMonitoredItem> monitoredItems = new List<IMonitoredItem>(count);
             List<ServiceResult> errors = new List<ServiceResult>(count);
@@ -1550,7 +1550,7 @@ namespace Opc.Ua.Server
 
                         continue;
                     }
-                    
+
                     IMonitoredItem monitoredItem = node.Value;
                     monitoredItems.Add(monitoredItem);
                     originalSamplingIntervals[ii] = monitoredItem.SamplingInterval;
@@ -1565,8 +1565,8 @@ namespace Opc.Ua.Server
                     }
                 }
             }
-                
-             // update items.
+
+            // update items.
             if (validItems)
             {
                 m_server.NodeManager.ModifyMonitoredItems(
@@ -1577,9 +1577,9 @@ namespace Opc.Ua.Server
                     errors,
                     filterResults);
             }
-                   
+
             lock (m_lock)
-            {             
+            {
                 // create results.
                 for (int ii = 0; ii < errors.Count; ii++)
                 {
@@ -1596,7 +1596,7 @@ namespace Opc.Ua.Server
                     {
                         result = new MonitoredItemModifyResult();
                     }
-                    
+
                     if (error == null)
                     {
                         result.StatusCode = StatusCodes.Good;
@@ -1634,7 +1634,7 @@ namespace Opc.Ua.Server
                 {
                     diagnosticInfos.Clear();
                 }
-                
+
                 // TraceState("ITEMS MODIFIED");
             }
         }
@@ -1655,13 +1655,13 @@ namespace Opc.Ua.Server
         /// Deletes the monitored items in a subscription.
         /// </summary>
         private void DeleteMonitoredItems(
-            OperationContext             context,
-            UInt32Collection             monitoredItemIds,
-            bool                         doNotCheckSession,
-            out StatusCodeCollection     results,
+            OperationContext context,
+            UInt32Collection monitoredItemIds,
+            bool doNotCheckSession,
+            out StatusCodeCollection results,
             out DiagnosticInfoCollection diagnosticInfos)
         {
-            if (context == null)          throw new ArgumentNullException(nameof(context));
+            if (context == null) throw new ArgumentNullException(nameof(context));
             if (monitoredItemIds == null) throw new ArgumentNullException(nameof(monitoredItemIds));
 
             int count = monitoredItemIds.Count;
@@ -1674,7 +1674,7 @@ namespace Opc.Ua.Server
             {
                 diagnosticInfos = new DiagnosticInfoCollection(count);
             }
-            
+
             // build list of items to modify.
             List<IMonitoredItem> monitoredItems = new List<IMonitoredItem>(count);
             List<ServiceResult> errors = new List<ServiceResult>(count);
@@ -1693,7 +1693,7 @@ namespace Opc.Ua.Server
 
                 // clear lifetime counter.
                 ResetLifetimeCount();
-                
+
                 for (int ii = 0; ii < count; ii++)
                 {
                     LinkedListNode<IMonitoredItem> node = null;
@@ -1713,7 +1713,7 @@ namespace Opc.Ua.Server
 
                         continue;
                     }
-                    
+
                     IMonitoredItem monitoredItem = node.Value;
                     monitoredItems.Add(monitoredItem);
 
@@ -1735,7 +1735,7 @@ namespace Opc.Ua.Server
                             }
                         }
                     }
-                    
+
                     if (node.List != null)
                     {
                         node.List.Remove(node);
@@ -1754,7 +1754,7 @@ namespace Opc.Ua.Server
                     }
                 }
             }
-   
+
             // update items.
             if (validItems)
             {
@@ -1764,7 +1764,7 @@ namespace Opc.Ua.Server
                     monitoredItems,
                     errors);
             }
-            
+
             lock (m_lock)
             {
                 // update diagnostics.
@@ -1806,18 +1806,18 @@ namespace Opc.Ua.Server
                 // TraceState("ITEMS DELETED");
             }
         }
-        
+
         /// <summary>
         /// Changes the monitoring mode for a set of items.
         /// </summary>
         public void SetMonitoringMode(
-            OperationContext             context,
-            MonitoringMode               monitoringMode,
-            UInt32Collection             monitoredItemIds,
-            out StatusCodeCollection     results, 
+            OperationContext context,
+            MonitoringMode monitoringMode,
+            UInt32Collection monitoredItemIds,
+            out StatusCodeCollection results,
             out DiagnosticInfoCollection diagnosticInfos)
-        {  
-            if (context == null)          throw new ArgumentNullException(nameof(context));
+        {
+            if (context == null) throw new ArgumentNullException(nameof(context));
             if (monitoredItemIds == null) throw new ArgumentNullException(nameof(monitoredItemIds));
 
             int count = monitoredItemIds.Count;
@@ -1830,7 +1830,7 @@ namespace Opc.Ua.Server
             {
                 diagnosticInfos = new DiagnosticInfoCollection(count);
             }
-        
+
             // build list of items to modify.
             List<IMonitoredItem> monitoredItems = new List<IMonitoredItem>(count);
             List<ServiceResult> errors = new List<ServiceResult>(count);
@@ -1865,7 +1865,7 @@ namespace Opc.Ua.Server
 
                         continue;
                     }
-                    
+
                     IMonitoredItem monitoredItem = node.Value;
                     monitoredItems.Add(monitoredItem);
                     originalMonitoringModes[ii] = monitoredItem.MonitoringMode;
@@ -1890,7 +1890,7 @@ namespace Opc.Ua.Server
                     monitoredItems,
                     errors);
             }
-                
+
             lock (m_lock)
             {
                 // update diagnostics.
@@ -1906,7 +1906,7 @@ namespace Opc.Ua.Server
                     {
                         results.Add(error.StatusCode);
                     }
-                    
+
                     // update diagnostics.
                     if (ServiceResult.IsGood(error))
                     {
@@ -1943,14 +1943,14 @@ namespace Opc.Ua.Server
                 }
             }
         }
-        
+
         /// <summary>
         /// Verifies that a condition refresh operation is permitted.
         /// </summary>
         public void ValidateConditionRefresh(OperationContext context)
         {
             lock (m_lock)
-            {  
+            {
                 VerifySession(context);
 
                 if (m_refreshInProgress)
@@ -1969,10 +1969,10 @@ namespace Opc.Ua.Server
             List<IEventMonitoredItem> monitoredItems = new List<IEventMonitoredItem>();
 
             lock (m_lock)
-            {  
+            {
                 // generate start event.
                 RefreshStartEventState e = new RefreshStartEventState(null);
-                            
+
                 TranslationInfo message = new TranslationInfo(
                     "RefreshStartEvent",
                     "en-US",
@@ -1984,7 +1984,7 @@ namespace Opc.Ua.Server
                     null,
                     EventSeverity.Low,
                     new LocalizedText(message));
-                
+
                 e.SetChildValue(systemContext, BrowseNames.SourceNode, m_diagnosticsId, false);
                 e.SetChildValue(systemContext, BrowseNames.SourceName, Utils.Format("Subscription/{0}", m_id), false);
                 e.SetChildValue(systemContext, BrowseNames.ReceiveTime, DateTime.UtcNow, false);
@@ -2010,7 +2010,7 @@ namespace Opc.Ua.Server
                     return;
                 }
             }
-            
+
             // tell the NodeManagers to report the current state of the conditions.
             try
             {
@@ -2023,12 +2023,12 @@ namespace Opc.Ua.Server
             {
                 m_refreshInProgress = false;
             }
-            
+
             lock (m_lock)
-            {  
+            {
                 // generate start event.
                 RefreshEndEventState e = new RefreshEndEventState(null);
-                            
+
                 TranslationInfo message = new TranslationInfo(
                     "RefreshEndEvent",
                     "en-US",
@@ -2040,11 +2040,11 @@ namespace Opc.Ua.Server
                     null,
                     EventSeverity.Low,
                     new LocalizedText(message));
-                
+
                 e.SetChildValue(systemContext, BrowseNames.SourceNode, m_diagnosticsId, false);
                 e.SetChildValue(systemContext, BrowseNames.SourceName, Utils.Format("Subscription/{0}", m_id), false);
                 e.SetChildValue(systemContext, BrowseNames.ReceiveTime, DateTime.UtcNow, false);
-                
+
                 // send refresh end event.
                 for (int ii = 0; ii < monitoredItems.Count; ii++)
                 {
@@ -2055,7 +2055,7 @@ namespace Opc.Ua.Server
                         monitoredItem.QueueEvent(e, true);
                     }
                 }
-                    
+
                 // TraceState("CONDITION REFRESH");
             }
         }
@@ -2070,7 +2070,7 @@ namespace Opc.Ua.Server
                 serverHandles = new uint[m_monitoredItems.Count];
                 clientHandles = new uint[m_monitoredItems.Count];
 
-                int ii = 0; 
+                int ii = 0;
 
                 foreach (KeyValuePair<uint, LinkedListNode<IMonitoredItem>> entry in m_monitoredItems)
                 {
@@ -2081,7 +2081,7 @@ namespace Opc.Ua.Server
             }
         }
         #endregion
-                
+
         #region Private Methods
         /// <summary>
         /// Returns a copy of the current diagnostics.
@@ -2114,7 +2114,7 @@ namespace Opc.Ua.Server
                 throw new ServiceResultException(StatusCodes.BadSubscriptionIdInvalid, "Subscription belongs to a different session.");
             }
         }
-        
+
         /// <summary>
         /// Dumps the current state of the session queue.
         /// </summary>
@@ -2126,11 +2126,11 @@ namespace Opc.Ua.Server
             }
 
             StringBuilder buffer = new StringBuilder();
-            
+
             lock (m_lock)
             {
                 buffer.AppendFormat("Subscription {0}", context);
-                
+
                 buffer.AppendFormat(", Id={0}", m_id);
                 buffer.AppendFormat(", Publishing={0}", m_publishingInterval);
                 buffer.AppendFormat(", KeepAlive={0}", m_maxKeepAliveCount);
@@ -2169,7 +2169,7 @@ namespace Opc.Ua.Server
         private int m_lastSentMessage;
         private long m_sequenceNumber;
         private uint m_maxMessageCount;
-        private Dictionary<uint,LinkedListNode<IMonitoredItem>> m_monitoredItems;
+        private Dictionary<uint, LinkedListNode<IMonitoredItem>> m_monitoredItems;
         private LinkedList<IMonitoredItem> m_itemsToCheck;
         private LinkedList<IMonitoredItem> m_itemsToPublish;
         private NodeId m_diagnosticsId;

--- a/Libraries/Opc.Ua.Server/Subscription/Subscription.cs
+++ b/Libraries/Opc.Ua.Server/Subscription/Subscription.cs
@@ -1052,7 +1052,7 @@ namespace Opc.Ua.Server
                 if (publishingInterval != m_publishingInterval)
                 {
                     m_publishingInterval = publishingInterval;
-                    m_publishTimerExpiry = (HiResClock.TickCount64) + (long)publishingInterval;
+                    m_publishTimerExpiry = HiResClock.TickCount64 + (long)publishingInterval;
                     ResetKeepaliveCount();
                 }
 

--- a/Stack/Opc.Ua.Core/Schema/ApplicationConfiguration.cs
+++ b/Stack/Opc.Ua.Core/Schema/ApplicationConfiguration.cs
@@ -223,7 +223,7 @@ namespace Opc.Ua
         /// <summary>
         /// Disabling / enabling high resolution clock 
         /// </summary>
-        /// <value><c>true</c> if high resolutioin clock is disabled; otherwise, <c>false</c>.</value>
+        /// <value><c>true</c> if high resolution clock is disabled; otherwise, <c>false</c>.</value>
         [DataMember(IsRequired = false, EmitDefaultValue = false, Order = 12)]
         public bool DisableHiResClock
         {

--- a/Stack/Opc.Ua.Core/Schema/ApplicationConfiguration.cs
+++ b/Stack/Opc.Ua.Core/Schema/ApplicationConfiguration.cs
@@ -42,7 +42,7 @@ namespace Opc.Ua
 
             m_securityConfiguration = new SecurityConfiguration();
             m_transportConfigurations = new TransportConfigurationCollection();
-            m_disableHiResClock = true;
+            m_disableHiResClock = false;
             m_properties = new Dictionary<string, object>();
             m_certificateValidator = new CertificateValidator();
         }

--- a/Stack/Opc.Ua.Core/Types/Utils/HiResClock.cs
+++ b/Stack/Opc.Ua.Core/Types/Utils/HiResClock.cs
@@ -10,9 +10,9 @@
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 */
 
+
 using System;
-using System.Collections.Generic;
-using System.Text;
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 
 namespace Opc.Ua
@@ -20,40 +20,151 @@ namespace Opc.Ua
     /// <summary>
     /// Produces high resolution timestamps.
     /// </summary>
-    public static class HiResClock
+    public class HiResClock
     {
-        // In Net Core 3.0+ has monotonic timer from system start.
-        // https://docs.microsoft.com/ru-ru/dotnet/api/system.environment.tickcount64?view=netcore-3.1
-#if NETCORE3_0 || NETCORE3_1
-        public static long TickCount64 { get { return Environment.TickCount64; } } 
-#else
+        /// <summary>
+        /// Returns the current UTC time (bugs in HALs on some computers can result in time jumping backwards).
+        /// </summary>
+        public static DateTime UtcNow
+        {
+            get
+            {
+                if (s_Default.m_disabled)
+                {
+                    return DateTime.UtcNow;
+                }
 
-        /// <summary>Get monotonic timer from system starts in Windows in Msec. In other systems using DateTime. (posible lost monitored items when combuter time shift. see #1121)</summary>
+                long counter = 0;
+#if NETFRAMEWORK
+                if (NativeMethods.QueryPerformanceCounter(out counter) == 0)
+                {
+                    return DateTime.UtcNow;
+                }
+#else
+                counter = Stopwatch.GetTimestamp();
+#endif
+                decimal ticks = (counter - s_Default.m_baseline) * s_Default.m_ratio;
+                return new DateTime((long)ticks + s_Default.m_offset);
+            }
+        }
+
+        /// <summary>
+        /// Returns a monotonic increasing tick count in milliseconds.
+        /// </summary>
         public static long TickCount64
         {
             get
             {
-                if (Environment.OSVersion.Platform == PlatformID.Win32NT)
-                    return GetTickCount64();
-                else
-                    return DateTime.UtcNow.Ticks / TimeSpan.TicksPerMillisecond;
+                if (s_Default.m_disabled)
+                {
+                    return (long)(DateTime.UtcNow.Ticks / TimeSpan.TicksPerMillisecond);
+                }
+#if NETFRAMEWORK
+                return NativeMethods.GetTickCount64();
+#else
+                if (s_Default.m_isWindowsOS)
+                {
+                    return NativeMethods.GetTickCount64();
+                }
+                long counter = 0;
+                counter = Stopwatch.GetTimestamp();
+                return (long)(counter / s_Default.m_ticksPerMillisecond);
+#endif
             }
         }
 
-        [System.Runtime.InteropServices.DllImport("kernel32.dll")]
-        public static extern long GetTickCount64();
+        /// <summary>
+        /// Return the frequency of the ticks.
+        /// </summary>
+        public static long Frequency => s_Default.m_frequency;
 
-#endif
+        /// <summary>
+        /// Return the number of ticks per millisecond.
+        /// </summary>
+        public static double TicksPerMillisecond => s_Default.m_ticksPerMillisecond;
 
-
-        /// <summary>Returns the current UTC time (bugs in HALs on some computers can result in time jumping backwards). </summary>
-        public static DateTime UtcNow
+        /// <summary>
+        /// Disables the hi-res clock (may be necessary on some machines with bugs in the HAL).
+        /// </summary>
+        public static bool Disabled
         {
-            get { return DateTime.UtcNow; }
+            get
+            {
+                return s_Default.m_disabled;
+            }
+
+            set
+            {
+                s_Default.m_disabled = value;
+            }
         }
 
-        /// <summary>Disables the hi-res clock (may be necessary on some machines with bugs in the HAL).</summary>
-        public static bool Disabled { get; set; }
+        /// <summary>
+        /// Constructs a class.
+        /// </summary>
+        private HiResClock()
+        {
+#if NETFRAMEWORK
+            if (NativeMethods.QueryPerformanceFrequency(out m_frequency) == 0)
+            {
+                m_frequency = TimeSpan.TicksPerSecond;
+            }
+            m_offset = DateTime.UtcNow.Ticks;
+            if (NativeMethods.QueryPerformanceCounter(out m_baseline) == 0)
+            {
+                m_baseline = m_offset;
+                m_disabled = true;
+            }
+            m_ratio = ((decimal)TimeSpan.TicksPerSecond) / m_frequency;
+#else
+            m_offset = DateTime.UtcNow.Ticks;
+            if (!Stopwatch.IsHighResolution)
+            {
+                m_frequency = TimeSpan.TicksPerSecond;
+                m_baseline = m_offset;
+                m_disabled = true;
+            }
+            else
+            {
+                m_baseline = Stopwatch.GetTimestamp();
+                m_frequency = Stopwatch.Frequency;
+            }
+            m_ratio = ((decimal)TimeSpan.TicksPerSecond) / m_frequency;
+#endif
+            m_ticksPerMillisecond = m_frequency / 1000.0;
+        }
+
+        /// <summary>
+        /// Defines a global instance.
+        /// </summary>
+        private static readonly HiResClock s_Default = new HiResClock();
+
+        /// <summary>
+        /// Defines the native methods used by the class.
+        /// </summary>
+        private static class NativeMethods
+        {
+#if NETFRAMEWORK
+            [DllImport("Kernel32.dll")]
+            public static extern int QueryPerformanceFrequency(out long lpFrequency);
+
+            [DllImport("Kernel32.dll")]
+            public static extern int QueryPerformanceCounter(out long lpFrequency);
+#endif
+            [DllImport("kernel32.dll")]
+            public static extern long GetTickCount64();
+        }
+
+        private long m_frequency;
+        private long m_baseline;
+        private long m_offset;
+        private double m_ticksPerMillisecond;
+        private decimal m_ratio;
+#if !NETFRAMEWORK
+        private bool m_isWindowsOS = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+#endif
+
+        private bool m_disabled;
     }
 
 }

--- a/Stack/Opc.Ua.Core/Types/Utils/HiResClock.cs
+++ b/Stack/Opc.Ua.Core/Types/Utils/HiResClock.cs
@@ -13,7 +13,6 @@
 
 using System;
 using System.Diagnostics;
-using System.Runtime.InteropServices;
 
 namespace Opc.Ua
 {
@@ -23,8 +22,12 @@ namespace Opc.Ua
     public class HiResClock
     {
         /// <summary>
-        /// Returns the current UTC time (bugs in HALs on some computers can result in time jumping backwards).
+        /// Returns the current UTC time with a high resolution.
         /// </summary>
+        /// <remarks>
+        /// This Utc time does not change if the system time is changed.
+        /// It returns the Utc time elapsed since the application started.
+        /// </remarks>
         public static DateTime UtcNow
         {
             get
@@ -33,16 +36,7 @@ namespace Opc.Ua
                 {
                     return DateTime.UtcNow;
                 }
-
-                long counter = 0;
-#if NETFRAMEWORK
-                if (NativeMethods.QueryPerformanceCounter(out counter) == 0)
-                {
-                    return DateTime.UtcNow;
-                }
-#else
-                counter = Stopwatch.GetTimestamp();
-#endif
+                long counter = Stopwatch.GetTimestamp();
                 decimal ticks = (counter - s_Default.m_baseline) * s_Default.m_ratio;
                 return new DateTime((long)ticks + s_Default.m_offset);
             }
@@ -59,32 +53,24 @@ namespace Opc.Ua
                 {
                     return (long)(DateTime.UtcNow.Ticks / TimeSpan.TicksPerMillisecond);
                 }
-#if NETFRAMEWORK
-                return NativeMethods.GetTickCount64();
-#else
-                if (s_Default.m_isWindowsOS)
-                {
-                    return NativeMethods.GetTickCount64();
-                }
-                long counter = 0;
-                counter = Stopwatch.GetTimestamp();
-                return (long)(counter / s_Default.m_ticksPerMillisecond);
-#endif
+                return (long)(Stopwatch.GetTimestamp() / s_Default.m_ticksPerMillisecond);
             }
         }
 
         /// <summary>
         /// Return the frequency of the ticks.
         /// </summary>
-        public static long Frequency => s_Default.m_frequency;
+        public static long Frequency => s_Default.m_disabled ?
+            TimeSpan.TicksPerSecond : s_Default.m_frequency;
 
         /// <summary>
         /// Return the number of ticks per millisecond.
         /// </summary>
-        public static double TicksPerMillisecond => s_Default.m_ticksPerMillisecond;
+        public static double TicksPerMillisecond => s_Default.m_disabled ?
+            TimeSpan.TicksPerMillisecond : s_Default.m_ticksPerMillisecond;
 
         /// <summary>
-        /// Disables the hi-res clock (may be necessary on some machines with bugs in the HAL).
+        /// Disables the hires clock.
         /// </summary>
         public static bool Disabled
         {
@@ -95,32 +81,32 @@ namespace Opc.Ua
 
             set
             {
-                s_Default.m_disabled = value;
+                // do not enable if unsupported
+                if (Stopwatch.IsHighResolution)
+                {
+                    if (s_Default.m_disabled && !value)
+                    {
+                        // reset baseline
+                        s_Default = new HiResClock();
+                    }
+                    else
+                    {
+                        s_Default.m_disabled = value;
+                    }
+                }
             }
         }
 
         /// <summary>
-        /// Constructs a class.
+        /// Constructs a HiRes clock class.
         /// </summary>
         private HiResClock()
         {
-#if NETFRAMEWORK
-            if (NativeMethods.QueryPerformanceFrequency(out m_frequency) == 0)
-            {
-                m_frequency = TimeSpan.TicksPerSecond;
-            }
-            m_offset = DateTime.UtcNow.Ticks;
-            if (NativeMethods.QueryPerformanceCounter(out m_baseline) == 0)
-            {
-                m_baseline = m_offset;
-                m_disabled = true;
-            }
-            m_ratio = ((decimal)TimeSpan.TicksPerSecond) / m_frequency;
-#else
             m_offset = DateTime.UtcNow.Ticks;
             if (!Stopwatch.IsHighResolution)
             {
                 m_frequency = TimeSpan.TicksPerSecond;
+                m_ticksPerMillisecond = TimeSpan.TicksPerMillisecond;
                 m_baseline = m_offset;
                 m_disabled = true;
             }
@@ -128,42 +114,21 @@ namespace Opc.Ua
             {
                 m_baseline = Stopwatch.GetTimestamp();
                 m_frequency = Stopwatch.Frequency;
+                m_ticksPerMillisecond = m_frequency / 1000.0;
             }
             m_ratio = ((decimal)TimeSpan.TicksPerSecond) / m_frequency;
-#endif
-            m_ticksPerMillisecond = m_frequency / 1000.0;
         }
 
         /// <summary>
         /// Defines a global instance.
         /// </summary>
-        private static readonly HiResClock s_Default = new HiResClock();
-
-        /// <summary>
-        /// Defines the native methods used by the class.
-        /// </summary>
-        private static class NativeMethods
-        {
-#if NETFRAMEWORK
-            [DllImport("Kernel32.dll")]
-            public static extern int QueryPerformanceFrequency(out long lpFrequency);
-
-            [DllImport("Kernel32.dll")]
-            public static extern int QueryPerformanceCounter(out long lpFrequency);
-#endif
-            [DllImport("kernel32.dll")]
-            public static extern long GetTickCount64();
-        }
+        private static HiResClock s_Default = new HiResClock();
 
         private long m_frequency;
         private long m_baseline;
         private long m_offset;
         private double m_ticksPerMillisecond;
         private decimal m_ratio;
-#if !NETFRAMEWORK
-        private bool m_isWindowsOS = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
-#endif
-
         private bool m_disabled;
     }
 

--- a/Stack/Opc.Ua.Core/Types/Utils/Utils.cs
+++ b/Stack/Opc.Ua.Core/Types/Utils/Utils.cs
@@ -488,12 +488,12 @@ namespace Opc.Ua
                 return;
             }
 
-            double seconds = ((double)(HiResClock.UtcNow.Ticks - s_BaseLineTicks)) / TimeSpan.TicksPerSecond;
+            double seconds = ((double)(DateTime.UtcNow.Ticks - s_BaseLineTicks)) / TimeSpan.TicksPerSecond;
 
             StringBuilder message = new StringBuilder();
 
             // append process and timestamp.
-            message.AppendFormat("{0:d} {0:HH:mm:ss.fff} ", HiResClock.UtcNow.ToLocalTime());
+            message.AppendFormat("{0:d} {0:HH:mm:ss.fff} ", DateTime.UtcNow.ToLocalTime());
 
             // format message.
             if (args != null && args.Length > 0)

--- a/Tests/Opc.Ua.Core.Tests/Types/Utils/HiResClock.cs
+++ b/Tests/Opc.Ua.Core.Tests/Types/Utils/HiResClock.cs
@@ -29,7 +29,6 @@
 
 using System;
 using System.Diagnostics;
-using System.Threading;
 using NUnit.Framework;
 
 namespace Opc.Ua.Core.Tests.Types.UtilsTests
@@ -45,6 +44,20 @@ namespace Opc.Ua.Core.Tests.Types.UtilsTests
         /// How long the tests are running.
         /// </summary>
         public const int HiResClockTestDuration = 2000;
+
+        #region Test Setup
+        [OneTimeTearDown]
+        protected void OneTimeTearDown()
+        {
+            HiResClock.Disabled = false;
+        }
+
+        [TearDown]
+        protected void TearDown()
+        {
+            HiResClock.Disabled = false;
+        }
+        #endregion
 
         #region Test Methods
         /// <summary>
@@ -129,7 +142,6 @@ namespace Opc.Ua.Core.Tests.Types.UtilsTests
             TestContext.Out.WriteLine("HiResClock counts: {0} resolution: {1}µs", counts, stopWatch.ElapsedMilliseconds * 1000 / counts);
             // test accuracy of counter vs. stop watch
             Assert.That(elapsed, Is.EqualTo(stopWatch.ElapsedMilliseconds).Within(2).Percent);
-            HiResClock.Disabled = false;
         }
         #endregion
     }

--- a/Tests/Opc.Ua.Core.Tests/Types/Utils/HiResClock.cs
+++ b/Tests/Opc.Ua.Core.Tests/Types/Utils/HiResClock.cs
@@ -1,0 +1,62 @@
+/* ========================================================================
+ * Copyright (c) 2005-2018 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ * 
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ * 
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System.Threading;
+using NUnit.Framework;
+
+namespace Opc.Ua.Core.Tests.Types.UtilsTests
+{
+    /// <summary>
+    /// Tests for the BuiltIn Types.
+    /// </summary>
+    [TestFixture, Category("Utils")]
+    [SetCulture("en-us"), SetUICulture("en-us")]
+    [Parallelizable]
+    public class HiResClockTests
+    {
+        #region Test Methods
+        [Test]
+        public void HiResClockTickCount()
+        {
+            Assert.LessOrEqual(1.0, HiResClock.TicksPerMillisecond);
+            Assert.LessOrEqual(1000, HiResClock.Frequency);
+            Assert.False(HiResClock.Disabled);
+            long lastTickCount = 0;
+            for (int i=0; i< 1000; i++)
+            {
+                var tickCount = HiResClock.TickCount64;
+                Assert.LessOrEqual(lastTickCount, tickCount);
+                lastTickCount = tickCount;
+                Thread.Sleep(1);
+            }
+        }
+        #endregion
+    }
+
+}


### PR DESCRIPTION
Update HiResClock class for use with monotonic timer.
This solved problem loss MonitoredItems, when changed system time.
Use HiResClock  when update nextSamplingTime.

Test with changing system time - all ok

Use standard Environment.TickCount64 for netcore 3.0/3.1
In other version:
1)  For windows platform - GetTickCount64 from kernel32.dll - get msec from system starts. 
2) for others platform -  DateTime.UtcNow.Ticks / TimeSpan.TicksPerMillisecond