### PR TITLE
Adding UnregisterNamespaceManager support to MasterNodeManager

### DIFF
--- a/Libraries/Opc.Ua.Server/NodeManager/MasterNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/NodeManager/MasterNodeManager.cs
@@ -2795,6 +2795,11 @@ namespace Opc.Ua.Server
         }
 
         /// <summary>
+        /// The namespace managers being managed
+        /// </summary>
+        internal INodeManager[][] NamespaceManagers => m_namespaceManagers;
+
+        /// <summary>
         /// Validates a monitoring attributes parameter.
         /// </summary>
         protected static ServiceResult ValidateMonitoringAttributes(MonitoringParameters attributes)

--- a/Tests/Opc.Ua.Server.Tests/MasterNodeManagerTests.cs
+++ b/Tests/Opc.Ua.Server.Tests/MasterNodeManagerTests.cs
@@ -28,7 +28,6 @@
  * ======================================================================*/
 
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using Moq;
 using NUnit.Framework;

--- a/Tests/Opc.Ua.Server.Tests/MasterNodeManagerTests.cs
+++ b/Tests/Opc.Ua.Server.Tests/MasterNodeManagerTests.cs
@@ -1,0 +1,269 @@
+/* ========================================================================
+ * Copyright (c) 2005-2020 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Moq;
+using NUnit.Framework;
+
+namespace Opc.Ua.Server.Tests
+{
+    /// <summary>
+    /// Test <see cref="MasterNodeManager"/>
+    /// </summary>
+    [TestFixture, Category("MasterNodeManager")]
+    [SetCulture("en-us"), SetUICulture("en-us")]
+    [Parallelizable]
+    public class MasterNodeManagerTests
+    {
+        #region Test Methods
+        /// <summary>
+        /// Test for registering a namespace manager for a namespace
+        /// not contained in the server's namespace table
+        /// </summary>
+        [Test]
+        public async Task RegisterNamespaceManagerNewNamespace()
+        {
+            var fixture = new ServerFixture<StandardServer>();
+
+            try
+            {
+                //-- Arrange
+                const string ns = "http://test.org/UA/Data/";
+
+                var nodeManager = new Mock<INodeManager>();
+                nodeManager.Setup(x => x.NamespaceUris).Returns(new List<string>());
+
+                //-- Act
+                var server = await fixture.StartAsync(TestContext.Out).ConfigureAwait(false);
+                var sut = new MasterNodeManager(
+                    server.CurrentInstance,
+                    fixture.Config,
+                    null,
+                    nodeManager.Object);
+                sut.RegisterNamespaceManager(ns, nodeManager.Object);
+
+                //-- Assert
+                Assert.Contains(ns, server.CurrentInstance.NamespaceUris.ToArray());
+                var registeredManagers = sut.NamespaceManagers[server.CurrentInstance.NamespaceUris.GetIndex(ns)];
+                Assert.AreEqual(1, registeredManagers.Length);
+                Assert.Contains(nodeManager.Object, registeredManagers);
+            }
+            finally
+            {
+                await fixture.StopAsync().ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
+        /// Test for registering a namespace manager for a namespace
+        /// contained in the server's namespace table
+        /// </summary>
+        [Test]
+        public async Task RegisterNamespaceManagerExistingNamespace()
+        {
+            var fixture = new ServerFixture<StandardServer>();
+
+            try
+            {
+                //-- Arrange
+                const string ns = "http://test.org/UA/Data/";
+                var namespaceUris = new List<string> { ns };
+
+                var originalNodeManager = new Mock<INodeManager>();
+                originalNodeManager.Setup(x => x.NamespaceUris).Returns(namespaceUris);
+
+                var newNodeManager = new Mock<INodeManager>();
+                newNodeManager.Setup(x => x.NamespaceUris).Returns(namespaceUris);
+
+                //-- Act
+                var server = await fixture.StartAsync(TestContext.Out).ConfigureAwait(false);
+                var sut = new MasterNodeManager(
+                    server.CurrentInstance,
+                    fixture.Config,
+                    null,
+                    originalNodeManager.Object);
+                sut.RegisterNamespaceManager(ns, newNodeManager.Object);
+
+                //-- Assert
+                Assert.Contains(ns, server.CurrentInstance.NamespaceUris.ToArray());
+                var registeredManagers = sut.NamespaceManagers[server.CurrentInstance.NamespaceUris.GetIndex(ns)];
+                Assert.AreEqual(2, registeredManagers.Length);
+                Assert.Contains(originalNodeManager.Object, registeredManagers);
+                Assert.Contains(newNodeManager.Object, registeredManagers);
+            }
+            finally
+            {
+                await fixture.StopAsync().ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
+        /// Test for unregistering a namespace manager which had previously
+        /// been registered
+        /// </summary>
+        [Test]
+        public async Task UnregisterNamespaceManagerInCollection()
+        {
+            var fixture = new ServerFixture<StandardServer>();
+
+            try
+            {
+                //-- Arrange
+                const string ns = "http://test.org/UA/Data/";
+                var namespaceUris = new List<string> { ns };
+
+                var firstNodeManager = new Mock<INodeManager>();
+                firstNodeManager.Setup(x => x.NamespaceUris).Returns(namespaceUris);
+
+                var secondNodeManager = new Mock<INodeManager>();
+                secondNodeManager.Setup(x => x.NamespaceUris).Returns(namespaceUris);
+
+                var thirdNodeManager = new Mock<INodeManager>();
+                thirdNodeManager.Setup(x => x.NamespaceUris).Returns(namespaceUris);
+
+                //-- Act
+                var server = await fixture.StartAsync(TestContext.Out).ConfigureAwait(false);
+                var sut = new MasterNodeManager(
+                    server.CurrentInstance,
+                    fixture.Config,
+                    null,
+                    firstNodeManager.Object,
+                    secondNodeManager.Object,
+                    thirdNodeManager.Object);
+                sut.UnregisterNamespaceManager(ns, secondNodeManager.Object);
+
+                //-- Assert
+                Assert.Contains(ns, server.CurrentInstance.NamespaceUris.ToArray());
+                var registeredManagers = sut.NamespaceManagers[server.CurrentInstance.NamespaceUris.GetIndex(ns)];
+                Assert.AreEqual(2, registeredManagers.Length);
+                Assert.Contains(firstNodeManager.Object, registeredManagers);
+                Assert.Contains(thirdNodeManager.Object, registeredManagers);
+            }
+            finally
+            {
+                await fixture.StopAsync().ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
+        /// Test for unregistering a namespace manager which had not
+        /// previously been registered
+        /// </summary>
+        [Test]
+        public async Task UnregisterNamespaceManagerNotInCollection()
+        {
+            var fixture = new ServerFixture<StandardServer>();
+
+            try
+            {
+                //-- Arrange
+                const string ns = "http://test.org/UA/Data/";
+                var namespaceUris = new List<string> { ns };
+
+                var firstNodeManager = new Mock<INodeManager>();
+                firstNodeManager.Setup(x => x.NamespaceUris).Returns(namespaceUris);
+
+                var secondNodeManager = new Mock<INodeManager>();
+                secondNodeManager.Setup(x => x.NamespaceUris).Returns(namespaceUris);
+
+                var thirdNodeManager = new Mock<INodeManager>();
+                thirdNodeManager.Setup(x => x.NamespaceUris).Returns(namespaceUris);
+
+                //-- Act
+                var server = await fixture.StartAsync(TestContext.Out).ConfigureAwait(false);
+                var sut = new MasterNodeManager(
+                    server.CurrentInstance,
+                    fixture.Config,
+                    null,
+                    firstNodeManager.Object,
+                    // Do not add the secondNodeManager to additionalManagers
+                    thirdNodeManager.Object);
+                sut.UnregisterNamespaceManager(ns, secondNodeManager.Object);
+
+                //-- Assert
+                Assert.Contains(ns, server.CurrentInstance.NamespaceUris.ToArray());
+                var registeredManagers = sut.NamespaceManagers[server.CurrentInstance.NamespaceUris.GetIndex(ns)];
+                Assert.AreEqual(2, registeredManagers.Length);
+                Assert.Contains(firstNodeManager.Object, registeredManagers);
+                Assert.Contains(thirdNodeManager.Object, registeredManagers);
+            }
+            finally
+            {
+                await fixture.StopAsync().ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
+        /// Test for unregistering a namespace manager which had not
+        /// previously been registered and is for a namespace
+        /// which is unknown by the server
+        /// </summary>
+        [Test]
+        public async Task UnregisterNamespaceManagerUnknownNamespace()
+        {
+            var fixture = new ServerFixture<StandardServer>();
+
+            try
+            {
+                //-- Arrange
+                const string originalNs = "http://test.org/UA/Data/";
+
+                var originalNodeManager = new Mock<INodeManager>();
+                originalNodeManager.Setup(x => x.NamespaceUris).Returns(new List<string> { originalNs });
+
+                const string newNs = "http://test.org/UA/Data/Instance";
+                var newNodeManager = new Mock<INodeManager>();
+                newNodeManager.Setup(x => x.NamespaceUris).Returns(new List<string> { originalNs, newNs });
+
+                //-- Act
+                var server = await fixture.StartAsync(TestContext.Out).ConfigureAwait(false);
+                var sut = new MasterNodeManager(
+                    server.CurrentInstance,
+                    fixture.Config,
+                    null,
+                    originalNodeManager.Object);
+                sut.UnregisterNamespaceManager(newNs, newNodeManager.Object);
+
+                //-- Assert
+                Assert.That(server.CurrentInstance.NamespaceUris.ToArray(), Has.No.Member(newNs));
+
+                Assert.Contains(originalNs, server.CurrentInstance.NamespaceUris.ToArray());
+                var registeredManagers = sut.NamespaceManagers[server.CurrentInstance.NamespaceUris.GetIndex(originalNs)];
+                Assert.AreEqual(1, registeredManagers.Length);
+                Assert.Contains(originalNodeManager.Object, registeredManagers);
+            }
+            finally
+            {
+                await fixture.StopAsync().ConfigureAwait(false);
+            }
+        }
+        #endregion
+    }
+}

--- a/Tests/Opc.Ua.Server.Tests/MasterNodeManagerTests.cs
+++ b/Tests/Opc.Ua.Server.Tests/MasterNodeManagerTests.cs
@@ -157,9 +157,10 @@ namespace Opc.Ua.Server.Tests
                     firstNodeManager.Object,
                     secondNodeManager.Object,
                     thirdNodeManager.Object);
-                sut.UnregisterNamespaceManager(ns, secondNodeManager.Object);
+                var result = sut.UnregisterNamespaceManager(ns, secondNodeManager.Object);
 
                 //-- Assert
+                Assert.IsTrue(result);
                 Assert.Contains(ns, server.CurrentInstance.NamespaceUris.ToArray());
                 var registeredManagers = sut.NamespaceManagers[server.CurrentInstance.NamespaceUris.GetIndex(ns)];
                 Assert.AreEqual(2, registeredManagers.Length);
@@ -205,9 +206,10 @@ namespace Opc.Ua.Server.Tests
                     firstNodeManager.Object,
                     // Do not add the secondNodeManager to additionalManagers
                     thirdNodeManager.Object);
-                sut.UnregisterNamespaceManager(ns, secondNodeManager.Object);
+                var result = sut.UnregisterNamespaceManager(ns, secondNodeManager.Object);
 
                 //-- Assert
+                Assert.IsFalse(result);
                 Assert.Contains(ns, server.CurrentInstance.NamespaceUris.ToArray());
                 var registeredManagers = sut.NamespaceManagers[server.CurrentInstance.NamespaceUris.GetIndex(ns)];
                 Assert.AreEqual(2, registeredManagers.Length);
@@ -249,9 +251,10 @@ namespace Opc.Ua.Server.Tests
                     fixture.Config,
                     null,
                     originalNodeManager.Object);
-                sut.UnregisterNamespaceManager(newNs, newNodeManager.Object);
+                var result = sut.UnregisterNamespaceManager(newNs, newNodeManager.Object);
 
                 //-- Assert
+                Assert.IsFalse(result);
                 Assert.That(server.CurrentInstance.NamespaceUris.ToArray(), Has.No.Member(newNs));
 
                 Assert.Contains(originalNs, server.CurrentInstance.NamespaceUris.ToArray());

--- a/Tests/Opc.Ua.Server.Tests/Opc.Ua.Server.Tests.csproj
+++ b/Tests/Opc.Ua.Server.Tests/Opc.Ua.Server.Tests.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="Moq" Version="4.18.1" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit.Console" Version="3.15.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1">


### PR DESCRIPTION
## Proposed changes

This new function provides the ability to undo changes to the private `m_namespaceManagers` field made by calls to `RegisterNamespaceManager`. 

This functionality is needed if we intend to support "on the fly" changes to the Node Managers and Namespace Managers that are owned by the `MasterNodeManager`.

## Related Issues

Potentially related to:
- https://github.com/OPCFoundation/UA-.NETStandard/issues/1299
- https://github.com/OPCFoundation/UA-.NETStandard/issues/1616

## Types of changes

What types of changes does your code introduce?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [x] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [x] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [x] I have added necessary documentation (if appropriate).
- [x] Any dependent changes have been merged and published in downstream modules.

## Further comments

N/A
