### PR TITLE
Add certificate password provider interface to support password protected pfx files.

### DIFF
--- a/Applications/ConsoleReferenceServer/ConsoleReferenceServer.csproj
+++ b/Applications/ConsoleReferenceServer/ConsoleReferenceServer.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>$(AppTargetFrameWork)</TargetFramework>
-    <AssemblyName>NetCoreReferenceServer</AssemblyName>
+    <AssemblyName>ConsoleReferenceServer</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>ConsoleReferenceServer</PackageId>
     <Company>OPC Foundation</Company>
@@ -36,7 +36,7 @@
     <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
-    <PackageReference Include="Serilog.Sinks.Debug" Version="1.0.1" />
+    <PackageReference Include="Serilog.Sinks.Debug" Version="2.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Applications/ConsoleReferenceServer/Program.cs
+++ b/Applications/ConsoleReferenceServer/Program.cs
@@ -237,7 +237,7 @@ namespace Quickstarts.ReferenceServer
         private async Task ConsoleSampleServer()
         {
             ApplicationInstance.MessageDlg = new ApplicationMessageDlg();
-            PasswordProvider PasswordProvider = new PasswordProvider(Password);
+            CertificatePasswordProvider PasswordProvider = new CertificatePasswordProvider(Password);
             ApplicationInstance application = new ApplicationInstance {
                 ApplicationName = "Quickstart Reference Server",
                 ApplicationType = ApplicationType.Server,
@@ -339,26 +339,5 @@ namespace Quickstarts.ReferenceServer
                 await Task.Delay(1000).ConfigureAwait(false);
             }
         }
-    }
-
-    /// <summary>
-    /// The certificate password provider.
-    /// </summary>
-    public class PasswordProvider : ICertificatePasswordProvider
-    {
-        public PasswordProvider(string password)
-        {
-            m_password = password;
-        }
-
-        /// <summary>
-        /// Return the password used for the certificate.
-        /// </summary>
-        public string GetPassword(CertificateIdentifier certificateIdentifier)
-        {
-            return m_password;
-        }
-
-        private string m_password;
     }
 }

--- a/Applications/ConsoleReferenceServer/Program.cs
+++ b/Applications/ConsoleReferenceServer/Program.cs
@@ -35,12 +35,16 @@ using Serilog;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Security.Cryptography;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace Quickstarts.ReferenceServer
 {
+    /// <summary>
+    /// A dialog which asks for user input.
+    /// </summary>
     public class ApplicationMessageDlg : IApplicationMessageDlg
     {
         private string m_message = string.Empty;
@@ -80,6 +84,9 @@ namespace Quickstarts.ReferenceServer
         }
     }
 
+    /// <summary>
+    /// The error code why the server exited.
+    /// </summary>
     public enum ExitCode : int
     {
         Ok = 0,
@@ -89,9 +96,12 @@ namespace Quickstarts.ReferenceServer
         ErrorInvalidCommandLine = 0x100
     };
 
-    public class Program
+    /// <summary>
+    /// The program.
+    /// </summary>
+    public static class Program
     {
-        public static int Main(string[] args)
+        public static async Task<int> Main(string[] args)
         {
             Console.WriteLine("{0} OPC UA Reference Server", Utils.IsRunningOnMono() ? "Mono" : ".Net Core");
 
@@ -99,11 +109,13 @@ namespace Quickstarts.ReferenceServer
             bool showHelp = false;
             bool autoAccept = false;
             bool console = false;
+            string password = null;
 
             Mono.Options.OptionSet options = new Mono.Options.OptionSet {
                 { "h|help", "show this message and exit", h => showHelp = h != null },
                 { "a|autoaccept", "auto accept certificates (for testing only)", a => autoAccept = a != null },
-                { "c|console", "log trace to console", c => console = c != null }
+                { "c|console", "log trace to console", c => console = c != null },
+                { "p|password=", "optional password for private key", (string p) => password = p }
             };
 
             try
@@ -131,10 +143,14 @@ namespace Quickstarts.ReferenceServer
                 return (int)ExitCode.ErrorInvalidCommandLine;
             }
 
-            MyRefServer server = new MyRefServer(autoAccept, console);
-            server.Run();
+            var server = new MyRefServer() {
+                AutoAccept = autoAccept,
+                LogConsole = console,
+                Password = password
+            };
+            await server.Run().ConfigureAwait(false);
 
-            return (int)MyRefServer.ExitCode;
+            return (int)server.ExitCode;
         }
     }
 
@@ -143,33 +159,28 @@ namespace Quickstarts.ReferenceServer
         private ReferenceServer m_server;
         private Task m_status;
         private DateTime m_lastEventTime;
-        private bool m_autoAccept = false;
-        private bool m_logConsole = false;
-        private static ExitCode s_exitCode;
+        public bool LogConsole { get; set; } = false;
+        public bool AutoAccept { get; set; } = false;
+        public string Password { get; set; } = null;
+        public ExitCode ExitCode { get; private set; }
 
