### PR TITLE
Escape special characters in JSON fieldnames.

### DIFF
--- a/Stack/Opc.Ua.Core/Types/Encoders/JsonEncoder.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/JsonEncoder.cs
@@ -334,7 +334,7 @@ namespace Opc.Ua
             if (!String.IsNullOrEmpty(fieldName))
             {
                 m_writer.Write("\"");
-                m_writer.Write(fieldName);
+                EscapeString(fieldName);
                 m_writer.Write("\":");
             }
             else if (!m_commaRequired)
@@ -366,7 +366,7 @@ namespace Opc.Ua
             if (!String.IsNullOrEmpty(fieldName))
             {
                 m_writer.Write("\"");
-                m_writer.Write(fieldName);
+                EscapeString(fieldName);
                 m_writer.Write("\":");
             }
             else if (!m_commaRequired)
@@ -461,7 +461,7 @@ namespace Opc.Ua
                 }
 
                 m_writer.Write("\"");
-                m_writer.Write(fieldName);
+                EscapeString(fieldName);
                 m_writer.Write("\":");
             }
             else
@@ -609,7 +609,7 @@ namespace Opc.Ua
                 return;
             }
 
-            WriteSimpleField(fieldName, "\"" + value.ToString(CultureInfo.InvariantCulture) + "\"", false);
+            WriteSimpleField(fieldName, value.ToString(CultureInfo.InvariantCulture), true);
         }
 
         /// <summary>
@@ -623,7 +623,7 @@ namespace Opc.Ua
                 return;
             }
 
-            WriteSimpleField(fieldName, "\"" + value.ToString(CultureInfo.InvariantCulture) + "\"", false);
+            WriteSimpleField(fieldName, value.ToString(CultureInfo.InvariantCulture), true);
         }
 
         /// <summary>
@@ -1124,7 +1124,7 @@ namespace Opc.Ua
             if (!String.IsNullOrEmpty(fieldName))
             {
                 m_writer.Write("\"");
-                m_writer.Write(fieldName);
+                EscapeString(fieldName);
                 m_writer.Write("\":");
             }
 
@@ -1334,7 +1334,7 @@ namespace Opc.Ua
             PopStructure();
 
             m_nestingLevel--;
-            
+
         }
 
         /// <summary>

--- a/Tests/Opc.Ua.Core.Tests/Types/Encoders/EncoderCommon.cs
+++ b/Tests/Opc.Ua.Core.Tests/Types/Encoders/EncoderCommon.cs
@@ -657,20 +657,30 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
                 m_resetCounter = true;
                 Count = Interlocked.Increment(ref s_count);
                 Foo = $"bar_{Count}";
+                FieldName = nameof(Foo);
             }
 
             public FooBarEncodeable(int count)
             {
                 Count = count;
                 Foo = $"bar_{Count}";
+                FieldName = nameof(Foo);
             }
 
             public FooBarEncodeable(string foo)
             {
                 Foo = foo;
+                FieldName = nameof(Foo);
+            }
+
+            public FooBarEncodeable(string fieldname, string foo)
+            {
+                Foo = foo;
+                FieldName = fieldname;
             }
 
             public string Foo { get; set; }
+            public string FieldName { get; set; }
             public int Count { get; set; }
 
             public ExpandedNodeId TypeId { get; }
@@ -680,14 +690,14 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
             public void Encode(IEncoder encoder)
             {
                 encoder.PushNamespace(ApplicationUri);
-                encoder.WriteString(nameof(Foo), Foo);
+                encoder.WriteString(FieldName, Foo);
                 encoder.PopNamespace();
             }
 
             public void Decode(IDecoder decoder)
             {
                 decoder.PushNamespace(ApplicationUri);
-                Foo = decoder.ReadString(nameof(Foo));
+                Foo = decoder.ReadString(FieldName);
                 decoder.PopNamespace();
             }
 

--- a/Tests/Opc.Ua.Core.Tests/Types/Encoders/JsonEncoderTests.cs
+++ b/Tests/Opc.Ua.Core.Tests/Types/Encoders/JsonEncoderTests.cs
@@ -361,7 +361,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
                 TestContext.Out.WriteLine(encoded);
 
                 TestContext.Out.WriteLine("Formatted Encoded:");
-                _= PrettifyAndValidateJson(encoded);
+                _ = PrettifyAndValidateJson(encoded);
 
                 Assert.That(encoded, Is.EqualTo(expected));
             }
@@ -439,8 +439,8 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
         public void Test_WriteMultipleEncodeablesWithoutFieldNames(bool topLevelIsArray, string expected)
         {
             TestContext.Out.WriteLine("Expected:");
-            _= PrettifyAndValidateJson(expected);
-            
+            _ = PrettifyAndValidateJson(expected);
+
 
             var encodeables = new List<FooBarEncodeable> { new FooBarEncodeable(), new FooBarEncodeable(), new FooBarEncodeable() };
             try
@@ -476,7 +476,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
             var expected = "{\"bar_1\":{\"Foo\":\"bar_1\"},\"bar_2\":{\"Foo\":\"bar_2\"},\"bar_3\":{\"Foo\":\"bar_3\"}}";
 
             TestContext.Out.WriteLine("Expected:");
-            _= PrettifyAndValidateJson(expected);
+            _ = PrettifyAndValidateJson(expected);
 
             var encodeables = new List<FooBarEncodeable> { new FooBarEncodeable(), new FooBarEncodeable(), new FooBarEncodeable() };
             try
@@ -564,6 +564,95 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
                 "[[{\"Foo\":\"bar_1\"},{\"Foo\":\"bar_2\"},{\"Foo\":\"bar_3\"}]]",
                 true);
         }
