### PR TITLE
Complex types: Ignore IsOptional fields for structure

### DIFF
--- a/Libraries/Opc.Ua.Client.ComplexTypes/ComplexTypeSystem.cs
+++ b/Libraries/Opc.Ua.Client.ComplexTypes/ComplexTypeSystem.cs
@@ -685,11 +685,6 @@ namespace Opc.Ua.Client.ComplexTypes
                     {
                         return null;
                     }
-                    if (structureDefinition.StructureType == StructureType.Structure &&
-                        field.IsOptional)
-                    {
-                        return null;
-                    }
                 }
                 return structureDefinition;
             }


### PR DESCRIPTION
fixes #1476 
some ModelCompiler versions produce invalid output, for Structure it can be ignored

