### PR TITLE
Prohibit Xml Dtd processing

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -259,3 +259,6 @@ dotnet_naming_symbols.all_members.applicable_kinds                            = 
 
 dotnet_naming_style.pascal_case_style.capitalization                          = pascal_case
 
+# CA3075: Insecure DTD processing in XML
+dotnet_diagnostic.CA3075.severity = warning
+

--- a/Stack/Opc.Ua.Core/Schema/UANodeSetHelpers.cs
+++ b/Stack/Opc.Ua.Core/Schema/UANodeSetHelpers.cs
@@ -40,16 +40,11 @@ namespace Opc.Ua.Export
         /// <returns>The set of nodes</returns>
         public static UANodeSet Read(Stream istrm)
         {
-            StreamReader reader = new StreamReader(istrm);
-
-            try
+            using (StreamReader reader = new StreamReader(istrm))
+            using (XmlReader xmlReader = XmlReader.Create(reader, Utils.DefaultXmlReaderSettings()))
             {
                 XmlSerializer serializer = new XmlSerializer(typeof(UANodeSet));
-                return serializer.Deserialize(reader) as UANodeSet;
-            }
-            finally
-            {
-                reader.Dispose();
+                return serializer.Deserialize(xmlReader) as UANodeSet;
             }
         }
 
@@ -103,7 +98,7 @@ namespace Opc.Ua.Export
                 Array.Copy(this.Aliases, aliases, this.Aliases.Length);
             }
 
-            aliases[count-1] = new NodeIdAlias() { Alias = alias, Value = Export(nodeId, context.NamespaceUris) };
+            aliases[count - 1] = new NodeIdAlias() { Alias = alias, Value = Export(nodeId, context.NamespaceUris) };
             this.Aliases = aliases;
         }
 
@@ -123,7 +118,7 @@ namespace Opc.Ua.Export
         /// <summary>
         /// Adds a node to the set.
         /// </summary>
-        public void Export(ISystemContext context, NodeState node, bool outputRedundantNames =true)
+        public void Export(ISystemContext context, NodeState node, bool outputRedundantNames = true)
         {
             if (node == null) throw new ArgumentNullException(nameof(node));
 
@@ -175,7 +170,7 @@ namespace Opc.Ua.Export
                         encoder.WriteVariantContents(variant.Value, variant.TypeInfo);
 
                         XmlDocument document = new XmlDocument();
-                        document.InnerXml = encoder.Close();
+                        document.LoadInnerXml(encoder.Close());
                         value.Value = document.DocumentElement;
                     }
 
@@ -238,7 +233,7 @@ namespace Opc.Ua.Export
                         encoder.WriteVariantContents(variant.Value, variant.TypeInfo);
 
                         XmlDocument document = new XmlDocument();
-                        document.InnerXml = encoder.Close();
+                        document.LoadInnerXml(encoder.Close());
                         value.Value = document.DocumentElement;
                     }
 
@@ -292,7 +287,7 @@ namespace Opc.Ua.Export
             }
             else
             {
-                exportedNode.Description = new LocalizedText[0];
+                exportedNode.Description = Array.Empty<LocalizedText>();
             }
 
             exportedNode.Documentation = node.NodeSetDocumentation;
@@ -351,7 +346,7 @@ namespace Opc.Ua.Export
                 Array.Copy(this.Items, nodes, this.Items.Length);
             }
 
-            nodes[count-1] = exportedNode;
+            nodes[count - 1] = exportedNode;
 
             this.Items = nodes;
 
@@ -957,7 +952,7 @@ namespace Opc.Ua.Export
                         }
                         else
                         {
-                            output.DisplayName = new LocalizedText[0];
+                            output.DisplayName = Array.Empty<LocalizedText>();
                         }
 
                         output.Description = Export(new Opc.Ua.LocalizedText[] { field.Description });
@@ -1042,7 +1037,7 @@ namespace Opc.Ua.Export
                             {
                                 output.IsOptional = false;
                             }
-                            else if(sd.StructureType == (StructureType)3 || //StructureType.StructureWithSubtypedValues ||
+                            else if (sd.StructureType == (StructureType)3 || //StructureType.StructureWithSubtypedValues ||
                                     sd.StructureType == (StructureType)4)   //StructureType.UnionWithSubtypedValues)
                             {
                                 output.IsOptional = field.AllowSubTypes;
@@ -1255,7 +1250,7 @@ namespace Opc.Ua.Export
                 {
                     if (this.NamespaceUris[ii] == targetUri)
                     {
-                        return (ushort)(ii+1); // add 1 to adjust for the well-known URIs which are not stored.
+                        return (ushort)(ii + 1); // add 1 to adjust for the well-known URIs which are not stored.
                     }
                 }
 
@@ -1270,7 +1265,7 @@ namespace Opc.Ua.Export
                 Array.Copy(this.NamespaceUris, uris, count - 1);
             }
 
-            uris[count-1] = targetUri;
+            uris[count - 1] = targetUri;
             this.NamespaceUris = uris;
 
             // return the new index.
@@ -1289,13 +1284,13 @@ namespace Opc.Ua.Export
             }
 
             // return a bad value if parameters are bad.
-            if (namespaceUris == null || this.NamespaceUris == null || this.NamespaceUris.Length <= namespaceIndex-1)
+            if (namespaceUris == null || this.NamespaceUris == null || this.NamespaceUris.Length <= namespaceIndex - 1)
             {
                 return UInt16.MaxValue;
             }
 
             // find or append uri.
-            return namespaceUris.GetIndexOrAppend(this.NamespaceUris[namespaceIndex-1]);
+            return namespaceUris.GetIndexOrAppend(this.NamespaceUris[namespaceIndex - 1]);
         }
 
         /// <summary>
@@ -1318,7 +1313,7 @@ namespace Opc.Ua.Export
             }
 
             // find an existing index.
-            int count = 1;;
+            int count = 1; ;
 
             if (this.NamespaceUris != null)
             {
@@ -1390,7 +1385,7 @@ namespace Opc.Ua.Export
                 Array.Copy(this.ServerUris, uris, count - 1);
             }
 
-            uris[count-1] = targetUri;
+            uris[count - 1] = targetUri;
             this.ServerUris = uris;
 
             // return the new index.
@@ -1409,7 +1404,7 @@ namespace Opc.Ua.Export
             }
 
             // return a bad value if parameters are bad.
