### PR TITLE
Fix regressions with reconnect handler and subscription transfer

### DIFF
--- a/Applications/ClientControls.Net4/Common/Client/ConnectServerCtrl.cs
+++ b/Applications/ClientControls.Net4/Common/Client/ConnectServerCtrl.cs
@@ -707,9 +707,9 @@ namespace Opc.Ua.Client.Controls
                     return;
                 }
 
+                // only apply session if reconnect was required
                 if (m_reconnectHandler.Session != null)
                 {
-                    Utils.SilentDispose(m_session);
                     m_session = m_reconnectHandler.Session;
                 }
 

--- a/Applications/ClientControls.Net4/Common/Client/ConnectServerCtrl.cs
+++ b/Applications/ClientControls.Net4/Common/Client/ConnectServerCtrl.cs
@@ -641,7 +641,7 @@ namespace Opc.Ua.Client.Controls
                             m_ReconnectStarting(this, e);
                         }
 
-                        m_reconnectHandler = new SessionReconnectHandler();
+                        m_reconnectHandler = new SessionReconnectHandler(true);
                         m_reconnectHandler.BeginReconnect(m_session, ReconnectPeriod * 1000, Server_ReconnectComplete);
                     }
 
@@ -707,7 +707,12 @@ namespace Opc.Ua.Client.Controls
                     return;
                 }
 
-                m_session = m_reconnectHandler.Session;
+                if (m_reconnectHandler.Session != null)
+                {
+                    Utils.SilentDispose(m_session);
+                    m_session = m_reconnectHandler.Session;
+                }
+
                 m_reconnectHandler.Dispose();
                 m_reconnectHandler = null;
 

--- a/Applications/ClientControls.Net4/Common/Client/ConnectServerCtrl.cs
+++ b/Applications/ClientControls.Net4/Common/Client/ConnectServerCtrl.cs
@@ -434,7 +434,7 @@ namespace Opc.Ua.Client.Controls
                 UseSecurityCK.Checked = useSecurity;
             }
 
-            return await Task.Run(() => Connect(serverUrl, useSecurity, sessionTimeout));
+            return await Connect(serverUrl, useSecurity, sessionTimeout);
         }
 
         /// <summary>