-        public MyRefServer(bool autoAccept, bool logConsole)
-        {
-            m_autoAccept = autoAccept;
-            m_logConsole = logConsole;
-        }
-
-        public void Run()
+        public async Task Run()
         {
             try
             {
-                s_exitCode = ExitCode.ErrorServerNotStarted;
-                ConsoleSampleServer().Wait();
+                ExitCode = ExitCode.ErrorServerNotStarted;
+                await ConsoleSampleServer().ConfigureAwait(false);
                 Console.WriteLine("Server started. Press Ctrl-C to exit...");
-                s_exitCode = ExitCode.ErrorServerRunning;
+                ExitCode = ExitCode.ErrorServerRunning;
             }
             catch (Exception ex)
             {
                 Console.WriteLine("Exception: {0}", ex.Message);
-                s_exitCode = ExitCode.ErrorServerException;
+                ExitCode = ExitCode.ErrorServerException;
                 return;
             }
 
-            ManualResetEvent quitEvent = new ManualResetEvent(false);
+            var quitEvent = new ManualResetEvent(false);
             try
             {
                 Console.CancelKeyPress += (sender, eArgs) => {
@@ -198,18 +209,16 @@ namespace Quickstarts.ReferenceServer
                 }
             }
 
-            s_exitCode = ExitCode.Ok;
+            ExitCode = ExitCode.Ok;
         }
-
-        public static ExitCode ExitCode { get => s_exitCode; }
 
         private void CertificateValidator_CertificateValidation(CertificateValidator validator, CertificateValidationEventArgs e)
         {
             if (e.Error.StatusCode == StatusCodes.BadCertificateUntrusted)
             {
-                if (m_autoAccept)
+                if (AutoAccept)
                 {
-                    if (!m_logConsole)
+                    if (!LogConsole)
                     {
                         Console.WriteLine("Accepted Certificate: {0}", e.Certificate.Subject);
                     }
@@ -218,7 +227,7 @@ namespace Quickstarts.ReferenceServer
                     return;
                 }
             }
-            if (!m_logConsole)
+            if (!LogConsole)
             {
                 Console.WriteLine("Rejected Certificate: {0} {1}", e.Error, e.Certificate.Subject);
             }
@@ -228,17 +237,19 @@ namespace Quickstarts.ReferenceServer
         private async Task ConsoleSampleServer()
         {
             ApplicationInstance.MessageDlg = new ApplicationMessageDlg();
+            PasswordProvider PasswordProvider = new PasswordProvider(Password);
             ApplicationInstance application = new ApplicationInstance {
                 ApplicationName = "Quickstart Reference Server",
                 ApplicationType = ApplicationType.Server,
-                ConfigSectionName = Utils.IsRunningOnMono() ? "Quickstarts.MonoReferenceServer" : "Quickstarts.ReferenceServer"
+                ConfigSectionName = Utils.IsRunningOnMono() ? "Quickstarts.MonoReferenceServer" : "Quickstarts.ReferenceServer",
+                CertificatePasswordProvider = PasswordProvider
             };
 
             // load the application configuration.
             ApplicationConfiguration config = await application.LoadApplicationConfiguration(false).ConfigureAwait(false);
 
             var loggerConfiguration = new Serilog.LoggerConfiguration();
-            if (m_logConsole)
+            if (LogConsole)
             {
                 loggerConfiguration.WriteTo.Console(restrictedToMinimumLevel: Serilog.Events.LogEventLevel.Warning);
             }
@@ -294,18 +305,18 @@ namespace Quickstarts.ReferenceServer
             lock (session.DiagnosticsLock)
             {
                 StringBuilder item = new StringBuilder();
-                item.Append(string.Format("{0,9}:{1,20}:", reason, session.SessionDiagnostics.SessionName));
+                item.AppendFormat("{0,9}:{1,20}:", reason, session.SessionDiagnostics.SessionName);
                 if (lastContact)
                 {
-                    item.Append(string.Format("Last Event:{0:HH:mm:ss}", session.SessionDiagnostics.ClientLastContactTime.ToLocalTime()));
+                    item.AppendFormat("Last Event:{0:HH:mm:ss}", session.SessionDiagnostics.ClientLastContactTime.ToLocalTime());
                 }
                 else
                 {
                     if (session.Identity != null)
                     {
-                        item.Append(string.Format(":{0,20}", session.Identity.DisplayName));
+                        item.AppendFormat(":{0,20}", session.Identity.DisplayName);
                     }
-                    item.Append(string.Format(":{0}", session.Id));
+                    item.AppendFormat(":{0}", session.Id);
                 }
                 Console.WriteLine(item.ToString());
             }
@@ -328,5 +339,26 @@ namespace Quickstarts.ReferenceServer
                 await Task.Delay(1000).ConfigureAwait(false);
             }
         }
+    }
+
+    /// <summary>
+    /// The certificate password provider.
+    /// </summary>
+    public class PasswordProvider : ICertificatePasswordProvider
+    {
+        public PasswordProvider(string password)
+        {
+            m_password = password;
+        }
+
+        /// <summary>
+        /// Return the password used for the certificate.
+        /// </summary>
+        public string GetPassword(CertificateIdentifier certificateIdentifier)
+        {
+            return m_password;
+        }
+
+        private string m_password;
     }
 }

--- a/Applications/ConsoleReferenceServer/Program.cs
+++ b/Applications/ConsoleReferenceServer/Program.cs
@@ -169,7 +169,7 @@ namespace Quickstarts.ReferenceServer
             try
             {
                 ExitCode = ExitCode.ErrorServerNotStarted;
-                await ConsoleSampleServer().ConfigureAwait(false);
+                await StartConsoleReferenceServerAsync().ConfigureAwait(false);
                 Console.WriteLine("Server started. Press Ctrl-C to exit...");
                 ExitCode = ExitCode.ErrorServerRunning;
             }
@@ -234,7 +234,7 @@ namespace Quickstarts.ReferenceServer
             Utils.Trace(Utils.TraceMasks.Security, "Rejected Certificate: {0} {1}", e.Error, e.Certificate.Subject);
         }
 
-        private async Task ConsoleSampleServer()
+        private async Task StartConsoleReferenceServerAsync()
         {
             ApplicationInstance.MessageDlg = new ApplicationMessageDlg();
             CertificatePasswordProvider PasswordProvider = new CertificatePasswordProvider(Password);
@@ -286,7 +286,7 @@ namespace Quickstarts.ReferenceServer
             }
 
             // start the status thread
