### PR TITLE
ActivateSession fix for changing identity from UserName to Anonymous

### DIFF
--- a/Applications/ReferenceServer/ReferenceServer.cs
+++ b/Applications/ReferenceServer/ReferenceServer.cs
@@ -221,9 +221,19 @@ namespace Quickstarts.ReferenceServer
                 return;
             }
 
-            // allow anonymous authentication and set Anonymous role for this authentication
-            args.Identity = new UserIdentity();
-            args.Identity.GrantedRoleIds.Add(ObjectIds.WellKnownRole_Anonymous);
+            // check for anonymous token.
+            if (args.NewIdentity is AnonymousIdentityToken || args.NewIdentity == null)
+            {
+                // allow anonymous authentication and set Anonymous role for this authentication
+                args.Identity = new UserIdentity();
+                args.Identity.GrantedRoleIds.Add(ObjectIds.WellKnownRole_Anonymous);
+
+                return;
+            }
+
+            // unsuported identity token type.
+            throw ServiceResultException.Create(StatusCodes.BadIdentityTokenInvalid,
+                   "Not supported user token type: {0}.", args.NewIdentity);
         }
 
         /// <summary>

--- a/Libraries/Opc.Ua.Server/Session/Session.cs
+++ b/Libraries/Opc.Ua.Server/Session/Session.cs
@@ -939,12 +939,6 @@ namespace Opc.Ua.Server
             if (identityToken == null || identityToken.Body == null ||
                 identityToken.Body.GetType() == typeof(Opc.Ua.AnonymousIdentityToken))
             {
-                // not changing the token if already activated.
-                if (m_activated)
-                {
-                    return null;
-                }
-
                 // check if an anonymous login is permitted.
                 if (m_endpoint.UserIdentityTokens != null && m_endpoint.UserIdentityTokens.Count > 0)
                 {


### PR DESCRIPTION
 - ActivateSession fix for changing identity from UserName to Anonymous. Fixes #1149 
 - Check for unsupported UserIdentity type in ReferenceServer e.g. IssuedToken identity

CTT tests pass for this change.