### PR TITLE
Set DefaultEncodingId in DataTypeDefinition, was always null NodeId

### DIFF
--- a/Libraries/Opc.Ua.Server/NodeManager/INodeManager.cs
+++ b/Libraries/Opc.Ua.Server/NodeManager/INodeManager.cs
@@ -34,10 +34,23 @@ using System.Text;
 namespace Opc.Ua.Server
 {
     /// <summary>
+    /// An interface to an object that creates a INodeManager object.
+    /// </summary>
+    public interface INodeManagerFactory
+    {
+        /// <summary>
+        /// The INodeManager factory.
+        /// </summary>
+        /// <param name="server">The server instance.</param>
+        /// <param name="configuration">The application configuration.</param>
+        INodeManager Create(IServerInternal server, ApplicationConfiguration configuration);
+    }
+
+    /// <summary>
     /// An interface to an object that manages a set of nodes in the address space.
     /// </summary>
     public interface INodeManager
-    {        
+    {
         /// <summary>
         /// Returns the NamespaceUris for the Nodes belonging to the NodeManager.
         /// </summary>
@@ -61,8 +74,8 @@ namespace Opc.Ua.Server
         /// by other node managers. In these cases, the node managers only manage one half of those references. The
         /// other half of the reference should be returned to the MasterNodeManager.
         /// </remarks>
-        void CreateAddressSpace(IDictionary<NodeId,IList<IReference>> externalReferences);
-        
+        void CreateAddressSpace(IDictionary<NodeId, IList<IReference>> externalReferences);
+
         /// <summary>
         /// Deletes the address by releasing all resources and disconnecting from any underlying system.
         /// </summary>
@@ -85,17 +98,17 @@ namespace Opc.Ua.Server
         /// <remarks>
         /// The node manager checks the dictionary for nodes that it owns and ensures the associated references exist.
         /// </remarks>
-        void AddReferences(IDictionary<NodeId,IList<IReference>> references);
-               
+        void AddReferences(IDictionary<NodeId, IList<IReference>> references);
+
         /// <summary>
         /// Deletes a reference.
         /// </summary>
         ServiceResult DeleteReference(
-            object         sourceHandle, 
-            NodeId         referenceTypeId,
-            bool           isInverse, 
-            ExpandedNodeId targetId, 
-            bool           deleteBidirectional);
+            object sourceHandle,
+            NodeId referenceTypeId,
+            bool isInverse,
+            ExpandedNodeId targetId,
+            bool deleteBidirectional);
 
         /// <summary>
         /// Returns the metadata associated with the node.
@@ -125,8 +138,8 @@ namespace Opc.Ua.Server
         /// <exception cref="ArgumentNullException">Thrown if the context, continuationPoint or references parameters are null.</exception>
         /// <exception cref="ServiceResultException">Thrown if an error occurs during processing.</exception>
         void Browse(
-            OperationContext            context,
-            ref ContinuationPoint       continuationPoint,
+            OperationContext context,
+            ref ContinuationPoint continuationPoint,
             IList<ReferenceDescription> references);
 
         /// <summary>
@@ -146,11 +159,11 @@ namespace Opc.Ua.Server
         /// </remarks>
         /// <exception cref="ArgumentNullException">Thrown if the sourceHandle, relativePath or targetIds parameters are null.</exception>
         void TranslateBrowsePath(
-            OperationContext      context,
-            object                sourceHandle, 
-            RelativePathElement   relativePath, 
+            OperationContext context,
+            object sourceHandle,
+            RelativePathElement relativePath,
             IList<ExpandedNodeId> targetIds,
-            IList<NodeId>         unresolvedTargetIds);
+            IList<NodeId> unresolvedTargetIds);
 
         /// <summary>
         /// Reads the attribute values for a set of nodes.
@@ -170,23 +183,23 @@ namespace Opc.Ua.Server
         /// The node manager must set the Processed flag for any ReadValueId that it processes.
         /// </remarks>
         void Read(
-            OperationContext     context,
-            double               maxAge,
-            IList<ReadValueId>   nodesToRead,
-            IList<DataValue>     values,
+            OperationContext context,
+            double maxAge,
+            IList<ReadValueId> nodesToRead,
+            IList<DataValue> values,
             IList<ServiceResult> errors);
-        
+
         /// <summary>
         /// Reads the history of a set of items.
         /// </summary>
         void HistoryRead(
-            OperationContext          context,
-            HistoryReadDetails        details, 
-            TimestampsToReturn        timestampsToReturn, 
-            bool                      releaseContinuationPoints, 
-            IList<HistoryReadValueId> nodesToRead, 
-            IList<HistoryReadResult>  results, 
-            IList<ServiceResult>      errors);
+            OperationContext context,
+            HistoryReadDetails details,
+            TimestampsToReturn timestampsToReturn,
+            bool releaseContinuationPoints,
+            IList<HistoryReadValueId> nodesToRead,
+            IList<HistoryReadResult> results,
+            IList<ServiceResult> errors);
 
         /// <summary>
         /// Writes a set of values.