-            m_status = Task.Run(new Action(StatusThread));
+            m_status = Task.Run(new Action(StatusThreadAsync));
 
             // print notification on session events
             m_server.CurrentInstance.SessionManager.SessionActivated += EventStatus;
@@ -322,7 +322,7 @@ namespace Quickstarts.ReferenceServer
             }
         }
 
-        private async void StatusThread()
+        private async void StatusThreadAsync()
         {
             while (m_server != null)
             {

--- a/Libraries/Opc.Ua.Configuration/ApplicationInstance.cs
+++ b/Libraries/Opc.Ua.Configuration/ApplicationInstance.cs
@@ -274,7 +274,9 @@ namespace Opc.Ua.Configuration
         /// </summary>
         public async Task<ApplicationConfiguration> LoadApplicationConfiguration(string filePath, bool silent)
         {
-            ApplicationConfiguration configuration = await LoadAppConfig(silent, filePath, ApplicationType, ConfigurationType, true, CertificatePasswordProvider).ConfigureAwait(false);
+            ApplicationConfiguration configuration = await LoadAppConfig(
+                silent, filePath, ApplicationType, ConfigurationType, true, CertificatePasswordProvider)
+                .ConfigureAwait(false);
 
             if (configuration == null)
             {
@@ -292,7 +294,9 @@ namespace Opc.Ua.Configuration
         public async Task<ApplicationConfiguration> LoadApplicationConfiguration(bool silent)
         {
             string filePath = ApplicationConfiguration.GetFilePathFromAppConfig(ConfigSectionName);
-            ApplicationConfiguration configuration = await LoadAppConfig(silent, filePath, ApplicationType, ConfigurationType, true, CertificatePasswordProvider).ConfigureAwait(false);
+            ApplicationConfiguration configuration = await LoadAppConfig(
+                silent, filePath, ApplicationType, ConfigurationType, true, CertificatePasswordProvider)
+                .ConfigureAwait(false);
 
             if (configuration == null)
             {

--- a/Libraries/Opc.Ua.Configuration/ApplicationInstance.cs
+++ b/Libraries/Opc.Ua.Configuration/ApplicationInstance.cs
@@ -143,6 +143,11 @@ namespace Opc.Ua.Configuration
         /// Get or set the message dialog.
         /// </summary>
         public static IApplicationMessageDlg MessageDlg { get; set; }
+
+        /// <summary>
+        /// Get or set the certificate password provider.
+        /// </summary>
+        public ICertificatePasswordProvider CertificatePasswordProvider { get; set; }
         #endregion
 
         #region Public Methods
@@ -177,7 +182,7 @@ namespace Opc.Ua.Configuration
 
             if (m_applicationConfiguration == null)
             {
-                await LoadApplicationConfiguration(false);
+                await LoadApplicationConfiguration(false).ConfigureAwait(false);
             }
 
             if (m_applicationConfiguration.CertificateValidator != null)
@@ -227,7 +232,8 @@ namespace Opc.Ua.Configuration
             string filePath,
             ApplicationType applicationType,
             Type configurationType,
-            bool applyTraceSettings)
+            bool applyTraceSettings,
+            ICertificatePasswordProvider certificatePasswordProvider = null)
         {
             Utils.Trace(Utils.TraceMasks.Information, "Loading application configuration file. {0}", filePath);
 
@@ -238,7 +244,9 @@ namespace Opc.Ua.Configuration
                     new System.IO.FileInfo(filePath),
                     applicationType,
                     configurationType,
-                    applyTraceSettings);
+                    applyTraceSettings,
+                    certificatePasswordProvider)
+                    .ConfigureAwait(false);
 
                 if (configuration == null)
                 {
@@ -253,7 +261,7 @@ namespace Opc.Ua.Configuration
                 if (!silent && MessageDlg != null)
                 {
                     MessageDlg.Message("Load Application Configuration: " + e.Message);
-                    await MessageDlg.ShowAsync();
+                    await MessageDlg.ShowAsync().ConfigureAwait(false);
                 }
 
                 Utils.Trace(e, "Could not load configuration file. {0}", filePath);
@@ -266,7 +274,7 @@ namespace Opc.Ua.Configuration
         /// </summary>
         public async Task<ApplicationConfiguration> LoadApplicationConfiguration(string filePath, bool silent)
         {
-            ApplicationConfiguration configuration = await LoadAppConfig(silent, filePath, ApplicationType, ConfigurationType, true);
+            ApplicationConfiguration configuration = await LoadAppConfig(silent, filePath, ApplicationType, ConfigurationType, true, CertificatePasswordProvider).ConfigureAwait(false);
 
             if (configuration == null)
             {
@@ -284,7 +292,7 @@ namespace Opc.Ua.Configuration
         public async Task<ApplicationConfiguration> LoadApplicationConfiguration(bool silent)
         {
             string filePath = ApplicationConfiguration.GetFilePathFromAppConfig(ConfigSectionName);
-            ApplicationConfiguration configuration = await LoadAppConfig(silent, filePath, ApplicationType, ConfigurationType, true);
+            ApplicationConfiguration configuration = await LoadAppConfig(silent, filePath, ApplicationType, ConfigurationType, true, CertificatePasswordProvider).ConfigureAwait(false);
 
             if (configuration == null)
             {
@@ -320,15 +328,12 @@ namespace Opc.Ua.Configuration
             ushort lifeTimeInMonths)
         {
             Utils.Trace(Utils.TraceMasks.Information, "Checking application instance certificate.");
-
-            ApplicationConfiguration configuration = null;
-
             if (m_applicationConfiguration == null)
             {
-                await LoadApplicationConfiguration(silent);
+                await LoadApplicationConfiguration(silent).ConfigureAwait(false);
             }
 
-            configuration = m_applicationConfiguration;
+            ApplicationConfiguration configuration = m_applicationConfiguration;
             bool certificateValid = false;
 
             // find the existing certificate.
@@ -340,17 +345,17 @@ namespace Opc.Ua.Configuration
                     "Configuration file does not specify a certificate.");
             }
 
-            X509Certificate2 certificate = await id.Find(true);
+            X509Certificate2 certificate = await id.Find(true).ConfigureAwait(false);
 
             // check that it is ok.
             if (certificate != null)
             {
-                certificateValid = await CheckApplicationInstanceCertificate(configuration, certificate, silent, minimumKeySize);
+                certificateValid = await CheckApplicationInstanceCertificate(configuration, certificate, silent, minimumKeySize).ConfigureAwait(false);
             }
             else
             {
                 // check for missing private key.
-                certificate = await id.Find(false);
+                certificate = await id.Find(false).ConfigureAwait(false);
 
                 if (certificate != null)
                 {
@@ -367,7 +372,7 @@ namespace Opc.Ua.Configuration
                         id2.StoreType = id.StoreType;
                         id2.StorePath = id.StorePath;
                         id2.SubjectName = id.SubjectName;
-                        certificate = await id2.Find(true);
+                        certificate = await id2.Find(true).ConfigureAwait(false);
                     }
 
                     if (certificate != null)
@@ -641,13 +646,15 @@ namespace Opc.Ua.Configuration
                 serverDomainNames)
                 .SetLifeTime(lifeTimeInMonths)
                 .SetRSAKeySize(keySize)
-                .CreateForRSA()
-                .AddToStore(
-                    id.StoreType,
-                    id.StorePath
-                );
+                .CreateForRSA();
 
             id.Certificate = certificate;
+            var passwordProvider = configuration.SecurityConfiguration.CertificatePasswordProvider;
+            certificate.AddToStore(
+                id.StoreType,
+                id.StorePath,
+                passwordProvider?.GetPassword(id)
+                );
 
             // ensure the certificate is trusted.
             if (configuration.SecurityConfiguration.AddAppCertToTrustedStore)
@@ -660,7 +667,7 @@ namespace Opc.Ua.Configuration
             Utils.Trace(Utils.TraceMasks.Information, "Certificate created. Thumbprint={0}", certificate.Thumbprint);
 
             // reload the certificate from disk.
-            await configuration.SecurityConfiguration.ApplicationCertificate.LoadPrivateKey(null);
+            await configuration.SecurityConfiguration.ApplicationCertificate.LoadPrivateKey(passwordProvider);
 
             return certificate;
         }

--- a/Libraries/Opc.Ua.Configuration/ApplicationInstance.cs
+++ b/Libraries/Opc.Ua.Configuration/ApplicationInstance.cs
@@ -671,7 +671,7 @@ namespace Opc.Ua.Configuration
             Utils.Trace(Utils.TraceMasks.Information, "Certificate created. Thumbprint={0}", certificate.Thumbprint);
 
             // reload the certificate from disk.
-            await configuration.SecurityConfiguration.ApplicationCertificate.LoadPrivateKey(passwordProvider);
+            await configuration.SecurityConfiguration.ApplicationCertificate.LoadPrivateKeyEx(passwordProvider);
 
             return certificate;
         }

--- a/Libraries/Opc.Ua.Gds.Server.Common/CertificateGroup.cs
+++ b/Libraries/Opc.Ua.Gds.Server.Common/CertificateGroup.cs
@@ -312,7 +312,7 @@ namespace Opc.Ua.Gds.Server
                 StorePath = m_authoritiesStorePath,
                 StoreType = m_authoritiesStoreType
             };
-            return await certIdentifier.LoadPrivateKey(new CertificatePasswordProvider(signingKeyPassword));
+            return await certIdentifier.LoadPrivateKey(signingKeyPassword);
         }
 
         /// <summary>
@@ -379,7 +379,7 @@ namespace Opc.Ua.Gds.Server
                     StorePath = storePath,
                     StoreType = CertificateStoreIdentifier.DetermineStoreType(storePath)
                 };
-                X509Certificate2 certCAWithPrivateKey = await certCAIdentifier.LoadPrivateKey(new CertificatePasswordProvider(issuerKeyFilePassword));
+                X509Certificate2 certCAWithPrivateKey = await certCAIdentifier.LoadPrivateKey(issuerKeyFilePassword);
 
                 if (certCAWithPrivateKey == null)
                 {

--- a/Libraries/Opc.Ua.Gds.Server.Common/CertificateGroup.cs
+++ b/Libraries/Opc.Ua.Gds.Server.Common/CertificateGroup.cs
@@ -312,7 +312,7 @@ namespace Opc.Ua.Gds.Server
                 StorePath = m_authoritiesStorePath,
                 StoreType = m_authoritiesStoreType
             };
-            return await certIdentifier.LoadPrivateKey(signingKeyPassword);
+            return await certIdentifier.LoadPrivateKey(new CertificatePasswordProvider(signingKeyPassword));
         }
 
         /// <summary>
