### PR TITLE
Adapt logging abstractions version to target framework

### DIFF
--- a/Applications/ConsoleReferenceServer/ConsoleReferenceServer.csproj
+++ b/Applications/ConsoleReferenceServer/ConsoleReferenceServer.csproj
@@ -29,18 +29,17 @@
   </ItemGroup>
 
   <Choose>
-    <!-- Note: If https support with kestrel is used on .NET Core 2.x or .NET framework, 
-         an incompatibility of Extensions.Primitives 3.x to version 6.0
-         requires downgrade to latest version 3.1.x -->
-    <When Condition="'$(TargetFramework)' == 'netcoreapp2.1' OR '$(TargetFramework)' == 'net462'">
+    <!-- Note: Due to incompatibilities of Microsoft.Extensions Nuget packages between versions 3.x and 6.0,
+         use latest versions only on .NET 5/6, otherwise 3.1.x -->
+    <When Condition="'$(TargetFramework)' == 'net5.0' OR '$(TargetFramework)' == 'net6.0'">
       <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.23" />
-        <PackageReference Include="Microsoft.Extensions.Primitives" Version="3.1.23" />
+        <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
       </ItemGroup>
     </When>
     <Otherwise>
       <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.23" />
+        <PackageReference Include="Microsoft.Extensions.Primitives" Version="3.1.23" />
       </ItemGroup>
     </Otherwise>
   </Choose>

--- a/Applications/ConsoleReferenceServer/ConsoleReferenceServer.csproj
+++ b/Applications/ConsoleReferenceServer/ConsoleReferenceServer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(AppTargetFrameWorks)</TargetFrameworks>
+    <TargetFrameworks>net462</TargetFrameworks>
     <AssemblyName>ConsoleReferenceServer</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>ConsoleReferenceServer</PackageId>
@@ -28,8 +28,24 @@
     <ProjectReference Include="..\Quickstarts.Servers\Quickstarts.Servers.csproj" />
   </ItemGroup>
 
+  <Choose>
+    <!-- Note: If https support with kestrel is used on .NET Core 2.x or .NET framework, 
+         an incompatibility of Extensions.Primitives 3.x to version 6.0
+         requires downgrade to latest version 3.1.x -->
+    <When Condition="'$(TargetFramework)' == 'netcoreapp2.1' OR '$(TargetFramework)' == 'net462'">
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.23" />
+        <PackageReference Include="Microsoft.Extensions.Primitives" Version="3.1.23" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Mono.Options" Version="6.12.0.148" />
     <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="Serilog.Expressions" Version="3.3.0" />

--- a/Applications/ConsoleReferenceServer/ConsoleReferenceServer.csproj
+++ b/Applications/ConsoleReferenceServer/ConsoleReferenceServer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462</TargetFrameworks>
+    <TargetFrameworks>$(AppTargetFrameWorks)</TargetFrameworks>
     <AssemblyName>ConsoleReferenceServer</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>ConsoleReferenceServer</PackageId>

--- a/Stack/Opc.Ua.Core/Opc.Ua.Core.csproj
+++ b/Stack/Opc.Ua.Core/Opc.Ua.Core.csproj
@@ -38,8 +38,23 @@
     <EmbeddedResource Include="Types\Schemas\StandardTypes.bsd" />
   </ItemGroup>
 
+  <Choose>
+    <!-- Note: If https support with kestrel is used on .NET Core 2.x or .NET framework, 
+         an incompatibility of Extensions.Primitives 3.x to version 6.0
+         requires downgrade to latest version 3.1.x -->
+    <When Condition="'$(TargetFramework)' == 'net5.0' OR '$(TargetFramework)' == 'net6.0'">
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.23" />
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 

--- a/Stack/Opc.Ua.Core/Opc.Ua.Core.csproj
+++ b/Stack/Opc.Ua.Core/Opc.Ua.Core.csproj
@@ -39,9 +39,8 @@
   </ItemGroup>
 
   <Choose>
-    <!-- Note: If https support with kestrel is used on .NET Core 2.x or .NET framework, 
-         an incompatibility of Extensions.Primitives 3.x to version 6.0
-         requires downgrade to latest version 3.1.x -->
+    <!-- Note: Due to incompatibilities of Microsoft.Extensions Nuget packages between versions 3.x and 6.0,
+         use latest versions only on .NET 5/6, otherwise 3.1.x -->
     <When Condition="'$(TargetFramework)' == 'net5.0' OR '$(TargetFramework)' == 'net6.0'">
       <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />


### PR DESCRIPTION
Technically the latest version of logging abstractions can be used for any target framework, however some incompatibilities in Extensions.Primitives used by the ASP .NET 2.1 https kestrel server and build issues with .NET Core 3.1 point to a better solution to only reference a lower nuget version of logging abstractions.