@@ -196,28 +209,28 @@ namespace Opc.Ua.Server
         /// must set the Processed flag in the WriteValue structure.
         /// </remarks>
         void Write(
-            OperationContext     context,
-            IList<WriteValue>    nodesToWrite, 
+            OperationContext context,
+            IList<WriteValue> nodesToWrite,
             IList<ServiceResult> errors);
-        
+
         /// <summary>
         /// Updates the history for a set of nodes.
         /// </summary>
         void HistoryUpdate(
-            OperationContext            context,
-            Type                        detailsType,
-            IList<HistoryUpdateDetails> nodesToUpdate, 
-            IList<HistoryUpdateResult>  results, 
-            IList<ServiceResult>        errors);
+            OperationContext context,
+            Type detailsType,
+            IList<HistoryUpdateDetails> nodesToUpdate,
+            IList<HistoryUpdateResult> results,
+            IList<ServiceResult> errors);
 
         /// <summary>
         /// Calls a method defined on a object.
         /// </summary>
         void Call(
-            OperationContext         context,
+            OperationContext context,
             IList<CallMethodRequest> methodsToCall,
-            IList<CallMethodResult>  results,
-            IList<ServiceResult>     errors);
+            IList<CallMethodResult> results,
+            IList<ServiceResult> errors);
 
         /// <summary>
         /// Tells the NodeManager to report events from the specified notifier.
@@ -226,13 +239,13 @@ namespace Opc.Ua.Server
         /// This method may be called multiple times for the name monitoredItemId if the
         /// context for that MonitoredItem changes (i.e. UserIdentity and/or Locales).
         /// </remarks>
-        ServiceResult SubscribeToEvents(            
-            OperationContext    context,
-            object              sourceId,
-            uint                subscriptionId,
+        ServiceResult SubscribeToEvents(
+            OperationContext context,
+            object sourceId,
+            uint subscriptionId,
             IEventMonitoredItem monitoredItem,
-            bool                unsubscribe);
-        
+            bool unsubscribe);
+
         /// <summary>
         /// Tells the NodeManager to report events all events from all sources.
         /// </summary>
@@ -240,64 +253,64 @@ namespace Opc.Ua.Server
         /// This method may be called multiple times for the name monitoredItemId if the
         /// context for that MonitoredItem changes (i.e. UserIdentity and/or Locales).
         /// </remarks>
-        ServiceResult SubscribeToAllEvents(            
-            OperationContext   context,
-            uint                subscriptionId,
+        ServiceResult SubscribeToAllEvents(
+            OperationContext context,
+            uint subscriptionId,
             IEventMonitoredItem monitoredItem,
-            bool                unsubscribe);
-        
+            bool unsubscribe);
+
         /// <summary>
         /// Tells the NodeManager to refresh any conditions.
         /// </summary>
-        ServiceResult ConditionRefresh(            
-            OperationContext           context,
+        ServiceResult ConditionRefresh(
+            OperationContext context,
             IList<IEventMonitoredItem> monitoredItems);
 
         /// <summary>
         /// Creates a set of monitored items.
         /// </summary>
         void CreateMonitoredItems(
-            OperationContext                  context,
-            uint                              subscriptionId,
-            double                            publishingInterval,
-            TimestampsToReturn                timestampsToReturn,
+            OperationContext context,
+            uint subscriptionId,
+            double publishingInterval,
+            TimestampsToReturn timestampsToReturn,
             IList<MonitoredItemCreateRequest> itemsToCreate,
-            IList<ServiceResult>              errors,
-            IList<MonitoringFilterResult>     filterErrors,
-            IList<IMonitoredItem>             monitoredItems,
-            ref long                          globalIdCounter);
-                
+            IList<ServiceResult> errors,
+            IList<MonitoringFilterResult> filterErrors,
+            IList<IMonitoredItem> monitoredItems,
+            ref long globalIdCounter);
+
         /// <summary>
         /// Modifies a set of monitored items.
         /// </summary>
         void ModifyMonitoredItems(
-            OperationContext                  context,
-            TimestampsToReturn                timestampsToReturn,
-            IList<IMonitoredItem>             monitoredItems,
+            OperationContext context,
+            TimestampsToReturn timestampsToReturn,
+            IList<IMonitoredItem> monitoredItems,
             IList<MonitoredItemModifyRequest> itemsToModify,
-            IList<ServiceResult>              errors,
-            IList<MonitoringFilterResult>     filterErrors);
+            IList<ServiceResult> errors,
+            IList<MonitoringFilterResult> filterErrors);
 
         /// <summary>
         /// Deletes a set of monitored items.
         /// </summary>
         void DeleteMonitoredItems(
-            OperationContext      context,
-            IList<IMonitoredItem> monitoredItems, 
-            IList<bool>           processedItems,
-            IList<ServiceResult>  errors);
-        
+            OperationContext context,
+            IList<IMonitoredItem> monitoredItems,
+            IList<bool> processedItems,
+            IList<ServiceResult> errors);
+
         /// <summary>
         /// Changes the monitoring mode for a set of monitored items.
         /// </summary>
         void SetMonitoringMode(
-            OperationContext      context,
-            MonitoringMode        monitoringMode,
-            IList<IMonitoredItem> monitoredItems, 
-            IList<bool>           processedItems,
-            IList<ServiceResult>  errors);
+            OperationContext context,
+            MonitoringMode monitoringMode,
+            IList<IMonitoredItem> monitoredItems,
+            IList<bool> processedItems,
+            IList<ServiceResult> errors);
     }
