### PR TITLE
Application config improvements for cert recreation

### DIFF
--- a/Libraries/Opc.Ua.Configuration/ApplicationConfigurationBuilder.cs
+++ b/Libraries/Opc.Ua.Configuration/ApplicationConfigurationBuilder.cs
@@ -29,6 +29,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using System.Xml;
@@ -100,51 +101,42 @@ namespace Opc.Ua.Configuration
             var appStoreType = CertificateStoreIdentifier.DetermineStoreType(appRoot);
             var pkiRootType = CertificateStoreIdentifier.DetermineStoreType(pkiRoot);
             var rejectedRootType = CertificateStoreIdentifier.DetermineStoreType(rejectedRoot);
-            ApplicationConfiguration.SecurityConfiguration = new SecurityConfiguration
-            {
+            ApplicationConfiguration.SecurityConfiguration = new SecurityConfiguration {
                 // app cert store
-                ApplicationCertificate = new CertificateIdentifier()
-                {
+                ApplicationCertificate = new CertificateIdentifier() {
                     StoreType = appStoreType,
                     StorePath = DefaultCertificateStorePath(TrustlistType.Application, appRoot),
                     SubjectName = Utils.ReplaceDCLocalhost(subjectName)
                 },
                 // App trusted & issuer
-                TrustedPeerCertificates = new CertificateTrustList()
-                {
+                TrustedPeerCertificates = new CertificateTrustList() {
                     StoreType = pkiRootType,
                     StorePath = DefaultCertificateStorePath(TrustlistType.Trusted, pkiRoot)
                 },
-                TrustedIssuerCertificates = new CertificateTrustList()
-                {
+                TrustedIssuerCertificates = new CertificateTrustList() {
                     StoreType = pkiRootType,
                     StorePath = DefaultCertificateStorePath(TrustlistType.Issuer, pkiRoot)
                 },
                 // Https trusted & issuer
-                TrustedHttpsCertificates = new CertificateTrustList()
-                {
+                TrustedHttpsCertificates = new CertificateTrustList() {
                     StoreType = pkiRootType,
                     StorePath = DefaultCertificateStorePath(TrustlistType.TrustedHttps, pkiRoot)
                 },
-                HttpsIssuerCertificates = new CertificateTrustList()
-                {
+                HttpsIssuerCertificates = new CertificateTrustList() {
                     StoreType = pkiRootType,
                     StorePath = DefaultCertificateStorePath(TrustlistType.IssuerHttps, pkiRoot)
                 },
                 // User trusted & issuer
-                TrustedUserCertificates = new CertificateTrustList()
-                {
+                TrustedUserCertificates = new CertificateTrustList() {
                     StoreType = pkiRootType,
                     StorePath = DefaultCertificateStorePath(TrustlistType.TrustedUser, pkiRoot)
                 },
-                UserIssuerCertificates = new CertificateTrustList()
-                {
+                UserIssuerCertificates = new CertificateTrustList() {
                     StoreType = pkiRootType,
                     StorePath = DefaultCertificateStorePath(TrustlistType.IssuerUser, pkiRoot)
                 },
                 // rejected store
-                RejectedCertificateStore = new CertificateTrustList()
-                {
+                RejectedCertificateStore = new CertificateTrustList() {
                     StoreType = rejectedRootType,
                     StorePath = DefaultCertificateStorePath(TrustlistType.Rejected, rejectedRoot)
                 },
@@ -776,21 +768,21 @@ namespace Opc.Ua.Configuration
                 switch (trustListType)
                 {
                     case TrustlistType.Application:
-                        return pkiRoot + "/own";
+                        return Path.Combine(pkiRoot, "own");
                     case TrustlistType.Trusted:
-                        return pkiRoot + "/trusted";
+                        return Path.Combine(pkiRoot, "trusted");
                     case TrustlistType.Issuer:
-                        return pkiRoot + "/issuer";
+                        return Path.Combine(pkiRoot, "issuer");
                     case TrustlistType.TrustedHttps:
-                        return pkiRoot + "/trustedHttps";
+                        return Path.Combine(pkiRoot, "trustedHttps");
                     case TrustlistType.IssuerHttps:
-                        return pkiRoot + "/issuerHttps";
+                        return Path.Combine(pkiRoot, "issuerHttps");
                     case TrustlistType.TrustedUser:
-                        return pkiRoot + "/trustedUser";
+                        return Path.Combine(pkiRoot, "trustedUser");
                     case TrustlistType.IssuerUser:
-                        return pkiRoot + "/issuerUser";
+                        return Path.Combine(pkiRoot, "issuerUser");
                     case TrustlistType.Rejected:
-                        return pkiRoot + "/rejected";
+                        return Path.Combine(pkiRoot, "rejected");
                 }
             }
             else if (pkiRootType.Equals(CertificateStoreType.X509Store, StringComparison.OrdinalIgnoreCase))
@@ -876,8 +868,7 @@ namespace Opc.Ua.Configuration
         private bool InternalAddPolicy(ServerSecurityPolicyCollection policies, MessageSecurityMode securityMode, string policyUri)
         {
             if (securityMode == MessageSecurityMode.Invalid) throw new ArgumentException("Invalid security mode selected", nameof(securityMode));
-            var newPolicy = new ServerSecurityPolicy()
-            {
+            var newPolicy = new ServerSecurityPolicy() {
                 SecurityMode = securityMode,
                 SecurityPolicyUri = policyUri
             };

--- a/Libraries/Opc.Ua.Configuration/ApplicationInstance.cs
+++ b/Libraries/Opc.Ua.Configuration/ApplicationInstance.cs
@@ -569,6 +569,8 @@ namespace Opc.Ua.Configuration
                     StatusCodes.BadCertificateUntrusted,
                     StatusCodes.BadCertificateTimeInvalid,
                     StatusCodes.BadCertificateHostNameInvalid,
+                    StatusCodes.BadCertificateRevocationUnknown,
+                    StatusCodes.BadCertificateIssuerRevocationUnknown,
                 });
 
             Utils.Trace(Utils.TraceMasks.Information, "Checking application instance certificate. {0}", certificate.Subject);

--- a/Libraries/Opc.Ua.Configuration/ApplicationInstance.cs
+++ b/Libraries/Opc.Ua.Configuration/ApplicationInstance.cs
@@ -30,6 +30,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
@@ -416,7 +417,6 @@ namespace Opc.Ua.Configuration
             }
 
             ApplicationConfiguration configuration = m_applicationConfiguration;
-            bool certificateValid = false;
 
             // find the existing certificate.
             CertificateIdentifier id = configuration.SecurityConfiguration.ApplicationCertificate;
@@ -427,12 +427,28 @@ namespace Opc.Ua.Configuration
                     "Configuration file does not specify a certificate.");
             }
 
+            // reload the certificate from disk in the cache.
+            var passwordProvider = configuration.SecurityConfiguration.CertificatePasswordProvider;
+            await configuration.SecurityConfiguration.ApplicationCertificate.LoadPrivateKeyEx(passwordProvider).ConfigureAwait(false);
+
+            // load the certificate
             X509Certificate2 certificate = await id.Find(true).ConfigureAwait(false);
 
             // check that it is ok.
             if (certificate != null)
             {
-                certificateValid = await CheckApplicationInstanceCertificate(configuration, certificate, silent, minimumKeySize).ConfigureAwait(false);
+                bool certificateValid = await CheckApplicationInstanceCertificate(configuration, certificate, silent, minimumKeySize).ConfigureAwait(false);
+
+                if (!certificateValid)
+                {
+                    var message = new StringBuilder();
+                    message.AppendLine("The certificate with subject {0} in the configuration is invalid.");
+                    message.AppendLine(" Please update or delete the certificate from this location:");
+                    message.AppendLine(" {1}");
+                    throw ServiceResultException.Create(StatusCodes.BadConfigurationError,
+                        message.ToString(), id.SubjectName, id.StorePath
+                        );
+                }
             }
             else
             {
@@ -481,7 +497,7 @@ namespace Opc.Ua.Configuration
                 }
             }
 
-            if ((certificate == null) || !certificateValid)
+            if (certificate == null)
             {
                 certificate = await CreateApplicationInstanceCertificate(configuration,
                     minimumKeySize, lifeTimeInMonths).ConfigureAwait(false);
@@ -513,6 +529,27 @@ namespace Opc.Ua.Configuration
 
         #region Private Methods
         /// <summary>
+        /// Helper to suppress errors which are allowed for the application certificate validation.
+        /// </summary>
+        private class CertValidationSuppressibleStatusCodes
+        {
+            public StatusCode[] ApprovedCodes { get; }
+
+            public CertValidationSuppressibleStatusCodes(StatusCode[] approvedCodes)
+            {
+                ApprovedCodes = approvedCodes;
+            }
+
+            public void OnCertificateValidation(object sender, CertificateValidationEventArgs e)
+            {
+                if (ApprovedCodes.Contains(e.Error.StatusCode))
+                {
+                    e.Accept = true;
+                }
+            }
+        }
+
+        /// <summary>
         /// Creates an application instance certificate if one does not already exist.
         /// </summary>
         private async Task<bool> CheckApplicationInstanceCertificate(
@@ -526,12 +563,21 @@ namespace Opc.Ua.Configuration
                 return false;
             }
 
+            // set suppressible errors
+            var certValidator = new CertValidationSuppressibleStatusCodes(
+                new StatusCode[] {
+                    StatusCodes.BadCertificateUntrusted,
+                    StatusCodes.BadCertificateTimeInvalid,
+                    StatusCodes.BadCertificateHostNameInvalid,
+                });
+
             Utils.Trace(Utils.TraceMasks.Information, "Checking application instance certificate. {0}", certificate.Subject);
 
             try
             {
                 // validate certificate.
-                configuration.CertificateValidator.Validate(certificate);
+                configuration.CertificateValidator.CertificateValidation += certValidator.OnCertificateValidation;
+                configuration.CertificateValidator.Validate(certificate.HasPrivateKey ? new X509Certificate2(certificate.RawData) : certificate);
             }
             catch (Exception ex)
             {
@@ -541,6 +587,10 @@ namespace Opc.Ua.Configuration
                 {
                     return false;
                 }
+            }
+            finally
+            {
+                configuration.CertificateValidator.CertificateValidation -= certValidator.OnCertificateValidation;
             }
 
             // check key size.
@@ -728,9 +778,7 @@ namespace Opc.Ua.Configuration
             Utils.Trace(Utils.TraceMasks.Information, "Certificate created. Thumbprint={0}", certificate.Thumbprint);
 
             // reload the certificate from disk.
-            await configuration.SecurityConfiguration.ApplicationCertificate.LoadPrivateKeyEx(passwordProvider).ConfigureAwait(false);
-
-            return certificate;
+            return await configuration.SecurityConfiguration.ApplicationCertificate.LoadPrivateKeyEx(passwordProvider).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -871,7 +919,7 @@ namespace Opc.Ua.Configuration
             }
             else
             {
-                Utils.Trace(message);
+                Utils.Trace(Utils.TraceMasks.Error, message);
                 return false;
             }
         }

--- a/Libraries/Opc.Ua.Security.Certificates/X509Certificate/CertificateBuilderBase.cs
+++ b/Libraries/Opc.Ua.Security.Certificates/X509Certificate/CertificateBuilderBase.cs
@@ -210,7 +210,7 @@ namespace Opc.Ua.Security.Certificates
         }
 
         /// <inheritdoc/>
-        public virtual ICertificateBuilderCreateForRSAAny SetRSAKeySize(int keySize)
+        public virtual ICertificateBuilderCreateForRSAAny SetRSAKeySize(ushort keySize)
         {
             if (keySize == 0)
             {

--- a/Libraries/Opc.Ua.Security.Certificates/X509Certificate/ICertificateBuilder.cs
+++ b/Libraries/Opc.Ua.Security.Certificates/X509Certificate/ICertificateBuilder.cs
@@ -241,7 +241,7 @@ namespace Opc.Ua.Security.Certificates
         /// Set the RSA key size in bits.
         /// </summary>
         /// <param name="keySize">The size of the RSA key.</param>
-        ICertificateBuilderCreateForRSAAny SetRSAKeySize(int keySize);
+        ICertificateBuilderCreateForRSAAny SetRSAKeySize(ushort keySize);
     }
 
 #if ECC_SUPPORT

--- a/Stack/Opc.Ua.Core/Security/Certificates/CertificateFactory.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/CertificateFactory.cs
@@ -98,12 +98,21 @@ namespace Opc.Ua
                     return certificate;
                 }
 
+                if (ensurePrivateKeyAccessible)
+                {
+                    if (!X509Utils.VerifyRSAKeyPair(certificate, certificate))
+                    {
+                        Utils.Trace(Utils.TraceMasks.Error, "WARNING - Trying to add certificate to cache with invalid private key.");
+                        return null;
+                    }
+                }
+
                 // update the cache.
                 m_certificates[certificate.Thumbprint] = certificate;
 
                 if (m_certificates.Count > 100)
                 {
-                    Utils.Trace("WARNING - Process certificate cache has {0} certificates in it.", m_certificates.Count);
+                    Utils.Trace(Utils.TraceMasks.Error, "WARNING - Process certificate cache has {0} certificates in it.", m_certificates.Count);
                 }
 
             }

--- a/Stack/Opc.Ua.Core/Security/Certificates/CertificateIdentifier.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/CertificateIdentifier.cs
@@ -218,10 +218,9 @@ namespace Opc.Ua
                         if (needPrivateKey && this.StoreType == CertificateStoreType.Directory)
                         {
                             var message = new StringBuilder();
-                            message.AppendLine("Loading a certificate with private key from the directory store.");
+                            message.AppendLine("Loaded a certificate with private key from the directory store.");
                             message.AppendLine("Ensure to call LoadPrivateKeyEx with password provider before calling Find(true).");
                             Utils.Trace(Utils.TraceMasks.Error, message.ToString());
-                            Debug.Assert(!needPrivateKey, message.ToString());
                         }
                     }
                 }