+
+        /// <summary>
+        /// Test if field names and values are properly escaped.
+        /// </summary>
+        [TestCase("\"Hello\".\"World\"", "\"Test\".\"Output\"",
+            "{\"\\\"Hello\\\".\\\"World\\\"\":{\"\\\"Hello\\\".\\\"World\\\"\":\"\\\"Test\\\".\\\"Output\\\"\"}}")]
+        [TestCase("\"Hello\".\"World\"\b\f\n\r\t\\", "\"Test\b\f\n\r\t\\\".\"Output\"",
+            "{\"\\\"Hello\\\".\\\"World\\\"\\b\\f\\n\\r\\t\\\\\":{\"\\\"Hello\\\".\\\"World\\\"\\b\\f\\n\\r\\t\\\\\":\"\\\"Test\\b\\f\\n\\r\\t\\\\\\\".\\\"Output\\\"\"}}")]
+        public void TestFieldValueEscapedEncodeable(string fieldname, string foo, string expected)
+        {
+            TestContext.Out.WriteLine("Expected:");
+            _ = PrettifyAndValidateJson(expected);
+
+            using (var encodeable = new FooBarEncodeable(fieldname, foo))
+            {
+                var encoder = new JsonEncoder(Context, true);
+                encoder.WriteEncodeable(encodeable.FieldName, encodeable, typeof(FooBarEncodeable));
+
+                var encoded = encoder.CloseAndReturnText();
+                TestContext.Out.WriteLine("Encoded:");
+                TestContext.Out.WriteLine(encoded);
+
+                TestContext.Out.WriteLine("Formatted Encoded:");
+                _ = PrettifyAndValidateJson(encoded);
+
+                Assert.That(encoded, Is.EqualTo(expected));
+            }
+        }
+
+        /// <summary>
+        /// Test if field names and values are properly escaped when used in an array.
+        /// </summary>
+        [TestCase("\"Hello\".\"World\"", "\"Test\".\"Output\"",
+            "{\"\\\"Hello\\\".\\\"World\\\"\":[" +
+            "{\"\\\"Hello\\\".\\\"World\\\"\":\"\\\"Test\\\".\\\"Output\\\"\"}," +
+            "{\"\\\"Hello\\\".\\\"World\\\"\":\"\\\"Test\\\".\\\"Output\\\"\"}" +
+            "]}")]
+        public void TestFieldValueEscapedArray(string fieldname, string foo, string expected)
+        {
+            TestContext.Out.WriteLine("Expected:");
+            _ = PrettifyAndValidateJson(expected);
+
+            using (var encodeable = new FooBarEncodeable(fieldname, foo))
+            {
+                var list = new List<IEncodeable>() { encodeable, encodeable };
+                var encoder = new JsonEncoder(Context, true);
+                encoder.WriteEncodeableArray(encodeable.FieldName, list, typeof(FooBarEncodeable));
+
+                var encoded = encoder.CloseAndReturnText();
+                TestContext.Out.WriteLine("Encoded:");
+                TestContext.Out.WriteLine(encoded);
+
+                TestContext.Out.WriteLine("Formatted Encoded:");
+                _ = PrettifyAndValidateJson(encoded);
+
+                Assert.That(encoded, Is.EqualTo(expected));
+            }
+        }
+
+        /// <summary>
+        /// Test if field names and values are properly escaped when used in a variant.
+        /// </summary>
+        [TestCase("\"Hello\".\"World\"", "\"Test\".\"Output\"",
+            "{\"\\\"Hello\\\".\\\"World\\\"\":" +
+            "{\"\\\"Hello\\\".\\\"World\\\"\":\"\\\"Test\\\".\\\"Output\\\"\"}" +
+            "}")]
+        public void TestFieldValueEscapedVariant(string fieldname, string foo, string expected)
+        {
+            TestContext.Out.WriteLine("Expected:");
+            _ = PrettifyAndValidateJson(expected);
+
+            using (var encodeable = new FooBarEncodeable(fieldname, foo))
+            {
+                var variant = new Variant(new ExtensionObject(encodeable));
+                // non reversible to save some space
+                var encoder = new JsonEncoder(Context, false);
+                encoder.WriteVariant(encodeable.FieldName, variant);
+
+                var encoded = encoder.CloseAndReturnText();
+                TestContext.Out.WriteLine("Encoded:");
+                TestContext.Out.WriteLine(encoded);
+
+                TestContext.Out.WriteLine("Formatted Encoded:");
+                _ = PrettifyAndValidateJson(encoded);
+
+                Assert.That(encoded, Is.EqualTo(expected));
+            }
+        }
+
         #endregion
 
         #region Private Methods
@@ -590,7 +679,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
                 TestContext.Out.WriteLine(encoded);
 
                 TestContext.Out.WriteLine("Formatted Encoded:");
-                _= PrettifyAndValidateJson(encoded);
+                _ = PrettifyAndValidateJson(encoded);
 
                 Assert.That(encoded, Is.EqualTo(expected));
             }


### PR DESCRIPTION
- Values were properly escaped, field names not.
- Fix fieldname encoding in various places
- Tests to verify strings are escaped in all codepaths.
- Fixes #1210

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opcfoundation/ua-.netstandard/1224)
<!-- Reviewable:end -->
