### PR TITLE
Alternate way to handle auto accept in cert handler

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -262,3 +262,5 @@ dotnet_naming_style.pascal_case_style.capitalization                          = 
 # CA3075: Insecure DTD processing in XML
 dotnet_diagnostic.CA3075.severity = warning
 
+# RCS1090: Add call to 'ConfigureAwait' (or vice versa)
+dotnet_diagnostic.RCS1090.severity = warning

--- a/Stack/Opc.Ua.Core/Security/Certificates/CertificateValidator.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/CertificateValidator.cs
@@ -33,10 +33,10 @@ namespace Opc.Ua
         public CertificateValidator()
         {
             m_validatedCertificates = new Dictionary<string, X509Certificate2>();
-            m_autoAcceptUntrustedCertificates = false;
-            m_rejectSHA1SignedCertificates = CertificateFactory.DefaultHashSize >= 256;
-            m_rejectUnknownRevocationStatus = false;
-            m_minimumCertificateKeySize = CertificateFactory.DefaultKeySize;
+            AutoAcceptUntrustedCertificates = false;
+            RejectSHA1SignedCertificates = CertificateFactory.DefaultHashSize >= 256;
+            RejectUnknownRevocationStatus = false;
+            MinimumCertificateKeySize = CertificateFactory.DefaultKeySize;
         }
         #endregion
 
@@ -173,10 +173,10 @@ namespace Opc.Ua
                     configuration.TrustedIssuerCertificates,
                     configuration.TrustedPeerCertificates,
                     configuration.RejectedCertificateStore);
-                m_autoAcceptUntrustedCertificates = configuration.AutoAcceptUntrustedCertificates;
-                m_rejectSHA1SignedCertificates = configuration.RejectSHA1SignedCertificates;
-                m_rejectUnknownRevocationStatus = configuration.RejectUnknownRevocationStatus;
-                m_minimumCertificateKeySize = configuration.MinimumCertificateKeySize;
+                AutoAcceptUntrustedCertificates = configuration.AutoAcceptUntrustedCertificates;
+                RejectSHA1SignedCertificates = configuration.RejectSHA1SignedCertificates;
+                RejectUnknownRevocationStatus = configuration.RejectUnknownRevocationStatus;
+                MinimumCertificateKeySize = configuration.MinimumCertificateKeySize;
             }
 
             if (configuration.ApplicationCertificate != null)
@@ -209,6 +209,25 @@ namespace Opc.Ua
             }
         }
 
+        /// <summary>
+        /// If untrusted certificates should be accepted.
+        /// </summary>
+        public bool AutoAcceptUntrustedCertificates { get; set; }
+
+        /// <summary>
+        /// If certificates using a SHA1 signature should be trusted.
+        /// </summary>
+        public bool RejectSHA1SignedCertificates { get; set; }
+
+        /// <summary>
+        /// if certificates with unknown revocation status should be rejected.
+        /// </summary>
+        public bool RejectUnknownRevocationStatus { get; set; }
+
+        /// <summary>
+        /// The minimum size of a certificate key to be trusted.
+        /// </summary>
+        public ushort MinimumCertificateKeySize { get; set; }
 
         /// <summary>
         /// Validates the specified certificate against the trust list.
@@ -298,7 +317,7 @@ namespace Opc.Ua
                             }
                             accept = args.Accept;
                         }
-                        else if (m_autoAcceptUntrustedCertificates &&
+                        else if (AutoAcceptUntrustedCertificates &&
                             serviceResult.StatusCode == StatusCodes.BadCertificateUntrusted)
                         {
                             accept = true;
@@ -652,7 +671,7 @@ namespace Opc.Ua
                                                 status.Code = StatusCodes.BadCertificateIssuerRevocationUnknown;
                                             }
 
-                                            if (m_rejectUnknownRevocationStatus)
+                                            if (RejectUnknownRevocationStatus)
                                             {
                                                 throw new ServiceResultException(status);
                                             }
@@ -829,14 +848,14 @@ namespace Opc.Ua
             }
 
             // check if minimum requirements are met
-            if (m_rejectSHA1SignedCertificates && IsSHA1SignatureAlgorithm(certificate.SignatureAlgorithm))
+            if (RejectSHA1SignedCertificates && IsSHA1SignatureAlgorithm(certificate.SignatureAlgorithm))
             {
                 sresult = new ServiceResult(StatusCodes.BadCertificatePolicyCheckFailed,
                     null, null, "SHA1 signed certificates are not trusted.", null, sresult);
             }
 
             int keySize = X509Utils.GetRSAPublicKeySize(certificate);
