### PR TITLE
Ref server fixes for CTT 

### DIFF
--- a/Libraries/Opc.Ua.Server/Diagnostics/DiagnosticsNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/Diagnostics/DiagnosticsNodeManager.cs
@@ -141,9 +141,9 @@ namespace Opc.Ua.Server
                 Server.CoreNodeManager.ImportNodes(SystemContext, PredefinedNodes.Values, true);
 
                 // hook up the server GetMonitoredItems method.
-                MethodState getMonitoredItems = (MethodState)FindPredefinedNode(
+                GetMonitoredItemsMethodState getMonitoredItems = (GetMonitoredItemsMethodState)FindPredefinedNode(
                     MethodIds.Server_GetMonitoredItems,
-                    typeof(MethodState));
+                    typeof(GetMonitoredItemsMethodState));
 
                 if (getMonitoredItems != null)
                 {
@@ -169,11 +169,29 @@ namespace Opc.Ua.Server
                         getMonitoredItemsOutputArguments.ClearChangeMasks(SystemContext, false);
                     }
                 }
+
+                // Subscription Durable mode not supported by the server.
+                ServerObjectState serverObject = (ServerObjectState)FindPredefinedNode(
+                    ObjectIds.Server,
+                    typeof(ServerObjectState));
+
+                if (serverObject != null)
+                {
+                    NodeState setSubscriptionDurableNode = serverObject.FindChild(
+                        SystemContext,
+                        BrowseNames.SetSubscriptionDurable);
+
+                    if (setSubscriptionDurableNode != null)
+                    {
+                        DeleteNode(SystemContext, MethodIds.Server_SetSubscriptionDurable);
+                        serverObject.SetSubscriptionDurable = null;
+                    }
+                }
             }
         }
 
         /// <summary>
-        /// Called when a client locks the server.
+        /// Called when a client gets the monitored items of a subscription.
         /// </summary>
         public ServiceResult OnGetMonitoredItems(
             ISystemContext context,

--- a/Libraries/Opc.Ua.Server/Subscription/SubscriptionManager.cs
+++ b/Libraries/Opc.Ua.Server/Subscription/SubscriptionManager.cs
@@ -443,10 +443,10 @@ namespace Opc.Ua.Server
 
                     if (!NodeId.IsNull(sessionId))
                     {
-                        // check that the subscrition is the owner.
+                        // check that the subscription is the owner.
                         if (context != null && !Object.ReferenceEquals(context.Session, subscription.Session))
                         {
-                            throw new ServiceResultException(StatusCodes.BadSessionIdInvalid);
+                            throw new ServiceResultException(StatusCodes.BadSubscriptionIdInvalid);
                         }
 
                         SessionPublishQueue queue = null;

--- a/Stack/Opc.Ua.Core/Stack/State/MethodState.cs
+++ b/Stack/Opc.Ua.Core/Stack/State/MethodState.cs
@@ -612,9 +612,14 @@ namespace Opc.Ua
                 expectedCount = InputArguments.Value.Length;
             }
 
-            if (expectedCount != inputArguments.Count)
+            if (expectedCount > inputArguments.Count)
             {
                 return StatusCodes.BadArgumentsMissing;
+            }
+            
+            if (expectedCount < inputArguments.Count)
+            {
+                return StatusCodes.BadTooManyArguments;
             }
             
             // validate individual arguements.

--- a/Stack/Opc.Ua.Core/Stack/State/NodeState.cs
+++ b/Stack/Opc.Ua.Core/Stack/State/NodeState.cs
@@ -3454,7 +3454,12 @@ namespace Opc.Ua
                         value = description;
                     }
 
-                    return result;
+                    if (value != null)
+                    {
+                        return result;
+                    }
+
+                    break;
                 }
 
                 case Attributes.WriteMask:
@@ -3505,7 +3510,12 @@ namespace Opc.Ua
                         value = rolePermissions;
                     }
 
