### PR TITLE
Removes assigning a new instance of CertificateValidator in ApplicationConfiguration

### DIFF
--- a/Stack/Opc.Ua.Core/Schema/ApplicationConfiguration.cs
+++ b/Stack/Opc.Ua.Core/Schema/ApplicationConfiguration.cs
@@ -30,7 +30,6 @@ namespace Opc.Ua
         /// </summary>
         public ApplicationConfiguration()
         {
-            m_certificateValidator = new CertificateValidator();
             Initialize();
         }
 
@@ -45,6 +44,7 @@ namespace Opc.Ua
             m_transportConfigurations = new TransportConfigurationCollection();
             m_disableHiResClock = true;
             m_properties = new Dictionary<string, object>();
+            m_certificateValidator = new CertificateValidator();
         }
 
         /// <summary>
@@ -251,7 +251,7 @@ namespace Opc.Ua
         private string m_sourceFilePath;
 
         private ServiceMessageContext m_messageContext;
-        private readonly CertificateValidator m_certificateValidator;
+        private CertificateValidator m_certificateValidator;
         private Dictionary<string, object> m_properties;
         #endregion
     }

--- a/Stack/Opc.Ua.Core/Schema/ApplicationConfiguration.cs
+++ b/Stack/Opc.Ua.Core/Schema/ApplicationConfiguration.cs
@@ -30,6 +30,7 @@ namespace Opc.Ua
         /// </summary>
         public ApplicationConfiguration()
         {
+            m_certificateValidator = new CertificateValidator();
             Initialize();
         }
 
@@ -44,7 +45,6 @@ namespace Opc.Ua
             m_transportConfigurations = new TransportConfigurationCollection();
             m_disableHiResClock = true;
             m_properties = new Dictionary<string, object>();
-            m_certificateValidator = new CertificateValidator();
         }
 
         /// <summary>
@@ -251,7 +251,7 @@ namespace Opc.Ua
         private string m_sourceFilePath;
 
         private ServiceMessageContext m_messageContext;
-        private CertificateValidator m_certificateValidator;
+        private readonly CertificateValidator m_certificateValidator;
         private Dictionary<string, object> m_properties;
         #endregion
     }

--- a/Stack/Opc.Ua.Core/Schema/ApplicationConfiguration.cs
+++ b/Stack/Opc.Ua.Core/Schema/ApplicationConfiguration.cs
@@ -44,6 +44,7 @@ namespace Opc.Ua
             m_transportConfigurations = new TransportConfigurationCollection();
             m_disableHiResClock = true;
             m_properties = new Dictionary<string, object>();
+            m_certificateValidator = new CertificateValidator();
         }
 
         /// <summary>

--- a/Stack/Opc.Ua.Core/Stack/Configuration/ApplicationConfiguration.cs
+++ b/Stack/Opc.Ua.Core/Stack/Configuration/ApplicationConfiguration.cs
@@ -142,11 +142,34 @@ namespace Opc.Ua
                 }
             }
 
-            var baseUrls = baseAddresses.Where(a => !String.IsNullOrEmpty(a)).Select(a => Utils.ParseUri(a));
-            var dnsNames = baseUrls.Where(u => u.HostNameType == UriHostNameType.Dns).Select(u => Utils.ReplaceLocalhost(u.DnsSafeHost));
-            var ipAddresses = baseUrls.Where(u => u.HostNameType != UriHostNameType.Dns).Select(u => Utils.NormalizedIPAddress(u.DnsSafeHost));
-            var allDistinctDomainNames = dnsNames.Concat(ipAddresses).Distinct();
-            return allDistinctDomainNames.ToList();
+            var domainNames = new List<string>();
+            for (int ii = 0; ii < baseAddresses.Count; ii++)
+            {
+                Uri url = Utils.ParseUri(baseAddresses[ii]);
+
+                if (url == null)
+                {
+                    continue;
+                }
+
+                string domainName = url.DnsSafeHost;
+
+                if (url.HostNameType == UriHostNameType.Dns)
+                {
+                    domainName = Utils.ReplaceLocalhost(domainName);
+                }
+                else // IPv4/IPv6 address
+                {
+                    domainName = Utils.NormalizedIPAddress(domainName);
+                }
+
+                if (!Utils.FindStringIgnoreCase(domainNames, domainName))
+                {
+                    domainNames.Add(domainName);
+                }
+            }
+
+            return domainNames;
         }
 
         /// <summary>

