### PR TITLE
Fix issue setting empty comments Issue 1264

### DIFF
--- a/Stack/Opc.Ua.Core/Stack/State/AcknowledgeableConditionState.cs
+++ b/Stack/Opc.Ua.Core/Stack/State/AcknowledgeableConditionState.cs
@@ -149,7 +149,10 @@ namespace Opc.Ua
             if (ServiceResult.IsGood(error))
             {
                 SetAcknowledgedState(context, true);
-                SetComment(context, comment, GetCurrentUserId(context));
+                if (CanSetComment(comment))
+                {
+                    SetComment(context, comment, GetCurrentUserId(context));
+                }
             }
 
             if (this.AreEventsMonitored)
@@ -291,7 +294,10 @@ namespace Opc.Ua
             if (ServiceResult.IsGood(error))
             {
                 SetConfirmedState(context, true);
-                SetComment(context, comment, GetCurrentUserId(context));
+                if (CanSetComment(comment))
+                {
+                    SetComment(context, comment, GetCurrentUserId(context));
+                }
             }
 
             if (this.AreEventsMonitored)
@@ -416,6 +422,36 @@ namespace Opc.Ua
 
                 UpdateEffectiveState(context);
             }
+        }
+
+        /// <summary>
+        /// Determines if a comment should be added on Acknowledgement or Confirm.
+        /// According to the specification for Alarms, the Acknowledgement states that
+        /// "If the comment field is NULL (both locale and text are empty) it will be
+        /// ignored and any existing comments will remain unchanged."
+        /// This also applies to the Confirm method, although the spec needs updating
+        /// (Mantis issue 6405)
+        /// </summary>
+        /// <param name="comment">The client provided comment.</param>
+        /// <returns>Boolean stating whether the comment should be set</returns>
+        private bool CanSetComment(LocalizedText comment)
+        {
+            bool canSetComment = false;
+
+            if (comment != null)
+            {
+                canSetComment = true;
+
+                bool emptyComment = comment.Text == null || comment.Text.Length == 0;
+                bool emptyLocale = comment.Locale == null || comment.Locale.Length == 0;
+
+                if (emptyComment && emptyLocale)
+                {
+                    canSetComment = false;
+                }
+            }
+
+            return canSetComment;
         }
         #endregion
 

--- a/Stack/Opc.Ua.Core/Stack/State/AcknowledgeableConditionState.cs
+++ b/Stack/Opc.Ua.Core/Stack/State/AcknowledgeableConditionState.cs
@@ -426,14 +426,16 @@ namespace Opc.Ua
 
         /// <summary>
         /// Determines if a comment should be added on Acknowledgement or Confirm.
+        /// </summary>
+        /// <param name="comment">The client provided comment.</param>
+        /// <returns>Boolean stating whether the comment should be set</returns>
+        /// <remarks>
         /// According to the specification for Alarms, the Acknowledgement states that
         /// "If the comment field is NULL (both locale and text are empty) it will be
         /// ignored and any existing comments will remain unchanged."
         /// This also applies to the Confirm method, although the spec needs updating
         /// (Mantis issue 6405)
-        /// </summary>
-        /// <param name="comment">The client provided comment.</param>
-        /// <returns>Boolean stating whether the comment should be set</returns>
+        /// </remarks>
         private bool CanSetComment(LocalizedText comment)
         {
             bool canSetComment = false;

--- a/Stack/Opc.Ua.Core/Stack/State/ConditionState.cs
+++ b/Stack/Opc.Ua.Core/Stack/State/ConditionState.cs
@@ -195,6 +195,8 @@ namespace Opc.Ua
                 this.Time.Value = DateTime.UtcNow;
                 this.ReceiveTime.Value = this.Time.Value;
 
+                ClearChangeMasks(context, includeChildren: true);
+
                 // report a state change event.
                 if (this.AreEventsMonitored)
                 {


### PR DESCRIPTION
Addresses Issue [1264](https://github.com/OPCFoundation/UA-.NETStandard/issues/1264)
On Acknowledge and Confirm, if a comment with an empty Locale and empty Text is passed from the client, then the comment should remain untouched.
Also fixed issue when firing an event, clearing the change mask on all children of the alarm will update any monitored item watching the alarm parameters, like Comment, EventId, etc.