### PR TITLE
Aggregate corrections for CTT 1.4.9.398

### DIFF
--- a/Libraries/Opc.Ua.Server/Aggregates/AggregateCalculator.cs
+++ b/Libraries/Opc.Ua.Server/Aggregates/AggregateCalculator.cs
@@ -1439,23 +1439,20 @@ namespace Opc.Ua.Server
                 }
             }
 
-            // default to good.
-            statusCode = statusCode.SetCodeBits(StatusCodes.Good);
-
-            // uncertain if the good duration is less than the configured threshold.
-            if ((goodCount / totalCount) * 100 < Configuration.PercentDataGood)
+            if (totalCount == 0 || (goodCount / totalCount) * 100 >= Configuration.PercentDataGood)
             {
-                statusCode = statusCode.SetCodeBits(StatusCodes.UncertainDataSubNormal);
+                // good if the good count is greater than or equal to the configured threshold.
+                statusCode = statusCode.SetCodeBits(StatusCodes.Good);
             }
-
-            // bad if the bad duration is greater than or equal to the configured threshold.
-            if ((badCount / totalCount) * 100 >= Configuration.PercentDataBad)
+            else if ((badCount / totalCount) * 100 >= Configuration.PercentDataBad)
             {
-                // if Configuration.PercentDataBad is equal to Configuration.PercentDataGood then PercentDataGood is used
-                if (Configuration.PercentDataBad != 50 && Configuration.PercentDataGood != 50)
-                {
-                    statusCode = StatusCodes.Bad;
-                }
+                // bad if the bad count is greater than or equal to the configured threshold.
+                statusCode = StatusCodes.Bad;
+            }
+            else
+            {
+                // uncertain if did not meet the Good or Bad requirements
+                statusCode = statusCode.SetCodeBits(StatusCodes.UncertainDataSubNormal);
             }
 
             return statusCode;
@@ -1511,22 +1508,20 @@ namespace Opc.Ua.Server
                 }
             }
 
-            // default to good.
-            statusCode = statusCode.SetCodeBits(StatusCodes.Good);
-
-            // uncertain if the good duration is less than the configured threshold.
-            if ((goodDuration/totalDuration)*100 < Configuration.PercentDataGood)
+            if (totalDuration == 0 || (goodDuration / totalDuration) * 100 >= Configuration.PercentDataGood)
             {
-                statusCode = statusCode.SetCodeBits(StatusCodes.UncertainDataSubNormal);
+                // good if the good duration is greater than or equal to the configured threshold.
+                statusCode = statusCode.SetCodeBits(StatusCodes.Good);
             }
-
-            // bad if the bad duration is greater than or equal to the configured threshold.
-            if ((badDuration / totalDuration) * 100 >= Configuration.PercentDataBad)
+            else if ((badDuration / totalDuration) * 100 >= Configuration.PercentDataBad)
             {
-                if (Configuration.PercentDataBad != 50 && Configuration.PercentDataGood != 50)
-                {
-                    statusCode = StatusCodes.Bad;
-                }
+                // bad if the bad duration is greater than or equal to the configured threshold.
+                statusCode = StatusCodes.Bad;
+            }
+            else
+            {
+                // uncertain if did not meet the Good or Bad requirements
+                statusCode = statusCode.SetCodeBits(StatusCodes.UncertainDataSubNormal);
             }
 
             // always calculated.

--- a/Libraries/Opc.Ua.Server/Aggregates/AggregateManager.cs
+++ b/Libraries/Opc.Ua.Server/Aggregates/AggregateManager.cs
@@ -185,7 +185,8 @@ namespace Opc.Ua.Server
 
             if (configuration.UseServerCapabilitiesDefaults)
             {
-                configuration = m_defaultConfiguration;
+                // ensure the configuration is initialized
+                configuration = GetDefaultConfiguration(null); 
             }
 
             IAggregateCalculator calculator = factory(aggregateId, startTime, endTime, processingInterval, stepped, configuration);

