### PR TITLE
InstanceStateSnapshot sets value of Handle when Initialize is called to "state" argument.

### DIFF
--- a/Stack/Opc.Ua.Core/Stack/State/BaseInstanceStateSnapshot.cs
+++ b/Stack/Opc.Ua.Core/Stack/State/BaseInstanceStateSnapshot.cs
@@ -42,6 +42,7 @@ namespace Opc.Ua
         {
             m_typeDefinitionId = state.TypeDefinitionId;
             m_snapshot = CreateChildNode(context, state);
+            m_handle = state;
         }
 
         /// <summary>

--- a/Stack/Opc.Ua.Core/Stack/State/ConditionState.cs
+++ b/Stack/Opc.Ua.Core/Stack/State/ConditionState.cs
@@ -416,7 +416,6 @@ namespace Opc.Ua
                 if (EventsMonitored())
                 {
                     InstanceStateSnapshot snapshot = new InstanceStateSnapshot();
-                    snapshot.Handle = this;
                     snapshot.Initialize(context, this);
                     ReportEvent(context, snapshot);
                 }


### PR DESCRIPTION
## Proposed changes

Automatically set the value of Handle to the provided "state" argument when InstanceStateSnapshot.Initialize(...) method is called, for convenience reasons.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [x] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

The change is provided to spare the user from setting the Handle value in a separate statement which might be skipped/ignored.
The Handle value is used in the process of validating role permissions for the hold state (ConditionState instance).
