### PR TITLE
fix issue with https binding .net core 3.0 support #1283

### DIFF
--- a/Stack/Opc.Ua.Bindings.Https/Stack/Https/HttpsTransportListener.cs
+++ b/Stack/Opc.Ua.Bindings.Https/Stack/Https/HttpsTransportListener.cs
@@ -237,7 +237,7 @@ namespace Opc.Ua.Bindings
             httpsOptions.SslProtocols = SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12;
             m_hostBuilder.UseKestrel(options => {
                 options.Listen(IPAddress.Any, m_uri.Port, listenOptions => {
-                    listenOptions.NoDelay = true;
+                    // listenOptions.NoDelay = true;
                     listenOptions.UseHttps(httpsOptions);
                 });
             });


### PR DESCRIPTION
commenting out Kestrel listenOptions.NoDelay b/c:
1. the default value = true
2. it was removed in .net core 3.0 and this can be configured in SocketTransportOptions