### PR TITLE
Support supplied keys and RSACng for the cert generator

### DIFF
--- a/Libraries/Opc.Ua.Security.Certificates/Org.BouncyCastle/CertificateBuilder.cs
+++ b/Libraries/Opc.Ua.Security.Certificates/Org.BouncyCastle/CertificateBuilder.cs
@@ -375,8 +375,7 @@ namespace Opc.Ua.Security.Certificates
         {
             // Cases locked out by API flow
             Debug.Assert(m_rsaPublicKey != null, "Need a public key for the certificate.");
-            Debug.Assert(IssuerCAKeyCert != null, "Need a issuer certificate to sign.");
-            if (!IssuerCAKeyCert.HasPrivateKey && signatureFactory == null)
+            if ((IssuerCAKeyCert == null || !IssuerCAKeyCert.HasPrivateKey) && signatureFactory == null)
             {
                 throw new NotSupportedException("Need an issuer certificate with a private key or a signature generator.");
             }

--- a/Libraries/Opc.Ua.Security.Certificates/X509Certificate/CertificateBuilder.cs
+++ b/Libraries/Opc.Ua.Security.Certificates/X509Certificate/CertificateBuilder.cs
@@ -138,9 +138,10 @@ namespace Opc.Ua.Security.Certificates
 
             CreateDefaults();
 
-            if (IssuerCAKeyCert == null)
+            var issuerSubjectName = SubjectName;
+            if (IssuerCAKeyCert != null)
             {
-                throw new NotSupportedException("X509 Signature generator requires an issuer certificate.");
+                issuerSubjectName = IssuerCAKeyCert.SubjectName;
             }
 
             RSA rsaKeyPair = null;
@@ -157,9 +158,8 @@ namespace Opc.Ua.Security.Certificates
 
             X509Certificate2 signedCert;
 
-            var issuerSubjectName = IssuerCAKeyCert.SubjectName;
             signedCert = request.Create(
-                IssuerCAKeyCert.SubjectName,
+                issuerSubjectName,
                 generator,
                 NotBefore,
                 NotAfter,

--- a/Libraries/Opc.Ua.Security.Certificates/X509Certificate/CertificateBuilder.cs
+++ b/Libraries/Opc.Ua.Security.Certificates/X509Certificate/CertificateBuilder.cs
@@ -80,7 +80,6 @@ namespace Opc.Ua.Security.Certificates
         /// <inheritdoc/>
         public override X509Certificate2 CreateForRSA()
         {
-
             CreateDefaults();
 
             if (m_rsaPublicKey != null &&
@@ -135,8 +134,12 @@ namespace Opc.Ua.Security.Certificates
         /// <inheritdoc/>
         public override X509Certificate2 CreateForRSA(X509SignatureGenerator generator)
         {
-
             CreateDefaults();
+
+            if (m_rsaPublicKey == null && IssuerCAKeyCert == null)
+            {
+                throw new NotSupportedException("Need an issuer certificate or a public key for a signature generator.");
+            }
 
             var issuerSubjectName = SubjectName;
             if (IssuerCAKeyCert != null)
@@ -156,9 +159,7 @@ namespace Opc.Ua.Security.Certificates
 
             CreateX509Extensions(request, false);
 
-            X509Certificate2 signedCert;
-
-            signedCert = request.Create(
+            X509Certificate2 signedCert = request.Create(
                 issuerSubjectName,
                 generator,
                 NotBefore,
@@ -335,7 +336,6 @@ namespace Opc.Ua.Security.Certificates
         /// <param name="forECDsa">If the certificate is for ECDsa, not RSA.</param>
         private void CreateX509Extensions(CertificateRequest request, bool forECDsa)
         {
-
             // Basic Constraints
             X509BasicConstraintsExtension bc = GetBasicContraints();
             request.CertificateExtensions.Add(bc);

--- a/Libraries/Opc.Ua.Security.Certificates/X509Certificate/ICertificateBuilder.cs
+++ b/Libraries/Opc.Ua.Security.Certificates/X509Certificate/ICertificateBuilder.cs
@@ -38,6 +38,7 @@ namespace Opc.Ua.Security.Certificates
     /// </summary>
     public interface ICertificateBuilder
         : ICertificateBuilderConfig
+        , ICertificateBuilderPublicKey
         , ICertificateBuilderSetIssuer
         , ICertificateBuilderParameter
         , ICertificateBuilderCreateForRSA

--- a/Tests/Opc.Ua.Security.Certificates.Tests/CertificateTestsForRSA.cs
+++ b/Tests/Opc.Ua.Security.Certificates.Tests/CertificateTestsForRSA.cs
@@ -452,9 +452,9 @@ namespace Opc.Ua.Security.Certificates.Tests
                 });
             }
         }
-#endregion
+        #endregion
 
-#region Private Methods
+        #region Private Methods
         private void WriteCertificate(X509Certificate2 cert, string message)
         {
             TestContext.Out.WriteLine(message);
@@ -464,10 +464,10 @@ namespace Opc.Ua.Security.Certificates.Tests
                 TestContext.Out.WriteLine(ext.Format(false));
             }
         }
-#endregion
+        #endregion
 
-#region Private Fields
-#endregion
+        #region Private Fields
+        #endregion
     }
 
 }

--- a/Tests/Opc.Ua.Security.Certificates.Tests/CertificateTestsForRSA.cs
+++ b/Tests/Opc.Ua.Security.Certificates.Tests/CertificateTestsForRSA.cs
@@ -33,6 +33,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
@@ -349,10 +350,14 @@ namespace Opc.Ua.Security.Certificates.Tests
             }
         }
 
-#if NET462_OR_GREATER
+#if NET462_OR_GREATER || NETCOREAPP3_1_OR_GREATER
         [Test]
         public void CreateIssuerRSACngWithSuppliedKeyPair()
         {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                Assert.Ignore("Cng provider only available on windows");
+            }
             X509Certificate2 issuer = null;
             CngKey cngKey = CngKey.Create(CngAlgorithm.Rsa);
             using (RSA rsaKeyPair = new RSACng(cngKey))

--- a/Tests/Opc.Ua.Security.Certificates.Tests/Opc.Ua.Security.Certificates.Tests.csproj
+++ b/Tests/Opc.Ua.Security.Certificates.Tests/Opc.Ua.Security.Certificates.Tests.csproj
@@ -38,7 +38,11 @@
   <ItemGroup>
     <Compile Include="..\Common\Main.cs"/>
   </ItemGroup>
-  
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+    <PackageReference Include="System.Security.Cryptography.Cng" Version="4.4.0" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="System.Formats.Asn1" Version="5.0.0" />
   </ItemGroup>


### PR DESCRIPTION
- Allow to call SetRSAPublicKey without Issuer being set
- Support to create self signed CA cert with supplied keys
- Test case for RSACng on .NET framework 

Issue reported by @eoursel