### PR TITLE
Fix the behavior in case of the server is reachable only via an alternate URL

### DIFF
--- a/Stack/Opc.Ua.Core/Stack/Server/ServerBase.cs
+++ b/Stack/Opc.Ua.Core/Stack/Server/ServerBase.cs
@@ -954,7 +954,7 @@ namespace Opc.Ua
                     {
                         if (alternateUrl.DnsSafeHost == endpointUrl.DnsSafeHost)
                         {
-                            accessibleAddresses.Add(baseAddress);
+                            accessibleAddresses.Add(new BaseAddress() { Url = alternateUrl, ProfileUri = baseAddress.ProfileUri, DiscoveryUrl = alternateUrl });
                             break;
                         }
                     }


### PR DESCRIPTION
This PR fixes the behavior in case of the OPC UA server is reachable only via an alternate URL- the alternate address matching the address, the client provides, is added to the list of accessible addresses so that the TranslateApplicationDescription method works correctly and the client gets back appropriate translated endpoints with the corresponding alternate address as base address within them.

Please accept or comment the PR since this blocks us using the .NETstandard based OPC UA Servers in our reverse connect scenario.