### PR TITLE
Performance update - Add IEquatable interface for DataValue

### DIFF
--- a/Stack/Opc.Ua.Core/Types/BuiltIn/DataValue.cs
+++ b/Stack/Opc.Ua.Core/Types/BuiltIn/DataValue.cs
@@ -285,7 +285,7 @@ namespace Opc.Ua
                     return false;
                 }
 
-                if (this.m_serverTimestamp != other.m_serverTimestamp)
+                if (this.m_sourcePicoseconds != other.m_sourcePicoseconds)
                 {
                     return false;
                 }

--- a/Stack/Opc.Ua.Core/Types/BuiltIn/DataValue.cs
+++ b/Stack/Opc.Ua.Core/Types/BuiltIn/DataValue.cs
@@ -56,7 +56,7 @@ namespace Opc.Ua
     /// <seealso cref="Variant"/>
     /// <seealso cref="StatusCode"/>
     [DataContract(Namespace = Namespaces.OpcUaXsd)]
-    public class DataValue : IFormattable
+    public class DataValue : IFormattable, IEquatable<DataValue>
     {
         #region Constructors
         /// <summary>
@@ -244,6 +244,53 @@ namespace Opc.Ua
                 }
 
                 return Utils.IsEqual(this.m_value.Value, value.m_value.Value);
+            }
+            
+            return false;
+        }
+
+        /// <summary>
+        /// Determines if the specified object is equal to the object.
+        /// </summary>
+        /// <remarks>
+        /// Determines if the specified object is equal to the object.
+        /// </remarks>
+        /// <param name="other">The DataValue to compare to *this*</param>
+        public bool Equals(DataValue other)
+        {
+            if (Object.ReferenceEquals(this, other))
+            {
+                return true;
+            }
+
+            if (other != null)
+            {
+                if (this.m_statusCode != other.m_statusCode)
+                {
+                    return false;
+                }
+
+                if (this.m_serverTimestamp != other.m_serverTimestamp)
+                {
+                    return false;
+                }
+
+                if (this.m_sourceTimestamp != other.m_sourceTimestamp)
+                {
+                    return false;
+                }
+
+                if (this.m_serverPicoseconds != other.m_serverPicoseconds)
+                {
+                    return false;
+                }
+
+                if (this.m_serverTimestamp != other.m_serverTimestamp)
+                {
+                    return false;
+                }
+
+                return Utils.IsEqual(this.m_value.Value, other.m_value.Value);
             }
 
             return false;

--- a/Stack/Opc.Ua.Core/Types/BuiltIn/StatusCode.cs
+++ b/Stack/Opc.Ua.Core/Types/BuiltIn/StatusCode.cs
@@ -90,7 +90,8 @@ namespace Opc.Ua
     /// <br/></para>
     /// </remarks>
     [DataContract(Name = "StatusCode", Namespace = Namespaces.OpcUaXsd)]
-    public struct StatusCode : IComparable, IFormattable
+    public struct StatusCode : IComparable, IFormattable,
+        IComparable<StatusCode>, IEquatable<StatusCode>
     {
         #region Constructors
 
@@ -426,6 +427,12 @@ namespace Opc.Ua
         /// <param name="obj">The object to compare to *this* object</param>
         public int CompareTo(object obj)
         {
+            // compare codes
+            if (obj is StatusCode)
+            {
+                return m_code.CompareTo(((StatusCode)obj).m_code);
+            }
+
             // check for null.
             if (obj == null)
             {
@@ -438,14 +445,21 @@ namespace Opc.Ua
                 return m_code.CompareTo((uint)obj);
             }
 
-            // compare codes.
-            if (obj is StatusCode)
-            {
-                return m_code.CompareTo(((StatusCode)obj).m_code);
-            }
-
             // objects not comparable.
             return -1;
+        }
+
+        /// <summary>
+        /// Compares the instance to another object.
+        /// </summary>
+        /// <remarks>
+        /// Compares the instance to another object.
+        /// </remarks>
+        /// <param name="other">The StatusCode to compare to *this* object</param>
+        public int CompareTo(StatusCode other)
+        {
+            // check for status code.
+            return m_code.CompareTo(other.Code);
         }
         #endregion
 
@@ -489,6 +503,18 @@ namespace Opc.Ua
         public override bool Equals(object obj)
         {
             return CompareTo(obj) == 0;
+        }
+
+        /// <summary>
+        /// Determines if the specified object is equal to the object.
+        /// </summary>
+        /// <remarks>
+        /// Determines if the specified object is equal to the object.
+        /// </remarks>
+        /// <param name="other">The StatusCode to compare to *this* object</param>
+        public bool Equals(StatusCode other)
+        {
+            return CompareTo(other) == 0;
         }
 
         /// <summary>

--- a/Stack/Opc.Ua.Core/Types/Utils/NumericRange.cs
+++ b/Stack/Opc.Ua.Core/Types/Utils/NumericRange.cs
@@ -23,7 +23,7 @@ namespace Opc.Ua
     /// <remarks>
     /// A class that stores a numeric range.
     /// </remarks>
-	public struct NumericRange : IFormattable
+    public struct NumericRange : IFormattable, IEquatable<NumericRange>
     {
         #region Constructors
         /// <summary>
@@ -268,14 +268,24 @@ namespace Opc.Ua
         /// <param name="obj">The object to test against this</param>
         public override bool Equals(object obj)
         {
-            NumericRange? range = obj as NumericRange?;
-
-            if (range == null)
+            if (obj is NumericRange)
             {
-                return false;
+                return this.Equals((NumericRange)obj);
             }
 
-            return (range.Value.m_begin == m_begin) && (range.Value.m_end == m_end);
+            return false;
+        }
+
+        /// <summary>
+        /// Returns true if the objects are equal.
+        /// </summary>
+        /// <remarks>
+        /// Returns true if the objects are equal.
+        /// </remarks>
+        /// <param name="other">The NumericRange to test against this</param>
+        public bool Equals(NumericRange other)
+        {
+            return (other.m_begin == m_begin) && (other.m_end == m_end);
         }
 
         /// <summary>


### PR DESCRIPTION
- Performance update

Implement strongly typed Equals() method and IEquatable for DataValue, StatusCode and NumericRange types so no boxing is required.
This brings a performance improvement for servers with high number of dynamic nodes and monitored items created where the compare method of DataValue is called intensively (100k -200k/sec) 