### PR TITLE
Suppress server nonce validation errors in Client Session for encrypted channels

### DIFF
--- a/Libraries/Opc.Ua.Client/Session.cs
+++ b/Libraries/Opc.Ua.Client/Session.cs
@@ -334,10 +334,9 @@ namespace Opc.Ua.Client
                 // the server nonce should be validated if the token includes a secret.
                 if (!Utils.Nonce.ValidateNonce(serverNonce, MessageSecurityMode.SignAndEncrypt, (uint)m_configuration.SecurityConfiguration.NonceLength))
                 {
-                    if (channelSecurityMode == MessageSecurityMode.SignAndEncrypt ||
-                        m_configuration.SecurityConfiguration.SuppressNonceValidationErrors)
+                    if (channelSecurityMode == MessageSecurityMode.SignAndEncrypt)
                     {
-                        Utils.Trace((int)TraceMasks.Security, "Warning: The server nonce has not the correct length or is not random enough. The error was suppressed.");
+                        Utils.Trace((int)TraceMasks.Security, "Warning: The server nonce has not the correct length or is not random enough. The error is suppressed because the channel is encrypted.");
                     }
                     else
                     {
@@ -351,7 +350,7 @@ namespace Opc.Ua.Client
                     if (channelSecurityMode == MessageSecurityMode.SignAndEncrypt ||
                         m_configuration.SecurityConfiguration.SuppressNonceValidationErrors)
                     {
-                        Utils.Trace((int)TraceMasks.Security, "Warning: The Server nonce is equal with previously returned nonce. The error was suppressed.");
+                        Utils.Trace((int)TraceMasks.Security, "Warning: The Server nonce is equal with previously returned nonce. The error is suppressed by user setting or because the channel is encrypted.");
                     }
                     else
                     {

--- a/Stack/Opc.Ua.Core/Schema/ApplicationConfiguration.cs
+++ b/Stack/Opc.Ua.Core/Schema/ApplicationConfiguration.cs
@@ -1005,7 +1005,9 @@ namespace Opc.Ua
         /// Gets or sets a value indicating whether the server nonce validation errors should be suppressed.
         /// </summary>
         /// <remarks>
+        /// Allows client interoperability with legacy servers which do not comply with the specification for nonce usage.
         /// If set to true the server nonce validation errors are suppressed.
+        /// Please set this flag to true only in close and secured networks since it can cause security vulnerabilities.
         /// </remarks>
         [DataMember(IsRequired = false, EmitDefaultValue = false, Order = 19)]
         public bool SuppressNonceValidationErrors

--- a/Stack/Opc.Ua.Core/Stack/Types/UserIdentityToken.cs
+++ b/Stack/Opc.Ua.Core/Stack/Types/UserIdentityToken.cs
@@ -54,11 +54,11 @@ namespace Opc.Ua
         #endregion
     }
 
-	/// <summary>
-	/// The UserIdentityToken class.
-	/// </summary>
-	public partial class UserNameIdentityToken
-	{
+    /// <summary>
+    /// The UserIdentityToken class.
+    /// </summary>
+    public partial class UserNameIdentityToken
+    {
         #region Public Properties
         /// <summary>
         /// The decrypted password associated with the token.
@@ -97,11 +97,11 @@ namespace Opc.Ua
                 certificate,
                 securityPolicyUri,
                 dataToEncrypt);
-                        
+
             m_password = encryptedData.Data;
             m_encryptionAlgorithm = encryptedData.Algorithm; 
         }
-                
+
         /// <summary>
         /// Decrypts the Password using the EncryptionAlgorithm and places the result in DecryptedPassword
         /// </summary>
@@ -113,7 +113,7 @@ namespace Opc.Ua
                 m_decryptedPassword = new UTF8Encoding().GetString(m_password, 0, m_password.Length);
                 return;
             }
-            
+
             // decrypt.
             EncryptedData encryptedData = new EncryptedData();
             encryptedData.Data = m_password;
@@ -148,7 +148,7 @@ namespace Opc.Ua
                     throw new ServiceResultException(StatusCodes.BadIdentityTokenRejected);
                 }
             }
-                     
+
             // convert to UTF-8.
             m_decryptedPassword = new UTF8Encoding().GetString(decryptedPassword, 0, startOfNonce);
         }
@@ -158,12 +158,12 @@ namespace Opc.Ua
         private string m_decryptedPassword;
         #endregion
     }
-    
-	/// <summary>
-	/// The X509IdentityToken class.
-	/// </summary>
-	public partial class X509IdentityToken
-	{        
+
+    /// <summary>
+    /// The X509IdentityToken class.
+    /// </summary>
+    public partial class X509IdentityToken
+    {
         #region Public Properties
         /// <summary>
         /// The certificate associated with the token.


### PR DESCRIPTION
This will allow client interoperability with some legacy servers that do not comply with the specification for nonce usage.