### PR TITLE
Add minThreadCount and maxThreadCount management

### DIFF
--- a/Stack/Opc.Ua.Core/Stack/Server/ServerBase.cs
+++ b/Stack/Opc.Ua.Core/Stack/Server/ServerBase.cs
@@ -1298,6 +1298,9 @@ namespace Opc.Ua
             /// <param name="maxRequestCount">The maximum number of requests that will placed in the queue.</param>
             public RequestQueue(ServerBase server, int minThreadCount, int maxThreadCount, int maxRequestCount)
             {
+                ThreadPool.SetMaxThreads(maxThreadCount, maxThreadCount);
+                ThreadPool.SetMinThreads(minThreadCount, minThreadCount);
+
                 m_server = server;
                 m_stopped = false;
             }


### PR DESCRIPTION
In RequestQueue class constructor the threadpool configuration has been added
in order to handle the minThreadCount and maxThreadCount parameters.
Those parameters are the ones coming from the server config .xml
(MinRequestThreadCount, MaxRequestThreadCount) and at the moment
are not handled in the code.

This modification allows correct setting of the threadpool so that the server can work
with the specified parameters, thus improving performances in a multiclient environment.

Co-Authored-By: macheronte <79026457+macheronte@users.noreply.github.com>