### PR TITLE
Fix for Usertokenpolicy Anonymous, security policy default should be None

### DIFF
--- a/Applications/ConsoleReferenceClient/Program.cs
+++ b/Applications/ConsoleReferenceClient/Program.cs
@@ -28,6 +28,7 @@
  * ======================================================================*/
 
 using System;
+using System.Globalization;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -49,6 +50,11 @@ namespace Quickstarts.ConsoleReferenceClient
         {
             TextWriter output = Console.Out;
             output.WriteLine("OPC UA Console Reference Client");
+
+            output.WriteLine("OPC UA library: {0} @ {1} -- {2}",
+                Utils.GetAssemblyBuildNumber(),
+                Utils.GetAssemblyTimestamp().ToString("G", CultureInfo.InvariantCulture),
+                Utils.GetAssemblySoftwareVersion());
 
             // The application name and config file names
             var applicationName = "ConsoleReferenceClient";

--- a/Applications/ConsoleReferenceServer/Program.cs
+++ b/Applications/ConsoleReferenceServer/Program.cs
@@ -28,6 +28,7 @@
  * ======================================================================*/
 
 using System;
+using System.Globalization;
 using System.IO;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -44,6 +45,11 @@ namespace Quickstarts.ReferenceServer
         {
             TextWriter output = Console.Out;
             output.WriteLine("{0} OPC UA Reference Server", Utils.IsRunningOnMono() ? "Mono" : ".NET Core");
+
+            output.WriteLine("OPC UA library: {0} @ {1} -- {2}",
+                Utils.GetAssemblyBuildNumber(),
+                Utils.GetAssemblyTimestamp().ToString("G", CultureInfo.InvariantCulture),
+                Utils.GetAssemblySoftwareVersion());
 
             // The application name and config file names
             var applicationName = Utils.IsRunningOnMono() ? "MonoReferenceServer" : "ConsoleReferenceServer";

--- a/Applications/ConsoleReferenceServer/Quickstarts.ReferenceServer.Config.xml
+++ b/Applications/ConsoleReferenceServer/Quickstarts.ReferenceServer.Config.xml
@@ -141,7 +141,7 @@
       <!-- Allows anonymous users -->
       <ua:UserTokenPolicy>
         <ua:TokenType>Anonymous_0</ua:TokenType>
-        <!-- passwords must be encrypted - no setting lets the stack select a secure profile -->
+        <!-- <ua:SecurityPolicyUri>http://opcfoundation.org/UA/SecurityPolicy#None</ua:SecurityPolicyUri> -->
       </ua:UserTokenPolicy>
 
       <!-- Allows username/password -->

--- a/Stack/Opc.Ua.Core/Stack/Server/ServerBase.cs
+++ b/Stack/Opc.Ua.Core/Stack/Server/ServerBase.cs
@@ -826,10 +826,19 @@ namespace Opc.Ua
                 {
                     if (description.SecurityMode == MessageSecurityMode.None)
                     {
-                        // ensure a security policy is specified for user tokens.
-                        clone.SecurityPolicyUri = SecurityPolicies.Basic256Sha256;
+                        if (clone.TokenType == UserTokenType.Anonymous)
+                        {
+                            // no need for security with anonymous token
+                            clone.SecurityPolicyUri = SecurityPolicies.None;
+                        }
+                        else
+                        {
+                            // ensure a security policy is specified for user tokens.
+                            clone.SecurityPolicyUri = SecurityPolicies.Basic256Sha256;
+                        }
                     }
                 }
+
                 // ensure each policy has a unique id within the context of the Server
                 clone.PolicyId = Utils.Format("{0}", ++m_userTokenPolicyId);
                 

--- a/Tests/Opc.Ua.Client.Tests/ClientTest.cs
+++ b/Tests/Opc.Ua.Client.Tests/ClientTest.cs
@@ -138,20 +138,29 @@ namespace Opc.Ua.Client.Tests
                 TestContext.Out.WriteLine("Endpoints:");
                 foreach (var endpoint in Endpoints)
                 {
-                    using (var cert = new X509Certificate2(endpoint.ServerCertificate))
+                    TestContext.Out.WriteLine("{0}", endpoint.Server.ApplicationName);
+                    TestContext.Out.WriteLine("  {0}", endpoint.Server.ApplicationUri);
+                    TestContext.Out.WriteLine(" {0}", endpoint.EndpointUrl);
+                    TestContext.Out.WriteLine("  {0}", endpoint.EncodingSupport);
+                    TestContext.Out.WriteLine("  {0}/{1}/{2}", endpoint.SecurityLevel, endpoint.SecurityMode, endpoint.SecurityPolicyUri);
+
+                    if (endpoint.ServerCertificate != null)
                     {
-                        TestContext.Out.WriteLine("{0}", endpoint.Server.ApplicationName);
-                        TestContext.Out.WriteLine("  {0}", endpoint.Server.ApplicationUri);
-                        TestContext.Out.WriteLine(" {0}", endpoint.EndpointUrl);
-                        TestContext.Out.WriteLine("  {0}", endpoint.EncodingSupport);
-                        TestContext.Out.WriteLine("  {0}/{1}/{2}", endpoint.SecurityLevel, endpoint.SecurityMode, endpoint.SecurityPolicyUri);
-                        TestContext.Out.WriteLine("  [{0}]", cert.Thumbprint);
-                        foreach (var userIdentity in endpoint.UserIdentityTokens)
+                        using (var cert = new X509Certificate2(endpoint.ServerCertificate))
                         {
-                            TestContext.Out.WriteLine("  {0}", userIdentity.TokenType);
-                            TestContext.Out.WriteLine("  {0}", userIdentity.PolicyId);
-                            TestContext.Out.WriteLine("  {0}", userIdentity.SecurityPolicyUri);
+                            TestContext.Out.WriteLine("  [{0}]", cert.Thumbprint);
                         }
+                    }
+                    else
+                    {
+                        TestContext.Out.WriteLine("  [no certificate]");
+                    }
+
+                    foreach (var userIdentity in endpoint.UserIdentityTokens)
+                    {
+                        TestContext.Out.WriteLine("  {0}", userIdentity.TokenType);
+                        TestContext.Out.WriteLine("  {0}", userIdentity.PolicyId);
+                        TestContext.Out.WriteLine("  {0}", userIdentity.SecurityPolicyUri);
                     }
                 }
             }


### PR DESCRIPTION
- If the config does not specify the security policy, for anonymous user token the security profile Basic256Sha256 was chosen. 
- This setting requires for the client to trust the server certificate if it tries to connect with security None, may cause IOP issues when no security is chosen and encryption is required for the anonymous user token.