-            if (keySize < m_minimumCertificateKeySize)
+            if (keySize < MinimumCertificateKeySize)
             {
                 sresult = new ServiceResult(StatusCodes.BadCertificatePolicyCheckFailed,
                     null, null, "Certificate doesn't meet minimum key length requirement.", null, sresult);
@@ -1155,10 +1174,6 @@ namespace Opc.Ua
         private event CertificateValidationEventHandler m_CertificateValidation;
         private event CertificateUpdateEventHandler m_CertificateUpdate;
         private X509Certificate2 m_applicationCertificate;
-        private bool m_autoAcceptUntrustedCertificates;
-        private bool m_rejectSHA1SignedCertificates;
-        private bool m_rejectUnknownRevocationStatus;
-        private ushort m_minimumCertificateKeySize;
         #endregion
     }
 

--- a/Stack/Opc.Ua.Core/Security/Certificates/CertificateValidator.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/CertificateValidator.cs
@@ -33,10 +33,10 @@ namespace Opc.Ua
         public CertificateValidator()
         {
             m_validatedCertificates = new Dictionary<string, X509Certificate2>();
-            AutoAcceptUntrustedCertificates = false;
-            RejectSHA1SignedCertificates = CertificateFactory.DefaultHashSize >= 256;
-            RejectUnknownRevocationStatus = false;
-            MinimumCertificateKeySize = CertificateFactory.DefaultKeySize;
+            m_autoAcceptUntrustedCertificates = false;
+            m_rejectSHA1SignedCertificates = CertificateFactory.DefaultHashSize >= 256;
+            m_rejectUnknownRevocationStatus = false;
+            m_minimumCertificateKeySize = CertificateFactory.DefaultKeySize;
         }
         #endregion
 
@@ -172,10 +172,10 @@ namespace Opc.Ua
                     configuration.TrustedIssuerCertificates,
                     configuration.TrustedPeerCertificates,
                     configuration.RejectedCertificateStore);
-                AutoAcceptUntrustedCertificates = configuration.AutoAcceptUntrustedCertificates;
-                RejectSHA1SignedCertificates = configuration.RejectSHA1SignedCertificates;
-                RejectUnknownRevocationStatus = configuration.RejectUnknownRevocationStatus;
-                MinimumCertificateKeySize = configuration.MinimumCertificateKeySize;
+                m_autoAcceptUntrustedCertificates = configuration.AutoAcceptUntrustedCertificates;
+                m_rejectSHA1SignedCertificates = configuration.RejectSHA1SignedCertificates;
+                m_rejectUnknownRevocationStatus = configuration.RejectUnknownRevocationStatus;
+                m_minimumCertificateKeySize = configuration.MinimumCertificateKeySize;
             }
 
             if (configuration.ApplicationCertificate != null)
@@ -394,7 +394,7 @@ namespace Opc.Ua
                             }
                             accept = args.Accept;
                         }
-                        else if (AutoAcceptUntrustedCertificates &&
+                        else if (m_autoAcceptUntrustedCertificates &&
                             serviceResult.StatusCode == StatusCodes.BadCertificateUntrusted)
                         {
                             accept = true;
@@ -748,7 +748,7 @@ namespace Opc.Ua
                                                 status.Code = StatusCodes.BadCertificateIssuerRevocationUnknown;
                                             }
 
-                                            if (RejectUnknownRevocationStatus)
+                                            if (m_rejectUnknownRevocationStatus)
                                             {
                                                 throw new ServiceResultException(status);
                                             }
@@ -925,14 +925,14 @@ namespace Opc.Ua
             }
 
             // check if minimum requirements are met
-            if (RejectSHA1SignedCertificates && IsSHA1SignatureAlgorithm(certificate.SignatureAlgorithm))
+            if (m_rejectSHA1SignedCertificates && IsSHA1SignatureAlgorithm(certificate.SignatureAlgorithm))
             {
                 sresult = new ServiceResult(StatusCodes.BadCertificatePolicyCheckFailed,
                     null, null, "SHA1 signed certificates are not trusted.", null, sresult);
             }
 
             int keySize = X509Utils.GetRSAPublicKeySize(certificate);
-            if (keySize < MinimumCertificateKeySize)
+            if (keySize < m_minimumCertificateKeySize)
             {
                 sresult = new ServiceResult(StatusCodes.BadCertificatePolicyCheckFailed,
                     null, null, "Certificate doesn't meet minimum key length requirement.", null, sresult);

--- a/Stack/Opc.Ua.Core/Types/Utils/Utils.cs
+++ b/Stack/Opc.Ua.Core/Types/Utils/Utils.cs
@@ -338,7 +338,6 @@ namespace Opc.Ua
 
                             writer.WriteLine(output);
                             writer.Flush();
-                            writer.Dispose();
                         }
                     }
                     catch (Exception e)
