### PR TITLE
Bump up Nuget packages to 6.0.0

### DIFF
--- a/Libraries/Opc.Ua.Security.Certificates/Opc.Ua.Security.Certificates.csproj
+++ b/Libraries/Opc.Ua.Security.Certificates/Opc.Ua.Security.Certificates.csproj
@@ -35,7 +35,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Formats.Asn1" Version="5.0.0" />
+    <PackageReference Include="System.Formats.Asn1" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">

--- a/Stack/Opc.Ua.Bindings.Https/Opc.Ua.Bindings.Https.csproj
+++ b/Stack/Opc.Ua.Bindings.Https/Opc.Ua.Bindings.Https.csproj
@@ -31,8 +31,8 @@
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Core" Version="2.1.25" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets" Version="2.1.3" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Https" Version="2.1.3" />
-    <PackageReference Include="System.Io.Pipelines" Version="5.0.1" />
-    <PackageReference Include="System.Text.Encodings.Web" Version="5.0.1" />
+    <PackageReference Include="System.Io.Pipelines" Version="6.0.0" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="6.0.0" />
     
   </ItemGroup>
 

--- a/Tests/Opc.Ua.Security.Certificates.Tests/Opc.Ua.Security.Certificates.Tests.csproj
+++ b/Tests/Opc.Ua.Security.Certificates.Tests/Opc.Ua.Security.Certificates.Tests.csproj
@@ -56,10 +56,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Formats.Asn1" Version="5.0.0" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\..\Stack\Opc.Ua.Core\Opc.Ua.Core.csproj" />
     <ProjectReference Include="..\..\Libraries\Opc.Ua.Security.Certificates\Opc.Ua.Security.Certificates.csproj" />
   </ItemGroup>

--- a/targets.props
+++ b/targets.props
@@ -1,4 +1,7 @@
 <Project>
+  <PropertyGroup>
+    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
+  </PropertyGroup>
   <Choose>
     <!-- Visual Studio 2022 -->
     <When  Condition="'$(VisualStudioVersion)' == '17.0'">


### PR DESCRIPTION
- workaround for the build error for .NET Core 2.1, which is EOL. Set `SuppressTfmSupportBuildWarnings`
- the workaround allows to build and test the netstandard2.0 target frameworks.
- the Nuget packages with references to 6.0 packages will also break build with .NET Core 2.1 apps, thats ok, users can add the workaround too if they insist to use unsupported .NET Core versions.