### PR TITLE
Fix: Server endpoints are not returned if GetHostEntry fails.

### DIFF
--- a/Stack/Opc.Ua.Core/Stack/Server/ServerBase.cs
+++ b/Stack/Opc.Ua.Core/Stack/Server/ServerBase.cs
@@ -888,13 +888,25 @@ namespace Opc.Ua
             }
 
             // check for aliases.
-            System.Net.IPHostEntry entry = System.Net.Dns.GetHostEntry(computerName);
+            IPHostEntry entry = null;
 
-            for (int ii = 0; ii < entry.Aliases.Length; ii++)
+            try
             {
-                if (Utils.AreDomainsEqual(hostname, entry.Aliases[ii]))
+                entry = Dns.GetHostEntry(computerName);
+            }
+            catch (System.Net.Sockets.SocketException e)
+            {
+                Utils.LogError(e, "Unable to check aliases for hostname {Hostname}.", computerName);
+            }
+
+            if (entry != null)
+            {
+                for (int ii = 0; ii < entry.Aliases.Length; ii++)
                 {
-                    return computerName.ToUpper();
+                    if (Utils.AreDomainsEqual(hostname, entry.Aliases[ii]))
+                    {
+                        return computerName.ToUpper();
+                    }
                 }
             }
 

--- a/Stack/Opc.Ua.Core/Stack/Server/ServerBase.cs
+++ b/Stack/Opc.Ua.Core/Stack/Server/ServerBase.cs
@@ -896,7 +896,7 @@ namespace Opc.Ua
             }
             catch (System.Net.Sockets.SocketException e)
             {
-                Utils.LogError(e, "Unable to check aliases for hostname {Hostname}.", computerName);
+                Utils.LogError(e, "Unable to check aliases for hostname {0}.", computerName);
             }
 
             if (entry != null)


### PR DESCRIPTION
We've recently had some issues with our DNS server which caused Dns.GetHostEntry to throw SocketExceptions.

This caused that our OPC UA servers couldn't return their endpoints to remote machines (Servers with python OPC UA SDK still did).  

This PR catches the SocketExceptions on Dns.GetHostEntry.