--- a/Stack/Opc.Ua.Core/Security/Certificates/CertificateIdentifier.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/CertificateIdentifier.cs
@@ -12,6 +12,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
@@ -154,9 +155,9 @@ namespace Opc.Ua
         /// <summary>
         /// Finds a certificate in a store.
         /// </summary>
-        public async Task<X509Certificate2> Find()
+        public Task<X509Certificate2> Find()
         {
-            return await Find(false).ConfigureAwait(false);
+            return Find(false);
         }
 
         /// <summary>
@@ -168,7 +169,7 @@ namespace Opc.Ua
         /// <summary>
         /// Loads the private key for the certificate with an optional password.
         /// </summary>
-        public async Task<X509Certificate2> LoadPrivateKeyEx(ICertificatePasswordProvider passwordProvider)
+        public Task<X509Certificate2> LoadPrivateKeyEx(ICertificatePasswordProvider passwordProvider)
         {
             if (this.StoreType == CertificateStoreType.Directory)
             {
@@ -177,19 +178,19 @@ namespace Opc.Ua
                     store.Open(this.StorePath);
                     string password = passwordProvider?.GetPassword(this);
                     m_certificate = store.LoadPrivateKey(this.Thumbprint, this.SubjectName, password);
-                    return m_certificate;
+                    return Task.FromResult(m_certificate);
                 }
             }
 
