### PR TITLE
Fix confusing async use of Utils.GetHostAddresses

### DIFF
--- a/Libraries/Opc.Ua.Configuration/ApplicationInstance.cs
+++ b/Libraries/Opc.Ua.Configuration/ApplicationInstance.cs
@@ -580,7 +580,7 @@ namespace Opc.Ua.Configuration
                     // get IP addresses only if necessary.
                     if (addresses == null)
                     {
-                        addresses = await Utils.GetHostAddresses(computerName);
+                        addresses = await Utils.GetHostAddressesAsync(computerName);
                     }
 
                     // check for ip addresses.

--- a/Libraries/Opc.Ua.Server/Server/StandardServer.cs
+++ b/Libraries/Opc.Ua.Server/Server/StandardServer.cs
@@ -2269,11 +2269,11 @@ namespace Opc.Ua.Server
         /// </summary>
         private void RegistrationValidator_CertificateValidation(CertificateValidator sender, CertificateValidationEventArgs e)
         {
-            System.Net.IPAddress[] targetAddresses = Utils.GetHostAddresses(Utils.GetHostName()).Result;
+            System.Net.IPAddress[] targetAddresses = Utils.GetHostAddresses(Utils.GetHostName());
 
             foreach (string domain in Utils.GetDomainsFromCertficate(e.Certificate))
             {
-                System.Net.IPAddress[] actualAddresses = Utils.GetHostAddresses(domain).Result;
+                System.Net.IPAddress[] actualAddresses = Utils.GetHostAddresses(domain);
 
                 foreach (System.Net.IPAddress actualAddress in actualAddresses)
                 {

--- a/Stack/Opc.Ua.Core/Stack/Server/ServerBase.cs
+++ b/Stack/Opc.Ua.Core/Stack/Server/ServerBase.cs
@@ -1017,7 +1017,7 @@ namespace Opc.Ua
         /// </summary>
         /// <param name="hostname">The hostname.</param>
         /// <returns>The hostname to use for URL filtering.</returns>
-        protected async Task<string> NormalizeHostname(string hostname)
+        protected string NormalizeHostname(string hostname)
         {
             string computerName = Utils.GetHostName();
 
@@ -1039,7 +1039,7 @@ namespace Opc.Ua
                 }
 
                 // substitute the computer name for any local IP if an IP is used by client.
-                IPAddress[] addresses = await Utils.GetHostAddresses(Utils.GetHostName());
+                IPAddress[] addresses = Utils.GetHostAddresses(Utils.GetHostName());
 
                 for (int ii = 0; ii < addresses.Length; ii++)
                 {

--- a/Stack/Opc.Ua.Core/Types/Utils/Utils.cs
+++ b/Stack/Opc.Ua.Core/Types/Utils/Utils.cs
@@ -951,9 +951,15 @@ namespace Opc.Ua
         }
 
         /// <inheritdoc cref="Dns.GetHostAddressesAsync"/>
-        public static Task<IPAddress[]> GetHostAddresses(string hostNameOrAddress)
+        public static Task<IPAddress[]> GetHostAddressesAsync(string hostNameOrAddress)
         {
             return Dns.GetHostAddressesAsync(hostNameOrAddress);
+        }
+
+        /// <inheritdoc cref="Dns.GetHostAddresses"/>
+        public static IPAddress[] GetHostAddresses(string hostNameOrAddress)
+        {
+            return Dns.GetHostAddresses(hostNameOrAddress);
         }
 
         /// <inheritdoc cref="Dns.GetHostName"/>


### PR DESCRIPTION
- due to the name change of the async version its a breaking change for the 364 release
- fixes #1132 