### PR TITLE
fix commands and .NET-version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,17 +63,17 @@ All the tools you need for .NET Standard come with the .NET Core tools. See [Get
 3. Hit `F5` to build and execute the sample.
 
 ## How to build and run the console samples on Windows, Linux and iOS
-This section describes how to run the and **NetCoreReferenceServer** sample application.
+This section describes how to run the **ReferenceServer** sample application.
 
-Please follow instructions in this [article](https://aka.ms/dotnetcoregs) to setup the dotnet command line environment for your platform. As of today .NET Core SDK 2.1 is required.
+Please follow instructions in this [article](https://aka.ms/dotnetcoregs) to setup the dotnet command line environment for your platform. As of today .NET Core SDK 3.1 is required.
 
 ### Prerequisites
-1. Once the `dotnet` command is available, navigate to the root folder in your local copy of the repository and execute `dotnet restore UA Reference.sln`. This command calls into NuGet to restore the tree of dependencies.
+1. Once the `dotnet` command is available, navigate to the root folder in your local copy of the repository and execute `dotnet restore 'UA Reference.sln'`. This command calls into NuGet to restore the tree of dependencies.
 
 ### Start the server 
 1. Open a command prompt. 
-2. Navigate to the folder **Applications/NetCoreReferenceServer**. 
-3. To run the server sample type `dotnet run --project NetCoreReferenceServer.csproj -a`. 
+2. Navigate to the folder **Applications/ReferenceServer**. 
+3. To run the server sample type `dotnet run --project ReferenceServer.csproj -a`. 
     - The server is now running and waiting for connections. 
 
 ## Remarks

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ All the tools you need for .NET Standard come with the .NET Core tools. See [Get
 ## How to build and run the console samples on Windows, Linux and iOS
 This section describes how to run the **ConsoleReferenceServer** sample application.
 
-Please follow instructions in this [article](https://aka.ms/dotnetcoregs) to setup the dotnet command line environment for your platform. As of today .NET Core SDK 3.1 is required.
+Please follow instructions in this [article](https://aka.ms/dotnetcoregs) to setup the dotnet command line environment for your platform. As of today .NET Core SDK 2.1 is required for Visual Studio 2017 and .NET Core SDK 3.1 is required for Visual Studio 2019.
 
 ### Prerequisites
 1. Once the `dotnet` command is available, navigate to the root folder in your local copy of the repository and execute `dotnet restore 'UA Reference.sln'`. This command calls into NuGet to restore the tree of dependencies.

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ All the tools you need for .NET Standard come with the .NET Core tools. See [Get
 3. Hit `F5` to build and execute the sample.
 
 ## How to build and run the console samples on Windows, Linux and iOS
-This section describes how to run the **ReferenceServer** sample application.
+This section describes how to run the **ConsoleReferenceServer** sample application.
 
 Please follow instructions in this [article](https://aka.ms/dotnetcoregs) to setup the dotnet command line environment for your platform. As of today .NET Core SDK 3.1 is required.
 
@@ -72,8 +72,8 @@ Please follow instructions in this [article](https://aka.ms/dotnetcoregs) to set
 
 ### Start the server 
 1. Open a command prompt. 
-2. Navigate to the folder **Applications/ReferenceServer**. 
-3. To run the server sample type `dotnet run --project ReferenceServer.csproj -a`. 
+2. Navigate to the folder **Applications/ConsoleReferenceServer**. 
+3. To run the server sample type `dotnet run --project ConsoleReferenceServer.csproj -a`. 
     - The server is now running and waiting for connections. 
 
 ## Remarks

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,9 +10,6 @@ pr:
   paths:
     include:
     - '*' 
-    exclude:
-    - 'Docs/*' 
-    - 'README.md' 
 
 stages:
 - stage: build


### PR DESCRIPTION
the .NET-Version in README is outdated, the pathes for reference-server are not existing anymore, so I fixed this:

fix required .NET-Version to 3.1
fix dotnet restore command to be compatible to bash (add ' )
fix pathes of ReferenceServer (update NetCore to Console in path)