-            if (serverUris == null ||  this.ServerUris == null || this.ServerUris.Length <= serverIndex-1)
+            if (serverUris == null || this.ServerUris == null || this.ServerUris.Length <= serverIndex - 1)
             {
                 return UInt16.MaxValue;
             }

--- a/Stack/Opc.Ua.Core/Stack/Configuration/ApplicationConfiguration.cs
+++ b/Stack/Opc.Ua.Core/Stack/Configuration/ApplicationConfiguration.cs
@@ -48,8 +48,7 @@ namespace Opc.Ua
                 element = element.NextSibling;
             }
 
-            XmlReader reader = XmlReader.Create(new StringReader(element.OuterXml),
-                new XmlReaderSettings() { DtdProcessing = DtdProcessing.Prohibit, XmlResolver = null });
+            XmlReader reader = XmlReader.Create(new StringReader(element.OuterXml), Utils.DefaultXmlReaderSettings());
 
             try
             {

--- a/Stack/Opc.Ua.Core/Stack/Configuration/ApplicationConfiguration.cs
+++ b/Stack/Opc.Ua.Core/Stack/Configuration/ApplicationConfiguration.cs
@@ -48,7 +48,8 @@ namespace Opc.Ua
                 element = element.NextSibling;
             }
 
-            XmlReader reader = XmlReader.Create(new StringReader(element.OuterXml));
+            XmlReader reader = XmlReader.Create(new StringReader(element.OuterXml),
+                new XmlReaderSettings() { DtdProcessing = DtdProcessing.Prohibit, XmlResolver = null });
 
             try
             {

--- a/Stack/Opc.Ua.Core/Stack/Configuration/SecurityConfigurationManager.cs
+++ b/Stack/Opc.Ua.Core/Stack/Configuration/SecurityConfigurationManager.cs
@@ -245,8 +245,11 @@ namespace Opc.Ua.Security
 
             // load from file.
             XmlDocument document = new XmlDocument();
-            document.Load(new FileStream(filePath, FileMode.Open));
-
+            using (var stream = new FileStream(filePath, FileMode.Open))
+            using (var xmlReader = XmlReader.Create(stream, Utils.DefaultXmlReaderSettings()))
+            {
+                document.Load(xmlReader);
+            }
             XmlElement element = Find(document.DocumentElement, "SecuredApplication", Namespaces.OpcUaSecurity);
 
             // update secured application.
@@ -377,7 +380,7 @@ namespace Opc.Ua.Security
 
                 // must extract the inner xml.
                 XmlDocument document = new XmlDocument();
-                document.InnerXml = Encoding.UTF8.GetString(memoryStream.ToArray());
+                document.LoadInnerXml(Encoding.UTF8.GetString(memoryStream.ToArray()));
                 return document.DocumentElement.InnerXml;
             }
         }

--- a/Stack/Opc.Ua.Core/Stack/Nodes/NodeSet.cs
+++ b/Stack/Opc.Ua.Core/Stack/Nodes/NodeSet.cs
@@ -18,7 +18,7 @@ using System.Text;
 using System.Xml;
 
 namespace Opc.Ua
-{    
+{
     /// <summary>
     /// A set of nodes in an address space.
     /// </summary>
@@ -31,7 +31,7 @@ namespace Opc.Ua
     [KnownType(typeof(DataTypeNode))]
     [KnownType(typeof(ReferenceTypeNode))]
     [KnownType(typeof(ViewNode))]
-    public partial class NodeSet  : IEnumerable<Node>
+    public partial class NodeSet : IEnumerable<Node>
     {
         #region Constructors
         /// <summary>
@@ -41,9 +41,9 @@ namespace Opc.Ua
         {
             m_namespaceUris = new NamespaceTable();
             m_serverUris = new StringTable();
-            m_nodes = new Dictionary<NodeId,Node>();
+            m_nodes = new Dictionary<NodeId, Node>();
         }
-        
+
         /// <summary>
         /// Loads a nodeset from a stream.
         /// </summary>
@@ -51,20 +51,13 @@ namespace Opc.Ua
         /// <returns>The set of nodes</returns>
         public static NodeSet Read(Stream istrm)
         {
-            XmlReader reader = XmlReader.Create(istrm,
-                new XmlReaderSettings() { DtdProcessing = DtdProcessing.Prohibit, XmlResolver = null });
-            
-            try
+            using (XmlReader reader = XmlReader.Create(istrm, Utils.DefaultXmlReaderSettings()))
             {
                 DataContractSerializer serializer = new DataContractSerializer(typeof(NodeSet));
                 return serializer.ReadObject(reader) as NodeSet;
             }
-            finally
-            {
-                reader.Dispose();
-            }
         }
-        
+
         /// <summary>
         /// Write a nodeset to a stream.
         /// </summary>
@@ -75,7 +68,7 @@ namespace Opc.Ua
             settings.Encoding = Encoding.UTF8;
             settings.Indent = true;
             XmlWriter writer = XmlWriter.Create(istrm, settings);
-                        
+
             try
             {
                 DataContractSerializer serializer = new DataContractSerializer(typeof(NodeSet));
@@ -88,7 +81,7 @@ namespace Opc.Ua
             }
         }
         #endregion
-        
+
         #region IEnumerable<IReference> Members
         /// <summary>
         /// Returns an enumerator that iterates through the collection.
@@ -131,7 +124,7 @@ namespace Opc.Ua
             {
                 throw new ArgumentException("A non-null NodeId must be specified.");
             }
-            
+
             if (m_nodes.ContainsKey(node.NodeId))
             {
                 throw new ArgumentException(Utils.Format("NodeID {0} already exists for node: {1}", node.NodeId, node));
@@ -160,7 +153,7 @@ namespace Opc.Ua
             {
                 dimensions[ii] = array.GetLength(ii);
             }
-            
+
             int length = array.Length;
             int[] indexes = new int[dimensions.Length];
 
@@ -171,11 +164,11 @@ namespace Opc.Ua
                 for (int jj = 0; jj < indexes.Length; jj++)
                 {
                     divisor /= dimensions[jj];
-                    indexes[jj] = (ii/divisor)%dimensions[jj];
+                    indexes[jj] = (ii / divisor) % dimensions[jj];
                 }
-                
+
                 object element = array.GetValue(indexes);
-                        
+
                 if (element != null)
                 {
                     if (elementType == BuiltInType.Variant)
@@ -184,7 +177,7 @@ namespace Opc.Ua
                     }
 
                     element = TranslateValue(element, namespaceUris, serverUris);
-                    
+
                     if (elementType == BuiltInType.Variant)
                     {
                         element = new Variant(element);
@@ -203,7 +196,7 @@ namespace Opc.Ua
         /// <param name="serverUris">The server URIs.</param>
         /// <returns>Translated value.</returns>
         private object TranslateValue(object value, NamespaceTable namespaceUris, StringTable serverUris)
-        {            
+        {
             TypeInfo typeInfo = TypeInfo.Construct(value);
 
             // do nothing for unknown types.
@@ -249,7 +242,7 @@ namespace Opc.Ua
                     return value;
                 }
             }
-                   
+
             return value;
         }
 
@@ -269,7 +262,7 @@ namespace Opc.Ua
 
             node.NodeId = Translate(nodeToExport.NodeId, m_namespaceUris, namespaceUris);
             node.BrowseName = Translate(nodeToExport.BrowseName, m_namespaceUris, namespaceUris);
-            
+
             VariableNode variableToExport = nodeToExport as VariableNode;
 
             if (variableToExport != null)
@@ -281,7 +274,7 @@ namespace Opc.Ua
 
                 variableNode.DataType = Translate(variableToExport.DataType, m_namespaceUris, namespaceUris);
             }
-            
+
             VariableTypeNode variableTypeToExport = nodeToExport as VariableTypeNode;
 
             if (variableTypeToExport != null)
@@ -299,8 +292,8 @@ namespace Opc.Ua
                 ReferenceNode reference = new ReferenceNode();
 
                 reference.ReferenceTypeId = Translate(referenceToExport.ReferenceTypeId, m_namespaceUris, namespaceUris);
-                reference.IsInverse       = referenceToExport.IsInverse;
-                reference.TargetId        = Translate(referenceToExport.TargetId, m_namespaceUris, m_serverUris, namespaceUris, serverUris); 
+                reference.IsInverse = referenceToExport.IsInverse;
+                reference.TargetId = Translate(referenceToExport.TargetId, m_namespaceUris, m_serverUris, namespaceUris, serverUris);
 
                 node.References.Add(reference);
             }
@@ -323,7 +316,7 @@ namespace Opc.Ua
 
             reference.ReferenceTypeId = Translate(referenceToExport.ReferenceTypeId, m_namespaceUris, namespaceUris);
             reference.IsInverse = referenceToExport.IsInverse;
-            reference.TargetId = Translate(referenceToExport.TargetId, m_namespaceUris, m_serverUris, namespaceUris, serverUris); 
+            reference.TargetId = Translate(referenceToExport.TargetId, m_namespaceUris, m_serverUris, namespaceUris, serverUris);
 
             node.References.Add(reference);
         }
