### PR TITLE
Fix Authority Key Identifier in SubCA and cert validator return codes.

### DIFF
--- a/Libraries/Opc.Ua.Security.Certificates/Extensions/X509Extensions.cs
+++ b/Libraries/Opc.Ua.Security.Certificates/Extensions/X509Extensions.cs
@@ -256,7 +256,7 @@ namespace Opc.Ua.Security.Certificates
             var ski = issuerCaCertificate.Extensions.OfType<X509SubjectKeyIdentifierExtension>().Single();
             return new X509AuthorityKeyIdentifierExtension(
                 ski.SubjectKeyIdentifier.FromHexString(),
-                issuerCaCertificate.SubjectName,
+                issuerCaCertificate.IssuerName,
                 issuerCaCertificate.GetSerialNumber());
         }
 

--- a/Libraries/Opc.Ua.Security.Certificates/X509Certificate/CertificateBuilder.cs
+++ b/Libraries/Opc.Ua.Security.Certificates/X509Certificate/CertificateBuilder.cs
@@ -356,9 +356,8 @@ namespace Opc.Ua.Security.Certificates
                 ? X509Extensions.BuildAuthorityKeyIdentifier(IssuerCAKeyCert)
                 : new X509AuthorityKeyIdentifierExtension(
                     ski.SubjectKeyIdentifier.FromHexString(),
-                    SubjectName,
-                    m_serialNumber
-                    );
+                    IssuerName,
+                    m_serialNumber);
             request.CertificateExtensions.Add(authorityKeyIdentifier);
 
             X509KeyUsageFlags keyUsageFlags;

--- a/Stack/Opc.Ua.Core/Security/Certificates/CertificateValidator.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/CertificateValidator.cs
@@ -456,7 +456,7 @@ namespace Opc.Ua
         /// must not be supressed according to (e.g.) version 1.04 of the spec)
         /// </summary>
         /// <param name="sr"></param>
-        static private bool ContainsUnsuppressibleSC(ServiceResult sr)
+        private static bool ContainsUnsuppressibleSC(ServiceResult sr)
         {
             while (sr != null)
             {
@@ -1064,21 +1064,23 @@ namespace Opc.Ua
                 case X509ChainStatusFlags.UntrustedRoot:
                 {
                     // self signed cert signature validation 
-                    // .Net Core ChainStatus returns NotSignatureValid only on Windows, 
+                    // .NET Core ChainStatus returns NotSignatureValid only on Windows, 
                     // so we have to do the extra cert signature check on all platforms
-                    if (issuer == null && !isIssuer &&
-                        id.Certificate != null && X509Utils.CompareDistinguishedName(id.Certificate.Subject, id.Certificate.Issuer))
+                    if (issuer == null && id.Certificate != null &&
+                        X509Utils.CompareDistinguishedName(id.Certificate.Subject, id.Certificate.Issuer))
                     {
                         if (!IsSignatureValid(id.Certificate))
                         {
                             goto case X509ChainStatusFlags.NotSignatureValid;
                         }
+                        break;
                     }
 
-                    // ignore this error because the root check is done
-                    // by looking the certificate up in the trusted issuer stores passed to the validator.
-                    // the ChainStatus uses the trusted issuer stores.
-                    break;
+                    return ServiceResult.Create(
+                        StatusCodes.BadCertificateChainIncomplete,
+                        "Certificate chain validation failed. {0}: {1}",
+                        status.Status,
+                        status.StatusInformation);
                 }
 
                 case X509ChainStatusFlags.RevocationStatusUnknown:
@@ -1117,7 +1119,6 @@ namespace Opc.Ua
                 {
                     if (id != null && ((id.ValidationOptions & CertificateValidationOptions.SuppressCertificateExpired) != 0))
                     {
-                        // TODO: add logging
                         break;
                     }
 
@@ -1385,7 +1386,6 @@ namespace Opc.Ua
 
         #endregion
     }
-
 
     /// <summary>
     /// Used to handle certificate update events.

--- a/Stack/Opc.Ua.Core/Stack/Tcp/TcpServerChannel.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/TcpServerChannel.cs
@@ -508,6 +508,7 @@ namespace Opc.Ua.Bindings
                         innerException.StatusCode == StatusCodes.BadCertificateChainIncomplete ||
                         innerException.StatusCode == StatusCodes.BadCertificateRevoked ||
                         innerException.StatusCode == StatusCodes.BadCertificateInvalid ||
+                        innerException.StatusCode == StatusCodes.BadCertificatePolicyCheckFailed ||
                         (innerException.InnerResult != null && innerException.InnerResult.StatusCode == StatusCodes.BadCertificateUntrusted))
                     {
                         ForceChannelFault(StatusCodes.BadSecurityChecksFailed, e.Message);
@@ -528,7 +529,7 @@ namespace Opc.Ua.Bindings
                     }
                 }
 
-                ForceChannelFault(e, StatusCodes.BadSecurityChecksFailed, "Could not verify security on OpenSecureChannel request.");
+                ForceChannelFault(StatusCodes.BadSecurityChecksFailed, "Could not verify security on OpenSecureChannel request.");
                 return false;
             }
 


### PR DESCRIPTION
- AuthorityKeyIdentifier in the SubCA contains the SubjectName of the Issuer instead of the IssuerName. Also an application certificate that is signed by a SubCA would contain the false information.
- The false information has no effect on Windows and macOS, however on linux OpenSSL tests all fields and a chain cannot be fully validated.
- For CTT tests a few error codes were false returned because ServiceResult replaces the error code with the InnerException.
- Do not allow to ignore PartialChain validation error, it may have different root cause then the error returned by GetIssuer.