-    
+
     /// <summary>
     /// An interface to an object that manages a set of nodes in the address space.
     /// </summary>
@@ -328,7 +341,7 @@ namespace Opc.Ua.Server
             Dictionary<NodeId, List<object>> uniqueNodesServiceAttributesCache,
             bool permissionsOnly);
     }
-    
+
     /// <summary>
     /// Stores metadata required to process requests related to a node.
     /// </summary>
@@ -344,7 +357,7 @@ namespace Opc.Ua.Server
             m_nodeId = nodeId;
         }
         #endregion
-        
+
         #region Public Properties
         /// <summary>
         /// The handle assigned by the NodeManager that owns the Node.
@@ -360,14 +373,14 @@ namespace Opc.Ua.Server
         public NodeId NodeId
         {
             get { return m_nodeId; }
-        }        
+        }
 
         /// <summary>
         /// The NodeClass for the Node.
         /// </summary>
         public NodeClass NodeClass
         {
-            get { return m_nodeClass;  }
+            get { return m_nodeClass; }
             set { m_nodeClass = value; }
         }
 
@@ -376,7 +389,7 @@ namespace Opc.Ua.Server
         /// </summary>
         public QualifiedName BrowseName
         {
-            get { return m_browseName;  }
+            get { return m_browseName; }
             set { m_browseName = value; }
         }
 
@@ -385,7 +398,7 @@ namespace Opc.Ua.Server
         /// </summary>
         public LocalizedText DisplayName
         {
-            get { return m_displayName;  }
+            get { return m_displayName; }
             set { m_displayName = value; }
         }
 
@@ -394,7 +407,7 @@ namespace Opc.Ua.Server
         /// </summary>
         public ExpandedNodeId TypeDefinition
         {
-            get { return m_typeDefinition;  }
+            get { return m_typeDefinition; }
             set { m_typeDefinition = value; }
         }
 
@@ -403,7 +416,7 @@ namespace Opc.Ua.Server
         /// </summary>
         public NodeId ModellingRule
         {
-            get { return m_modellingRule;  }
+            get { return m_modellingRule; }
             set { m_modellingRule = value; }
         }
 
@@ -412,7 +425,7 @@ namespace Opc.Ua.Server
         /// </summary>
         public AttributeWriteMask WriteMask
         {
-            get { return m_writeMask;  }
+            get { return m_writeMask; }
             set { m_writeMask = value; }
         }
 
@@ -421,16 +434,16 @@ namespace Opc.Ua.Server
         /// </summary>
         public byte EventNotifier
         {
-            get { return m_eventNotifier;  }
+            get { return m_eventNotifier; }
             set { m_eventNotifier = value; }
         }
-        
+
         /// <summary>
         /// Whether the Node can be use to read or write current or historical values.
         /// </summary>
         public byte AccessLevel
         {
-            get { return m_accessLevel;  }
+            get { return m_accessLevel; }
             set { m_accessLevel = value; }
         }
 
@@ -439,7 +452,7 @@ namespace Opc.Ua.Server
         /// </summary>
         public bool Executable
         {
-            get { return m_executable;  }
+            get { return m_executable; }
             set { m_executable = value; }
         }
 
@@ -448,7 +461,7 @@ namespace Opc.Ua.Server
         /// </summary>
         public NodeId DataType
         {
-            get { return m_dataType;  }
+            get { return m_dataType; }
             set { m_dataType = value; }
         }
 
@@ -457,7 +470,7 @@ namespace Opc.Ua.Server
         /// </summary>
         public int ValueRank
         {
-            get { return m_valueRank;  }
+            get { return m_valueRank; }
             set { m_valueRank = value; }
         }
 