@@ -379,7 +379,7 @@ namespace Opc.Ua.Gds.Server
                     StorePath = storePath,
                     StoreType = CertificateStoreIdentifier.DetermineStoreType(storePath)
                 };
-                X509Certificate2 certCAWithPrivateKey = await certCAIdentifier.LoadPrivateKey(issuerKeyFilePassword);
+                X509Certificate2 certCAWithPrivateKey = await certCAIdentifier.LoadPrivateKey(new CertificatePasswordProvider(issuerKeyFilePassword));
 
                 if (certCAWithPrivateKey == null)
                 {

--- a/Libraries/Opc.Ua.Server/Configuration/ConfigurationNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/Configuration/ConfigurationNodeManager.cs
@@ -450,7 +450,7 @@ namespace Opc.Ua.Server
                     case null:
                     case "":
                     {
-                        X509Certificate2 certWithPrivateKey = certificateGroup.ApplicationCertificate.LoadPrivateKey(passwordProvider).Result;
+                        X509Certificate2 certWithPrivateKey = certificateGroup.ApplicationCertificate.LoadPrivateKeyEx(passwordProvider).Result;
                         updateCertificate.CertificateWithPrivateKey = CertificateFactory.CreateCertificateWithPrivateKey(newCert, certWithPrivateKey);
                         break;
                     }
@@ -543,7 +543,7 @@ namespace Opc.Ua.Server
             // TODO: use nonce for generating the private key
 
             var passwordProvider = m_configuration.SecurityConfiguration.CertificatePasswordProvider;
-            X509Certificate2 certWithPrivateKey = certificateGroup.ApplicationCertificate.LoadPrivateKey(passwordProvider).Result;
+            X509Certificate2 certWithPrivateKey = certificateGroup.ApplicationCertificate.LoadPrivateKeyEx(passwordProvider).Result;
             certificateRequest = CertificateFactory.CreateSigningRequest(certWithPrivateKey, X509Utils.GetDomainsFromCertficate(certWithPrivateKey));
             return ServiceResult.Good;
         }

