### PR TITLE
Handle subscription transfer special cases + tests

### DIFF
--- a/Libraries/Opc.Ua.Client/MonitoredItem.cs
+++ b/Libraries/Opc.Ua.Client/MonitoredItem.cs
@@ -746,13 +746,15 @@ namespace Opc.Ua.Client
         /// </summary>
         public void SetTransferResult(uint clientHandle)
         {
+            // ensure the global counter is not duplicating future handle ids
+            Utils.LowerLimitIdentifier(ref s_GlobalClientHandle, clientHandle);
             m_clientHandle = clientHandle;  
             m_status.SetTransferResult(this);
             m_attributesModified = false;
         }
 
         /// <summary>
-        /// Updates the object with the results of a modify monitored item request.
+        /// Updates the object with the results of a delete monitored item request.
         /// </summary>
         public void SetDeleteResult(
             StatusCode result,

--- a/Libraries/Opc.Ua.Client/Session.cs
+++ b/Libraries/Opc.Ua.Client/Session.cs
@@ -267,7 +267,7 @@ namespace Opc.Ua.Client
                 PublishingEnabled = true
             };
         }
-        
+
         /// <summary>
         /// Check if all required configuration fields are populated.
         /// </summary>
@@ -3467,9 +3467,9 @@ namespace Opc.Ua.Client
 
             return true;
         }
-#endregion
+        #endregion
 
-#region Browse Methods
+        #region Browse Methods
         /// <summary>
         /// Invokes the Browse service.
         /// </summary>
@@ -3612,9 +3612,9 @@ namespace Opc.Ua.Client
 
             return responseHeader;
         }
-#endregion
+        #endregion
 
-#region BrowseNext Methods
+        #region BrowseNext Methods
         /// <summary>
         /// Invokes the BrowseNext service.
         /// </summary>
@@ -3704,9 +3704,9 @@ namespace Opc.Ua.Client
 
             return responseHeader;
         }
-#endregion
+        #endregion
 
-#region Call Methods
+        #region Call Methods
         /// <summary>
         /// Calls the specified method and returns the output arguments.
         /// </summary>
@@ -3761,9 +3761,9 @@ namespace Opc.Ua.Client
 
             return outputArguments;
         }
-#endregion
+        #endregion
 
-#region Protected Methods
+        #region Protected Methods
         /// <summary>
         /// Returns the software certificates assigned to the application.
         /// </summary>
@@ -4133,9 +4133,9 @@ namespace Opc.Ua.Client
             }
             return removed;
         }
-#endregion
+        #endregion
 
-#region Publish Methods
+        #region Publish Methods
         /// <summary>
         /// Sends an additional publish request.
         /// </summary>
@@ -4728,9 +4728,9 @@ namespace Opc.Ua.Client
             return (m_tooManyPublishRequests == 0) ||
                 (requestCount < m_tooManyPublishRequests);
         }
-#endregion
+        #endregion
 
-#region Private Fields
+        #region Private Fields
         private SubscriptionAcknowledgementCollection m_acknowledgementsToSend;
         private Dictionary<uint, uint> m_latestAcknowledgementsSent;
         private List<Subscription> m_subscriptions;
@@ -4785,16 +4785,16 @@ namespace Opc.Ua.Client
         private event PublishErrorEventHandler m_PublishError;
         private event EventHandler m_SubscriptionsChanged;
         private event EventHandler m_SessionClosing;
-#endregion
+        #endregion
     }
 
-#region KeepAliveEventArgs Class
+    #region KeepAliveEventArgs Class
     /// <summary>
     /// The event arguments provided when a keep alive response arrives.
     /// </summary>
     public class KeepAliveEventArgs : EventArgs
     {
-#region Constructors
+        #region Constructors
         /// <summary>
         /// Creates a new instance.
         /// </summary>
@@ -4807,9 +4807,9 @@ namespace Opc.Ua.Client
             m_currentState = currentState;
             m_currentTime = currentTime;
         }
-#endregion
+        #endregion
 
-#region Public Properties
+        #region Public Properties
         /// <summary>
         /// Gets the status associated with the keep alive operation.
         /// </summary>
@@ -4833,29 +4833,29 @@ namespace Opc.Ua.Client
             get { return m_cancelKeepAlive; }
             set { m_cancelKeepAlive = value; }
         }
-#endregion
+        #endregion
 
-#region Private Fields
+        #region Private Fields
         private readonly ServiceResult m_status;
         private readonly ServerState m_currentState;
         private readonly DateTime m_currentTime;
         private bool m_cancelKeepAlive;
-#endregion
+        #endregion
     }
 
     /// <summary>
     /// The delegate used to receive keep alive notifications.
     /// </summary>
     public delegate void KeepAliveEventHandler(Session session, KeepAliveEventArgs e);
-#endregion
+    #endregion
 
-#region NotificationEventArgs Class
+    #region NotificationEventArgs Class
     /// <summary>
     /// Represents the event arguments provided when a new notification message arrives.
     /// </summary>
     public class NotificationEventArgs : EventArgs
     {
-#region Constructors
+        #region Constructors
         /// <summary>
         /// Creates a new instance.
         /// </summary>
@@ -4868,9 +4868,9 @@ namespace Opc.Ua.Client
             m_notificationMessage = notificationMessage;
             m_stringTable = stringTable;
         }
-#endregion
+        #endregion
 
-#region Public Properties
+        #region Public Properties
         /// <summary>
         /// Gets the subscription that the notification applies to.
         /// </summary>
@@ -4885,28 +4885,28 @@ namespace Opc.Ua.Client
         /// Gets the string table returned with the notification message.
         /// </summary>
         public IList<string> StringTable => m_stringTable;
-#endregion
+        #endregion
 
-#region Private Fields
+        #region Private Fields
         private readonly Subscription m_subscription;
         private readonly NotificationMessage m_notificationMessage;
         private readonly IList<string> m_stringTable;
-#endregion
+        #endregion
     }
 
     /// <summary>
     /// The delegate used to receive publish notifications.
     /// </summary>
     public delegate void NotificationEventHandler(Session session, NotificationEventArgs e);
-#endregion
+    #endregion
 
-#region PublishErrorEventArgs Class
+    #region PublishErrorEventArgs Class
     /// <summary>
     /// Represents the event arguments provided when a publish error occurs.
     /// </summary>
     public class PublishErrorEventArgs : EventArgs
     {
-#region Constructors
+        #region Constructors
         /// <summary>
         /// Creates a new instance.
         /// </summary>
@@ -4924,9 +4924,9 @@ namespace Opc.Ua.Client
             m_subscriptionId = subscriptionId;
             m_sequenceNumber = sequenceNumber;
         }
-#endregion
+        #endregion
 
-#region Public Properties
+        #region Public Properties
         /// <summary>
         /// Gets the status associated with the keep alive operation.
         /// </summary>
@@ -4941,18 +4941,18 @@ namespace Opc.Ua.Client
         /// Gets the sequence number for the message that could not be republished.
         /// </summary>
         public uint SequenceNumber => m_sequenceNumber;
-#endregion
+        #endregion
 
-#region Private Fields
+        #region Private Fields
         private readonly uint m_subscriptionId;
         private readonly uint m_sequenceNumber;
         private readonly ServiceResult m_status;
-#endregion
+        #endregion
     }
 
     /// <summary>
     /// The delegate used to receive pubish error notifications.
     /// </summary>
     public delegate void PublishErrorEventHandler(Session session, PublishErrorEventArgs e);
-#endregion
+    #endregion
 }

--- a/Libraries/Opc.Ua.Client/Session.cs
+++ b/Libraries/Opc.Ua.Client/Session.cs
@@ -4504,6 +4504,11 @@ namespace Opc.Ua.Client
                     acknowledgementsToSend.Add(acknowledgement);
                 }
 
