### PR TITLE
PubSub fixes

### DIFF
--- a/Libraries/Opc.Ua.PubSub/Encoding/JsonDataSetMessage.cs
+++ b/Libraries/Opc.Ua.PubSub/Encoding/JsonDataSetMessage.cs
@@ -404,7 +404,7 @@ namespace Opc.Ua.PubSub.Encoding
         {
             if ((DataSetMessageContentMask & JsonDataSetMessageContentMask.DataSetWriterId) != 0)
             {
-                encoder.WriteString(nameof(DataSetWriterId), DataSetWriterId.ToString());
+                encoder.WriteUInt16(nameof(DataSetWriterId), DataSetWriterId);
             }
 
             if ((DataSetMessageContentMask & JsonDataSetMessageContentMask.SequenceNumber) != 0)
@@ -567,7 +567,7 @@ namespace Opc.Ua.PubSub.Encoding
             {
                 if (jsonDecoder.ReadField(nameof(DataSetWriterId), out token))
                 {
-                    DataSetWriterId = Convert.ToUInt16(jsonDecoder.ReadString(nameof(DataSetWriterId)));
+                    DataSetWriterId = jsonDecoder.ReadUInt16(nameof(DataSetWriterId));
                 }
             }
 

--- a/Libraries/Opc.Ua.PubSub/Encoding/JsonDataSetMessage.cs
+++ b/Libraries/Opc.Ua.PubSub/Encoding/JsonDataSetMessage.cs
@@ -36,7 +36,7 @@ namespace Opc.Ua.PubSub.Encoding
 {
     /// <summary>
     /// The JsonDataSetMessage class handler.
-    /// It handles the JsonDataSetMessage encoding 
+    /// It handles the JsonDataSetMessage encoding
     /// </summary>
     public class JsonDataSetMessage : UaDataSetMessage
     {
@@ -46,23 +46,14 @@ namespace Opc.Ua.PubSub.Encoding
         #endregion
 
         #region Constructors
-
-        /// <summary>
-        /// Create new instance of <see cref="JsonDataSetMessage"/>.
-        /// </summary>
-        public JsonDataSetMessage() : base()
-        {
-        }
-
         /// <summary>
         /// Create new instance of <see cref="JsonDataSetMessage"/> with DataSet parameter
         /// </summary>
-        /// <param name="dataSet"></param>        
-        public JsonDataSetMessage(DataSet dataSet = null) : this()
+        /// <param name="dataSet"></param>
+        public JsonDataSetMessage(DataSet dataSet = null) 
         {
             DataSet = dataSet;
         }
-
         #endregion
 
         #region Properties
@@ -84,7 +75,7 @@ namespace Opc.Ua.PubSub.Encoding
         #region Public Methods
 
         /// <summary>
-        /// Set DataSetFieldContentMask 
+        /// Set DataSetFieldContentMask
         /// </summary>
         /// <param name="fieldContentMask">The new <see cref="DataSetFieldContentMask"/> for this dataset</param>
         public override void SetFieldContentMask(DataSetFieldContentMask fieldContentMask)
@@ -114,9 +105,10 @@ namespace Opc.Ua.PubSub.Encoding
         }
 
         /// <summary>
-        /// Set MessageContentMask 
+        /// Set MessageContentMask
         /// </summary>
         /// <param name="messageContentMask">The new <see cref="JsonDataSetMessageContentMask"/>.</param>
+        /// TODO: Why extra set method?
         public void SetMessageContentMask(JsonDataSetMessageContentMask messageContentMask)
         {
             DataSetMessageContentMask = messageContentMask;
@@ -127,6 +119,7 @@ namespace Opc.Ua.PubSub.Encoding
         /// </summary>
         /// <param name="jsonEncoder">The <see cref="JsonEncoder"/> used to encode this object.</param>
         /// <param name="fieldName">The field name to be used to encode this object, by default it is null.</param>
+        // TODO: do we need extra IJsonEncoder
         public void Encode(JsonEncoder jsonEncoder, string fieldName = null)
         {
             jsonEncoder.PushStructure(fieldName);
@@ -149,7 +142,7 @@ namespace Opc.Ua.PubSub.Encoding
         /// <param name="jsonDecoder">The json decoder trhat contains the json stream.</param>
         /// <param name="messagesCount">Number of Messages found in current jsonDecoder. If 0 then there is SingleDataSetMessage</param>
         /// <param name="messagesListName">The name of the Messages list</param>
-        /// <param name="dataSetReader">The <see cref="DataSetReaderDataType"/> used to decode the data set.</param>        
+        /// <param name="dataSetReader">The <see cref="DataSetReaderDataType"/> used to decode the data set.</param>
         public void DecodePossibleDataSetReader(JsonDecoder jsonDecoder, int messagesCount, string messagesListName, DataSetReaderDataType dataSetReader)
         {
             if (messagesCount == 0)
@@ -375,7 +368,7 @@ namespace Opc.Ua.PubSub.Encoding
                 Field dataField = new Field();
                 dataField.FieldMetaData = dataSetMetaData?.Fields[i];
                 dataField.Value = dataValues[i];
-                
+
                 if (targetVariablesData != null && targetVariablesData.TargetVariables != null
                     && i < targetVariablesData.TargetVariables.Count)
                 {
@@ -400,7 +393,7 @@ namespace Opc.Ua.PubSub.Encoding
         /// <summary>
         /// Encode DataSet message header
         /// </summary>
-        private void EncodeDataSetMessageHeader(JsonEncoder encoder)
+        private void EncodeDataSetMessageHeader(IEncoder encoder)
         {
             if ((DataSetMessageContentMask & JsonDataSetMessageContentMask.DataSetWriterId) != 0)
             {
@@ -525,7 +518,7 @@ namespace Opc.Ua.PubSub.Encoding
         #region Private Decode Methods
 
         /// <summary>
-        /// Decode RawData type 
+        /// Decode RawData type
         /// </summary>
         /// <returns></returns>
         private object DecodeRawData(JsonDecoder jsonDecoder, FieldMetaData fieldMetaData, string fieldName)

--- a/Libraries/Opc.Ua.PubSub/Encoding/JsonDataSetMessage.cs
+++ b/Libraries/Opc.Ua.PubSub/Encoding/JsonDataSetMessage.cs
@@ -57,13 +57,12 @@ namespace Opc.Ua.PubSub.Encoding
         #endregion
 
         #region Properties
-
         /// <summary>
         /// Get JsonDataSetMessageContentMask
         /// The DataSetWriterMessageContentMask defines the flags for the content of the DataSetMessage header.
         /// The Json message mapping specific flags are defined by the <see cref="JsonDataSetMessageContentMask"/> enum.
         /// </summary>
-        public JsonDataSetMessageContentMask DataSetMessageContentMask { get; private set; }
+        public JsonDataSetMessageContentMask DataSetMessageContentMask { get; set; }
 
         /// <summary>
         /// Flag that indicates if the dataset message header is encoded
@@ -73,7 +72,6 @@ namespace Opc.Ua.PubSub.Encoding
         #endregion Properties
 
         #region Public Methods
-
         /// <summary>
         /// Set DataSetFieldContentMask
         /// </summary>
@@ -102,16 +100,6 @@ namespace Opc.Ua.PubSub.Encoding
                 // 10 DataValue Field Encoding
                 m_fieldTypeEncoding = FieldTypeEncodingMask.DataValue;
             }
-        }
-
-        /// <summary>
-        /// Set MessageContentMask
-        /// </summary>
-        /// <param name="messageContentMask">The new <see cref="JsonDataSetMessageContentMask"/>.</param>
-        /// TODO: Why extra set method?
-        public void SetMessageContentMask(JsonDataSetMessageContentMask messageContentMask)
-        {
-            DataSetMessageContentMask = messageContentMask;
         }
 
         /// <summary>
@@ -389,7 +377,6 @@ namespace Opc.Ua.PubSub.Encoding
         #endregion
 
         #region Private Encode Methods
-
         /// <summary>
         /// Encode DataSet message header
         /// </summary>

--- a/Libraries/Opc.Ua.PubSub/Encoding/JsonDataSetMessage.cs
+++ b/Libraries/Opc.Ua.PubSub/Encoding/JsonDataSetMessage.cs
@@ -96,6 +96,12 @@ namespace Opc.Ua.PubSub.Encoding
                 // 00 Variant Field Encoding
                 m_fieldTypeEncoding = FieldTypeEncodingMask.Variant;
             }
+            else if ((FieldContentMask & DataSetFieldContentMask.RawData) != 0)
+            {
+                // If the RawData flag is set, all other bits are ignored.
+                // 01 RawData Field Encoding
+                m_fieldTypeEncoding = FieldTypeEncodingMask.RawData;
+            }
             else if ((FieldContentMask & (DataSetFieldContentMask.StatusCode
                                           | DataSetFieldContentMask.SourceTimestamp
                                           | DataSetFieldContentMask.ServerTimestamp
@@ -104,11 +110,6 @@ namespace Opc.Ua.PubSub.Encoding
             {
                 // 10 DataValue Field Encoding
                 m_fieldTypeEncoding = FieldTypeEncodingMask.DataValue;
-            }
-            else if ((FieldContentMask & DataSetFieldContentMask.RawData) != 0)
-            {
-                // 01 RawData Field Encoding
-                m_fieldTypeEncoding = FieldTypeEncodingMask.RawData;
             }
         }
 

--- a/Libraries/Opc.Ua.PubSub/Encoding/JsonDataSetMessage.cs
+++ b/Libraries/Opc.Ua.PubSub/Encoding/JsonDataSetMessage.cs
@@ -107,7 +107,6 @@ namespace Opc.Ua.PubSub.Encoding
         /// </summary>
         /// <param name="jsonEncoder">The <see cref="JsonEncoder"/> used to encode this object.</param>
         /// <param name="fieldName">The field name to be used to encode this object, by default it is null.</param>
-        // TODO: do we need extra IJsonEncoder
         public void Encode(JsonEncoder jsonEncoder, string fieldName = null)
         {
             jsonEncoder.PushStructure(fieldName);

--- a/Libraries/Opc.Ua.PubSub/Encoding/JsonNetworkMessage.cs
+++ b/Libraries/Opc.Ua.PubSub/Encoding/JsonNetworkMessage.cs
@@ -165,7 +165,7 @@ namespace Opc.Ua.PubSub.Encoding
 
             bool topLevelIsArray = !HasNetworkMessageHeader && !HasSingleDataSetMessage;
 
-            using (JsonEncoder encoder = new JsonEncoder(messageContext, false, null, topLevelIsArray))
+            using (JsonEncoder encoder = new JsonEncoder(messageContext, true, null, topLevelIsArray))
             {
                 // handle no header
                 if (HasNetworkMessageHeader)

--- a/Libraries/Opc.Ua.PubSub/Encoding/JsonNetworkMessage.cs
+++ b/Libraries/Opc.Ua.PubSub/Encoding/JsonNetworkMessage.cs
@@ -148,8 +148,6 @@ namespace Opc.Ua.PubSub.Encoding
         {
             NetworkMessageContentMask = networkMessageContentMask;
 
-            // TODO: duplicate info for DataSetMessageContentMask..
-            // remove from jsondatasetmessage
             foreach (JsonDataSetMessage jsonDataSetMessage in DataSetMessages)
             {
                 jsonDataSetMessage.HasDataSetMessageHeader = HasDataSetMessageHeader;
@@ -199,8 +197,6 @@ namespace Opc.Ua.PubSub.Encoding
                         JsonDataSetMessage jsonDataSetMessage = DataSetMessages[0] as JsonDataSetMessage;
                         if (jsonDataSetMessage != null)
                         {
-                            // TODO: HasDataSetMessageHeader is local to this class
-                            // pass hasdatasetmessage header in encode..
                             if (!jsonDataSetMessage.HasDataSetMessageHeader)
                             {
                                 // If the NetworkMessageHeader and the DataSetMessageHeader bits are not set
@@ -427,7 +423,6 @@ namespace Opc.Ua.PubSub.Encoding
                 }
                 else
                 {
-                    // can this be implemented with EncodeableArray?
                     encoder.PushArray(kFieldMessages);
                     foreach (var message in DataSetMessages)
                     {

--- a/Libraries/Opc.Ua.PubSub/Encoding/JsonNetworkMessage.cs
+++ b/Libraries/Opc.Ua.PubSub/Encoding/JsonNetworkMessage.cs
@@ -57,7 +57,7 @@ namespace Opc.Ua.PubSub.Encoding
         /// <summary>
         /// Create new instance of <see cref="JsonNetworkMessage"/>
         /// </summary>
-        /// <param name="writerGroupConfiguration">The <see cref="WriterGroupDataType"/> confguration object that produced this message.</param>  
+        /// <param name="writerGroupConfiguration">The <see cref="WriterGroupDataType"/> confguration object that produced this message.</param>
         /// <param name="jsonDataSetMessages"><see cref="JsonDataSetMessage"/> list as input</param>
         public JsonNetworkMessage(WriterGroupDataType writerGroupConfiguration, List<JsonDataSetMessage> jsonDataSetMessages)
             : base(writerGroupConfiguration, jsonDataSetMessages?.ConvertAll<UaDataSetMessage>(x=> (UaDataSetMessage)x) ?? new List<UaDataSetMessage>())
@@ -69,7 +69,7 @@ namespace Opc.Ua.PubSub.Encoding
 
         #region Properties
         /// <summary>
-        /// NetworkMessageContentMask contains the mask that will be used to check NetworkMessage options selected for usage  
+        /// NetworkMessageContentMask contains the mask that will be used to check NetworkMessage options selected for usage
         /// </summary>
         public JsonNetworkMessageContentMask NetworkMessageContentMask { get; private set; }
 
@@ -85,7 +85,7 @@ namespace Opc.Ua.PubSub.Encoding
         }
 
         /// <summary>
-        /// Flag that indicates if the Network message contains a single dataset message 
+        /// Flag that indicates if the Network message contains a single dataset message
         /// </summary>
         public bool HasSingleDataSetMessage
         {
@@ -148,6 +148,8 @@ namespace Opc.Ua.PubSub.Encoding
         {
             NetworkMessageContentMask = networkMessageContentMask;
 
+            // TODO: duplicate info for DataSetMessageContentMask..
+            // remove from jsondatasetmessage
             foreach (JsonDataSetMessage jsonDataSetMessage in DataSetMessages)
             {
                 jsonDataSetMessage.HasDataSetMessageHeader = HasDataSetMessageHeader;
@@ -197,6 +199,8 @@ namespace Opc.Ua.PubSub.Encoding
                         JsonDataSetMessage jsonDataSetMessage = DataSetMessages[0] as JsonDataSetMessage;
                         if (jsonDataSetMessage != null)
                         {
+                            // TODO: HasDataSetMessageHeader is local to this class
+                            // pass hasdatasetmessage header in encode..
                             if (!jsonDataSetMessage.HasDataSetMessageHeader)
                             {
                                 // If the NetworkMessageHeader and the DataSetMessageHeader bits are not set
@@ -230,7 +234,7 @@ namespace Opc.Ua.PubSub.Encoding
         }
 
         /// <summary>
-        /// Decodes the message 
+        /// Decodes the message
         /// </summary>
         /// <param name="message"></param>
         /// <param name="dataSetReaders"></param>
@@ -254,8 +258,8 @@ namespace Opc.Ua.PubSub.Encoding
         }
 
         /// <summary>
-        /// Decode the stream from decoder parameter and produce a Dataset 
-        /// </summary> 
+        /// Decode the stream from decoder parameter and produce a Dataset
+        /// </summary>
         /// <param name="jsonDecoder"></param>
         /// <param name="dataSetReaders"></param>
         /// <returns></returns>
@@ -389,7 +393,7 @@ namespace Opc.Ua.PubSub.Encoding
         /// <summary>
         ///  Encode Network Message Header
         /// </summary>
-        private void EncodeNetworkMessageHeader(JsonEncoder jsonEncoder)
+        private void EncodeNetworkMessageHeader(IEncoder jsonEncoder)
         {
             jsonEncoder.WriteString(nameof(MessageId), MessageId);
             jsonEncoder.WriteString(nameof(MessageType), MessageType);
@@ -423,6 +427,7 @@ namespace Opc.Ua.PubSub.Encoding
                 }
                 else
                 {
+                    // can this be implemented with EncodeableArray?
                     encoder.PushArray(kFieldMessages);
                     foreach (var message in DataSetMessages)
                     {
@@ -440,7 +445,7 @@ namespace Opc.Ua.PubSub.Encoding
         /// <summary>
         /// Encode ReplyTo
         /// </summary>
-        private void EncodeReplyTo(JsonEncoder jsonEncoder)
+        private void EncodeReplyTo(IEncoder jsonEncoder)
         {
             if ((NetworkMessageContentMask & JsonNetworkMessageContentMask.ReplyTo) != 0)
             {

--- a/Libraries/Opc.Ua.PubSub/Encoding/JsonNetworkMessage.cs
+++ b/Libraries/Opc.Ua.PubSub/Encoding/JsonNetworkMessage.cs
@@ -350,7 +350,7 @@ namespace Opc.Ua.PubSub.Encoding
 
                         // initialize the dataset message
                         JsonDataSetMessage jsonDataSetMessage = new JsonDataSetMessage();
-                        jsonDataSetMessage.SetMessageContentMask((JsonDataSetMessageContentMask)jsonMessageSettings.DataSetMessageContentMask);
+                        jsonDataSetMessage.DataSetMessageContentMask = (JsonDataSetMessageContentMask)jsonMessageSettings.DataSetMessageContentMask;
                         jsonDataSetMessage.SetFieldContentMask((DataSetFieldContentMask)dataSetReader.DataSetFieldContentMask);
                         // set the flag that indicates if dataset message shall have a header
                         jsonDataSetMessage.HasDataSetMessageHeader = (networkMessageContentMask & JsonNetworkMessageContentMask.DataSetMessageHeader) != 0;

--- a/Libraries/Opc.Ua.PubSub/Encoding/JsonNetworkMessage.cs
+++ b/Libraries/Opc.Ua.PubSub/Encoding/JsonNetworkMessage.cs
@@ -50,7 +50,7 @@ namespace Opc.Ua.PubSub.Encoding
         /// <summary>
         /// Create new instance of <see cref="JsonNetworkMessage"/>
         /// </summary>
-        public JsonNetworkMessage() : this(null, new List<UaDataSetMessage>())
+        public JsonNetworkMessage() : this(null, new List<JsonDataSetMessage>())
         {
         }
 
@@ -59,7 +59,8 @@ namespace Opc.Ua.PubSub.Encoding
         /// </summary>
         /// <param name="writerGroupConfiguration">The <see cref="WriterGroupDataType"/> confguration object that produced this message.</param>  
         /// <param name="jsonDataSetMessages"><see cref="JsonDataSetMessage"/> list as input</param>
-        public JsonNetworkMessage(WriterGroupDataType writerGroupConfiguration, List<UaDataSetMessage> jsonDataSetMessages) : base(writerGroupConfiguration, jsonDataSetMessages)
+        public JsonNetworkMessage(WriterGroupDataType writerGroupConfiguration, List<JsonDataSetMessage> jsonDataSetMessages)
+            : base(writerGroupConfiguration, jsonDataSetMessages?.ConvertAll<UaDataSetMessage>(x=> (UaDataSetMessage)x) ?? new List<UaDataSetMessage>())
         {
             MessageType = kDefaultMessageType;
             DataSetClassId = string.Empty;

--- a/Libraries/Opc.Ua.PubSub/Encoding/UadpDataSetMessage.cs
+++ b/Libraries/Opc.Ua.PubSub/Encoding/UadpDataSetMessage.cs
@@ -68,8 +68,7 @@ namespace Opc.Ua.PubSub.Encoding
 
         #endregion
 
-        #region Properties   
-
+        #region Properties
         /// <summary>
         /// Get UadpDataSetMessageContentMask
         /// The DataSetWriterMessageContentMask defines the flags for the content of the DataSetMessage header.
@@ -148,7 +147,6 @@ namespace Opc.Ua.PubSub.Encoding
                 // 10 DataValue Field Encoding
                 fieldType = FieldTypeEncodingMask.DataValue;
             }
-           
 
             DataSetFlags1 |= (DataSetFlags1EncodingMask)((byte)fieldType << 1);
 

--- a/Libraries/Opc.Ua.PubSub/Encoding/UadpDataSetMessage.cs
+++ b/Libraries/Opc.Ua.PubSub/Encoding/UadpDataSetMessage.cs
@@ -134,6 +134,11 @@ namespace Opc.Ua.PubSub.Encoding
                 // 00 Variant Field Encoding
                 fieldType = FieldTypeEncodingMask.Variant;
             }
+            else if ((FieldContentMask & DataSetFieldContentMask.RawData) != 0)
+            {
+                // 01 RawData Field Encoding
+                fieldType = FieldTypeEncodingMask.RawData;
+            }
             else if ((FieldContentMask & (DataSetFieldContentMask.StatusCode
                                           | DataSetFieldContentMask.SourceTimestamp
                                           | DataSetFieldContentMask.ServerTimestamp
@@ -143,11 +148,7 @@ namespace Opc.Ua.PubSub.Encoding
                 // 10 DataValue Field Encoding
                 fieldType = FieldTypeEncodingMask.DataValue;
             }
-            else if ((FieldContentMask & DataSetFieldContentMask.RawData) != 0)
-            {
-                // 01 RawData Field Encoding
-                fieldType = FieldTypeEncodingMask.RawData;
-            }
+           
 
             DataSetFlags1 |= (DataSetFlags1EncodingMask)((byte)fieldType << 1);
 

--- a/Libraries/Opc.Ua.PubSub/Encoding/UadpNetworkMessage.cs
+++ b/Libraries/Opc.Ua.PubSub/Encoding/UadpNetworkMessage.cs
@@ -767,8 +767,7 @@ namespace Opc.Ua.PubSub.Encoding
                 uadpDataSetMessage.Encode(encoder);
             }
 
-            if (DataSetMessages.Count > 1
-                && (NetworkMessageContentMask & UadpNetworkMessageContentMask.PayloadHeader) != 0)
+            if (DataSetMessages.Count > 1 && (NetworkMessageContentMask & UadpNetworkMessageContentMask.PayloadHeader) != 0)
             {
                 int payloadEndPositionInStream = encoder.Position;
                 encoder.Position = payloadStartPositionInStream;

--- a/Libraries/Opc.Ua.PubSub/Encoding/UadpNetworkMessage.cs
+++ b/Libraries/Opc.Ua.PubSub/Encoding/UadpNetworkMessage.cs
@@ -29,6 +29,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Text;
 
 namespace Opc.Ua.PubSub.Encoding
 {
@@ -258,14 +260,29 @@ namespace Opc.Ua.PubSub.Encoding
         /// <returns></returns>
         public override byte[] Encode()
         {
-            ServiceMessageContext messageContext = new ServiceMessageContext();
-            byte[] bytes = null;
-            using (BinaryEncoder encoder = new BinaryEncoder(messageContext))
+            ServiceMessageContext messageContext = new ServiceMessageContext {
+                NamespaceUris = ServiceMessageContext.GlobalContext.NamespaceUris,
+                ServerUris = ServiceMessageContext.GlobalContext.ServerUris
+            };
+
+            using (MemoryStream stream = new MemoryStream())
+            using (var writer = new StreamWriter(stream, new UTF8Encoding(false)))
+            {
+                Encode(messageContext, writer);
+                return stream.ToArray();
+            }
+        }
+
+        /// <summary>
+        /// Encodes the object in the specified stream.
+        /// </summary>
+        /// <param name="messageContext">The system context.</param>
+        /// <param name="writer">The stream to use.</param>
+        public override void Encode(ServiceMessageContext messageContext, StreamWriter writer)
+        {
+            using (BinaryEncoder encoder = new BinaryEncoder(writer.BaseStream, messageContext))
             {
                 Encode(encoder);
-                bytes = ReadBytes(encoder.BaseStream);
-
-                return bytes;
             }
         }
 

--- a/Libraries/Opc.Ua.PubSub/Encoding/UadpNetworkMessage.cs
+++ b/Libraries/Opc.Ua.PubSub/Encoding/UadpNetworkMessage.cs
@@ -56,7 +56,7 @@ namespace Opc.Ua.PubSub.Encoding
         /// <summary>
         /// Create new instance of UadpNetworkMessage
         /// </summary>
-        internal UadpNetworkMessage() : this(null, new List<UaDataSetMessage>())
+        internal UadpNetworkMessage() : this(null, new List<UadpDataSetMessage>())
         {
 
         }
@@ -65,8 +65,9 @@ namespace Opc.Ua.PubSub.Encoding
         /// Create new instance of UadpNetworkMessage
         /// </summary>
         /// <param name="writerGroupConfiguration">The <see cref="WriterGroupDataType"/> confguration object that produced this message.</param> 
-        /// <param name="uadpDataSetMessages">UadpDataSetMessage list as input</param>
-        public UadpNetworkMessage(WriterGroupDataType writerGroupConfiguration, List<UaDataSetMessage> uadpDataSetMessages) : base(writerGroupConfiguration, uadpDataSetMessages)
+        /// <param name="uadpDataSetMessages"><see cref="UadpDataSetMessage"/> list as input</param>
+        public UadpNetworkMessage(WriterGroupDataType writerGroupConfiguration, List<UadpDataSetMessage> uadpDataSetMessages)
+            : base(writerGroupConfiguration, uadpDataSetMessages?.ConvertAll<UaDataSetMessage>(x => (UaDataSetMessage)x) ?? new List<UaDataSetMessage>())
         {
             UADPVersion = kUadpVersion;
             DataSetClassId = Guid.Empty;

--- a/Libraries/Opc.Ua.PubSub/Opc.Ua.PubSub.csproj
+++ b/Libraries/Opc.Ua.PubSub/Opc.Ua.PubSub.csproj
@@ -24,14 +24,6 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
-    <Reference Include="System.IdentityModel" />
-    <Reference Include="System.IdentityModel.Selectors" />
-    <Reference Include="System.Security" />
-    <Reference Include="System.Linq" />
-    <Reference Include="System.ServiceModel" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
   </ItemGroup>
   

--- a/Libraries/Opc.Ua.PubSub/PublishedData/DataCollector.cs
+++ b/Libraries/Opc.Ua.PubSub/PublishedData/DataCollector.cs
@@ -178,6 +178,8 @@ namespace Opc.Ua.PubSub.PublishedData
                                 }
                                 else
                                 {
+                                    dataValue = Utils.Clone(dataValue) as DataValue;
+
                                     //check StatusCode and return SubstituteValue if possible
                                     if (dataValue.StatusCode == StatusCodes.Bad && publishedVariable.SubstituteValue != Variant.Null)
                                     {
@@ -185,9 +187,10 @@ namespace Opc.Ua.PubSub.PublishedData
                                         dataValue.StatusCode = StatusCodes.UncertainSubstituteValue;
                                     }
                                 }
+
                                 dataValue.ServerTimestamp = DateTime.UtcNow;
 
-                                #region FieldMetaData -> MaxStringLength size validation                                 
+                                #region FieldMetaData -> MaxStringLength size validation
 
                                 Field field = dataSet.Fields[i];
                                 Variant variant = dataValue.WrappedValue;

--- a/Libraries/Opc.Ua.PubSub/Transport/MqttPubSubConnection.cs
+++ b/Libraries/Opc.Ua.PubSub/Transport/MqttPubSubConnection.cs
@@ -184,6 +184,7 @@ namespace Opc.Ua.PubSub.Transport
                         {
                             // set common properties of dataset message
                             uaDataSetMessage.DataSetWriterId = dataSetWriter.DataSetWriterId;
+                            // why ushort? SequenceNumber is uint
                             uaDataSetMessage.SequenceNumber = (ushort)(Utils.IncrementIdentifier(ref m_dataSetSequenceNumber) % UInt16.MaxValue);
                             if (publishedDataSet.DataSetMetaData != null)
                             {

--- a/Libraries/Opc.Ua.PubSub/Transport/MqttPubSubConnection.cs
+++ b/Libraries/Opc.Ua.PubSub/Transport/MqttPubSubConnection.cs
@@ -215,7 +215,7 @@ namespace Opc.Ua.PubSub.Transport
             }
             else if (m_messageMapping == MessageMapping.Json)
             {
-                // each entry of this loist will generate a network message
+                // each entry of this list will generate a network message
                 List<List<UaDataSetMessage>> dataSetMessagesList = new List<List<UaDataSetMessage>>();
                 if ((((JsonNetworkMessageContentMask)jsonMessageSettings?.NetworkMessageContentMask) & JsonNetworkMessageContentMask.SingleDataSetMessage) != 0)
                 {

--- a/Libraries/Opc.Ua.PubSub/Transport/MqttPubSubConnection.cs
+++ b/Libraries/Opc.Ua.PubSub/Transport/MqttPubSubConnection.cs
@@ -134,7 +134,8 @@ namespace Opc.Ua.PubSub.Transport
             }
 
             //Create list of dataSet messages to be sent
-            List<UaDataSetMessage> dataSetMessages = new List<UaDataSetMessage>();
+            List<UadpDataSetMessage> uadpDataSetMessages = new List<UadpDataSetMessage>();
+            List<JsonDataSetMessage> jsonDataSetMessages = new List<JsonDataSetMessage>();
             foreach (DataSetWriterDataType dataSetWriter in writerGroupConfiguration.DataSetWriters)
             {
                 //check if dataSetWriter enabled
@@ -160,6 +161,8 @@ namespace Opc.Ua.PubSub.Transport
                                 uadpDataSetMessage.ConfiguredSize = uadpDataSetMessageSettings.ConfiguredSize;
                                 uadpDataSetMessage.DataSetOffset = uadpDataSetMessageSettings.DataSetOffset;
                                 uaDataSetMessage = uadpDataSetMessage;
+
+                                uadpDataSetMessages.Add(uadpDataSetMessage);
                             }
                         }
                         else if (m_messageMapping == MessageMapping.Json && jsonMessageSettings != null)
@@ -172,6 +175,8 @@ namespace Opc.Ua.PubSub.Transport
                                 jsonDataSetMessage.SetMessageContentMask((JsonDataSetMessageContentMask)jsonDataSetMessageSettings.DataSetMessageContentMask);
                                 jsonDataSetMessage.SetFieldContentMask((DataSetFieldContentMask)dataSetWriter.DataSetFieldContentMask);
                                 uaDataSetMessage = jsonDataSetMessage;
+
+                                jsonDataSetMessages.Add(jsonDataSetMessage);
                             }
                         }
 
@@ -186,21 +191,20 @@ namespace Opc.Ua.PubSub.Transport
                             }
                             uaDataSetMessage.Timestamp = DateTime.UtcNow;
                             uaDataSetMessage.Status = StatusCodes.Good;
-                            dataSetMessages.Add(uaDataSetMessage);
                         }
                     }
                 }
             }
 
-            //cancel send if no dataset message
-            if (dataSetMessages.Count == 0)
-            {
-                return null;
-            }
-
             if (m_messageMapping == MessageMapping.Uadp)
             {
-                UadpNetworkMessage uadpNetworkMessage = new UadpNetworkMessage(writerGroupConfiguration, dataSetMessages);
+                //cancel send if no dataset message
+                if (uadpDataSetMessages.Count == 0)
+                {
+                    return null;
+                }
+
+                UadpNetworkMessage uadpNetworkMessage = new UadpNetworkMessage(writerGroupConfiguration, uadpDataSetMessages);
                 uadpNetworkMessage.SetNetworkMessageContentMask((UadpNetworkMessageContentMask)uadpMessageSettings?.NetworkMessageContentMask);
                 // Network message header
                 uadpNetworkMessage.PublisherId = PubSubConnectionConfiguration.PublisherId.Value;
@@ -215,24 +219,30 @@ namespace Opc.Ua.PubSub.Transport
             }
             else if (m_messageMapping == MessageMapping.Json)
             {
+                //cancel send if no dataset message
+                if (jsonDataSetMessages.Count == 0)
+                {
+                    return null;
+                }
+
                 // each entry of this list will generate a network message
-                List<List<UaDataSetMessage>> dataSetMessagesList = new List<List<UaDataSetMessage>>();
+                List<List<JsonDataSetMessage>> dataSetMessagesList = new List<List<JsonDataSetMessage>>();
                 if ((((JsonNetworkMessageContentMask)jsonMessageSettings?.NetworkMessageContentMask) & JsonNetworkMessageContentMask.SingleDataSetMessage) != 0)
                 {
                     // create a new network message for each dataset
-                    foreach (UaDataSetMessage dataSetMessage in dataSetMessages)
+                    foreach (JsonDataSetMessage dataSetMessage in jsonDataSetMessages)
                     {
-                        dataSetMessagesList.Add(new List<UaDataSetMessage>() { dataSetMessage });
+                        dataSetMessagesList.Add(new List<JsonDataSetMessage>() { dataSetMessage });
                     }
                 }
                 else
                 {
-                    dataSetMessagesList.Add(dataSetMessages);
+                    dataSetMessagesList.Add(jsonDataSetMessages);
                 }
 
                 List<UaNetworkMessage> networkMessages = new List<UaNetworkMessage>();
 
-                foreach (List<UaDataSetMessage> dataSetMessagesToUse in dataSetMessagesList)
+                foreach (List<JsonDataSetMessage> dataSetMessagesToUse in dataSetMessagesList)
                 {
                     JsonNetworkMessage jsonNetworkMessage = new JsonNetworkMessage(writerGroupConfiguration, dataSetMessagesToUse);
                     jsonNetworkMessage.SetNetworkMessageContentMask((JsonNetworkMessageContentMask)jsonMessageSettings?.NetworkMessageContentMask);

--- a/Libraries/Opc.Ua.PubSub/Transport/MqttPubSubConnection.cs
+++ b/Libraries/Opc.Ua.PubSub/Transport/MqttPubSubConnection.cs
@@ -172,7 +172,7 @@ namespace Opc.Ua.PubSub.Transport
                             if (jsonDataSetMessageSettings != null)
                             {
                                 JsonDataSetMessage jsonDataSetMessage = new JsonDataSetMessage(dataSet);
-                                jsonDataSetMessage.SetMessageContentMask((JsonDataSetMessageContentMask)jsonDataSetMessageSettings.DataSetMessageContentMask);
+                                jsonDataSetMessage.DataSetMessageContentMask = (JsonDataSetMessageContentMask)jsonDataSetMessageSettings.DataSetMessageContentMask;
                                 jsonDataSetMessage.SetFieldContentMask((DataSetFieldContentMask)dataSetWriter.DataSetFieldContentMask);
                                 uaDataSetMessage = jsonDataSetMessage;
 
@@ -184,8 +184,8 @@ namespace Opc.Ua.PubSub.Transport
                         {
                             // set common properties of dataset message
                             uaDataSetMessage.DataSetWriterId = dataSetWriter.DataSetWriterId;
-                            // why ushort? SequenceNumber is uint
-                            uaDataSetMessage.SequenceNumber = (ushort)(Utils.IncrementIdentifier(ref m_dataSetSequenceNumber) % UInt16.MaxValue);
+                            uaDataSetMessage.SequenceNumber = (uint)Utils.IncrementIdentifier(ref m_dataSetSequenceNumber);
+
                             if (publishedDataSet.DataSetMetaData != null)
                             {
                                 uaDataSetMessage.MetaDataVersion = publishedDataSet.DataSetMetaData.ConfigurationVersion;

--- a/Libraries/Opc.Ua.PubSub/Transport/UdpPubSubConnection.cs
+++ b/Libraries/Opc.Ua.PubSub/Transport/UdpPubSubConnection.cs
@@ -406,21 +406,6 @@ namespace Opc.Ua.PubSub.Transport
         }
 
         /// <summary>
-        /// Read All bytes from a given stream
-        /// </summary>
-        /// <param name="stream"></param>
-        /// <returns></returns>
-        private byte[] ReadBytes(Stream stream)
-        {
-            stream.Position = 0;
-            using (MemoryStream ms = new MemoryStream())
-            {
-                stream.CopyTo(ms);
-                return ms.ToArray();
-            }
-        }
-
-        /// <summary>
         /// Raise DataReceived event
         /// </summary>
         /// <param name="e"></param>

--- a/Libraries/Opc.Ua.PubSub/Transport/UdpPubSubConnection.cs
+++ b/Libraries/Opc.Ua.PubSub/Transport/UdpPubSubConnection.cs
@@ -193,7 +193,7 @@ namespace Opc.Ua.PubSub.Transport
             }
 
             //Create list of dataSet messages to be sent
-            List<UaDataSetMessage> dataSetMessages = new List<UaDataSetMessage>();
+            List<UadpDataSetMessage> dataSetMessages = new List<UadpDataSetMessage>();
             foreach (DataSetWriterDataType dataSetWriter in writerGroupConfiguration.DataSetWriters)
             {
                 //check if dataSetWriter enabled

--- a/Libraries/Opc.Ua.PubSub/UaDataSetMessage.cs
+++ b/Libraries/Opc.Ua.PubSub/UaDataSetMessage.cs
@@ -47,8 +47,6 @@ namespace Opc.Ua.PubSub
         /// Default value for Configured MetaDataVersion.MinorVersion
         /// </summary>
         protected const UInt32 ConfigMinorVersion = 1;
-
-        private DataSet m_dataSet;
         #endregion
 
         #region Constructor
@@ -69,17 +67,7 @@ namespace Opc.Ua.PubSub
         /// <summary>
         /// Get DataSet
         /// </summary>
-        public DataSet DataSet
-        {
-            get
-            {
-                return m_dataSet;
-            }
-            internal set
-            {
-                m_dataSet = value;
-            }
-        }
+        public DataSet DataSet { get; internal set; }
 
         /// <summary>
         /// Get and Set corresponding DataSetWriterId

--- a/Libraries/Opc.Ua.PubSub/UaDataSetMessage.cs
+++ b/Libraries/Opc.Ua.PubSub/UaDataSetMessage.cs
@@ -42,11 +42,11 @@ namespace Opc.Ua.PubSub
         /// <summary>
         /// Default value for Configured MetaDataVersion.MajorVersion
         /// </summary>
-        protected const UInt32 ConfigMajorVersion = 1;
+        protected const UInt32 ConfigMajorVersion = 0;
         /// <summary>
         /// Default value for Configured MetaDataVersion.MinorVersion
         /// </summary>
-        protected const UInt32 ConfigMinorVersion = 1;
+        protected const UInt32 ConfigMinorVersion = 0;
         #endregion
 
         #region Constructor

--- a/Libraries/Opc.Ua.PubSub/UaNetworkMessage.cs
+++ b/Libraries/Opc.Ua.PubSub/UaNetworkMessage.cs
@@ -41,10 +41,9 @@ namespace Opc.Ua.PubSub
     {
         #region Protected Fields
         /// <summary>
-        /// list of DataSet messages
+        /// List of DataSet messages
         /// </summary>
-        /// // TODO: why readonly?
-        protected readonly List<UaDataSetMessage> m_uaDataSetMessages;
+        protected List<UaDataSetMessage> m_uaDataSetMessages;
         #endregion
 
         #region Constructor
@@ -69,11 +68,11 @@ namespace Opc.Ua.PubSub
         /// <summary>
         /// DataSet messages
         /// </summary>
-        public ReadOnlyCollection<UaDataSetMessage> DataSetMessages
+        public List<UaDataSetMessage> DataSetMessages
         {
             get
             {
-                return new ReadOnlyCollection<UaDataSetMessage>(m_uaDataSetMessages);
+                return m_uaDataSetMessages;
             }
         }
 
@@ -104,7 +103,5 @@ namespace Opc.Ua.PubSub
         /// <param name="dataSetReaders"></param>
         public abstract void Decode(byte[] message, IList<DataSetReaderDataType> dataSetReaders);
         #endregion
-
-        // TODO: removed, as this was just a generic helper?
     }
 }

--- a/Libraries/Opc.Ua.PubSub/UaNetworkMessage.cs
+++ b/Libraries/Opc.Ua.PubSub/UaNetworkMessage.cs
@@ -43,6 +43,7 @@ namespace Opc.Ua.PubSub
         /// <summary>
         /// list of DataSet messages
         /// </summary>
+        /// // TODO: why readonly?
         protected readonly List<UaDataSetMessage> m_uaDataSetMessages;
         #endregion
 
@@ -97,28 +98,13 @@ namespace Opc.Ua.PubSub
         public abstract void Encode(ServiceMessageContext messageContext, StreamWriter writer);
 
         /// <summary>
-        /// Decodes the message 
+        /// Decodes the message
         /// </summary>
         /// <param name="message"></param>
         /// <param name="dataSetReaders"></param>
         public abstract void Decode(byte[] message, IList<DataSetReaderDataType> dataSetReaders);
         #endregion
 
-        #region Protectd Methods
-        /// <summary>
-        /// Read the bytes from a Stream
-        /// </summary>
-        /// <param name="stream"></param>
-        /// <returns></returns>
-        protected byte[] ReadBytes(Stream stream)
-        {
-            stream.Position = 0;
-            using (MemoryStream ms = new MemoryStream())
-            {
-                stream.CopyTo(ms);
-                return ms.ToArray();
-            }
-        }
-        #endregion
+        // TODO: removed, as this was just a generic helper?
     }
 }

--- a/Libraries/Opc.Ua.PubSub/UaNetworkMessage.cs
+++ b/Libraries/Opc.Ua.PubSub/UaNetworkMessage.cs
@@ -90,6 +90,13 @@ namespace Opc.Ua.PubSub
         public abstract byte[] Encode();
 
         /// <summary>
+        /// Encodes the object in the specified stream.
+        /// </summary>
+        /// <param name="messageContext">The context.</param>
+        /// <param name="writer">The stream to use.</param>
+        public abstract void Encode(ServiceMessageContext messageContext, StreamWriter writer);
+
+        /// <summary>
         /// Decodes the message 
         /// </summary>
         /// <param name="message"></param>

--- a/Libraries/Opc.Ua.PubSub/UaPubSubConnection.cs
+++ b/Libraries/Opc.Ua.PubSub/UaPubSubConnection.cs
@@ -36,7 +36,7 @@ namespace Opc.Ua.PubSub
     /// <summary>
     /// Abstract class that represents a working connection for PubSub
     /// </summary>
-    internal abstract class UaPubSubConnection : IUaPubSubConnection, IDisposable
+    internal abstract class UaPubSubConnection : IUaPubSubConnection
     {
         #region Fields
         protected object m_lock = new object();

--- a/Libraries/Opc.Ua.PubSub/UaPubSubDataStore.cs
+++ b/Libraries/Opc.Ua.PubSub/UaPubSubDataStore.cs
@@ -74,11 +74,6 @@ namespace Opc.Ua.PubSub
             {
                 throw new ArgumentException(nameof(attributeId));
             }
-            //copy instance of dataValue to be stored
-            if (dataValue != null)
-            {
-                dataValue = Utils.Clone(dataValue) as DataValue;
-            }
             lock (m_lock)
             {
                 if (m_store.ContainsKey(nodeId))

--- a/Libraries/Opc.Ua.PubSub/UaPublisher.cs
+++ b/Libraries/Opc.Ua.PubSub/UaPublisher.cs
@@ -37,7 +37,7 @@ namespace Opc.Ua.PubSub
     /// <summary>
     /// A class responsible with calculating and triggering publish messages.
     /// </summary>
-    internal class UaPublisher : IUaPublisher, IDisposable
+    internal class UaPublisher : IUaPublisher
     {
         #region Fields
         private const int kMinPublishingInterval = 10;

--- a/Libraries/Opc.Ua.PubSub/UaPublisher.cs
+++ b/Libraries/Opc.Ua.PubSub/UaPublisher.cs
@@ -226,7 +226,7 @@ namespace Opc.Ua.PubSub
                                 "UaPublisher.PublishNetworkMessage, WriterGroupId:{0}; success = {1}", m_writerGroupConfiguration.WriterGroupId, success.ToString());
                         }
                     }
-                }                
+                }
             }
             catch (Exception e)
             {

--- a/Stack/Opc.Ua.Core/Stack/Client/ClientBase.cs
+++ b/Stack/Opc.Ua.Core/Stack/Client/ClientBase.cs
@@ -153,7 +153,7 @@ namespace Opc.Ua
                         channel.Close();
                         channel.Dispose();
                     }
-                    catch (Exception)
+                    catch
                     {
                         // ignore errors.
                     }

--- a/Stack/Opc.Ua.Core/Types/Encoders/JsonDecoder.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/JsonDecoder.cs
@@ -75,10 +75,6 @@ namespace Opc.Ua
         }
 
         /// <summary>
-        /// Get referece to current JsonTextReader
-        /// </summary>
-        public JsonTextReader Reader { get { return m_reader; } }
-        /// <summary>
         /// Create a JSON decoder to decode a <see cref="Type"/>from a <see cref="JsonTextReader"/>.
         /// </summary>
         /// <param name="systemType">The system type of the encoded JSON stram.</param>


### PR DESCRIPTION
 - Extend JsonNetworkMessage.Encode to accept external stream and context
 - Set useReversibleEncoding flag in JsonNetworkMessage.Encode()
 - Encode DataSetWriterId as Uint16 in DataSetMessageHeader, according to errata 1.04.2
 - Fix for RawData flag in DataSetFieldContentMask
 - Change JsonNetworkMessage and UadpNetworkMessage constructor signature