### PR TITLE
Remove the code which allows UpdateCertificate to accept a CRL

### DIFF
--- a/Libraries/Opc.Ua.Gds.Client.Common/ServerPushConfigurationClient.cs
+++ b/Libraries/Opc.Ua.Gds.Client.Common/ServerPushConfigurationClient.cs
@@ -529,33 +529,6 @@ namespace Opc.Ua.Gds.Client
         }
 
         /// <summary>
-        /// Add certificate.
-        /// </summary>
-        public void AddCrl(X509CRL crl, bool isTrustedCertificate)
-        {
-            if (!IsConnected)
-            {
-                Connect();
-            }
-
-            IUserIdentity oldUser = ElevatePermissions();
-            try
-            {
-                m_session.Call(
-                    ExpandedNodeId.ToNodeId(Opc.Ua.ObjectIds.ServerConfiguration_CertificateGroups_DefaultApplicationGroup_TrustList, m_session.NamespaceUris),
-                    ExpandedNodeId.ToNodeId(Opc.Ua.MethodIds.ServerConfiguration_CertificateGroups_DefaultApplicationGroup_TrustList_AddCertificate, m_session.NamespaceUris),
-                    crl.RawData,
-                    isTrustedCertificate
-                    );
-            }
-            finally
-            {
-                RevertPermissions(oldUser);
-            }
-        }
-
-
-        /// <summary>
         /// Remove certificate.
         /// </summary>
         public void RemoveCertificate(string thumbprint, bool isTrustedCertificate)

--- a/Libraries/Opc.Ua.Server/Configuration/TrustList.cs
+++ b/Libraries/Opc.Ua.Server/Configuration/TrustList.cs
@@ -435,21 +435,16 @@ namespace Opc.Ua.Server
                 }
 
                 X509Certificate2 cert = null;
-                X509CRL crl = null;
                 try
                 {
                     cert = new X509Certificate2(certificate);
                 }
                 catch
                 {
-                    try
-                    {
-                        crl = new X509CRL(certificate);
-                    }
-                    catch
-                    {
-                        return StatusCodes.BadCertificateInvalid;
-                    }
+                    // note: a previous version of the sample code accepted also CRL,
+                    // but the behaviour was not as specified and removed
+                    // https://mantis.opcfoundation.org/view.php?id=6342
+                    return StatusCodes.BadCertificateInvalid;
                 }
 
                 using (ICertificateStore store = CertificateStoreIdentifier.OpenStore(isTrustedCertificate ? m_trustedStorePath : m_issuerStorePath))
@@ -457,10 +452,6 @@ namespace Opc.Ua.Server
                     if (cert != null)
                     {
                         store.Add(cert).Wait();
-                    }
-                    if (crl != null)
-                    {
-                        store.AddCRL(crl);
                     }
                 }
 

--- a/Tests/Opc.Ua.Gds.Tests/PushTest.cs
+++ b/Tests/Opc.Ua.Gds.Tests/PushTest.cs
@@ -223,10 +223,9 @@ namespace Opc.Ua.Gds.Tests
             ConnectPushClient(true);
             TrustListDataType beforeTrustList = m_pushClient.PushClient.ReadTrustList();
             m_pushClient.PushClient.AddCertificate(m_caCert, true);
-            m_pushClient.PushClient.AddCrl(m_caCrl, true);
             TrustListDataType afterAddTrustList = m_pushClient.PushClient.ReadTrustList();
             Assert.Greater(afterAddTrustList.TrustedCertificates.Count, beforeTrustList.TrustedCertificates.Count);
-            Assert.Greater(afterAddTrustList.TrustedCrls.Count, beforeTrustList.TrustedCrls.Count);
+            Assert.AreEqual(afterAddTrustList.TrustedCrls.Count, beforeTrustList.TrustedCrls.Count);
             Assert.IsFalse(Utils.IsEqual(beforeTrustList, afterAddTrustList));
             var serviceResultException = Assert.Throws<ServiceResultException>(() => { m_pushClient.PushClient.RemoveCertificate(m_caCert.Thumbprint, false); });
             Assert.AreEqual(StatusCodes.BadInvalidArgument, serviceResultException.StatusCode, serviceResultException.Message);
@@ -243,10 +242,9 @@ namespace Opc.Ua.Gds.Tests
             ConnectPushClient(true);
             TrustListDataType beforeTrustList = m_pushClient.PushClient.ReadTrustList();
             m_pushClient.PushClient.AddCertificate(m_caCert, false);
-            m_pushClient.PushClient.AddCrl(m_caCrl, false);
             TrustListDataType afterAddTrustList = m_pushClient.PushClient.ReadTrustList();
             Assert.Greater(afterAddTrustList.IssuerCertificates.Count, beforeTrustList.IssuerCertificates.Count);
-            Assert.Greater(afterAddTrustList.IssuerCrls.Count, beforeTrustList.IssuerCrls.Count);
+            Assert.AreEqual(afterAddTrustList.IssuerCrls.Count, beforeTrustList.IssuerCrls.Count);
             Assert.IsFalse(Utils.IsEqual(beforeTrustList, afterAddTrustList));
             Assert.That(() => { m_pushClient.PushClient.RemoveCertificate(m_caCert.Thumbprint, true); }, Throws.Exception);
             TrustListDataType afterRemoveTrustList = m_pushClient.PushClient.ReadTrustList();


### PR DESCRIPTION
fixes #1343

remove a hack which allowed a CRL to be decoded from the AddCertificate blob

https://mantis.opcfoundation.org/view.php?id=6342
