### PR TITLE
Fix VS2017 build issue with Roslynator

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -276,7 +276,9 @@ dotnet_code_quality.CA1822.api_surface                                        = 
 
 # CA3075: Insecure DTD processing in XML
 dotnet_diagnostic.CA3075.severity                                             = warning
+dotnet_diagnostic.CA3077.severity                                             = warning
 
 # RCS1090: Add call to 'ConfigureAwait' (or vice versa)
+# Opt-In to avoid many warnings in WinForms apps
 dotnet_diagnostic.RCS1090.severity                                            = silent
 

--- a/Applications/Quickstarts.Servers/MemoryBuffer/MemoryBufferState.cs
+++ b/Applications/Quickstarts.Servers/MemoryBuffer/MemoryBufferState.cs
@@ -438,26 +438,26 @@ namespace MemoryBuffer
         /// </summary>
         public MemoryBufferMonitoredItem CreateDataChangeItem(
             ServerSystemContext context,
-            MemoryTagState      tag,
-            uint                subscriptionId,
-            uint                monitoredItemId,
-            ReadValueId         itemToMonitor,
-            DiagnosticsMasks    diagnosticsMasks,
-            TimestampsToReturn  timestampsToReturn,
-            MonitoringMode      monitoringMode,
-            uint                clientHandle,
-            double              samplingInterval)
-
-            /*
-            ISystemContext context,
             MemoryTagState tag,
+            uint subscriptionId,
             uint monitoredItemId,
-            uint attributeId,
+            ReadValueId itemToMonitor,
             DiagnosticsMasks diagnosticsMasks,
             TimestampsToReturn timestampsToReturn,
             MonitoringMode monitoringMode,
             uint clientHandle,
-            double samplingInterval)*/
+            double samplingInterval)
+
+        /*
+        ISystemContext context,
+        MemoryTagState tag,
+        uint monitoredItemId,
+        uint attributeId,
+        DiagnosticsMasks diagnosticsMasks,
+        TimestampsToReturn timestampsToReturn,
+        MonitoringMode monitoringMode,
+        uint clientHandle,
+        double samplingInterval)*/
         {
             lock (m_dataLock)
             {
@@ -553,7 +553,7 @@ namespace MemoryBuffer
 
             DateTime end1 = DateTime.UtcNow;
 
-            double delta1 = ((double)(end1.Ticks-start1.Ticks))/TimeSpan.TicksPerMillisecond;
+            double delta1 = ((double)(end1.Ticks - start1.Ticks)) / TimeSpan.TicksPerMillisecond;
 
             if (delta1 > 100)
             {
@@ -669,7 +669,7 @@ namespace MemoryBuffer
 
             DateTime end1 = DateTime.UtcNow;
 
-            double delta1 = ((double)(end1.Ticks-start1.Ticks))/TimeSpan.TicksPerMillisecond;
+            double delta1 = ((double)(end1.Ticks - start1.Ticks)) / TimeSpan.TicksPerMillisecond;
 
             if (delta1 > 100)
             {
@@ -683,7 +683,7 @@ namespace MemoryBuffer
         private IServerInternal m_server;
         private INodeManager m_nodeManager;
         private MemoryBufferMonitoredItem[][] m_monitoringTable;
-        private Dictionary<uint,MemoryBufferMonitoredItem> m_nonValueMonitoredItems;
+        private Dictionary<uint, MemoryBufferMonitoredItem> m_nonValueMonitoredItems;
         private BuiltInType m_elementType;
         private int m_elementSize;
         private DateTime m_lastScanTime;

--- a/Applications/Quickstarts.Servers/SampleNodeManager/SampleNodeManager.cs
+++ b/Applications/Quickstarts.Servers/SampleNodeManager/SampleNodeManager.cs
@@ -1986,7 +1986,6 @@ namespace Opc.Ua.Sample
             bool unsubscribe)
         {
             ServerSystemContext systemContext = m_systemContext.Copy(context);
-            IDictionary<NodeId, NodeState> operationCache = new NodeIdDictionary<NodeState>();
 
             lock (Lock)
             {
@@ -2051,7 +2050,6 @@ namespace Opc.Ua.Sample
             bool unsubscribe)
         {
             ServerSystemContext systemContext = m_systemContext.Copy(context);
-            IDictionary<NodeId, NodeState> operationCache = new NodeIdDictionary<NodeState>();
 
             lock (Lock)
             {

--- a/Libraries/Opc.Ua.Client.ComplexTypes/Properties/AssemblyInfo.cs
+++ b/Libraries/Opc.Ua.Client.ComplexTypes/Properties/AssemblyInfo.cs
@@ -1,14 +1,32 @@
-/* Copyright (c) 1996-2020 The OPC Foundation. All rights reserved.
-   The source code in this file is covered under a dual-license scenario:
-     - RCL: for OPC Foundation members in good-standing
-     - GPL V2: everybody else
-   RCL license terms accompanied with this source code. See http://opcfoundation.org/License/RCL/1.00/
-   GNU General Public License as published by the Free Software Foundation;
-   version 2 of the License are accompanied with this source code. See http://opcfoundation.org/License/GPLv2
-   This source code is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-*/
+/* ========================================================================
+ * Copyright (c) 2005-2021 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ * 
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ * 
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
 using System.Runtime.CompilerServices;
 
 #if SIGNASSEMBLY

--- a/Libraries/Opc.Ua.Client/OpcUaClientEventSource.cs
+++ b/Libraries/Opc.Ua.Client/OpcUaClientEventSource.cs
@@ -1,14 +1,31 @@
-/* Copyright (c) 1996-2021 The OPC Foundation. All rights reserved.
-   The source code in this file is covered under a dual-license scenario:
-     - RCL: for OPC Foundation members in good-standing
-     - GPL V2: everybody else
-   RCL license terms accompanied with this source code. See http://opcfoundation.org/License/RCL/1.00/
-   GNU General Public License as published by the Free Software Foundation;
-   version 2 of the License are accompanied with this source code. See http://opcfoundation.org/License/GPLv2
-   This source code is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-*/
+/* ========================================================================
+ * Copyright (c) 2005-2021 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ * 
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ * 
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
 
 using System;
 using System.Diagnostics.Tracing;

--- a/Libraries/Opc.Ua.Client/Properties/AssemblyInfo.cs
+++ b/Libraries/Opc.Ua.Client/Properties/AssemblyInfo.cs
@@ -1,14 +1,32 @@
-/* Copyright (c) 1996-2020 The OPC Foundation. All rights reserved.
-   The source code in this file is covered under a dual-license scenario:
-     - RCL: for OPC Foundation members in good-standing
-     - GPL V2: everybody else
-   RCL license terms accompanied with this source code. See http://opcfoundation.org/License/RCL/1.00/
-   GNU General Public License as published by the Free Software Foundation;
-   version 2 of the License are accompanied with this source code. See http://opcfoundation.org/License/GPLv2
-   This source code is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-*/
+/* ========================================================================
+ * Copyright (c) 2005-2021 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ * 
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ * 
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
 using System.Runtime.CompilerServices;
 
 #if SIGNASSEMBLY

--- a/Libraries/Opc.Ua.Configuration/ApplicationConfigurationBuilder.cs
+++ b/Libraries/Opc.Ua.Configuration/ApplicationConfigurationBuilder.cs
@@ -820,9 +820,9 @@ namespace Opc.Ua.Configuration
         /// <summary>
         /// Add specified groups of security policies and security modes.
         /// </summary>
-        /// <param name="includeSign"></param>
-        /// <param name="deprecated"></param>
-        /// <param name="policyNone"></param>
+        /// <param name="includeSign">Include the Sign only policies.</param>
+        /// <param name="deprecated">Include the deprecated policies.</param>
+        /// <param name="policyNone">Include policy 'None'. (no security!)</param>
         private void AddSecurityPolicies(bool includeSign = false, bool deprecated = false, bool policyNone = false)
         {
             // create list of supported policies
@@ -839,6 +839,7 @@ namespace Opc.Ua.Configuration
                         deprecatedPolicyList.Add(uri);
                     }
                 }
+                defaultPolicyUris = deprecatedPolicyList.ToArray();
             }
 
             foreach (MessageSecurityMode securityMode in typeof(MessageSecurityMode).GetEnumValues())

--- a/Libraries/Opc.Ua.Configuration/ApplicationConfigurationBuilder.cs
+++ b/Libraries/Opc.Ua.Configuration/ApplicationConfigurationBuilder.cs
@@ -182,7 +182,7 @@ namespace Opc.Ua.Configuration
 
             ApplicationConfiguration.TraceConfiguration?.ApplySettings();
 
-            await ApplicationConfiguration.Validate(ApplicationInstance.ApplicationType);
+            await ApplicationConfiguration.Validate(ApplicationInstance.ApplicationType).ConfigureAwait(false);
 
             await ApplicationConfiguration.CertificateValidator.
                 Update(ApplicationConfiguration.SecurityConfiguration).ConfigureAwait(false);

--- a/Libraries/Opc.Ua.Configuration/ApplicationConfigurationBuilder.cs
+++ b/Libraries/Opc.Ua.Configuration/ApplicationConfigurationBuilder.cs
@@ -182,7 +182,7 @@ namespace Opc.Ua.Configuration
 
             ApplicationConfiguration.TraceConfiguration?.ApplySettings();
 
-            await ApplicationConfiguration.Validate(ApplicationInstance.ApplicationType).ConfigureAwait(false);
+            await ApplicationConfiguration.Validate(ApplicationInstance.ApplicationType);
 
             await ApplicationConfiguration.CertificateValidator.
                 Update(ApplicationConfiguration.SecurityConfiguration).ConfigureAwait(false);

--- a/Libraries/Opc.Ua.Security.Certificates/Org.BouncyCastle/CertificateFactoryRandomGenerator.cs
+++ b/Libraries/Opc.Ua.Security.Certificates/Org.BouncyCastle/CertificateFactoryRandomGenerator.cs
@@ -1,14 +1,31 @@
-/* Copyright (c) 1996-2020 The OPC Foundation. All rights reserved.
-   The source code in this file is covered under a dual-license scenario:
-     - RCL: for OPC Foundation members in good-standing
-     - GPL V2: everybody else
-   RCL license terms accompanied with this source code. See http://opcfoundation.org/License/RCL/1.00/
-   GNU General Public License as published by the Free Software Foundation;
-   version 2 of the License are accompanied with this source code. See http://opcfoundation.org/License/GPLv2
-   This source code is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-*/
+/* ========================================================================
+ * Copyright (c) 2005-2021 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ * 
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ * 
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
 
 #if !NETSTANDARD2_1 && !NET472_OR_GREATER && !NET5_0_OR_GREATER
 using System;

--- a/Libraries/Opc.Ua.Security.Certificates/Org.BouncyCastle/CertificateFactoryX509Name.cs
+++ b/Libraries/Opc.Ua.Security.Certificates/Org.BouncyCastle/CertificateFactoryX509Name.cs
@@ -1,14 +1,31 @@
-/* Copyright (c) 1996-2020 The OPC Foundation. All rights reserved.
-   The source code in this file is covered under a dual-license scenario:
-     - RCL: for OPC Foundation members in good-standing
-     - GPL V2: everybody else
-   RCL license terms accompanied with this source code. See http://opcfoundation.org/License/RCL/1.00/
-   GNU General Public License as published by the Free Software Foundation;
-   version 2 of the License are accompanied with this source code. See http://opcfoundation.org/License/GPLv2
-   This source code is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-*/
+/* ========================================================================
+ * Copyright (c) 2005-2021 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ * 
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ * 
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
 
 #if !NETSTANDARD2_1 && !NET472_OR_GREATER && !NET5_0_OR_GREATER
 

--- a/Libraries/Opc.Ua.Security.Certificates/Org.BouncyCastle/X509Utils.cs
+++ b/Libraries/Opc.Ua.Security.Certificates/Org.BouncyCastle/X509Utils.cs
@@ -1,14 +1,31 @@
-/* Copyright (c) 1996-2020 The OPC Foundation. All rights reserved.
-   The source code in this file is covered under a dual-license scenario:
-     - RCL: for OPC Foundation members in good-standing
-     - GPL V2: everybody else
-   RCL license terms accompanied with this source code. See http://opcfoundation.org/License/RCL/1.00/
-   GNU General Public License as published by the Free Software Foundation;
-   version 2 of the License are accompanied with this source code. See http://opcfoundation.org/License/GPLv2
-   This source code is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-*/
+/* ========================================================================
+ * Copyright (c) 2005-2021 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ * 
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ * 
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
 
 #if !NETSTANDARD2_1 && !NET5_0_OR_GREATER
 using System;

--- a/Libraries/Opc.Ua.Security.Certificates/Properties/AssemblyInfo.cs
+++ b/Libraries/Opc.Ua.Security.Certificates/Properties/AssemblyInfo.cs
@@ -1,14 +1,32 @@
-/* Copyright (c) 1996-2020 The OPC Foundation. All rights reserved.
-   The source code in this file is covered under a dual-license scenario:
-     - RCL: for OPC Foundation members in good-standing
-     - GPL V2: everybody else
-   RCL license terms accompanied with this source code. See http://opcfoundation.org/License/RCL/1.00/
-   GNU General Public License as published by the Free Software Foundation;
-   version 2 of the License are accompanied with this source code. See http://opcfoundation.org/License/GPLv2
-   This source code is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-*/
+/* ========================================================================
+ * Copyright (c) 2005-2021 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ * 
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ * 
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
 using System.Runtime.CompilerServices;
 
 #if SIGNASSEMBLY

--- a/Libraries/Opc.Ua.Security.Certificates/X509Certificate/X509PfxUtils.cs
+++ b/Libraries/Opc.Ua.Security.Certificates/X509Certificate/X509PfxUtils.cs
@@ -1,14 +1,31 @@
-/* Copyright (c) 1996-2020 The OPC Foundation. All rights reserved.
-   The source code in this file is covered under a dual-license scenario:
-     - RCL: for OPC Foundation members in good-standing
-     - GPL V2: everybody else
-   RCL license terms accompanied with this source code. See http://opcfoundation.org/License/RCL/1.00/
-   GNU General Public License as published by the Free Software Foundation;
-   version 2 of the License are accompanied with this source code. See http://opcfoundation.org/License/GPLv2
-   This source code is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-*/
+/* ========================================================================
+ * Copyright (c) 2005-2021 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ * 
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ * 
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
 
 using System;
 using System.Linq;

--- a/Libraries/Opc.Ua.Server/Properties/AssemblyInfo.cs
+++ b/Libraries/Opc.Ua.Server/Properties/AssemblyInfo.cs
@@ -1,14 +1,32 @@
-/* Copyright (c) 1996-2020 The OPC Foundation. All rights reserved.
-   The source code in this file is covered under a dual-license scenario:
-     - RCL: for OPC Foundation members in good-standing
-     - GPL V2: everybody else
-   RCL license terms accompanied with this source code. See http://opcfoundation.org/License/RCL/1.00/
-   GNU General Public License as published by the Free Software Foundation;
-   version 2 of the License are accompanied with this source code. See http://opcfoundation.org/License/GPLv2
-   This source code is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-*/
+/* ========================================================================
+ * Copyright (c) 2005-2021 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ * 
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ * 
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
 using System.Runtime.CompilerServices;
 
 #if SIGNASSEMBLY

--- a/Libraries/Opc.Ua.Server/Server/OpcUaServerEventSource.cs
+++ b/Libraries/Opc.Ua.Server/Server/OpcUaServerEventSource.cs
@@ -1,14 +1,31 @@
-/* Copyright (c) 1996-2021 The OPC Foundation. All rights reserved.
-   The source code in this file is covered under a dual-license scenario:
-     - RCL: for OPC Foundation members in good-standing
-     - GPL V2: everybody else
-   RCL license terms accompanied with this source code. See http://opcfoundation.org/License/RCL/1.00/
-   GNU General Public License as published by the Free Software Foundation;
-   version 2 of the License are accompanied with this source code. See http://opcfoundation.org/License/GPLv2
-   This source code is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-*/
+/* ========================================================================
+ * Copyright (c) 2005-2021 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ * 
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ * 
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
 
 using System.Diagnostics.Tracing;
 using Microsoft.Extensions.Logging;

--- a/Stack/.editorconfig
+++ b/Stack/.editorconfig
@@ -1,8 +1,8 @@
-# Editorconfig for libraries
+# Editorconfig for Core Stack
 
 root = false
 
-# Diagnostic settings specific to libraries
+# Diagnostic settings specific to core
 [*.cs]
 
 # RCS1090: Add call to 'ConfigureAwait' (or vice versa)

--- a/Stack/Opc.Ua.Core/Stack/Nodes/ContentFilter.cs
+++ b/Stack/Opc.Ua.Core/Stack/Nodes/ContentFilter.cs
@@ -763,16 +763,16 @@ namespace Opc.Ua
                     
                 case FilterOperator.InList:
                 {
-                    buffer.AppendFormat("'{0}' in {", operand1);
+                    buffer.AppendFormat("'{0}' in ", operand1);
+                    buffer.Append('{');
 
                     for (int ii = 1; ii < operands.Count; ii++)
                     {
+                        buffer.AppendFormat("'{0}'", operands[ii].ToString());
                         if (ii < operands.Count-1)
                         {
                             buffer.Append(", ");
                         }
-
-                        buffer.AppendFormat("'{0}'", operands[ii].ToString());
                     }
                             
                     buffer.Append('}');

--- a/Stack/Opc.Ua.Core/Stack/State/NodeState.cs
+++ b/Stack/Opc.Ua.Core/Stack/State/NodeState.cs
@@ -2447,7 +2447,7 @@ namespace Opc.Ua
 
         /// <summary>
         /// Returns any notifiers with the specified notifier type (NodeId) and direction.
-        /// </summary> 
+        /// </summary>
         public virtual void GetNotifiers(
             ISystemContext context,
             IList<Notifier> notifiers,
@@ -4124,7 +4124,7 @@ namespace Opc.Ua
         }
 
         /// <summary>
-        /// Adds a child to the node. 
+        /// Adds a child to the node.
         /// </summary>
         public void AddChild(BaseInstanceState child)
         {
@@ -4179,7 +4179,7 @@ namespace Opc.Ua
         }
 
         /// <summary>
-        /// Adds a child from the node. 
+        /// Removes a child from the node.
         /// </summary>
         public void RemoveChild(BaseInstanceState child)
         {
@@ -4507,7 +4507,7 @@ namespace Opc.Ua
         /// <param name="children">The list of children to populate.</param>
         /// <remarks>
         /// This method returns the children that are in memory and does not attempt to
-        /// access an underlying system. The PopulateBrowser method is used to discover those references. 
+        /// access an underlying system. The PopulateBrowser method is used to discover those references.
         /// </remarks>
         public virtual void GetChildren(
             ISystemContext context,
@@ -4528,11 +4528,11 @@ namespace Opc.Ua
         /// <param name="context">The context for the system being accessed.</param>
         /// <param name="references">The list of references to populate.</param>
         /// <remarks>
-        /// This method only returns references that are not implied by the parent-child 
+        /// This method only returns references that are not implied by the parent-child
         /// relation or references which are intrinsic to the NodeState classes (e.g. HasTypeDefinition)
-        /// 
+        ///
         /// This method also only returns the reference that are in memory and does not attempt to
-        /// access an underlying system. The PopulateBrowser method is used to discover those references.        
+        /// access an underlying system. The PopulateBrowser method is used to discover those references.
         /// </remarks>
         public virtual void GetReferences(
             ISystemContext context,

--- a/Tests/.editorconfig
+++ b/Tests/.editorconfig
@@ -1,8 +1,8 @@
-# Editorconfig for libraries
+# Editorconfig for Tests
 
 root = false
 
-# Diagnostic settings specific to libraries
+# Diagnostic settings specific to Tests
 [*.cs]
 
 # RCS1090: Add call to 'ConfigureAwait' (or vice versa)

--- a/Tests/Opc.Ua.Core.Tests/Types/Utils/HiResClock.cs
+++ b/Tests/Opc.Ua.Core.Tests/Types/Utils/HiResClock.cs
@@ -29,6 +29,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 using NUnit.Framework;
 
 namespace Opc.Ua.Core.Tests.Types.UtilsTests
@@ -44,6 +45,11 @@ namespace Opc.Ua.Core.Tests.Types.UtilsTests
         /// How long the tests are running.
         /// </summary>
         public const int HiResClockTestDuration = 2000;
+        /// <summary>
+        /// On MacOS allow higher margin due to flaky tests in CI builds.
+        /// </summary>
+        public readonly int Percent = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? 5 : 2;
+
 
         #region Test Setup
         [OneTimeTearDown]
@@ -111,7 +117,7 @@ namespace Opc.Ua.Core.Tests.Types.UtilsTests
             long elapsed = lastTickCount - firstTickCount;
             TestContext.Out.WriteLine("HiResClock counts: {0} resolution: {1}µs", counts, stopWatch.ElapsedMilliseconds * 1000 / counts);
             // test accuracy of counter vs. stop watch
-            Assert.That(elapsed, Is.EqualTo(stopWatch.ElapsedMilliseconds).Within(2).Percent);
+            Assert.That(elapsed, Is.EqualTo(stopWatch.ElapsedMilliseconds).Within(Percent).Percent);
         }
 
         /// <summary>
@@ -144,7 +150,7 @@ namespace Opc.Ua.Core.Tests.Types.UtilsTests
             long elapsed = (lastTickCount - firstTickCount) / TimeSpan.TicksPerMillisecond;
             TestContext.Out.WriteLine("HiResClock counts: {0} resolution: {1}µs", counts, stopWatch.ElapsedMilliseconds * 1000 / counts);
             // test accuracy of counter vs. stop watch
-            Assert.That(elapsed, Is.EqualTo(stopWatch.ElapsedMilliseconds).Within(2).Percent);
+            Assert.That(elapsed, Is.EqualTo(stopWatch.ElapsedMilliseconds).Within(Percent).Percent);
         }
         #endregion
     }

--- a/common.props
+++ b/common.props
@@ -33,14 +33,19 @@
     <None Include="$(MSBuildThisFileDirectory)/nuget/logo.jpg" Pack="true" PackagePath="$(PackageIcon)"/>
   </ItemGroup>
 
-  <ItemGroup Condition="'$(RCS)' == 'true'">
-    <PackageReference Include="Roslynator.Analyzers" Version="3.3.0" PrivateAssets="All" />
-  </ItemGroup>
+  <Choose>
+    <!-- VS 2017 workaround -->
+    <When  Condition="'$(RCS)' == 'true'">
+      <ItemGroup>
+        <PackageReference Include="Roslynator.Analyzers" Version="3.3.0" PrivateAssets="All" />
+      </ItemGroup>
+    </When>
+  </Choose>
 
   <ItemGroup Condition="'$(NBGV_PublicRelease)' != ''">
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
   </ItemGroup>
-  
+
   <!-- Deterministic build is currently not supported for code coverage tests. -->
   <PropertyGroup Condition="'$(CollectCoverage)' != 'true' AND ('$(TF_BUILD)' == 'true' OR '$(GITHUB_ACTIONS)' == 'true')">
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>


### PR DESCRIPTION
- vs2017 now only supports .NET 4.6.2 builds, .NET Core 2.1 is end of life. 
- Roslynator was not properly excluded in VS2017, change the condition to <Choose>
- fixes #1630 
- fix a few lgtm warnings
- fix a few license headers (everything outside of \Stack is MIT)
- fix flaky Hiresclock test.