+#if DEBUG_SEQUENTIALPUBLISHING
+                // Checks for debug info only. 
+                // Once more than a single publish request is queued, the checks are invalid
+                // because a publish response may not include the latest ack information yet.
+
                 uint lastSentSequenceNumber = 0;
                 if (availableSequenceNumbers != null)
                 {
@@ -4512,7 +4517,6 @@ namespace Opc.Ua.Client
                         if (m_latestAcknowledgementsSent.ContainsKey(subscriptionId))
                         {
                             lastSentSequenceNumber = m_latestAcknowledgementsSent[subscriptionId];
-
                             // If the last sent sequence number is uint.Max do not display the warning; the counter rolled over
                             // If the last sent sequence number is greater or equal to the available sequence number (returned by the publish),
                             // a warning must be logged.
@@ -4530,12 +4534,14 @@ namespace Opc.Ua.Client
                     lastSentSequenceNumber = m_latestAcknowledgementsSent[subscriptionId];
 
                     // If the last sent sequence number is uint.Max do not display the warning; the counter rolled over
-                    // If the last sent sequence number is greater or equal to the notificationMessage's sequence number (returned by the publish), a warning must be logged.
+                    // If the last sent sequence number is greater or equal to the notificationMessage's sequence number (returned by the publish),
+                    // a warning must be logged.
                     if (((lastSentSequenceNumber >= notificationMessage.SequenceNumber) && (lastSentSequenceNumber != uint.MaxValue)) || (lastSentSequenceNumber == notificationMessage.SequenceNumber) && (lastSentSequenceNumber == uint.MaxValue))
                     {
                         Utils.LogWarning("Received sequence number which was already acknowledged={0}", notificationMessage.SequenceNumber);
                     }
                 }
+#endif
 
                 if (availableSequenceNumbers != null)
                 {

--- a/Libraries/Opc.Ua.Client/Subscription.cs
+++ b/Libraries/Opc.Ua.Client/Subscription.cs
@@ -101,10 +101,9 @@ namespace Opc.Ua.Client
                 m_timestampsToReturn = template.m_timestampsToReturn;
                 m_maxMessageCount = template.m_maxMessageCount;
                 m_sequentialPublishing = template.m_sequentialPublishing;
+                m_republishAfterTransfer = template.m_republishAfterTransfer;
                 m_defaultItem = (MonitoredItem)template.m_defaultItem.MemberwiseClone();
-                m_defaultItem = template.m_defaultItem;
                 m_handle = template.m_handle;
-                m_maxMessageCount = template.m_maxMessageCount;
                 m_disableMonitoredItemCache = template.m_disableMonitoredItemCache;
 
                 if (copyEventHandlers)
@@ -149,6 +148,7 @@ namespace Opc.Ua.Client
             m_publishingEnabled = false;
             m_timestampsToReturn = TimestampsToReturn.Both;
             m_maxMessageCount = 10;
+            m_republishAfterTransfer = false;
             m_outstandingMessageWorkers = 0;
             m_sequentialPublishing = false;
             m_lastSequenceNumberProcessed = 0;
@@ -343,7 +343,7 @@ namespace Opc.Ua.Client
         /// <summary>
         /// The minimum lifetime for subscriptions in milliseconds.
         /// </summary>
-        [DataMember(Order = 11)]
+        [DataMember(Order = 12)]
         public uint MinLifetimeInterval
         {
             get => m_minLifetimeInterval;
@@ -360,7 +360,7 @@ namespace Opc.Ua.Client
         /// Applications must process the Session.Notication event if this is set to true.
         /// This flag improves performance by eliminating the processing involved in updating the cache.
         /// </remarks>
-        [DataMember(Order = 12)]
+        [DataMember(Order = 13)]
         public bool DisableMonitoredItemCache
         {
             get => m_disableMonitoredItemCache;
@@ -377,7 +377,7 @@ namespace Opc.Ua.Client
         /// Setting <see cref="SequentialPublishing"/> to <c>true</c> means incoming messages are processed in
         /// a "single-threaded" manner and callbacks will not be invoked in parallel.
         /// </remarks>
-        [DataMember(Order = 13)]
+        [DataMember(Order = 14)]
         public bool SequentialPublishing
         {
             get
@@ -398,9 +398,25 @@ namespace Opc.Ua.Client
         }
 
         /// <summary>
+        /// If the available sequence numbers of a subscription
+        /// are republished or acknoledged after a transfer. 
+        /// </summary>
+        /// <remarks>
+        /// Default <c>false</c>, set to <c>true</c> if no data loss is important
+        /// and available publish requests (sequence numbers) that were never acknoledged should be
+        /// recovered with a republish. The setting is used after a subscription transfer.
+        /// </remarks>   
+        [DataMember(Name = "RepublishAfterTransfer", Order = 15)]
+        public bool RepublishAfterTransfer
+        {
+            get { return m_republishAfterTransfer; }
+            set { lock (m_cache) { m_republishAfterTransfer = value; } }
+        }
+
+        /// <summary>
         /// The unique identifier assigned by the server which can be used to transfer a session.
         /// </summary>
-        [DataMember(Name = "TransferId", Order = 14)]
+        [DataMember(Name = "TransferId", Order = 16)]
         public uint TransferId
         {
             get => m_transferId;
@@ -557,7 +573,7 @@ namespace Opc.Ua.Client
         /// <summary>
         /// The current publishing interval.
         /// </summary>
-        [DataMember(Name = "CurrentPublishInterval", Order = 15)]
+        [DataMember(Name = "CurrentPublishInterval", Order = 20)]
         public double CurrentPublishingInterval
         {
             get => m_currentPublishingInterval;
@@ -567,7 +583,7 @@ namespace Opc.Ua.Client
         /// <summary>
         /// The current keep alive count.
         /// </summary>
-        [DataMember(Name = "CurrentKeepAliveCount", Order = 16)]
+        [DataMember(Name = "CurrentKeepAliveCount", Order = 21)]
         public uint CurrentKeepAliveCount
         {
             get => m_currentKeepAliveCount;
@@ -577,7 +593,7 @@ namespace Opc.Ua.Client
         /// <summary>
         /// The current lifetime count.
         /// </summary>
-        [DataMember(Name = "CurrentLifetimeCount", Order = 17)]
+        [DataMember(Name = "CurrentLifetimeCount", Order = 22)]
         public uint CurrentLifetimeCount
         {
             get => m_currentLifetimeCount;
@@ -803,13 +819,15 @@ namespace Opc.Ua.Client
                     return false;
                 }
 
-                if (!m_session.RemoveTransferredSubscription(this))
+                if (m_session?.RemoveTransferredSubscription(this) != true)
                 {
+                    Utils.LogError("SubscriptionId {0}: Failed to remove transferred subscription from owner SessionId={1}.", Id, m_session?.SessionId);
                     return false;
                 }
 
                 if (!session.AddSubscription(this))
                 {
+                    Utils.LogError("SubscriptionId {0}: Failed to add transferred subscription to SessionId={1}.", Id, session.SessionId);
                     return false;
                 }
             }
@@ -817,6 +835,7 @@ namespace Opc.Ua.Client
             {
                 if (!GetMonitoredItems(out UInt32Collection serverHandles, out UInt32Collection clientHandles))
                 {
+                    Utils.LogError("SubscriptionId {0}: The server failed to respond to GetMonitoredItems after transfer.", Id);
                     return false;
                 }
 
@@ -824,16 +843,20 @@ namespace Opc.Ua.Client
                     clientHandles.Count != m_monitoredItems.Count)
                 {
                     // invalid state
+                    Utils.LogError("SubscriptionId {0}: Number of Monitored Items on client and server do not match after transfer {1}!={2}",
+                        Id, serverHandles.Count, m_monitoredItems.Count);
                     return false;
                 }
 
+                // sets state to 'Created'
                 m_id = id;
-                m_availableSequenceNumbers = availableSequenceNumbers;
-
                 TransferItems(serverHandles, clientHandles, out IList<MonitoredItem> itemsToModify);
 
                 ModifyItems();
             }
+
+            // add available sequence numbers to incoming 
+            ProcessTransferredSequenceNumbers(availableSequenceNumbers);
 
             m_changeMask |= SubscriptionChangeMask.Transferred;
             ChangesCompleted();
@@ -1276,7 +1299,7 @@ namespace Opc.Ua.Client
                     TraceState("PUBLISHING RECOVERED");
                 }
 
-                m_lastNotificationTime = DateTime.UtcNow;
+                DateTime now = m_lastNotificationTime = DateTime.UtcNow;
 
                 // save the string table that came with notification.
                 message.StringTable = new List<string>(stringTable);
@@ -1288,40 +1311,7 @@ namespace Opc.Ua.Client
                 }
 
                 // find or create an entry for the incoming sequence number.
-                IncomingMessage entry = null;
-                LinkedListNode<IncomingMessage> node = m_incomingMessages.Last;
-
-                while (node != null)
-                {
-                    entry = node.Value;
-                    LinkedListNode<IncomingMessage> previous = node.Previous;
-
-                    if (entry.SequenceNumber == message.SequenceNumber)
-                    {
-                        entry.Timestamp = DateTime.UtcNow;
-                        break;
-                    }
-
-                    if (entry.SequenceNumber < message.SequenceNumber)
-                    {
-                        entry = new IncomingMessage();
-                        entry.SequenceNumber = message.SequenceNumber;
-                        entry.Timestamp = DateTime.UtcNow;
-                        m_incomingMessages.AddAfter(node, entry);
-                        break;
-                    }
-
-                    node = previous;
-                    entry = null;
-                }
-
-                if (entry == null)
-                {
-                    entry = new IncomingMessage();
-                    entry.SequenceNumber = message.SequenceNumber;
-                    entry.Timestamp = DateTime.UtcNow;
-                    m_incomingMessages.AddLast(entry);
-                }
+                IncomingMessage entry = FindOrCreateEntry(now, message.SequenceNumber);
 
                 // check for keep alive.
                 if (message.NotificationData.Count > 0)
@@ -1331,7 +1321,7 @@ namespace Opc.Ua.Client
                 }
 
                 // fill in any gaps in the queue
-                node = m_incomingMessages.First;
+                LinkedListNode<IncomingMessage> node = m_incomingMessages.First;
 
                 while (node != null)
                 {
@@ -1342,7 +1332,7 @@ namespace Opc.Ua.Client
                     {
                         IncomingMessage placeholder = new IncomingMessage();
                         placeholder.SequenceNumber = entry.SequenceNumber + 1;
-                        placeholder.Timestamp = DateTime.UtcNow;
+                        placeholder.Timestamp = now;
                         node = m_incomingMessages.AddAfter(node, placeholder);
                         continue;
                     }
@@ -1359,7 +1349,7 @@ namespace Opc.Ua.Client
                     LinkedListNode<IncomingMessage> next = node.Next;
 
                     // can only pull off processed or expired messages.
-                    if (!entry.Processed && !(entry.Republished && entry.Timestamp.AddSeconds(10) < DateTime.UtcNow))
+                    if (!entry.Processed && !(entry.Republished && entry.Timestamp.AddSeconds(10) < now))
                     {
                         break;
                     }
@@ -1550,6 +1540,43 @@ namespace Opc.Ua.Client
         #endregion
 
         #region Private Methods
+        /// <summary>
+        /// Updates the available sequence numbers and queues after transfer.
+        /// </summary>
+        /// <remarks>
+        /// If <see cref="RepublishAfterTransfer"/> is set to <c>true</c>, sequence numbers
+        /// are queued for republish, otherwise ack may be sent.
+        /// </remarks>
+        /// <param name="availableSequenceNumbers">The list of available sequence numbers on the server.</param>
+        private void ProcessTransferredSequenceNumbers(UInt32Collection availableSequenceNumbers)
+        {
+            lock (m_cache)
+            {
+                // save available sequence numbers
+                m_availableSequenceNumbers = (UInt32Collection)availableSequenceNumbers.MemberwiseClone();
+
+                if (availableSequenceNumbers.Count != 0 && m_republishAfterTransfer)
+                {
+                    // create queue for the first time.
+                    if (m_incomingMessages == null)
+                    {
+                        m_incomingMessages = new LinkedList<IncomingMessage>();
+                    }
+
+                    // triggers the republish mechanism immediately,
+                    // if event is in the past
+                    var now = DateTime.UtcNow.AddSeconds(-5);
+                    foreach (var sequenceNumber in availableSequenceNumbers)
+                    {
+                        FindOrCreateEntry(now, sequenceNumber);
+                    }
+
+                    // sequence numbers handled for republish, clear for caller so no ack
+                    availableSequenceNumbers.Clear();
+                }
+            }
+        }
+
         /// <summary>
         /// Call the GetMonitoredItems method on the server.
         /// </summary>
@@ -1811,7 +1838,7 @@ namespace Opc.Ua.Client
         /// </summary>
         private async Task OnMessageReceived()
         {
-            //Avoid semaphore being replaced for this instance while running, retain reference locally.
+            // Avoid semaphore being replaced for this instance while running, retain reference locally.
             SemaphoreSlim semaphore;
             lock (m_cache)
             {
@@ -1820,7 +1847,7 @@ namespace Opc.Ua.Client
                 semaphore = m_messageWorkersSemaphore;
             }
 
-            //Later used to know if releasing the semaphore is needed. Assumed entered if needed.
+            // Later used to know if releasing the semaphore is needed. Assumed entered if needed.
             var needSemaphore = semaphore != null;
             if (needSemaphore)
             {
@@ -1839,6 +1866,7 @@ namespace Opc.Ua.Client
                     needSemaphore = false;
                 }
             }
+
             try
             {
                 Interlocked.Increment(ref m_outstandingMessageWorkers);
@@ -1858,7 +1886,7 @@ namespace Opc.Ua.Client
                     {
                         // update monitored items with unprocessed messages.
                         if (ii.Value.Message != null && !ii.Value.Processed &&
-                            //If sequential publishing is enabled, only release messages in perfect sequence. 
+                            // If sequential publishing is enabled, only release messages in perfect sequence. 
                             (!m_sequentialPublishing || ii.Value.SequenceNumber <= m_lastSequenceNumberProcessed + 1))
                         {
                             if (messagesToProcess == null)
@@ -2337,6 +2365,51 @@ namespace Opc.Ua.Client
                 }
             }
         }
+
+        /// <summary>
+        /// Find or create an entry for the incoming sequence number.
+        /// </summary>
+        /// <param name="utcNow">The current Utc time.</param>
+        /// <param name="sequenceNumber">The sequence number for the new entry.</param>
+        private IncomingMessage FindOrCreateEntry(DateTime utcNow, uint sequenceNumber)
+        {
+            IncomingMessage entry = null;
+            LinkedListNode<IncomingMessage> node = m_incomingMessages.Last;
+
+            while (node != null)
+            {
+                entry = node.Value;
+                LinkedListNode<IncomingMessage> previous = node.Previous;
+
+                if (entry.SequenceNumber == sequenceNumber)
+                {
+                    entry.Timestamp = utcNow;
+                    break;
+                }
+
+                if (entry.SequenceNumber < sequenceNumber)
+                {
+                    entry = new IncomingMessage();
+                    entry.SequenceNumber = sequenceNumber;
+                    entry.Timestamp = utcNow;
+                    m_incomingMessages.AddAfter(node, entry);
+                    break;
+                }
+
+                node = previous;
+                entry = null;
+            }
+
+            if (entry == null)
+            {
+                entry = new IncomingMessage();
+                entry.SequenceNumber = sequenceNumber;
+                entry.Timestamp = utcNow;
+                m_incomingMessages.AddLast(entry);
+            }
+
+            return entry;
+        }
         #endregion
 
         #region Private Fields
@@ -2372,6 +2445,7 @@ namespace Opc.Ua.Client
         private LinkedList<NotificationMessage> m_messageCache;
         private IList<uint> m_availableSequenceNumbers;
         private int m_maxMessageCount;
+        private bool m_republishAfterTransfer;
         private SortedDictionary<uint, MonitoredItem> m_monitoredItems;
         private bool m_disableMonitoredItemCache;
         private FastDataChangeNotificationEventHandler m_fastDataChangeCallback;

--- a/Libraries/Opc.Ua.Server/Server/OpcUaServerEventSource.cs
+++ b/Libraries/Opc.Ua.Server/Server/OpcUaServerEventSource.cs
@@ -72,7 +72,6 @@ namespace Opc.Ua.Server
         private readonly EventId SessionStateMessageEventId = new EventId(TraceMasks.Information, nameof(SessionState));
         private readonly EventId MonitoredItemReadyEventId = new EventId(TraceMasks.OperationDetail, nameof(MonitoredItemReady));
 
-
         /// <summary>
         /// The send response.
         /// </summary>

--- a/Stack/Opc.Ua.Core/Types/Utils/Utils.cs
+++ b/Stack/Opc.Ua.Core/Types/Utils/Utils.cs
@@ -1371,6 +1371,26 @@ namespace Opc.Ua
         }
 
         /// <summary>
+        /// Sets the identifier to a lower limit if smaller. Thread safe.
+        /// </summary>
+        /// <returns>Returns the new value.</returns>
+        public static uint LowerLimitIdentifier(ref long identifier, uint lowerLimit)
+        {
+            long value;
+            long exchangedValue;
+            do
+            {
+                value = System.Threading.Interlocked.Read(ref identifier);
+                exchangedValue = value;
+                if (value < lowerLimit)
+                {
+                    exchangedValue = System.Threading.Interlocked.CompareExchange(ref identifier, lowerLimit, value);
+                }
+            } while (exchangedValue != value);
+            return (uint)System.Threading.Interlocked.Read(ref identifier);
+        }
+
+        /// <summary>
         /// Increments a identifier (wraps around if max exceeded).
         /// </summary>
         public static uint IncrementIdentifier(ref long identifier)

--- a/Tests/Opc.Ua.Client.Tests/ClientFixture.cs
+++ b/Tests/Opc.Ua.Client.Tests/ClientFixture.cs
@@ -28,7 +28,10 @@
  * ======================================================================*/
 
 using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using Opc.Ua.Configuration;
@@ -41,6 +44,7 @@ namespace Opc.Ua.Client.Tests
     /// </summary>
     public class ClientFixture
     {
+        private NUnitTraceLogger m_traceLogger;
         public ApplicationConfiguration Config { get; private set; }
         public ConfiguredEndpoint Endpoint { get; private set; }
         public string EndpointUrl { get; private set; }
@@ -48,7 +52,7 @@ namespace Opc.Ua.Client.Tests
         public ReverseConnectManager ReverseConnectManager { get; private set; }
         public uint SessionTimeout { get; set; } = 10000;
         public int OperationTimeout { get; set; } = 10000;
-        public int TraceMasks { get; set; } = Utils.TraceMasks.Error | Utils.TraceMasks.Security;
+        public int TraceMasks { get; set; } = Utils.TraceMasks.Error | Utils.TraceMasks.StackTrace | Utils.TraceMasks.Security | Utils.TraceMasks.Information;
 
         #region Public Methods
         /// <summary>
@@ -282,6 +286,21 @@ namespace Opc.Ua.Client.Tests
             using (var client = DiscoveryClient.Create(url, endpointConfiguration))
             {
                 return await client.GetEndpointsAsync(null).ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
+        /// Connect the nunit writer with the logger.
+        /// </summary>
+        public void SetTraceOutput(TextWriter writer)
+        {
+            if (m_traceLogger == null)
+            {
+                m_traceLogger = NUnitTraceLogger.Create(writer, Config, TraceMasks);
+            }
+            else
+            {
+                m_traceLogger.SetWriter(writer);
             }
         }
         #endregion

--- a/Tests/Opc.Ua.Client.Tests/ClientTest.cs
+++ b/Tests/Opc.Ua.Client.Tests/ClientTest.cs
@@ -60,7 +60,7 @@ namespace Opc.Ua.Client.Tests
         }
 
         #region DataPointSources
-        public static NodeId[] TypeSystems = {
+        public static readonly NodeId[] TypeSystems = {
             ObjectIds.OPCBinarySchema_TypeSystem,
             ObjectIds.XmlSchema_TypeSystem
         };
@@ -73,6 +73,7 @@ namespace Opc.Ua.Client.Tests
         [OneTimeSetUp]
         public new Task OneTimeSetUp()
         {
+            SupportsExternalServerUrl = true;
             return base.OneTimeSetUp();
         }
 
@@ -131,11 +132,11 @@ namespace Opc.Ua.Client.Tests
             var endpointConfiguration = EndpointConfiguration.Create();
             endpointConfiguration.OperationTimeout = 10000;
 
-            using (var client = DiscoveryClient.Create(m_url, endpointConfiguration))
+            using (var client = DiscoveryClient.Create(ServerUrl, endpointConfiguration))
             {
-                m_endpoints = await client.GetEndpointsAsync(null).ConfigureAwait(false);
+                Endpoints = await client.GetEndpointsAsync(null).ConfigureAwait(false);
                 TestContext.Out.WriteLine("Endpoints:");
-                foreach (var endpoint in m_endpoints)
+                foreach (var endpoint in Endpoints)
                 {
                     using (var cert = new X509Certificate2(endpoint.ServerCertificate))
                     {
@@ -162,7 +163,7 @@ namespace Opc.Ua.Client.Tests
             var endpointConfiguration = EndpointConfiguration.Create();
             endpointConfiguration.OperationTimeout = 10000;
 
-            using (var client = DiscoveryClient.Create(m_url, endpointConfiguration))
+            using (var client = DiscoveryClient.Create(ServerUrl, endpointConfiguration))
             {
                 var servers = await client.FindServersAsync(null).ConfigureAwait(false);
                 foreach (var server in servers)
@@ -183,19 +184,19 @@ namespace Opc.Ua.Client.Tests
         public async Task InvalidConfiguration()
         {
             var applicationInstance = new ApplicationInstance() {
-                ApplicationName = m_clientFixture.Config.ApplicationName
+                ApplicationName = ClientFixture.Config.ApplicationName
             };
             Assert.NotNull(applicationInstance);
-            ApplicationConfiguration config = await applicationInstance.Build(m_clientFixture.Config.ApplicationUri, m_clientFixture.Config.ProductUri)
+            ApplicationConfiguration config = await applicationInstance.Build(ClientFixture.Config.ApplicationUri, ClientFixture.Config.ProductUri)
                 .AsClient()
-                .AddSecurityConfiguration(m_clientFixture.Config.SecurityConfiguration.ApplicationCertificate.SubjectName)
+                .AddSecurityConfiguration(ClientFixture.Config.SecurityConfiguration.ApplicationCertificate.SubjectName)
                 .Create().ConfigureAwait(false);
         }
 
         [Theory, Order(200)]
         public async Task Connect(string securityPolicy)
         {
-            var session = await m_clientFixture.ConnectAsync(m_url, securityPolicy, m_endpoints).ConfigureAwait(false);
+            var session = await ClientFixture.ConnectAsync(ServerUrl, securityPolicy, Endpoints).ConfigureAwait(false);
             Assert.NotNull(session);
             var result = session.Close();
             Assert.NotNull(result);
@@ -206,7 +207,7 @@ namespace Opc.Ua.Client.Tests
         public async Task ConnectAndReconnectAsync()
         {
             const int Timeout = MaxTimeout;
-            var session = await m_clientFixture.ConnectAsync(m_url, SecurityPolicies.Basic256Sha256, m_endpoints).ConfigureAwait(false);
+            var session = await ClientFixture.ConnectAsync(ServerUrl, SecurityPolicies.Basic256Sha256, Endpoints).ConfigureAwait(false);
             Assert.NotNull(session);
 
             ManualResetEvent quitEvent = new ManualResetEvent(false);
@@ -241,29 +242,29 @@ namespace Opc.Ua.Client.Tests
         [Test]
         public void ReadPublicProperties()
         {
-            TestContext.Out.WriteLine("Identity         : {0}", m_session.Identity);
-            TestContext.Out.WriteLine("IdentityHistory  : {0}", m_session.IdentityHistory);
-            TestContext.Out.WriteLine("NamespaceUris    : {0}", m_session.NamespaceUris);
-            TestContext.Out.WriteLine("ServerUris       : {0}", m_session.ServerUris);
-            TestContext.Out.WriteLine("SystemContext    : {0}", m_session.SystemContext);
-            TestContext.Out.WriteLine("Factory          : {0}", m_session.Factory);
-            TestContext.Out.WriteLine("TypeTree         : {0}", m_session.TypeTree);
-            TestContext.Out.WriteLine("FilterContext    : {0}", m_session.FilterContext);
-            TestContext.Out.WriteLine("PreferredLocales : {0}", m_session.PreferredLocales);
-            TestContext.Out.WriteLine("DataTypeSystem   : {0}", m_session.DataTypeSystem);
-            TestContext.Out.WriteLine("Subscriptions    : {0}", m_session.Subscriptions);
-            TestContext.Out.WriteLine("SubscriptionCount: {0}", m_session.SubscriptionCount);
-            TestContext.Out.WriteLine("DefaultSubscription: {0}", m_session.DefaultSubscription);
-            TestContext.Out.WriteLine("LastKeepAliveTime: {0}", m_session.LastKeepAliveTime);
-            TestContext.Out.WriteLine("KeepAliveInterval: {0}", m_session.KeepAliveInterval);
-            m_session.KeepAliveInterval += 1000;
-            TestContext.Out.WriteLine("KeepAliveInterval: {0}", m_session.KeepAliveInterval);
-            m_session.KeepAliveInterval -= 1000;
-            TestContext.Out.WriteLine("KeepAliveInterval: {0}", m_session.KeepAliveInterval);
-            TestContext.Out.WriteLine("KeepAliveStopped : {0}", m_session.KeepAliveStopped);
-            TestContext.Out.WriteLine("OutstandingRequestCount : {0}", m_session.OutstandingRequestCount);
-            TestContext.Out.WriteLine("DefunctRequestCount     : {0}", m_session.DefunctRequestCount);
-            TestContext.Out.WriteLine("GoodPublishRequestCount : {0}", m_session.GoodPublishRequestCount);
+            TestContext.Out.WriteLine("Identity         : {0}", Session.Identity);
+            TestContext.Out.WriteLine("IdentityHistory  : {0}", Session.IdentityHistory);
+            TestContext.Out.WriteLine("NamespaceUris    : {0}", Session.NamespaceUris);
+            TestContext.Out.WriteLine("ServerUris       : {0}", Session.ServerUris);
+            TestContext.Out.WriteLine("SystemContext    : {0}", Session.SystemContext);
+            TestContext.Out.WriteLine("Factory          : {0}", Session.Factory);
+            TestContext.Out.WriteLine("TypeTree         : {0}", Session.TypeTree);
+            TestContext.Out.WriteLine("FilterContext    : {0}", Session.FilterContext);
+            TestContext.Out.WriteLine("PreferredLocales : {0}", Session.PreferredLocales);
+            TestContext.Out.WriteLine("DataTypeSystem   : {0}", Session.DataTypeSystem);
+            TestContext.Out.WriteLine("Subscriptions    : {0}", Session.Subscriptions);
+            TestContext.Out.WriteLine("SubscriptionCount: {0}", Session.SubscriptionCount);
+            TestContext.Out.WriteLine("DefaultSubscription: {0}", Session.DefaultSubscription);
+            TestContext.Out.WriteLine("LastKeepAliveTime: {0}", Session.LastKeepAliveTime);
+            TestContext.Out.WriteLine("KeepAliveInterval: {0}", Session.KeepAliveInterval);
+            Session.KeepAliveInterval += 1000;
+            TestContext.Out.WriteLine("KeepAliveInterval: {0}", Session.KeepAliveInterval);
+            Session.KeepAliveInterval -= 1000;
+            TestContext.Out.WriteLine("KeepAliveInterval: {0}", Session.KeepAliveInterval);
+            TestContext.Out.WriteLine("KeepAliveStopped : {0}", Session.KeepAliveStopped);
+            TestContext.Out.WriteLine("OutstandingRequestCount : {0}", Session.OutstandingRequestCount);
+            TestContext.Out.WriteLine("DefunctRequestCount     : {0}", Session.DefunctRequestCount);
+            TestContext.Out.WriteLine("GoodPublishRequestCount : {0}", Session.GoodPublishRequestCount);
         }
 
         [Test]
@@ -271,28 +272,28 @@ namespace Opc.Ua.Client.Tests
         {
             // change locale
             var localeCollection = new StringCollection() { "de-de", "en-us" };
-            m_session.ChangePreferredLocales(localeCollection);
+            Session.ChangePreferredLocales(localeCollection);
         }
 
         [Test]
         public void ReadValue()
         {
             // Test ReadValue
-            _ = m_session.ReadValue(VariableIds.Server_ServerRedundancy_RedundancySupport, typeof(Int32));
-            _ = m_session.ReadValue(VariableIds.Server_ServerStatus, typeof(ServerStatusDataType));
-            var sre = Assert.Throws<ServiceResultException>(() => m_session.ReadValue(VariableIds.Server_ServerStatus, typeof(ServiceHost)));
+            _ = Session.ReadValue(VariableIds.Server_ServerRedundancy_RedundancySupport, typeof(Int32));
+            _ = Session.ReadValue(VariableIds.Server_ServerStatus, typeof(ServerStatusDataType));
+            var sre = Assert.Throws<ServiceResultException>(() => Session.ReadValue(VariableIds.Server_ServerStatus, typeof(ServiceHost)));
             Assert.AreEqual(StatusCodes.BadTypeMismatch, sre.StatusCode);
         }
 
         [Test]
         public void ReadValues()
         {
-            var namespaceUris = m_session.NamespaceUris;
-            var testSet = CommonTestWorkers.NodeIdTestSetStatic.Select(n => ExpandedNodeId.ToNodeId(n, namespaceUris)).ToList();
-            testSet.AddRange(CommonTestWorkers.NodeIdTestSetSimulation.Select(n => ExpandedNodeId.ToNodeId(n, namespaceUris)));
+            var namespaceUris = Session.NamespaceUris;
+            var testSet = GetTestSetStatic(namespaceUris).ToList();
+            testSet.AddRange(GetTestSetSimulation(namespaceUris));
             foreach (var nodeId in testSet)
             {
-                var dataValue = m_session.ReadValue(nodeId);
+                var dataValue = Session.ReadValue(nodeId);
                 Assert.NotNull(dataValue);
                 Assert.NotNull(dataValue.Value);
             }
@@ -302,7 +303,7 @@ namespace Opc.Ua.Client.Tests
         public void ReadDataTypeDefinition()
         {
             // Test Read a DataType Node
-            var node = m_session.ReadNode(DataTypeIds.ProgramDiagnosticDataType);
+            var node = Session.ReadNode(DataTypeIds.ProgramDiagnosticDataType);
             Assert.NotNull(node);
             var dataTypeNode = (DataTypeNode)node;
             Assert.NotNull(dataTypeNode);
@@ -318,7 +319,7 @@ namespace Opc.Ua.Client.Tests
         [Theory, Order(400)]
         public async Task BrowseFullAddressSpace(string securityPolicy)
         {
-            if (m_operationLimits == null) { GetOperationLimits(); }
+            if (OperationLimits == null) { GetOperationLimits(); }
 
             var requestHeader = new RequestHeader();
             requestHeader.Timestamp = DateTime.UtcNow;
@@ -328,15 +329,15 @@ namespace Opc.Ua.Client.Tests
             Session session;
             if (securityPolicy != null)
             {
-                session = await m_clientFixture.ConnectAsync(m_url, securityPolicy, m_endpoints).ConfigureAwait(false);
+                session = await ClientFixture.ConnectAsync(ServerUrl, securityPolicy, Endpoints).ConfigureAwait(false);
             }
             else
             {
-                session = m_session;
+                session = Session;
             }
 
             var clientTestServices = new ClientTestServices(session);
-            m_referenceDescriptions = CommonTestWorkers.BrowseFullAddressSpaceWorker(clientTestServices, requestHeader, m_operationLimits);
+            ReferenceDescriptions = CommonTestWorkers.BrowseFullAddressSpaceWorker(clientTestServices, requestHeader, OperationLimits);
 
             if (securityPolicy != null)
             {
@@ -348,26 +349,26 @@ namespace Opc.Ua.Client.Tests
         [Test, Order(410)]
         public async Task ReadDisplayNames()
         {
-            if (m_referenceDescriptions == null) { await BrowseFullAddressSpace(null).ConfigureAwait(false); }
-            var nodeIds = m_referenceDescriptions.Select(n => ExpandedNodeId.ToNodeId(n.NodeId, m_session.NamespaceUris)).ToList();
-            if (m_operationLimits.MaxNodesPerRead > 0 &&
-                nodeIds.Count > m_operationLimits.MaxNodesPerRead)
+            if (ReferenceDescriptions == null) { await BrowseFullAddressSpace(null).ConfigureAwait(false); }
+            var nodeIds = ReferenceDescriptions.Select(n => ExpandedNodeId.ToNodeId(n.NodeId, Session.NamespaceUris)).ToList();
+            if (OperationLimits.MaxNodesPerRead > 0 &&
+                nodeIds.Count > OperationLimits.MaxNodesPerRead)
             {
-                var sre = Assert.Throws<ServiceResultException>(() => m_session.ReadDisplayName(nodeIds, out var displayNames, out var errors));
+                var sre = Assert.Throws<ServiceResultException>(() => Session.ReadDisplayName(nodeIds, out var displayNames, out var errors));
                 Assert.AreEqual(StatusCodes.BadTooManyOperations, sre.StatusCode);
                 while (nodeIds.Count > 0)
                 {
-                    m_session.ReadDisplayName(nodeIds.Take((int)m_operationLimits.MaxNodesPerRead).ToArray(), out var displayNames, out var errors);
+                    Session.ReadDisplayName(nodeIds.Take((int)OperationLimits.MaxNodesPerRead).ToArray(), out var displayNames, out var errors);
                     foreach (var name in displayNames)
                     {
                         TestContext.Out.WriteLine("{0}", name);
                     }
-                    nodeIds = nodeIds.Skip((int)m_operationLimits.MaxNodesPerRead).ToList();
+                    nodeIds = nodeIds.Skip((int)OperationLimits.MaxNodesPerRead).ToList();
                 }
             }
             else
             {
-                m_session.ReadDisplayName(nodeIds, out var displayNames, out var errors);
+                Session.ReadDisplayName(nodeIds, out var displayNames, out var errors);
                 foreach (var name in displayNames)
                 {
                     TestContext.Out.WriteLine("{0}", name);
@@ -382,7 +383,7 @@ namespace Opc.Ua.Client.Tests
             requestHeader.Timestamp = DateTime.UtcNow;
             requestHeader.TimeoutHint = MaxTimeout;
 
-            var clientTestServices = new ClientTestServices(m_session);
+            var clientTestServices = new ClientTestServices(Session);
             CommonTestWorkers.SubscriptionTest(clientTestServices, requestHeader);
         }
 
@@ -392,17 +393,17 @@ namespace Opc.Ua.Client.Tests
         [Test, Order(500)]
         public void NodeCache_LoadUaDefinedTypes()
         {
-            INodeCache nodeCache = m_session.NodeCache;
+            INodeCache nodeCache = Session.NodeCache;
             Assert.IsNotNull(nodeCache);
 
             // clear node cache
             nodeCache.Clear();
 
             // load the predefined types
-            nodeCache.LoadUaDefinedTypes(m_session.SystemContext);
+            nodeCache.LoadUaDefinedTypes(Session.SystemContext);
 
             // reload the predefined types
-            nodeCache.LoadUaDefinedTypes(m_session.SystemContext);
+            nodeCache.LoadUaDefinedTypes(Session.SystemContext);
         }
 
         /// <summary>
@@ -415,8 +416,8 @@ namespace Opc.Ua.Client.Tests
             var nodesToBrowse = new ExpandedNodeIdCollection {
                 ObjectIds.ObjectsFolder
             };
-            m_session.NodeCache.Clear();
-            m_session.NodeCache.LoadUaDefinedTypes(m_session.SystemContext);
+            Session.NodeCache.Clear();
+            Session.NodeCache.LoadUaDefinedTypes(Session.SystemContext);
             while (nodesToBrowse.Count > 0)
             {
                 var nextNodesToBrowse = new ExpandedNodeIdCollection();
@@ -424,7 +425,7 @@ namespace Opc.Ua.Client.Tests
                 {
                     try
                     {
-                        var organizers = m_session.NodeCache.FindReferences(
+                        var organizers = Session.NodeCache.FindReferences(
                             node,
                             ReferenceTypeIds.HierarchicalReferences,
                             false,
@@ -460,11 +461,11 @@ namespace Opc.Ua.Client.Tests
         [Test, Order(520)]
         public void NodeCache_References()
         {
-            INodeCache nodeCache = m_session.NodeCache;
+            INodeCache nodeCache = Session.NodeCache;
             Assert.IsNotNull(nodeCache);
 
             // ensure the predefined types are loaded
-            nodeCache.LoadUaDefinedTypes(m_session.SystemContext);
+            nodeCache.LoadUaDefinedTypes(Session.SystemContext);
 
             // check on all reference type ids
             var refTypeDictionary = typeof(ReferenceTypeIds).GetFields(BindingFlags.Public | BindingFlags.Static)
@@ -488,15 +489,15 @@ namespace Opc.Ua.Client.Tests
                 Assert.IsTrue(isKnown);
                 // is it a reference?
                 var isTypeOf = nodeCache.IsTypeOf(
-                    NodeId.ToExpandedNodeId(refId, m_session.NamespaceUris),
-                    NodeId.ToExpandedNodeId(ReferenceTypeIds.References, m_session.NamespaceUris));
+                    NodeId.ToExpandedNodeId(refId, Session.NamespaceUris),
+                    NodeId.ToExpandedNodeId(ReferenceTypeIds.References, Session.NamespaceUris));
                 Assert.IsTrue(isTypeOf);
                 // negative test
                 isTypeOf = nodeCache.IsTypeOf(
-                    NodeId.ToExpandedNodeId(refId, m_session.NamespaceUris),
-                    NodeId.ToExpandedNodeId(DataTypeIds.Byte, m_session.NamespaceUris));
+                    NodeId.ToExpandedNodeId(refId, Session.NamespaceUris),
+                    NodeId.ToExpandedNodeId(DataTypeIds.Byte, Session.NamespaceUris));
                 Assert.IsFalse(isTypeOf);
-                var subTypes = nodeCache.FindSubTypes(NodeId.ToExpandedNodeId(refId, m_session.NamespaceUris));
+                var subTypes = nodeCache.FindSubTypes(NodeId.ToExpandedNodeId(refId, Session.NamespaceUris));
                 Assert.NotNull(subTypes);
             }
         }
@@ -504,22 +505,22 @@ namespace Opc.Ua.Client.Tests
         [Test, Order(550)]
         public async Task Read()
         {
-            if (m_referenceDescriptions == null)
+            if (ReferenceDescriptions == null)
             {
                 await BrowseFullAddressSpace(null).ConfigureAwait(false);
             }
 
-            foreach (var reference in m_referenceDescriptions.Take(MaxReferences))
+            foreach (var reference in ReferenceDescriptions.Take(MaxReferences))
             {
-                var nodeId = ExpandedNodeId.ToNodeId(reference.NodeId, m_session.NamespaceUris);
-                var node = m_session.ReadNode(nodeId);
+                var nodeId = ExpandedNodeId.ToNodeId(reference.NodeId, Session.NamespaceUris);
+                var node = Session.ReadNode(nodeId);
                 Assert.NotNull(node);
                 TestContext.Out.WriteLine("NodeId: {0} Node: {1}", nodeId, node);
                 if (node is VariableNode)
                 {
                     try
                     {
-                        var value = m_session.ReadValue(nodeId);
+                        var value = Session.ReadValue(nodeId);
                         Assert.NotNull(value);
                         TestContext.Out.WriteLine("-- Value {0} ", value);
                     }
@@ -534,15 +535,15 @@ namespace Opc.Ua.Client.Tests
         [Test, Order(600)]
         public async Task NodeCache_Read()
         {
-            if (m_referenceDescriptions == null)
+            if (ReferenceDescriptions == null)
             {
                 await BrowseFullAddressSpace(null).ConfigureAwait(false);
             }
 
-            foreach (var reference in m_referenceDescriptions.Take(MaxReferences))
+            foreach (var reference in ReferenceDescriptions.Take(MaxReferences))
             {
-                var nodeId = ExpandedNodeId.ToNodeId(reference.NodeId, m_session.NamespaceUris);
-                var node = m_session.NodeCache.Find(reference.NodeId);
+                var nodeId = ExpandedNodeId.ToNodeId(reference.NodeId, Session.NamespaceUris);
+                var node = Session.NodeCache.Find(reference.NodeId);
                 TestContext.Out.WriteLine("NodeId: {0} Node: {1}", nodeId, node);
             }
         }
@@ -550,15 +551,15 @@ namespace Opc.Ua.Client.Tests
         [Test, Order(610)]
         public void FetchTypeTree()
         {
-            m_session.FetchTypeTree(NodeId.ToExpandedNodeId(DataTypeIds.BaseDataType, m_session.NamespaceUris));
+            Session.FetchTypeTree(NodeId.ToExpandedNodeId(DataTypeIds.BaseDataType, Session.NamespaceUris));
         }
 
         [Test, Order(620)]
         public void ReadAvailableEncodings()
         {
-            var sre = Assert.Throws<ServiceResultException>(() => m_session.ReadAvailableEncodings(DataTypeIds.BaseDataType));
+            var sre = Assert.Throws<ServiceResultException>(() => Session.ReadAvailableEncodings(DataTypeIds.BaseDataType));
             Assert.AreEqual(StatusCodes.BadNodeIdInvalid, sre.StatusCode);
-            var encoding = m_session.ReadAvailableEncodings(VariableIds.Server_ServerStatus_CurrentTime);
+            var encoding = Session.ReadAvailableEncodings(VariableIds.Server_ServerStatus_CurrentTime);
             Assert.NotNull(encoding);
             Assert.AreEqual(0, encoding.Count);
         }
@@ -567,14 +568,14 @@ namespace Opc.Ua.Client.Tests
         public async Task LoadStandardDataTypeSystem()
         {
             var sre = Assert.ThrowsAsync<ServiceResultException>(async () => {
-                var t = await m_session.LoadDataTypeSystem(ObjectIds.ObjectAttributes_Encoding_DefaultJson).ConfigureAwait(false);
+                var t = await Session.LoadDataTypeSystem(ObjectIds.ObjectAttributes_Encoding_DefaultJson).ConfigureAwait(false);
             });
             Assert.AreEqual(StatusCodes.BadNodeIdInvalid, sre.StatusCode);
-            var typeSystem = await m_session.LoadDataTypeSystem().ConfigureAwait(false);
+            var typeSystem = await Session.LoadDataTypeSystem().ConfigureAwait(false);
             Assert.NotNull(typeSystem);
-            typeSystem = await m_session.LoadDataTypeSystem(ObjectIds.OPCBinarySchema_TypeSystem).ConfigureAwait(false);
+            typeSystem = await Session.LoadDataTypeSystem(ObjectIds.OPCBinarySchema_TypeSystem).ConfigureAwait(false);
             Assert.NotNull(typeSystem);
-            typeSystem = await m_session.LoadDataTypeSystem(ObjectIds.XmlSchema_TypeSystem).ConfigureAwait(false);
+            typeSystem = await Session.LoadDataTypeSystem(ObjectIds.XmlSchema_TypeSystem).ConfigureAwait(false);
             Assert.NotNull(typeSystem);
         }
 
@@ -583,7 +584,7 @@ namespace Opc.Ua.Client.Tests
         public async Task LoadAllServerDataTypeSystems(NodeId dataTypeSystem)
         {
             // find the dictionary for the description.
-            Browser browser = new Browser(m_session) {
+            Browser browser = new Browser(Session) {
                 BrowseDirection = BrowseDirection.Forward,
                 ReferenceTypeId = ReferenceTypeIds.HasComponent,
                 IncludeSubtypes = false,
@@ -598,9 +599,9 @@ namespace Opc.Ua.Client.Tests
             // read all type dictionaries in the type system
             foreach (var r in references)
             {
-                NodeId dictionaryId = ExpandedNodeId.ToNodeId(r.NodeId, m_session.NamespaceUris);
+                NodeId dictionaryId = ExpandedNodeId.ToNodeId(r.NodeId, Session.NamespaceUris);
                 TestContext.Out.WriteLine("  ReadDictionary {0} {1}", r.BrowseName.Name, dictionaryId);
-                var dictionaryToLoad = new DataDictionary(m_session);
+                var dictionaryToLoad = new DataDictionary(Session);
                 await dictionaryToLoad.Load(dictionaryId, r.BrowseName.Name).ConfigureAwait(false);
 
                 // internal API for testing only
@@ -646,15 +647,15 @@ namespace Opc.Ua.Client.Tests
 
                 // to validate the behavior of the sendInitialValue flag,
                 // use a static variable to avoid sampled notifications in publish requests
-                var namespaceUris = m_session.NamespaceUris;
+                var namespaceUris = Session.NamespaceUris;
                 NodeId[] testSet = CommonTestWorkers.NodeIdTestSetStatic.Select(n => ExpandedNodeId.ToNodeId(n, namespaceUris)).ToArray();
-                var clientTestServices = new ClientTestServices(m_session);
+                var clientTestServices = new ClientTestServices(Session);
                 CommonTestWorkers.CreateSubscriptionForTransfer(clientTestServices, requestHeader, testSet, out var subscriptionIds);
 
                 TestContext.Out.WriteLine("Transfer SubscriptionIds: {0}", subscriptionIds[0]);
 
-                transferSession = await m_clientFixture.ConnectAsync(m_url, SecurityPolicies.Basic256Sha256, m_endpoints).ConfigureAwait(false);
-                Assert.AreNotEqual(m_session.SessionId, transferSession.SessionId);
+                transferSession = await ClientFixture.ConnectAsync(ServerUrl, SecurityPolicies.Basic256Sha256, Endpoints).ConfigureAwait(false);
+                Assert.AreNotEqual(Session.SessionId, transferSession.SessionId);
 
                 requestHeader = new RequestHeader {
                     Timestamp = DateTime.UtcNow,

--- a/Tests/Opc.Ua.Client.Tests/Opc.Ua.Client.Tests.csproj
+++ b/Tests/Opc.Ua.Client.Tests/Opc.Ua.Client.Tests.csproj
@@ -23,7 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="..\Common\Main.cs"/>
+    <Compile Include="..\Common\Main.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tests/Opc.Ua.Client.Tests/ReverseConnectTest.cs
+++ b/Tests/Opc.Ua.Client.Tests/ReverseConnectTest.cs
@@ -67,24 +67,24 @@ namespace Opc.Ua.Client.Tests
             }
 
             // pki directory root for test runs. 
-            m_pkiRoot = Path.GetTempPath() + Path.GetRandomFileName();
+            PkiRoot = Path.GetTempPath() + Path.GetRandomFileName();
 
             // start ref server with reverse connect
-            m_serverFixture = new ServerFixture<ReferenceServer> {
+            ServerFixture = new ServerFixture<ReferenceServer> {
                 AutoAccept = true,
                 SecurityNone = true,
                 ReverseConnectTimeout = MaxTimeout,
                 TraceMasks = Utils.TraceMasks.Error | Utils.TraceMasks.Security
             };
-            m_server = await m_serverFixture.StartAsync(TestContext.Out, m_pkiRoot).ConfigureAwait(false);
+            ReferenceServer = await ServerFixture.StartAsync(TestContext.Out, PkiRoot).ConfigureAwait(false);
 
             // create client
-            m_clientFixture = new ClientFixture();
-            await m_clientFixture.LoadClientConfiguration(m_pkiRoot).ConfigureAwait(false);
-            await m_clientFixture.StartReverseConnectHost().ConfigureAwait(false);
-            m_endpointUrl = new Uri(Utils.ReplaceLocalhost("opc.tcp://localhost:" + m_serverFixture.Port.ToString()));
+            ClientFixture = new ClientFixture();
+            await ClientFixture.LoadClientConfiguration(PkiRoot).ConfigureAwait(false);
+            await ClientFixture.StartReverseConnectHost().ConfigureAwait(false);
+            m_endpointUrl = new Uri(Utils.ReplaceLocalhost("opc.tcp://localhost:" + ServerFixture.Port.ToString()));
             // start reverse connection
-            m_server.AddReverseConnection(new Uri(m_clientFixture.ReverseConnectUri), MaxTimeout);
+            ReferenceServer.AddReverseConnection(new Uri(ClientFixture.ReverseConnectUri), MaxTimeout);
         }
 
         /// <summary>
@@ -130,11 +130,11 @@ namespace Opc.Ua.Client.Tests
         /// </summary>
         public async Task GetEndpointsInternal()
         {
-            var config = m_clientFixture.Config;
+            var config = ClientFixture.Config;
             ITransportWaitingConnection connection;
             using (var cancellationTokenSource = new CancellationTokenSource(MaxTimeout))
             {
-                connection = await m_clientFixture.ReverseConnectManager.WaitForConnection(
+                connection = await ClientFixture.ReverseConnectManager.WaitForConnection(
                     m_endpointUrl, null, cancellationTokenSource.Token).ConfigureAwait(false);
                 Assert.NotNull(connection, "Failed to get connection.");
             }
@@ -142,18 +142,18 @@ namespace Opc.Ua.Client.Tests
             endpointConfiguration.OperationTimeout = MaxTimeout;
             using (DiscoveryClient client = DiscoveryClient.Create(config, connection, endpointConfiguration))
             {
-                m_endpoints = client.GetEndpoints(null);
+                Endpoints = client.GetEndpoints(null);
             }
         }
 
         [Test, Order(200)]
         public async Task SelectEndpoint()
         {
-            var config = m_clientFixture.Config;
+            var config = ClientFixture.Config;
             ITransportWaitingConnection connection;
             using (var cancellationTokenSource = new CancellationTokenSource(MaxTimeout))
             {
-                connection = await m_clientFixture.ReverseConnectManager.WaitForConnection(
+                connection = await ClientFixture.ReverseConnectManager.WaitForConnection(
                     m_endpointUrl, null, cancellationTokenSource.Token).ConfigureAwait(false);
                 Assert.NotNull(connection, "Failed to get connection.");
             }
@@ -168,18 +168,18 @@ namespace Opc.Ua.Client.Tests
             await RequireEndpoints().ConfigureAwait(false);
 
             // get a connection
-            var config = m_clientFixture.Config;
+            var config = ClientFixture.Config;
             ITransportWaitingConnection connection;
             using (var cancellationTokenSource = new CancellationTokenSource(MaxTimeout))
             {
-                connection = await m_clientFixture.ReverseConnectManager.WaitForConnection(
+                connection = await ClientFixture.ReverseConnectManager.WaitForConnection(
                     m_endpointUrl, null, cancellationTokenSource.Token).ConfigureAwait(false);
                 Assert.NotNull(connection, "Failed to get connection.");
             }
 
             // select the secure endpoint
             var endpointConfiguration = EndpointConfiguration.Create(config);
-            var selectedEndpoint = ClientFixture.SelectEndpoint(config, m_endpoints, m_endpointUrl, securityPolicy);
+            var selectedEndpoint = ClientFixture.SelectEndpoint(config, Endpoints, m_endpointUrl, securityPolicy);
             Assert.NotNull(selectedEndpoint);
             var endpoint = new ConfiguredEndpoint(null, selectedEndpoint, endpointConfiguration);
             Assert.NotNull(endpoint);
@@ -214,17 +214,17 @@ namespace Opc.Ua.Client.Tests
             await RequireEndpoints().ConfigureAwait(false);
 
             // get a connection
-            var config = m_clientFixture.Config;
+            var config = ClientFixture.Config;
 
             // select the secure endpoint
             var endpointConfiguration = EndpointConfiguration.Create(config);
-            var selectedEndpoint = ClientFixture.SelectEndpoint(config, m_endpoints, m_endpointUrl, securityPolicy);
+            var selectedEndpoint = ClientFixture.SelectEndpoint(config, Endpoints, m_endpointUrl, securityPolicy);
             Assert.NotNull(selectedEndpoint);
             var endpoint = new ConfiguredEndpoint(null, selectedEndpoint, endpointConfiguration);
             Assert.NotNull(endpoint);
 
             // connect
-            var session = await Session.Create(config, m_clientFixture.ReverseConnectManager, endpoint, updateBeforeConnect, checkDomain, "Reverse Connect Client",
+            var session = await Session.Create(config, ClientFixture.ReverseConnectManager, endpoint, updateBeforeConnect, checkDomain, "Reverse Connect Client",
                 MaxTimeout, new UserIdentity(new AnonymousIdentityToken()), null).ConfigureAwait(false);
             Assert.NotNull(session);
 
@@ -251,7 +251,7 @@ namespace Opc.Ua.Client.Tests
             await m_requiredLock.WaitAsync().ConfigureAwait(false);
             try
             {
-                if (m_endpoints == null)
+                if (Endpoints == null)
                 {
                     await GetEndpointsInternal().ConfigureAwait(false);
                 }

--- a/Tests/Opc.Ua.Client.Tests/runsettings.sample
+++ b/Tests/Opc.Ua.Client.Tests/runsettings.sample
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <!-- Parameters used by tests at runtime. -->
+  <!-- Run Parameters for the client test framework, to run tests against an external server-->
+  <!-- copy the runsettings file to the root of the solution as .runsettings to activate in VS. -->
+  <TestRunParameters>
+    <Parameter name="ServerUrl" value="opc.tcp://localhost:48010" />
+    <!-- Test set for static and simulated nodes of a server, ExpandedNodeId separated by #-->
+    <Parameter name="TestSetStatic" value="ns=2;s=Demo.Static.Scalar.Double#ns=2;s=Demo.Static.Scalar.UInt32"/>
+    <Parameter name="TestSetSimulation" value="ns=2;s=Demo.Dynamic.Scalar.Double#ns=2;s=Demo.Dynamic.Scalar.UInt32"/>
+  </TestRunParameters>
+</RunSettings>


### PR DESCRIPTION
- Fixed issue: After transfer, available sequence numbers were not properly ack/republished.
- Fixed issue: After transfer, race condition could delete subscription before transfer finished.
- Fixed issue: After reload of a subscription, duplicate client handles may have been used.
- Add tests which emulate the disconnection of a client/server, then transfers
- Add subscription variable to select if missing publish requests are just acknoledged (default) or republished after transfer completes. Set `Subscription.RepublishAfterTransfer` to `true`.
- Improve test framework to allow for testing against external servers using a .runsettings file
- improve publish request logging, by moving calls into `CoreClientUtils.EventLog`
- disable available sequence numbers check, it causes false negatives when many subscriptions are active