@@ -339,8 +332,8 @@ namespace Opc.Ua
         public bool Remove(NodeId nodeId)
         {
             return m_nodes.Remove(nodeId);
-        }        
-        
+        }
+
         /// <summary>
         /// Returns true if the node exists in the nodeset.
         /// </summary>
@@ -355,7 +348,7 @@ namespace Opc.Ua
         {
             return m_nodes.ContainsKey(nodeId);
         }
-        
+
         /// <summary>
         /// Returns the node in the set.
         /// </summary>
@@ -374,8 +367,8 @@ namespace Opc.Ua
             }
 
             return null;
-        }        
-        
+        }
+
         /// <summary>
         /// Returns the node in the set.
         /// </summary>
@@ -397,10 +390,10 @@ namespace Opc.Ua
             {
                 return null;
             }
-            
+
             // check for unknown namespace uri.
             int nsIndex = m_namespaceUris.GetIndex(ns);
-            
+
             if (nsIndex < 0)
             {
                 return null;
@@ -418,8 +411,8 @@ namespace Opc.Ua
             }
 
             return null;
-        }        
-        
+        }
+
         /// <summary>
         /// Translates all namespace/server indexes in attributes or references and returns a copy of the node.
         /// </summary>
@@ -443,22 +436,22 @@ namespace Opc.Ua
             {
                 VariableNode variable = (VariableNode)node;
 
-                variable.DataType = Translate(variableToImport.DataType, namespaceUris, m_namespaceUris); 
+                variable.DataType = Translate(variableToImport.DataType, namespaceUris, m_namespaceUris);
 
                 if (variableToImport.Value.Value != null)
                 {
                     variable.Value = new Variant(ImportValue(variableToImport.Value.Value, namespaceUris, serverUris));
                 }
             }
-            
+
             VariableTypeNode variableTypeToImport = nodeToImport as VariableTypeNode;
 
             if (variableTypeToImport != null)
             {
                 VariableTypeNode variableType = (VariableTypeNode)node;
 
-                variableType.DataType = Translate(variableTypeToImport.DataType, namespaceUris, m_namespaceUris); 
-                
+                variableType.DataType = Translate(variableTypeToImport.DataType, namespaceUris, m_namespaceUris);
+
                 if (variableTypeToImport.Value.Value != null)
                 {
                     variableType.Value = new Variant(ImportValue(variableTypeToImport.Value.Value, namespaceUris, serverUris));
@@ -470,8 +463,8 @@ namespace Opc.Ua
                 ReferenceNode reference = new ReferenceNode();
 
                 reference.ReferenceTypeId = Translate(referenceToImport.ReferenceTypeId, namespaceUris, m_namespaceUris);
-                reference.IsInverse       = referenceToImport.IsInverse;
-                reference.TargetId        = Translate(referenceToImport.TargetId, namespaceUris, serverUris, m_namespaceUris, m_serverUris); 
+                reference.IsInverse = referenceToImport.IsInverse;
+                reference.TargetId = Translate(referenceToImport.TargetId, namespaceUris, serverUris, m_namespaceUris, m_serverUris);
 
                 node.References.Add(reference);
             }
@@ -509,21 +502,21 @@ namespace Opc.Ua
                 return copy;
             }
 
-            NodeId nodeId = value as NodeId; 
+            NodeId nodeId = value as NodeId;
 
             if (nodeId != null)
             {
                 return Import(nodeId, namespaceUris);
             }
 
-            ExpandedNodeId expandedNodeId = value as ExpandedNodeId; 
+            ExpandedNodeId expandedNodeId = value as ExpandedNodeId;
 
             if (expandedNodeId != null)
             {
                 return Import(expandedNodeId, namespaceUris, serverUris);
             }
 
-            ExtensionObject extension = value as ExtensionObject; 
+            ExtensionObject extension = value as ExtensionObject;
 
             if (extension != null)
             {
@@ -537,7 +530,7 @@ namespace Opc.Ua
 
             return value;
         }
