### PR TITLE
UA Nodeset Xml export should omit ArrayDimension with size 0

### DIFF
--- a/Stack/Opc.Ua.Core/Schema/UANodeSetHelpers.cs
+++ b/Stack/Opc.Ua.Core/Schema/UANodeSetHelpers.cs
@@ -924,9 +924,13 @@ namespace Opc.Ua.Export
                         }
 
                         output.ValueRank = field.ValueRank;
+
                         if (field.ArrayDimensions != null && field.ArrayDimensions.Count != 0)
                         {
-                            output.ArrayDimensions = BaseVariableState.ArrayDimensionsToXml(field.ArrayDimensions);
+                            if (output.ValueRank > 1 || field.ArrayDimensions[0] > 0)
+                            {
+                                output.ArrayDimensions = BaseVariableState.ArrayDimensionsToXml(field.ArrayDimensions);
+                            }
                         }
 
                         output.MaxStringLength = field.MaxStringLength;
@@ -1038,9 +1042,12 @@ namespace Opc.Ua.Export
                             output.Description = Import(field.Description);
                             output.DataType = ImportNodeId(field.DataType, namespaceUris, true);
                             output.ValueRank = field.ValueRank;
-                            if (!string.IsNullOrWhiteSpace(field.ArrayDimensions))
+                            if (!String.IsNullOrWhiteSpace(field.ArrayDimensions))
                             {
-                                output.ArrayDimensions = new UInt32Collection(BaseVariableState.ArrayDimensionsFromXml(field.ArrayDimensions));
+                                if (output.ValueRank > 1 || field.ArrayDimensions[0] > 0)
+                                {
+                                    output.ArrayDimensions = new UInt32Collection(BaseVariableState.ArrayDimensionsFromXml(field.ArrayDimensions));
+                                }
                             }
 
                             output.MaxStringLength = field.MaxStringLength;

--- a/Tests/Opc.Ua.Core.Tests/Stack/Schema/UANodeSetHelpersTests.cs
+++ b/Tests/Opc.Ua.Core.Tests/Stack/Schema/UANodeSetHelpersTests.cs
@@ -108,15 +108,15 @@ namespace Opc.Ua.Core.Tests.Stack.Schema
                       <Field Name='Scalar Boolean' DataType='i=1' />
                       <Field Name='Scalar Duration' DataType='i=290' />
                       <Field Name='Scalar String within max length' DataType='i=12' MaxStringLength='256' />
-                      <Field Name='1D Array String no max length' DataType='i=12' ValueRank='1' ArrayDimensions='0' />
-                      <Field Name='1D Array String within max length' DataType='i=12' ValueRank='1' ArrayDimensions='0' MaxStringLength='256' />
+                      <Field Name='1D Array String no max length' DataType='i=12' ValueRank='1' />
+                      <Field Name='1D Array String within max length' DataType='i=12' ValueRank='1' MaxStringLength='256' />
                       <Field Name='1D Array of Simple Structure 1' DataType='ns=1;s=Simple Structure' ValueRank='1' ArrayDimensions='2' />
                       <Field Name='1D Array of Simple Structure 2' DataType='ns=1;s=Simple Structure' ValueRank='1' ArrayDimensions='3' />
-                      <Field Name='1D Array of BuildInfo' DataType='i=338' ValueRank='1' ArrayDimensions='0' />
-                      <Field Name='1D Array of Simple Structure' DataType='ns=1;s=Simple Structure' ValueRank='1' ArrayDimensions='0' />
-                      <Field Name='1D Array of Boolean' DataType='i=1' ValueRank='1' ArrayDimensions='0' />
-                      <Field Name='1D Array of Duration' DataType='i=290' ValueRank='1' ArrayDimensions='0' />
-                      <Field Name='1D Array of MessageSecurityMode' DataType='i=302' ValueRank='1' ArrayDimensions='0' />
+                      <Field Name='1D Array of BuildInfo' DataType='i=338' ValueRank='1' />
+                      <Field Name='1D Array of Simple Structure' DataType='ns=1;s=Simple Structure' ValueRank='1' />
+                      <Field Name='1D Array of Boolean' DataType='i=1' ValueRank='1' />
+                      <Field Name='1D Array of Duration' DataType='i=290' ValueRank='1' />
+                      <Field Name='1D Array of MessageSecurityMode' DataType='i=302' ValueRank='1' />
                       <Field Name='2D Array of Structure' DataType='i=22' ValueRank='2' ArrayDimensions='2,3' />
                       <Field Name='2D Array of BuildInfo' DataType='i=338' ValueRank='2' ArrayDimensions='2,3' />
                       <Field Name='2D Array of Simple Structure' DataType='ns=1;s=Simple Structure' ValueRank='2' ArrayDimensions='2,3' />


### PR DESCRIPTION
- Modelcompiler output contained unnecessary ArrayDimension fields which can be omitted