--- a/Libraries/Opc.Ua.Server/Aggregates/AverageAggregateCalculator.cs
+++ b/Libraries/Opc.Ua.Server/Aggregates/AverageAggregateCalculator.cs
@@ -126,7 +126,7 @@ namespace Opc.Ua.Server
 
             for (int ii = 0; ii < values.Count; ii++)
             {
-                if (IsGood(values[ii]))
+                if (StatusCode.IsGood(values[ii].StatusCode))
                 {
                     try
                     {

--- a/Libraries/Opc.Ua.Server/Aggregates/AverageAggregateCalculator.cs
+++ b/Libraries/Opc.Ua.Server/Aggregates/AverageAggregateCalculator.cs
@@ -126,7 +126,7 @@ namespace Opc.Ua.Server
 
             for (int ii = 0; ii < values.Count; ii++)
             {
-                if (StatusCode.IsGood(values[ii].StatusCode))
+                if (IsGood(values[ii]))
                 {
                     try
                     {

--- a/Libraries/Opc.Ua.Server/Aggregates/CountAggregateCalculator.cs
+++ b/Libraries/Opc.Ua.Server/Aggregates/CountAggregateCalculator.cs
@@ -125,7 +125,7 @@ namespace Opc.Ua.Server
 
             for (int ii = 0; ii < values.Count; ii++)
             {
-                if (IsGood(values[ii]))
+                if (StatusCode.IsGood(values[ii].StatusCode))
                 {
                     count++;
                 }

--- a/Libraries/Opc.Ua.Server/Aggregates/CountAggregateCalculator.cs
+++ b/Libraries/Opc.Ua.Server/Aggregates/CountAggregateCalculator.cs
@@ -125,7 +125,7 @@ namespace Opc.Ua.Server
 
             for (int ii = 0; ii < values.Count; ii++)
             {
-                if (StatusCode.IsGood(values[ii].StatusCode))
+                if (IsGood(values[ii]))
                 {
                     count++;
                 }
@@ -135,10 +135,14 @@ namespace Opc.Ua.Server
             DataValue value = new DataValue();
             value.WrappedValue = new Variant(count, TypeInfo.Scalars.Int32);
             value.SourceTimestamp = GetTimestamp(slice);
-            value.ServerTimestamp = GetTimestamp(slice);           
-            value.StatusCode = value.StatusCode.SetAggregateBits(AggregateBits.Calculated);
+            value.ServerTimestamp = GetTimestamp(slice);     
             value.StatusCode = GetValueBasedStatusCode(slice, values, value.StatusCode);
 
+            if (!StatusCode.IsBad(value.StatusCode))
+            {
+                // set aggregate bits fon non Bad values
+                value.StatusCode = value.StatusCode.SetAggregateBits(AggregateBits.Calculated);
+            }
             // return result.
             return value;
         }
@@ -222,9 +226,9 @@ namespace Opc.Ua.Server
             DataValue value = new DataValue();
             value.WrappedValue = new Variant(duration, TypeInfo.Scalars.Double);
             value.SourceTimestamp = GetTimestamp(slice);
-            value.ServerTimestamp = GetTimestamp(slice);
-            value.StatusCode = value.StatusCode.SetAggregateBits(AggregateBits.Calculated);
+            value.ServerTimestamp = GetTimestamp(slice);            
             value.StatusCode = GetTimeBasedStatusCode(regions, value.StatusCode);
+            value.StatusCode = value.StatusCode.SetAggregateBits(AggregateBits.Calculated);
 
             // return result.
             return value;

--- a/Libraries/Opc.Ua.Server/Aggregates/MinMaxAggregateCalculator.cs
+++ b/Libraries/Opc.Ua.Server/Aggregates/MinMaxAggregateCalculator.cs
@@ -234,7 +234,7 @@ namespace Opc.Ua.Server
                 }
             }
 
-            // check if at least on good value exists.
+            // check if at least one good value exists.
             if (!goodValueExists)
             {
                 return GetNoDataValue(slice);
@@ -418,10 +418,16 @@ namespace Opc.Ua.Server
                 }
             }
 
-            // check if at least on good value exists.
+            // check if at least one good value exists.
             if (!goodValueExists)
             {
-                return GetNoDataValue(slice);
+                DataValue noDataValue = GetNoDataValue(slice);
+                // check if interval is partial and set the flag accordingly
+                if (slice.Partial)
+                {
+                    noDataValue.StatusCode = noDataValue.StatusCode.SetAggregateBits(AggregateBits.Partial);
+                }
+                return noDataValue;
             }
 
             // determine the calculated value to return.

--- a/Libraries/Opc.Ua.Server/Aggregates/StartEndAggregateCalculator.cs
+++ b/Libraries/Opc.Ua.Server/Aggregates/StartEndAggregateCalculator.cs
@@ -154,7 +154,7 @@ namespace Opc.Ua.Server
 
             // find start value.
             DataValue start = null;
-            double startValue = 0;
+            double startValue = Double.NaN;
             TypeInfo originalType = null;
             bool badDataSkipped = false;
 
@@ -162,7 +162,7 @@ namespace Opc.Ua.Server
             {
                 start = values[ii];
 
-                if (StatusCode.IsGood(start.StatusCode))
+                if (IsGood(start))
                 {
                     try
                     {
@@ -182,13 +182,13 @@ namespace Opc.Ua.Server
 
             // find end value.
             DataValue end = null;
-            double endValue = 0;
+            double endValue = Double.NaN;
 
             for (int ii = values.Count - 1; ii >= 0; ii--)
             {
                 end = values[ii];
 
-                if (StatusCode.IsGood(end.StatusCode))
+                if (IsGood(end))    
                 {
                     try
                     {
@@ -270,6 +270,11 @@ namespace Opc.Ua.Server
                 value = values[values.Count - 1];
             }
 
+            if (!IsGood(value))
+            {
+                value.StatusCode = StatusCodes.BadNoData;
+            }
+
             if (returnEnd)
             {
                 value.SourceTimestamp = GetTimestamp(slice);
@@ -302,7 +307,7 @@ namespace Opc.Ua.Server
             DataValue end = values[values.Count-1];
 
             // check for bad bounds.
-            if (StatusCode.IsBad(start.StatusCode) || StatusCode.IsBad(end.StatusCode))
+            if (!IsGood(start) || !IsGood(end))
             {
                 return GetNoDataValue(slice);
             }
@@ -342,7 +347,7 @@ namespace Opc.Ua.Server
             value.SourceTimestamp = GetTimestamp(slice);
             value.ServerTimestamp = GetTimestamp(slice);
 
-            if (StatusCode.IsNotGood(start.StatusCode) || StatusCode.IsNotGood(end.StatusCode))
+            if (!IsGood(start) || !IsGood(end))
             {
                 value.StatusCode = StatusCodes.UncertainDataSubNormal;
             }


### PR DESCRIPTION
## Proposed changes

Use IsGood instead of StatusCode.IsGood to take into account the configured TreatUncertainAsBad
Handle corectly the rule: if PercentDataBad == PercentDataGood the PercentDataGood rule is used. When they both are 50 the result was calculated using the PercentDataBad
Other fixes

- Fixes # for Aggregate calculations based on the CTT 1.4.9.398 test runs