-                
+
         /// <summary>
         /// Updates the nodeset string tables and returns a NodeId that references those tables.
         /// </summary>
@@ -548,7 +541,7 @@ namespace Opc.Ua
         {
             return Translate(nodeId, m_namespaceUris, namespaceUris);
         }
-        
+
         /// <summary>
         /// Updates the specified namespace tables and returns a NodeId that references those tables.
         /// </summary>
@@ -559,7 +552,7 @@ namespace Opc.Ua
         {
             return Translate(nodeId, namespaceUris, m_namespaceUris);
         }
-        
+
         /// <summary>
         /// Updates the nodeset string tables and returns a NodeId that references those tables.
         /// </summary>
@@ -571,7 +564,7 @@ namespace Opc.Ua
         {
             return Translate(nodeId, m_namespaceUris, m_serverUris, namespaceUris, serverUris);
         }
-        
+
         /// <summary>
         /// Updates the specified string tables and returns a NodeId that references those tables.
         /// </summary>
@@ -584,19 +577,19 @@ namespace Opc.Ua
             return Translate(nodeId, namespaceUris, serverUris, m_namespaceUris, m_serverUris);
         }
         #endregion
-        
+
         #region Private Members
-		/// <summary>
-		/// The table of namespaces.
-		/// </summary>
-		[DataMember(Name = "NamespaceUris", Order = 1)]
+        /// <summary>
+        /// The table of namespaces.
+        /// </summary>
+        [DataMember(Name = "NamespaceUris", Order = 1)]
         internal StringCollection NamespaceUris
         {
-            get 
-            { 
+            get
+            {
                 return new StringCollection(m_namespaceUris.ToArray());
             }
-            
+
             set
             {
                 if (value == null)
@@ -609,18 +602,18 @@ namespace Opc.Ua
                 }
             }
         }
-        
-		/// <summary>
-		/// The table of servers.
-		/// </summary>
-		[DataMember(Name = "ServerUris", Order = 2)]
+
+        /// <summary>
+        /// The table of servers.
+        /// </summary>
+        [DataMember(Name = "ServerUris", Order = 2)]
         internal StringCollection ServerUris
         {
-            get 
-            { 
+            get
+            {
                 return new StringCollection(m_serverUris.ToArray());
             }
-            
+
             set
             {
                 if (value == null)
@@ -633,21 +626,21 @@ namespace Opc.Ua
                 }
             }
         }
