### PR TITLE
fix comment spelling mistakes - 'refernces' to 'references' - closes issue #1272

### DIFF
--- a/Libraries/Opc.Ua.Server/Diagnostics/CustomNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/Diagnostics/CustomNodeManager.cs
@@ -529,7 +529,7 @@ namespace Opc.Ua.Server
                 AddPredefinedNode(context, predefinedNodes[ii]);
             }
 
-            // ensure the reverse refernces exist.
+            // ensure the reverse references exist.
             AddReverseReferences(externalReferences);
         }
 
@@ -557,7 +557,7 @@ namespace Opc.Ua.Server
                 AddPredefinedNode(context, predefinedNodes[ii]);
             }
 
-            // ensure the reverse refernces exist.
+            // ensure the reverse references exist.
             AddReverseReferences(externalReferences);
         }
 

--- a/Libraries/Opc.Ua.Server/Diagnostics/v10/CustomNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/Diagnostics/v10/CustomNodeManager.cs
@@ -371,7 +371,7 @@ namespace Opc.Ua.Server
                 AddPredefinedNode(context, predefinedNodes[ii]);
             }
 
-            // ensure the reverse refernces exist.
+            // ensure the reverse references exist.
             AddReverseReferences(externalReferences);
         }
 
@@ -399,7 +399,7 @@ namespace Opc.Ua.Server
                 AddPredefinedNode(context, predefinedNodes[ii]);
             }
 
-            // ensure the reverse refernces exist.
+            // ensure the reverse references exist.
             AddReverseReferences(externalReferences);
         }
 

--- a/Stack/Opc.Ua.Core/Stack/State/NodeState.cs
+++ b/Stack/Opc.Ua.Core/Stack/State/NodeState.cs
@@ -2853,7 +2853,7 @@ namespace Opc.Ua
         /// <param name="browseName">The browse name of the targets to return.</param>
         /// <param name="additionalReferences">Any additional references that should be included in the list.</param>
         /// <param name="internalOnly">Only return references that are stored in memory.</param>
-        /// <returns>A thread safe object which enumerates the refernces for an entity.</returns>
+        /// <returns>A thread safe object which enumerates the references for an entity.</returns>
         public virtual INodeBrowser CreateBrowser(
             ISystemContext context,
             ViewDescription view,


### PR DESCRIPTION
This PR closes issue #1272 