### PR TITLE
Allow to set HiResClock Enabled/Disabled only once. Fixes #1269

### DIFF
--- a/Stack/Opc.Ua.Core/Stack/Configuration/ApplicationConfiguration.cs
+++ b/Stack/Opc.Ua.Core/Stack/Configuration/ApplicationConfiguration.cs
@@ -450,7 +450,7 @@ namespace Opc.Ua
             // toggle the state of the hi-res clock.
             HiResClock.Disabled = m_disableHiResClock;
 
-            if (m_disableHiResClock)
+            if (HiResClock.Disabled)
             {
                 if (m_serverConfiguration != null)
                 {

--- a/Stack/Opc.Ua.Core/Types/Utils/HiResClock.cs
+++ b/Stack/Opc.Ua.Core/Types/Utils/HiResClock.cs
@@ -84,17 +84,37 @@ namespace Opc.Ua
                 // do not enable if unsupported
                 if (Stopwatch.IsHighResolution)
                 {
-                    if (s_Default.m_disabled && !value)
+                    // check if already initialized.
+                    if (!s_Default.m_initialized)
                     {
-                        // reset baseline
-                        s_Default = new HiResClock();
+                        if (s_Default.m_disabled && !value)
+                        {
+                            // reset baseline
+                            s_Default = new HiResClock();
+                        }
+                        else
+                        {
+                            s_Default.m_disabled = value;
+                        }
+
+                        s_Default.m_initialized = true;
                     }
                     else
                     {
-                        s_Default.m_disabled = value;
+                        // do not allow to set the value multiple times since 
+                        // it affects the notifications for existing monitored items.
                     }
                 }
             }
+        }
+
+        /// <summary>
+        /// Reset the baseline and allow a new initialization.
+        /// </summary>
+        public static void Reset()
+        {
+            // reset baseline
+            s_Default = new HiResClock();
         }
 
         /// <summary>
@@ -102,6 +122,7 @@ namespace Opc.Ua
         /// </summary>
         private HiResClock()
         {
+            m_initialized = false;
             m_offset = DateTime.UtcNow.Ticks;
             if (!Stopwatch.IsHighResolution)
             {
@@ -130,6 +151,7 @@ namespace Opc.Ua
         private double m_ticksPerMillisecond;
         private decimal m_ratio;
         private bool m_disabled;
+        private bool m_initialized;
     }
 
 }

--- a/Tests/Opc.Ua.Core.Tests/Types/Utils/HiResClock.cs
+++ b/Tests/Opc.Ua.Core.Tests/Types/Utils/HiResClock.cs
@@ -49,13 +49,13 @@ namespace Opc.Ua.Core.Tests.Types.UtilsTests
         [OneTimeTearDown]
         protected void OneTimeTearDown()
         {
-            HiResClock.Disabled = false;
+            HiResClock.Reset();
         }
 
         [TearDown]
         protected void TearDown()
         {
-            HiResClock.Disabled = false;
+            HiResClock.Reset();
         }
         #endregion
 
@@ -74,6 +74,9 @@ namespace Opc.Ua.Core.Tests.Types.UtilsTests
             Assert.True(HiResClock.Disabled);
             Assert.AreEqual(TimeSpan.TicksPerSecond, HiResClock.Frequency);
             Assert.AreEqual(TimeSpan.TicksPerMillisecond, HiResClock.TicksPerMillisecond);
+            HiResClock.Disabled = false;
+            Assert.True(HiResClock.Disabled);
+            HiResClock.Reset();
             HiResClock.Disabled = false;
             Assert.False(HiResClock.Disabled);
         }


### PR DESCRIPTION
Add a Reset() method to allow testing.