-            return await Find(true).ConfigureAwait(false);
+            return Find(true);
         }
 
         /// <summary>
         /// Finds a certificate in a store.
         /// </summary>
         /// <param name="needPrivateKey">if set to <c>true</c> the returned certificate must contain the private key.</param>
-        /// <returns>An instance of the <see cref="X509Certificate2"/> that is emebeded by this instance or find it in 
-        /// the selected strore pointed out by the <see cref="StorePath"/> using selected <see cref="SubjectName"/>.</returns>
+        /// <returns>An instance of the <see cref="X509Certificate2"/> that is embedded by this instance or find it in 
+        /// the selected store pointed out by the <see cref="StorePath"/> using selected <see cref="SubjectName"/>.</returns>
         public async Task<X509Certificate2> Find(bool needPrivateKey)
         {
             X509Certificate2 certificate = null;
@@ -213,6 +214,15 @@ namespace Opc.Ua
                     if (certificate != null)
                     {
                         m_certificate = certificate;
+
+                        if (needPrivateKey && this.StoreType == CertificateStoreType.Directory)
+                        {
+                            var message = new StringBuilder();
+                            message.AppendLine("Loading a certificate with private key from the directory store.");
+                            message.AppendLine("Ensure to call LoadPrivateKeyEx with password provider before calling Find(true).");
+                            Utils.Trace(Utils.TraceMasks.Error, message.ToString());
+                            Debug.Assert(!needPrivateKey, message.ToString());
+                        }
                     }
                 }
             }

--- a/Stack/Opc.Ua.Core/Security/Certificates/CertificateStoreIdentifier.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/CertificateStoreIdentifier.cs
@@ -11,6 +11,7 @@
 */
 
 using System;
+using System.IO;
 
 namespace Opc.Ua
 {
@@ -74,10 +75,11 @@ namespace Opc.Ua
         /// The path to the default PKI Root.
         /// </summary>
 #if NETFRAMEWORK
-        public static readonly string DefaultPKIRoot = "%CommonApplicationData%/OPC Foundation/pki";
+        public static readonly string DefaultPKIRoot = Path.Combine("%CommonApplicationData%", "OPC Foundation", "pki");
 #else
-        public static readonly string DefaultPKIRoot = "%LocalApplicationData%/OPC Foundation/pki";
+        public static readonly string DefaultPKIRoot = Path.Combine("%LocalApplicationData%","OPC Foundation","pki");
 #endif
+
         /// <summary>
         /// The path to the current user X509Store.
         /// </summary>

--- a/Stack/Opc.Ua.Core/Security/Certificates/CertificateValidator.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/CertificateValidator.cs
@@ -208,9 +208,9 @@ namespace Opc.Ua
                 securityConfiguration.ApplicationCertificate.Certificate = null;
             }
 
-            await Update(securityConfiguration).ConfigureAwait(false);
             await securityConfiguration.ApplicationCertificate.LoadPrivateKeyEx(
                 securityConfiguration.CertificatePasswordProvider).ConfigureAwait(false);
+            await Update(securityConfiguration).ConfigureAwait(false);
 
             lock (m_callbackLock)
             {

--- a/Stack/Opc.Ua.Core/Security/Certificates/CertificateValidator.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/CertificateValidator.cs
@@ -1014,9 +1014,9 @@ namespace Opc.Ua
                 }
             }
         }
-#endregion
+        #endregion
 
-#region Private Methods
+        #region Private Methods
         /// <summary>
         /// Returns an error if the chain status indicates a fatal error.
         /// </summary>
@@ -1249,9 +1249,9 @@ namespace Opc.Ua
             }
             return domainFound;
         }
-#endregion
+        #endregion
 
-#region Private Enum
+        #region Private Enum
         /// <summary>
         /// Flag to protect setting by application
         /// from a modification by a SecurityConfiguration.
@@ -1264,9 +1264,9 @@ namespace Opc.Ua
             RejectUnknownRevocationStatus = 4,
             MinimumCertificateKeySize = 8
         };
-#endregion
+        #endregion
 
-#region Private Fields
+        #region Private Fields
         private object m_lock = new object();
         private object m_callbackLock = new object();
         private Dictionary<string, X509Certificate2> m_validatedCertificates;
@@ -1283,16 +1283,16 @@ namespace Opc.Ua
         private bool m_rejectSHA1SignedCertificates;
         private bool m_rejectUnknownRevocationStatus;
         private ushort m_minimumCertificateKeySize;
-#endregion
+        #endregion
     }
 
-#region CertificateValidationEventArgs Class
+    #region CertificateValidationEventArgs Class
     /// <summary>
     /// The event arguments provided when a certificate validation error occurs.
     /// </summary>
     public class CertificateValidationEventArgs : EventArgs
     {
-#region Constructors
+        #region Constructors
         /// <summary>
         /// Creates a new instance.
         /// </summary>
@@ -1301,9 +1301,9 @@ namespace Opc.Ua
             m_error = error;
             m_certificate = certificate;
         }