--- a/Stack/Opc.Ua.Core/Stack/Configuration/ApplicationConfiguration.cs
+++ b/Stack/Opc.Ua.Core/Stack/Configuration/ApplicationConfiguration.cs
@@ -13,6 +13,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Runtime.Serialization;
 using System.Text;
 using System.Threading.Tasks;
@@ -96,19 +97,12 @@ namespace Opc.Ua
         /// Gets the file that was used to load the configuration.
         /// </summary>
         /// <value>The source file path.</value>
-        public string SourceFilePath
-        {
-            get { return m_sourceFilePath; }
-        }
+        public string SourceFilePath => m_sourceFilePath; 
 
         /// <summary>
-        /// Get or set the certificate validator which is configured to use.
+        /// Gets the certificate validator which is configured to use.
         /// </summary>
-        public CertificateValidator CertificateValidator
-        {
-            get { return m_certificateValidator; }
-            set { m_certificateValidator = value; }
-        }
+        public CertificateValidator CertificateValidator => m_certificateValidator;
 
         /// <summary>
         /// Returns the domain names which the server is configured to use.
@@ -116,8 +110,6 @@ namespace Opc.Ua
         /// <returns>A list of domain names.</returns>
         public IList<string> GetServerDomainNames()
         {
-            List<string> domainNames = new List<string>();
-
             StringCollection baseAddresses = new StringCollection();
 
             if (this.ServerConfiguration != null)
@@ -146,33 +138,11 @@ namespace Opc.Ua
                 }
             }
 
-            for (int ii = 0; ii < baseAddresses.Count; ii++)
-            {
-                Uri url = Utils.ParseUri(baseAddresses[ii]);
-
-                if (url == null)
-                {
-                    continue;
-                }
-
-                string domainName = url.DnsSafeHost;
-
-                if (url.HostNameType == UriHostNameType.Dns)
-                {
-                    domainName = Utils.ReplaceLocalhost(domainName);
-                }
-                else // IPv4/IPv6 address
-                {
-                    domainName = Utils.NormalizedIPAddress(domainName);
-                }
-
-                if (!Utils.FindStringIgnoreCase(domainNames, domainName))
-                {
-                    domainNames.Add(domainName);
-                }
-            }
-
-            return domainNames;
+            var baseUrls = baseAddresses.Where(a => !String.IsNullOrEmpty(a)).Select(a => Utils.ParseUri(a));
+            var dnsNames = baseUrls.Where(u => u.HostNameType == UriHostNameType.Dns).Select(u => Utils.ReplaceLocalhost(u.DnsSafeHost));
+            var ipAddresses = baseUrls.Where(u => u.HostNameType != UriHostNameType.Dns).Select(u => Utils.NormalizedIPAddress(u.DnsSafeHost));
+            var allDistinctDomainNames = dnsNames.Concat(ipAddresses).Distinct();
+            return allDistinctDomainNames.ToList();
         }
 
         /// <summary>
@@ -224,10 +194,8 @@ namespace Opc.Ua
         /// <param name="sectionName">Name of configuration section for the current application's default configuration containing <see cref="ConfigurationLocation"/>.</param>
         /// <param name="applicationType">Type of the application.</param>
         /// <returns>Application configuration</returns>
-        public static async Task<ApplicationConfiguration> Load(string sectionName, ApplicationType applicationType)
-        {
-            return await Load(sectionName, applicationType, typeof(ApplicationConfiguration));
-        }
+        public static Task<ApplicationConfiguration> Load(string sectionName, ApplicationType applicationType) =>
+            Load(sectionName, applicationType, typeof(ApplicationConfiguration));
 
         /// <summary>
         /// Loads and validates the application configuration from a configuration section.
