### PR TITLE
Enable the coexistence of a Server and Client sessions in the same process, which consume custom data types. 

### DIFF
--- a/Stack/Opc.Ua.Core/Stack/Configuration/ApplicationConfiguration.cs
+++ b/Stack/Opc.Ua.Core/Stack/Configuration/ApplicationConfiguration.cs
@@ -169,7 +169,7 @@ namespace Opc.Ua
         /// Creates the message context from the configuration.
         /// </summary>
         /// <returns>A new instance of a ServiceMessageContext object.</returns>
-        public ServiceMessageContext CreateMessageContext(bool clonedFactory = false)
+        public ServiceMessageContext CreateMessageContext(bool newFactory = false)
         {
             ServiceMessageContext messageContext = new ServiceMessageContext();
 
@@ -183,9 +183,9 @@ namespace Opc.Ua
 
             messageContext.NamespaceUris = new NamespaceTable();
             messageContext.ServerUris = new StringTable();
-            if (clonedFactory)
+            if (newFactory)
             {
-                messageContext.Factory = new EncodeableFactory(EncodeableFactory.GlobalFactory);
+                messageContext.Factory = new EncodeableFactory();
             }
             return messageContext;
         }

--- a/Stack/Opc.Ua.Core/Stack/Configuration/ApplicationConfiguration.cs
+++ b/Stack/Opc.Ua.Core/Stack/Configuration/ApplicationConfiguration.cs
@@ -169,7 +169,7 @@ namespace Opc.Ua
         /// Creates the message context from the configuration.
         /// </summary>
         /// <returns>A new instance of a ServiceMessageContext object.</returns>
-        public ServiceMessageContext CreateMessageContext(bool newFactory = false)
+        public ServiceMessageContext CreateMessageContext(bool clonedFactory = false)
         {
             ServiceMessageContext messageContext = new ServiceMessageContext();
 
@@ -183,9 +183,9 @@ namespace Opc.Ua
 
             messageContext.NamespaceUris = new NamespaceTable();
             messageContext.ServerUris = new StringTable();
-            if (newFactory)
+            if (clonedFactory)
             {
-                messageContext.Factory = new EncodeableFactory();
+                messageContext.Factory = new EncodeableFactory(EncodeableFactory.GlobalFactory);
             }
             return messageContext;
         }

--- a/Stack/Opc.Ua.Core/Stack/Server/ServerBase.cs
+++ b/Stack/Opc.Ua.Core/Stack/Server/ServerBase.cs
@@ -1258,7 +1258,7 @@ namespace Opc.Ua
             }
 
             // use the message context from the configuration to ensure the channels are using the same one.
-            ServiceMessageContext messageContext = configuration.CreateMessageContext();
+            ServiceMessageContext messageContext = configuration.CreateMessageContext(true);
             messageContext.NamespaceUris = new NamespaceTable();
             MessageContext = messageContext;
 


### PR DESCRIPTION
The context of this change is the following:

If the application process is used to create a Server instance and also a Client session to a different server, than if custom data types have been initialized from the current Server instance, the Client session cannot decode the received custom types from the remote Server, due to the collision with the cloned existing ones from the current Server instance.
The type ids from the singleton GlobalFactory which in this case have already been set up by the local Server instance are copied and used instead.

The apparent working solution is to avoid the clone and create a new EncodeableFactory per CreateMessageContext that originates from a Client session. 