-#endregion
+        #endregion
 
-#region Public Properties
+        #region Public Properties
         /// <summary>
         /// The error that occurred.
         /// </summary>
@@ -1333,29 +1333,29 @@ namespace Opc.Ua
             get { return m_acceptAll; }
             set { m_acceptAll = value; }
         }
-#endregion
+        #endregion
 
-#region Private Fields
+        #region Private Fields
         private ServiceResult m_error;
         private X509Certificate2 m_certificate;
         private bool m_accept;
         private bool m_acceptAll;
-#endregion
+        #endregion
     }
 
     /// <summary>
     /// Used to handled certificate validation errors.
     /// </summary>
     public delegate void CertificateValidationEventHandler(CertificateValidator sender, CertificateValidationEventArgs e);
-#endregion
+    #endregion
 
-#region CertificateUpdateEventArgs Class
+    #region CertificateUpdateEventArgs Class
     /// <summary>
     /// The event arguments provided when a certificate validation error occurs.
     /// </summary>
     public class CertificateUpdateEventArgs : EventArgs
     {
-#region Constructors
+        #region Constructors
         /// <summary>
         /// Creates a new instance.
         /// </summary>
@@ -1366,9 +1366,9 @@ namespace Opc.Ua
             SecurityConfiguration = configuration;
             CertificateValidator = validator;
         }
-#endregion
+        #endregion
 
-#region Public Properties
+        #region Public Properties
         /// <summary>
         /// The new security configuration.
         /// </summary>
@@ -1378,7 +1378,7 @@ namespace Opc.Ua
         /// </summary>
         public ICertificateValidator CertificateValidator { get; private set; }
 
-#endregion
+        #endregion
     }
 
 
@@ -1387,6 +1387,6 @@ namespace Opc.Ua
     /// </summary>
     public delegate void CertificateUpdateEventHandler(CertificateValidator sender, CertificateUpdateEventArgs e);
 
-#endregion
+    #endregion
 
 }

--- a/Stack/Opc.Ua.Core/Security/Certificates/CertificateValidator.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/CertificateValidator.cs
@@ -1014,9 +1014,9 @@ namespace Opc.Ua
                 }
             }
         }
-        #endregion
+#endregion
 
-        #region Private Methods
+#region Private Methods
         /// <summary>
         /// Returns an error if the chain status indicates a fatal error.
         /// </summary>
@@ -1249,9 +1249,9 @@ namespace Opc.Ua
             }
             return domainFound;
         }
-        #endregion
+#endregion
 
-        #region Private Enum
+#region Private Enum
         /// <summary>
         /// Flag to protect setting by application
         /// from a modification by a SecurityConfiguration.
@@ -1264,9 +1264,9 @@ namespace Opc.Ua
             RejectUnknownRevocationStatus = 4,
             MinimumCertificateKeySize = 8
         };
-        #endregion
+#endregion
 
-        #region Private Fields
+#region Private Fields
         private object m_lock = new object();
         private object m_callbackLock = new object();
         private Dictionary<string, X509Certificate2> m_validatedCertificates;
@@ -1283,16 +1283,16 @@ namespace Opc.Ua
         private bool m_rejectSHA1SignedCertificates;
         private bool m_rejectUnknownRevocationStatus;
         private ushort m_minimumCertificateKeySize;
-        #endregion
+#endregion
     }
 
-    #region CertificateValidationEventArgs Class
+#region CertificateValidationEventArgs Class
     /// <summary>
     /// The event arguments provided when a certificate validation error occurs.
     /// </summary>
     public class CertificateValidationEventArgs : EventArgs
     {
-        #region Constructors
+#region Constructors
         /// <summary>
         /// Creates a new instance.
         /// </summary>
@@ -1301,9 +1301,9 @@ namespace Opc.Ua
             m_error = error;
             m_certificate = certificate;
         }
-        #endregion
+#endregion
 
-        #region Public Properties
+#region Public Properties
         /// <summary>
         /// The error that occurred.
         /// </summary>
@@ -1333,29 +1333,29 @@ namespace Opc.Ua
             get { return m_acceptAll; }
             set { m_acceptAll = value; }
         }
-        #endregion
+#endregion
 
-        #region Private Fields
+#region Private Fields
         private ServiceResult m_error;
         private X509Certificate2 m_certificate;
         private bool m_accept;
         private bool m_acceptAll;
-        #endregion
+#endregion
     }
 
     /// <summary>
     /// Used to handled certificate validation errors.
     /// </summary>
     public delegate void CertificateValidationEventHandler(CertificateValidator sender, CertificateValidationEventArgs e);
-    #endregion
+#endregion
 
-    #region CertificateUpdateEventArgs Class
+#region CertificateUpdateEventArgs Class
     /// <summary>
     /// The event arguments provided when a certificate validation error occurs.
     /// </summary>
     public class CertificateUpdateEventArgs : EventArgs
     {
-        #region Constructors
+#region Constructors
         /// <summary>
         /// Creates a new instance.
         /// </summary>
@@ -1366,9 +1366,9 @@ namespace Opc.Ua
             SecurityConfiguration = configuration;
             CertificateValidator = validator;
         }
-        #endregion
+#endregion
 
-        #region Public Properties
+#region Public Properties
         /// <summary>
         /// The new security configuration.
         /// </summary>
@@ -1378,7 +1378,7 @@ namespace Opc.Ua
         /// </summary>
         public ICertificateValidator CertificateValidator { get; private set; }
 
-        #endregion
+#endregion
     }
 
 
@@ -1387,6 +1387,6 @@ namespace Opc.Ua
     /// </summary>
     public delegate void CertificateUpdateEventHandler(CertificateValidator sender, CertificateUpdateEventArgs e);
 
-    #endregion
+#endregion
 
 }

--- a/Tests/Opc.Ua.Client.Tests/ClientTest.cs
+++ b/Tests/Opc.Ua.Client.Tests/ClientTest.cs
@@ -303,6 +303,52 @@ namespace Opc.Ua.Client.Tests
             m_session.ChangePreferredLocales(locale);
         }
 