--- a/Libraries/Opc.Ua.Server/Configuration/ConfigurationNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/Configuration/ConfigurationNodeManager.cs
@@ -444,25 +444,25 @@ namespace Opc.Ua.Server
             var updateCertificate = new UpdateCertificateData();
             try
             {
-                string password = String.Empty;
+                var passwordProvider = m_configuration.SecurityConfiguration.CertificatePasswordProvider;
                 switch (privateKeyFormat)
                 {
                     case null:
                     case "":
                     {
-                        X509Certificate2 certWithPrivateKey = certificateGroup.ApplicationCertificate.LoadPrivateKey(password).Result;
+                        X509Certificate2 certWithPrivateKey = certificateGroup.ApplicationCertificate.LoadPrivateKey(passwordProvider).Result;
                         updateCertificate.CertificateWithPrivateKey = CertificateFactory.CreateCertificateWithPrivateKey(newCert, certWithPrivateKey);
                         break;
                     }
                     case "PFX":
                     {
-                        X509Certificate2 certWithPrivateKey = X509Utils.CreateCertificateFromPKCS12(privateKey, password);
+                        X509Certificate2 certWithPrivateKey = X509Utils.CreateCertificateFromPKCS12(privateKey, passwordProvider?.GetPassword(certificateGroup.ApplicationCertificate));
                         updateCertificate.CertificateWithPrivateKey = CertificateFactory.CreateCertificateWithPrivateKey(newCert, certWithPrivateKey);
                         break;
                     }
                     case "PEM":
                     {
-                        updateCertificate.CertificateWithPrivateKey = CertificateFactory.CreateCertificateWithPEMPrivateKey(newCert, privateKey, password);
+                        updateCertificate.CertificateWithPrivateKey = CertificateFactory.CreateCertificateWithPEMPrivateKey(newCert, privateKey, passwordProvider?.GetPassword(certificateGroup.ApplicationCertificate));
                         break;
                     }
                 }
@@ -486,7 +486,8 @@ namespace Opc.Ua.Server
                         Utils.Trace(Utils.TraceMasks.Security, "Delete application certificate {0}", certificateGroup.ApplicationCertificate.Thumbprint);
                         appStore.Delete(certificateGroup.ApplicationCertificate.Thumbprint).Wait();
                         Utils.Trace(Utils.TraceMasks.Security, "Add new application certificate {0}", updateCertificate.CertificateWithPrivateKey);
-                        appStore.Add(updateCertificate.CertificateWithPrivateKey).Wait();
+                        var passwordProvider = m_configuration.SecurityConfiguration.CertificatePasswordProvider;
+                        appStore.Add(updateCertificate.CertificateWithPrivateKey, passwordProvider?.GetPassword(certificateGroup.ApplicationCertificate)).Wait();
                         // keep only track of cert without private key
                         var certOnly = new X509Certificate2(updateCertificate.CertificateWithPrivateKey.RawData);
                         updateCertificate.CertificateWithPrivateKey.Dispose();
@@ -541,8 +542,8 @@ namespace Opc.Ua.Server
             // TODO: implement regeneratePrivateKey
             // TODO: use nonce for generating the private key
 
-            string password = String.Empty;
-            X509Certificate2 certWithPrivateKey = certificateGroup.ApplicationCertificate.LoadPrivateKey(password).Result;
+            var passwordProvider = m_configuration.SecurityConfiguration.CertificatePasswordProvider;
+            X509Certificate2 certWithPrivateKey = certificateGroup.ApplicationCertificate.LoadPrivateKey(passwordProvider).Result;
             certificateRequest = CertificateFactory.CreateSigningRequest(certWithPrivateKey, X509Utils.GetDomainsFromCertficate(certWithPrivateKey));
             return ServiceResult.Good;
         }