@@ -466,7 +479,7 @@ namespace Opc.Ua.Server
         /// </summary>
         public IList<uint> ArrayDimensions
         {
-            get { return m_arrayDimensions;  }
+            get { return m_arrayDimensions; }
             set { m_arrayDimensions = value; }
         }
 

--- a/Stack/Opc.Ua.Core/Stack/Nodes/TypeTable.cs
+++ b/Stack/Opc.Ua.Core/Stack/Nodes/TypeTable.cs
@@ -15,7 +15,7 @@ using System.Collections.Generic;
 namespace Opc.Ua
 {
     /// <summary>
-    /// Stores the type tree for a server. 
+    /// Stores the type tree for a server.
     /// </summary>
     public class TypeTable : ITypeTable
     {
@@ -26,24 +26,24 @@ namespace Opc.Ua
         /// <param name="namespaceUris">The namespace URIs.</param>
         public TypeTable(NamespaceTable namespaceUris)
         {
-            m_namespaceUris  = namespaceUris;
-            m_referenceTypes = new SortedDictionary<QualifiedName,TypeInfo>();
+            m_namespaceUris = namespaceUris;
+            m_referenceTypes = new SortedDictionary<QualifiedName, TypeInfo>();
             m_nodes = new NodeIdDictionary<TypeInfo>();
             m_encodings = new NodeIdDictionary<TypeInfo>();
         }
         #endregion
 
         #region ITypeTable Methods
-        /// <summary cref="ITypeTable.IsKnown(ExpandedNodeId)" />
+        /// <inheritdoc/>
         public bool IsKnown(ExpandedNodeId typeId)
-        {            
+        {
             if (NodeId.IsNull(typeId) || typeId.ServerIndex != 0)
             {
                 return false;
             }
 
             NodeId localId = ExpandedNodeId.ToNodeId(typeId, m_namespaceUris);
-            
+
             if (localId == null)
             {
                 return false;
@@ -55,9 +55,9 @@ namespace Opc.Ua
             }
         }
 
-        /// <summary cref="ITypeTable.IsKnown(NodeId)" />
+        /// <inheritdoc/>
         public bool IsKnown(NodeId typeId)
-        {            
+        {
             if (NodeId.IsNull(typeId))
             {
                 return false;
@@ -67,18 +67,18 @@ namespace Opc.Ua
             {
                 return m_nodes.ContainsKey(typeId);
             }
-        }                
-                
-        /// <summary cref="ITypeTable.FindSuperType(ExpandedNodeId)" />
+        }
+
+        /// <inheritdoc/>
         public NodeId FindSuperType(ExpandedNodeId typeId)
         {
             if (NodeId.IsNull(typeId) || typeId.ServerIndex != 0)
             {
                 return NodeId.Null;
             }
-            
+
             NodeId localId = ExpandedNodeId.ToNodeId(typeId, m_namespaceUris);
-            
+
             if (localId == null)
             {
                 return NodeId.Null;
@@ -101,10 +101,10 @@ namespace Opc.Ua
                 return NodeId.Null;
             }
         }
-                
-        /// <summary cref="ITypeTable.FindSuperType(NodeId)" />
+
+        /// <inheritdoc/>
         public NodeId FindSuperType(NodeId typeId)
-        {            
+        {
             if (typeId == null)
             {
                 return NodeId.Null;
@@ -128,7 +128,7 @@ namespace Opc.Ua
             }
         }
 
-        /// <summary cref="ITypeTable.FindSubTypes(ExpandedNodeId)" />
+        /// <inheritdoc/>
         public IList<NodeId> FindSubTypes(ExpandedNodeId typeId)
         {
             List<NodeId> subtypes = new List<NodeId>();
@@ -158,14 +158,14 @@ namespace Opc.Ua
             }
         }
 
-        /// <summary cref="ITypeTable.IsTypeOf(ExpandedNodeId, ExpandedNodeId)" />
+        /// <inheritdoc/>
         public bool IsTypeOf(ExpandedNodeId subTypeId, ExpandedNodeId superTypeId)
         {
             if (NodeId.IsNull(subTypeId) || subTypeId.ServerIndex != 0)
             {
                 return false;
             }
-            
+
             if (NodeId.IsNull(superTypeId) || superTypeId.ServerIndex != 0)
             {
                 return false;
@@ -178,14 +178,14 @@ namespace Opc.Ua
             }
 
             NodeId startId = ExpandedNodeId.ToNodeId(subTypeId, m_namespaceUris);
-            
+
             if (startId == null)
             {
                 return false;
             }
 
             NodeId targetId = ExpandedNodeId.ToNodeId(superTypeId, m_namespaceUris);
-            
+
             if (targetId == null)
             {
                 return false;
@@ -204,7 +204,7 @@ namespace Opc.Ua
             }
         }
 
-        /// <summary cref="ITypeTable.IsTypeOf(NodeId,NodeId)" />
+        /// <inheritdoc/>
         public bool IsTypeOf(NodeId subTypeId, NodeId superTypeId)
         {
             // check for null.
@@ -218,7 +218,7 @@ namespace Opc.Ua
             {
                 return true;
             }
-            
+
             lock (m_lock)
             {
                 TypeInfo typeInfo = null;
@@ -231,9 +231,8 @@ namespace Opc.Ua
                 return typeInfo.IsTypeOf(superTypeId);
             }
         }
-        
-        
-        /// <summary cref="ITypeTable.FindReferenceTypeName" />
+
+        /// <inheritdoc/>
         public QualifiedName FindReferenceTypeName(NodeId referenceTypeId)
         {
             lock (m_lock)
@@ -249,7 +248,7 @@ namespace Opc.Ua
             }
         }
 
-        /// <summary cref="ITypeTable.FindReferenceType" />
+        /// <inheritdoc/>
         public NodeId FindReferenceType(QualifiedName browseName)
         {
             // check for empty name.
@@ -270,8 +269,8 @@ namespace Opc.Ua
                 return typeInfo.NodeId;
             }
         }
-        
-        /// <summary cref="ITypeTable.IsEncodingOf(ExpandedNodeId, ExpandedNodeId)" />
+
+        /// <inheritdoc/>
         public bool IsEncodingOf(ExpandedNodeId encodingId, ExpandedNodeId datatypeId)
         {
             // check for invalid ids.
@@ -279,7 +278,7 @@ namespace Opc.Ua
             {
                 return false;
             }
-            
+
             NodeId localId = ExpandedNodeId.ToNodeId(encodingId, m_namespaceUris);
 
             if (localId == null)
@@ -288,7 +287,7 @@ namespace Opc.Ua
             }
 
             NodeId localTypeId = ExpandedNodeId.ToNodeId(datatypeId, m_namespaceUris);
-            
+
             if (localTypeId == null)
             {
                 return false;
@@ -327,8 +326,8 @@ namespace Opc.Ua
                 return false;
             }
         }
-        
-        /// <summary cref="ITypeTable.IsEncodingFor(NodeId, ExtensionObject)" />
+
+        /// <inheritdoc/>
         public bool IsEncodingFor(NodeId expectedTypeId, ExtensionObject value)
         {
             // no match on null values.
@@ -347,7 +346,7 @@ namespace Opc.Ua
             return false;
         }
 
-        /// <summary cref="ITypeTable.IsEncodingFor(NodeId, object)" />
+        /// <inheritdoc/>
         public bool IsEncodingFor(NodeId expectedTypeId, object value)
         {
             // null actual datatype matches nothing.
@@ -381,12 +380,12 @@ namespace Opc.Ua
 
             // for structure types must try to determine the subtype.
             ExtensionObject extension = value as ExtensionObject;
-            
+
             if (extension != null)
             {
                 return IsEncodingFor(expectedTypeId, extension);
             }
-            
+
             // every element in an array must match.
             ExtensionObject[] extensions = value as ExtensionObject[];
 
@@ -406,10 +405,10 @@ namespace Opc.Ua
             // can only get here if the value is an unrecognized data type.
             return false;
         }
-        
-        /// <summary cref="ITypeTable.FindDataTypeId(ExpandedNodeId)" />
-        public NodeId FindDataTypeId(ExpandedNodeId encodingId)            
-        {            
+
+        /// <inheritdoc/>
+        public NodeId FindDataTypeId(ExpandedNodeId encodingId)
+        {
             NodeId localId = ExpandedNodeId.ToNodeId(encodingId, m_namespaceUris);
 
             if (localId == null)
@@ -430,8 +429,8 @@ namespace Opc.Ua
             }
         }
 
-        /// <summary cref="ITypeTable.FindDataTypeId(NodeId)" />
-        public NodeId FindDataTypeId(NodeId encodingId)            
+        /// <inheritdoc/>
+        public NodeId FindDataTypeId(NodeId encodingId)
         {
             lock (m_lock)
             {
@@ -472,7 +471,7 @@ namespace Opc.Ua
             {
                 return;
             }
-            
+
             // ignore non-types.
             if ((node.NodeClass & (NodeClass.ObjectType | NodeClass.VariableType | NodeClass.ReferenceType | NodeClass.DataType)) == 0)
             {
@@ -487,11 +486,11 @@ namespace Opc.Ua
             if (superTypeId != null)
             {
                 localsuperTypeId = ExpandedNodeId.ToNodeId(superTypeId, m_namespaceUris);
-                
+
                 if (localsuperTypeId == null)
                 {
                     throw ServiceResultException.Create(StatusCodes.BadNodeIdInvalid, "A valid supertype identifier is required.");
-                }              
+                }
             }
 
             lock (m_lock)
@@ -515,7 +514,7 @@ namespace Opc.Ua
                     typeInfo = new TypeInfo();
                     m_nodes.Add(node.NodeId, typeInfo);
                 }
-                
+
                 // update the info.
                 typeInfo.NodeId = node.NodeId;
                 typeInfo.SuperType = superTypeInfo;
@@ -526,7 +525,7 @@ namespace Opc.Ua
                 {
                     superTypeInfo.AddSubType(typeInfo);
                 }
-                                
+
                 // remove the encodings.
                 if (typeInfo.Encodings != null)
                 {
@@ -549,7 +548,7 @@ namespace Opc.Ua
                         m_encodings[typeInfo.Encodings[ii]] = typeInfo;
                     }
                 }
-                
+
                 // add reference type.
                 if ((node.NodeClass & NodeClass.ReferenceType) != 0)
                 {
@@ -557,14 +556,14 @@ namespace Opc.Ua
                     {
                         m_referenceTypes.Remove(typeInfo.BrowseName);
                     }
-                    
+
                     typeInfo.BrowseName = node.BrowseName;
 
                     m_referenceTypes[node.BrowseName] = typeInfo;
                 }
             }
         }
