### PR TITLE
Limit recursion in XmlDecoder.ReadMatrix() and XmlEncoder.WriteMatrix()

### DIFF
--- a/Stack/Opc.Ua.Core/Types/Encoders/XmlDecoder.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/XmlDecoder.cs
@@ -2625,6 +2625,17 @@ namespace Opc.Ua
         /// </summary>
         private Matrix ReadMatrix(string fieldName)
         {
+            // check the nesting level for avoiding a stack overflow.
+            if (m_nestingLevel > m_context.MaxEncodingNestingLevels)
+            {
+                throw ServiceResultException.Create(
+                    StatusCodes.BadEncodingLimitsExceeded,
+                    "Maximum nesting level of {0} was exceeded",
+                    m_context.MaxEncodingNestingLevels);
+            }
+
+            m_nestingLevel++;
+
             Array elements = null;
             Int32Collection dimensions = null;
             TypeInfo typeInfo = null;
@@ -2646,6 +2657,8 @@ namespace Opc.Ua
 
                 EndField(fieldName);
             }
+
+            m_nestingLevel--;
 
             if (elements == null)
             {

--- a/Stack/Opc.Ua.Core/Types/Encoders/XmlEncoder.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/XmlEncoder.cs
@@ -1950,6 +1950,17 @@ namespace Opc.Ua
         /// </summary>
         private void WriteMatrix(string fieldName, Matrix value)
         {
+            // check the nesting level for avoiding a stack overflow.
+            if (m_nestingLevel > m_context.MaxEncodingNestingLevels)
+            {
+                throw ServiceResultException.Create(
+                    StatusCodes.BadEncodingLimitsExceeded,
+                    "Maximum nesting level of {0} was exceeded",
+                    m_context.MaxEncodingNestingLevels);
+            }
+
+            m_nestingLevel++;
+
             if (BeginField(fieldName, value == null, true, true))
             {
                 PushNamespace(Namespaces.OpcUaXsd);
@@ -1967,6 +1978,8 @@ namespace Opc.Ua
 
                 EndField(fieldName);
             }
+
+            m_nestingLevel--;
         }
 
         /// <summary>


### PR DESCRIPTION
Limit recursion level in XmlDecoder.ReadMatrix() and XmlEncoder.Write.Matrix()