--- a/Libraries/Opc.Ua.Server/Server/StandardServer.cs
+++ b/Libraries/Opc.Ua.Server/Server/StandardServer.cs
@@ -2155,7 +2155,8 @@ namespace Opc.Ua.Server
         /// <returns>Boolean value.</returns>
         public async Task<bool> RegisterWithDiscoveryServer()
         {
-            ApplicationConfiguration configuration = string.IsNullOrEmpty(base.Configuration.SourceFilePath) ? base.Configuration : await ApplicationConfiguration.Load(new FileInfo(base.Configuration.SourceFilePath), ApplicationType.Server, null, false);
+            ApplicationConfiguration configuration = string.IsNullOrEmpty(base.Configuration.SourceFilePath) ?
+                base.Configuration : await ApplicationConfiguration.Load(new FileInfo(base.Configuration.SourceFilePath), ApplicationType.Server, null, false);
             CertificateValidationEventHandler registrationCertificateValidator = new CertificateValidationEventHandler(RegistrationValidator_CertificateValidation);
             configuration.CertificateValidator.CertificateValidation += registrationCertificateValidator;
 

--- a/Stack/Opc.Ua.Core/Schema/ApplicationConfiguration.cs
+++ b/Stack/Opc.Ua.Core/Schema/ApplicationConfiguration.cs
@@ -740,6 +740,7 @@ namespace Opc.Ua
             m_minCertificateKeySize = CertificateFactory.DefaultKeySize;
             m_addAppCertToTrustedStore = true;
             m_sendCertificateChain = false;
+            m_suppressNonceValidationErrors = false;
         }
 
         /// <summary>
@@ -3260,7 +3261,7 @@ namespace Opc.Ua
         /// The reverse connect information.
         /// </summary>
         [DataMember(Name = "ReverseConnect", Order = 8, IsRequired = false)]