@@ -236,7 +204,7 @@ namespace Opc.Ua
         /// <param name="applicationType">A description for the ApplicationType DataType.</param>
         /// <param name="systemType">A user type of the configuration instance.</param>
         /// <returns>Application configuration</returns>
-        public static async Task<ApplicationConfiguration> Load(string sectionName, ApplicationType applicationType, Type systemType)
+        public static Task<ApplicationConfiguration> Load(string sectionName, ApplicationType applicationType, Type systemType)
         {
             string filePath = GetFilePathFromAppConfig(sectionName);
 
@@ -251,7 +219,7 @@ namespace Opc.Ua
                     Directory.GetCurrentDirectory());
             }
 
-            return await Load(file, applicationType, systemType);
+            return Load(file, applicationType, systemType);
         }
 
         /// <summary>
@@ -263,33 +231,30 @@ namespace Opc.Ua
         /// <remarks>Use this method to ensure the configuration is not changed during loading.</remarks>
         public static ApplicationConfiguration LoadWithNoValidation(FileInfo file, Type systemType)
         {
-            FileStream stream = new FileStream(file.FullName, FileMode.Open, FileAccess.Read);
-
-            try
+            using (var stream = new FileStream(file.FullName, FileMode.Open, FileAccess.Read))
             {
-                DataContractSerializer serializer = new DataContractSerializer(systemType);
-
-                ApplicationConfiguration configuration = serializer.ReadObject(stream) as ApplicationConfiguration;
-
-                if (configuration != null)
+                try
                 {
-                    configuration.m_sourceFilePath = file.FullName;
-                }
+                    DataContractSerializer serializer = new DataContractSerializer(systemType);
 
-                return configuration;
-            }
-            catch (Exception e)
-            {
-                throw ServiceResultException.Create(
-                    StatusCodes.BadConfigurationError,
-                    e,
-                    "Configuration file could not be loaded: {0}\r\nError is: {1}",
-                    file.FullName,
-                    e.Message);
-            }
-            finally
-            {
-                stream.Dispose();
+                    ApplicationConfiguration configuration = serializer.ReadObject(stream) as ApplicationConfiguration;
+
+                    if (configuration != null)
+                    {
+                        configuration.m_sourceFilePath = file.FullName;
+                    }
+
+                    return configuration;
+                }
+                catch (Exception e)
+                {
+                    throw ServiceResultException.Create(
+                        StatusCodes.BadConfigurationError,
+                        e,
+                        "Configuration file could not be loaded: {0}\r\nError is: {1}",
+                        file.FullName,
+                        e.Message);
+                }
             }
         }
 
@@ -300,10 +265,8 @@ namespace Opc.Ua
         /// <param name="applicationType">Type of the application.</param>
         /// <param name="systemType">Type of the system.</param>
         /// <returns>Application configuration</returns>
-        public static async Task<ApplicationConfiguration> Load(FileInfo file, ApplicationType applicationType, Type systemType)
-        {
-            return await ApplicationConfiguration.Load(file, applicationType, systemType, true);
-        }
+        public static Task<ApplicationConfiguration> Load(FileInfo file, ApplicationType applicationType, Type systemType) =>
+            ApplicationConfiguration.Load(file, applicationType, systemType, true);
 
         /// <summary>
         /// Loads and validates the application configuration from a configuration section.