-        
+
         /// <summary>
         /// Adds type to the table. A browse name is only required if it is a ReferenceType.
         /// </summary>
@@ -607,7 +606,7 @@ namespace Opc.Ua
             lock (m_lock)
             {
                 TypeInfo typeInfo = null;
-                
+
                 if (!m_nodes.TryGetValue(dataTypeId, out typeInfo))
                 {
                     return false;
@@ -662,7 +661,7 @@ namespace Opc.Ua
                     typeInfo = new TypeInfo();
                     m_nodes.Add(subTypeId, typeInfo);
                 }
-                
+
                 // update the info.
                 typeInfo.NodeId = subTypeId;
                 typeInfo.SuperType = superTypeInfo;
@@ -682,7 +681,7 @@ namespace Opc.Ua
                         m_encodings.Remove(encoding);
                     }
                 }
-                
+
                 // add reference type.
                 if (!QualifiedName.IsNull(browseName))
                 {
@@ -701,7 +700,7 @@ namespace Opc.Ua
             {
                 return;
             }
-            
+
             NodeId localId = ExpandedNodeId.ToNodeId(typeId, m_namespaceUris);
 
             if (localId == null)
@@ -716,7 +715,7 @@ namespace Opc.Ua
 
                 if (!m_nodes.TryGetValue(localId, out typeInfo))
                 {
-                    return;               
+                    return;
                 }
 
                 m_nodes.Remove(localId);
@@ -738,7 +737,7 @@ namespace Opc.Ua
                         m_encodings.Remove(typeInfo.Encodings[ii]);
                     }
                 }