-                    return result;
+                    if (value != null)
+                    {
+                        return result;
+                    }
+
+                    break;
                 }
 
                 case Attributes.UserRolePermissions:
@@ -3522,7 +3532,12 @@ namespace Opc.Ua
                         value = userRolePermissions;
                     }
 
-                    return result;
+                    if (value != null)
+                    {
+                        return result;
+                    }
+
+                    break;
                 }
 
                 case Attributes.AccessRestrictions:

--- a/Stack/Opc.Ua.Core/Types/BuiltIn/Variant.cs
+++ b/Stack/Opc.Ua.Core/Types/BuiltIn/Variant.cs
@@ -862,6 +862,24 @@ namespace Opc.Ua
         }
 
         /// <summary>
+        /// Append a ByteString as a hex string.
+        /// </summary>
+        private void AppendByteString(StringBuilder buffer, byte[] bytes, IFormatProvider formatProvider)
+        {
+            if (bytes != null)
+            {
+                for (int ii = 0; ii < bytes.Length; ii++)
+                {
+                    buffer.AppendFormat(formatProvider, "{0:X2}", bytes[ii]);
+                }
+            }
+            else
+            {
+                buffer.Append("(null)");
+            }
+        }
+
+        /// <summary>
         /// Formats a value as a string.
         /// </summary>
         private void AppendFormat(StringBuilder buffer, object value, IFormatProvider formatProvider)
@@ -877,12 +895,7 @@ namespace Opc.Ua
             if (m_typeInfo.BuiltInType == BuiltInType.ByteString && m_typeInfo.ValueRank < 0)
             {
                 byte[] bytes = (byte[])value;
-
-                for (int ii = 0; ii < bytes.Length; ii++)
-                {
-                    buffer.AppendFormat(formatProvider, "{0:X2}", bytes[ii]);
-                }
-
+                AppendByteString(buffer, bytes, formatProvider);
                 return;
             }
 
@@ -901,15 +914,33 @@ namespace Opc.Ua
             {
                 buffer.Append('{');
 
-                if (array.Length > 0)
+                if (m_typeInfo.BuiltInType == BuiltInType.ByteString)
                 {
-                    AppendFormat(buffer, array.GetValue(0), formatProvider);
-                }
+                    if (array.Length > 0)
+                    {
+                        byte[] bytes = (byte[])array.GetValue(0);
+                        AppendByteString(buffer, bytes, formatProvider);
+                    }
 
-                for (int ii = 1; ii < array.Length; ii++)
+                    for (int ii = 1; ii < array.Length; ii++)
+                    {
+                        buffer.Append('|');
+                        byte[] bytes = (byte[])array.GetValue(ii);
+                        AppendByteString(buffer, bytes, formatProvider);
+                    }
+                }
+                else
                 {
-                    buffer.Append(" |");
-                    AppendFormat(buffer, array.GetValue(ii), formatProvider);
+                    if (array.Length > 0)
+                    {
+                        AppendFormat(buffer, array.GetValue(0), formatProvider);
+                    }
+
+                    for (int ii = 1; ii < array.Length; ii++)
+                    {
+                        buffer.Append('|');
+                        AppendFormat(buffer, array.GetValue(ii), formatProvider);
+                    }
                 }
 
                 buffer.Append('}');

--- a/Stack/Opc.Ua.Core/Types/Encoders/BinaryDecoder.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/BinaryDecoder.cs
@@ -2205,7 +2205,7 @@ namespace Opc.Ua
                     }
                     else
                     {
-                        value = new Variant(array);
+                        value = new Variant(array, new TypeInfo(builtInType, 1));
                     }
                 }
             }


### PR DESCRIPTION
- remove the SetDurableSubscription method, to skip the test cases
- DeleteSubscription returns BadSubscriptionIdInvalid
- MethodState return also BadTooManyArguments
- return AttributeIdInvalid for null attributes (fix UA Expert display)
- fix ToString of Variant array of ByteString
- fix Variant decoding 1-dim array of bytestring