### PR TITLE
Use value from OnReadUserAccessLevel at Read/Write. Fixes #1302

### DIFF
--- a/Stack/Opc.Ua.Core/Stack/State/BaseVariableState.cs
+++ b/Stack/Opc.Ua.Core/Stack/State/BaseVariableState.cs
@@ -1486,7 +1486,11 @@ namespace Opc.Ua
                 return StatusCodes.BadNotReadable;
             }
 
-            if ((m_userAccessLevel & AccessLevels.CurrentRead) == 0)
+            // check the user access level for the variable.
+            byte userAccessLevel = m_userAccessLevel;
+            OnReadUserAccessLevel?.Invoke(context, this, ref userAccessLevel);
+
+            if ((userAccessLevel & AccessLevels.CurrentRead) == 0)
             {
                 return StatusCodes.BadUserAccessDenied;
             }
@@ -1867,7 +1871,11 @@ namespace Opc.Ua
                 return StatusCodes.BadNotWritable;
             }
 
-            if ((m_userAccessLevel & AccessLevels.CurrentWrite) == 0)
+            // check the user access level for the variable.
+            byte userAccessLevel = m_userAccessLevel;
+            OnReadUserAccessLevel?.Invoke(context, this, ref userAccessLevel);
+
+            if ((userAccessLevel & AccessLevels.CurrentWrite) == 0)
             {
                 return StatusCodes.BadUserAccessDenied;
             }


### PR DESCRIPTION
- Fix the case when the application has implementation for OnReadUserAccessLevel  and default Variable.UserAccessLevel does not allow Read or Write
- Use value from OnReadUserAccessLevel at Read/WriteNonValueAttribute if handler exists.