-                        
+
                 // remove reference type.
                 if (!QualifiedName.IsNull(typeInfo.BrowseName))
                 {
@@ -771,7 +770,7 @@ namespace Opc.Ua
             public bool IsTypeOf(NodeId nodeId)
             {
                 TypeInfo typeInfo = SuperType;
-                
+
                 while (typeInfo != null)
                 {
                     if (!typeInfo.Deleted && typeInfo.NodeId == nodeId)
@@ -834,11 +833,11 @@ namespace Opc.Ua
             }
         }
         #endregion
-        
+
         #region Private Fields
         private object m_lock = new object();
         private NamespaceTable m_namespaceUris;
-        private SortedDictionary<QualifiedName,TypeInfo> m_referenceTypes;
+        private SortedDictionary<QualifiedName, TypeInfo> m_referenceTypes;
         private NodeIdDictionary<TypeInfo> m_nodes;
         private NodeIdDictionary<TypeInfo> m_encodings;
         #endregion

--- a/Stack/Opc.Ua.Core/Stack/State/DataTypeState.cs
+++ b/Stack/Opc.Ua.Core/Stack/State/DataTypeState.cs
@@ -193,14 +193,8 @@ namespace Opc.Ua
                         if (dataTypeDefinition?.Body is StructureDefinition structureType &&
                             structureType.DefaultEncodingId.IsNullNodeId)
                         {
-                            // note: custom types must be added to the encodeable factory by the node manager to be found
-                            var systemType = context?.EncodeableFactory?.GetSystemType(NodeId.ToExpandedNodeId(NodeId, context.NamespaceUris));
-                            if (systemType != null &&
-                                Activator.CreateInstance(systemType) is IEncodeable encodeable)
-                            {
-                                // one time set the id for binary encoding, currently the only supported encoding
-                                structureType.DefaultEncodingId = ExpandedNodeId.ToNodeId(encodeable.BinaryEncodingId, context.NamespaceUris);
-                            }
+                            // one time set the id for binary encoding, currently the only supported encoding
+                            structureType.SetDefaultEncodingId(context, NodeId, null);
                         }
                         value = dataTypeDefinition;
                     }

