### PR TITLE
Add property to get local endpoint from IMessageSocket

### DIFF
--- a/Stack/Opc.Ua.Core/Stack/Tcp/TcpMessageSocket.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/TcpMessageSocket.cs
@@ -314,6 +314,15 @@ namespace Opc.Ua.Bindings
         public int Handle => m_socket != null ? m_socket.GetHashCode() : -1;
 
         /// <summary>
+        /// Gets the local endpoint.
+        /// </summary>
+        /// <exception cref="System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.
+        /// See the Remarks section for more information.</exception>
+        /// <exception cref="System.ObjectDisposedException">The System.Net.Sockets.Socket has been closed.</exception>
+        /// <returns>The System.Net.EndPoint that the System.Net.Sockets.Socket is using for communications.</returns>
+        public EndPoint LocalEndpoint => m_socket.LocalEndPoint;
+        
+        /// <summary>
         /// Gets the transport channel features implemented by this message socket.
         /// </summary>
         /// <value>The transport channel feature.</value>

--- a/Stack/Opc.Ua.Core/Stack/Transport/IMessageSocket.cs
+++ b/Stack/Opc.Ua.Core/Stack/Transport/IMessageSocket.cs
@@ -136,6 +136,15 @@ namespace Opc.Ua.Bindings
         int Handle { get; }
 
         /// <summary>
+        /// Gets the local endpoint.
+        /// </summary>
+        /// <exception cref="System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.
+        /// See the Remarks section for more information.</exception>
+        /// <exception cref="System.ObjectDisposedException">The Socket has been closed.</exception>
+        /// <returns>The System.Net.EndPoint that the Socket is using for communications.</returns>
+        System.Net.EndPoint LocalEndpoint { get; }
+
+        /// <summary>
         /// Returns the features implemented by the message socket.
         /// </summary>
         TransportChannelFeatures MessageSocketFeatures { get; }

--- a/Tests/Opc.Ua.Core.Tests/Opc.Ua.Core.Tests.csproj
+++ b/Tests/Opc.Ua.Core.Tests/Opc.Ua.Core.Tests.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="Moq" Version="4.17.2" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit.Console" Version="3.15.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1">

--- a/Tests/Opc.Ua.Core.Tests/Stack/Transport/MessageSocketTests.cs
+++ b/Tests/Opc.Ua.Core.Tests/Stack/Transport/MessageSocketTests.cs
@@ -8,7 +8,7 @@ using Moq;
 using NUnit.Framework;
 using Opc.Ua.Bindings;
 
-namespace Opc.Ua.Core.Tests.Stack.Types
+namespace Opc.Ua.Core.Tests.Stack.Transport
 {
     /// <summary>
     /// Tests for the BuiltIn Types.

--- a/Tests/Opc.Ua.Core.Tests/Stack/Types/MessageSocketTests.cs
+++ b/Tests/Opc.Ua.Core.Tests/Stack/Types/MessageSocketTests.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+using Moq;
+using NUnit.Framework;
+using Opc.Ua.Bindings;
+
+namespace Opc.Ua.Core.Tests.Stack.Types
+{
+    /// <summary>
+    /// Tests for the BuiltIn Types.
+    /// </summary>
+    [TestFixture, Category("MessageSocketTests")]
+    [SetCulture("en-us"), SetUICulture("en-us")]
+    [Parallelizable]
+    public class MessageSocketTests
+    {
+
+        #region Test Setup
+        [OneTimeSetUp]
+        protected void OneTimeSetUp()
+        {
+        }
+
+        [OneTimeTearDown]
+        protected void OneTimeTearDown()
+        {
+        }
+
+        [SetUp]
+        protected void SetUp()
+        {
+
+        }
+
+        [TearDown]
+        protected void TearDown()
+        {
+        }
+        #endregion
+
+        #region Test Methods
+
+        [Test]
+        public void IMessageSocket_IPEndpoint_Returned()
+        {
+            var messageSocketMock = new Mock<IMessageSocket>();
+            var endPoint = new IPEndPoint(IPAddress.Parse("192.168.0.1"), 55062);
+            messageSocketMock.Setup(x => x.LocalEndpoint).Returns(endPoint);
+
+            var messageSocket = messageSocketMock.Object;
+            var gotEndpoint = messageSocket.LocalEndpoint;
+
+            Assert.IsTrue(gotEndpoint.Equals(endPoint));
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
Add the getter (since the System.Net.Sockets.Socket: m_socket does not implement a setter) for the LocalEndPoint so that a user can access the Information on which IP+Port the Socket is running on

## Proposed changes
Add the getter (since the System.Net.Sockets.Socket: m_socket does not implement a setter) for the LocalEndPoint so that a user can access the Information on which IP+Port the Socket is running on

## Related Issues

- Fixes #
https://github.com/OPCFoundation/UA-.NETStandard/issues/1792

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [x] I ran tests locally with my changes, all passed.
- [x] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [x] I have added necessary documentation (if appropriate).
- [x] Any dependent changes have been merged and published in downstream modules.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