+        [Test]
+        public void ReadDataTypeDefinition()
+        {
+            // Test Read a DataType Node
+            var node = m_session.ReadNode(DataTypeIds.ProgramDiagnosticDataType);
+            Assert.NotNull(node);
+            var dataTypeNode = (DataTypeNode)node;
+            Assert.NotNull(dataTypeNode);
+            var dataTypeDefinition = dataTypeNode.DataTypeDefinition;
+            Assert.NotNull(dataTypeDefinition);
+            Assert.True(dataTypeDefinition is ExtensionObject);
+            Assert.NotNull(dataTypeDefinition.Body);
+            Assert.True(dataTypeDefinition.Body is StructureDefinition);
+            StructureDefinition structureDefinition = dataTypeDefinition.Body as StructureDefinition;
+            Assert.AreEqual(ObjectIds.ProgramDiagnosticDataType_Encoding_DefaultBinary, structureDefinition.DefaultEncodingId);
+        }
+
+        [Test]
+        public async Task ReadWriteDataTypeDefinition()
+        {
+            // Test Read a DataType Node
+            var typeId = DataTypeIds.PubSubGroupDataType;
+            var node = m_session.ReadNode(typeId);
+            Assert.NotNull(node);
+            var dataTypeNode = (DataTypeNode)node;
+            Assert.NotNull(dataTypeNode);
+            var dataTypeDefinition = dataTypeNode.DataTypeDefinition;
+            Assert.NotNull(dataTypeDefinition);
+            Assert.True(dataTypeDefinition is ExtensionObject);
+            Assert.NotNull(dataTypeDefinition.Body);
+            Assert.True(dataTypeDefinition.Body is StructureDefinition);
+            StructureDefinition structureDefinition = dataTypeDefinition.Body as StructureDefinition;
+            Assert.AreEqual(ObjectIds.PubSubGroupDataType_Encoding_DefaultBinary, structureDefinition.DefaultEncodingId);
+            structureDefinition.DefaultEncodingId = ObjectIds.PubSubGroupDataType_Encoding_DefaultJson;
+
+            var writeValueCollection = new WriteValueCollection();
+            writeValueCollection.Add(new WriteValue() {
+                AttributeId = Attributes.DataTypeDefinition,
+                NodeId = typeId,
+                Value = new DataValue(new Variant(dataTypeDefinition))
+            });
+            var response = await m_session.WriteAsync(null, writeValueCollection, CancellationToken.None);
+            Assert.AreEqual(StatusCodes.BadNotWritable, response.Results[0].Code);
+            Assert.NotNull(response);
+        }
+
         [Theory, Order(400)]
         public async Task BrowseFullAddressSpace(string securityPolicy)
         {

--- a/Tests/Opc.Ua.Client.Tests/ClientTest.cs
+++ b/Tests/Opc.Ua.Client.Tests/ClientTest.cs
@@ -320,35 +320,6 @@ namespace Opc.Ua.Client.Tests
             Assert.AreEqual(ObjectIds.ProgramDiagnosticDataType_Encoding_DefaultBinary, structureDefinition.DefaultEncodingId);
         }
 
-        [Test]
-        public async Task ReadWriteDataTypeDefinition()
-        {
-            // Test Read a DataType Node
-            var typeId = DataTypeIds.PubSubGroupDataType;
-            var node = m_session.ReadNode(typeId);
-            Assert.NotNull(node);
-            var dataTypeNode = (DataTypeNode)node;
-            Assert.NotNull(dataTypeNode);
-            var dataTypeDefinition = dataTypeNode.DataTypeDefinition;
-            Assert.NotNull(dataTypeDefinition);
-            Assert.True(dataTypeDefinition is ExtensionObject);
-            Assert.NotNull(dataTypeDefinition.Body);
-            Assert.True(dataTypeDefinition.Body is StructureDefinition);
-            StructureDefinition structureDefinition = dataTypeDefinition.Body as StructureDefinition;
-            Assert.AreEqual(ObjectIds.PubSubGroupDataType_Encoding_DefaultBinary, structureDefinition.DefaultEncodingId);
-            structureDefinition.DefaultEncodingId = ObjectIds.PubSubGroupDataType_Encoding_DefaultJson;
-
-            var writeValueCollection = new WriteValueCollection();
-            writeValueCollection.Add(new WriteValue() {
-                AttributeId = Attributes.DataTypeDefinition,
-                NodeId = typeId,
-                Value = new DataValue(new Variant(dataTypeDefinition))
-            });
-            var response = await m_session.WriteAsync(null, writeValueCollection, CancellationToken.None);
-            Assert.AreEqual(StatusCodes.BadNotWritable, response.Results[0].Code);
-            Assert.NotNull(response);
-        }
-
         [Theory, Order(400)]
         public async Task BrowseFullAddressSpace(string securityPolicy)
         {

--- a/Tests/Opc.Ua.Configuration.Tests/ApplicationInstanceTests.cs
+++ b/Tests/Opc.Ua.Configuration.Tests/ApplicationInstanceTests.cs
@@ -52,6 +52,33 @@ namespace Opc.Ua.Configuration.Tests
         public const string EndpointUrl = "opc.tcp://localhost:51000";
         #endregion
 
+        #region Test Setup
+        /// <summary>
+        /// Test setup.
+        /// </summary>
+        [SetUp]
+        public void SetUp()
+        {
+            // pki directory root for test runs. 
+            m_pkiRoot = Path.GetTempPath() + Path.GetRandomFileName() + Path.DirectorySeparatorChar;
+        }
+
+        /// <summary>
+        /// Test setup.
+        /// </summary>
+        [TearDown]
+        public void TearDown()
+        {
+            try
+            {
+                // pki directory root for test runs. 
+                Directory.Delete(m_pkiRoot);
+            }
+            catch
+            { }
+        }
+        #endregion
+
         #region Test Methods
         /// <summary>
         /// Load a file configuration.
@@ -80,7 +107,7 @@ namespace Opc.Ua.Configuration.Tests
             Assert.NotNull(applicationInstance);
             ApplicationConfiguration config = await applicationInstance.Build(ApplicationUri, ProductUri)
                 .AsClient()
-                .AddSecurityConfiguration(SubjectName)
+                .AddSecurityConfiguration(SubjectName, m_pkiRoot)
                 .Create().ConfigureAwait(false);
             Assert.NotNull(config);
             bool certOK = await applicationInstance.CheckApplicationInstanceCertificate(true, 0).ConfigureAwait(false);
@@ -96,7 +123,7 @@ namespace Opc.Ua.Configuration.Tests
             Assert.ThrowsAsync<ServiceResultException>(async () =>
                await applicationInstance.Build(ApplicationUri, ProductUri)
                    .AsServer(new string[] { EndpointUrl })
-                   .AddSecurityConfiguration(SubjectName)
+                   .AddSecurityConfiguration(SubjectName, m_pkiRoot)
                    .Create()
             );
             // discoveryserver can not be combined with client/server
@@ -107,13 +134,13 @@ namespace Opc.Ua.Configuration.Tests
             Assert.ThrowsAsync<ArgumentException>(async () =>
                await applicationInstance.Build(ApplicationUri, ProductUri)
                    .AsClient()
-                   .AddSecurityConfiguration(SubjectName)
+                   .AddSecurityConfiguration(SubjectName, m_pkiRoot)
                    .Create()
             );
             Assert.ThrowsAsync<ArgumentException>(async () =>
                await applicationInstance.Build(ApplicationUri, ProductUri)
                    .AsServer(new string[] { EndpointUrl })
-                   .AddSecurityConfiguration(SubjectName)
+                   .AddSecurityConfiguration(SubjectName, m_pkiRoot)
                    .Create()
             );
             // server overrides client settings
@@ -124,7 +151,7 @@ namespace Opc.Ua.Configuration.Tests
 
             var config = await applicationInstance.Build(ApplicationUri, ProductUri)
                 .AsServer(new string[] { EndpointUrl })
-                .AddSecurityConfiguration(SubjectName)
+                .AddSecurityConfiguration(SubjectName, m_pkiRoot)
                 .Create();
             Assert.AreEqual(ApplicationType.Server, applicationInstance.ApplicationType);
 
@@ -136,7 +163,7 @@ namespace Opc.Ua.Configuration.Tests
 
             await applicationInstance.Build(ApplicationUri, ProductUri)
                 .AsClient()
-                .AddSecurityConfiguration(SubjectName)
+                .AddSecurityConfiguration(SubjectName, m_pkiRoot)
                 .Create();
             Assert.AreEqual(ApplicationType.Client, applicationInstance.ApplicationType);
 
@@ -149,7 +176,7 @@ namespace Opc.Ua.Configuration.Tests
                await applicationInstance.Build(ApplicationUri, ProductUri)
                    .AsServer(new string[] { EndpointUrl })
                    .AddPolicy(MessageSecurityMode.None, SecurityPolicies.None)
-                   .AddSecurityConfiguration(SubjectName)
+                   .AddSecurityConfiguration(SubjectName, m_pkiRoot)
                    .Create()
             );
             // invalid mix sign / none
