### PR TITLE
Fix the AuthorityKeyIdentifier SubCA Issuer for Bouncy Castle CertificateBuilder.

### DIFF
--- a/Libraries/Opc.Ua.Security.Certificates/Org.BouncyCastle/CertificateBuilder.cs
+++ b/Libraries/Opc.Ua.Security.Certificates/Org.BouncyCastle/CertificateBuilder.cs
@@ -271,16 +271,19 @@ namespace Opc.Ua.Security.Certificates
         private void CreateMandatoryFields(X509V3CertificateGenerator cg)
         {
             m_subjectDN = new CertificateFactoryX509Name(SubjectName.Name);
-            // subject and issuer DN
+            // subject and issuer DN, issuer of issuer for AKI
             m_issuerDN = null;
+            m_issuerIssuerAKI = null;
             if (IssuerCAKeyCert != null)
             {
                 m_issuerDN = new CertificateFactoryX509Name(IssuerCAKeyCert.Subject);
+                m_issuerIssuerAKI = new CertificateFactoryX509Name(IssuerCAKeyCert.Issuer);
             }
             else
             {
                 // self signed 
                 m_issuerDN = m_subjectDN;
+                m_issuerIssuerAKI = m_subjectDN;
             }
             cg.SetIssuerDN(m_issuerDN);
             cg.SetSubjectDN(m_subjectDN);
@@ -332,7 +335,7 @@ namespace Opc.Ua.Security.Certificates
 
             cg.AddExtension(Org.BouncyCastle.Asn1.X509.X509Extensions.AuthorityKeyIdentifier.Id, false,
                 new AuthorityKeyIdentifier(SubjectPublicKeyInfoFactory.CreateSubjectPublicKeyInfo(issuerPublicKey),
-                    new GeneralNames(new GeneralName(m_issuerDN)), issuerSerialNumber));
+                    new GeneralNames(new GeneralName(m_issuerIssuerAKI)), issuerSerialNumber));
 
             if (!m_isCA)
             {
@@ -492,6 +495,7 @@ namespace Opc.Ua.Security.Certificates
 
         #region Private Fields
         private X509Name m_issuerDN;
+        private X509Name m_issuerIssuerAKI;
         private X509Name m_subjectDN;
         #endregion
     }


### PR DESCRIPTION
- The missing fix in https://github.com/OPCFoundation/UA-.NETStandard/commit/6747b471920ce165b59411d37c227e08d49dd047 for the bouncy castle certificate builder which was used in .NET Core 2.1 (eol) and .NET 4.6.2, unnoticed in the tests because windows only uses the keyId to validate the chain.
- AuthorityKeyIdentifier in the SubCA contains the SubjectName of the Issuer instead of the IssuerName. Also an application certificate that is signed by a SubCA would contain the false information.
- The false information has no effect on Windows and macOS, however on linux OpenSSL tests all fields and a chain cannot be fully validated.