@@ -316,31 +279,24 @@ namespace Opc.Ua
         public static async Task<ApplicationConfiguration> Load(FileInfo file, ApplicationType applicationType, Type systemType, bool applyTraceSettings)
         {
             ApplicationConfiguration configuration = null;
+            systemType = systemType ?? typeof(ApplicationConfiguration);
 
-            if (systemType == null)
+            using (FileStream stream = new FileStream(file.FullName, FileMode.Open, FileAccess.Read))
             {
-                systemType = typeof(ApplicationConfiguration);
-            }
-
-            FileStream stream = new FileStream(file.FullName, FileMode.Open, FileAccess.Read);
-
-            try
-            {
-                DataContractSerializer serializer = new DataContractSerializer(systemType);
-                configuration = (ApplicationConfiguration)serializer.ReadObject(stream);
-            }
-            catch (Exception e)
-            {
-                throw ServiceResultException.Create(
-                    StatusCodes.BadConfigurationError,
-                    e,
-                    "Configuration file could not be loaded: {0}\r\nError is: {1}",
-                    file.FullName,
-                    e.Message);
-            }
-            finally
-            {
-                stream.Dispose();
+                try
+                {
+                    DataContractSerializer serializer = new DataContractSerializer(systemType);
+                    configuration = (ApplicationConfiguration)serializer.ReadObject(stream);
+                }
+                catch (Exception e)
+                {
+                    throw ServiceResultException.Create(
+                        StatusCodes.BadConfigurationError,
+                        e,
+                        "Configuration file could not be loaded: {0}\r\nError is: {1}",
+                        file.FullName,
+                        e.Message);
+                }
             }
 
             if (configuration != null)
@@ -369,14 +325,7 @@ namespace Opc.Ua
         {
             // convert to absolute file path (expands environment strings).
             string absolutePath = Utils.GetAbsoluteFilePath(sectionName + ".Config.xml", true, false, false);
-            if (absolutePath != null)
-            {
-                return absolutePath;
-            }
-            else
-            {
-                return sectionName + ".Config.xml";
-            }
+            return (absolutePath != null) ? absolutePath : sectionName + ".Config.xml";
         }
 
         /// <summary>
@@ -386,14 +335,13 @@ namespace Opc.Ua
         /// <remarks>Calls GetType() on the current instance and passes that to the DataContractSerializer.</remarks>
         public void SaveToFile(string filePath)
         {
-            Stream ostrm = File.Open(filePath, FileMode.Create, FileAccess.ReadWrite);
+            XmlWriterSettings settings = new XmlWriterSettings() {
+                Encoding = Encoding.UTF8,
+                Indent = true,
+                CloseOutput = true
+            };
 
-            XmlWriterSettings settings = new XmlWriterSettings();
-
-            settings.Encoding = System.Text.Encoding.UTF8;
-            settings.Indent = true;
-            settings.CloseOutput = true;
-
+            using (Stream ostrm = File.Open(filePath, FileMode.Create, FileAccess.ReadWrite))
             using (XmlWriter writer = XmlDictionaryWriter.Create(ostrm, settings))
             {
                 DataContractSerializer serializer = new DataContractSerializer(GetType());
@@ -422,18 +370,16 @@ namespace Opc.Ua
             // load private key
             await SecurityConfiguration.ApplicationCertificate.LoadPrivateKey(null);
 
-            //  generate a default uri if null
-            if (String.IsNullOrEmpty(ApplicationUri))
-            {
-                StringBuilder buffer = new StringBuilder();
+            Func<string> generateDefaultUri = () => {
+                var sb = new StringBuilder();
+                sb.Append("urn:");
+                sb.Append(Utils.GetHostName());
+                sb.Append(":");
+                sb.Append(ApplicationName);
+                return sb.ToString();
+            };
 
-                buffer.Append("urn:");
-                buffer.Append(Utils.GetHostName());
-                buffer.Append(":");
-                buffer.Append(ApplicationName);
-
-                m_applicationUri = buffer.ToString();
-            }
+            if (String.IsNullOrEmpty(ApplicationUri)) m_applicationUri = generateDefaultUri();
 
             if (applicationType == ApplicationType.Client || applicationType == ApplicationType.ClientAndServer)
             {
@@ -479,8 +425,6 @@ namespace Opc.Ua
                 }
             }
 
-            // create the certificate validator.
-            m_certificateValidator = new CertificateValidator();
             await m_certificateValidator.Update(this.SecurityConfiguration);
         }
 
@@ -490,10 +434,7 @@ namespace Opc.Ua
         /// <param name="createAlways">if set to <c>true</c> ConfiguredEndpointCollection is always returned,
         ///	even if loading from disk fails</param>
         /// <returns>Colection of configured endpoints from the disk.</returns>
-        public ConfiguredEndpointCollection LoadCachedEndpoints(bool createAlways)
-        {
-            return LoadCachedEndpoints(createAlways, false);
-        }
+        public ConfiguredEndpointCollection LoadCachedEndpoints(bool createAlways) => LoadCachedEndpoints(createAlways, false);
 
         /// <summary>
         /// Loads the endpoints cached on disk.
@@ -557,10 +498,7 @@ namespace Opc.Ua
         /// <remarks>
         /// The containing element must use the name and namespace uri specified by the DataContractAttribute for the type.
         /// </remarks>
-        public T ParseExtension<T>()
-        {
-            return ParseExtension<T>(null);
-        }
+        public T ParseExtension<T>() => ParseExtension<T>(null);
 
         /// <summary>
         /// Looks for an extension with the specified type and uses the DataContractSerializer to parse it.
@@ -568,10 +506,7 @@ namespace Opc.Ua
         /// <typeparam name="T">The type of extension.</typeparam>
         /// <param name="elementName">Name of the element (null means use type name).</param>
         /// <returns>The extension if found. Null otherwise.</returns>
-        public T ParseExtension<T>(XmlQualifiedName elementName)
-        {
-            return Utils.ParseExtension<T>(m_extensions, elementName);
-        }
+        public T ParseExtension<T>(XmlQualifiedName elementName) => Utils.ParseExtension<T>(m_extensions, elementName);
 
         /// <summary>
         /// Updates the extension.
@@ -579,10 +514,8 @@ namespace Opc.Ua
         /// <typeparam name="T">The type of extension.</typeparam>
         /// <param name="elementName">Name of the element (null means use type name).</param>
         /// <param name="value">The value.</param>
-        public void UpdateExtension<T>(XmlQualifiedName elementName, object value)
-        {
+        public void UpdateExtension<T>(XmlQualifiedName elementName, object value) =>
             Utils.UpdateExtension<T>(ref m_extensions, elementName, value);
-        }
 
         /// <summary>
         /// Updates the extension.

--- a/Stack/Opc.Ua.Core/Stack/Configuration/ApplicationConfiguration.cs
+++ b/Stack/Opc.Ua.Core/Stack/Configuration/ApplicationConfiguration.cs
@@ -100,9 +100,13 @@ namespace Opc.Ua
         public string SourceFilePath => m_sourceFilePath; 
 
         /// <summary>
-        /// Gets the certificate validator which is configured to use.
+        /// Gets or sets the certificate validator which is configured to use.
         /// </summary>
-        public CertificateValidator CertificateValidator => m_certificateValidator;
+        public CertificateValidator CertificateValidator
+        {
+            get { return m_certificateValidator; }
+            set { m_certificateValidator = value; }
+        }
 
         /// <summary>
         /// Returns the domain names which the server is configured to use.

--- a/Tests/Opc.Ua.Core.Tests/Security/Certificates/CertificateValidatorTest.cs
+++ b/Tests/Opc.Ua.Core.Tests/Security/Certificates/CertificateValidatorTest.cs
@@ -718,6 +718,14 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
             var serviceResultException = Assert.Throws<ServiceResultException>(() => { certValidator.Validate(cert); });
             Assert.AreEqual(StatusCodes.BadCertificateTimeInvalid, serviceResultException.StatusCode, serviceResultException.Message);
         }
+
+        [Test, Order(602)]
+        public void CertificateValidatorAssignableFromAppConfig() => Assert.DoesNotThrow(() => {
+            var appConfig = new ApplicationConfiguration() {
+                CertificateValidator = new CertificateValidator()
+            };
+        });
+
         #endregion
         #region Private Methods
         private CertificateValidator InitValidatorWithStores()


### PR DESCRIPTION
The `Validate(ApplicationType)` method was assigning m_certificateValidator to a new instance of `CertificateValidator` before calling `CertificateValidator.Update`.  If you load the configuration, attach an event handler to the `CertificateValidator.CertificateValidation` event, and then call `ApplicationConfiguration.Validate(...)` the event handler gets removed due to the assignment at the end of `Validate`.  Making the property and the private member read-only and assigning it in the default constructor of `ApplicationConfiguration` will ensure that memory address stays as is.

There are also some general refactoring that was done so streams were using the `using` statements to ensure disposal instead of try/catch/finally, the use of LINQ expressions to clean up the for loop when getting server domain names, and additional usage of expression-bodied members.