@@ -165,7 +192,7 @@ namespace Opc.Ua.Configuration.Tests
                await applicationInstance.Build(ApplicationUri, ProductUri)
                    .AsServer(new string[] { EndpointUrl })
                    .AddPolicy(MessageSecurityMode.Sign, "123")
-                   .AddSecurityConfiguration(SubjectName)
+                   .AddSecurityConfiguration(SubjectName, m_pkiRoot)
                    .Create()
             );
             // invalid user token policy
@@ -173,7 +200,7 @@ namespace Opc.Ua.Configuration.Tests
                await applicationInstance.Build(ApplicationUri, ProductUri)
                    .AsServer(new string[] { EndpointUrl })
                    .AddUserTokenPolicy(null)
-                   .AddSecurityConfiguration(SubjectName)
+                   .AddSecurityConfiguration(SubjectName, m_pkiRoot)
                    .Create()
             );
         }
@@ -188,7 +215,7 @@ namespace Opc.Ua.Configuration.Tests
             ApplicationConfiguration config = await applicationInstance.Build(ApplicationUri, ProductUri)
                 .SetOperationTimeout(10000)
                 .AsServer(new string[] { EndpointUrl })
-                .AddSecurityConfiguration(SubjectName)
+                .AddSecurityConfiguration(SubjectName, m_pkiRoot)
                 .Create().ConfigureAwait(false);
             Assert.NotNull(config);
             bool certOK = await applicationInstance.CheckApplicationInstanceCertificate(true, 0).ConfigureAwait(false);
@@ -217,7 +244,7 @@ namespace Opc.Ua.Configuration.Tests
                 .AddUserTokenPolicy(new UserTokenPolicy(UserTokenType.Certificate) { SecurityPolicyUri = SecurityPolicies.Basic256Sha256 })
                 .SetDiagnosticsEnabled(true)
                 .SetPublishingResolution(100)
-                .AddSecurityConfiguration(SubjectName)
+                .AddSecurityConfiguration(SubjectName, m_pkiRoot)
                 .SetAddAppCertToTrustedStore(true)
                 .SetAutoAcceptUntrustedCertificates(true)
                 .SetMinimumCertificateKeySize(1024)
@@ -295,7 +322,7 @@ namespace Opc.Ua.Configuration.Tests
             Assert.NotNull(applicationInstance);
             ApplicationConfiguration config = await applicationInstance.Build(ApplicationUri, ProductUri)
                 .AsServer(new string[] { EndpointUrl, "https://localhost:51001" }, new string[] { "opc.tcp://192.168.1.100:51000" })
-                .AddSecurityConfiguration(SubjectName)
+                .AddSecurityConfiguration(SubjectName, m_pkiRoot)
                 .SetAddAppCertToTrustedStore(true)
                 .Create().ConfigureAwait(false);
             Assert.NotNull(config);
@@ -306,8 +333,11 @@ namespace Opc.Ua.Configuration.Tests
         public enum InvalidCertType
         {
             NoIssues,
+            NoIssuer,
             Expired,
+            IssuerExpired,
             NotYetValid,
+            IssuerNotYetValid,
             KeySize1024,
             HostName
         };
@@ -352,7 +382,7 @@ namespace Opc.Ua.Configuration.Tests
             CertificateIdentifier applicationCertificate = applicationInstance.ApplicationConfiguration.SecurityConfiguration.ApplicationCertificate;
             Assert.IsNull(applicationCertificate.Certificate);
 
-            X509Certificate2 expiredApplicationCert = null;
+            X509Certificate2 publicKey = null;
             using (var testCert = CreateInvalidCert(certType))
             {
                 Assert.NotNull(testCert);
@@ -361,7 +391,7 @@ namespace Opc.Ua.Configuration.Tests
                     applicationCertificate.StoreType,
                     applicationCertificate.StorePath
                     );
-                expiredApplicationCert = new X509Certificate2(testCert.RawData);
+                publicKey = new X509Certificate2(testCert.RawData);
             }
 
             if (suppress)
@@ -369,7 +399,7 @@ namespace Opc.Ua.Configuration.Tests
                 bool certOK = await applicationInstance.CheckApplicationInstanceCertificate(true, 0).ConfigureAwait(false);
 
                 Assert.True(certOK);
-                Assert.AreEqual(expiredApplicationCert, applicationCertificate.Certificate);
+                Assert.AreEqual(publicKey, applicationCertificate.Certificate);
             }
             else
             {
@@ -377,7 +407,91 @@ namespace Opc.Ua.Configuration.Tests
                 Assert.AreEqual(StatusCodes.BadConfigurationError, sre.StatusCode);
             }
         }
