### PR TITLE
bugfix in RelativePath.ParseName(..): update variable last for loop i…

### DIFF
--- a/Stack/Opc.Ua.Core/Types/Utils/RelativePath.cs
+++ b/Stack/Opc.Ua.Core/Types/Utils/RelativePath.cs
@@ -740,10 +740,8 @@ namespace Opc.Ua
 
                 int last = reader.Peek();
 
-                for (int next = last; next != -1; next = reader.Peek())
+                for (int next = last; next != -1; next = reader.Peek(), last=next)
                 {
-                    last = next;
-
                     if (!Char.IsDigit((char)next))
                     {
                         if (next == ':')

--- a/Tests/Opc.Ua.Core.Tests/Types/Utils/UtilTests.cs
+++ b/Tests/Opc.Ua.Core.Tests/Types/Utils/UtilTests.cs
@@ -121,7 +121,7 @@ namespace Opc.Ua.Core.Tests.Types.UtilsTests
         {
             TypeTable typeTable = new TypeTable(new NamespaceTable());
             string str = "/123A/78B9";
-            Assert.AreEqual(str,RelativePath.Parse(str, typeTable));
+            Assert.AreEqual(str,RelativePath.Parse(str, typeTable).Format(typeTable));
         }
 
         /// <summary>
@@ -132,7 +132,7 @@ namespace Opc.Ua.Core.Tests.Types.UtilsTests
         {
             TypeTable typeTable = new TypeTable(new NamespaceTable());
             string str = "/AA123A/bb78B9";
-            Assert.AreEqual(str, RelativePath.Parse(str, typeTable));
+            Assert.AreEqual(str, RelativePath.Parse(str, typeTable).Format(typeTable));
         }
 
         /// <summary>
@@ -143,7 +143,7 @@ namespace Opc.Ua.Core.Tests.Types.UtilsTests
         {
             TypeTable typeTable = new TypeTable(new NamespaceTable());
             string str = "/abc/def";
-            Assert.AreEqual(str, RelativePath.Parse(str, typeTable));
+            Assert.AreEqual(str, RelativePath.Parse(str, typeTable).Format(typeTable));
         }
 
         /// <summary>
@@ -154,7 +154,7 @@ namespace Opc.Ua.Core.Tests.Types.UtilsTests
         {
             TypeTable typeTable = new TypeTable(new NamespaceTable());
             string str = "/1:abc/2:def";
-            Assert.AreEqual(str, RelativePath.Parse(str, typeTable));
+            Assert.AreEqual(str, RelativePath.Parse(str, typeTable).Format(typeTable));
         }
 
         #endregion

--- a/Tests/Opc.Ua.Core.Tests/Types/Utils/UtilTests.cs
+++ b/Tests/Opc.Ua.Core.Tests/Types/Utils/UtilTests.cs
@@ -39,7 +39,7 @@ namespace Opc.Ua.Core.Tests.Types.UtilsTests
     [Parallelizable]
     public class UtilsTests
     {
-        #region Test Methods
+        #region misc
         /// <summary>
         /// Convert to and from little endian hex string.
         /// </summary>
@@ -88,65 +88,73 @@ namespace Opc.Ua.Core.Tests.Types.UtilsTests
             Assert.AreEqual(hex, hexutil);
         }
 
+        #endregion
 
+        #region RelativePath.Parse
         /// <summary>
-        /// 
+        /// parse simple plain path string containing only numeric chars.
         /// </summary>
         [Test]
         public void RelativePathParseNumericStringNonDeep()
         {
             TypeTable typeTable = new TypeTable(new NamespaceTable());
             string str = "/11";
-            Assert.AreEqual(str,
-                RelativePath.Parse(str, typeTable).Format(typeTable));
+            Assert.AreEqual(str,RelativePath.Parse(str, typeTable).Format(typeTable));
         }
 
         /// <summary>
-        /// 
+        /// parse deep path string containing only numeric chars.
         /// </summary>
         [Test]
         public void RelativePathParseNumericStringDeepPath()
         {
             TypeTable typeTable = new TypeTable(new NamespaceTable());
             string str = "/123/789";
-            Assert.AreEqual(str,
-                RelativePath.Parse(str, typeTable).Format(typeTable));
+            Assert.AreEqual(str,RelativePath.Parse(str, typeTable).Format(typeTable));
         }
 
         /// <summary>
-        /// 
+        /// parse deep path string containing alphanumeric chars, staring with numeric chars.
         /// </summary>
         [Test]
         public void RelativePathParseAlphanumericStringPath()
         {
+            TypeTable typeTable = new TypeTable(new NamespaceTable());
             string str = "/123A/78B9";
-            // In Little Endian it's written as CE FA
-            Assert.AreEqual(str, RelativePath.Parse(str, new TypeTable(new NamespaceTable())).Format(new TypeTable(new NamespaceTable())));
+            Assert.AreEqual(str,RelativePath.Parse(str, typeTable));
         }
 
         /// <summary>
-        /// 
+        /// parse deep path string containing alphanumeric chars (mixed), starting with alphabetical chars.
         /// </summary>
         [Test]
         public void RelativePathParseAlphanumericStringPath2()
         {
+            TypeTable typeTable = new TypeTable(new NamespaceTable());
             string str = "/AA123A/bb78B9";
-            // In Little Endian it's written as CE FA
-            Assert.AreEqual(str, RelativePath.Parse(str, new TypeTable(new NamespaceTable())).Format(new TypeTable(new NamespaceTable())));
+            Assert.AreEqual(str, RelativePath.Parse(str, typeTable));
         }
 
+        /// <summary>
+        /// parse deep path string containing only alphabetical chars.
+        /// </summary>
         [Test]
         public void RelativePathParseAlphaStringPath()
         {
+            TypeTable typeTable = new TypeTable(new NamespaceTable());
             string str = "/abc/def";
-            Assert.AreEqual(str, RelativePath.Parse(str, new TypeTable(new NamespaceTable())).Format(new TypeTable(new NamespaceTable())));
+            Assert.AreEqual(str, RelativePath.Parse(str, typeTable));
         }
 
+        /// <summary>
+        /// parse deep path string containing only alphabetical chars with namespace index
+        /// </summary>
         [Test]
-        public void RelativePathParseAlphanumericWithNsiStringPath()
+        public void RelativePathParseAlphanumericWithNamespaceIndexStringPath()
         {
+            TypeTable typeTable = new TypeTable(new NamespaceTable());
             string str = "/1:abc/2:def";
-            Assert.AreEqual(str, RelativePath.Parse(str, new TypeTable(new NamespaceTable())).Format(new TypeTable(new NamespaceTable())));
+            Assert.AreEqual(str, RelativePath.Parse(str, typeTable));
         }
 
         #endregion

--- a/Tests/Opc.Ua.Core.Tests/Types/Utils/UtilTests.cs
+++ b/Tests/Opc.Ua.Core.Tests/Types/Utils/UtilTests.cs
@@ -87,6 +87,68 @@ namespace Opc.Ua.Core.Tests.Types.UtilsTests
             var hexutil = Utils.ToHexString(blob, true);
             Assert.AreEqual(hex, hexutil);
         }
+
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [Test]
+        public void RelativePathParseNumericStringNonDeep()
+        {
+            TypeTable typeTable = new TypeTable(new NamespaceTable());
+            string str = "/11";
+            Assert.AreEqual(str,
+                RelativePath.Parse(str, typeTable).Format(typeTable));
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [Test]
+        public void RelativePathParseNumericStringDeepPath()
+        {
+            TypeTable typeTable = new TypeTable(new NamespaceTable());
+            string str = "/123/789";
+            Assert.AreEqual(str,
+                RelativePath.Parse(str, typeTable).Format(typeTable));
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [Test]
+        public void RelativePathParseAlphanumericStringPath()
+        {
+            string str = "/123A/78B9";
+            // In Little Endian it's written as CE FA
+            Assert.AreEqual(str, RelativePath.Parse(str, new TypeTable(new NamespaceTable())).Format(new TypeTable(new NamespaceTable())));
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [Test]
+        public void RelativePathParseAlphanumericStringPath2()
+        {
+            string str = "/AA123A/bb78B9";
+            // In Little Endian it's written as CE FA
+            Assert.AreEqual(str, RelativePath.Parse(str, new TypeTable(new NamespaceTable())).Format(new TypeTable(new NamespaceTable())));
+        }
+
+        [Test]
+        public void RelativePathParseAlphaStringPath()
+        {
+            string str = "/abc/def";
+            Assert.AreEqual(str, RelativePath.Parse(str, new TypeTable(new NamespaceTable())).Format(new TypeTable(new NamespaceTable())));
+        }
+
+        [Test]
+        public void RelativePathParseAlphanumericWithNsiStringPath()
+        {
+            string str = "/1:abc/2:def";
+            Assert.AreEqual(str, RelativePath.Parse(str, new TypeTable(new NamespaceTable())).Format(new TypeTable(new NamespaceTable())));
+        }
+
         #endregion
     }
 


### PR DESCRIPTION
bugfix in RelativePath.ParseName(..): update variable last for loop increment statement to keep it for further processing

sould fix this issue: #1325 