### PR TITLE
Stick with EndpointDescription if SecPol is null for the UserToken

### DIFF
--- a/Libraries/Opc.Ua.Client/Session.cs
+++ b/Libraries/Opc.Ua.Client/Session.cs
@@ -2342,11 +2342,12 @@ namespace Opc.Ua.Client
             }
 
             bool requireEncryption = securityPolicyUri != SecurityPolicies.None;
+
             if (!requireEncryption)
             {
-                if (identityPolicy.SecurityPolicyUri != null)
-                    requireEncryption = identityPolicy.SecurityPolicyUri != SecurityPolicies.None;
-            }
+                requireEncryption = identityPolicy.SecurityPolicyUri != SecurityPolicies.None && 
+                    !String.IsNullOrEmpty(identityPolicy.SecurityPolicyUri);
+            }           
 
             // validate the server certificate /certificate chain.
             X509Certificate2 serverCertificate = null;

--- a/Libraries/Opc.Ua.Client/Session.cs
+++ b/Libraries/Opc.Ua.Client/Session.cs
@@ -2344,7 +2344,8 @@ namespace Opc.Ua.Client
             bool requireEncryption = securityPolicyUri != SecurityPolicies.None;
             if (!requireEncryption)
             {
-                requireEncryption = identityPolicy.SecurityPolicyUri != SecurityPolicies.None;
+                if (identityPolicy.SecurityPolicyUri != null)
+                    requireEncryption = identityPolicy.SecurityPolicyUri != SecurityPolicies.None;
             }
 
             // validate the server certificate /certificate chain.


### PR DESCRIPTION
this is meant to fix issue #1323 
It will avoid checking the certificates for encryption if the EndpointDescription SecurityPolicy is None and the UserIdentity SecurityPolicy is not set at all in line with the OPC UA spec 7.36.2.1.

From the specification (release 1.04):
If this SecurityPolicy is omitted then the Client uses the SecurityPolicy in the EndpointDescription. If the matching SecurityPolicy is set to None then no encryption or signature is required.