+        /// <summary>
+        /// Test to verify that an existing cert with suppressible issues
+        /// is not recreated/replaced.
+        /// </summary>
+        [Test]
+        [TestCase(InvalidCertType.NoIssues, true, true)]
+        [TestCase(InvalidCertType.NoIssuer, true, false)]
+        [TestCase(InvalidCertType.NotYetValid, true, true)]
+        [TestCase(InvalidCertType.Expired, true, true)]
+        [TestCase(InvalidCertType.IssuerNotYetValid, true, true)]
+        [TestCase(InvalidCertType.IssuerExpired, true, true)]
+        [TestCase(InvalidCertType.HostName, true, false)]
+        [TestCase(InvalidCertType.HostName, false, true)]
+        //TODO [TestCase(InvalidCertType.KeySize1024, true, false)]
+        public async Task TestInvalidAppCertChainDoNotRecreate(InvalidCertType certType, bool server, bool suppress)
+        {
+            // pki directory root for test runs. 
+            var pkiRoot = Path.GetTempPath() + Path.GetRandomFileName() + Path.DirectorySeparatorChar;
 
+            var applicationInstance = new ApplicationInstance() {
+                ApplicationName = ApplicationName
+            };
+            Assert.NotNull(applicationInstance);
+            ApplicationConfiguration config;
+            if (server)
+            {
+                config = await applicationInstance.Build(ApplicationUri, ProductUri)
+                    .AsServer(new string[] { "opc.tcp://localhost:12345/Configuration" })
+                    .AddSecurityConfiguration(SubjectName, pkiRoot)
+                    .Create().ConfigureAwait(false);
+            }
+            else
+            {
+                config = await applicationInstance.Build(ApplicationUri, ProductUri)
+                    .AsClient()
+                    .AddSecurityConfiguration(SubjectName, pkiRoot)
+                    .Create().ConfigureAwait(false);
+            }
+            Assert.NotNull(config);
+
+            CertificateIdentifier applicationCertificate = applicationInstance.ApplicationConfiguration.SecurityConfiguration.ApplicationCertificate;
+            Assert.IsNull(applicationCertificate.Certificate);
+
+            var testCerts = CreateInvalidCertChain(certType);
+            if (certType != InvalidCertType.NoIssuer)
+            {
+                using (var issuerCert = testCerts[1])
+                {
+                    Assert.NotNull(issuerCert);
+                    Assert.False(issuerCert.HasPrivateKey);
+                    issuerCert.AddToStore(
+                        applicationInstance.ApplicationConfiguration.SecurityConfiguration.TrustedIssuerCertificates.StoreType,
+                        applicationInstance.ApplicationConfiguration.SecurityConfiguration.TrustedIssuerCertificates.StorePath
+                        );
+                }
+            }
+
+            X509Certificate2 publicKey = null;
+            using (var testCert = testCerts[0])
+            {
+                Assert.NotNull(testCert);
+                Assert.True(testCert.HasPrivateKey);
+                testCert.AddToStore(
+                    applicationCertificate.StoreType,
+                    applicationCertificate.StorePath
+                    );
+                publicKey = new X509Certificate2(testCert.RawData);
+            }
+
+            if (suppress)
+            {
+                bool certOK = await applicationInstance.CheckApplicationInstanceCertificate(true, 0).ConfigureAwait(false);
+
+                Assert.True(certOK);
+                Assert.AreEqual(publicKey, applicationCertificate.Certificate);
+            }
+            else
+            {
+                var sre = Assert.ThrowsAsync<ServiceResultException>(async () => await applicationInstance.CheckApplicationInstanceCertificate(true, 0).ConfigureAwait(false));
+                Assert.AreEqual(StatusCodes.BadConfigurationError, sre.StatusCode);
+            }
+        }
+        #endregion
+
+        #region Private Methods
         private X509Certificate2 CreateInvalidCert(InvalidCertType certType)
         {
             // reasonable defaults
@@ -415,6 +529,68 @@ namespace Opc.Ua.Configuration.Tests
                 .SetRSAKeySize(keySize)
                 .CreateForRSA();
         }
+
+        private X509Certificate2Collection CreateInvalidCertChain(InvalidCertType certType)
+        {
+            // reasonable defaults
+            DateTime notBefore = DateTime.Today.AddYears(-1);
+            DateTime notAfter = DateTime.Today.AddYears(1);
+            DateTime issuerNotBefore = notBefore;
+            DateTime issuerNotAfter = notAfter;
+            ushort keySize = CertificateFactory.DefaultKeySize;
+            string[] domainNames = new string[] { Utils.GetHostName() };
+            switch (certType)
+            {
+                case InvalidCertType.Expired:
+                    notAfter = DateTime.Today.AddDays(-7);
+                    break;
+                case InvalidCertType.IssuerExpired:
+                    issuerNotAfter = DateTime.Today.AddDays(-7);
+                    break;
+                case InvalidCertType.NotYetValid:
+                    notBefore = DateTime.Today.AddDays(7);
+                    break;
+                case InvalidCertType.IssuerNotYetValid:
+                    issuerNotBefore = DateTime.Today.AddDays(7);
+                    break;
+                case InvalidCertType.KeySize1024:
+                    keySize = 1024;
+                    break;
+                case InvalidCertType.HostName:
+                    domainNames = new string[] { "myhost", "1.2.3.4" };
+                    break;
+                default:
+                    break;
+            }
+
+            string rootCASubjectName = "CN=Root CA Test";
+            var rootCA = CertificateFactory.CreateCertificate(rootCASubjectName)
+                .SetNotBefore(issuerNotBefore)
+                .SetNotAfter(issuerNotAfter)
+                .SetCAConstraint(-1)
+                .CreateForRSA();
+
+            var appCert = CertificateFactory.CreateCertificate(
+                ApplicationUri,
+                ApplicationName,
+                SubjectName,
+                domainNames)
+                .SetNotBefore(notBefore)
+                .SetNotAfter(notAfter)
+                .SetIssuer(rootCA)
+                .SetRSAKeySize(keySize)
+                .CreateForRSA();
+
+            var result = new X509Certificate2Collection();
+            result.Add(appCert);
+            result.Add(new X509Certificate2(rootCA.RawData));
+            return result;
+        }
+
+        #endregion
+
+        #region Private Fields
+        string m_pkiRoot;
         #endregion
     }
 }

--- a/Tests/Opc.Ua.Configuration.Tests/ApplicationInstanceTests.cs
+++ b/Tests/Opc.Ua.Configuration.Tests/ApplicationInstanceTests.cs
@@ -358,15 +358,13 @@ namespace Opc.Ua.Configuration.Tests
             // pki directory root for test runs. 
             var pkiRoot = Path.GetTempPath() + Path.GetRandomFileName() + Path.DirectorySeparatorChar;
 
-            var applicationInstance = new ApplicationInstance() {
-                ApplicationName = ApplicationName
-            };
+            var applicationInstance = new ApplicationInstance() {ApplicationName = ApplicationName};
             Assert.NotNull(applicationInstance);
             ApplicationConfiguration config;
             if (server)
             {
                 config = await applicationInstance.Build(ApplicationUri, ProductUri)
-                    .AsServer(new string[] { "opc.tcp://localhost:12345/Configuration" })
+                    .AsServer(new string[] {"opc.tcp://localhost:12345/Configuration"})
                     .AddSecurityConfiguration(SubjectName, pkiRoot)
                     .Create().ConfigureAwait(false);
             }
