### PR TITLE
Enable call of methods that are part of the types or super types of the objectId on which the method is called

### DIFF
--- a/Libraries/Opc.Ua.Server/Diagnostics/CustomNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/Diagnostics/CustomNodeManager.cs
@@ -2989,6 +2989,14 @@ namespace Opc.Ua.Server
 
                     // find the method.
                     method = source.FindMethod(systemContext, methodToCall.MethodId);
+                    // if the found method is not the actual method tried to be called
+                    // This might happen in case the method.MethodDeclarationId == methodToCall.MethodId
+                    if ((method != null) && 
+                        (method.NodeId != methodToCall.MethodId) &&
+                        (method.MethodDeclarationId == methodToCall.MethodId))
+                    {
+                        method = FindMethodInType(systemContext, source, methodToCall.MethodId);
+                    }
 
                     if (method == null)
                     {

--- a/Libraries/Opc.Ua.Server/Diagnostics/CustomNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/Diagnostics/CustomNodeManager.cs
@@ -2990,11 +2990,12 @@ namespace Opc.Ua.Server
                     // find the method.
                     method = source.FindMethod(systemContext, methodToCall.MethodId);
                     // if the found method is not the actual method tried to be called
-                    // This might happen in case the method.MethodDeclarationId == methodToCall.MethodId
+                    // this might happen in case the method.MethodDeclarationId == methodToCall.MethodId
                     if ((method != null) && 
                         (method.NodeId != methodToCall.MethodId) &&
                         (method.MethodDeclarationId == methodToCall.MethodId))
                     {
+                        // try to find the actual method to be called on the type hierarchy
                         method = FindMethodInType(systemContext, source, methodToCall.MethodId);
                     }
 


### PR DESCRIPTION
Enable call of methods that are part of the types or super types of the objectId on which the method is called.
Closes #1696 