### PR TITLE
Fixed session recreate TransferSubscriptions bug. #1734 and #1733

### DIFF
--- a/Libraries/Opc.Ua.Client/Session.cs
+++ b/Libraries/Opc.Ua.Client/Session.cs
@@ -3442,6 +3442,7 @@ namespace Opc.Ua.Client
                     }
                     ClientBase.ValidateResponse(results, subscriptionIds);
                     ClientBase.ValidateDiagnosticInfos(diagnosticInfos, subscriptionIds);
+                    var failedSubscriptionIds = new UInt32Collection();
 
                     for (int ii = 0; ii < subscriptions.Count; ii++)
                     {
@@ -3462,13 +3463,17 @@ namespace Opc.Ua.Client
                         else
                         {
                             Utils.LogError("SubscriptionId {0} failed to transfer, StatusCode={1}", subscriptionIds[ii], results[ii].StatusCode);
-                            return false;
+                            failedSubscriptionIds.Add(subscriptions[ii].TransferId);
                         }
+                    }
+                    if(failedSubscriptionIds.Count > 0)
+                    {
+                        return false;
                     }
                 }
                 else
                 {
-                    Utils.LogInfo("There is no subscriptions need TransferSubscription");
+                    Utils.LogInfo("No subscriptions. Transfersubscription skipped.");
                 }
 
                 


### PR DESCRIPTION
1. When session is recreated and there is no subscription is needed to transfer, it will throw Exception - BadNothingToDo. After adding check the subscriptions count, it won't try to subscribe non-existing subscriptions.

2. When session is recreated and there are subscriptions are needed to transer, it transfered wrong subscriptions. It should transfer old subscriptions in old session, but current code transfer new subscriptions in new session to new session - which will always throw Exception - "A subscription can not be transferred due to missing transfer Id"