@@ -377,9 +375,11 @@ namespace Opc.Ua.Configuration.Tests
                     .AddSecurityConfiguration(SubjectName, pkiRoot)
                     .Create().ConfigureAwait(false);
             }
+
             Assert.NotNull(config);
 
-            CertificateIdentifier applicationCertificate = applicationInstance.ApplicationConfiguration.SecurityConfiguration.ApplicationCertificate;
+            CertificateIdentifier applicationCertificate =
+                applicationInstance.ApplicationConfiguration.SecurityConfiguration.ApplicationCertificate;
             Assert.IsNull(applicationCertificate.Certificate);
 
             X509Certificate2 publicKey = null;
@@ -390,21 +390,26 @@ namespace Opc.Ua.Configuration.Tests
                 testCert.AddToStore(
                     applicationCertificate.StoreType,
                     applicationCertificate.StorePath
-                    );
+                );
                 publicKey = new X509Certificate2(testCert.RawData);
             }
 
-            if (suppress)
+            using (publicKey)
             {
-                bool certOK = await applicationInstance.CheckApplicationInstanceCertificate(true, 0).ConfigureAwait(false);
+                if (suppress)
+                {
+                    bool certOK = await applicationInstance.CheckApplicationInstanceCertificate(true, 0)
+                        .ConfigureAwait(false);
 
-                Assert.True(certOK);
-                Assert.AreEqual(publicKey, applicationCertificate.Certificate);
-            }
-            else
-            {
-                var sre = Assert.ThrowsAsync<ServiceResultException>(async () => await applicationInstance.CheckApplicationInstanceCertificate(true, 0).ConfigureAwait(false));
-                Assert.AreEqual(StatusCodes.BadConfigurationError, sre.StatusCode);
+                    Assert.True(certOK);
+                    Assert.AreEqual(publicKey, applicationCertificate.Certificate);
+                }
+                else
+                {
+                    var sre = Assert.ThrowsAsync<ServiceResultException>(async () =>
+                        await applicationInstance.CheckApplicationInstanceCertificate(true, 0).ConfigureAwait(false));
+                    Assert.AreEqual(StatusCodes.BadConfigurationError, sre.StatusCode);
+                }
             }
         }
         /// <summary>
@@ -476,17 +481,22 @@ namespace Opc.Ua.Configuration.Tests
                 publicKey = new X509Certificate2(testCert.RawData);
             }
 
-            if (suppress)
+            using (publicKey)
             {
-                bool certOK = await applicationInstance.CheckApplicationInstanceCertificate(true, 0).ConfigureAwait(false);
+                if (suppress)
+                {
+                    bool certOK = await applicationInstance.CheckApplicationInstanceCertificate(true, 0)
+                        .ConfigureAwait(false);
 
-                Assert.True(certOK);
-                Assert.AreEqual(publicKey, applicationCertificate.Certificate);
-            }
-            else
-            {
-                var sre = Assert.ThrowsAsync<ServiceResultException>(async () => await applicationInstance.CheckApplicationInstanceCertificate(true, 0).ConfigureAwait(false));
-                Assert.AreEqual(StatusCodes.BadConfigurationError, sre.StatusCode);
+                    Assert.True(certOK);
+                    Assert.AreEqual(publicKey, applicationCertificate.Certificate);
+                }
+                else
+                {
+                    var sre = Assert.ThrowsAsync<ServiceResultException>(async () =>
+                        await applicationInstance.CheckApplicationInstanceCertificate(true, 0).ConfigureAwait(false));
+                    Assert.AreEqual(StatusCodes.BadConfigurationError, sre.StatusCode);
+                }
             }
         }
         #endregion

--- a/Tests/Opc.Ua.Core.Tests/Security/Certificates/CertificateFactoryTest.cs
+++ b/Tests/Opc.Ua.Core.Tests/Security/Certificates/CertificateFactoryTest.cs
@@ -193,7 +193,7 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
             {
                 var cert = CertificateFactory.CreateCertificate($"CN=Test Cert {i}")
                     .SetIssuer(issuerCertificate)
-                    .SetRSAKeySize(keyHashPair.KeySize <= 2048 ? keyHashPair.KeySize : 2048)
+                    .SetRSAKeySize((ushort) (keyHashPair.KeySize <= 2048 ? keyHashPair.KeySize : 2048))
                     .CreateForRSA();
                 revokedCerts.Add(cert);
                 Assert.False(X509Utils.VerifySelfSigned(cert));

--- a/Tests/Opc.Ua.Gds.Tests/PushTest.cs
+++ b/Tests/Opc.Ua.Gds.Tests/PushTest.cs
@@ -323,7 +323,7 @@ namespace Opc.Ua.Gds.Tests
         }
 
         [Test, Order(500)]
-        public void UpdateCertificateSelfSignedNoPrivateKey()
+        public void UpdateCertificateSelfSignedNoPrivateKeyAsserts()
         {
             ConnectPushClient(true);
             using (X509Certificate2 invalidCert = CertificateFactory.CreateCertificate("uri:x:y:z", "TestApp", "CN=Push Server Test", null).CreateForRSA())
@@ -350,6 +350,19 @@ namespace Opc.Ua.Gds.Tests
                 Assert.That(() => { m_pushClient.PushClient.UpdateCertificate(null, null, invalidRawCert, null, null, new byte[][] { serverCert.RawData, invalidCert.RawData }); }, Throws.Exception);
                 Assert.That(() => { m_pushClient.PushClient.UpdateCertificate(null, null, serverCert.RawData, null, null, new byte[][] { serverCert.RawData, invalidRawCert }); }, Throws.Exception);
                 Assert.That(() => { m_pushClient.PushClient.UpdateCertificate(null, null, serverCert.RawData, null, null, null); }, Throws.Exception);
+            }
+        }
+
+        [Test, Order(501)]
+        public void UpdateCertificateSelfSignedNoPrivateKey()
+        {
+            ConnectPushClient(true);
+            using (X509Certificate2 serverCert = new X509Certificate2(m_pushClient.PushClient.Session.ConfiguredEndpoint.Description.ServerCertificate))
+            {
+                if (!X509Utils.CompareDistinguishedName(serverCert.Subject, serverCert.Issuer))
+                {
+                    Assert.Ignore("Server has no self signed cert in use.");
+                }
                 var success = m_pushClient.PushClient.UpdateCertificate(
                     null,
                     m_pushClient.PushClient.ApplicationCertificateType,


### PR DESCRIPTION
- do not silent recreate a certificate if a matching cert subject is available, enforce manual deletion or replacement
- allow the application cert to be used when expired or not yet valid
- warn/assert if an app cert is loaded without loading the private key 
fixes #1162 , fixes #1102