@@ -924,10 +923,6 @@ namespace Opc.Ua
         #endregion
 
         #region String, Object and Data Convienence Functions
-        private const int MAX_MESSAGE_LENGTH = 1024;
-        private const uint FORMAT_MESSAGE_IGNORE_INSERTS = 0x00000200;
-        private const uint FORMAT_MESSAGE_FROM_SYSTEM = 0x00001000;
-
         /// <summary>
         /// Supresses any exceptions while disposing the object.
         /// </summary>
@@ -937,22 +932,25 @@ namespace Opc.Ua
         public static void SilentDispose(object objectToDispose)
         {
             IDisposable disposable = objectToDispose as IDisposable;
+            SilentDispose(disposable);
+        }
 
-            if (disposable != null)
+        /// <summary>
+        /// Supresses any exceptions while disposing the object.
+        /// </summary>
+        /// <remarks>
+        /// Writes errors to trace output in DEBUG builds.
+        /// </remarks>
+        public static void SilentDispose(IDisposable disposable)
+        {
+            try
             {
-                try
-                {
-                    disposable.Dispose();
-                }
+                disposable?.Dispose();
+            }
+            catch (Exception e)
+            {
 #if DEBUG
-                catch (Exception e)
-                {
-                    Utils.Trace(e, "Error disposing object: {0}", disposable.GetType().Name);
-                }
-#else
-                catch (Exception)
-                {
-                }
+                Utils.Trace(e, "Error disposing object: {0}", disposable.GetType().Name);
 #endif
             }
         }

--- a/Stack/Opc.Ua.Core/Types/Utils/Utils.cs
+++ b/Stack/Opc.Ua.Core/Types/Utils/Utils.cs
@@ -947,12 +947,14 @@ namespace Opc.Ua
             {
                 disposable?.Dispose();
             }
+#if DEBUG
             catch (Exception e)
             {
-#if DEBUG
                 Utils.Trace(e, "Error disposing object: {0}", disposable.GetType().Name);
-#endif
             }
+#else
+            catch (Exception) {;}
+#endif
         }
 
         /// <summary>

--- a/Tests/Opc.Ua.Core.Tests/Security/Certificates/CertificateValidatorTest.cs
+++ b/Tests/Opc.Ua.Core.Tests/Security/Certificates/CertificateValidatorTest.cs
@@ -963,7 +963,7 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
             certValidator.RejectSHA1SignedCertificates = rejectSHA1;
             if (rejectSHA1)
             {
-                var serviceResultException = Assert.Throws<ServiceResultException>(() => certValidator.Validate(cert); );
+                var serviceResultException = Assert.Throws<ServiceResultException>(() => certValidator.Validate(cert));
                 Assert.AreEqual(StatusCodes.BadCertificatePolicyCheckFailed, serviceResultException.StatusCode, serviceResultException.Message);
                 Assert.NotNull(serviceResultException.InnerResult);
                 ServiceResult innerResult = serviceResultException.InnerResult.InnerResult;
@@ -987,7 +987,7 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
                 }
                 else
                 {
-                    var serviceResultException = Assert.Throws<ServiceResultException>(() => certValidator.Validate(cert); );
+                    var serviceResultException = Assert.Throws<ServiceResultException>(() => certValidator.Validate(cert));
                     Assert.AreEqual(StatusCodes.BadCertificateUntrusted, serviceResultException.StatusCode, serviceResultException.Message);
                     Assert.NotNull(serviceResultException.InnerResult);
                 }

--- a/Tests/Opc.Ua.Gds.Tests/PushTest.cs
+++ b/Tests/Opc.Ua.Gds.Tests/PushTest.cs
@@ -370,11 +370,11 @@ namespace Opc.Ua.Gds.Tests
         [Test, Order(510)]
         public void UpdateCertificateCASigned()
         {
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
             // this test fails on macOS, ignore
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
-                Assert.Ignore("Update CA signed certifcate fails on mac OS.");
+                Assert.Ignore("Update CA signed certificate fails on mac OS.");
             }
 #endif
             ConnectPushClient(true);


### PR DESCRIPTION
- if a cert validator is enabled, use it and ignore auto accept flag.
- trace auto accept message, if used
- make all config flags public, otherwise they can only be configured using a SecurityConfiguration. Once a config flag is set using a property, it is protected from modification by a SecurityConfiguration. This way apps can override behaviour.
- add tests for the SHA1 and AutoAccept configuration vars
- add a method to reset the validated list of certificates. The list of certs should be revalidated from time to time to catch expired or revoked certificates. Applications can call `ResetValidatedCertificates` to clear the list.