### PR TITLE
Fix a new private key can not be reloaded in virtualized windows environment

### DIFF
--- a/Stack/Opc.Ua.Core/Security/Certificates/DirectoryCertificateStore.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/DirectoryCertificateStore.cs
@@ -839,18 +839,15 @@ namespace Opc.Ua
             }
 
             // write file.
-            using (FileStream fileStream = fileInfo.Open(FileMode.Create))
-            using (BinaryWriter writer = new BinaryWriter(fileStream))
+            BinaryWriter writer = new BinaryWriter(fileInfo.Open(FileMode.Create));
+            try
             {
-                try
-                {
-                    writer.Write(data);
-                }
-                finally
-                {
-                    writer.Flush();
-                    fileStream.Flush();
-                }
+                writer.Write(data);
+            }
+            finally
+            {
+                writer.Flush();
+                writer.Dispose();
             }
 
             m_certificateSubdir.Refresh();


### PR DESCRIPTION
fixes #1670 

The docker windows application may fail to start when a new certificate is created with error "The specified network password is not correct."
The error disappears when the certificated is imported after a short timeout.

Adding a retry mechanism and more logging information in the 'security' tracemask.