### PR TITLE
Preferer a higher SecurityMode over SecurityLevel in CoreClientUtils.…

### DIFF
--- a/Libraries/Opc.Ua.Client/CoreClientUtils.cs
+++ b/Libraries/Opc.Ua.Client/CoreClientUtils.cs
@@ -282,7 +282,11 @@ namespace Opc.Ua.Client
                     // The security level is a relative measure assigned by the server to the 
                     // endpoints that it returns. Clients should always pick the highest level
                     // unless they have a reason not too.
-                    if (endpoint.SecurityLevel > selectedEndpoint.SecurityLevel)
+                    // Some servers however, mess this up a bit. So prefer a higher SecurityMode
+                    // over the SecurityLevel.
+                    if (endpoint.SecurityMode > selectedEndpoint.SecurityMode
+                        || (endpoint.SecurityMode == selectedEndpoint.SecurityMode
+                            && endpoint.SecurityLevel > selectedEndpoint.SecurityLevel))
                     {
                         selectedEndpoint = endpoint;
                     }


### PR DESCRIPTION
…SelectEndpoint()

Normally a server should give a higher SecurityLevel when SignAndEncrypt is used, but often this is messed up. The sample client preferes SignAndEncrypt over the SecurityLevel, so it seems to make sense to do the same in this function.


The Siemens server I tested returns the following list:
![afbeelding](https://user-images.githubusercontent.com/5014119/118877261-82bbb900-b8ee-11eb-986e-733abf41733f.png)

Where securityLevel is 1, 2, 3, 4 in this list. So when selecting by only the SecurityLevel, the last item is used (Sign - Basic256).

Kepware does this a bit better and gives the highest level score to SignAndEncrypt.

Reference server gives SignAndEncrypt a +100 score.