-        
-		/// <summary>
-		/// The table of nodes.
-		/// </summary>
-		[DataMember(Name = "Nodes", Order = 3)]
+
+        /// <summary>
+        /// The table of nodes.
+        /// </summary>
+        [DataMember(Name = "Nodes", Order = 3)]
         internal NodeCollection Nodes
         {
-            get 
-            { 
+            get
+            {
                 return new NodeCollection(m_nodes.Values);
             }
-            
+
             set
             {
-                m_nodes = new Dictionary<NodeId,Node>();
+                m_nodes = new Dictionary<NodeId, Node>();
 
                 if (value != null)
                 {
@@ -667,8 +660,8 @@ namespace Opc.Ua
         /// <param name="sourceNamespaceUris">The source namespace URIs.</param>
         /// <returns>A NodeId that references those tables.</returns>
         private static NodeId Translate(
-            NodeId nodeId, 
-            NamespaceTable targetNamespaceUris, 
+            NodeId nodeId,
+            NamespaceTable targetNamespaceUris,
             NamespaceTable sourceNamespaceUris)
         {
             if (targetNamespaceUris == null) throw new ArgumentNullException(nameof(targetNamespaceUris));
@@ -680,7 +673,7 @@ namespace Opc.Ua
             }
 
             ushort namespaceIndex = 0;
-            
+
             if (nodeId.NamespaceIndex > 0)
             {
                 string uri = sourceNamespaceUris.GetString(nodeId.NamespaceIndex);
@@ -697,7 +690,7 @@ namespace Opc.Ua
 
             return new NodeId(nodeId.Identifier, namespaceIndex);
         }
-        
+
         /// <summary>
         /// Updates the nodeset string tables and returns a NodeId that references those tables.
         /// </summary>
@@ -706,8 +699,8 @@ namespace Opc.Ua
         /// <param name="sourceNamespaceUris">The source namespace URIs.</param>
         /// <returns>A NodeId that references those tables.</returns>
         private static QualifiedName Translate(
-            QualifiedName  qname, 
-            NamespaceTable targetNamespaceUris, 
+            QualifiedName qname,
+            NamespaceTable targetNamespaceUris,
             NamespaceTable sourceNamespaceUris)
         {
             if (targetNamespaceUris == null) throw new ArgumentNullException(nameof(targetNamespaceUris));
@@ -719,7 +712,7 @@ namespace Opc.Ua
             }
 
             ushort namespaceIndex = 0;
-            
+
             if (qname.NamespaceIndex > 0)
             {
                 string uri = sourceNamespaceUris.GetString(qname.NamespaceIndex);
@@ -740,7 +733,7 @@ namespace Opc.Ua
             }
 
             return new QualifiedName(qname.Name, namespaceIndex);
-        }        
+        }
 
         /// <summary>
         /// Updates the nodeset string tables and returns a NodeId that references those tables.
@@ -752,15 +745,15 @@ namespace Opc.Ua
         /// <param name="sourceServerUris">The source server URIs.</param>
         /// <returns>A NodeId that references those tables.</returns>
         private static ExpandedNodeId Translate(
-            ExpandedNodeId nodeId, 
-            NamespaceTable targetNamespaceUris, 
-            StringTable    targetServerUris, 
-            NamespaceTable sourceNamespaceUris, 
-            StringTable    sourceServerUris)
+            ExpandedNodeId nodeId,
+            NamespaceTable targetNamespaceUris,
+            StringTable targetServerUris,
+            NamespaceTable sourceNamespaceUris,
+            StringTable sourceServerUris)
         {
             if (targetNamespaceUris == null) throw new ArgumentNullException(nameof(targetNamespaceUris));
             if (sourceNamespaceUris == null) throw new ArgumentNullException(nameof(sourceNamespaceUris));
-        
+
             if (nodeId.ServerIndex > 0)
             {
                 if (targetServerUris == null) throw new ArgumentNullException(nameof(targetServerUris));
@@ -776,11 +769,11 @@ namespace Opc.Ua
             {
                 return Translate((NodeId)nodeId, targetNamespaceUris, sourceNamespaceUris);
             }
-             
+
             string namespaceUri = nodeId.NamespaceUri;
-           
+
             if (nodeId.ServerIndex > 0)
-            {                
+            {
                 if (String.IsNullOrEmpty(namespaceUri))
                 {
                     namespaceUri = sourceNamespaceUris.GetString(nodeId.NamespaceIndex);
@@ -794,10 +787,10 @@ namespace Opc.Ua
                 {
                     index = targetServerUris.Append(serverUri);
                 }
-                
+
                 return new ExpandedNodeId(new NodeId(nodeId.Identifier, 0), namespaceUri, (uint)index);
             }
-            
+
             ushort namespaceIndex = 0;
 
             if (!String.IsNullOrEmpty(namespaceUri))
@@ -815,11 +808,11 @@ namespace Opc.Ua
             return new NodeId(nodeId.Identifier, namespaceIndex);
         }
         #endregion
-        
+
         #region Private Fields
         private NamespaceTable m_namespaceUris;
         private StringTable m_serverUris;
-        private Dictionary<NodeId,Node> m_nodes;
+        private Dictionary<NodeId, Node> m_nodes;
         #endregion
     }
 }

--- a/Stack/Opc.Ua.Core/Stack/Nodes/NodeSet.cs
+++ b/Stack/Opc.Ua.Core/Stack/Nodes/NodeSet.cs
@@ -51,7 +51,8 @@ namespace Opc.Ua
         /// <returns>The set of nodes</returns>
         public static NodeSet Read(Stream istrm)
         {
-            XmlReader reader = XmlReader.Create(istrm);
+            XmlReader reader = XmlReader.Create(istrm,
+                new XmlReaderSettings() { DtdProcessing = DtdProcessing.Prohibit, XmlResolver = null });
             
             try
             {

--- a/Stack/Opc.Ua.Core/Stack/State/NodeState.cs
+++ b/Stack/Opc.Ua.Core/Stack/State/NodeState.cs
@@ -1201,13 +1201,7 @@ namespace Opc.Ua
         /// <param name="input">The stream to read.</param>
         public void LoadFromXml(ISystemContext context, TextReader input)
         {
-            XmlReaderSettings settings = new XmlReaderSettings() {
-                DtdProcessing = DtdProcessing.Prohibit,
-                XmlResolver = null,
-                ConformanceLevel = ConformanceLevel.Document
-            };
-
-            using (XmlReader reader = XmlReader.Create(input, settings))
+            using (XmlReader reader = XmlReader.Create(input, Utils.DefaultXmlReaderSettings()))
             {
                 LoadFromXml(context, reader);
             }
@@ -1220,13 +1214,7 @@ namespace Opc.Ua
         /// <param name="input">The stream to read.</param>
         public void LoadFromXml(ISystemContext context, Stream input)
         {
-            XmlReaderSettings settings = new XmlReaderSettings() {
-                DtdProcessing = DtdProcessing.Prohibit,
-                XmlResolver = null,
-                ConformanceLevel = ConformanceLevel.Document
-            };
-
-            using (XmlReader reader = XmlReader.Create(input, settings))
+            using (XmlReader reader = XmlReader.Create(input, Utils.DefaultXmlReaderSettings()))
             {
                 LoadFromXml(context, reader);
             }

--- a/Stack/Opc.Ua.Core/Stack/State/NodeState.cs
+++ b/Stack/Opc.Ua.Core/Stack/State/NodeState.cs
@@ -1201,8 +1201,11 @@ namespace Opc.Ua
         /// <param name="input">The stream to read.</param>
         public void LoadFromXml(ISystemContext context, TextReader input)
         {
-            XmlReaderSettings settings = new XmlReaderSettings();
-            settings.ConformanceLevel = ConformanceLevel.Document;
+            XmlReaderSettings settings = new XmlReaderSettings() {
+                DtdProcessing = DtdProcessing.Prohibit,
+                XmlResolver = null,
+                ConformanceLevel = ConformanceLevel.Document
+            };
 
             using (XmlReader reader = XmlReader.Create(input, settings))
             {
@@ -1217,8 +1220,11 @@ namespace Opc.Ua
         /// <param name="input">The stream to read.</param>
         public void LoadFromXml(ISystemContext context, Stream input)
         {
-            XmlReaderSettings settings = new XmlReaderSettings();
-            settings.ConformanceLevel = ConformanceLevel.Document;
+            XmlReaderSettings settings = new XmlReaderSettings() {
+                DtdProcessing = DtdProcessing.Prohibit,
+                XmlResolver = null,
+                ConformanceLevel = ConformanceLevel.Document
+            };
 
             using (XmlReader reader = XmlReader.Create(input, settings))
             {

--- a/Stack/Opc.Ua.Core/Stack/State/NodeStateCollection.cs
+++ b/Stack/Opc.Ua.Core/Stack/State/NodeStateCollection.cs
@@ -333,12 +333,7 @@ namespace Opc.Ua
             messageContext.ServerUris = context.ServerUris;
             messageContext.Factory = context.EncodeableFactory;
 
-            XmlReaderSettings settings = new XmlReaderSettings() {
-                DtdProcessing = DtdProcessing.Prohibit,
-                XmlResolver = null
-            };
-
-            using (XmlReader reader = XmlReader.Create(istrm, settings))
+            using (XmlReader reader = XmlReader.Create(istrm, Utils.DefaultXmlReaderSettings()))
             {
                 XmlQualifiedName root = new XmlQualifiedName("ListOfNodeState", Namespaces.OpcUaXsd);
                 XmlDecoder decoder = new XmlDecoder(null, reader, messageContext);

--- a/Stack/Opc.Ua.Core/Stack/State/NodeStateCollection.cs
+++ b/Stack/Opc.Ua.Core/Stack/State/NodeStateCollection.cs
@@ -333,7 +333,12 @@ namespace Opc.Ua
             messageContext.ServerUris = context.ServerUris;
             messageContext.Factory = context.EncodeableFactory;
 
-            using (XmlReader reader = XmlReader.Create(istrm))
+            XmlReaderSettings settings = new XmlReaderSettings() {
+                DtdProcessing = DtdProcessing.Prohibit,
+                XmlResolver = null
+            };
+
+            using (XmlReader reader = XmlReader.Create(istrm, settings))
             {
                 XmlQualifiedName root = new XmlQualifiedName("ListOfNodeState", Namespaces.OpcUaXsd);
                 XmlDecoder decoder = new XmlDecoder(null, reader, messageContext);

--- a/Stack/Opc.Ua.Core/Types/BuiltIn/ExtensionObject.cs
+++ b/Stack/Opc.Ua.Core/Types/BuiltIn/ExtensionObject.cs
@@ -750,7 +750,7 @@ namespace Opc.Ua
 
                 // create document from encoder.
                 XmlDocument document = new XmlDocument();
-                document.InnerXml = encoder.Close();
+                document.LoadInnerXml(encoder.Close());
 
                 // return root element.
                 return document.DocumentElement;

--- a/Stack/Opc.Ua.Core/Types/BuiltIn/Variant.cs
+++ b/Stack/Opc.Ua.Core/Types/BuiltIn/Variant.cs
@@ -780,7 +780,7 @@ namespace Opc.Ua
 
                 // create document from encoder.
                 XmlDocument document = new XmlDocument();
-                document.InnerXml = encoder.Close();
+                document.LoadInnerXml(encoder.Close());
 
                 // return element.
                 return document.DocumentElement;

--- a/Stack/Opc.Ua.Core/Types/Encoders/BinaryDecoder.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/BinaryDecoder.cs
@@ -508,9 +508,8 @@ namespace Opc.Ua
                 // If 0 terminated, decrease length by one before converting to string
                 var utf8StringLength = bytes[bytes.Length - 1] == 0 ? bytes.Length - 1 : bytes.Length;
                 string xmlString = Encoding.UTF8.GetString(bytes, 0, utf8StringLength);
-
-                using (XmlReader reader = XmlReader.Create(new StringReader(xmlString), new XmlReaderSettings()
-                    { DtdProcessing = DtdProcessing.Prohibit, XmlResolver = null }))
+                using (StringReader stream = new StringReader(xmlString))
+                using (XmlReader reader = XmlReader.Create(stream, Utils.DefaultXmlReaderSettings()))
                 {
                     document.Load(reader);
                 }

--- a/Stack/Opc.Ua.Core/Types/Encoders/BinaryDecoder.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/BinaryDecoder.cs
@@ -510,7 +510,7 @@ namespace Opc.Ua
                 string xmlString = Encoding.UTF8.GetString(bytes, 0, utf8StringLength);
 
                 using (XmlReader reader = XmlReader.Create(new StringReader(xmlString), new XmlReaderSettings()
-                    { DtdProcessing = System.Xml.DtdProcessing.Prohibit }))
+                    { DtdProcessing = DtdProcessing.Prohibit, XmlResolver = null }))
                 {
                     document.Load(reader);
                 }

--- a/Stack/Opc.Ua.Core/Types/Encoders/EncodableObject.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/EncodableObject.cs
@@ -24,19 +24,19 @@ namespace Opc.Ua
     public abstract class EncodeableObject : IEncodeable
     {
         #region IEncodeable Methods
-        /// <summary cref="IEncodeable.TypeId" />
+        /// <inheritdoc/>
         public abstract ExpandedNodeId TypeId { get; }
 
-        /// <summary cref="IEncodeable.BinaryEncodingId" />
+        /// <inheritdoc/>
         public abstract ExpandedNodeId BinaryEncodingId { get; }
 
-        /// <summary cref="IEncodeable.XmlEncodingId" />
+        /// <inheritdoc/>
         public abstract ExpandedNodeId XmlEncodingId { get; }
 
-        /// <summary cref="IEncodeable.Encode" />
+        /// <inheritdoc/>
         public virtual void Encode(IEncoder encoder) { }
 
-        /// <summary cref="IEncodeable.Decode" />
+        /// <inheritdoc/>
 		public virtual void Decode(IDecoder decoder) { }
 
         /// <summary>
@@ -182,7 +182,7 @@ namespace Opc.Ua
 
             // create document from encoder.
             XmlDocument document = new XmlDocument();
-            document.InnerXml = encoder.Close();
+            document.LoadInnerXml(encoder.Close());
 
             // return root element.
             return document.DocumentElement;

--- a/Stack/Opc.Ua.Core/Types/Encoders/JsonDecoder.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/JsonDecoder.cs
@@ -846,7 +846,7 @@ namespace Opc.Ua
                 string xmlString = new UTF8Encoding().GetString(bytes, 0, bytes.Length);
 
                 using (XmlReader reader = XmlReader.Create(new StringReader(xmlString),
-                    new XmlReaderSettings() { DtdProcessing = System.Xml.DtdProcessing.Prohibit }))
+                    new XmlReaderSettings() { DtdProcessing = DtdProcessing.Prohibit, XmlResolver = null }))
                 {
                     document.Load(reader);
                 }

--- a/Stack/Opc.Ua.Core/Types/Encoders/JsonDecoder.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/JsonDecoder.cs
@@ -621,15 +621,15 @@ namespace Opc.Ua
                 {
                     if (text != null)
                     {
-                        if (String.Compare(text, "Infinity", StringComparison.OrdinalIgnoreCase) == 0)
+                        if (String.Equals(text, "Infinity", StringComparison.OrdinalIgnoreCase))
                         {
                             return Single.PositiveInfinity;
                         }
-                        else if (String.Compare(text, "-Infinity", StringComparison.OrdinalIgnoreCase) == 0)
+                        else if (String.Equals(text, "-Infinity", StringComparison.OrdinalIgnoreCase))
                         {
                             return Single.NegativeInfinity;
                         }
-                        else if (String.Compare(text, "NaN", StringComparison.OrdinalIgnoreCase) == 0)
+                        else if (String.Equals(text, "NaN", StringComparison.OrdinalIgnoreCase))
                         {
                             return Single.NaN;
                         }
@@ -679,15 +679,15 @@ namespace Opc.Ua
                 {
                     if (text != null)
                     {
-                        if (String.Compare(text, "Infinity", StringComparison.OrdinalIgnoreCase) == 0)
+                        if (String.Equals(text, "Infinity", StringComparison.OrdinalIgnoreCase))
                         {
                             return Double.PositiveInfinity;
                         }
-                        else if (String.Compare(text, "-Infinity", StringComparison.OrdinalIgnoreCase) == 0)
+                        else if (String.Equals(text, "-Infinity", StringComparison.OrdinalIgnoreCase))
                         {
                             return Double.NegativeInfinity;
                         }
-                        else if (String.Compare(text, "NaN", StringComparison.OrdinalIgnoreCase) == 0)
+                        else if (String.Equals(text, "NaN", StringComparison.OrdinalIgnoreCase))
                         {
                             return Double.NaN;
                         }
@@ -806,7 +806,7 @@ namespace Opc.Ua
             var value = token as string;
             if (value == null)
             {
-                return new byte[0];
+                return Array.Empty<byte>();
             }
 
             var bytes = Convert.FromBase64String(value);
@@ -845,8 +845,7 @@ namespace Opc.Ua
                 XmlDocument document = new XmlDocument();
                 string xmlString = new UTF8Encoding().GetString(bytes, 0, bytes.Length);
 
-                using (XmlReader reader = XmlReader.Create(new StringReader(xmlString),
-                    new XmlReaderSettings() { DtdProcessing = DtdProcessing.Prohibit, XmlResolver = null }))
+                using (XmlReader reader = XmlReader.Create(new StringReader(xmlString), Utils.DefaultXmlReaderSettings()))
                 {
                     document.Load(reader);
                 }
@@ -1417,7 +1416,7 @@ namespace Opc.Ua
                 if (encoding == (byte)ExtensionObjectEncoding.Binary)
                 {
                     var bytes = ReadByteString("Body");
-                    return new ExtensionObject(typeId, bytes ?? new byte[0]);
+                    return new ExtensionObject(typeId, bytes ?? Array.Empty<byte>());
                 }
 
                 if (encoding == (byte)ExtensionObjectEncoding.Xml)
@@ -2870,7 +2869,7 @@ namespace Opc.Ua
 
                 case IdType.Opaque:
                 {
-                    return new NodeId(new byte[0], namespaceIndex);
+                    return new NodeId(Array.Empty<byte>(), namespaceIndex);
                 }
 
                 case IdType.String:

--- a/Stack/Opc.Ua.Core/Types/Encoders/XmlDecoder.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/XmlDecoder.cs
@@ -562,7 +562,8 @@ namespace Opc.Ua
             // return undecoded xml body.
             var xmlString = m_reader.ReadOuterXml();
 
-            using (XmlReader reader = XmlReader.Create(new StringReader(xmlString), new XmlReaderSettings() { DtdProcessing = System.Xml.DtdProcessing.Prohibit }))
+            using (StringReader stream = new StringReader(xmlString))
+            using (XmlReader reader = XmlReader.Create(stream, Utils.DefaultXmlReaderSettings()))
             {
                 document.Load(reader);
             }
@@ -989,7 +990,7 @@ namespace Opc.Ua
                 }
                 else
                 {
-                    value = new byte[0];
+                    value = Array.Empty<byte>();
                 }
 
                 // check the length.
@@ -1004,7 +1005,7 @@ namespace Opc.Ua
 
             if (!isNil)
             {
-                return new byte[0];
+                return Array.Empty<byte>();
             }
 
             return null;

--- a/Stack/Opc.Ua.Core/Types/Schemas/SchemaValidator.cs
+++ b/Stack/Opc.Ua.Core/Types/Schemas/SchemaValidator.cs
@@ -216,16 +216,11 @@ namespace Opc.Ua.Schema
         /// </summary>
         protected static object LoadFile(System.Type type, string path)
         {
-            StreamReader reader = new StreamReader(new FileStream(path, FileMode.Open));
-
-            try
+            using (StreamReader reader = new StreamReader(new FileStream(path, FileMode.Open)))
+            using (XmlReader xmlReader = XmlReader.Create(reader, Utils.DefaultXmlReaderSettings()))
             {
                 XmlSerializer serializer = new XmlSerializer(type);
-                return serializer.Deserialize(reader);
-            }
-            finally
-            {
-                reader.Dispose();
+                return serializer.Deserialize(xmlReader);
             }
         }
 
@@ -234,16 +229,11 @@ namespace Opc.Ua.Schema
         /// </summary>
         protected static object LoadFile(System.Type type, Stream stream)
         {
-            StreamReader reader = new StreamReader(stream);
-
-            try
+            using (StreamReader reader = new StreamReader(stream))
+            using (XmlReader xmlReader = XmlReader.Create(reader, Utils.DefaultXmlReaderSettings()))
             {
                 XmlSerializer serializer = new XmlSerializer(type);
-                return serializer.Deserialize(reader);
-            }
-            finally
-            {
-                reader.Dispose();
+                return serializer.Deserialize(xmlReader);
             }
         }
 
@@ -259,17 +249,13 @@ namespace Opc.Ua.Schema
                     assembly = typeof(SchemaValidator).GetTypeInfo().Assembly;
                 }
 
-                StreamReader reader = new StreamReader(assembly.GetManifestResourceStream(path));
-
-                try
+                using (StreamReader reader = new StreamReader(assembly.GetManifestResourceStream(path)))
+                using (XmlReader xmlReader = XmlReader.Create(reader, Utils.DefaultXmlReaderSettings()))
                 {
                     XmlSerializer serializer = new XmlSerializer(type);
-                    return serializer.Deserialize(reader);
+                    return serializer.Deserialize(xmlReader);
                 }
-                finally
-                {
-                    reader.Dispose();
-                }
+
             }
             catch (Exception e)
             {

--- a/Stack/Opc.Ua.Core/Types/Utils/TypeInfo.cs
+++ b/Stack/Opc.Ua.Core/Types/Utils/TypeInfo.cs
@@ -2324,7 +2324,7 @@ namespace Opc.Ua
 
                     if (text.Length == 0)
                     {
-                        return new byte[0];
+                        return Array.Empty<byte>();
                     }
 
                     using (System.IO.MemoryStream ostrm = new System.IO.MemoryStream())
@@ -2402,7 +2402,7 @@ namespace Opc.Ua
                 case BuiltInType.String:
                 {
                     XmlDocument document = new XmlDocument();
-                    document.InnerXml = (string)value;
+                    document.LoadInnerXml((string)value);
                     return document.DocumentElement;
                 }
             }
@@ -3014,14 +3014,14 @@ namespace Opc.Ua
 
                 if (m_valueRank >= 0)
                 {
-                    buffer.Append("[");
+                    buffer.Append('[');
 
                     for (int ii = 1; ii < m_valueRank; ii++)
                     {
-                        buffer.Append(",");
+                        buffer.Append(',');
                     }
 
-                    buffer.Append("]");
+                    buffer.Append(']');
                 }
 
                 return buffer.ToString();

--- a/Stack/Opc.Ua.Core/Types/Utils/Utils.cs
+++ b/Stack/Opc.Ua.Core/Types/Utils/Utils.cs
@@ -2635,6 +2635,22 @@ namespace Opc.Ua
 
         #region Security Helper Functions
         /// <summary>
+        /// Returns a XmlReaderSetting with safe defaults with
+        /// DtdProcessing Prohibited and the XmlResolver as null.
+        /// </summary>
+        /// <remarks>
+        /// </remarks>
+        internal static XmlReaderSettings GetXmlReaderSettings()
+        {
+            // create a safe default for XmlReaderSettings
+            // to avoid false negatives for DtdProcessing
+            return new XmlReaderSettings() {
+                DtdProcessing = DtdProcessing.Prohibit,
+                XmlResolver = null
+            };
+        }
+
+        /// <summary>
         /// Appends a list of byte arrays.
         /// </summary>
         public static byte[] Append(params byte[][] arrays)

--- a/Stack/Opc.Ua.Core/Types/Utils/Utils.cs
+++ b/Stack/Opc.Ua.Core/Types/Utils/Utils.cs
@@ -1386,7 +1386,7 @@ namespace Opc.Ua
 
             if (buffer.Length == 0)
             {
-                return new byte[0];
+                return Array.Empty<byte>();
             }
 
             string text = buffer.ToUpperInvariant();
@@ -2482,7 +2482,7 @@ namespace Opc.Ua
                         writer.Dispose();
                     }
 
-                    document.InnerXml = buffer.ToString();
+                    document.LoadInnerXml(buffer.ToString());
                 }
             }
 
@@ -2635,19 +2635,32 @@ namespace Opc.Ua
 
         #region Security Helper Functions
         /// <summary>
-        /// Returns a XmlReaderSetting with safe defaults with
-        /// DtdProcessing Prohibited and the XmlResolver as null.
+        /// Returns a XmlReaderSetting with safe defaults.
+        /// DtdProcessing Prohibited, XmlResolver disabled and
+        /// ConformanceLevel Document. 
         /// </summary>
-        /// <remarks>
-        /// </remarks>
-        internal static XmlReaderSettings GetXmlReaderSettings()
+        internal static XmlReaderSettings DefaultXmlReaderSettings()
         {
-            // create a safe default for XmlReaderSettings
-            // to avoid false negatives for DtdProcessing
             return new XmlReaderSettings() {
                 DtdProcessing = DtdProcessing.Prohibit,
-                XmlResolver = null
+                XmlResolver = null,
+                ConformanceLevel = ConformanceLevel.Document
             };
+        }
+
+        /// <summary>
+        /// Safe version for assignment of InnerXml.
+        /// </summary>
+        /// <param name="doc">The XmlDocument.</param>
+        /// <param name="xml">The Xml document string.</param>
+        internal static void LoadInnerXml(this XmlDocument doc, string xml)
+        {
+            using (var sreader = new StringReader(xml))
+            using (var reader = XmlReader.Create(sreader, DefaultXmlReaderSettings()))
+            {
+                doc.XmlResolver = null;
+                doc.Load(reader);
+            }
         }
 
         /// <summary>
@@ -2657,7 +2670,7 @@ namespace Opc.Ua
         {
             if (arrays == null)
             {
-                return new byte[0];
+                return Array.Empty<byte>();
             }
 
             int length = 0;

--- a/Tests/Opc.Ua.Core.Tests/Types/Utils/UtilTests.cs
+++ b/Tests/Opc.Ua.Core.Tests/Types/Utils/UtilTests.cs
@@ -78,7 +78,8 @@ namespace Opc.Ua.Core.Tests.Types.UtilsTests
             // big endian is written as FA CE.
             Assert.AreEqual("FACE", Utils.ToHexString(littleEndian, true));
             // In Little Endian it's written as CE FA
-            Assert.AreEqual("CEFA", Utils.ToHexString(littleEndian, false));        }
+            Assert.AreEqual("CEFA", Utils.ToHexString(littleEndian, false));
+        }
 
         /// <summary>
         /// Convert to big endian hex string.
@@ -101,7 +102,7 @@ namespace Opc.Ua.Core.Tests.Types.UtilsTests
         {
             TypeTable typeTable = new TypeTable(new NamespaceTable());
             string str = "/11";
-            Assert.AreEqual(str,RelativePath.Parse(str, typeTable).Format(typeTable));
+            Assert.AreEqual(str, RelativePath.Parse(str, typeTable).Format(typeTable));
         }
 
         /// <summary>
@@ -112,7 +113,7 @@ namespace Opc.Ua.Core.Tests.Types.UtilsTests
         {
             TypeTable typeTable = new TypeTable(new NamespaceTable());
             string str = "/123/789";
-            Assert.AreEqual(str,RelativePath.Parse(str, typeTable).Format(typeTable));
+            Assert.AreEqual(str, RelativePath.Parse(str, typeTable).Format(typeTable));
         }
 
         /// <summary>
@@ -123,7 +124,7 @@ namespace Opc.Ua.Core.Tests.Types.UtilsTests
         {
             TypeTable typeTable = new TypeTable(new NamespaceTable());
             string str = "/123A/78B9";
-            Assert.AreEqual(str,RelativePath.Parse(str, typeTable).Format(typeTable));
+            Assert.AreEqual(str, RelativePath.Parse(str, typeTable).Format(typeTable));
         }
 
         /// <summary>
@@ -198,12 +199,15 @@ namespace Opc.Ua.Core.Tests.Types.UtilsTests
 
             // Validate the default Xml Reader settings prohibit Dtd (recommended)
             TestContext.Out.WriteLine("Testing XmlDocument.Load with default xml reader.");
-            XmlReader reader = XmlReader.Create(new StringReader(xmlEEXX.ToString()), Utils.DefaultXmlReaderSettings());
-            ex = Assert.Throws<XmlException>(() => {
-                XmlDocument document = new XmlDocument();
-                document.Load(reader);
-            });
-            TestContext.Out.WriteLine(ex.Message);
+            using (StringReader stream = new StringReader(xmlEEXX.ToString()))
+            using (XmlReader reader = XmlReader.Create(stream, Utils.DefaultXmlReaderSettings()))
+            {
+                ex = Assert.Throws<XmlException>(() => {
+                    XmlDocument document = new XmlDocument();
+                    document.Load(reader);
+                });
+                TestContext.Out.WriteLine(ex.Message);
+            }
 
             // Validate the LoadInnerXml helper settings prohibit Dtd (recommended)
             TestContext.Out.WriteLine("Testing LoadInnerXml helper.");


### PR DESCRIPTION
- enable CA3075 as warning (on windows)
- Dtd processing is by default not prohibited, only limited to 10000000 chars.
- ensure to only use safe defaults for all xml processing
