### PR TITLE
Fixes brought to the process of validating permissions

### DIFF
--- a/Libraries/Opc.Ua.Server/Diagnostics/CustomNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/Diagnostics/CustomNodeManager.cs
@@ -1139,47 +1139,7 @@ namespace Opc.Ua.Server
                     metadata.UserRolePermissions = new RolePermissionTypeCollection(ExtensionObject.ToList<RolePermissionType>(values[12]));
                 }
 
-                // check if NamespaceMetadata is defined for NamespaceUri
-                string namespaceUri = Server.NamespaceUris.GetString(target.NodeId.NamespaceIndex);
-                NamespaceMetadataState namespaceMetadataState = Server.NodeManager.ConfigurationNodeManager.GetNamespaceMetadataState(namespaceUri);
-
-                if (namespaceMetadataState != null)
-                {
-                    List<object> namespaceMetadataValues;
-
-                    if (namespaceMetadataState.DefaultAccessRestrictions != null)
-                    {
-                        // get DefaultAccessRestrictions for Namespace
-                        namespaceMetadataValues = namespaceMetadataState.DefaultAccessRestrictions.ReadAttributes(systemContext, Attributes.Value);
-
-                        if (namespaceMetadataValues[0] != null)
-                        {
-                            metadata.DefaultAccessRestrictions = (AccessRestrictionType)Enum.ToObject(typeof(AccessRestrictionType), namespaceMetadataValues[0]);
-                        }
-                    }
-
-                    if (namespaceMetadataState.DefaultRolePermissions != null)
-                    {
-                        // get DefaultRolePermissions for Namespace
-                        namespaceMetadataValues = namespaceMetadataState.DefaultRolePermissions.ReadAttributes(systemContext, Attributes.Value);
-
-                        if (namespaceMetadataValues[0] != null)
-                        {
-                            metadata.DefaultRolePermissions = new RolePermissionTypeCollection(ExtensionObject.ToList<RolePermissionType>(namespaceMetadataValues[0]));
-                        }
-                    }
-
-                    if (namespaceMetadataState.DefaultUserRolePermissions != null)
-                    {
-                        // get DefaultUserRolePermissions for Namespace
-                        namespaceMetadataValues = namespaceMetadataState.DefaultUserRolePermissions.ReadAttributes(systemContext, Attributes.Value);
-
-                        if (namespaceMetadataValues[0] != null)
-                        {
-                            metadata.DefaultUserRolePermissions = new RolePermissionTypeCollection(ExtensionObject.ToList<RolePermissionType>(namespaceMetadataValues[0]));
-                        }
-                    }
-                }
+                SetDefaultPermissions(systemContext, target, metadata);
 
                 // get instance references.
                 BaseInstanceState instance = target as BaseInstanceState;
@@ -4424,8 +4384,62 @@ namespace Opc.Ua.Server
                     values = ReadValidationAttributes(systemContext, target);
                     SetAccessAndRolePermissions(values, metadata);
                 }
-               
+
+                SetDefaultPermissions(systemContext, target, metadata);
+
                 return metadata;
+            }
+        }
+
+
+        /// <summary>
+        /// Set the metadata default permission values for DefaultAccessRestrictions, DefaultRolePermissions and DefaultUserRolePermissions
+        /// </summary>
+        /// <param name="systemContext"></param>
+        /// <param name="target"></param>
+        /// <param name="metadata"></param>
+        private void SetDefaultPermissions(ServerSystemContext systemContext, NodeState target, NodeMetadata metadata)
+        {
+            // check if NamespaceMetadata is defined for NamespaceUri
+            string namespaceUri = Server.NamespaceUris.GetString(target.NodeId.NamespaceIndex);
+            NamespaceMetadataState namespaceMetadataState = Server.NodeManager.ConfigurationNodeManager.GetNamespaceMetadataState(namespaceUri);
+
+            if (namespaceMetadataState != null)
+            {
+                List<object> namespaceMetadataValues;
+
+                if (namespaceMetadataState.DefaultAccessRestrictions != null)
+                {
+                    // get DefaultAccessRestrictions for Namespace
+                    namespaceMetadataValues = namespaceMetadataState.DefaultAccessRestrictions.ReadAttributes(systemContext, Attributes.Value);
+
+                    if (namespaceMetadataValues[0] != null)
+                    {
+                        metadata.DefaultAccessRestrictions = (AccessRestrictionType)Enum.ToObject(typeof(AccessRestrictionType), namespaceMetadataValues[0]);
+                    }
+                }
+
+                if (namespaceMetadataState.DefaultRolePermissions != null)
+                {
+                    // get DefaultRolePermissions for Namespace
+                    namespaceMetadataValues = namespaceMetadataState.DefaultRolePermissions.ReadAttributes(systemContext, Attributes.Value);
+
+                    if (namespaceMetadataValues[0] != null)
+                    {
+                        metadata.DefaultRolePermissions = new RolePermissionTypeCollection(ExtensionObject.ToList<RolePermissionType>(namespaceMetadataValues[0]));
+                    }
+                }
+
+                if (namespaceMetadataState.DefaultUserRolePermissions != null)
+                {
+                    // get DefaultUserRolePermissions for Namespace
+                    namespaceMetadataValues = namespaceMetadataState.DefaultUserRolePermissions.ReadAttributes(systemContext, Attributes.Value);
+
+                    if (namespaceMetadataValues[0] != null)
+                    {
+                        metadata.DefaultUserRolePermissions = new RolePermissionTypeCollection(ExtensionObject.ToList<RolePermissionType>(namespaceMetadataValues[0]));
+                    }
+                }
             }
         }
         #endregion

--- a/Libraries/Opc.Ua.Server/NodeManager/MasterNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/NodeManager/MasterNodeManager.cs
@@ -802,7 +802,7 @@ namespace Opc.Ua.Server
                 }
             }
             // validate access rights and role permissions
-            ServiceResult serviceResult = ValidatePermissions(context, nodeManager, sourceHandle, PermissionType.Browse);
+            ServiceResult serviceResult = ValidatePermissions(context, nodeManager, sourceHandle, PermissionType.Browse, null, true);
             if (ServiceResult.IsGood(serviceResult))
             {
                 // translate path only if validation is passing


### PR DESCRIPTION
Hi.

These changes are needed for correctly handling the default access restriction and default role permission values as well as the validation of permissions on the TranslateBrowsePath service:

- Fixed adding default permission values to the resulting metadata under GetPermissionMetadata method

- Fixed call to ValidatePermissions method from the TranslateBrowsePath service