-        public ReverseConnectEndpoint ReverseConnect 
+        public ReverseConnectEndpoint ReverseConnect
         {
             get { return m_reverseConnect; }
             set { m_reverseConnect = value; }
@@ -3329,7 +3330,8 @@ namespace Opc.Ua
         /// <summary>
         /// The default constructor.
         /// </summary>
-        public ReverseConnectEndpoint() {
+        public ReverseConnectEndpoint()
+        {
             Initialize();
         }
 
@@ -3342,7 +3344,8 @@ namespace Opc.Ua
         /// <summary>
         /// Sets private members to default values.
         /// </summary>
-        private void Initialize() {
+        private void Initialize()
+        {
             m_enabled = false;
             m_serverUri = null;
             m_thumbprint = null;
@@ -3354,7 +3357,8 @@ namespace Opc.Ua
         /// Whether reverse connect is enabled for the endpoint.
         /// </summary>
         [DataMember(Name = "Enabled", Order = 1, IsRequired = false)]
-        public bool Enabled {
+        public bool Enabled
+        {
             get { return m_enabled; }
             set { m_enabled = value; }
         }
@@ -3363,7 +3367,8 @@ namespace Opc.Ua
         /// The server Uri of the endpoint.
         /// </summary>
         [DataMember(Name = "ServerUri", Order = 2, IsRequired = false)]
-        public string ServerUri {
+        public string ServerUri
+        {
             get { return m_serverUri; }
             set { m_serverUri = value; }
         }
@@ -3373,7 +3378,8 @@ namespace Opc.Ua
         /// the server Uri.
         /// </summary>
         [DataMember(Name = "Thumbprint", Order = 3, IsRequired = false)]
-        public string Thumbprint {
+        public string Thumbprint
+        {
             get { return m_thumbprint; }
             set { m_thumbprint = value; }
         }

--- a/Stack/Opc.Ua.Core/Security/Certificates/CertificateIdentifier.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/CertificateIdentifier.cs
@@ -162,7 +162,13 @@ namespace Opc.Ua
         /// <summary>
         /// Loads the private key for the certificate with an optional password.
         /// </summary>
-        public async Task<X509Certificate2> LoadPrivateKey(ICertificatePasswordProvider passwordProvider)
+        public Task<X509Certificate2> LoadPrivateKey(string password)
+            => LoadPrivateKeyEx(password != null ? new CertificatePasswordProvider(password) : null);
+
+        /// <summary>
+        /// Loads the private key for the certificate with an optional password.
+        /// </summary>
+        public async Task<X509Certificate2> LoadPrivateKeyEx(ICertificatePasswordProvider passwordProvider)
         {
             if (this.StoreType == CertificateStoreType.Directory)
             {

--- a/Stack/Opc.Ua.Core/Security/Certificates/CertificateIdentifier.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/CertificateIdentifier.cs
@@ -147,7 +147,7 @@ namespace Opc.Ua
         /// <value>The X509 certificate used by this instance.</value>
         public X509Certificate2 Certificate
         {
-            get { return m_certificate;  }
+            get { return m_certificate; }
             set { m_certificate = value; }
         }
 
@@ -162,18 +162,19 @@ namespace Opc.Ua
         /// <summary>
         /// Loads the private key for the certificate with an optional password.
         /// </summary>
-        public async Task<X509Certificate2> LoadPrivateKey(String password)
+        public async Task<X509Certificate2> LoadPrivateKey(ICertificatePasswordProvider passwordProvider)
         {
             if (this.StoreType == CertificateStoreType.Directory)
-            {                
+            {
                 using (DirectoryCertificateStore store = new DirectoryCertificateStore())
                 {
                     store.Open(this.StorePath);
+                    string password = passwordProvider?.GetPassword(this);
                     m_certificate = store.LoadPrivateKey(this.Thumbprint, this.SubjectName, password);
                     return m_certificate;
                 }
             }
-            
+
             return await Find(true);
         }
 
@@ -434,16 +435,16 @@ namespace Opc.Ua
 
             byte[] rawData = encodedData;
             byte[] data = certificate.RawData;
-        
+
             int processedBytes = data.Length;
-            
+
             if (encodedData.Length < processedBytes)
             {
-                byte[] buffer = new byte[encodedData.Length-processedBytes];
+                byte[] buffer = new byte[encodedData.Length - processedBytes];
 
                 do
                 {
-                    Array.Copy(encodedData, processedBytes, buffer, 0, encodedData.Length-processedBytes);
+                    Array.Copy(encodedData, processedBytes, buffer, 0, encodedData.Length - processedBytes);
 
                     if (!IsValidCertificateBlob(buffer))
                     {
@@ -504,7 +505,7 @@ namespace Opc.Ua
             {
                 length = octet & 0x7F;
 
-                if (2+length < rawData.Length)
+                if (2 + length < rawData.Length)
                 {
                     return false;
                 }
@@ -514,8 +515,8 @@ namespace Opc.Ua
 
             // extract number of bytes for the length.
             int lengthBytes = octet & 0x7F;
-            
-            if (rawData.Length <= 2+lengthBytes)
+
+            if (rawData.Length <= 2 + lengthBytes)
             {
                 return false;
             }
@@ -529,13 +530,13 @@ namespace Opc.Ua
             // extract length.
             length = rawData[2];
 
-            for (int ii = 0; ii < lengthBytes-1; ii++)
+            for (int ii = 0; ii < lengthBytes - 1; ii++)
             {
                 length <<= 8;
-                length |= rawData[ii+3];
+                length |= rawData[ii + 3];
             }
 
-            if (2+lengthBytes+length > rawData.Length)
+            if (2 + lengthBytes + length > rawData.Length)
             {
                 return false;
             }
@@ -569,13 +570,13 @@ namespace Opc.Ua
 
             return collection;
         }
-        
+
         #region IDisposable Members
         /// <summary>
         /// Frees any unmanaged resources.
         /// </summary>
         public void Dispose()
-        {   
+        {
             Dispose(true);
         }
 
@@ -725,7 +726,7 @@ namespace Opc.Ua
         {
             return StatusCodes.BadNotSupported;
         }
-        
+
         /// <summary>
         /// Returns the CRLs in the store.
         /// </summary>

--- a/Stack/Opc.Ua.Core/Security/Certificates/CertificatePasswordProvider.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/CertificatePasswordProvider.cs
@@ -1,0 +1,55 @@
+/* Copyright (c) 1996-2021 The OPC Foundation. All rights reserved.
+   The source code in this file is covered under a dual-license scenario:
+     - RCL: for OPC Foundation members in good-standing
+     - GPL V2: everybody else
+   RCL license terms accompanied with this source code. See http://opcfoundation.org/License/RCL/1.00/
+   GNU General Public License as published by the Free Software Foundation;
+   version 2 of the License are accompanied with this source code. See http://opcfoundation.org/License/GPLv2
+   This source code is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+*/
+
+namespace Opc.Ua
+{
+    #region ICertificatePasswordProvider Interface
+    /// <summary>
+    /// An interface for a password provider for certificate private keys.
+    /// </summary>
+    public interface ICertificatePasswordProvider
+    {
+        /// <summary>
+        /// Return the password for a certificate private key.
+        /// </summary>
+        /// <param name="certificateIdentifier">The certificate identifier for which the password is needed.</param>
+        string GetPassword(CertificateIdentifier certificateIdentifier);
+    }
+    #endregion
+
+    #region CertificatePasswordProvider
+    /// <summary>
+    /// The default certificate password provider implementation.
+    /// </summary>
+    public class CertificatePasswordProvider : ICertificatePasswordProvider
+    {
+        /// <summary>
+        /// Constructor which takes a password string.
+        /// </summary>
+        /// <param name="password"></param>
+        public CertificatePasswordProvider(string password)
+        {
+            m_password = password;
+        }
+
+        /// <summary>
+        /// Return the password used for the certificate.
+        /// </summary>
+        public string GetPassword(CertificateIdentifier certificateIdentifier)
+        {
+            return m_password;
+        }
+
+        private string m_password;
+    }
+    #endregion
+}

--- a/Stack/Opc.Ua.Core/Security/Certificates/CertificateValidator.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/CertificateValidator.cs
@@ -194,7 +194,8 @@ namespace Opc.Ua
             }
 
             await Update(securityConfiguration);
-            await securityConfiguration.ApplicationCertificate.LoadPrivateKey(null);
+            await securityConfiguration.ApplicationCertificate.LoadPrivateKey(
+                securityConfiguration.CertificatePasswordProvider);
 
             lock (m_callbackLock)
             {

--- a/Stack/Opc.Ua.Core/Security/Certificates/CertificateValidator.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/CertificateValidator.cs
@@ -194,7 +194,7 @@ namespace Opc.Ua
             }
 
             await Update(securityConfiguration);
-            await securityConfiguration.ApplicationCertificate.LoadPrivateKey(
+            await securityConfiguration.ApplicationCertificate.LoadPrivateKeyEx(
                 securityConfiguration.CertificatePasswordProvider);
 
             lock (m_callbackLock)

--- a/Stack/Opc.Ua.Core/Security/Certificates/SecurityConfiguration.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/SecurityConfiguration.cs
@@ -10,10 +10,26 @@
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 */
 
+using System;
 using System.IO;
+using System.Security.Cryptography.X509Certificates;
 
 namespace Opc.Ua
 {
+    #region ICertificatePasswordProvider Interface
+    /// <summary>
+    /// An interface for a password provider for private keys.
+    /// </summary>
+    public interface ICertificatePasswordProvider
+    {
+        /// <summary>
+        /// Return the password for a certificate private key.
+        /// </summary>
+        /// <param name="certificateIdentifier">The certificate identifier for which the password is needed.</param>
+        string GetPassword(CertificateIdentifier certificateIdentifier);
+    }
+    #endregion
+
     #region SecurityConfiguration Class
     /// <summary>
     /// The security configuration for the application.
@@ -70,6 +86,12 @@ namespace Opc.Ua
 
             return new CertificateTrustList();
         }
+
+        /// <summary>
+        /// Get the provider which is invoked when a password
+        /// for a private key is requested.
+        /// </summary>
+        public ICertificatePasswordProvider CertificatePasswordProvider { get; set; }
         #endregion
     }
     #endregion

--- a/Stack/Opc.Ua.Core/Security/Certificates/SecurityConfiguration.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/SecurityConfiguration.cs
@@ -10,26 +10,10 @@
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 */
 
-using System;
 using System.IO;
-using System.Security.Cryptography.X509Certificates;
 
 namespace Opc.Ua
 {
-    #region ICertificatePasswordProvider Interface
-    /// <summary>
-    /// An interface for a password provider for private keys.
-    /// </summary>
-    public interface ICertificatePasswordProvider
-    {
-        /// <summary>
-        /// Return the password for a certificate private key.
-        /// </summary>
-        /// <param name="certificateIdentifier">The certificate identifier for which the password is needed.</param>
-        string GetPassword(CertificateIdentifier certificateIdentifier);
-    }
-    #endregion
-
     #region SecurityConfiguration Class
     /// <summary>
     /// The security configuration for the application.

--- a/Stack/Opc.Ua.Core/Stack/Configuration/ApplicationConfiguration.cs
+++ b/Stack/Opc.Ua.Core/Stack/Configuration/ApplicationConfiguration.cs
@@ -404,7 +404,7 @@ namespace Opc.Ua
             SecurityConfiguration.Validate();
 
             // load private key
-            await SecurityConfiguration.ApplicationCertificate.LoadPrivateKey(SecurityConfiguration.CertificatePasswordProvider);
+            await SecurityConfiguration.ApplicationCertificate.LoadPrivateKeyEx(SecurityConfiguration.CertificatePasswordProvider);
 
             Func<string> generateDefaultUri = () => {
                 var sb = new StringBuilder();

--- a/Stack/Opc.Ua.Core/Stack/Configuration/ApplicationConfiguration.cs
+++ b/Stack/Opc.Ua.Core/Stack/Configuration/ApplicationConfiguration.cs
@@ -303,8 +303,14 @@ namespace Opc.Ua
         /// <param name="applicationType">Type of the application.</param>
         /// <param name="systemType">Type of the system.</param>
         /// <param name="applyTraceSettings">if set to <c>true</c> apply trace settings after validation.</param>
+        /// <param name="certificatePasswordProvider">The certificate password provider.</param>
         /// <returns>Application configuration</returns>
-        public static async Task<ApplicationConfiguration> Load(FileInfo file, ApplicationType applicationType, Type systemType, bool applyTraceSettings)
+        public static async Task<ApplicationConfiguration> Load(
+            FileInfo file,
+            ApplicationType applicationType,
+            Type systemType,
+            bool applyTraceSettings,
+            ICertificatePasswordProvider certificatePasswordProvider = null)
         {
             ApplicationConfiguration configuration = null;
             systemType = systemType ?? typeof(ApplicationConfiguration);
@@ -334,6 +340,8 @@ namespace Opc.Ua
                 {
                     configuration.TraceConfiguration.ApplySettings();
                 }
+
+                configuration.SecurityConfiguration.CertificatePasswordProvider = certificatePasswordProvider;
 
                 await configuration.Validate(applicationType);
 
@@ -396,7 +404,7 @@ namespace Opc.Ua
             SecurityConfiguration.Validate();
 
             // load private key
-            await SecurityConfiguration.ApplicationCertificate.LoadPrivateKey(null);
+            await SecurityConfiguration.ApplicationCertificate.LoadPrivateKey(SecurityConfiguration.CertificatePasswordProvider);
 
             Func<string> generateDefaultUri = () => {
                 var sb = new StringBuilder();

--- a/Tests/Opc.Ua.Core.Tests/Security/Certificates/CertificateStoreTest.cs
+++ b/Tests/Opc.Ua.Core.Tests/Security/Certificates/CertificateStoreTest.cs
@@ -155,11 +155,17 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
 
                 {
                     // check invalid password fails to load
-                    var nullKey = await id.LoadPrivateKey(new CertificatePasswordProvider("123"));
+                    var nullKey = await id.LoadPrivateKey("123");
                     Assert.IsNull(nullKey);
                 }
 
-                var privateKey = await id.LoadPrivateKey(new CertificatePasswordProvider(password));
+                {
+                    // check invalid password fails to load
+                    var nullKey = await id.LoadPrivateKeyEx(new CertificatePasswordProvider("123"));
+                    Assert.IsNull(nullKey);
+                }
+
+                var privateKey = await id.LoadPrivateKeyEx(new CertificatePasswordProvider(password));
 
                 Assert.NotNull(privateKey);
                 Assert.True(privateKey.HasPrivateKey);


### PR DESCRIPTION
- add CertificatePasswordProvider to SecurityConfiguration, if set, it is used when a private key is loaded
- on purpose password cannot be set in config files, ICertificatePasswordProvider must be implemented to allow custom implementation of secure storage of the private key password
- sample in ref server how to use it.
- implementation in ApplicationInstance/Config to avoid breaking changes.