--- a/Stack/Opc.Ua.Core/Stack/State/DataTypeState.cs
+++ b/Stack/Opc.Ua.Core/Stack/State/DataTypeState.cs
@@ -190,11 +190,11 @@ namespace Opc.Ua
 
                     if (ServiceResult.IsGood(result))
                     {
-                        if (dataTypeDefinition.Body is StructureDefinition structureType &&
+                        if (dataTypeDefinition?.Body is StructureDefinition structureType &&
                             structureType.DefaultEncodingId.IsNullNodeId)
                         {
                             // note: custom types must be added to the encodeable factory by the node manager to be found
-                            var systemType = context.EncodeableFactory.GetSystemType(NodeId.ToExpandedNodeId(NodeId, context.NamespaceUris));
+                            var systemType = context?.EncodeableFactory?.GetSystemType(NodeId.ToExpandedNodeId(NodeId, context.NamespaceUris));
                             if (systemType != null &&
                                 Activator.CreateInstance(systemType) is IEncodeable encodeable)
                             {

--- a/Stack/Opc.Ua.Core/Stack/State/ModelCompilerExtension.cs
+++ b/Stack/Opc.Ua.Core/Stack/State/ModelCompilerExtension.cs
@@ -1,3 +1,15 @@
+/* Copyright (c) 1996-2020 The OPC Foundation. All rights reserved.
+   The source code in this file is covered under a dual-license scenario:
+     - RCL: for OPC Foundation members in good-standing
+     - GPL V2: everybody else
+   RCL license terms accompanied with this source code. See http://opcfoundation.org/License/RCL/1.00/
+   GNU General Public License as published by the Free Software Foundation;
+   version 2 of the License are accompanied with this source code. See http://opcfoundation.org/License/GPLv2
+   This source code is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+*/
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Stack/Opc.Ua.Core/Stack/Types/StructureDefinition.cs
+++ b/Stack/Opc.Ua.Core/Stack/Types/StructureDefinition.cs
@@ -1,0 +1,58 @@
+/* Copyright (c) 1996-2020 The OPC Foundation. All rights reserved.
+   The source code in this file is covered under a dual-license scenario:
+     - RCL: for OPC Foundation members in good-standing
+     - GPL V2: everybody else
+   RCL license terms accompanied with this source code. See http://opcfoundation.org/License/RCL/1.00/
+   GNU General Public License as published by the Free Software Foundation;
+   version 2 of the License are accompanied with this source code. See http://opcfoundation.org/License/GPLv2
+   This source code is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Xml;
+using System.Runtime.Serialization;
+
+namespace Opc.Ua
+{
+    #region StructureDefinition Class
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <exclude />
+    public partial class StructureDefinition : DataTypeDefinition
+    {
+        /// <summary>
+        /// Set the default encoding id for the requested data encoding.
+        /// </summary>
+        /// <param name="context">The system context with the encodeable factory.</param>
+        /// <param name="typeId">The type id of the Data Type.</param>
+        /// <param name="dataEncoding">The data encoding to apply to the default encoding id.</param>
+        public void SetDefaultEncodingId(ISystemContext context, NodeId typeId, QualifiedName dataEncoding)
+        {
+            if (dataEncoding?.Name == BrowseNames.DefaultJson)
+            {
+                DefaultEncodingId = ExpandedNodeId.ToNodeId(typeId, context.NamespaceUris);
+                return;
+            }
+
+            // note: custom types must be added to the encodeable factory by the node manager to be found
+            var systemType = context?.EncodeableFactory?.GetSystemType(NodeId.ToExpandedNodeId(typeId, context.NamespaceUris));
+            if (systemType != null && Activator.CreateInstance(systemType) is IEncodeable encodeable)
+            {
+                if (dataEncoding == null || dataEncoding.Name == BrowseNames.DefaultBinary)
+                {
+                    DefaultEncodingId = ExpandedNodeId.ToNodeId(encodeable.BinaryEncodingId, context.NamespaceUris);
+                }
+                else if (dataEncoding.Name == BrowseNames.DefaultXml)
+                {
+                    DefaultEncodingId = ExpandedNodeId.ToNodeId(encodeable.XmlEncodingId, context.NamespaceUris);
+                }
+            }
+        }
+    }
+    #endregion
+}

--- a/Stack/Opc.Ua.Core/Stack/Types/StructureDefinition.cs
+++ b/Stack/Opc.Ua.Core/Stack/Types/StructureDefinition.cs
@@ -33,6 +33,7 @@ namespace Opc.Ua
         /// <param name="dataEncoding">The data encoding to apply to the default encoding id.</param>
         public void SetDefaultEncodingId(ISystemContext context, NodeId typeId, QualifiedName dataEncoding)
         {
+            if (context == null) throw new ArgumentNullException(nameof(context));
             if (dataEncoding?.Name == BrowseNames.DefaultJson)
             {
                 DefaultEncodingId = ExpandedNodeId.ToNodeId(typeId, context.NamespaceUris);
@@ -40,7 +41,7 @@ namespace Opc.Ua
             }
 
             // note: custom types must be added to the encodeable factory by the node manager to be found
-            var systemType = context?.EncodeableFactory?.GetSystemType(NodeId.ToExpandedNodeId(typeId, context.NamespaceUris));
+            var systemType = context.EncodeableFactory?.GetSystemType(NodeId.ToExpandedNodeId(typeId, context.NamespaceUris));
             if (systemType != null && Activator.CreateInstance(systemType) is IEncodeable encodeable)
             {
                 if (dataEncoding == null || dataEncoding.Name == BrowseNames.DefaultBinary)

--- a/Stack/Opc.Ua.Core/Types/Encoders/EncodeableFactory.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/EncodeableFactory.cs
@@ -342,6 +342,26 @@ namespace Opc.Ua
         }
 
         /// <summary>
+        /// Adds an enumerable of extension types to the factory.
+        /// </summary>
+        /// <param name="systemTypes">The underlying system types to add to the factory</param>
+        public void AddEncodeableTypes(IEnumerable<System.Type> systemTypes)
+        {
+            lock (m_lock)
+            {
+                foreach (var type in systemTypes)
+                {
+                    if (type.GetTypeInfo().IsAbstract)
+                    {
+                        continue;
+                    }
+
+                    AddEncodeableType(type);
+                }
+            }
+        }
+
+        /// <summary>
         /// Returns the system type for the specified type id.
         /// </summary>
         /// <remarks>

--- a/Stack/Opc.Ua.Core/Types/Encoders/IEncodeableFactory.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/IEncodeableFactory.cs
@@ -46,9 +46,6 @@ namespace Opc.Ua
         /// <summary>
         /// Adds an extension type to the factory.
         /// </summary>
-        /// <remarks>
-        /// Adds an extension type to the factory.
-        /// </remarks>
         /// <param name="systemType">The underlying system type to add to the factory</param>
         void AddEncodeableType(Type systemType);
 
@@ -74,6 +71,12 @@ namespace Opc.Ua
         /// </remarks>
         /// <param name="assembly">The assembly containing the types to add to the factory</param>
         void AddEncodeableTypes(Assembly assembly);
+
+        /// <summary>
+        /// Adds an enumerable of extension types to the factory.
+        /// </summary>
+        /// <param name="systemTypes">The underlying system types to add to the factory</param>
+        void AddEncodeableTypes(IEnumerable<Type> systemTypes);
 
         /// <summary>
         /// Returns the system type for the specified type id.

--- a/Tests/Opc.Ua.Client.Tests/ClientTest.cs
+++ b/Tests/Opc.Ua.Client.Tests/ClientTest.cs
@@ -303,6 +303,23 @@ namespace Opc.Ua.Client.Tests
             m_session.ChangePreferredLocales(locale);
         }
 
+        [Test]
+        public void ReadDataTypeDefinition()
+        {
+            // Test Read a DataType Node
+            var node = m_session.ReadNode(DataTypeIds.ProgramDiagnosticDataType);
+            Assert.NotNull(node);
+            var dataTypeNode = (DataTypeNode)node;
+            Assert.NotNull(dataTypeNode);
+            var dataTypeDefinition = dataTypeNode.DataTypeDefinition;
+            Assert.NotNull(dataTypeDefinition);
+            Assert.True(dataTypeDefinition is ExtensionObject);
+            Assert.NotNull(dataTypeDefinition.Body);
+            Assert.True(dataTypeDefinition.Body is StructureDefinition);
+            StructureDefinition structureDefinition = dataTypeDefinition.Body as StructureDefinition;
+            Assert.AreEqual(ObjectIds.ProgramDiagnosticDataType_Encoding_DefaultBinary, structureDefinition.DefaultEncodingId);
+        }
+
         [Theory, Order(400)]
         public async Task BrowseFullAddressSpace(string securityPolicy)
         {


### PR DESCRIPTION
- DefaultEncodingId is always set to binary encoding id
- the default encoding id is derived for the encodeable factory, since the typetree does not contain sufficent information to find the proper binary encoding id
- add a few helper functions in core for an upcoming PR that was used for testing with custom types, will simplify to add more nodemanagers to servers with custom types