--- a/Applications/ConsoleReferenceClient/ClientSamples.cs
+++ b/Applications/ConsoleReferenceClient/ClientSamples.cs
@@ -1,0 +1,366 @@
+/* ========================================================================
+ * Copyright (c) 2005-2021 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ * 
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ * 
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using Opc.Ua;
+using Opc.Ua.Client;
+
+namespace Quickstarts.ConsoleReferenceClient
+{
+    /// <summary>
+    /// Sample Session calls based on the reference server node model.
+    /// </summary>
+    public class ClientSamples
+    {
+
+        public ClientSamples(TextWriter output, Action<IList, IList> validateResponse)
+        {
+            m_output = output;
+            m_validateResponse = validateResponse;
+        }
+
+        #region Public Sample Methods
+        /// <summary>
+        /// Read a list of nodes from Server
+        /// </summary>
+        public void ReadNodes(Session session)
+        {
+            if (session == null || session.Connected == false)
+            {
+                m_output.WriteLine("Session not connected!");
+                return;
+            }
+
+            try
+            {
+                #region Read a node by calling the Read Service
+
+                // build a list of nodes to be read
+                ReadValueIdCollection nodesToRead = new ReadValueIdCollection()
+                {
+                    // Value of ServerStatus
+                    new ReadValueId() { NodeId = Variables.Server_ServerStatus, AttributeId = Attributes.Value },
+                    // BrowseName of ServerStatus_StartTime
+                    new ReadValueId() { NodeId = Variables.Server_ServerStatus_StartTime, AttributeId = Attributes.BrowseName },
+                    // Value of ServerStatus_StartTime
+                    new ReadValueId() { NodeId = Variables.Server_ServerStatus_StartTime, AttributeId = Attributes.Value }
+                };
+
+                // Read the node attributes
+                m_output.WriteLine("Reading nodes...");
+
+                // Call Read Service
+                session.Read(
+                    null,
+                    0,
+                    TimestampsToReturn.Both,
+                    nodesToRead,
+                    out DataValueCollection resultsValues,
+                    out DiagnosticInfoCollection diagnosticInfos);
+
+                // Validate the results
+                m_validateResponse(resultsValues, nodesToRead);
+
+                // Display the results.
+                foreach (DataValue result in resultsValues)
+                {
+                    m_output.WriteLine("Read Value = {0} , StatusCode = {1}", result.Value, result.StatusCode);
+                }
+                #endregion
+
+                #region Read the Value attribute of a node by calling the Session.ReadValue method
+                // Read Server NamespaceArray
+                m_output.WriteLine("Reading Value of NamespaceArray node...");
+                DataValue namespaceArray = session.ReadValue(Variables.Server_NamespaceArray);
+                // Display the result
+                m_output.WriteLine($"NamespaceArray Value = {namespaceArray}");
+                #endregion
+            }
+            catch (Exception ex)
+            {
+                // Log Error
+                m_output.WriteLine($"Read Nodes Error : {ex.Message}.");
+            }
+        }
+
+        /// <summary>
+        /// Write a list of nodes to the Server
+        /// </summary>
+        public void WriteNodes(Session session)
+        {
+            if (session == null || session.Connected == false)
+            {
+                m_output.WriteLine("Session not connected!");
+                return;
+            }
+
+            try
+            {
+                // Write the configured nodes
+                WriteValueCollection nodesToWrite = new WriteValueCollection();
+
+                // Int32 Node - Objects\CTT\Scalar\Scalar_Static\Int32
+                WriteValue intWriteVal = new WriteValue();
+                intWriteVal.NodeId = new NodeId("ns=2;s=Scalar_Static_Int32");
+                intWriteVal.AttributeId = Attributes.Value;
+                intWriteVal.Value = new DataValue();
+                intWriteVal.Value.Value = (int)100;
+                nodesToWrite.Add(intWriteVal);
+
+                // Float Node - Objects\CTT\Scalar\Scalar_Static\Float
+                WriteValue floatWriteVal = new WriteValue();
+                floatWriteVal.NodeId = new NodeId("ns=2;s=Scalar_Static_Float");
+                floatWriteVal.AttributeId = Attributes.Value;
+                floatWriteVal.Value = new DataValue();
+                floatWriteVal.Value.Value = (float)100.5;
+                nodesToWrite.Add(floatWriteVal);
+
+                // String Node - Objects\CTT\Scalar\Scalar_Static\String
+                WriteValue stringWriteVal = new WriteValue();
+                stringWriteVal.NodeId = new NodeId("ns=2;s=Scalar_Static_String");
+                stringWriteVal.AttributeId = Attributes.Value;
+                stringWriteVal.Value = new DataValue();
+                stringWriteVal.Value.Value = "String Test";
+                nodesToWrite.Add(stringWriteVal);
+
+                // Write the node attributes
+                StatusCodeCollection results = null;
+                DiagnosticInfoCollection diagnosticInfos;
+                m_output.WriteLine("Writing nodes...");
+
+                // Call Write Service
+                session.Write(null,
+                                nodesToWrite,
+                                out results,
+                                out diagnosticInfos);
+
+                // Validate the response
+                m_validateResponse(results, nodesToWrite);
+
+                // Display the results.
+                m_output.WriteLine("Write Results :");
+
+                foreach (StatusCode writeResult in results)
+                {
+                    m_output.WriteLine("     {0}", writeResult);
+                }
+            }
+            catch (Exception ex)
+            {
+                // Log Error
+                m_output.WriteLine($"Write Nodes Error : {ex.Message}.");
+            }
+        }
+
+        /// <summary>
+        /// Browse Server nodes
+        /// </summary>
+        public void Browse(Session session)
+        {
+            if (session == null || session.Connected == false)
+            {
+                m_output.WriteLine("Session not connected!");
+                return;
+            }
+
+            try
+            {
+                // Create a Browser object
+                Browser browser = new Browser(session);
+
+                // Set browse parameters
+                browser.BrowseDirection = BrowseDirection.Forward;
+                browser.NodeClassMask = (int)NodeClass.Object | (int)NodeClass.Variable;
+                browser.ReferenceTypeId = ReferenceTypeIds.HierarchicalReferences;
+
+                NodeId nodeToBrowse = ObjectIds.Server;
+
+                // Call Browse service
+                m_output.WriteLine("Browsing {0} node...", nodeToBrowse);
+                ReferenceDescriptionCollection browseResults = browser.Browse(nodeToBrowse);
+
+                // Display the results
+                m_output.WriteLine("Browse returned {0} results:", browseResults.Count);
+
+                foreach (ReferenceDescription result in browseResults)
+                {
+                    m_output.WriteLine("     DisplayName = {0}, NodeClass = {1}", result.DisplayName.Text, result.NodeClass);
+                }
+            }
+            catch (Exception ex)
+            {
+                // Log Error
+                m_output.WriteLine($"Browse Error : {ex.Message}.");
+            }
+        }
+
+        /// <summary>
+        /// Call UA method
+        /// </summary>
+        public void CallMethod(Session session)
+        {
+            if (session == null || session.Connected == false)
+            {
+                m_output.WriteLine("Session not connected!");
+                return;
+            }
+
+            try
+            {
+                // Define the UA Method to call
+                // Parent node - Objects\CTT\Methods
+                // Method node - Objects\CTT\Methods\Add
+                NodeId objectId = new NodeId("ns=2;s=Methods");
+                NodeId methodId = new NodeId("ns=2;s=Methods_Add");
+
+                // Define the method parameters
+                // Input argument requires a Float and an UInt32 value
+                object[] inputArguments = new object[] { (float)10.5, (uint)10 };
+                IList<object> outputArguments = null;
+
+                // Invoke Call service
+                m_output.WriteLine("Calling UAMethod for node {0} ...", methodId);
+                outputArguments = session.Call(objectId, methodId, inputArguments);
+
+                // Display results
+                m_output.WriteLine("Method call returned {0} output argument(s):", outputArguments.Count);
+
+                foreach (var outputArgument in outputArguments)
+                {
+                    m_output.WriteLine("     OutputValue = {0}", outputArgument.ToString());
+                }
+            }
+            catch (Exception ex)
+            {
+                m_output.WriteLine("Method call error: {0}", ex.Message);
+            }
+        }
+
+        /// <summary>
+        /// Create Subscription and MonitoredItems for DataChanges
+        /// </summary>
+        public void SubscribeToDataChanges(Session session)
+        {
+            if (session == null || session.Connected == false)
+            {
+                m_output.WriteLine("Session not connected!");
+                return;
+            }
+
+            try
+            {
+                // Create a subscription for receiving data change notifications
+
+                // Define Subscription parameters
+                Subscription subscription = new Subscription(session.DefaultSubscription) {
+                    DisplayName = "Console ReferenceClient Subscription",
+                    PublishingEnabled = true,
+                    PublishingInterval = 1000,
+                    MinLifetimeInterval = 120000
+                };
+
+                session.AddSubscription(subscription);
+
+                // Create the subscription on Server side
+                subscription.Create();
+                m_output.WriteLine("New Subscription created with SubscriptionId = {0}.", subscription.Id);
+
+                // Create MonitoredItems for data changes (Reference Server)
+
+                MonitoredItem intMonitoredItem = new MonitoredItem(subscription.DefaultItem);
+                // Int32 Node - Objects\CTT\Scalar\Simulation\Int32
+                intMonitoredItem.StartNodeId = new NodeId("ns=2;s=Scalar_Simulation_Int32");
+                intMonitoredItem.AttributeId = Attributes.Value;
+                intMonitoredItem.DisplayName = "Int32 Variable";
+                intMonitoredItem.SamplingInterval = 1000;
+                intMonitoredItem.QueueSize = 10;
+                intMonitoredItem.DiscardOldest = true;
+                intMonitoredItem.Notification += OnMonitoredItemNotification;
+
+                subscription.AddItem(intMonitoredItem);
+
+                MonitoredItem floatMonitoredItem = new MonitoredItem(subscription.DefaultItem);
+                // Float Node - Objects\CTT\Scalar\Simulation\Float
+                floatMonitoredItem.StartNodeId = new NodeId("ns=2;s=Scalar_Simulation_Float");
+                floatMonitoredItem.AttributeId = Attributes.Value;
+                floatMonitoredItem.DisplayName = "Float Variable";
+                floatMonitoredItem.SamplingInterval = 1000;
+                floatMonitoredItem.QueueSize = 10;
+                floatMonitoredItem.Notification += OnMonitoredItemNotification;
+
+                subscription.AddItem(floatMonitoredItem);
+
+                MonitoredItem stringMonitoredItem = new MonitoredItem(subscription.DefaultItem);
+                // String Node - Objects\CTT\Scalar\Simulation\String
+                stringMonitoredItem.StartNodeId = new NodeId("ns=2;s=Scalar_Simulation_String");
+                stringMonitoredItem.AttributeId = Attributes.Value;
+                stringMonitoredItem.DisplayName = "String Variable";
+                stringMonitoredItem.SamplingInterval = 1000;
+                stringMonitoredItem.QueueSize = 10;
+                stringMonitoredItem.Notification += OnMonitoredItemNotification;
+
+                subscription.AddItem(stringMonitoredItem);
+
+                // Create the monitored items on Server side
+                subscription.ApplyChanges();
+                m_output.WriteLine("MonitoredItems created for SubscriptionId = {0}.", subscription.Id);
+            }
+            catch (Exception ex)
+            {
+                m_output.WriteLine("Subscribe error: {0}", ex.Message);
+            }
+        }
+        #endregion
+
+        #region Private Methods
+        /// <summary>
+        /// Handle DataChange notifications from Server
+        /// </summary>
+        private void OnMonitoredItemNotification(MonitoredItem monitoredItem, MonitoredItemNotificationEventArgs e)
+        {
+            try
+            {
+                // Log MonitoredItem Notification event
+                MonitoredItemNotification notification = e.NotificationValue as MonitoredItemNotification;
+                m_output.WriteLine("Notification: {0} \"{1}\" and Value = {2}.", notification.Message.SequenceNumber, monitoredItem.DisplayName, notification.Value);
+            }
+            catch (Exception ex)
+            {
+                m_output.WriteLine("OnMonitoredItemNotification error: {0}", ex.Message);
+            }
+        }
+        #endregion
+
+        private Action<IList, IList> m_validateResponse;
+        private TextWriter m_output;
+    }
+}

--- a/Applications/ConsoleReferenceClient/ClientSamples.cs
+++ b/Applications/ConsoleReferenceClient/ClientSamples.cs
@@ -268,7 +268,7 @@ namespace Quickstarts.ConsoleReferenceClient
         /// <summary>
         /// Create Subscription and MonitoredItems for DataChanges
         /// </summary>
-        public void SubscribeToDataChanges(Session session)
+        public void SubscribeToDataChanges(Session session, uint minLifeTime)
         {
             if (session == null || session.Connected == false)
             {
@@ -285,7 +285,8 @@ namespace Quickstarts.ConsoleReferenceClient
                     DisplayName = "Console ReferenceClient Subscription",
                     PublishingEnabled = true,
                     PublishingInterval = 1000,
-                    MinLifetimeInterval = 120000
+                    LifetimeCount = 0,
+                    MinLifetimeInterval = minLifeTime,
                 };
 
                 session.AddSubscription(subscription);

--- a/Applications/ConsoleReferenceClient/Program.cs
+++ b/Applications/ConsoleReferenceClient/Program.cs
@@ -69,6 +69,7 @@ namespace Quickstarts.ConsoleReferenceClient
             bool renewCertificate = false;
             string password = null;
             int timeout = Timeout.Infinite;
+            string logFile = null;
 
             Mono.Options.OptionSet options = new Mono.Options.OptionSet {
                 usage,
@@ -79,6 +80,7 @@ namespace Quickstarts.ConsoleReferenceClient
                 { "p|password=", "optional password for private key", (string p) => password = p },
                 { "r|renew", "renew application certificate", r => renewCertificate = r != null },
                 { "t|timeout=", "timeout in seconds to exit application", (int t) => timeout = t * 1000 },
+                { "logfile=", "custom file name for log output", l => { if (l != null) { logFile = l; } } },
             };
 
             try
@@ -111,6 +113,16 @@ namespace Quickstarts.ConsoleReferenceClient
 
                 // load the application configuration.
                 var config = await application.LoadApplicationConfiguration(silent: false);
+
+                // override logfile
+                if (logFile != null)
+                {
+                    var logFilePath = config.TraceConfiguration.OutputFilePath;
+                    var filename = Path.GetFileNameWithoutExtension(logFilePath);
+                    config.TraceConfiguration.OutputFilePath = logFilePath.Replace(filename, logFile);
+                    config.TraceConfiguration.DeleteOnLoad = true;
+                    config.TraceConfiguration.ApplySettings();
+                }
 
                 // setup the logging
                 ConsoleUtils.ConfigureLogging(config, applicationName, logConsole, LogLevel.Information);
@@ -147,35 +159,42 @@ namespace Quickstarts.ConsoleReferenceClient
                     }
 
                     // create the UA Client object and connect to configured server.
-                    UAClient uaClient = new UAClient(application.ApplicationConfiguration, output, ClientBase.ValidateResponse) {
+                    using (UAClient uaClient = new UAClient(
+                        application.ApplicationConfiguration, output, ClientBase.ValidateResponse) {
                         AutoAccept = autoAccept
-                    };
-
-                    bool connected = await uaClient.ConnectAsync(serverUrl.ToString());
-                    if (connected)
+                    })
                     {
-                        // Run tests for available methods.
-                        uaClient.ReadNodes();
-                        uaClient.WriteNodes();
-                        uaClient.Browse();
-                        uaClient.CallMethod();
+                        bool connected = await uaClient.ConnectAsync(serverUrl.ToString());
+                        if (connected)
+                        {
+                            output.WriteLine("Connected! Ctrl-C to quit.");
 
-                        uaClient.SubscribeToDataChanges();
+                            // enable subscription transfer
+                            uaClient.Session.TransferSubscriptionsOnReconnect = true;
 
-                        // Wait for some DataChange notifications from MonitoredItems
-                        quit = quitEvent.WaitOne(Math.Min(30_000, waitTime));
+                            // Run tests for available methods on reference server.
+                            var samples = new ClientSamples(output, ClientBase.ValidateResponse);
+                            samples.ReadNodes(uaClient.Session);
+                            samples.WriteNodes(uaClient.Session);
+                            samples.Browse(uaClient.Session);
+                            samples.CallMethod(uaClient.Session);
+                            samples.SubscribeToDataChanges(uaClient.Session);
 
-                        uaClient.Disconnect();
-                    }
-                    else
-                    {
-                        output.WriteLine("Could not connect to server! Retry in 10 seconds or Ctrl-C to quit.");
-                        quit = quitEvent.WaitOne(Math.Min(10_000, waitTime));
+                            // Wait for some DataChange notifications from MonitoredItems
+                            quit = quitEvent.WaitOne(timeout > 0 ? waitTime : 30_000);
+
+                            uaClient.Disconnect();
+                        }
+                        else
+                        {
+                            output.WriteLine("Could not connect to server! Retry in 10 seconds or Ctrl-C to quit.");
+                            quit = quitEvent.WaitOne(Math.Min(10_000, waitTime));
+                        }
                     }
 
                 } while (!quit);
 
-                output.WriteLine("\nClient stopped.");
+                output.WriteLine("Client stopped.");
             }
             catch (Exception ex)
             {

--- a/Applications/ConsoleReferenceClient/Program.cs
+++ b/Applications/ConsoleReferenceClient/Program.cs
@@ -178,7 +178,7 @@ namespace Quickstarts.ConsoleReferenceClient
                             samples.WriteNodes(uaClient.Session);
                             samples.Browse(uaClient.Session);
                             samples.CallMethod(uaClient.Session);
-                            samples.SubscribeToDataChanges(uaClient.Session);
+                            samples.SubscribeToDataChanges(uaClient.Session, 120_000);
 
                             // Wait for some DataChange notifications from MonitoredItems
                             quit = quitEvent.WaitOne(timeout > 0 ? waitTime : 30_000);

--- a/Applications/ConsoleReferenceClient/Quickstarts.ReferenceClient.Config.xml
+++ b/Applications/ConsoleReferenceClient/Quickstarts.ReferenceClient.Config.xml
@@ -45,7 +45,7 @@
   <TransportConfigurations></TransportConfigurations>
   
   <TransportQuotas>
-    <OperationTimeout>600000</OperationTimeout>
+    <OperationTimeout>120000</OperationTimeout>
     <MaxStringLength>1048576</MaxStringLength>
     <MaxByteStringLength>1048576</MaxByteStringLength>
     <MaxArrayLength>65535</MaxArrayLength>

--- a/Applications/ConsoleReferenceClient/UAClient.cs
+++ b/Applications/ConsoleReferenceClient/UAClient.cs
@@ -283,7 +283,6 @@ namespace Quickstarts
                 // if session recovered, Session property is null
                 if (m_reconnectHandler.Session != null)
                 {
-                    Utils.SilentDispose(m_session);
                     m_session = m_reconnectHandler.Session;
                 }
 

--- a/Applications/ConsoleReferenceClient/UAClient.cs
+++ b/Applications/ConsoleReferenceClient/UAClient.cs
@@ -29,7 +29,6 @@
 
 using System;
 using System.Collections;
-using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using Opc.Ua;
@@ -40,7 +39,7 @@ namespace Quickstarts
     /// <summary>
     /// OPC UA Client with examples of basic functionality.
     /// </summary>
-    class UAClient
+    class UAClient : IDisposable
     {
         #region Constructors
         /// <summary>
@@ -55,23 +54,87 @@ namespace Quickstarts
         }
         #endregion
 
+        #region IDisposable
+        /// <summary>
+        /// Default dispose implementation.
+        /// </summary>
+        /// <param name="disposing"></param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!m_disposed)
+            {
+                if (disposing)
+                {
+                    // dispose managed state (managed objects)
+                    Utils.SilentDispose(m_session);
+                }
+
+                // TODO: free unmanaged resources (unmanaged objects) and override finalizer
+                // TODO: set large fields to null
+                m_configuration.CertificateValidator.CertificateValidation -= CertificateValidation;
+                m_disposed = true;
+            }
+        }
+
+        ~UAClient()
+        {
+            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+            Dispose(disposing: false);
+        }
+
+        /// <summary>
+        /// Dispose 
+        /// </summary>
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
+        }
+        #endregion
+
         #region Public Properties
+        /// <summary>
+        /// Action used 
+        /// </summary>
+        Action<IList, IList> ValidateResponse => m_validateResponse;
+
         /// <summary>
         /// Gets the client session.
         /// </summary>
         public Session Session => m_session;
 
         /// <summary>
+        /// The session keepalive interval to be used in ms.
+        /// </summary>
+        public int KeepAliveInterval { get; set; } = 5000;
+
+        /// <summary>
+        /// The reconnect period to be used in ms.
+        /// </summary>
+        public int ReconnectPeriod { get; set; } = 10000;
+
+        /// <summary>
+        /// The session lifetime.
+        /// </summary>
+        public uint SessionLifeTime { get; set; } = 30 * 1000;
+
+        /// <summary>
         /// Auto accept untrusted certificates.
         /// </summary>
         public bool AutoAccept { get; set; } = false;
+
+        /// <summary>
+        /// The file to use for log output.
+        /// </summary>
+        public string LogFile { get; set; }
         #endregion
 
         #region Public Methods
         /// <summary>
         /// Creates a session with the UA server
         /// </summary>
-        public async Task<bool> ConnectAsync(string serverUrl)
+        public async Task<bool> ConnectAsync(string serverUrl, bool useSecurity = true)
         {
             if (serverUrl == null) throw new ArgumentNullException(nameof(serverUrl));
 
@@ -87,7 +150,7 @@ namespace Quickstarts
 
                     // Get the endpoint by connecting to server's discovery endpoint.
                     // Try to find the first endopint with security.
-                    EndpointDescription endpointDescription = CoreClientUtils.SelectEndpoint(m_configuration, serverUrl, true);
+                    EndpointDescription endpointDescription = CoreClientUtils.SelectEndpoint(m_configuration, serverUrl, useSecurity);
                     EndpointConfiguration endpointConfiguration = EndpointConfiguration.Create(m_configuration);
                     ConfiguredEndpoint endpoint = new ConfiguredEndpoint(null, endpointDescription, endpointConfiguration);
 
@@ -98,7 +161,7 @@ namespace Quickstarts
                         false,
                         false,
                         m_configuration.ApplicationName,
-                        30 * 60 * 1000,
+                        SessionLifeTime,
                         new UserIdentity(),
                         null
                     );
@@ -107,6 +170,12 @@ namespace Quickstarts
                     if (session != null && session.Connected)
                     {
                         m_session = session;
+
+                        // override keep alive interval
+                        m_session.KeepAliveInterval = KeepAliveInterval;
+
+                        // set up keep alive callback.
+                        m_session.KeepAlive += new KeepAliveEventHandler(Session_KeepAlive);
                     }
 
                     // Session created successfully.
@@ -152,317 +221,83 @@ namespace Quickstarts
                 m_output.WriteLine($"Disconnect Error : {ex.Message}");
             }
         }
-
         /// <summary>
-        /// Read a list of nodes from Server
+        /// Handles a keep alive event from a session and triggers a reconnect if necessary.
         /// </summary>
-        public void ReadNodes()
+        private void Session_KeepAlive(Session session, KeepAliveEventArgs e)
         {
-            if (m_session == null || m_session.Connected == false)
-            {
-                m_output.WriteLine("Session not connected!");
-                return;
-            }
-
             try
             {
-                #region Read a node by calling the Read Service
-
-                // build a list of nodes to be read
-                ReadValueIdCollection nodesToRead = new ReadValueIdCollection()
+                // check for events from discarded sessions.
+                if (!Object.ReferenceEquals(session, m_session))
                 {
-                    // Value of ServerStatus
-                    new ReadValueId() { NodeId = Variables.Server_ServerStatus, AttributeId = Attributes.Value },
-                    // BrowseName of ServerStatus_StartTime
-                    new ReadValueId() { NodeId = Variables.Server_ServerStatus_StartTime, AttributeId = Attributes.BrowseName },
-                    // Value of ServerStatus_StartTime
-                    new ReadValueId() { NodeId = Variables.Server_ServerStatus_StartTime, AttributeId = Attributes.Value }
-                };
-
-                // Read the node attributes
-                m_output.WriteLine("Reading nodes...");
-
-                // Call Read Service
-                m_session.Read(
-                    null,
-                    0,
-                    TimestampsToReturn.Both,
-                    nodesToRead,
-                    out DataValueCollection resultsValues,
-                    out DiagnosticInfoCollection diagnosticInfos);
-
-                // Validate the results
-                m_validateResponse(resultsValues, nodesToRead);
-
-                // Display the results.
-                foreach (DataValue result in resultsValues)
-                {
-                    m_output.WriteLine("Read Value = {0} , StatusCode = {1}", result.Value, result.StatusCode);
+                    return;
                 }
-                #endregion
 
-                #region Read the Value attribute of a node by calling the Session.ReadValue method
-                // Read Server NamespaceArray
-                m_output.WriteLine("Reading Value of NamespaceArray node...");
-                DataValue namespaceArray = m_session.ReadValue(Variables.Server_NamespaceArray);
-                // Display the result
-                m_output.WriteLine($"NamespaceArray Value = {namespaceArray}");
-                #endregion
+                // start reconnect sequence on communication error.
+                if (ServiceResult.IsBad(e.Status))
+                {
+                    if (ReconnectPeriod <= 0)
+                    {
+                        Utils.LogWarning("KeepAlive status {0}, but reconnect is disabled.", e.Status);
+                        return;
+                    }
+
+                    lock (m_lock)
+                    {
+                        if (m_reconnectHandler == null)
+                        {
+                            Utils.LogInfo("KeepAlive status {0}, reconnecting in {1}ms.", e.Status, ReconnectPeriod);
+                            m_output.WriteLine("--- RECONNECTING {0} ---", e.Status);
+                            m_reconnectHandler = new SessionReconnectHandler();
+                            m_reconnectHandler.BeginReconnect(m_session, ReconnectPeriod, Client_ReconnectComplete);
+                        }
+                        else
+                        {
+                            Utils.LogInfo("KeepAlive status {0}, reconnect in progress.", e.Status);
+                        }
+                    }
+
+                    return;
+                }
+
             }
-            catch (Exception ex)
+            catch (Exception exception)
             {
-                // Log Error
-                m_output.WriteLine($"Read Nodes Error : {ex.Message}.");
+                Utils.LogError(exception, "Error in OnKeepAlive.");
             }
         }
 
         /// <summary>
-        /// Write a list of nodes to the Server
+        /// Called when the reconnect attempt was successful.
         /// </summary>
-        public void WriteNodes()
+        private void Client_ReconnectComplete(object sender, EventArgs e)
         {
-            if (m_session == null || m_session.Connected == false)
+            // ignore callbacks from discarded objects.
+            if (!Object.ReferenceEquals(sender, m_reconnectHandler))
             {
-                m_output.WriteLine("Session not connected!");
                 return;
             }
 
-            try
+            lock (m_lock)
             {
-                // Write the configured nodes
-                WriteValueCollection nodesToWrite = new WriteValueCollection();
+                Utils.SilentDispose(m_session);
+                m_session = m_reconnectHandler.Session;
 
-                // Int32 Node - Objects\CTT\Scalar\Scalar_Static\Int32
-                WriteValue intWriteVal = new WriteValue();
-                intWriteVal.NodeId = new NodeId("ns=2;s=Scalar_Static_Int32");
-                intWriteVal.AttributeId = Attributes.Value;
-                intWriteVal.Value = new DataValue();
-                intWriteVal.Value.Value = (int)100;
-                nodesToWrite.Add(intWriteVal);
-
-                // Float Node - Objects\CTT\Scalar\Scalar_Static\Float
-                WriteValue floatWriteVal = new WriteValue();
-                floatWriteVal.NodeId = new NodeId("ns=2;s=Scalar_Static_Float");
-                floatWriteVal.AttributeId = Attributes.Value;
-                floatWriteVal.Value = new DataValue();
-                floatWriteVal.Value.Value = (float)100.5;
-                nodesToWrite.Add(floatWriteVal);
-
-                // String Node - Objects\CTT\Scalar\Scalar_Static\String
-                WriteValue stringWriteVal = new WriteValue();
-                stringWriteVal.NodeId = new NodeId("ns=2;s=Scalar_Static_String");
-                stringWriteVal.AttributeId = Attributes.Value;
-                stringWriteVal.Value = new DataValue();
-                stringWriteVal.Value.Value = "String Test";
-                nodesToWrite.Add(stringWriteVal);
-
-                // Write the node attributes
-                StatusCodeCollection results = null;
-                DiagnosticInfoCollection diagnosticInfos;
-                m_output.WriteLine("Writing nodes...");
-
-                // Call Write Service
-                m_session.Write(null,
-                                nodesToWrite,
-                                out results,
-                                out diagnosticInfos);
-
-                // Validate the response
-                m_validateResponse(results, nodesToWrite);
-
-                // Display the results.
-                m_output.WriteLine("Write Results :");
-
-                foreach (StatusCode writeResult in results)
-                {
-                    m_output.WriteLine("     {0}", writeResult);
-                }
-            }
-            catch (Exception ex)
-            {
-                // Log Error
-                m_output.WriteLine($"Write Nodes Error : {ex.Message}.");
-            }
-        }
-
-        /// <summary>
-        /// Browse Server nodes
-        /// </summary>
-        public void Browse()
-        {
-            if (m_session == null || m_session.Connected == false)
-            {
-                m_output.WriteLine("Session not connected!");
-                return;
+                m_reconnectHandler.Dispose();
+                m_reconnectHandler = null;
             }
 
-            try
-            {
-                // Create a Browser object
-                Browser browser = new Browser(m_session);
-
-                // Set browse parameters
-                browser.BrowseDirection = BrowseDirection.Forward;
-                browser.NodeClassMask = (int)NodeClass.Object | (int)NodeClass.Variable;
-                browser.ReferenceTypeId = ReferenceTypeIds.HierarchicalReferences;
-
-                NodeId nodeToBrowse = ObjectIds.Server;
-
-                // Call Browse service
-                m_output.WriteLine("Browsing {0} node...", nodeToBrowse);
-                ReferenceDescriptionCollection browseResults = browser.Browse(nodeToBrowse);
-
-                // Display the results
-                m_output.WriteLine("Browse returned {0} results:", browseResults.Count);
-
-                foreach (ReferenceDescription result in browseResults)
-                {
-                    m_output.WriteLine("     DisplayName = {0}, NodeClass = {1}", result.DisplayName.Text, result.NodeClass);
-                }
-            }
-            catch (Exception ex)
-            {
-                // Log Error
-                m_output.WriteLine($"Browse Error : {ex.Message}.");
-            }
-        }
-
-        /// <summary>
-        /// Call UA method
-        /// </summary>
-        public void CallMethod()
-        {
-            if (m_session == null || m_session.Connected == false)
-            {
-                m_output.WriteLine("Session not connected!");
-                return;
-            }
-
-            try
-            {
-                // Define the UA Method to call
-                // Parent node - Objects\CTT\Methods
-                // Method node - Objects\CTT\Methods\Add
-                NodeId objectId = new NodeId("ns=2;s=Methods");
-                NodeId methodId = new NodeId("ns=2;s=Methods_Add");
-
-                // Define the method parameters
-                // Input argument requires a Float and an UInt32 value
-                object[] inputArguments = new object[] { (float)10.5, (uint)10 };
-                IList<object> outputArguments = null;
-
-                // Invoke Call service
-                m_output.WriteLine("Calling UAMethod for node {0} ...", methodId);
-                outputArguments = m_session.Call(objectId, methodId, inputArguments);
-
-                // Display results
-                m_output.WriteLine("Method call returned {0} output argument(s):", outputArguments.Count);
-
-                foreach (var outputArgument in outputArguments)
-                {
-                    m_output.WriteLine("     OutputValue = {0}", outputArgument.ToString());
-                }
-            }
-            catch (Exception ex)
-            {
-                m_output.WriteLine("Method call error: {0}", ex.Message);
-            }
-        }
-
-        /// <summary>
-        /// Create Subscription and MonitoredItems for DataChanges
-        /// </summary>
-        public void SubscribeToDataChanges()
-        {
-            if (m_session == null || m_session.Connected == false)
-            {
-                m_output.WriteLine("Session not connected!");
-                return;
-            }
-
-            try
-            {
-                // Create a subscription for receiving data change notifications
-
-                // Define Subscription parameters
-                Subscription subscription = new Subscription(m_session.DefaultSubscription);
-
-                subscription.DisplayName = "Console ReferenceClient Subscription";
-                subscription.PublishingEnabled = true;
-                subscription.PublishingInterval = 1000;
-
-                m_session.AddSubscription(subscription);
-
-                // Create the subscription on Server side
-                subscription.Create();
-                m_output.WriteLine("New Subscription created with SubscriptionId = {0}.", subscription.Id);
-
-                // Create MonitoredItems for data changes (Reference Server)
-
-                MonitoredItem intMonitoredItem = new MonitoredItem(subscription.DefaultItem);
-                // Int32 Node - Objects\CTT\Scalar\Simulation\Int32
-                intMonitoredItem.StartNodeId = new NodeId("ns=2;s=Scalar_Simulation_Int32");
-                intMonitoredItem.AttributeId = Attributes.Value;
-                intMonitoredItem.DisplayName = "Int32 Variable";
-                intMonitoredItem.SamplingInterval = 1000;
-                intMonitoredItem.Notification += OnMonitoredItemNotification;
-
-                subscription.AddItem(intMonitoredItem);
-
-                MonitoredItem floatMonitoredItem = new MonitoredItem(subscription.DefaultItem);
-                // Float Node - Objects\CTT\Scalar\Simulation\Float
-                floatMonitoredItem.StartNodeId = new NodeId("ns=2;s=Scalar_Simulation_Float");
-                floatMonitoredItem.AttributeId = Attributes.Value;
-                floatMonitoredItem.DisplayName = "Float Variable";
-                floatMonitoredItem.SamplingInterval = 1000;
-                floatMonitoredItem.Notification += OnMonitoredItemNotification;
-
-                subscription.AddItem(floatMonitoredItem);
-
-                MonitoredItem stringMonitoredItem = new MonitoredItem(subscription.DefaultItem);
-                // String Node - Objects\CTT\Scalar\Simulation\String
-                stringMonitoredItem.StartNodeId = new NodeId("ns=2;s=Scalar_Simulation_String");
-                stringMonitoredItem.AttributeId = Attributes.Value;
-                stringMonitoredItem.DisplayName = "String Variable";
-                stringMonitoredItem.SamplingInterval = 1000;
-                stringMonitoredItem.Notification += OnMonitoredItemNotification;
-
-                subscription.AddItem(stringMonitoredItem);
-
-                // Create the monitored items on Server side
-                subscription.ApplyChanges();
-                m_output.WriteLine("MonitoredItems created for SubscriptionId = {0}.", subscription.Id);
-            }
-            catch (Exception ex)
-            {
-                m_output.WriteLine("Subscribe error: {0}", ex.Message);
-            }
+            m_output.WriteLine("--- RECONNECTED ---");
         }
         #endregion
 
-        #region Private Methods
-        /// <summary>
-        /// Handle DataChange notifications from Server
-        /// </summary>
-        private void OnMonitoredItemNotification(MonitoredItem monitoredItem, MonitoredItemNotificationEventArgs e)
-        {
-            try
-            {
-                // Log MonitoredItem Notification event
-                MonitoredItemNotification notification = e.NotificationValue as MonitoredItemNotification;
-                m_output.WriteLine("Notification Received for Variable \"{0}\" and Value = {1}.", monitoredItem.DisplayName, notification.Value);
-            }
-            catch (Exception ex)
-            {
-                m_output.WriteLine("OnMonitoredItemNotification error: {0}", ex.Message);
-            }
-        }
-
+        #region Protected Methods
         /// <summary>
         /// Handles the certificate validation event.
         /// This event is triggered every time an untrusted certificate is received from the server.
         /// </summary>
-        private void CertificateValidation(CertificateValidator sender, CertificateValidationEventArgs e)
+        protected virtual void CertificateValidation(CertificateValidator sender, CertificateValidationEventArgs e)
         {
             bool certificateAccepted = false;
 
@@ -492,8 +327,11 @@ namespace Quickstarts
         #endregion
 
         #region Private Fields
+        private object m_lock = new object();
         private ApplicationConfiguration m_configuration;
         private Session m_session;
+        private bool m_disposed;
+        private SessionReconnectHandler m_reconnectHandler;
         private readonly TextWriter m_output;
         private readonly Action<IList, IList> m_validateResponse;
         #endregion

--- a/Applications/ConsoleReferenceClient/UAClient.cs
+++ b/Applications/ConsoleReferenceClient/UAClient.cs
@@ -249,7 +249,7 @@ namespace Quickstarts
                         {
                             Utils.LogInfo("KeepAlive status {0}, reconnecting in {1}ms.", e.Status, ReconnectPeriod);
                             m_output.WriteLine("--- RECONNECTING {0} ---", e.Status);
-                            m_reconnectHandler = new SessionReconnectHandler();
+                            m_reconnectHandler = new SessionReconnectHandler(true);
                             m_reconnectHandler.BeginReconnect(m_session, ReconnectPeriod, Client_ReconnectComplete);
                         }
                         else
@@ -260,7 +260,6 @@ namespace Quickstarts
 
                     return;
                 }
-
             }
             catch (Exception exception)
             {
@@ -281,8 +280,12 @@ namespace Quickstarts
 
             lock (m_lock)
             {
-                Utils.SilentDispose(m_session);
-                m_session = m_reconnectHandler.Session;
+                // if session recovered, Session property is null
+                if (m_reconnectHandler.Session != null)
+                {
+                    Utils.SilentDispose(m_session);
+                    m_session = m_reconnectHandler.Session;
+                }
 
                 m_reconnectHandler.Dispose();
                 m_reconnectHandler = null;

--- a/Libraries/Opc.Ua.Client/Session.cs
+++ b/Libraries/Opc.Ua.Client/Session.cs
@@ -1223,8 +1223,9 @@ namespace Opc.Ua.Client
 
                 Utils.LogInfo("Session RE-ACTIVATING session.");
 
+                RequestHeader header = new RequestHeader() { TimeoutHint = kReconnectTimeout };
                 IAsyncResult result = BeginActivateSession(
-                    null,
+                    header,
                     clientSignature,
                     null,
                     m_preferredLocales,
@@ -1233,7 +1234,7 @@ namespace Opc.Ua.Client
                     null,
                     null);
 
-                if (!result.AsyncWaitHandle.WaitOne(5000))
+                if (!result.AsyncWaitHandle.WaitOne(kReconnectTimeout / 2))
                 {
                     Utils.LogWarning("WARNING: ACTIVATE SESSION timed out. {0}/{1}", GoodPublishRequestCount, OutstandingRequestCount);
                 }
@@ -4807,6 +4808,7 @@ namespace Opc.Ua.Client
         private Timer m_keepAliveTimer;
         private long m_keepAliveCounter;
         private bool m_reconnecting;
+        private const int kReconnectTimeout = 15000;
         private LinkedList<AsyncRequestState> m_outstandingRequests;
         private readonly EndpointDescriptionCollection m_discoveryServerEndpoints;
         private readonly StringCollection m_discoveryProfileUris;

--- a/Libraries/Opc.Ua.Client/Session.cs
+++ b/Libraries/Opc.Ua.Client/Session.cs
@@ -107,6 +107,7 @@ namespace Opc.Ua.Client
 
             m_defaultSubscription = template.m_defaultSubscription;
             m_deleteSubscriptionsOnClose = template.m_deleteSubscriptionsOnClose;
+            m_transferSubscriptionsOnReconnect = template.m_transferSubscriptionsOnReconnect;
             m_sessionTimeout = template.m_sessionTimeout;
             m_maxRequestMessageSize = template.m_maxRequestMessageSize;
             m_preferredLocales = template.m_preferredLocales;
@@ -115,6 +116,10 @@ namespace Opc.Ua.Client
             m_identity = template.m_identity;
             m_keepAliveInterval = template.m_keepAliveInterval;
             m_checkDomain = template.m_checkDomain;
+            if (template.OperationTimeout > 0)
+            {
+                OperationTimeout = template.OperationTimeout;
+            }
 
             if (copyEventHandlers)
             {
@@ -253,10 +258,11 @@ namespace Opc.Ua.Client
             m_latestAcknowledgementsSent = new Dictionary<uint, uint>();
             m_identityHistory = new List<IUserIdentity>();
             m_outstandingRequests = new LinkedList<AsyncRequestState>();
-            m_keepAliveInterval = 50000;
+            m_keepAliveInterval = 5000;
             m_tooManyPublishRequests = 0;
             m_sessionName = "";
             m_deleteSubscriptionsOnClose = true;
+            m_transferSubscriptionsOnReconnect = false;
 
             m_defaultSubscription = new Subscription {
                 DisplayName = "Subscription",
@@ -347,22 +353,6 @@ namespace Opc.Ua.Client
                 }
             }
         }
-
-        /// <summary>
-        /// Dispose and stop the keep alive timer.
-        /// </summary>
-        private void DisposeKeepAliveTimer()
-        {
-            lock (SyncRoot)
-            {
-                // stop the keep alive timer.
-                if (m_keepAliveTimer != null)
-                {
-                    Utils.SilentDispose(m_keepAliveTimer);
-                    m_keepAliveTimer = null;
-                }
-            }
-        }
         #endregion
 
         #region IDisposable Members
@@ -373,7 +363,8 @@ namespace Opc.Ua.Client
         {
             if (disposing)
             {
-                DisposeKeepAliveTimer();
+                Utils.SilentDispose(m_keepAliveTimer);
+                m_keepAliveTimer = null;
 
                 Utils.SilentDispose(m_defaultSubscription);
                 m_defaultSubscription = null;
@@ -628,6 +619,19 @@ namespace Opc.Ua.Client
         {
             get { return m_deleteSubscriptionsOnClose; }
             set { m_deleteSubscriptionsOnClose = value; }
+        }
+
+        /// <summary>
+        /// If the subscriptions are transferred when a session is reconnected. 
+        /// </summary>
+        /// <remarks>
+        /// Default <c>false</c>, set to <c>true</c> if subscriptions should
+        /// be transferred after reconnect. Service must be supported by server.
+        /// </remarks>   
+        public bool TransferSubscriptionsOnReconnect
+        {
+            get { return m_transferSubscriptionsOnReconnect; }
+            set { m_transferSubscriptionsOnReconnect = value; }
         }
 
         /// <summary>
@@ -1002,15 +1006,7 @@ namespace Opc.Ua.Client
                     template.m_preferredLocales,
                     template.m_checkDomain);
 
-                // try transfer
-                if (!session.TransferSubscriptions(new SubscriptionCollection(template.Subscriptions), false))
-                {
-                    // if transfer failed, create the subscriptions.
-                    foreach (Subscription subscription in session.Subscriptions)
-                    {
-                        subscription.Create();
-                    }
-                }
+                session.RecreateSubscriptions(template.Subscriptions);
             }
             catch (Exception e)
             {
@@ -1056,15 +1052,7 @@ namespace Opc.Ua.Client
                     template.m_preferredLocales,
                     template.m_checkDomain);
 
-                // try transfer
-                if (!session.TransferSubscriptions(new SubscriptionCollection(template.Subscriptions), false))
-                {
-                    // if transfer failed, create the subscriptions.
-                    foreach (Subscription subscription in session.Subscriptions)
-                    {
-                        subscription.Create();
-                    }
-                }
+                session.RecreateSubscriptions(template.Subscriptions);
             }
             catch (Exception e)
             {
@@ -1126,7 +1114,8 @@ namespace Opc.Ua.Client
                     m_reconnecting = true;
 
                     // stop keep alives.
-                    DisposeKeepAliveTimer();
+                    Utils.SilentDispose(m_keepAliveTimer);
+                    m_keepAliveTimer = null;
                 }
 
                 // create the client signature.
@@ -3222,7 +3211,9 @@ namespace Opc.Ua.Client
 
             StatusCode result = StatusCodes.Good;
 
-            DisposeKeepAliveTimer();
+            // stop the keep alive timer.
+            Utils.SilentDispose(m_keepAliveTimer);
+            m_keepAliveTimer = null;
 
             // check if currectly connected.
             bool connected = Connected;
@@ -3459,7 +3450,7 @@ namespace Opc.Ua.Client
                             failedSubscriptionIds.Add(subscriptions[ii].TransferId);
                         }
                     }
-                    if(failedSubscriptionIds.Count > 0)
+                    if (failedSubscriptionIds.Count > 0)
                     {
                         return false;
                     }
@@ -3468,8 +3459,6 @@ namespace Opc.Ua.Client
                 {
                     Utils.LogInfo("No subscriptions. Transfersubscription skipped.");
                 }
-
-                
             }
 
             return true;
@@ -3829,7 +3818,8 @@ namespace Opc.Ua.Client
             // restart the publish timer.
             lock (SyncRoot)
             {
-                DisposeKeepAliveTimer();
+                Utils.SilentDispose(m_keepAliveTimer);
+                m_keepAliveTimer = null;
 
                 // start timer.
                 m_keepAliveTimer = new Timer(OnKeepAlive, nodesToRead, keepAliveInterval, keepAliveInterval);
@@ -4633,6 +4623,43 @@ namespace Opc.Ua.Client
         }
 
         /// <summary>
+        /// Recreate the subscriptions in a reconnected session.
+        /// Uses Transfer service if <see cref="TransferSubscriptionsOnReconnect"/> is set to <c>true</c>.
+        /// </summary>
+        /// <param name="subscriptionsTemplate">The template for the subscriptions.</param>
+        private void RecreateSubscriptions(IEnumerable<Subscription> subscriptionsTemplate)
+        {
+            bool transferred = false;
+            if (TransferSubscriptionsOnReconnect)
+            {
+                try
+                {
+                    transferred = TransferSubscriptions(new SubscriptionCollection(subscriptionsTemplate), false);
+                }
+                catch (ServiceResultException sre)
+                {
+                    Utils.LogError(sre, "Transfer subscriptions failed.");
+                }
+                catch (Exception ex)
+                {
+                    Utils.LogError(ex, "Unexpected Transfer subscriptions error.");
+                }
+            }
+
+            if (!transferred)
+            {
+                // Create the subscriptions which were not transferred.
+                foreach (Subscription subscription in Subscriptions)
+                {
+                    if (!subscription.Created)
+                    {
+                        subscription.Create();
+                    }
+                }
+            }
+        }
+
+        /// <summary>
         /// Raises an event indicating that publish has returned a notification.
         /// </summary>
         private void OnRaisePublishNotification(object state)
@@ -4750,6 +4777,7 @@ namespace Opc.Ua.Client
         private Dictionary<NodeId, DataDictionary> m_dictionaries;
         private Subscription m_defaultSubscription;
         private bool m_deleteSubscriptionsOnClose;
+        private bool m_transferSubscriptionsOnReconnect;
         private double m_sessionTimeout;
         private uint m_maxRequestMessageSize;
         private StringCollection m_preferredLocales;

--- a/Libraries/Opc.Ua.Client/Subscription.cs
+++ b/Libraries/Opc.Ua.Client/Subscription.cs
@@ -259,7 +259,9 @@ namespace Opc.Ua.Client
         }
 
         /// <summary>
-        /// The maximum number of notifications per publish request.
+        /// The life time of of the subscription in counts of
+        /// publish interval.
+        /// LifetimeCount shall be at least 3*KeepAliveCount.
         /// </summary>
         [DataMember(Order = 4)]
         public uint LifetimeCount

--- a/Libraries/Opc.Ua.Client/Subscription.cs
+++ b/Libraries/Opc.Ua.Client/Subscription.cs
@@ -839,7 +839,7 @@ namespace Opc.Ua.Client
                     session.RemoveSubscription(subscription);
                 }
 
-                // add transferreded subscription to session
+                // add transferred subscription to session
                 if (!session.AddSubscription(this))
                 {
                     Utils.LogError("SubscriptionId {0}: Failed to add transferred subscription to SessionId={1}.", Id, session.SessionId);

--- a/Stack/Opc.Ua.Core/Stack/Tcp/UaSCBinaryClientChannel.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/UaSCBinaryClientChannel.cs
@@ -644,7 +644,8 @@ namespace Opc.Ua.Bindings
                 m_reconnecting = false;
 
                 // enable reconnects.
-                m_waitBetweenReconnects = TcpMessageLimits.MinTimeBetweenReconnects;
+                m_waitBetweenReconnects = Timeout.Infinite;
+                //m_waitBetweenReconnects = TcpMessageLimits.MinTimeBetweenReconnects;
 
                 // schedule reconnect before token expires.
                 ScheduleTokenRenewal(CurrentToken);

--- a/Stack/Opc.Ua.Core/Stack/Tcp/UaSCBinaryClientChannel.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/UaSCBinaryClientChannel.cs
@@ -643,9 +643,9 @@ namespace Opc.Ua.Bindings
                 State = TcpChannelState.Open;
                 m_reconnecting = false;
 
-                // enable reconnects.
+                // enable reconnects. DO NOT USE! 
+                // m_waitBetweenReconnects = TcpMessageLimits.MinTimeBetweenReconnects;
                 m_waitBetweenReconnects = Timeout.Infinite;
-                //m_waitBetweenReconnects = TcpMessageLimits.MinTimeBetweenReconnects;
 
                 // schedule reconnect before token expires.
                 ScheduleTokenRenewal(CurrentToken);


### PR DESCRIPTION
## Proposed changes
- set `KeepAliveTimeout` default back to 5s, was unintentionally set to 50s in 368 release
- fix a bug that duplicate subscriptions were created after reconnect when transfer succeeds.
- add a property to enable subscription transfer in reconnect, set `Session.TransferSubscriptionsOnReconnect=true` to enable, IOP issues may not allow to use it with some servers.
- add a `SessionReconnectHandler(true)` constructor to support reconnect abort, if the connection recovers before reconnect timer called. If the new constructor is used, its a breaking change: Needs check of  `Session` property in Reconnect handler callback, if aborted `Session==null`.
- Reduce warning log output if server timestamp > client time.
- Add handling when subscriptions can not be transferred, e.g. when false user credentials or no security prevent transfer.
- Improve the reconnect timer handling by using `OperationLimit` in reconnect.
- Add sample for `SessionReconnectHandler` in console client.
- Seperate session sample code from `UAClient`.
- Tested on popular demo servers of various SDK vendors.
- Fix Winforms ref client

## Related Issues

- Fixes #1796, #1783

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [x] I ran tests locally with my changes, all passed.
- [x] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [x] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

Mostly rolling behavior back to 367 release, only if the `Session.TransferSubscriptionsOnReconnect=true` feature is enabled the Transfer subscription service is tried to recover a subscription.
