### PR TITLE
Compliance fixes for OperationLimits and SetTriggering

### DIFF
--- a/Applications/ConsoleReferenceServer/Quickstarts.ReferenceServer.Config.xml
+++ b/Applications/ConsoleReferenceServer/Quickstarts.ReferenceServer.Config.xml
@@ -252,7 +252,10 @@
     -->
     <OperationLimits>
       <MaxNodesPerRead>1000</MaxNodesPerRead>
-      <MaxNodesPerBrowse>250</MaxNodesPerBrowse>
+      <MaxNodesPerWrite>1000</MaxNodesPerWrite>
+      <MaxNodesPerMethodCall>250</MaxNodesPerMethodCall>
+      <MaxNodesPerBrowse>2500</MaxNodesPerBrowse>
+      <MaxNodesPerTranslateBrowsePathsToNodeIds>1000</MaxNodesPerTranslateBrowsePathsToNodeIds>
       <MaxMonitoredItemsPerCall>1000</MaxMonitoredItemsPerCall>
     </OperationLimits>
   </ServerConfiguration>

--- a/Applications/ReferenceServer/Quickstarts.ReferenceServer.Config.xml
+++ b/Applications/ReferenceServer/Quickstarts.ReferenceServer.Config.xml
@@ -258,10 +258,10 @@
     <OperationLimits>
       <MaxNodesPerRead>1000</MaxNodesPerRead>
       <MaxNodesPerWrite>1000</MaxNodesPerWrite>
-      <MaxNodesPerBrowse>2500</MaxNodesPerBrowse>
-      <MaxMonitoredItemsPerCall>500</MaxMonitoredItemsPerCall>
       <MaxNodesPerMethodCall>250</MaxNodesPerMethodCall>
+      <MaxNodesPerBrowse>2500</MaxNodesPerBrowse>
       <MaxNodesPerTranslateBrowsePathsToNodeIds>1000</MaxNodesPerTranslateBrowsePathsToNodeIds>
+      <MaxMonitoredItemsPerCall>1000</MaxMonitoredItemsPerCall>
     </OperationLimits>
   </ServerConfiguration>
 

--- a/Libraries/Opc.Ua.Server/Server/StandardServer.cs
+++ b/Libraries/Opc.Ua.Server/Server/StandardServer.cs
@@ -1747,9 +1747,15 @@ namespace Opc.Ua.Server
 
             try
             {
-                ValidateOperationLimits(linksToAdd, OperationLimits.MaxMonitoredItemsPerCall);
-                ValidateOperationLimits(linksToRemove, OperationLimits.MaxMonitoredItemsPerCall);
-                ValidateOperationLimits(linksToAdd.Count + linksToRemove.Count, OperationLimits.MaxMonitoredItemsPerCall);
+                if ((linksToAdd == null || linksToAdd.Count == 0) && (linksToRemove == null || linksToRemove.Count == 0))
+                {
+                    throw new ServiceResultException(StatusCodes.BadNothingToDo);
+                }
+
+                int monitoredItemsCount = 0;
+                monitoredItemsCount += (linksToAdd?.Count) ?? 0;
+                monitoredItemsCount += (linksToRemove?.Count) ?? 0;
+                ValidateOperationLimits(monitoredItemsCount, OperationLimits.MaxMonitoredItemsPerCall);
 
                 ServerInternal.SubscriptionManager.SetTriggering(
                     context,


### PR DESCRIPTION
Some regressions from PR #1434 were found after testing with latest CTT version 1.4.9.398.

- CTT compliance fix for OperationLimits settings. Order of some elements in Config.xml was incorrect.\
- Fix SetTriggering call validations. Validate should check if at least one of _linksToAdd_ or _linksToRemove_ is specified, instead of requesting both parameters to contain values.