### PR TITLE
Definition is considered to be an enumeration if at least a field is not default value -1

### DIFF
--- a/Stack/Opc.Ua.Core/Schema/UANodeSetHelpers.cs
+++ b/Stack/Opc.Ua.Core/Schema/UANodeSetHelpers.cs
@@ -996,11 +996,11 @@ namespace Opc.Ua.Export
             if (source.Field != null)
             {
                 // check if definition is for enumeration or structure.
-                bool isStructure = Array.Exists<DataTypeField>(source.Field, delegate (DataTypeField fieldLookup) {
-                    return fieldLookup.Value == -1;
+                bool isEnumeration = Array.Exists<DataTypeField>(source.Field, delegate (DataTypeField fieldLookup) {
+                    return fieldLookup.Value != -1;
                 });
 
-                if (isStructure)
+                if (!isEnumeration)
                 {
                     StructureDefinition sd = new StructureDefinition();
                     sd.BaseDataType = ImportNodeId(source.BaseType, namespaceUris, true);


### PR DESCRIPTION
Definition is considered to be an enumeration if at least a field is not default value -1, since there is a very small probability for an enumeration to contain one field only.
Should fix issue #1568. 
