### PR TITLE
Test to validate client publish request count 

### DIFF
--- a/Tests/Opc.Ua.Client.Tests/SubscriptionTest.cs
+++ b/Tests/Opc.Ua.Client.Tests/SubscriptionTest.cs
@@ -483,12 +483,14 @@ namespace Opc.Ua.Client.Tests
 
             var stopwatch = Stopwatch.StartNew();
 
+            await Task.Delay(1000);
+
             // verify that number of active publishrequests is never exceeded
             while (stopwatch.ElapsedMilliseconds < TestWaitTime)
             {
                 // use the sample server default for max publish request count
                 Assert.GreaterOrEqual(MaxServerPublishRequest, m_session.GoodPublishRequestCount);
-                await Task.Delay(10);
+                await Task.Delay(100);
             }
 
             foreach (var subscription in subscriptionList)

--- a/Tests/Opc.Ua.Client.Tests/SubscriptionTest.cs
+++ b/Tests/Opc.Ua.Client.Tests/SubscriptionTest.cs
@@ -383,12 +383,14 @@ namespace Opc.Ua.Client.Tests
                 subscription.FastDataChangeCallback = (_, notification, __) => {
                     notification.MonitoredItems.ForEach(item => {
                         Interlocked.Increment(ref numOfNotifications);
-                        if (dict[item.ClientHandle] > item.Value.SourceTimestamp)
+                        if (enabled)
                         {
-                            sequenceBroken.Set(); //Out of order encountered
+                            if (dict[item.ClientHandle] > item.Value.SourceTimestamp)
+                            {
+                                sequenceBroken.Set(); //Out of order encountered
+                            }
+                            dict[item.ClientHandle] = item.Value.SourceTimestamp;
                         }
-
-                        dict[item.ClientHandle] = item.Value.SourceTimestamp;
                     });
                 };
             }


### PR DESCRIPTION
fixes #1455 
Test validates that client handles the BadTooManyPublishrequest properly and lowers number of active requests if necessary.