### PR TITLE
XmlSerializer in .NET 6 Omits Line Breaks by Default

### DIFF
--- a/Libraries/Opc.Ua.Client/Session.cs
+++ b/Libraries/Opc.Ua.Client/Session.cs
@@ -1295,11 +1295,8 @@ namespace Opc.Ua.Client
         public void Save(Stream stream, IEnumerable<Subscription> subscriptions)
         {
             SubscriptionCollection subscriptionList = new SubscriptionCollection(subscriptions);
-            XmlWriterSettings settings = new XmlWriterSettings {
-                Indent = true,
-                OmitXmlDeclaration = false,
-                Encoding = Encoding.UTF8
-            };
+            XmlWriterSettings settings = Utils.DefaultXmlWriterSettings();
+
             using (XmlWriter writer = XmlWriter.Create(stream, settings))
             {
                 DataContractSerializer serializer = new DataContractSerializer(typeof(SubscriptionCollection));

--- a/Libraries/Opc.Ua.Client/Session.cs
+++ b/Libraries/Opc.Ua.Client/Session.cs
@@ -1326,12 +1326,8 @@ namespace Opc.Ua.Client
         public IEnumerable<Subscription> Load(Stream stream)
         {
             // secure settings
-            XmlReaderSettings settings = new XmlReaderSettings {
-                DtdProcessing = DtdProcessing.Prohibit,
-                XmlResolver = null,
-                ConformanceLevel = ConformanceLevel.Document,
-                CloseInput = true
-            };
+            XmlReaderSettings settings = Utils.DefaultXmlReaderSettings();
+            settings.CloseInput = true;
 
             using (XmlReader reader = XmlReader.Create(stream, settings))
             {

--- a/Libraries/Opc.Ua.PubSub/Configuration/UaPubSubConfigurationHelper.cs
+++ b/Libraries/Opc.Ua.PubSub/Configuration/UaPubSubConfigurationHelper.cs
@@ -49,10 +49,7 @@ namespace Opc.Ua.PubSub.Configuration
         {
             Stream ostrm = File.Open(filePath, FileMode.Create, FileAccess.ReadWrite);
 
-            XmlWriterSettings settings = new XmlWriterSettings();
-
-            settings.Encoding = System.Text.Encoding.UTF8;
-            settings.Indent = true;
+            XmlWriterSettings settings = Utils.DefaultXmlWriterSettings();
             settings.CloseOutput = true;
 
             using (XmlWriter writer = XmlDictionaryWriter.Create(ostrm, settings))

--- a/Stack/Opc.Ua.Core/Schema/UANodeSetHelpers.cs
+++ b/Stack/Opc.Ua.Core/Schema/UANodeSetHelpers.cs
@@ -54,7 +54,10 @@ namespace Opc.Ua.Export
         /// <param name="istrm">The input stream.</param>
         public void Write(Stream istrm)
         {
-            var writer = XmlWriter.Create(istrm, Utils.DefaultXmlWriterSettings());
+            var setting = Utils.DefaultXmlWriterSettings();
+            setting.CloseOutput = true;
+
+            var writer = XmlWriter.Create(istrm, setting);
 
             try
             {

--- a/Stack/Opc.Ua.Core/Schema/UANodeSetHelpers.cs
+++ b/Stack/Opc.Ua.Core/Schema/UANodeSetHelpers.cs
@@ -54,12 +54,18 @@ namespace Opc.Ua.Export
         /// <param name="istrm">The input stream.</param>
         public void Write(Stream istrm)
         {
-            StreamWriter writer = new StreamWriter(istrm, Encoding.UTF8);
+            XmlWriterSettings settings = new XmlWriterSettings() {
+                Indent = true,
+                Encoding = Encoding.UTF8,
+                IndentChars = "    "
+            };
+
+            var writer = XmlWriter.Create(istrm, settings);
 
             try
             {
                 XmlSerializer serializer = new XmlSerializer(typeof(UANodeSet));
-                serializer.Serialize(writer, this);
+                serializer.Serialize(writer, this, null);
             }
             finally
             {

--- a/Stack/Opc.Ua.Core/Schema/UANodeSetHelpers.cs
+++ b/Stack/Opc.Ua.Core/Schema/UANodeSetHelpers.cs
@@ -54,13 +54,7 @@ namespace Opc.Ua.Export
         /// <param name="istrm">The input stream.</param>
         public void Write(Stream istrm)
         {
-            XmlWriterSettings settings = new XmlWriterSettings() {
-                Indent = true,
-                Encoding = Encoding.UTF8,
-                IndentChars = "    "
-            };
-
-            var writer = XmlWriter.Create(istrm, settings);
+            var writer = XmlWriter.Create(istrm, Utils.DefaultXmlWriterSettings());
 
             try
             {

--- a/Stack/Opc.Ua.Core/Stack/Configuration/ApplicationConfiguration.cs
+++ b/Stack/Opc.Ua.Core/Stack/Configuration/ApplicationConfiguration.cs
@@ -407,12 +407,8 @@ namespace Opc.Ua
         /// <remarks>Calls GetType() on the current instance and passes that to the DataContractSerializer.</remarks>
         public void SaveToFile(string filePath)
         {
-            XmlWriterSettings settings = new XmlWriterSettings()
-            {
-                Encoding = Encoding.UTF8,
-                Indent = true,
-                CloseOutput = true
-            };
+            XmlWriterSettings settings = Utils.DefaultXmlWriterSettings();
+            settings.CloseOutput = true;
 
             using (Stream ostrm = File.Open(filePath, FileMode.Create, FileAccess.ReadWrite))
             using (XmlWriter writer = XmlDictionaryWriter.Create(ostrm, settings))

--- a/Stack/Opc.Ua.Core/Stack/Configuration/ConfiguredEndpoints.cs
+++ b/Stack/Opc.Ua.Core/Stack/Configuration/ConfiguredEndpoints.cs
@@ -197,7 +197,7 @@ namespace Opc.Ua
             }
             catch (Exception e)
             {
-                Utils.LogError(e, "Unexpected error loading ConfiguredEnpoints.");
+                Utils.LogError(e, "Unexpected error loading ConfiguredEndpoints.");
                 throw;
             }
         }

--- a/Stack/Opc.Ua.Core/Stack/Nodes/NodeSet.cs
+++ b/Stack/Opc.Ua.Core/Stack/Nodes/NodeSet.cs
@@ -64,13 +64,7 @@ namespace Opc.Ua
         /// <param name="istrm">The input stream.</param>
         public void Write(Stream istrm)
         {
-            XmlWriterSettings settings = new XmlWriterSettings {
-                Encoding = Encoding.UTF8,
-                Indent = true,
-                IndentChars = "    "
-            };
-
-            var writer = XmlWriter.Create(istrm, settings);
+            var writer = XmlWriter.Create(istrm, Utils.DefaultXmlWriterSettings());
 
             try
             {

--- a/Stack/Opc.Ua.Core/Stack/Nodes/NodeSet.cs
+++ b/Stack/Opc.Ua.Core/Stack/Nodes/NodeSet.cs
@@ -64,10 +64,13 @@ namespace Opc.Ua
         /// <param name="istrm">The input stream.</param>
         public void Write(Stream istrm)
         {
-            XmlWriterSettings settings = new XmlWriterSettings();
-            settings.Encoding = Encoding.UTF8;
-            settings.Indent = true;
-            XmlWriter writer = XmlWriter.Create(istrm, settings);
+            XmlWriterSettings settings = new XmlWriterSettings {
+                Encoding = Encoding.UTF8,
+                Indent = true,
+                IndentChars = "    "
+            };
+
+            var writer = XmlWriter.Create(istrm, settings);
 
             try
             {

--- a/Stack/Opc.Ua.Core/Stack/State/NodeState.cs
+++ b/Stack/Opc.Ua.Core/Stack/State/NodeState.cs
@@ -528,19 +528,14 @@ namespace Opc.Ua
         /// <param name="ostrm">The stream to write.</param>
         public void SaveAsXml(ISystemContext context, Stream ostrm)
         {
-            ServiceMessageContext messageContext = new ServiceMessageContext();
+            ServiceMessageContext messageContext = new ServiceMessageContext {
+                NamespaceUris = context.NamespaceUris,
+                ServerUris = context.ServerUris,
+                Factory = context.EncodeableFactory
+            };
 
-            messageContext.NamespaceUris = context.NamespaceUris;
-            messageContext.ServerUris = context.ServerUris;
-            messageContext.Factory = context.EncodeableFactory;
-
-            XmlWriterSettings settings = new XmlWriterSettings();
-
-            settings.Encoding = Encoding.UTF8;
+            XmlWriterSettings settings = Utils.DefaultXmlWriterSettings();
             settings.CloseOutput = true;
-            settings.ConformanceLevel = ConformanceLevel.Document;
-            settings.Indent = true;
-
             using (XmlWriter writer = XmlWriter.Create(ostrm, settings))
             {
                 XmlQualifiedName root = new XmlQualifiedName(this.SymbolicName, context.NamespaceUris.GetString(this.BrowseName.NamespaceIndex));

--- a/Stack/Opc.Ua.Core/Stack/State/NodeStateCollection.cs
+++ b/Stack/Opc.Ua.Core/Stack/State/NodeStateCollection.cs
@@ -74,12 +74,7 @@ namespace Opc.Ua
             }
 
             XmlWriterSettings settings = new XmlWriterSettings();
-
-            settings.Encoding = Encoding.UTF8;
             settings.CloseOutput = true;
-            settings.ConformanceLevel = ConformanceLevel.Document;
-            settings.Indent = true;
-
             using (XmlWriter writer = XmlWriter.Create(ostrm, settings))
             {
                 DataContractSerializer serializer = new DataContractSerializer(typeof(NodeSet));
@@ -200,18 +195,14 @@ namespace Opc.Ua
         /// </summary>
         public void SaveAsXml(ISystemContext context, Stream ostrm, bool keepStreamOpen)
         {
-            XmlWriterSettings settings = new XmlWriterSettings();
-
-            settings.Encoding = Encoding.UTF8;
+            XmlWriterSettings settings = Utils.DefaultXmlWriterSettings();
             settings.CloseOutput = !keepStreamOpen;
-            settings.ConformanceLevel = ConformanceLevel.Document;
-            settings.Indent = true;
 
-            ServiceMessageContext messageContext = new ServiceMessageContext();
-
-            messageContext.NamespaceUris = context.NamespaceUris;
-            messageContext.ServerUris = context.ServerUris;
-            messageContext.Factory = context.EncodeableFactory;
+            ServiceMessageContext messageContext = new ServiceMessageContext {
+                NamespaceUris = context.NamespaceUris,
+                ServerUris = context.ServerUris,
+                Factory = context.EncodeableFactory
+            };
 
             using (XmlWriter writer = XmlWriter.Create(ostrm, settings))
             {

--- a/Stack/Opc.Ua.Core/Stack/State/NodeStateCollection.cs
+++ b/Stack/Opc.Ua.Core/Stack/State/NodeStateCollection.cs
@@ -73,7 +73,7 @@ namespace Opc.Ua
                 nodeSet.Add(node, nodeTable.NamespaceUris, nodeTable.ServerUris);
             }
 
-            XmlWriterSettings settings = new XmlWriterSettings();
+            XmlWriterSettings settings = Utils.DefaultXmlWriterSettings();
             settings.CloseOutput = true;
             using (XmlWriter writer = XmlWriter.Create(ostrm, settings))
             {

--- a/Stack/Opc.Ua.Core/Types/Encoders/XmlEncoder.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/XmlEncoder.cs
@@ -36,7 +36,7 @@ namespace Opc.Ua
             m_context = context;
             m_nestingLevel = 0;
 
-            XmlWriterSettings settings = new XmlWriterSettings();
+            XmlWriterSettings settings = Utils.DefaultXmlWriterSettings();
             settings.CheckCharacters = false;
             settings.ConformanceLevel = ConformanceLevel.Auto;
             settings.NamespaceHandling = NamespaceHandling.OmitDuplicates;

--- a/Stack/Opc.Ua.Core/Types/Schemas/BinarySchemaValidator.cs
+++ b/Stack/Opc.Ua.Core/Types/Schemas/BinarySchemaValidator.cs
@@ -86,11 +86,7 @@ namespace Opc.Ua.Schema.Binary
         /// </summary>
         public override string GetSchema(string typeName)
         {
-            XmlWriterSettings settings = new XmlWriterSettings {
-                Encoding = Encoding.UTF8,
-                Indent = true,
-                IndentChars = "    "
-            };
+            XmlWriterSettings settings = Utils.DefaultXmlWriterSettings();
 
             MemoryStream ostrm = new MemoryStream();
             XmlWriter writer = XmlWriter.Create(ostrm, settings);

--- a/Stack/Opc.Ua.Core/Types/Schemas/BinarySchemaValidator.cs
+++ b/Stack/Opc.Ua.Core/Types/Schemas/BinarySchemaValidator.cs
@@ -86,11 +86,11 @@ namespace Opc.Ua.Schema.Binary
         /// </summary>
         public override string GetSchema(string typeName)
         {
-            XmlWriterSettings settings = new XmlWriterSettings();
-
-            settings.Encoding = Encoding.UTF8;
-            settings.Indent = true;
-            settings.IndentChars = "    ";
+            XmlWriterSettings settings = new XmlWriterSettings {
+                Encoding = Encoding.UTF8,
+                Indent = true,
+                IndentChars = "    "
+            };
 
             MemoryStream ostrm = new MemoryStream();
             XmlWriter writer = XmlWriter.Create(ostrm, settings);

--- a/Stack/Opc.Ua.Core/Types/Schemas/XmlSchemaValidator.cs
+++ b/Stack/Opc.Ua.Core/Types/Schemas/XmlSchemaValidator.cs
@@ -114,11 +114,7 @@ namespace Opc.Ua.Schema.Xml
         /// </summary>
         public override string GetSchema(string typeName)
         {
-            XmlWriterSettings settings = new XmlWriterSettings();
-
-            settings.Encoding = Encoding.UTF8;
-            settings.Indent = true;
-            settings.IndentChars = "    ";
+            XmlWriterSettings settings = Utils.DefaultXmlWriterSettings();
 
             MemoryStream ostrm = new MemoryStream();
             XmlWriter writer = XmlWriter.Create(ostrm, settings);

--- a/Stack/Opc.Ua.Core/Types/Utils/Utils.cs
+++ b/Stack/Opc.Ua.Core/Types/Utils/Utils.cs
@@ -2801,12 +2801,26 @@ namespace Opc.Ua
         /// DtdProcessing Prohibited, XmlResolver disabled and
         /// ConformanceLevel Document.
         /// </summary>
-        internal static XmlReaderSettings DefaultXmlReaderSettings()
+        public static XmlReaderSettings DefaultXmlReaderSettings()
         {
             return new XmlReaderSettings() {
                 DtdProcessing = DtdProcessing.Prohibit,
                 XmlResolver = null,
                 ConformanceLevel = ConformanceLevel.Document
+            };
+        }
+
+        /// <summary>
+        /// Returns a XmlWriterSetting with deterministic defaults across .NET versions.
+        /// </summary>
+        public static XmlWriterSettings DefaultXmlWriterSettings()
+        {
+            return new XmlWriterSettings() {
+                Encoding = Encoding.UTF8,
+                Indent = true,
+                ConformanceLevel = ConformanceLevel.Document,
+                IndentChars = "  ",
+                CloseOutput = false,
             };
         }
 

--- a/Tests/Opc.Ua.Core.Tests/Security/Certificates/CertificateValidatorTest.cs
+++ b/Tests/Opc.Ua.Core.Tests/Security/Certificates/CertificateValidatorTest.cs
@@ -1117,6 +1117,7 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
         /// Test if a key below min length is detected.
         /// </summary>
         [Theory]
+        [NonParallelizable]
         public async Task TestMinimumKeyRejected(bool trusted)
         {
             var cert = CertificateFactory.CreateCertificate(null, null, "CN=1k Key", null)
@@ -1165,6 +1166,7 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
         /// Test auto accept.
         /// </summary>
         [Theory]
+        [NonParallelizable]
         public async Task TestAutoAccept(bool trusted, bool autoAccept)
         {
             var cert = CertificateFactory.CreateCertificate(null, null, "CN=Test", null)

--- a/Tests/Opc.Ua.Core.Tests/Types/Utils/UtilTests.cs
+++ b/Tests/Opc.Ua.Core.Tests/Types/Utils/UtilTests.cs
@@ -268,6 +268,27 @@ namespace Opc.Ua.Core.Tests.Types.UtilsTests
             }
         }
 
+        [Test]
+        public void ValidateXmlWriterSettings()
+        {
+            XmlWriterSettings settings = Utils.DefaultXmlWriterSettings();
+            Assert.AreEqual(Encoding.UTF8, settings.Encoding);
+            Assert.AreEqual(false, settings.CloseOutput);
+            Assert.AreEqual(true, settings.Indent);
+            Assert.AreEqual(ConformanceLevel.Document, settings.ConformanceLevel);
+            Assert.AreEqual(false, settings.OmitXmlDeclaration);
+            Assert.AreEqual("  ", settings.IndentChars);
+        }
+
+        [Test]
+        public void ValidateXmlReaderSettings()
+        {
+            XmlReaderSettings settings = Utils.DefaultXmlReaderSettings();
+            Assert.AreEqual(DtdProcessing.Prohibit, settings.DtdProcessing);
+            //Assert.AreEqual(null, settings.XmlResolver);
+            Assert.AreEqual(ConformanceLevel.Document, settings.ConformanceLevel);
+            Assert.AreEqual(false, settings.CloseInput);
+        }
         #endregion
     }
 


### PR DESCRIPTION
fixes #1759 