### PR TITLE
Enhance GetBuiltintype to support simple datatypes

### DIFF
--- a/Stack/Opc.Ua.Core/Types/Utils/TypeInfo.cs
+++ b/Stack/Opc.Ua.Core/Types/Utils/TypeInfo.cs
@@ -366,6 +366,39 @@ namespace Opc.Ua
             {
                 return BuiltInType.Null;
             }
+            switch ((uint)datatypeId.Identifier)
+            {
+                // subtype of DateTime
+                case DataTypes.UtcTime: return BuiltInType.DateTime;
+                // subtype of ByteString
+                case DataTypes.ApplicationInstanceCertificate:
+                case DataTypes.AudioDataType:
+                case DataTypes.ContinuationPoint:
+                case DataTypes.Image:
+                case DataTypes.ImageBMP:
+                case DataTypes.ImageGIF:
+                case DataTypes.ImageJPG:
+                case DataTypes.ImagePNG: return BuiltInType.ByteString;
+                // subtype of NodeId
+                case DataTypes.SessionAuthenticationToken: return BuiltInType.NodeId;
+                // subtype of Double
+                case DataTypes.Duration: return BuiltInType.Double;
+                // subtype of UInt32
+                case DataTypes.IntegerId:
+                case DataTypes.Index:
+                case DataTypes.VersionTime:
+                case DataTypes.Counter: return BuiltInType.UInt32;
+                // subtype of UInt64
+                case DataTypes.BitFieldMaskDataType: return BuiltInType.UInt64;
+                // subtype of String
+                case DataTypes.DateString:
+                case DataTypes.DecimalString:
+                case DataTypes.DurationString:
+                case DataTypes.LocaleId:
+                case DataTypes.NormalizedString:
+                case DataTypes.NumericRange:
+                case DataTypes.TimeString: return BuiltInType.String;
+            }
 
             return (BuiltInType)Enum.ToObject(typeof(BuiltInType), datatypeId.Identifier);
         }

--- a/Tests/Opc.Ua.Core.Tests/Types/Utils/UtilTests.cs
+++ b/Tests/Opc.Ua.Core.Tests/Types/Utils/UtilTests.cs
@@ -27,7 +27,10 @@
  * http://opcfoundation.org/License/MIT/1.00/
  * ======================================================================*/
 
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using System.Reflection;
 using System.Text;
 using System.Xml;
 using NUnit.Framework;
@@ -222,6 +225,49 @@ namespace Opc.Ua.Core.Tests.Types.UtilsTests
             TestContext.Out.WriteLine(ex.Message);
 
         }
+
+        /// <summary>
+        /// Test the built-in type of the Simple data types
+        /// </summary>
+        [Test]
+        public void BuiltInTypeOfSimpleDataTypes()
+            
+        {
+            Assert.AreEqual(BuiltInType.DateTime, TypeInfo.GetBuiltInType(DataTypeIds.UtcTime));
+
+            List<string> bnList = new List<string> { BrowseNames.ApplicationInstanceCertificate, BrowseNames.AudioDataType,
+                BrowseNames.ContinuationPoint, BrowseNames.Image,
+                BrowseNames.ImageBMP, BrowseNames.ImageGIF,
+                BrowseNames.ImageJPG, BrowseNames.ImagePNG };
+            foreach (string name in bnList)
+            {
+                var staticValue = typeof(DataTypeIds).GetFields(BindingFlags.Public | BindingFlags.Static).Where(f => f.Name == name).First().GetValue(null);
+                Assert.AreEqual(BuiltInType.ByteString, TypeInfo.GetBuiltInType((NodeId)staticValue));
+            }
+
+            Assert.AreEqual(BuiltInType.NodeId, TypeInfo.GetBuiltInType(DataTypeIds.SessionAuthenticationToken));
+            Assert.AreEqual(BuiltInType.Double, TypeInfo.GetBuiltInType(DataTypeIds.Duration));
+
+            bnList = new List<string> { BrowseNames.IntegerId, BrowseNames.Index, BrowseNames.VersionTime, BrowseNames.Counter };
+            foreach (string name in bnList)
+            {
+                var staticValue = typeof(DataTypeIds).GetFields(BindingFlags.Public | BindingFlags.Static).Where(f => f.Name == name).First().GetValue(null);
+                Assert.AreEqual(BuiltInType.UInt32, TypeInfo.GetBuiltInType((NodeId)staticValue));
+            }
+
+            Assert.AreEqual(BuiltInType.UInt64, TypeInfo.GetBuiltInType(DataTypeIds.BitFieldMaskDataType));
+
+            bnList = new List<string> { BrowseNames.DateString, BrowseNames.DecimalString,
+                BrowseNames.DurationString, BrowseNames.LocaleId,
+                BrowseNames.NormalizedString, BrowseNames.NumericRange,
+                BrowseNames.TimeString };
+            foreach (string name in bnList)
+            {
+                var staticValue = typeof(DataTypeIds).GetFields(BindingFlags.Public | BindingFlags.Static).Where(f => f.Name == name).First().GetValue(null);
+                Assert.AreEqual(BuiltInType.String, TypeInfo.GetBuiltInType((NodeId)staticValue));
+            }
+        }
+      
         #endregion
     }
 


### PR DESCRIPTION
Enhance GetBuiltintype method to support simple data types. Fixes issue #1478 