### PR TITLE
Fix Issues 1274 and 1275

### DIFF
--- a/Stack/Opc.Ua.Core/Stack/State/AlarmConditionState.cs
+++ b/Stack/Opc.Ua.Core/Stack/State/AlarmConditionState.cs
@@ -80,6 +80,10 @@ namespace Opc.Ua
 
         #region Public Properties - Operational
 
+        /// <summary>
+        /// Defines how often to update the UnshelveTime when Shelving State is TimedShelve or OneShotShelved.
+        /// Defaults to 1000 ms
+        /// </summary>
         public int UnshelveTimeUpdateRate
         {
             get


### PR DESCRIPTION
Adds a timer specifically to update UnshelveTime periodically.

Initializes Unshelve to double maximum value or MaxTimeShelved if it exists, even for OneShotShelve method calls (Mantis 6462).  