### PR TITLE
Refactor audit events

### DIFF
--- a/Applications/ConsoleReferenceServer/Quickstarts.ReferenceServer.Config.xml
+++ b/Applications/ConsoleReferenceServer/Quickstarts.ReferenceServer.Config.xml
@@ -270,7 +270,7 @@
       <MaxNodesPerNodeManagement>2500</MaxNodesPerNodeManagement>
       <MaxMonitoredItemsPerCall>2500</MaxMonitoredItemsPerCall>
     </OperationLimits>
-
+    <AuditingEnabled>true</AuditingEnabled>
   </ServerConfiguration>
 
   <Extensions>

--- a/Applications/Quickstarts.Servers/Alarms/AlarmNodeManager.cs
+++ b/Applications/Quickstarts.Servers/Alarms/AlarmNodeManager.cs
@@ -555,7 +555,7 @@ namespace Alarms
                 }
             }
 
-            return Opc.Ua.StatusCodes.Good;
+            return StatusCodes.Good;
         }
 
         #endregion
@@ -714,8 +714,8 @@ namespace Alarms
             {
                 CallMethodRequest methodToCall = methodsToCall[ii];
 
-                bool refreshMethod = methodToCall.MethodId.Equals(Opc.Ua.MethodIds.ConditionType_ConditionRefresh) ||
-                    methodToCall.MethodId.Equals(Opc.Ua.MethodIds.ConditionType_ConditionRefresh2);
+                bool refreshMethod = methodToCall.MethodId.Equals(MethodIds.ConditionType_ConditionRefresh) ||
+                    methodToCall.MethodId.Equals(MethodIds.ConditionType_ConditionRefresh2);
 
                 if (refreshMethod)
                 {
@@ -731,13 +731,13 @@ namespace Alarms
                     }
                 }
 
-                bool ackMethod = methodToCall.MethodId.Equals(Opc.Ua.MethodIds.AcknowledgeableConditionType_Acknowledge);
-                bool confirmMethod = methodToCall.MethodId.Equals(Opc.Ua.MethodIds.AcknowledgeableConditionType_Confirm);
-                bool commentMethod = methodToCall.MethodId.Equals(Opc.Ua.MethodIds.ConditionType_AddComment);
+                bool ackMethod = methodToCall.MethodId.Equals(MethodIds.AcknowledgeableConditionType_Acknowledge);
+                bool confirmMethod = methodToCall.MethodId.Equals(MethodIds.AcknowledgeableConditionType_Confirm);
+                bool commentMethod = methodToCall.MethodId.Equals(MethodIds.ConditionType_AddComment);
                 bool ackConfirmMethod = ackMethod || confirmMethod || commentMethod;
 
                 // Need to try to capture any calls to ConditionType::Acknowledge
-                if (methodToCall.ObjectId.Equals(Opc.Ua.ObjectTypeIds.ConditionType) && (ackConfirmMethod))
+                if (methodToCall.ObjectId.Equals(ObjectTypeIds.ConditionType) && (ackConfirmMethod))
                 {
                     // Mantis Issue 6944 which is a duplicate of 5544 - result is Confirm should be Bad_NodeIdInvalid
                     // Override any other errors that may be there, even if this is 'Processed'
@@ -937,8 +937,8 @@ namespace Alarms
         private bool IsAckConfirm(NodeId methodId)
         {
             bool isAckConfirm = false;
-            if (methodId.Equals(Opc.Ua.MethodIds.AcknowledgeableConditionType_Acknowledge) ||
-                 methodId.Equals(Opc.Ua.MethodIds.AcknowledgeableConditionType_Confirm))
+            if (methodId.Equals(MethodIds.AcknowledgeableConditionType_Acknowledge) ||
+                 methodId.Equals(MethodIds.AcknowledgeableConditionType_Confirm))
             {
                 isAckConfirm = true;
 

--- a/Applications/Quickstarts.Servers/ReferenceServer/ReferenceNodeManager.cs
+++ b/Applications/Quickstarts.Servers/ReferenceServer/ReferenceNodeManager.cs
@@ -28,15 +28,15 @@
  * ======================================================================*/
 
 using System;
-using System.Diagnostics;
 using System.Collections.Generic;
-using System.Xml;
-using System.Threading;
+using System.Diagnostics;
 using System.Numerics;
+using System.Threading;
+using System.Xml;
 using Opc.Ua;
 using Opc.Ua.Server;
-using Range = Opc.Ua.Range;
 using Opc.Ua.Test;
+using Range = Opc.Ua.Range;
 
 namespace Quickstarts.ReferenceServer
 {
@@ -801,10 +801,10 @@ namespace Quickstarts.ReferenceServer
                     };
                     variables.Add(rpAuthenticatedUser);
 
-                    BaseDataVariableState rpAdminUser = CreateVariable(folderRolePermissions, rolePermissions + "AdminUser", "AdminUser", BuiltInType.Int16, ValueRanks.Scalar);
-                    rpAdminUser.Description = "This node can be accessed by users that have SecurityAdmin Role over an encrypted connection";
-                    rpAdminUser.AccessRestrictions = AccessRestrictionType.EncryptionRequired;
-                    rpAdminUser.RolePermissions = new RolePermissionTypeCollection()
+                    BaseDataVariableState rpSecurityAdminUser = CreateVariable(folderRolePermissions, rolePermissions + "SecurityAdmin", "SecurityAdmin", BuiltInType.Int16, ValueRanks.Scalar);
+                    rpSecurityAdminUser.Description = "This node can be accessed by users that have SecurityAdmin Role over an encrypted connection";
+                    rpSecurityAdminUser.AccessRestrictions = AccessRestrictionType.EncryptionRequired;
+                    rpSecurityAdminUser.RolePermissions = new RolePermissionTypeCollection()
                     {
                         // allow access to users with SecurityAdmin role
                         new RolePermissionType()
@@ -813,7 +813,21 @@ namespace Quickstarts.ReferenceServer
                             Permissions = (uint)(PermissionType.Browse |PermissionType.Read|PermissionType.ReadRolePermissions | PermissionType.Write)
                         },
                     };
-                    variables.Add(rpAdminUser);
+                    variables.Add(rpSecurityAdminUser);
+
+                    BaseDataVariableState rpConfigAdminUser = CreateVariable(folderRolePermissions, rolePermissions + "ConfigureAdmin", "ConfigureAdmin", BuiltInType.Int16, ValueRanks.Scalar);
+                    rpConfigAdminUser.Description = "This node can be accessed by users that have ConfigureAdmin Role over an encrypted connection";
+                    rpConfigAdminUser.AccessRestrictions = AccessRestrictionType.EncryptionRequired;
+                    rpConfigAdminUser.RolePermissions = new RolePermissionTypeCollection()
+                    {
+                        // allow access to users with ConfigureAdmin role
+                        new RolePermissionType()
+                        {
+                            RoleId = ObjectIds.WellKnownRole_ConfigureAdmin,
+                            Permissions = (uint)(PermissionType.Browse |PermissionType.Read|PermissionType.ReadRolePermissions | PermissionType.Write)
+                        },
+                    };
+                    variables.Add(rpConfigAdminUser);
 
                     // sub-folder for "AccessRestrictions"
                     FolderState folderAccessRestrictions = CreateFolder(folderAccessRights, "AccessRights_AccessRestrictions", "AccessRestrictions");

--- a/Applications/ReferenceServer/Quickstarts.ReferenceServer.Config.xml
+++ b/Applications/ReferenceServer/Quickstarts.ReferenceServer.Config.xml
@@ -264,9 +264,26 @@
       <MaxNodesPerTranslateBrowsePathsToNodeIds>1000</MaxNodesPerTranslateBrowsePathsToNodeIds>
       <MaxMonitoredItemsPerCall>1000</MaxMonitoredItemsPerCall>
     </OperationLimits>
+    <AuditingEnabled>true</AuditingEnabled>
   </ServerConfiguration>
 
   <Extensions>
+    <ua:XmlElement>
+      <MemoryBufferConfiguration xmlns="http://samples.org/UA/MemoryBuffer">
+        <Buffers>
+          <MemoryBufferInstance>
+            <Name>UInt32</Name>
+            <TagCount>100</TagCount>
+            <DataType>UInt32</DataType>
+          </MemoryBufferInstance>
+          <MemoryBufferInstance>
+            <Name>Double</Name>
+            <TagCount>100</TagCount>
+            <DataType>Double</DataType>
+          </MemoryBufferInstance>
+        </Buffers>
+      </MemoryBufferConfiguration>
+    </ua:XmlElement>
     <ua:XmlElement>
       <!-- For CTT testing set ShowCertificateValidationDialog to false -->
       <ReferenceServerConfiguration xmlns="http://opcfoundation.org/Quickstarts/ReferenceServer">

--- a/Libraries/Opc.Ua.Configuration/ApplicationConfigurationBuilder.cs
+++ b/Libraries/Opc.Ua.Configuration/ApplicationConfigurationBuilder.cs
@@ -661,6 +661,13 @@ namespace Opc.Ua.Configuration
         }
 
         /// <inheritdoc/>
+        public IApplicationConfigurationBuilderServerOptions SetAuditingEnabled(bool auditingEnabled)
+        {
+            ApplicationConfiguration.ServerConfiguration.AuditingEnabled = auditingEnabled;
+            return this;
+        }
+
+        /// <inheritdoc/>
         public IApplicationConfigurationBuilderClientOptions SetDefaultSessionTimeout(int defaultSessionTimeout)
         {
             ApplicationConfiguration.ClientConfiguration.DefaultSessionTimeout = defaultSessionTimeout;

--- a/Libraries/Opc.Ua.Configuration/IApplicationConfigurationBuilder.cs
+++ b/Libraries/Opc.Ua.Configuration/IApplicationConfigurationBuilder.cs
@@ -246,6 +246,9 @@ namespace Opc.Ua.Configuration
 
         /// <inheritdoc cref="ServerConfiguration.OperationLimits"/>
         IApplicationConfigurationBuilderServerOptions SetOperationLimits(OperationLimits operationLimits);
+
+        /// <inheritdoc cref="ServerConfiguration.AuditingEnabled"/>
+        IApplicationConfigurationBuilderServerOptions SetAuditingEnabled(bool auditingEnabled);
     }
 
     /// <summary>

--- a/Libraries/Opc.Ua.Server/Diagnostics/AuditEvents.cs
+++ b/Libraries/Opc.Ua.Server/Diagnostics/AuditEvents.cs
@@ -1,0 +1,1419 @@
+/* ========================================================================
+ * Copyright (c) 2005-2022 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Security.Cryptography.X509Certificates;
+
+namespace Opc.Ua.Server
+{
+    /// <summary>
+    /// An interface to report audit events in the server.
+    /// </summary>
+    public interface IAuditEventServer
+    {
+        /// <summary>
+        /// If auditing is enabled.
+        /// </summary>
+        bool Auditing { get; }
+
+        /// <summary>
+        /// The default system context for the audit events.
+        /// </summary>
+        ISystemContext DefaultAuditContext { get; }
+
+        /// <summary>
+        /// Called by any component to report an audit event.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="e">The event.</param>
+        void ReportAuditEvent(ISystemContext context, IFilterTarget e);
+    }
+
+    /// <summary>
+    /// The implementation of audit events.
+    /// </summary>
+    public static class AuditEvents
+    {
+        #region Report Audit Events
+        /// <summary>
+        /// Report Audit event
+        /// </summary>
+        /// <param name="server">The server which reports audit events.</param>
+        /// <param name="operationContext">Client operation info</param>
+        /// <param name="methodName">Audit method name</param>
+        /// <param name="serviceResultException">The service exception that includes also a status code</param>
+        public static void ReportAuditEvent(
+            this IAuditEventServer server,
+            OperationContext operationContext,
+            string methodName,
+            ServiceResultException serviceResultException)
+        {
+            if (server?.Auditing != true)
+            {
+                // current server does not support auditing
+                return;
+            }
+
+            try
+            {
+                ISystemContext systemContext = server.DefaultAuditContext;
+
+                AuditEventState e = new AuditEventState(null);
+
+                TranslationInfo message = new TranslationInfo(
+                   "AuditEvent",
+                   "en-US",
+                   $"Method {methodName} failed. Result: {serviceResultException.Message}.");
+
+                e.Initialize(
+                   systemContext,
+                   null,
+                   EventSeverity.Min,
+                   new LocalizedText(message),
+                   StatusCode.IsGood(serviceResultException.StatusCode),
+                   DateTime.UtcNow);  // initializes Status, ActionTimeStamp, ServerId, ClientAuditEntryId, ClientUserId
+
+                e.SetChildValue(systemContext, BrowseNames.SourceNode, ObjectIds.Server, false);
+                e.SetChildValue(systemContext, BrowseNames.SourceName, $"Attribute/{methodName}", false);
+                e.SetChildValue(systemContext, BrowseNames.LocalTime, Utils.GetTimeZoneInfo(), false);
+
+                e.SetChildValue(systemContext, BrowseNames.ClientUserId, operationContext?.UserIdentity?.DisplayName, false);
+                e.SetChildValue(systemContext, BrowseNames.ClientAuditEntryId, operationContext?.AuditEntryId, false);
+
+                server.ReportAuditEvent(systemContext, e);
+            }
+            catch (Exception ex)
+            {
+                Utils.LogError(ex, "Error while reporting AuditEvent event.");
+            }
+        }
+
+        /// <summary>
+        /// Reports an AuditWriteUpdate event.
+        /// </summary>
+        /// <param name="server">The server which reports audit events.</param>
+        /// <param name="systemContext">The current system context.</param>
+        /// <param name="writeValue">The value to write.</param>
+        /// <param name="oldValue">The old value of the node.</param>
+        /// <param name="statusCode">The resulted status code.</param>
+        public static void ReportAuditWriteUpdateEvent(
+            this IAuditEventServer server,
+            SystemContext systemContext,
+            WriteValue writeValue,
+            object oldValue,
+            StatusCode statusCode)
+        {
+            if (server?.Auditing != true)
+            {
+                // current server does not support auditing
+                return;
+            }
+
+            if (systemContext?.OperationContext == null || systemContext?.UserIdentity == null)
+            {
+                return;
+            }
+
+            try
+            {
+                AuditWriteUpdateEventState e = new AuditWriteUpdateEventState(null);
+
+                TranslationInfo message = new TranslationInfo(
+                   "AuditWriteUpdateEvent",
+                    "en-US",
+                    "AuditWriteUpdateEvent.");
+
+                e.Initialize(
+                   systemContext,
+                   null,
+                   EventSeverity.Min,
+                   new LocalizedText(message),
+                   StatusCode.IsGood(statusCode),
+                   DateTime.UtcNow);  // initializes Status, ActionTimeStamp, ServerId, ClientAuditEntryId, ClientUserId
+
+                e.SetChildValue(systemContext, BrowseNames.SourceNode, writeValue.NodeId, false);
+                e.SetChildValue(systemContext, BrowseNames.SourceName, "Attribute/Write", false);
+                e.SetChildValue(systemContext, BrowseNames.LocalTime, Utils.GetTimeZoneInfo(), false);
+
+                e.SetChildValue(systemContext, BrowseNames.ClientUserId, systemContext?.UserIdentity?.DisplayName, false);
+                e.SetChildValue(systemContext, BrowseNames.ClientAuditEntryId, systemContext?.AuditEntryId, false);
+
+                e.SetChildValue(systemContext, BrowseNames.AttributeId, writeValue.AttributeId, false);
+                e.SetChildValue(systemContext, BrowseNames.IndexRange, writeValue.IndexRange, false);
+
+                object newValue = writeValue.Value?.Value;
+                if (writeValue.ParsedIndexRange != NumericRange.Empty)
+                {
+                    writeValue.ParsedIndexRange.UpdateRange(ref newValue, writeValue.Value?.Value);
+                }
+
+                e.SetChildValue(systemContext, BrowseNames.NewValue, newValue, false);
+                e.SetChildValue(systemContext, BrowseNames.OldValue, oldValue, false);
+
+                server.ReportAuditEvent(systemContext, e);
+            }
+            catch (Exception ex)
+            {
+                Utils.LogError(ex, "Error while reporting AuditWriteUpdateEvent event.");
+            }
+        }
+
+        /// <summary>
+        /// Reports an AuditHistoryValueUpdate event.
+        /// </summary>
+        /// <param name="server">The server which reports audit events.</param>
+        /// <param name="systemContext">The current system context.</param>
+        /// <param name="updateDataDetails">Update data details</param>
+        /// <param name="oldValues">The old values</param>
+        /// <param name="statusCode">The resulting status code</param>
+        public static void ReportAuditHistoryValueUpdateEvent(
+            this IAuditEventServer server,
+            ISystemContext systemContext,
+            UpdateDataDetails updateDataDetails,
+            DataValue[] oldValues,
+            StatusCode statusCode)
+        {
+            if (server?.Auditing != true)
+            {
+                // current server does not support auditing
+                return;
+            }
+
+            try
+            {
+                AuditHistoryValueUpdateEventState e = new AuditHistoryValueUpdateEventState(null);
+
+                InitializeAuditHistoryUpdateEvent(e,
+                        systemContext,
+                        "AuditHistoryValueUpdateEvent",
+                        "Attribute/HistoryValueUpdate",
+                        updateDataDetails,
+                        statusCode);
+
+                e.SetChildValue(systemContext, BrowseNames.UpdatedNode, updateDataDetails.NodeId, false);
+                e.SetChildValue(systemContext, BrowseNames.PerformInsertReplace, updateDataDetails.PerformInsertReplace, false);
+                e.SetChildValue(systemContext, BrowseNames.NewValues, updateDataDetails.UpdateValues.ToArray(), false);
+                e.SetChildValue(systemContext, BrowseNames.OldValues, oldValues, false);
+
+                server.ReportAuditEvent(systemContext, e);
+            }
+            catch (Exception ex)
+            {
+                Utils.LogError(ex, "Error while reporting AuditHistoryValueUpdateEvent event.");
+            }
+        }
+
+        /// <summary>
+        /// Reports an AuditHistoryValueUpdate event.
+        /// </summary>
+        /// <param name="server">The server which reports audit events.</param>
+        /// <param name="systemContext">The current system context.</param>
+        /// <param name="updateStructureDataDetails">Update structure data details</param>
+        /// <param name="oldValues">The old values</param>
+        /// <param name="statusCode">The resulting status code</param>
+        public static void ReportAuditHistoryAnnotationUpdateEvent(
+            this IAuditEventServer server,
+            ISystemContext systemContext,
+            UpdateStructureDataDetails updateStructureDataDetails,
+            DataValue[] oldValues,
+            StatusCode statusCode)
+        {
+            if (server?.Auditing != true)
+            {
+                // current server does not support auditing
+                return;
+            }
+
+            try
+            {
+                AuditHistoryAnnotationUpdateEventState e = new AuditHistoryAnnotationUpdateEventState(null);
+
+                InitializeAuditHistoryUpdateEvent(e,
+                    systemContext,
+                    "AuditHistoryAnnotationUpdateEvent",
+                    "Attribute/HistoryAnnotationUpdate",
+                    updateStructureDataDetails,
+                    statusCode);
+
+                e.SetChildValue(systemContext, BrowseNames.PerformInsertReplace, updateStructureDataDetails.PerformInsertReplace, false);
+                e.SetChildValue(systemContext, BrowseNames.NewValues, updateStructureDataDetails.UpdateValues?.ToArray(), false);
+                e.SetChildValue(systemContext, BrowseNames.OldValues, oldValues, false);
+
+                server.ReportAuditEvent(systemContext, e);
+            }
+            catch (Exception ex)
+            {
+                Utils.LogError(ex, "Error while reporting AuditHistoryValueUpdateEvent event.");
+            }
+        }
+
+        /// <summary>
+        /// Reports an AuditHistoryEventUpdate event.
+        /// </summary>
+        /// <param name="server">The server which reports audit events.</param>
+        /// <param name="systemContext">The current system context.</param>
+        /// <param name="updateEventDetails">Update event details</param>
+        /// <param name="oldValues">The old values</param>
+        /// <param name="statusCode">The resulting status code</param>
+        public static void ReportAuditHistoryEventUpdateEvent(
+            this IAuditEventServer server,
+            ISystemContext systemContext,
+            UpdateEventDetails updateEventDetails,
+            HistoryEventFieldList[] oldValues,
+            StatusCode statusCode)
+        {
+            if (server?.Auditing != true)
+            {
+                // current server does not support auditing
+                return;
+            }
+
+            try
+            {
+                AuditHistoryEventUpdateEventState e = new AuditHistoryEventUpdateEventState(null);
+
+                InitializeAuditHistoryUpdateEvent(e,
+                    systemContext,
+                    "AuditHistoryEventUpdateEvent",
+                    "Attribute/HistoryEventUpdate",
+                    updateEventDetails,
+                    statusCode);
+
+                e.SetChildValue(systemContext, BrowseNames.UpdatedNode, updateEventDetails.NodeId, false);
+                e.SetChildValue(systemContext, BrowseNames.PerformInsertReplace, updateEventDetails.PerformInsertReplace, false);
+                e.SetChildValue(systemContext, BrowseNames.Filter, updateEventDetails.Filter, false);
+                e.SetChildValue(systemContext, BrowseNames.NewValues, updateEventDetails.EventData.ToArray(), false);
+                e.SetChildValue(systemContext, BrowseNames.OldValues, oldValues, false);
+
+                server.ReportAuditEvent(systemContext, e);
+            }
+            catch (Exception ex)
+            {
+                Utils.LogError(ex, "Error while reporting AuditHistoryEventUpdateEvent event.");
+            }
+        }
+
+        /// <summary>
+        /// Reports an AuditHistoryRawModifyDelete event.
+        /// </summary>
+        /// <param name="server">The server which reports audit events.</param>
+        /// <param name="systemContext">The current system context.</param>
+        /// <param name="deleteRawModifiedDetails">History raw modified details</param>
+        /// <param name="oldValues">The old values</param>
+        /// <param name="statusCode">The resulting status code</param>
+        public static void ReportAuditHistoryRawModifyDeleteEvent(
+            this IAuditEventServer server,
+            ISystemContext systemContext,
+            DeleteRawModifiedDetails deleteRawModifiedDetails,
+            DataValue[] oldValues,
+            StatusCode statusCode)
+        {
+            if (server?.Auditing != true)
+            {
+                // current server does not support auditing
+                return;
+            }
+
+            try
+            {
+                AuditHistoryRawModifyDeleteEventState e = new AuditHistoryRawModifyDeleteEventState(null);
+
+                InitializeAuditHistoryUpdateEvent(e,
+                    systemContext,
+                    "AuditHistoryRawModifyDeleteEvent",
+                    "Attribute/HistoryRawModifyDelete",
+                    deleteRawModifiedDetails,
+                    statusCode);
+
+                e.SetChildValue(systemContext, BrowseNames.UpdatedNode, deleteRawModifiedDetails.NodeId, false);
+                e.SetChildValue(systemContext, BrowseNames.IsDeleteModified, deleteRawModifiedDetails.IsDeleteModified, false);
+                e.SetChildValue(systemContext, BrowseNames.StartTime, deleteRawModifiedDetails.StartTime, false);
+                e.SetChildValue(systemContext, BrowseNames.EndTime, deleteRawModifiedDetails.EndTime, false);
+                e.SetChildValue(systemContext, BrowseNames.OldValues, oldValues, false);
+
+                server.ReportAuditEvent(systemContext, e);
+            }
+            catch (Exception ex)
+            {
+                Utils.LogError(ex, "Error while reporting AuditHistoryRawModifyDeleteEvent event.");
+            }
+        }
+
+        /// <summary>
+        /// Reports an AuditHistoryAtTimeDelete event.
+        /// </summary>
+        /// <param name="server">The server which reports audit events.</param>
+        /// <param name="systemContext">The current system context.</param>
+        /// <param name="deleteAtTimeDetails">History delete at time details</param>
+        /// <param name="oldValues">The old values</param>
+        /// <param name="statusCode">The resulting status code</param>
+        public static void ReportAuditHistoryAtTimeDeleteEvent(
+            this IAuditEventServer server,
+            ISystemContext systemContext,
+            DeleteAtTimeDetails deleteAtTimeDetails,
+            DataValue[] oldValues,
+            StatusCode statusCode)
+        {
+            if (server?.Auditing != true)
+            {
+                // current server does not support auditing
+                return;
+            }
+
+            try
+            {
+                AuditHistoryAtTimeDeleteEventState e = new AuditHistoryAtTimeDeleteEventState(null);
+
+                InitializeAuditHistoryUpdateEvent(e,
+                    systemContext,
+                    "AuditHistoryAtTimeDeleteEvent",
+                    "Attribute/HistoryAtTimeDelete",
+                    deleteAtTimeDetails,
+                    statusCode);
+
+                e.SetChildValue(systemContext, BrowseNames.UpdatedNode, deleteAtTimeDetails.NodeId, false);
+                e.SetChildValue(systemContext, BrowseNames.ReqTimes, deleteAtTimeDetails.ReqTimes.ToArray(), false);
+                e.SetChildValue(systemContext, BrowseNames.OldValues, oldValues, false);
+
+                server.ReportAuditEvent(systemContext, e);
+            }
+            catch (Exception ex)
+            {
+                Utils.LogError(ex, "Error while reporting AuditHistoryAtTimeDeleteEvent event.");
+            }
+
+        }
+
+        /// <summary>
+        /// Reports an AuditHistoryEventDelete event.
+        /// </summary>
+        /// <param name="server">The server which reports audit events.</param>
+        /// <param name="systemContext">The current system context.</param>
+        /// <param name="deleteEventDetails">History delete event details</param>
+        /// <param name="oldValues">The old values</param>
+        /// <param name="statusCode">The resulting status code</param>
+        public static void ReportAuditHistoryEventDeleteEvent(
+            this IAuditEventServer server,
+            ISystemContext systemContext,
+            DeleteEventDetails deleteEventDetails,
+            DataValue[] oldValues,
+            StatusCode statusCode)
+        {
+            if (server?.Auditing != true)
+            {
+                // current server does not support auditing
+                return;
+            }
+
+            try
+            {
+                AuditHistoryEventDeleteEventState e = new AuditHistoryEventDeleteEventState(null);
+
+                InitializeAuditHistoryUpdateEvent(e,
+                    systemContext,
+                    "AuditHistoryEventDeleteEvent",
+                    "Attribute/HistoryEventDelete",
+                    deleteEventDetails,
+                    statusCode);
+
+                e.SetChildValue(systemContext, BrowseNames.UpdatedNode, deleteEventDetails.NodeId, false);
+                e.SetChildValue(systemContext, BrowseNames.EventIds, deleteEventDetails.EventIds.ToArray(), false);
+                e.SetChildValue(systemContext, BrowseNames.OldValues, oldValues, false);
+
+                server.ReportAuditEvent(systemContext, e);
+            }
+            catch (Exception ex)
+            {
+                Utils.LogError(ex, "Error while reporting AuditHistoryEventDeleteEvent event.");
+            }
+        }
+
+        /// <summary>
+        ///  Reports all audit events for client certificate ServiceResultException. It goes recursively for all service results stored in the exception
+        /// </summary>
+        /// <param name="server">The server which reports audit events.</param>
+        /// <param name="clientCertificate">The client certificate.</param>
+        /// <param name="exception">The Exception that triggers a certificate audit event.</param>
+        public static void ReportAuditCertificateEvent(
+            this IAuditEventServer server,
+            X509Certificate2 clientCertificate,
+            Exception exception)
+        {
+            if (exception == null)
+            {
+                return;
+            }
+
+            if (server?.Auditing != true)
+            {
+                // current server does not support auditing
+                return;
+            }
+
+            try
+            {
+                ISystemContext systemContext = server.DefaultAuditContext;
+
+                while (exception != null)
+                {
+                    if (exception is ServiceResultException sre && sre.InnerResult != null)
+                    {
+                        // Each validation step has a unique error status and audit event type that shall be reported if the check fails.
+                        server.ReportAuditCertificateEvent(systemContext, clientCertificate, sre);
+                    }
+                    exception = exception.InnerException;
+                }
+            }
+            catch (Exception ex)
+            {
+                Utils.LogError(ex, "Error while reporting ReportAuditCertificateDataMismatch event.");
+            }
+        }
+
+        /// <summary>
+        /// Report the audit certificate event for the specified ServiceResultException
+        /// </summary>
+        private static void ReportAuditCertificateEvent(
+            this IAuditEventServer server,
+            ISystemContext systemContext,
+            X509Certificate2 clientCertificate,
+            ServiceResultException sre)
+        {
+            try
+            {
+                if (StatusCode.IsBad(sre.InnerResult.Code))
+                {
+                    AuditCertificateEventState auditCertificateEventState = null;
+                    switch (sre.StatusCode)
+                    {
+                        case StatusCodes.BadCertificateTimeInvalid:
+                        case StatusCodes.BadCertificateIssuerTimeInvalid:
+                            // create AuditCertificateExpiredEventType
+                            auditCertificateEventState = new AuditCertificateExpiredEventState(null);
+                            break;
+                        case StatusCodes.BadCertificateInvalid:
+                        case StatusCodes.BadCertificateChainIncomplete:
+                        case StatusCodes.BadCertificatePolicyCheckFailed:
+                            // create AuditCertificateInvalidEventType
+                            auditCertificateEventState = new AuditCertificateInvalidEventState(null);
+                            break;
+                        case StatusCodes.BadCertificateUntrusted:
+                            // create AuditCertificateUntrustedEventType
+                            auditCertificateEventState = new AuditCertificateUntrustedEventState(null);
+                            break;
+                        case StatusCodes.BadCertificateRevoked:
+                        case StatusCodes.BadCertificateIssuerRevoked:
+                        case StatusCodes.BadCertificateRevocationUnknown:
+                        case StatusCodes.BadCertificateIssuerRevocationUnknown:
+                            // create AuditCertificateRevokedEventType
+                            auditCertificateEventState = new AuditCertificateRevokedEventState(null);
+                            break;
+                        case StatusCodes.BadCertificateUseNotAllowed:
+                        case StatusCodes.BadCertificateIssuerUseNotAllowed:
+                            // create AuditCertificateMismatchEventType
+                            auditCertificateEventState = new AuditCertificateMismatchEventState(null);
+                            break;
+                    }
+                    if (auditCertificateEventState != null)
+                    {
+                        auditCertificateEventState.Initialize(
+                              systemContext,
+                              null,
+                              EventSeverity.Min,
+                              sre.Message,
+                              false,
+                              DateTime.UtcNow);  // initializes Status, ActionTimeStamp, ServerId, ClientAuditEntryId, ClientUserId
+
+                        auditCertificateEventState.SetChildValue(systemContext, BrowseNames.SourceName, "Security/Certificate", false);
+
+                        // set AuditSecurityEventType fields
+                        auditCertificateEventState.SetChildValue(systemContext, BrowseNames.StatusCodeId, (StatusCode)sre.InnerResult.StatusCode, false);
+
+                        // set AuditCertificateEventType fields
+                        auditCertificateEventState.SetChildValue(systemContext, BrowseNames.Certificate, clientCertificate?.RawData, false);
+
+                        server.ReportAuditEvent(systemContext, auditCertificateEventState);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Utils.LogError(ex, "Error while reporting ReportAuditCertificateDataMismatch event.");
+            }
+        }
+
+        /// <summary>
+        /// Reports the AuditCertificateDataMismatchEventType for Invalid Uri
+        /// </summary>
+        /// <param name="server">The server which reports audit events.</param>
+        /// <param name="clientCertificate">The client certificate</param>
+        /// <param name="invalidHostName">The string that represents the host name passed in as part of the URL that is found to be invalid. If the host name was not invalid it can be null.</param>
+        /// <param name="invalidUri">The URI that was passed in and found to not match what is contained in the certificate. If the URI was not invalid it can be null.</param>
+        /// <param name="statusCode">The status code.</param>
+        public static void ReportAuditCertificateDataMismatchEvent(
+            this IAuditEventServer server,
+            X509Certificate2 clientCertificate,
+            string invalidHostName,
+            string invalidUri,
+            StatusCode statusCode)
+        {
+            if (server?.Auditing != true)
+            {
+                // current server does not support auditing
+                return;
+            }
+
+            try
+            {
+                ISystemContext systemContext = server.DefaultAuditContext;
+
+                // create AuditCertificateDataMismatchEventType
+                AuditCertificateDataMismatchEventState e = new AuditCertificateDataMismatchEventState(null);
+
+                e.Initialize(
+                   systemContext,
+                   null,
+                   EventSeverity.Min,
+                   null,
+                   StatusCode.IsGood(statusCode),
+                   DateTime.UtcNow);  // initializes Status, ActionTimeStamp, ServerId, ClientAuditEntryId, ClientUserId
+
+                e.SetChildValue(systemContext, BrowseNames.SourceName, "Security/Certificate", false);
+                e.SetChildValue(systemContext, BrowseNames.SourceNode, ObjectIds.Server, false);
+                e.SetChildValue(systemContext, BrowseNames.LocalTime, Utils.GetTimeZoneInfo(), false);
+
+                // set AuditSecurityEventType fields
+                e.SetChildValue(systemContext, BrowseNames.StatusCodeId, statusCode, false);
+                // set AuditCertificateEventType fields
+                e.SetChildValue(systemContext, BrowseNames.Certificate, clientCertificate?.RawData, false);
+                // set AuditCertificateDataMismatchEventState fields
+                e.SetChildValue(systemContext, BrowseNames.InvalidUri, invalidUri, false);
+                e.SetChildValue(systemContext, BrowseNames.InvalidHostname, invalidHostName, false);
+
+                server.ReportAuditEvent(systemContext, e);
+            }
+            catch (Exception ex)
+            {
+                Utils.LogError(ex, "Error while reporting ReportAuditCertificateDataMismatchEvent event.");
+            }
+        }
+
+        /// <summary>
+        /// Report the AuditCancelEventState
+        /// </summary>
+        /// <param name="server">The server which reports audit events.</param>
+        /// <param name="sessionId">Session id of the current session</param>
+        /// <param name="requestHandle">The handle of the canceled request</param>
+        /// <param name="statusCode">The resulted status code of cancel request.</param>
+        public static void ReportAuditCancelEvent(
+            this IAuditEventServer server,
+            NodeId sessionId,
+            uint requestHandle,
+            StatusCode statusCode)
+        {
+            if (server?.Auditing != true)
+            {
+                // current server does not support auditing
+                return;
+            }
+
+            try
+            {
+                ISystemContext systemContext = server.DefaultAuditContext;
+
+                // create AuditCancelEventState
+                AuditCancelEventState e = new AuditCancelEventState(null);
+
+                e.Initialize(
+                   systemContext,
+                   null,
+                   EventSeverity.Min,
+                   $"Cancel requested for sessionId: {sessionId} with requestHandle: {requestHandle}",
+                   StatusCode.IsGood(statusCode),
+                   DateTime.UtcNow);  // initializes Status, ActionTimeStamp, ServerId, ClientAuditEntryId, ClientUserId
+
+                e.SetChildValue(systemContext, BrowseNames.SourceName, "Session/Cancel", false);
+                e.SetChildValue(systemContext, BrowseNames.SourceNode, ObjectIds.Server, false);
+                e.SetChildValue(systemContext, BrowseNames.LocalTime, Utils.GetTimeZoneInfo(), false);
+
+                // set AuditSecurityEventType fields
+                e.SetChildValue(systemContext, BrowseNames.StatusCodeId, statusCode, false);
+                // set AuditSessionEventType fields
+                e.SetChildValue(systemContext, BrowseNames.SessionId, sessionId, false);
+                // set AuditCancelEventType fields
+                e.SetChildValue(systemContext, BrowseNames.RequestHandle, requestHandle, false);
+
+                server.ReportAuditEvent(systemContext, e);
+            }
+            catch (Exception ex)
+            {
+                Utils.LogError(ex, "Error while reporting ReportAuditCancelEvent event.");
+            }
+        }
+
+        /// <summary>
+        /// Reports a RoleMappingRuleChangedAuditEvent when a method is called on a RoleType instance
+        /// </summary>
+        /// <param name="server">The server which reports audit events.</param>
+        /// <param name="systemContext">The current system context.</param>
+        /// <param name="roleStateObjectId"></param>
+        /// <param name="method"></param>
+        /// <param name="inputArguments"></param>
+        /// <param name="status"></param>
+        public static void ReportAuditRoleMappingRuleChangedEvent(
+            this IAuditEventServer server,
+            ISystemContext systemContext,
+            NodeId roleStateObjectId,
+            MethodState method,
+            object[] inputArguments,
+            bool status)
+        {
+            if (server?.Auditing != true)
+            {
+                // current server does not support auditing
+                return;
+            }
+
+            try
+            {
+                // create RoleMappingRuleChangedAuditEventState
+                RoleMappingRuleChangedAuditEventState e = new RoleMappingRuleChangedAuditEventState(null);
+
+                e.Initialize(
+                   systemContext,
+                   null,
+                   EventSeverity.Min,
+                   $"RoleMappingRuleChanged - {method?.BrowseName}",
+                   status,
+                   DateTime.UtcNow);  // initializes Status, ActionTimeStamp, ServerId, ClientAuditEntryId, ClientUserId
+
+                e.SetChildValue(systemContext, BrowseNames.SourceName, "Attribute/Call", false);
+                e.SetChildValue(systemContext, BrowseNames.SourceNode, roleStateObjectId, false);
+                e.SetChildValue(systemContext, BrowseNames.LocalTime, Utils.GetTimeZoneInfo(), false);
+
+                // set AuditUpdateMethodEventType fields
+                e.SetChildValue(systemContext, BrowseNames.MethodId, method?.NodeId, false);
+                e.SetChildValue(systemContext, BrowseNames.InputArguments, inputArguments, false);
+
+                server.ReportAuditEvent(systemContext, e);
+            }
+            catch (Exception ex)
+            {
+                Utils.LogError(ex, "Error while reporting ReportRoleMappingRuleChangedAuditEvent event.");
+            }
+        }
+
+        /// <summary>
+        /// Reports an audit create session event.
+        /// </summary>
+        /// <param name="server">The server which reports audit events.</param>
+        /// <param name="auditEntryId">The audit entry id.</param>
+        /// <param name="session">The session object that was created.</param>
+        /// <param name="revisedSessionTimeout">The revised session timeout</param>
+        /// <param name="exception">The exception received during create session request</param> 
+        public static void ReportAuditCreateSessionEvent(
+            this IAuditEventServer server,
+            string auditEntryId,
+            Session session,
+            double revisedSessionTimeout,
+            Exception exception = null)
+        {
+            if (server?.Auditing != true)
+            {
+                // current server does not support auditing
+                return;
+            }
+
+            try
+            {
+                ISystemContext systemContext = server.DefaultAuditContext;
+
+                // raise an audit event.
+                AuditCreateSessionEventState e = new AuditCreateSessionEventState(null);
+
+                TranslationInfo message = null;
+                if (exception == null)
+                {
+                    message = new TranslationInfo(
+                      "AuditCreateSessionEvent",
+                      "en-US",
+                      $"Session with ID:{session?.Id} was created.");
+                }
+                else
+                {
+                    message = new TranslationInfo(
+                      "AuditCreateSessionEvent",
+                      "en-US",
+                      $"Error while creating session with ID:{session?.Id}: Exception: {exception.Message}.");
+                }
+
+                InitializeAuditSessionEvent(systemContext, e, message, exception == null, session, auditEntryId);
+
+                e.SetChildValue(systemContext, BrowseNames.SourceName, "Session/CreateSession", false);
+
+                // set AuditCreateSessionEventState fields
+                e.SetChildValue(systemContext, BrowseNames.ClientCertificate, session?.ClientCertificate?.RawData, false);
+                e.SetChildValue(systemContext, BrowseNames.ClientCertificateThumbprint, session?.ClientCertificate?.Thumbprint, false);
+                e.SetChildValue(systemContext, BrowseNames.RevisedSessionTimeout, revisedSessionTimeout, false);
+
+                server.ReportAuditEvent(systemContext, e);
+            }
+            catch (Exception ex)
+            {
+                Utils.LogError(ex, "Error while reporting AuditCreateSessionEvent event for SessionId {0}.", session?.Id);
+            }
+        }
+
+        /// <summary>
+        /// Reports an audit activate session event.
+        /// </summary>
+        /// <param name="server">The server which reports audit events.</param>
+        /// <param name="auditEntryId">The audit entry id.</param>
+        /// <param name="session">The session that is activated.</param>
+        /// <param name="softwareCertificates">The software certificates</param>
+        /// <param name="exception">The exception received during activate session request</param> 
+        public static void ReportAuditActivateSessionEvent(
+            this IAuditEventServer server,
+            string auditEntryId,
+            Session session,
+            IList<SoftwareCertificate> softwareCertificates,
+            Exception exception = null)
+        {
+            if (server?.Auditing != true)
+            {
+                // current server does not support auditing
+                return;
+            }
+
+            try
+            {
+                ISystemContext systemContext = server.DefaultAuditContext;
+
+                AuditActivateSessionEventState e = new AuditActivateSessionEventState(null);
+
+                TranslationInfo message = null;
+                if (exception == null)
+                {
+                    message = new TranslationInfo(
+                     "AuditActivateSessionEvent",
+                    "en-US",
+                    $"Session with Id:{session.Id} was activated.");
+                }
+                else
+                {
+                    message = new TranslationInfo(
+                      "AuditActivateSessionEvent",
+                      "en-US",
+                      $"Error while activate session with ID:{session?.Id}. Exception: {exception.Message}.");
+                }
+
+                InitializeAuditSessionEvent(systemContext, e, message, exception == null, session, auditEntryId);
+
+                e.SetChildValue(systemContext, BrowseNames.SourceName, "Session/ActivateSession", false);
+                e.SetChildValue(systemContext, BrowseNames.UserIdentityToken, Utils.Clone(session?.IdentityToken), false);
+
+                if (softwareCertificates != null)
+                {
+                    // build the list of SignedSoftwareCertificate
+                    List<SignedSoftwareCertificate> signedSoftwareCertificates = new List<SignedSoftwareCertificate>();
+                    foreach (SoftwareCertificate softwareCertificate in softwareCertificates)
+                    {
+                        SignedSoftwareCertificate item = new SignedSoftwareCertificate();
+                        item.CertificateData = softwareCertificate.SignedCertificate.RawData;
+                        signedSoftwareCertificates.Add(item);
+                    }
+                    e.SetChildValue(systemContext, BrowseNames.ClientSoftwareCertificates, signedSoftwareCertificates.ToArray(), false);
+                }
+
+                server.ReportAuditEvent(systemContext, e);
+            }
+            catch (Exception e)
+            {
+                Utils.LogError(e, "Error while reporting AuditActivateSessionEvent event for SessionId {0}.", session?.Id);
+            }
+        }
+
+        /// <summary>
+        /// Reports an audit Url Mismatch event.
+        /// </summary>
+        /// <param name="server">The server which reports audit events.</param>
+        /// <param name="auditEntryId">The audit entry id.</param>
+        /// <param name="session">The session object that was created.</param>
+        /// <param name="revisedSessionTimeout">The revised session timeout</param>
+        /// <param name="endpointUrl">The invalid endpoint url</param> 
+        public static void ReportAuditUrlMismatchEvent(
+            this IAuditEventServer server,
+            string auditEntryId,
+            Session session,
+            double revisedSessionTimeout,
+            string endpointUrl)
+        {
+            if (server?.Auditing != true)
+            {
+                // current server does not support auditing
+                return;
+            }
+
+            try
+            {
+                ISystemContext systemContext = server.DefaultAuditContext;
+
+                AuditUrlMismatchEventState e = new AuditUrlMismatchEventState(null);
+
+                TranslationInfo message = new TranslationInfo(
+                     "AuditUrlMismatchEvent",
+                     "en-US",
+                     $"Session with ID:{session.Id} was cannot be created because endpoint URL does not match the Server’s HostNames.");
+
+                InitializeAuditSessionEvent(systemContext, e, message, false, session, auditEntryId);
+
+                e.SetChildValue(systemContext, BrowseNames.SourceName, "Session/CreateSession", false);
+
+                // set AuditCreateSessionEventState fields
+                e.SetChildValue(systemContext, BrowseNames.ClientCertificate, session?.ClientCertificate?.RawData, false);
+                e.SetChildValue(systemContext, BrowseNames.ClientCertificateThumbprint, session?.ClientCertificate?.Thumbprint, false);
+                e.SetChildValue(systemContext, BrowseNames.RevisedSessionTimeout, revisedSessionTimeout, false);
+
+                // set AuditUrlMismatchEventState
+                e.SetChildValue(systemContext, BrowseNames.EndpointUrl, endpointUrl, false);
+
+                server.ReportAuditEvent(systemContext, e);
+            }
+            catch (Exception e)
+            {
+                Utils.LogError(e, "Error while reporting AuditUrlMismatchEvent event for SessionId {0}.", session?.Id);
+            }
+        }
+
+        /// <summary>
+        /// Reports an audit close session event.
+        /// </summary>
+        /// <param name="server">The server which reports audit events.</param>
+        /// <param name="auditEntryId">The audit entry id.</param>
+        /// <param name="session">The session object that was created.</param>
+        /// <param name="sourceName">Session/CloseSession when the session is closed by request
+        /// “Session/Timeout” for a Session timeout
+        /// “Session/Terminated” for all other cases.</param>
+        public static void ReportAuditCloseSessionEvent(
+            this IAuditEventServer server,
+            string auditEntryId,
+            Session session,
+            string sourceName = "Session/Terminated")
+        {
+            if (server?.Auditing != true)
+            {
+                // current server does not support auditing
+                return;
+            }
+
+            try
+            {
+                ISystemContext systemContext = server.DefaultAuditContext;
+
+                // raise an audit event.
+                AuditSessionEventState e = new AuditSessionEventState(null);
+
+                TranslationInfo message = new TranslationInfo(
+                    "AuditCloseSessionEvent",
+                    "en-US",
+                    $"Session with ID:{session?.Id} was closed.");
+
+                InitializeAuditSessionEvent(systemContext, e, message, true, session, auditEntryId);
+
+                e.SetChildValue(systemContext, BrowseNames.SourceName, sourceName, false);
+
+                server.ReportAuditEvent(systemContext, e);
+            }
+            catch (Exception ex)
+            {
+                Utils.LogError(ex, "Error while reporting AuditSessionEventState close event for SessionId {0}.", session?.Id);
+            }
+        }
+
+        /// <summary>
+        /// Reports an audit session event for the transfer subscription.
+        /// </summary>
+        /// <param name="server">The server which reports audit events.</param>
+        /// <param name="auditEntryId">The audit entry id.</param>
+        /// <param name="session">The session object that was created.</param>
+        /// <param name="statusCode">The status code resulting .</param>
+        public static void ReportAuditTransferSubscriptionEvent(
+            this IAuditEventServer server,
+            string auditEntryId,
+            Session session,
+            StatusCode statusCode)
+        {
+            if (server?.Auditing != true)
+            {
+                // current server does not support auditing
+                return;
+            }
+
+            try
+            {
+                ISystemContext systemContext = server.DefaultAuditContext;
+
+                // raise an audit event.
+                AuditSessionEventState e = new AuditSessionEventState(null);
+
+                TranslationInfo message = new TranslationInfo(
+                    "AuditSessionEventState",
+                    "en-US",
+                    $"Transfer subscription for session ID:{session?.Id} has statusCode {statusCode}.");
+
+                InitializeAuditSessionEvent(systemContext, e, message, StatusCode.IsGood(statusCode), session, auditEntryId);
+
+                e.SetChildValue(systemContext, BrowseNames.SourceNode, session.Id, false);
+                e.SetChildValue(systemContext, BrowseNames.SourceName, "Session/TransferSubscriptions", false);
+
+                server.ReportAuditEvent(systemContext, e);
+            }
+            catch (Exception ex)
+            {
+                Utils.LogError(ex, "Error while reporting AuditSessionEventState close event for SessionId {0}.", session?.Id);
+            }
+        }
+
+        /// <summary>
+        /// Raise CertificateUpdatedAudit event
+        /// </summary>
+        /// <param name="server">The server which reports audit events.</param>
+        /// <param name="systemContext">The current system context.</param>
+        /// <param name="objectId">The id of the object ued for update certificate method</param>
+        /// <param name="method">The method that triggered the audit event.</param>
+        /// <param name="inputArguments">The input arguments used to call the method that triggered the audit event.</param>
+        /// <param name="certificateGroupId">The id of the certificate group</param>
+        /// <param name="certificateTypeId">the certificate ype id</param>
+        /// <param name="exception">The exception resulted after executing the UpdateCertificate method. If null, the operation was successfull.</param>
+        public static void ReportCertificateUpdatedAuditEvent(
+            this IAuditEventServer server,
+            ISystemContext systemContext,
+            NodeId objectId,
+            MethodState method,
+            object[] inputArguments,
+            NodeId certificateGroupId,
+            NodeId certificateTypeId,
+            Exception exception = null)
+        {
+            try
+            {
+                CertificateUpdatedAuditEventState e = new CertificateUpdatedAuditEventState(null);
+
+                TranslationInfo message = null;
+                if (exception == null)
+                {
+                    message = new TranslationInfo(
+                       "CertificateUpdatedAuditEvent",
+                       "en-US",
+                       "CertificateUpdatedAuditEvent.");
+                }
+                else
+                {
+                    message = new TranslationInfo(
+                      "CertificateUpdatedAuditEvent",
+                      "en-US",
+                      $"CertificateUpdatedAuditEvent - Exception: {exception.Message}.");
+                }
+
+                e.Initialize(
+                   systemContext,
+                   null,
+                   EventSeverity.Min,
+                   new LocalizedText(message),
+                   exception == null,
+                   DateTime.UtcNow);  // initializes Status, ActionTimeStamp, ServerId, ClientAuditEntryId, ClientUserId
+
+                e.SetChildValue(systemContext, BrowseNames.SourceNode, objectId, false);
+                e.SetChildValue(systemContext, BrowseNames.SourceName, "Method/UpdateCertificate", false);
+                e.SetChildValue(systemContext, BrowseNames.LocalTime, Utils.GetTimeZoneInfo(), false);
+
+                e.SetChildValue(systemContext, BrowseNames.MethodId, method.NodeId, false);
+                e.SetChildValue(systemContext, BrowseNames.InputArguments, inputArguments, false);
+
+                e.SetChildValue(systemContext, BrowseNames.CertificateGroup, certificateGroupId, false);
+                e.SetChildValue(systemContext, BrowseNames.CertificateType, certificateTypeId, false);
+
+                server.ReportAuditEvent(systemContext, e);
+            }
+            catch (Exception ex)
+            {
+                Utils.LogError(ex, "Error while reporting ReportCertificateUpdatedAuditEvent event.");
+            }
+        }
+
+        /// <summary>
+        /// Report the AuditAddNodesEvent
+        /// </summary>
+        /// <param name="server">The server which reports audit events.</param>
+        /// <param name="systemContext">The current system context.</param>
+        /// <param name="addNodesItems">The added nodes information.</param>
+        /// <param name="customMessage">Custom message for add nodes audit event.</param>
+        /// <param name="statusCode">The resulting status code.</param>
+        public static void ReportAuditAddNodesEvent(
+            this IAuditEventServer server,
+            ISystemContext systemContext,
+            AddNodesItem[] addNodesItems,
+            string customMessage,
+            StatusCode statusCode)
+        {
+            if (server?.Auditing != true)
+            {
+                // current server does not support auditing
+                return;
+            }
+
+            try
+            {
+                AuditAddNodesEventState e = new AuditAddNodesEventState(null);
+
+                TranslationInfo message = new TranslationInfo(
+                           "AuditAddNodesEventState",
+                           "en-US",
+                           $"'{customMessage}' returns StatusCode: {statusCode.ToString(null, CultureInfo.InvariantCulture)}.");
+
+                e.Initialize(
+                   systemContext,
+                   null,
+                   EventSeverity.Min,
+                   new LocalizedText(message),
+                   StatusCode.IsGood(statusCode),
+                   DateTime.UtcNow);  // initializes Status, ActionTimeStamp, ServerId, ClientAuditEntryId, ClientUserId
+
+                e.SetChildValue(systemContext, BrowseNames.SourceNode, ObjectIds.Server, false);
+                e.SetChildValue(systemContext, BrowseNames.SourceName, "NodeManagement/AddNodes", false);
+                e.SetChildValue(systemContext, BrowseNames.LocalTime, Utils.GetTimeZoneInfo(), false);
+
+                e.SetChildValue(systemContext, BrowseNames.NodesToAdd, addNodesItems, false);
+
+                server.ReportAuditEvent(systemContext, e);
+            }
+            catch (Exception ex)
+            {
+                Utils.LogError(ex, "Error while reporting AuditAddNodesEvent event.");
+            }
+        }
+
+        /// <summary>
+        /// Reports the AuditDeleteNodesEven
+        /// </summary>
+        /// <param name="server">The server which reports audit events.</param>
+        /// <param name="systemContext">The current system context.</param>
+        /// <param name="nodesToDelete">The delete nodes information.</param>
+        /// <param name="customMessage">Custom message for delete nodes.</param>
+        /// <param name="statusCode">The resulting status code.</param>
+        public static void ReportAuditDeleteNodesEvent(
+            this IAuditEventServer server,
+            ISystemContext systemContext,
+            DeleteNodesItem[] nodesToDelete,
+            string customMessage,
+            StatusCode statusCode)
+        {
+            if (server?.Auditing != true)
+            {
+                // current server does not support auditing
+                return;
+            }
+
+            try
+            {
+                AuditDeleteNodesEventState e = new AuditDeleteNodesEventState(null);
+
+                TranslationInfo message = new TranslationInfo(
+                           "AuditDeleteNodesEventState",
+                           "en-US",
+                           $"'{customMessage}' returns StatusCode: {statusCode.ToString(null, CultureInfo.InvariantCulture)}.");
+
+                e.Initialize(
+                   systemContext,
+                   null,
+                   EventSeverity.Min,
+                   new LocalizedText(message),
+                   StatusCode.IsGood(statusCode),
+                   DateTime.UtcNow);  // initializes Status, ActionTimeStamp, ServerId, ClientAuditEntryId, ClientUserId
+
+                e.SetChildValue(systemContext, BrowseNames.SourceNode, ObjectIds.Server, false);
+                e.SetChildValue(systemContext, BrowseNames.SourceName, "NodeManagement/DeleteNodes", false);
+                e.SetChildValue(systemContext, BrowseNames.LocalTime, Utils.GetTimeZoneInfo(), false);
+
+                e.SetChildValue(systemContext, BrowseNames.NodesToDelete, nodesToDelete, false);
+
+                server.ReportAuditEvent(systemContext, e);
+            }
+            catch (Exception ex)
+            {
+                Utils.LogError(ex, "Error while reporting AuditDeleteNodesEvent event.");
+            }
+        }
+
+        /// <summary>
+        /// Report the open secure channel audit event
+        /// </summary>
+        /// <param name="server">The server which reports audit events.</param>
+        /// <param name="channel">The <see cref="Bindings.TcpServerChannel"/> that processes the open secure channel request.</param>
+        /// <param name="request">The incoming <see cref="OpenSecureChannelRequest"/></param>
+        /// <param name="clientCertificate">The client certificate.</param>
+        /// <param name="exception">The exception resulted from the open secure channel request.</param>
+        public static void ReportAuditOpenSecureChannelEvent(
+            this IAuditEventServer server,
+            Bindings.TcpServerChannel channel,
+            OpenSecureChannelRequest request,
+            X509Certificate2 clientCertificate,
+            Exception exception)
+        {
+            if (server?.Auditing != true)
+            {
+                // current server does not support auditing
+                return;
+            }
+
+            try
+            {
+                // raise an audit event.
+                AuditOpenSecureChannelEventState e = new AuditOpenSecureChannelEventState(null);
+                TranslationInfo message = null;
+                if (exception == null)
+                {
+                    message = new TranslationInfo(
+                        "AuditOpenSecureChannelEvent",
+                        "en-US",
+                        "AuditOpenSecureChannelEvent");
+                }
+                else
+                {
+                    message = new TranslationInfo(
+                        "AuditOpenSecureChannelEvent",
+                        "en-US",
+                        $"AuditOpenSecureChannelEvent - Exception: {exception.Message}.");
+                }
+
+                StatusCode statusCode = StatusCodes.Good;
+                while (exception != null && !(exception is ServiceResultException))
+                {
+                    exception = exception.InnerException;
+                }
+                if (exception is ServiceResultException sre)
+                {
+                    statusCode = sre.InnerResult.StatusCode;
+                }
+
+                ISystemContext systemContext = server.DefaultAuditContext;
+
+                DateTime actionTimestamp = DateTime.UtcNow;
+                if (request?.RequestHeader?.Timestamp != null)
+                {
+                    actionTimestamp = request.RequestHeader.Timestamp;
+                }
+
+                e.Initialize(
+                    systemContext,
+                    null,
+                    EventSeverity.Min,
+                    new LocalizedText(message),
+                    exception == null,
+                    actionTimestamp);  // initializes Status, ActionTimeStamp, ServerId, ClientAuditEntryId, ClientUserId
+
+                e.SetChildValue(systemContext, BrowseNames.SourceName, "SecureChannel/OpenSecureChannel", false);
+                e.SetChildValue(systemContext, BrowseNames.ClientUserId, "System/OpenSecureChannel", false);
+                e.SetChildValue(systemContext, BrowseNames.SourceNode, ObjectIds.Server, false);
+                e.SetChildValue(systemContext, BrowseNames.LocalTime, Utils.GetTimeZoneInfo(), false);
+
+                // set AuditSecurityEventType fields
+                e.SetChildValue(systemContext, BrowseNames.StatusCodeId, statusCode, false);
+
+                // set AuditChannelEventType fields
+                e.SetChildValue(systemContext, BrowseNames.SecureChannelId, channel.GlobalChannelId, false);
+
+                // set AuditOpenSecureChannelEventType fields
+                e.SetChildValue(systemContext, BrowseNames.ClientCertificate, clientCertificate?.RawData, false);
+                e.SetChildValue(systemContext, BrowseNames.ClientCertificateThumbprint, clientCertificate?.Thumbprint, false);
+                e.SetChildValue(systemContext, BrowseNames.RequestType, request?.RequestType, false);
+                e.SetChildValue(systemContext, BrowseNames.SecurityPolicyUri, channel.EndpointDescription?.SecurityPolicyUri, false);
+                e.SetChildValue(systemContext, BrowseNames.SecurityMode, channel.EndpointDescription?.SecurityMode, false);
+                e.SetChildValue(systemContext, BrowseNames.RequestedLifetime, request?.RequestedLifetime, false);
+
+                server.ReportAuditEvent(systemContext, e);
+            }
+            catch (Exception ex)
+            {
+                Utils.LogError(ex, "Error while reporting AuditOpenSecureChannelEvent event.");
+            }
+        }
+
+        /// <summary>
+        /// Report the close secure channel audit event
+        /// </summary>
+        /// <param name="server">The server which reports audit events.</param>
+        /// <param name="channel">The server channel.</param>
+        /// <param name="exception">The exception resulted from the open secure channel request.</param>
+        public static void ReportAuditCloseSecureChannelEvent(
+            this IAuditEventServer server,
+            Bindings.TcpServerChannel channel,
+            Exception exception)
+        {
+            if (server?.Auditing != true)
+            {
+                // current server does not support auditing
+                return;
+            }
+
+            try
+            {
+                // raise an audit event.
+                AuditChannelEventState e = new AuditChannelEventState(null);
+
+                TranslationInfo message = null;
+                if (exception == null)
+                {
+                    message = new TranslationInfo(
+                        "AuditCloseSecureChannelEvent",
+                        "en-US",
+                        "AuditCloseSecureChannelEvent");
+                }
+                else
+                {
+                    message = new TranslationInfo(
+                        "AuditCloseSecureChannelEvent",
+                        "en-US",
+                        $"AuditCloseSecureChannelEvent - Exception: {exception.Message}.");
+                }
+
+                StatusCode statusCode = StatusCodes.Good;
+                while (exception != null && !(exception is ServiceResultException))
+                {
+                    exception = exception.InnerException;
+                }
+                if (exception is ServiceResultException sre)
+                {
+                    statusCode = sre.InnerResult.StatusCode;
+                }
+
+                ISystemContext systemContext = server.DefaultAuditContext;
+
+                e.Initialize(
+                    systemContext,
+                    null,
+                    EventSeverity.Min,
+                    new LocalizedText(message),
+                    exception == null,
+                    DateTime.UtcNow);  // initializes Status, ActionTimeStamp, ServerId, ClientAuditEntryId, ClientUserId
+
+                e.SetChildValue(systemContext, BrowseNames.SourceName, "SecureChannel/CloseSecureChannel", false);
+
+                string clientUserId = "System/CloseSecureChannel";
+                //operationContext.UserIdentity?.DisplayName, or ”System/CloseSecureChannel”
+
+                e.SetChildValue(systemContext, BrowseNames.ClientUserId, clientUserId, false);
+                e.SetChildValue(systemContext, BrowseNames.SourceNode, ObjectIds.Server, false);
+                e.SetChildValue(systemContext, BrowseNames.LocalTime, Utils.GetTimeZoneInfo(), false);
+
+                // set AuditSecurityEventType fields
+                e.SetChildValue(systemContext, BrowseNames.StatusCodeId, statusCode, false);
+
+                // set AuditChannelEventType fields
+                e.SetChildValue(systemContext, BrowseNames.SecureChannelId, channel.GlobalChannelId, false);
+
+                server.ReportAuditEvent(systemContext, e);
+            }
+            catch (Exception ex)
+            {
+                Utils.LogError(ex, "Error while reporting AuditOpenSecureChannelEvent event.");
+            }
+        }
+        #endregion Report Audit Events
+
+        #region Private helpers
+        /// <summary>
+        /// Initialize the properties of an AuditUpdateEventState.
+        /// </summary>
+        /// <param name="e">AuditUpdate event reference</param>
+        /// <param name="systemContext">The current system context.</param>
+        /// <param name="auditEventName">Audit event name</param>
+        /// <param name="sourceName">Source name</param>
+        /// <param name="historyUpdateDetails">History update details</param>
+        /// <param name="statusCode">The resulting status code</param>
+        private static void InitializeAuditHistoryUpdateEvent(
+            AuditUpdateEventState e,
+            ISystemContext systemContext,
+            string auditEventName,
+            string sourceName,
+            HistoryUpdateDetails historyUpdateDetails,
+            StatusCode statusCode)
+        {
+            TranslationInfo message = new TranslationInfo(
+               auditEventName,
+               "en-US",
+               $"{auditEventName} has Result: {statusCode.ToString(null, CultureInfo.InvariantCulture)}.");
+
+            e.Initialize(
+               systemContext,
+               null,
+               EventSeverity.Min,
+               new LocalizedText(message),
+               StatusCode.IsGood(statusCode),
+               DateTime.UtcNow);  // initializes Status, ActionTimeStamp, ServerId, ClientAuditEntryId, ClientUserId
+
+            e.SetChildValue(systemContext, BrowseNames.SourceNode, historyUpdateDetails.NodeId, false);
+            e.SetChildValue(systemContext, BrowseNames.SourceName, sourceName, false);
+            e.SetChildValue(systemContext, BrowseNames.LocalTime, Utils.GetTimeZoneInfo(), false);
+
+            e.SetChildValue(systemContext, BrowseNames.ClientUserId, systemContext?.UserIdentity?.DisplayName, false);
+            e.SetChildValue(systemContext, BrowseNames.ClientAuditEntryId, systemContext?.AuditEntryId, false);
+
+            e.SetChildValue(systemContext, BrowseNames.ParameterDataTypeId, historyUpdateDetails.TypeId, false);
+        }
+
+        /// <summary>
+        /// Initializes a session audit event.
+        /// </summary>
+        private static void InitializeAuditSessionEvent(ISystemContext systemContext, AuditEventState e, TranslationInfo message, bool status, Session session, string auditEntryId)
+        {
+            e.Initialize(
+                systemContext,
+                null,
+                EventSeverity.Min,
+                new LocalizedText(message),
+                status,
+                DateTime.UtcNow);
+
+            e.SetChildValue(systemContext, BrowseNames.SourceNode, ObjectIds.Server, false);
+
+            // set AuditEventType properties
+            e.SetChildValue(systemContext, BrowseNames.ClientUserId, session?.Identity?.DisplayName, false);
+            e.SetChildValue(systemContext, BrowseNames.ClientAuditEntryId, auditEntryId, false);
+            // set AuditCreateSessionEventType & AuditActivateSessionsEventType properties
+            e.SetChildValue(systemContext, BrowseNames.SecureChannelId, session?.SecureChannelId, false);
+            // set AuditSessionEventType 
+            e.SetChildValue(systemContext, BrowseNames.SessionId, session?.Id, false);
+        }
+        #endregion
+    }
+}

--- a/Libraries/Opc.Ua.Server/Diagnostics/AuditEvents.cs
+++ b/Libraries/Opc.Ua.Server/Diagnostics/AuditEvents.cs
@@ -1123,7 +1123,7 @@ namespace Opc.Ua.Server
         }
 
         /// <summary>
-        /// Reports the AuditDeleteNodesEven
+        /// Reports the AuditDeleteNodesEvent.
         /// </summary>
         /// <param name="server">The server which reports audit events.</param>
         /// <param name="systemContext">The current system context.</param>
@@ -1175,16 +1175,18 @@ namespace Opc.Ua.Server
         }
 
         /// <summary>
-        /// Report the open secure channel audit event
+        /// Report the open secure channel audit event.
         /// </summary>
         /// <param name="server">The server which reports audit events.</param>
-        /// <param name="channel">The <see cref="Bindings.TcpServerChannel"/> that processes the open secure channel request.</param>
+        /// <param name="globalChannelId">The global unique channel id.</param>
+        /// <param name="endpointDescription">The endpoint description used for the request.</param>
         /// <param name="request">The incoming <see cref="OpenSecureChannelRequest"/></param>
         /// <param name="clientCertificate">The client certificate.</param>
         /// <param name="exception">The exception resulted from the open secure channel request.</param>
         public static void ReportAuditOpenSecureChannelEvent(
             this IAuditEventServer server,
-            Bindings.TcpServerChannel channel,
+            string globalChannelId,
+            EndpointDescription endpointDescription,
             OpenSecureChannelRequest request,
             X509Certificate2 clientCertificate,
             Exception exception)
@@ -1250,14 +1252,14 @@ namespace Opc.Ua.Server
                 e.SetChildValue(systemContext, BrowseNames.StatusCodeId, statusCode, false);
 
                 // set AuditChannelEventType fields
-                e.SetChildValue(systemContext, BrowseNames.SecureChannelId, channel.GlobalChannelId, false);
+                e.SetChildValue(systemContext, BrowseNames.SecureChannelId, globalChannelId, false);
 
                 // set AuditOpenSecureChannelEventType fields
                 e.SetChildValue(systemContext, BrowseNames.ClientCertificate, clientCertificate?.RawData, false);
                 e.SetChildValue(systemContext, BrowseNames.ClientCertificateThumbprint, clientCertificate?.Thumbprint, false);
                 e.SetChildValue(systemContext, BrowseNames.RequestType, request?.RequestType, false);
-                e.SetChildValue(systemContext, BrowseNames.SecurityPolicyUri, channel.EndpointDescription?.SecurityPolicyUri, false);
-                e.SetChildValue(systemContext, BrowseNames.SecurityMode, channel.EndpointDescription?.SecurityMode, false);
+                e.SetChildValue(systemContext, BrowseNames.SecurityPolicyUri, endpointDescription?.SecurityPolicyUri, false);
+                e.SetChildValue(systemContext, BrowseNames.SecurityMode, endpointDescription?.SecurityMode, false);
                 e.SetChildValue(systemContext, BrowseNames.RequestedLifetime, request?.RequestedLifetime, false);
 
                 server.ReportAuditEvent(systemContext, e);
@@ -1269,14 +1271,14 @@ namespace Opc.Ua.Server
         }
 
         /// <summary>
-        /// Report the close secure channel audit event
+        /// Report the close secure channel audit event.
         /// </summary>
         /// <param name="server">The server which reports audit events.</param>
-        /// <param name="channel">The server channel.</param>
+        /// <param name="globalChannelId">The global unique channel id.</param>
         /// <param name="exception">The exception resulted from the open secure channel request.</param>
         public static void ReportAuditCloseSecureChannelEvent(
             this IAuditEventServer server,
-            Bindings.TcpServerChannel channel,
+            string globalChannelId,
             Exception exception)
         {
             if (server?.Auditing != true)
@@ -1339,7 +1341,7 @@ namespace Opc.Ua.Server
                 e.SetChildValue(systemContext, BrowseNames.StatusCodeId, statusCode, false);
 
                 // set AuditChannelEventType fields
-                e.SetChildValue(systemContext, BrowseNames.SecureChannelId, channel.GlobalChannelId, false);
+                e.SetChildValue(systemContext, BrowseNames.SecureChannelId, globalChannelId, false);
 
                 server.ReportAuditEvent(systemContext, e);
             }

--- a/Libraries/Opc.Ua.Server/Diagnostics/CustomNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/Diagnostics/CustomNodeManager.cs
@@ -401,7 +401,7 @@ namespace Opc.Ua.Server
                 AddPredefinedNode(contextToUse, instance);
 
                 // report audit event
-                if (Server?.EventManager?.ServerAuditing == true)
+                if (Server?.Auditing == true)
                 {
                     // current server supports auditing, prepare the added nodes info
                     AddNodesItem[] addNodesItems = GetFlattenedNodeTree(context, instance).Select(n => new AddNodesItem() {
@@ -413,7 +413,7 @@ namespace Opc.Ua.Server
                         ParentNodeId = n.Parent?.NodeId
                     }).ToArray();
 
-                    ReportAuditAddNodesEvent(context, addNodesItems, "CreateNode", StatusCodes.Good);
+                    Server.ReportAuditAddNodesEvent(context, addNodesItems, "CreateNode", StatusCodes.Good);
                 }
 
                 return instance.NodeId;
@@ -444,7 +444,7 @@ namespace Opc.Ua.Server
                 if (PredefinedNodes.TryGetValue(nodeId, out node))
                 {
                     // report audit event
-                    if (Server?.EventManager?.ServerAuditing == true)
+                    if (Server?.Auditing == true)
                     {
                         // current server supports auditing, prepare the deleted nodes info
                         DeleteNodesItem[] nodesToDelete = GetFlattenedNodeTree(context, node as BaseInstanceState).Select(n => new DeleteNodesItem() {
@@ -452,7 +452,7 @@ namespace Opc.Ua.Server
                             DeleteTargetReferences = true
                         }).ToArray();
 
-                        ReportAuditDeleteNodesEvent(context, nodesToDelete, "DeleteNode", StatusCodes.Good);
+                        Server.ReportAuditDeleteNodesEvent(context, nodesToDelete, "DeleteNode", StatusCodes.Good);
                     }
 
                     RemovePredefinedNode(contextToUse, node, referencesToRemove);
@@ -1913,7 +1913,6 @@ namespace Opc.Ua.Server
             {
                 for (int ii = 0; ii < nodesToWrite.Count; ii++)
                 {
-
                     WriteValue nodeToWrite = nodesToWrite[ii];
 
                     // skip items that have already been processed.
@@ -1997,7 +1996,7 @@ namespace Opc.Ua.Server
 
                     DataValue oldValue = null;
 
-                    if (Server?.EventManager?.ServerAuditing == true)
+                    if (Server?.Auditing == true)
                     {
                         //current server supports auditing 
                         oldValue = new DataValue();
@@ -2013,7 +2012,7 @@ namespace Opc.Ua.Server
                         nodeToWrite.Value);
 
                     // report the write value audit event 
-                    ReportAuditWriteUpdateEvent(systemContext, nodeToWrite, oldValue?.Value, errors[ii]?.StatusCode ?? StatusCodes.Good);
+                    Server.ReportAuditWriteUpdateEvent(systemContext, nodeToWrite, oldValue?.Value, errors[ii]?.StatusCode ?? StatusCodes.Good);
 
                     if (!ServiceResult.IsGood(errors[ii]))
                     {
@@ -3624,13 +3623,12 @@ namespace Opc.Ua.Server
                 return StatusCodes.BadAttributeIdInvalid;
             }
 
-            NodeState cachedNode = AddNodeToComponentCache(context, handle, handle.Node);
-
             // check if the node is already being monitored.
             MonitoredNode2 monitoredNode = null;
 
             if (!m_monitoredNodes.TryGetValue(handle.Node.NodeId, out monitoredNode))
             {
+                NodeState cachedNode = AddNodeToComponentCache(context, handle, handle.Node);
                 m_monitoredNodes[handle.Node.NodeId] = monitoredNode = new MonitoredNode2(this, cachedNode);
             }
 
@@ -4271,6 +4269,7 @@ namespace Opc.Ua.Server
         }
         #endregion
 
+        #region TransferMonitoredItems Support Functions
         /// <summary>
         /// Transfers a set of monitored items.
         /// </summary>
@@ -4308,12 +4307,10 @@ namespace Opc.Ua.Server
                     // owned by this node manager.
                     processedItems[ii] = true;
                     transferredItems.Add(monitoredItems[ii]);
-
                     if (sendInitialValues)
                     {
                         monitoredItems[ii].SetupResendDataTrigger();
                     }
-
                     errors[ii] = StatusCodes.Good;
                 }
             }
@@ -4334,6 +4331,7 @@ namespace Opc.Ua.Server
         {
             // defined by the sub-class
         }
+        #endregion
 
         /// <summary>
         /// Changes the monitoring mode for a set of monitored items.
@@ -4612,457 +4610,6 @@ namespace Opc.Ua.Server
         }
         #endregion
 
-        #region Report Audit Events
-        /// <summary>
-        /// Reports an AuditWriteUpdate event.
-        /// </summary>
-        /// <param name="systemContext">Current  system context</param>
-        /// <param name="writeValue">The value to write.</param>
-        /// <param name="oldValue">The old value of the node.</param>
-        /// <param name="statusCode">The resulted status code.</param>
-        private void ReportAuditWriteUpdateEvent(SystemContext systemContext,
-            WriteValue writeValue,
-            object oldValue,
-            StatusCode statusCode)
-        {
-            if (systemContext?.OperationContext == null || systemContext?.UserIdentity == null)
-            {
-                return;
-            }
-
-            if (Server?.EventManager?.ServerAuditing != true)
-            {
-                // current server does not support auditing
-                return;
-            }
-
-            try
-            {
-
-                AuditWriteUpdateEventState e = new AuditWriteUpdateEventState(null);
-
-                TranslationInfo message = new TranslationInfo(
-                   "AuditWriteUpdateEvent",
-                    "en-US",
-                    "AuditWriteUpdateEvent.");
-
-                e.Initialize(
-                   systemContext,
-                   null,
-                   EventSeverity.Min,
-                   new LocalizedText(message),
-                   StatusCode.IsGood(statusCode),
-                   DateTime.UtcNow);  // initializes Status, ActionTimeStamp, ServerId, ClientAuditEntryId, ClientUserId
-
-                e.SetChildValue(systemContext, BrowseNames.SourceNode, writeValue.NodeId, false);
-                e.SetChildValue(systemContext, BrowseNames.SourceName, "Attribute/Write", false);
-                e.SetChildValue(systemContext, BrowseNames.LocalTime, Utils.GetTimeZoneInfo(), false);
-
-                e.SetChildValue(systemContext, BrowseNames.ClientUserId, systemContext?.UserIdentity?.DisplayName, false);
-                e.SetChildValue(systemContext, BrowseNames.ClientAuditEntryId, systemContext?.AuditEntryId, false);
-
-                e.SetChildValue(systemContext, BrowseNames.AttributeId, writeValue.AttributeId, false);
-                e.SetChildValue(systemContext, BrowseNames.IndexRange, writeValue.IndexRange, false);
-
-                object newValue = writeValue.Value?.Value;
-                if (writeValue.ParsedIndexRange != NumericRange.Empty)
-                {
-                    writeValue.ParsedIndexRange.UpdateRange(ref newValue, writeValue.Value?.Value);
-                }
-
-                e.SetChildValue(systemContext, BrowseNames.NewValue, newValue, false);
-                e.SetChildValue(systemContext, BrowseNames.OldValue, oldValue, false);
-
-                Server?.ReportEvent(systemContext, e);
-            }
-            catch (Exception ex)
-            {
-                Utils.LogError(ex, "Error while reporting AuditWriteUpdateEvent event.");
-            }
-        }
-
-        /// <summary>
-        /// Initialize the properties of an AuditUpdateEventState.
-        /// </summary>
-        /// <param name="e">AuditUpdate event reference</param>
-        /// <param name="systemContext">Server information</param>
-        /// <param name="auditEventName">Audit event name</param>
-        /// <param name="sourceName">Source name</param>
-        /// <param name="historyUpdateDetails">History update details</param>
-        /// <param name="statusCode">The resulting status code</param>
-        private void InitializeAuditHistoryUpdateEvent(AuditHistoryUpdateEventState e,
-             ISystemContext systemContext,
-             string auditEventName,
-             string sourceName,
-             HistoryUpdateDetails historyUpdateDetails,
-             StatusCode statusCode)
-        {
-            TranslationInfo message = new TranslationInfo(
-               auditEventName,
-               "en-US",
-               $"{auditEventName} has Result: {statusCode.ToString(null, CultureInfo.InvariantCulture)}.");
-
-            e.Initialize(
-               systemContext,
-               null,
-               EventSeverity.Min,
-               new LocalizedText(message),
-               StatusCode.IsGood(statusCode),
-               DateTime.UtcNow);  // initializes Status, ActionTimeStamp, ServerId, ClientAuditEntryId, ClientUserId
-
-            e.SetChildValue(systemContext, BrowseNames.SourceNode, historyUpdateDetails.NodeId, false);
-            e.SetChildValue(systemContext, BrowseNames.SourceName, sourceName, false);
-            e.SetChildValue(systemContext, BrowseNames.LocalTime, Utils.GetTimeZoneInfo(), false);
-
-            e.SetChildValue(systemContext, BrowseNames.ClientUserId, systemContext?.UserIdentity?.DisplayName, false);
-            e.SetChildValue(systemContext, BrowseNames.ClientAuditEntryId, systemContext?.AuditEntryId, false);
-
-            e.SetChildValue(systemContext, BrowseNames.ParameterDataTypeId, historyUpdateDetails.TypeId, false);
-        }
-
-        /// <summary>
-        /// Reports an AuditHistoryValueUpdate event.
-        /// </summary>
-        /// <param name="systemContext">Server information</param>>
-        /// <param name="updateDataDetails">Update data details</param>
-        /// <param name="oldValues">The old values</param>
-        /// <param name="statusCode">The resulting status code</param>
-        protected void ReportAuditHistoryValueUpdateEvent(ISystemContext systemContext,
-            UpdateDataDetails updateDataDetails,
-            DataValue[] oldValues,
-            StatusCode statusCode)
-        {
-            if (Server?.EventManager?.ServerAuditing != true)
-            {
-                // current server does not support auditing
-                return;
-            }
-
-            try
-            {
-                AuditHistoryValueUpdateEventState e = new AuditHistoryValueUpdateEventState(null);
-
-                InitializeAuditHistoryUpdateEvent(e,
-                        systemContext,
-                        "AuditHistoryValueUpdateEvent",
-                        "Attribute/HistoryValueUpdate",
-                        updateDataDetails,
-                        statusCode);
-
-                e.SetChildValue(systemContext, BrowseNames.UpdatedNode, updateDataDetails.NodeId, false);
-                e.SetChildValue(systemContext, BrowseNames.PerformInsertReplace, updateDataDetails.PerformInsertReplace, false);
-                e.SetChildValue(systemContext, BrowseNames.NewValues, updateDataDetails.UpdateValues.ToArray(), false);
-                e.SetChildValue(systemContext, BrowseNames.OldValues, oldValues, false);
-
-                Server.ReportEvent(systemContext, e);
-            }
-            catch (Exception ex)
-            {
-                Utils.LogError(ex, "Error while reporting AuditHistoryValueUpdateEvent event.");
-            }
-        }
-
-        /// <summary>
-        /// Reports an AuditHistoryValueUpdate event.
-        /// </summary>
-        /// <param name="systemContext">Server information</param>
-        /// <param name="updateStructureDataDetails">Update structure data details</param>
-        /// <param name="oldValues">The old values</param>
-        /// <param name="statusCode">The resulting status code</param>
-        protected void ReportAuditHistoryAnnotationUpdateEvent(ServerSystemContext systemContext,
-            UpdateStructureDataDetails updateStructureDataDetails,
-            DataValue[] oldValues,
-            StatusCode statusCode)
-        {
-            if (Server?.EventManager?.ServerAuditing != true)
-            {
-                // current server does not support auditing
-                return;
-            }
-
-            try
-            {
-                AuditHistoryAnnotationUpdateEventState e = new AuditHistoryAnnotationUpdateEventState(null);
-
-                InitializeAuditHistoryUpdateEvent(e,
-                    systemContext,
-                    "AuditHistoryAnnotationUpdateEvent",
-                    "Attribute/HistoryAnnotationUpdate",
-                    updateStructureDataDetails,
-                    statusCode);
-
-                e.SetChildValue(systemContext, BrowseNames.PerformInsertReplace, updateStructureDataDetails.PerformInsertReplace, false);
-                e.SetChildValue(systemContext, BrowseNames.NewValues, updateStructureDataDetails.UpdateValues?.ToArray(), false);
-                e.SetChildValue(systemContext, BrowseNames.OldValues, oldValues, false);
-
-                Server.ReportEvent(systemContext, e);
-            }
-            catch (Exception ex)
-            {
-                Utils.LogError(ex, "Error while reporting AuditHistoryValueUpdateEvent event.");
-            }
-        }
-
-        /// <summary>
-        /// Reports an AuditHistoryEventUpdate event.
-        /// </summary>
-        /// <param name="systemContext">Server information</param>
-        /// <param name="updateEventDetails">Update event details</param>
-        /// <param name="oldValues">The old values</param>
-        /// <param name="statusCode">The resulting status code</param>
-        protected void ReportAuditHistoryEventUpdateEvent(ISystemContext systemContext,
-            UpdateEventDetails updateEventDetails,
-            HistoryEventFieldList[] oldValues,
-            StatusCode statusCode)
-        {
-            if (Server?.EventManager?.ServerAuditing != true)
-            {
-                // current server does not support auditing
-                return;
-            }
-
-            try
-            {
-                AuditHistoryEventUpdateEventState e = new AuditHistoryEventUpdateEventState(null);
-
-                InitializeAuditHistoryUpdateEvent(e,
-                    systemContext,
-                    "AuditHistoryEventUpdateEvent",
-                    "Attribute/HistoryEventUpdate",
-                    updateEventDetails,
-                    statusCode);
-
-                e.SetChildValue(systemContext, BrowseNames.UpdatedNode, updateEventDetails.NodeId, false);
-                e.SetChildValue(systemContext, BrowseNames.PerformInsertReplace, updateEventDetails.PerformInsertReplace, false);
-                e.SetChildValue(systemContext, BrowseNames.Filter, updateEventDetails.Filter, false);
-                e.SetChildValue(systemContext, BrowseNames.NewValues, updateEventDetails.EventData.ToArray(), false);
-                e.SetChildValue(systemContext, BrowseNames.OldValues, oldValues, false);
-
-                Server.ReportEvent(systemContext, e);
-            }
-            catch (Exception ex)
-            {
-                Utils.LogError(ex, "Error while reporting AuditHistoryEventUpdateEvent event.");
-            }
-        }
-
-        /// <summary>
-        /// Reports an AuditHistoryRawModifyDelete event.
-        /// </summary>
-        /// <param name="systemContext">Server information</param>
-        /// <param name="deleteRawModifiedDetails">History raw modified details</param>
-        /// <param name="oldValues">The old values</param>
-        /// <param name="statusCode">The resulting status code</param>
-        protected void ReportAuditHistoryRawModifyDeleteEvent(ISystemContext systemContext,
-            DeleteRawModifiedDetails deleteRawModifiedDetails,
-            DataValue[] oldValues,
-            StatusCode statusCode)
-        {
-            if (Server?.EventManager?.ServerAuditing != true)
-            {
-                // current server does not support auditing
-                return;
-            }
-
-            try
-            {
-                AuditHistoryRawModifyDeleteEventState e = new AuditHistoryRawModifyDeleteEventState(null);
-
-                InitializeAuditHistoryUpdateEvent(e,
-                    systemContext,
-                    "AuditHistoryRawModifyDeleteEvent",
-                    "Attribute/HistoryRawModifyDelete",
-                    deleteRawModifiedDetails,
-                    statusCode);
-
-                e.SetChildValue(systemContext, BrowseNames.UpdatedNode, deleteRawModifiedDetails.NodeId, false);
-                e.SetChildValue(systemContext, BrowseNames.IsDeleteModified, deleteRawModifiedDetails.IsDeleteModified, false);
-                e.SetChildValue(systemContext, BrowseNames.StartTime, deleteRawModifiedDetails.StartTime, false);
-                e.SetChildValue(systemContext, BrowseNames.EndTime, deleteRawModifiedDetails.EndTime, false);
-                e.SetChildValue(systemContext, BrowseNames.OldValues, oldValues, false);
-
-                Server.ReportEvent(systemContext, e);
-            }
-            catch (Exception ex)
-            {
-                Utils.LogError(ex, "Error while reporting AuditHistoryRawModifyDeleteEvent event.");
-            }
-        }
-
-        /// <summary>
-        /// Reports an AuditHistoryAtTimeDelete event.
-        /// </summary>
-        /// <param name="systemContext">Server information</param>
-        /// <param name="deleteAtTimeDetails">History delete at time details</param>
-        /// <param name="oldValues">The old values</param>
-        /// <param name="statusCode">The resulting status code</param>
-        protected void ReportAuditHistoryAtTimeDeleteEvent(ISystemContext systemContext,
-            DeleteAtTimeDetails deleteAtTimeDetails,
-            DataValue[] oldValues,
-            StatusCode statusCode)
-        {
-            if (Server?.EventManager?.ServerAuditing != true)
-            {
-                // current server does not support auditing
-                return;
-            }
-
-            try
-            {
-                AuditHistoryAtTimeDeleteEventState e = new AuditHistoryAtTimeDeleteEventState(null);
-
-                InitializeAuditHistoryUpdateEvent(e,
-                    systemContext,
-                    "AuditHistoryAtTimeDeleteEvent",
-                    "Attribute/HistoryAtTimeDelete",
-                    deleteAtTimeDetails,
-                    statusCode);
-
-                e.SetChildValue(systemContext, BrowseNames.UpdatedNode, deleteAtTimeDetails.NodeId, false);
-                e.SetChildValue(systemContext, BrowseNames.ReqTimes, deleteAtTimeDetails.ReqTimes.ToArray(), false);
-                e.SetChildValue(systemContext, BrowseNames.OldValues, oldValues, false);
-
-                Server.ReportEvent(systemContext, e);
-            }
-            catch (Exception ex)
-            {
-                Utils.LogError(ex, "Error while reporting AuditHistoryAtTimeDeleteEvent event.");
-            }
-
-        }
-
-        /// <summary>
-        /// Reports an AuditHistoryEventDelete event.
-        /// </summary>
-        /// <param name="systemContext">Server information</param>
-        /// <param name="deleteEventDetails">History delete event details</param>
-        /// <param name="oldValues">The old values</param>
-        /// <param name="statusCode">The resulting status code</param>
-        protected void ReportAuditHistoryEventDeleteEvent(ISystemContext systemContext,
-            DeleteEventDetails deleteEventDetails,
-            DataValue[] oldValues,
-            StatusCode statusCode)
-        {
-            if (Server?.EventManager?.ServerAuditing != true)
-            {
-                // current server does not support auditing
-                return;
-            }
-
-            try
-            {
-                AuditHistoryEventDeleteEventState e = new AuditHistoryEventDeleteEventState(null);
-
-                InitializeAuditHistoryUpdateEvent(e,
-                    systemContext,
-                    "AuditHistoryEventDeleteEvent",
-                    "Attribute/HistoryEventDelete",
-                    deleteEventDetails,
-                    statusCode);
-
-                e.SetChildValue(systemContext, BrowseNames.UpdatedNode, deleteEventDetails.NodeId, false);
-                e.SetChildValue(systemContext, BrowseNames.EventIds, deleteEventDetails.EventIds.ToArray(), false);
-                e.SetChildValue(systemContext, BrowseNames.OldValues, oldValues, false);
-
-                Server.ReportEvent(systemContext, e);
-            }
-            catch (Exception ex)
-            {
-                Utils.LogError(ex, "Error while reporting AuditHistoryEventDeleteEvent event.");
-            }
-        }
-
-
-        /// <summary>
-        /// Report the AuditAddNodesEvent
-        /// </summary>
-        /// <param name="systemContext">Server information.</param>
-        /// <param name="addNodesItems">The added nodes information.</param>
-        /// <param name="customMessage">Custom message for add nodes audit event.</param>
-        /// <param name="statusCode">The resulting status code.</param>
-        protected void ReportAuditAddNodesEvent(ISystemContext systemContext, AddNodesItem[] addNodesItems, string customMessage, StatusCode statusCode)
-        {
-            if (Server?.EventManager?.ServerAuditing != true)
-            {
-                // current server does not support auditing
-                return;
-            }
-            try
-            {
-                AuditAddNodesEventState e = new AuditAddNodesEventState(null);
-
-                TranslationInfo message = new TranslationInfo(
-                           "AuditAddNodesEventState",
-                           "en-US",
-                           $"'{customMessage}' returns StatusCode: {statusCode.ToString(null, CultureInfo.InvariantCulture)}.");
-
-                e.Initialize(
-                   systemContext,
-                   null,
-                   EventSeverity.Min,
-                   new LocalizedText(message),
-                   StatusCode.IsGood(statusCode),
-                   DateTime.UtcNow);  // initializes Status, ActionTimeStamp, ServerId, ClientAuditEntryId, ClientUserId
-
-                e.SetChildValue(systemContext, BrowseNames.SourceNode, ObjectIds.Server, false);
-                e.SetChildValue(systemContext, BrowseNames.SourceName, "NodeManagement/AddNodes", false);
-                e.SetChildValue(systemContext, BrowseNames.LocalTime, Utils.GetTimeZoneInfo(), false);
-
-                e.SetChildValue(systemContext, BrowseNames.NodesToAdd, addNodesItems, false);
-
-                Server.ReportEvent(systemContext, e);
-            }
-            catch (Exception ex)
-            {
-                Utils.LogError(ex, "Error while reporting AuditAddNodesEvent event.");
-            }
-        }
-
-        /// <summary>
-        /// Reports the AuditDeleteNodesEven
-        /// </summary>
-        /// <param name="systemContext">Server information.</param>
-        /// <param name="nodesToDelete">The delete nodes information.</param>
-        /// <param name="customMessage">Custom message for delete nodes.</param>
-        /// <param name="statusCode">The resulting status code.</param>
-        protected void ReportAuditDeleteNodesEvent(ISystemContext systemContext, DeleteNodesItem[] nodesToDelete, string customMessage, StatusCode statusCode)
-        {
-            if (Server?.EventManager?.ServerAuditing != true)
-            {
-                // current server does not support auditing
-                return;
-            }
-            try
-            {
-                AuditDeleteNodesEventState e = new AuditDeleteNodesEventState(null);
-
-                TranslationInfo message = new TranslationInfo(
-                           "AuditDeleteNodesEventState",
-                           "en-US",
-                           $"'{customMessage}' returns StatusCode: {statusCode.ToString(null, CultureInfo.InvariantCulture)}.");
-
-                e.Initialize(
-                   systemContext,
-                   null,
-                   EventSeverity.Min,
-                   new LocalizedText(message),
-                   StatusCode.IsGood(statusCode),
-                   DateTime.UtcNow);  // initializes Status, ActionTimeStamp, ServerId, ClientAuditEntryId, ClientUserId
-
-                e.SetChildValue(systemContext, BrowseNames.SourceNode, ObjectIds.Server, false);
-                e.SetChildValue(systemContext, BrowseNames.SourceName, "NodeManagement/DeleteNodes", false);
-                e.SetChildValue(systemContext, BrowseNames.LocalTime, Utils.GetTimeZoneInfo(), false);
-
-                e.SetChildValue(systemContext, BrowseNames.NodesToDelete, nodesToDelete, false);
-
-                Server.ReportEvent(systemContext, e);
-            }
-            catch (Exception ex)
-            {
-                Utils.LogError(ex, "Error while reporting AuditDeleteNodesEvent event.");
-            }
-        }
-        #endregion Report Audit Events
 
         #region ComponentCache Functions
         /// <summary>

--- a/Libraries/Opc.Ua.Server/Diagnostics/DiagnosticsNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/Diagnostics/DiagnosticsNodeManager.cs
@@ -1377,9 +1377,9 @@ namespace Opc.Ua.Server
         /// <param name="value"></param>
         /// <returns></returns>
         private ServiceResult OnReadUserRolePermissions(
-        ISystemContext context,
-        NodeState node,
-        ref RolePermissionTypeCollection value)
+            ISystemContext context,
+            NodeState node,
+            ref RolePermissionTypeCollection value)
         {
             bool admitUser;
 
@@ -2110,7 +2110,7 @@ namespace Opc.Ua.Server
         #endregion
 
         #region Private Readonly Fields
-        private readonly NodeId[] m_kWellKnownRoles = {
+        private static readonly NodeId[] m_kWellKnownRoles = {
             ObjectIds.WellKnownRole_Anonymous,
             ObjectIds.WellKnownRole_AuthenticatedUser,
             ObjectIds.WellKnownRole_ConfigureAdmin,

--- a/Libraries/Opc.Ua.Server/Diagnostics/MonitoredNode.cs
+++ b/Libraries/Opc.Ua.Server/Diagnostics/MonitoredNode.cs
@@ -225,7 +225,7 @@ namespace Opc.Ua.Server
                 if (e is AuditEventState)
                 {
                     // check Server.Auditing flag and skip if false
-                    if (!NodeManager.Server.EventManager.ServerAuditing)
+                    if (!NodeManager.Server.Auditing)
                     {
                         continue;
                     }

--- a/Libraries/Opc.Ua.Server/NodeManager/EventManager.cs
+++ b/Libraries/Opc.Ua.Server/NodeManager/EventManager.cs
@@ -51,18 +51,6 @@ namespace Opc.Ua.Server
             m_server = server;
             m_monitoredItems = new Dictionary<uint,IEventMonitoredItem>();
             m_maxEventQueueSize = maxQueueSize;
-
-            m_ServerAuditing = new Lazy<bool>(() => {
-                // Extract the value of the Server_Auditing node
-                // Note: The value is cached and it is not updated dynamically
-                BaseVariableState auditing = m_server.NodeManager.DiagnosticsNodeManager.FindPredefinedNode(VariableIds.Server_Auditing,
-                    typeof(BaseVariableState)) as BaseVariableState;
-                if (auditing != null)
-                {
-                    return Convert.ToBoolean(auditing.Value, System.Globalization.CultureInfo.InvariantCulture);
-                }
-                return false;
-            });
         }
         #endregion
 
@@ -260,30 +248,11 @@ namespace Opc.Ua.Server
         }
         #endregion
 
-        #region Public Properties
-        /// <summary>
-        /// Returns the cached read value of Server_Auditing
-        /// </summary>
-        public bool ServerAuditing
-        {
-            get{
-
-                if (m_server.NodeManager == null)
-                {
-                    return false;
-                }
-
-                return m_ServerAuditing.Value;
-            }
-        }
-        #endregion
-
         #region Private Fields
         private object m_lock = new object();
         private IServerInternal m_server;
         private Dictionary<uint, IEventMonitoredItem> m_monitoredItems;
         private uint m_maxEventQueueSize;
-        private Lazy<bool> m_ServerAuditing;
         #endregion
     }
 }

--- a/Libraries/Opc.Ua.Server/Server/IServerInternal.cs
+++ b/Libraries/Opc.Ua.Server/Server/IServerInternal.cs
@@ -28,12 +28,7 @@
  * ======================================================================*/
 
 using System;
-using System.Collections.ObjectModel;
 using System.Collections.Generic;
-using System.Text;
-using System.Runtime.Serialization;
-using System.Security.Principal;
-using System.Security.Cryptography.X509Certificates;
 
 #pragma warning disable 0618
 
@@ -90,7 +85,7 @@ namespace Opc.Ua.Server
         /// This object is thread safe.
         /// </remarks>
         TypeTable TypeTree { get; }
-        
+
         /// <summary>
         /// The master node manager for the server.
         /// </summary>
@@ -126,7 +121,7 @@ namespace Opc.Ua.Server
         /// </summary>
         /// <value>The request manager.</value>
         RequestManager RequestManager { get; }
-        
+
         /// <summary>
         /// A manager for aggregate calculators supported by the server.
         /// </summary>
@@ -143,7 +138,7 @@ namespace Opc.Ua.Server
         /// The manager for active subscriptions.
         /// </summary>
         ISubscriptionManager SubscriptionManager { get; }
-        
+
         /// <summary>
         /// Whether the server is currently running.
         /// </summary>
@@ -192,7 +187,7 @@ namespace Opc.Ua.Server
         /// </summary>
         /// <value>The server diagnostics.</value>
         ServerDiagnosticsSummaryDataType ServerDiagnostics { get; }
-        
+
         /// <summary>
         /// Whether the server is collecting diagnostics.
         /// </summary>

--- a/Libraries/Opc.Ua.Server/Server/IServerInternal.cs
+++ b/Libraries/Opc.Ua.Server/Server/IServerInternal.cs
@@ -42,7 +42,7 @@ namespace Opc.Ua.Server
     /// <summary>
     /// The interface that a server exposes to objects that it contains.
     /// </summary>
-    public interface IServerInternal
+    public interface IServerInternal : IAuditEventServer
     {
         /// <summary>
         /// The endpoint addresses used by the server.
@@ -240,47 +240,5 @@ namespace Opc.Ua.Server
         /// <param name="subscriptionId">The subscription identifier.</param>
         /// <param name="monitoredItemId">The monitored item identifier.</param>
         void ConditionRefresh2(OperationContext context, uint subscriptionId, uint monitoredItemId);
-
-        /// <summary>
-        /// Reports all audit events for client certificate ServiceResultException. It goes recursively for all service results stored in the exception
-        /// </summary>
-        /// <param name="clientCertificate">The client certificate.</param>
-        /// <param name="exception">The Exception that triggers a certificate audit event.</param>
-        void ReportAuditCertificateEvent(X509Certificate2 clientCertificate, Exception exception);
-
-        /// <summary>
-        /// Report the AuditCancelEventState
-        /// </summary>
-        /// <param name="sessionId">Session id of the current session</param>
-        /// <param name="requestHandle">The handle of the canceled request</param>
-        /// <param name="statusCode">The resulted status code of cancel request.</param>
-        void ReportAuditCancelEvent(NodeId sessionId, uint requestHandle, StatusCode statusCode);
-
-        /// <summary>
-        /// Reports a RoleMappingRuleChangedAuditEvent when a method is called on a RoleType instance
-        /// </summary>
-        /// <param name="roleStateObjectId"></param>
-        /// <param name="method"></param>
-        /// <param name="inputArguments"></param>
-        /// <param name="status"></param>
-        void ReportRoleMappingRuleChangedAuditEvent(NodeId roleStateObjectId, MethodState method, object[] inputArguments, bool status);
-
-        /// <summary>
-        /// Reports an audit close session event.
-        /// </summary>
-        /// <param name="auditEntryId">The audit entry id.</param>
-        /// <param name="session">The session object that was created.</param>
-        /// <param name="sourceName">Session/CloseSession when the session is closed by request
-        /// “Session/Timeout” for a Session timeout
-        /// “Session/Terminated” for all other cases.</param>
-        void ReportAuditCloseSessionEvent(string auditEntryId, Session session, string sourceName = "Session/Terminated");
-
-        /// <summary>
-        /// Reports an audit session event for the transfer subscription.
-        /// </summary>
-        /// <param name="auditEntryId">The audit entry id.</param>
-        /// <param name="session">The session object that was created.</param>
-        /// <param name="statusCode">The status code resulting .</param>
-        void ReportAuditTransferSubscriptionEvent(string auditEntryId, Session session, StatusCode statusCode);
     }
 }

--- a/Libraries/Opc.Ua.Server/Server/ServerInternalData.cs
+++ b/Libraries/Opc.Ua.Server/Server/ServerInternalData.cs
@@ -644,11 +644,11 @@ namespace Opc.Ua.Server
                 serverObject.ServerDiagnostics.EnabledFlag.MinimumSamplingInterval = 1000;
 
                 // initialize status.
-                ServerStatusDataType serverStatus = new ServerStatusDataType();
-
-                serverStatus.StartTime = DateTime.UtcNow;
-                serverStatus.CurrentTime = DateTime.UtcNow;
-                serverStatus.State = ServerState.Shutdown;
+                ServerStatusDataType serverStatus = new ServerStatusDataType {
+                    StartTime = DateTime.UtcNow,
+                    CurrentTime = DateTime.UtcNow,
+                    State = ServerState.Shutdown
+                };
                 serverStatus.BuildInfo.ProductName = m_serverDescription.ProductName;
                 serverStatus.BuildInfo.ProductUri = m_serverDescription.ProductUri;
                 serverStatus.BuildInfo.ManufacturerName = m_serverDescription.ManufacturerName;
@@ -699,13 +699,11 @@ namespace Opc.Ua.Server
                     m_configuration);
 
                 m_auditing = m_configuration.ServerConfiguration.AuditingEnabled;
-                BaseVariableState auditing = (BaseVariableState)m_diagnosticsNodeManager.FindPredefinedNode(VariableIds.Server_Auditing, typeof(BaseVariableState));
-                if (auditing != null)
-                {
-                    auditing.OnSimpleWriteValue += OnWriteAuditing;
-                    auditing.OnSimpleReadValue += OnReadAuditing;
-                    auditing.Value = m_auditing;
-                    auditing.RolePermissions = new RolePermissionTypeCollection {
+                PropertyState<bool> auditing = serverObject.Auditing;
+                auditing.OnSimpleWriteValue += OnWriteAuditing;
+                auditing.OnSimpleReadValue += OnReadAuditing;
+                auditing.Value = m_auditing;
+                auditing.RolePermissions = new RolePermissionTypeCollection {
                         new RolePermissionType {
                             RoleId = ObjectIds.WellKnownRole_Anonymous,
                             Permissions = (uint)(PermissionType.Browse|PermissionType.Read)
@@ -718,10 +716,9 @@ namespace Opc.Ua.Server
                             RoleId = ObjectIds.WellKnownRole_ConfigureAdmin,
                             Permissions = (uint)(PermissionType.Browse|PermissionType.Write|PermissionType.ReadRolePermissions|PermissionType.Read)
                             }};
-                    auditing.AccessLevel = AccessLevels.CurrentReadOrWrite;
-                    auditing.UserAccessLevel = AccessLevels.CurrentReadOrWrite;
-                    auditing.MinimumSamplingInterval = 1000;
-                }
+                auditing.AccessLevel = AccessLevels.CurrentReadOrWrite;
+                auditing.UserAccessLevel = AccessLevels.CurrentReadOrWrite;
+                auditing.MinimumSamplingInterval = 1000;
             }
         }
 

--- a/Libraries/Opc.Ua.Server/Server/ServerInternalData.cs
+++ b/Libraries/Opc.Ua.Server/Server/ServerInternalData.cs
@@ -31,7 +31,6 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Security.Cryptography.X509Certificates;
-using Opc.Ua.Bindings;
 
 #pragma warning disable 0618
 
@@ -706,7 +705,19 @@ namespace Opc.Ua.Server
                     auditing.OnSimpleWriteValue += OnWriteAuditing;
                     auditing.OnSimpleReadValue += OnReadAuditing;
                     auditing.Value = m_auditing;
-// TODO: admin only
+                    auditing.RolePermissions = new RolePermissionTypeCollection {
+                        new RolePermissionType {
+                            RoleId = ObjectIds.WellKnownRole_Anonymous,
+                            Permissions = (uint)(PermissionType.Browse|PermissionType.Read)
+                            },
+                        new RolePermissionType {
+                            RoleId = ObjectIds.WellKnownRole_AuthenticatedUser,
+                            Permissions = (uint)(PermissionType.Browse|PermissionType.Read)
+                            },
+                        new RolePermissionType {
+                            RoleId = ObjectIds.WellKnownRole_ConfigureAdmin,
+                            Permissions = (uint)(PermissionType.Browse|PermissionType.Write|PermissionType.ReadRolePermissions|PermissionType.Read)
+                            }};
                     auditing.AccessLevel = AccessLevels.CurrentReadOrWrite;
                     auditing.UserAccessLevel = AccessLevels.CurrentReadOrWrite;
                 }

--- a/Libraries/Opc.Ua.Server/Server/ServerInternalData.cs
+++ b/Libraries/Opc.Ua.Server/Server/ServerInternalData.cs
@@ -720,6 +720,7 @@ namespace Opc.Ua.Server
                             }};
                     auditing.AccessLevel = AccessLevels.CurrentReadOrWrite;
                     auditing.UserAccessLevel = AccessLevels.CurrentReadOrWrite;
+                    auditing.MinimumSamplingInterval = 1000;
                 }
             }
         }
@@ -738,36 +739,6 @@ namespace Opc.Ua.Server
                 m_serverStatus.Timestamp = now;
                 m_serverStatus.Value.CurrentTime = now;
             }
-        }
-
-        /// <summary>
-        /// Updates the server auditing value.
-        /// </summary>
-        private ServiceResult OnWriteAuditing(
-            ISystemContext context,
-            NodeState node,
-            ref object value)
-        {
-            lock (m_dataLock)
-            {
-                m_auditing = Convert.ToBoolean(value, CultureInfo.InvariantCulture);
-            }
-            return ServiceResult.Good;
-        }
-
-        /// <summary>
-        /// Updates the server auditing value.
-        /// </summary>
-        private ServiceResult OnReadAuditing(
-            ISystemContext context,
-            NodeState node,
-            ref object value)
-        {
-            lock (m_dataLock)
-            {
-                value = m_auditing;
-            }
-            return ServiceResult.Good;
         }
 
         /// <summary>
@@ -819,6 +790,30 @@ namespace Opc.Ua.Server
                 m_defaultSystemContext,
                 enabled);
 
+            return ServiceResult.Good;
+        }
+
+        /// <summary>
+        /// Updates the Server.Auditing flag.
+        /// </summary>
+        private ServiceResult OnWriteAuditing(
+            ISystemContext context,
+            NodeState node,
+            ref object value)
+        {
+            m_auditing = Convert.ToBoolean(value, CultureInfo.InvariantCulture);
+            return ServiceResult.Good;
+        }
+
+        /// <summary>
+        /// Updates the Server.Auditing flag.
+        /// </summary>
+        private ServiceResult OnReadAuditing(
+            ISystemContext context,
+            NodeState node,
+            ref object value)
+        {
+            value = m_auditing;
             return ServiceResult.Good;
         }
 

--- a/Libraries/Opc.Ua.Server/Server/ServerInternalData.cs
+++ b/Libraries/Opc.Ua.Server/Server/ServerInternalData.cs
@@ -705,18 +705,14 @@ namespace Opc.Ua.Server
                 auditing.Value = m_auditing;
                 auditing.RolePermissions = new RolePermissionTypeCollection {
                         new RolePermissionType {
-                            RoleId = ObjectIds.WellKnownRole_Anonymous,
-                            Permissions = (uint)(PermissionType.Browse|PermissionType.Read)
-                            },
-                        new RolePermissionType {
                             RoleId = ObjectIds.WellKnownRole_AuthenticatedUser,
                             Permissions = (uint)(PermissionType.Browse|PermissionType.Read)
                             },
                         new RolePermissionType {
-                            RoleId = ObjectIds.WellKnownRole_ConfigureAdmin,
+                            RoleId = ObjectIds.WellKnownRole_SecurityAdmin,
                             Permissions = (uint)(PermissionType.Browse|PermissionType.Write|PermissionType.ReadRolePermissions|PermissionType.Read)
                             }};
-                auditing.AccessLevel = AccessLevels.CurrentReadOrWrite;
+                auditing.AccessLevel = AccessLevels.CurrentRead;
                 auditing.UserAccessLevel = AccessLevels.CurrentReadOrWrite;
                 auditing.MinimumSamplingInterval = 1000;
             }

--- a/Libraries/Opc.Ua.Server/Server/ServerInternalData.cs
+++ b/Libraries/Opc.Ua.Server/Server/ServerInternalData.cs
@@ -29,6 +29,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Security.Cryptography.X509Certificates;
 using Opc.Ua.Bindings;
 
@@ -511,16 +512,7 @@ namespace Opc.Ua.Server
         /// <param name="e">The event.</param>
         public void ReportEvent(ISystemContext context, IFilterTarget e)
         {
-            if (e is AuditEventState && (EventManager?.ServerAuditing == false))
-            {
-                // do not report auditing events if server Auditing flag is false
-                return;
-            }
-
-            if (m_serverObject != null)
-            {
-                m_serverObject.ReportEvent(context, e);
-            }
+            m_serverObject?.ReportEvent(context, e);
         }
 
         /// <summary>
@@ -543,528 +535,27 @@ namespace Opc.Ua.Server
         {
             m_subscriptionManager.ConditionRefresh2(context, subscriptionId, monitoredItemId);
         }
-
         #endregion
 
-        #region Report Audit Events        
+        #region IAuditReportEvents Members
+        /// <inheritdoc/>
+        public bool Auditing => m_auditing;
 
-        /// <summary>
-        ///  Reports all audit events for client certificate ServiceResultException. It goes recursively for all service results stored in the exception
-        /// </summary>
-        /// <param name="clientCertificate">The client certificate.</param>
-        /// <param name="exception">The Exception that triggers a certificate audit event.</param>
-        public void ReportAuditCertificateEvent(X509Certificate2 clientCertificate, Exception exception)
+        /// <inheritdoc/>
+        public ISystemContext DefaultAuditContext => DefaultSystemContext.Copy();
+
+        /// <inheritdoc/>
+        public void ReportAuditEvent(ISystemContext context, IFilterTarget e)
         {
-            if (exception == null)
+            if ((e is AuditEventState) && (Auditing == false))
             {
+                // do not report auditing events if server Auditing flag is false
                 return;
             }
 
-            if (EventManager?.ServerAuditing != true)
-            {
-                // current server does not support auditing
-                return;
-            }
-
-            try
-            {
-                ServerSystemContext systemContext = DefaultSystemContext.Copy();
-                while (exception != null)
-                {
-                    if (exception is ServiceResultException sre && sre.InnerResult != null)
-                    {
-                        // Each validation step has a unique error status and audit event type that shall be reported if the check fails.
-                        ReportAuditCertificateEvent(systemContext, clientCertificate, sre);
-                    }
-                    exception = exception.InnerException;
-                }
-            }
-            catch (Exception ex)
-            {
-                Utils.LogError(ex, "Error while reporting ReportAuditCertificateDataMismatch event.");
-            }
+            ReportEvent(context, e);
         }
-
-        /// <summary>
-        /// Report the audit certificate event for the specified ServiceResultException
-        /// </summary>
-        private void ReportAuditCertificateEvent(ServerSystemContext systemContext, X509Certificate2 clientCertificate, ServiceResultException sre)
-        {
-            try
-            {
-                if (StatusCode.IsBad(sre.InnerResult.Code))
-                {
-                    AuditCertificateEventState auditCertificateEventState = null;
-                    switch (sre.StatusCode)
-                    {
-                        case StatusCodes.BadCertificateTimeInvalid:
-                        case StatusCodes.BadCertificateIssuerTimeInvalid:
-                            // create AuditCertificateExpiredEventType
-                            auditCertificateEventState = new AuditCertificateExpiredEventState(null);
-                            break;
-                        case StatusCodes.BadCertificateInvalid:
-                        case StatusCodes.BadCertificateChainIncomplete:
-                        case StatusCodes.BadCertificatePolicyCheckFailed:
-                            // create AuditCertificateInvalidEventType
-                            auditCertificateEventState = new AuditCertificateInvalidEventState(null);
-                            break;
-                        case StatusCodes.BadCertificateUntrusted:
-                            // create AuditCertificateUntrustedEventType
-                            auditCertificateEventState = new AuditCertificateUntrustedEventState(null);
-                            break;
-                        case StatusCodes.BadCertificateRevoked:
-                        case StatusCodes.BadCertificateIssuerRevoked:
-                        case StatusCodes.BadCertificateRevocationUnknown:
-                        case StatusCodes.BadCertificateIssuerRevocationUnknown:
-                            // create AuditCertificateRevokedEventType
-                            auditCertificateEventState = new AuditCertificateRevokedEventState(null);
-                            break;
-                        case StatusCodes.BadCertificateUseNotAllowed:
-                        case StatusCodes.BadCertificateIssuerUseNotAllowed:
-                            // create AuditCertificateMismatchEventType
-                            auditCertificateEventState = new AuditCertificateMismatchEventState(null);
-                            break;
-                    }
-                    if (auditCertificateEventState != null)
-                    {
-                        auditCertificateEventState.Initialize(
-                              systemContext,
-                              null,
-                              EventSeverity.Min,
-                              sre.Message,
-                              false,
-                              DateTime.UtcNow);  // initializes Status, ActionTimeStamp, ServerId, ClientAuditEntryId, ClientUserId
-
-                        auditCertificateEventState.SetChildValue(systemContext, BrowseNames.SourceName, "Security/Certificate", false);
-
-                        // set AuditSecurityEventType fields
-                        auditCertificateEventState.SetChildValue(systemContext, BrowseNames.StatusCodeId, (StatusCode)sre.InnerResult.StatusCode, false);
-
-                        // set AuditCertificateEventType fields
-                        auditCertificateEventState.SetChildValue(systemContext, BrowseNames.Certificate, clientCertificate?.RawData, false);
-
-                        ReportEvent(systemContext, auditCertificateEventState);
-                    }
-                }
-            }
-            catch (Exception ex)
-            {
-                Utils.LogError(ex, "Error while reporting ReportAuditCertificateDataMismatch event.");
-            }
-        }
-
-        /// <summary>
-        /// Reports the AuditCertificateDataMismatchEventType for Invalid Uri
-        /// </summary>        
-        /// <param name="clientCertificate">The client certificate</param>
-        /// <param name="invalidHostName">The string that represents the host name passed in as part of the URL that is found to be invalid. If the host name was not invalid it can be null.</param>
-        /// <param name="invalidUri">The URI that was passed in and found to not match what is contained in the certificate. If the URI was not invalid it can be null.</param>
-        /// <param name="statusCode">The status code.</param>
-        public void ReportAuditCertificateDataMismatchEvent(X509Certificate2 clientCertificate, string invalidHostName, string invalidUri, StatusCode statusCode)
-        {
-            if (EventManager?.ServerAuditing != true)
-            {
-                // current server does not support auditing
-                return;
-            }
-
-            try
-            {
-                ServerSystemContext systemContext = DefaultSystemContext.Copy();
-
-                // create AuditCertificateDataMismatchEventType
-                AuditCertificateDataMismatchEventState e = new AuditCertificateDataMismatchEventState(null);
-
-                e.Initialize(
-                   systemContext,
-                   null,
-                   EventSeverity.Min,
-                   null,
-                   StatusCode.IsGood(statusCode),
-                   DateTime.UtcNow);  // initializes Status, ActionTimeStamp, ServerId, ClientAuditEntryId, ClientUserId
-
-                e.SetChildValue(systemContext, BrowseNames.SourceName, "Security/Certificate", false);
-                e.SetChildValue(systemContext, BrowseNames.SourceNode, ObjectIds.Server, false);
-                e.SetChildValue(systemContext, BrowseNames.LocalTime, Utils.GetTimeZoneInfo(), false);
-
-                // set AuditSecurityEventType fields
-                e.SetChildValue(systemContext, BrowseNames.StatusCodeId, statusCode, false);
-                // set AuditCertificateEventType fields
-                e.SetChildValue(systemContext, BrowseNames.Certificate, clientCertificate?.RawData, false);
-                // set AuditCertificateDataMismatchEventState fields
-                e.SetChildValue(systemContext, BrowseNames.InvalidUri, invalidUri, false);
-                e.SetChildValue(systemContext, BrowseNames.InvalidHostname, invalidHostName, false);
-
-                ReportEvent(systemContext, e);
-            }
-            catch (Exception ex)
-            {
-                Utils.LogError(ex, "Error while reporting ReportAuditCertificateDataMismatchEvent event.");
-            }
-        }
-
-        /// <summary>
-        /// Report the AuditCancelEventState
-        /// </summary>
-        /// <param name="sessionId">Session id of the current session</param>
-        /// <param name="requestHandle">The handle of the canceled request</param>
-        /// <param name="statusCode">The resulted status code of cancel request.</param>
-        public void ReportAuditCancelEvent(NodeId sessionId, uint requestHandle, StatusCode statusCode)
-        {
-            if (EventManager?.ServerAuditing != true)
-            {
-                // current server does not support auditing
-                return;
-            }
-
-            try
-            {
-                ServerSystemContext systemContext = DefaultSystemContext.Copy();
-
-                // create AuditCancelEventState
-                AuditCancelEventState e = new AuditCancelEventState(null);
-
-                e.Initialize(
-                   systemContext,
-                   null,
-                   EventSeverity.Min,
-                   $"Cancel requested for sessionId: {sessionId} with requestHandle: {requestHandle}",
-                   StatusCode.IsGood(statusCode),
-                   DateTime.UtcNow);  // initializes Status, ActionTimeStamp, ServerId, ClientAuditEntryId, ClientUserId
-
-                e.SetChildValue(systemContext, BrowseNames.SourceName, "Session/Cancel", false);
-                e.SetChildValue(systemContext, BrowseNames.SourceNode, ObjectIds.Server, false);
-                e.SetChildValue(systemContext, BrowseNames.LocalTime, Utils.GetTimeZoneInfo(), false);
-
-                // set AuditSecurityEventType fields
-                e.SetChildValue(systemContext, BrowseNames.StatusCodeId, statusCode, false);
-                // set AuditSessionEventType fields
-                e.SetChildValue(systemContext, BrowseNames.SessionId, sessionId, false);
-                // set AuditCancelEventType fields
-                e.SetChildValue(systemContext, BrowseNames.RequestHandle, requestHandle, false);
-
-                ReportEvent(systemContext, e);
-            }
-            catch (Exception ex)
-            {
-                Utils.LogError(ex, "Error while reporting ReportAuditCancelEvent event.");
-            }
-        }
-
-        /// <summary>
-        /// Reports a RoleMappingRuleChangedAuditEvent when a method is called on a RoleType instance
-        /// </summary>
-        /// <param name="roleStateObjectId"></param>
-        /// <param name="method"></param>
-        /// <param name="inputArguments"></param>
-        /// <param name="status"></param>
-        public void ReportRoleMappingRuleChangedAuditEvent(NodeId roleStateObjectId, MethodState method, object[] inputArguments, bool status)
-        {
-            if (EventManager?.ServerAuditing != true)
-            {
-                // current server does not support auditing
-                return;
-            }
-
-            try
-            {
-                ServerSystemContext systemContext = DefaultSystemContext.Copy();
-
-                // create RoleMappingRuleChangedAuditEventState
-                RoleMappingRuleChangedAuditEventState e = new RoleMappingRuleChangedAuditEventState(null);
-
-                e.Initialize(
-                   systemContext,
-                   null,
-                   EventSeverity.Min,
-                   $"RoleMappingRuleChanged - {method?.BrowseName}",
-                   status,
-                   DateTime.UtcNow);  // initializes Status, ActionTimeStamp, ServerId, ClientAuditEntryId, ClientUserId
-
-                e.SetChildValue(systemContext, BrowseNames.SourceName, "Attribute/Call", false);
-                e.SetChildValue(systemContext, BrowseNames.SourceNode, roleStateObjectId, false);
-                e.SetChildValue(systemContext, BrowseNames.LocalTime, Utils.GetTimeZoneInfo(), false);
-
-                // set AuditUpdateMethodEventType fields
-                e.SetChildValue(systemContext, BrowseNames.MethodId, method?.NodeId, false);
-                e.SetChildValue(systemContext, BrowseNames.InputArguments, inputArguments, false);
-
-                ReportEvent(systemContext, e);
-            }
-            catch (Exception ex)
-            {
-                Utils.LogError(ex, "Error while reporting ReportRoleMappingRuleChangedAuditEvent event.");
-            }
-        }
-
-        /// <summary>
-        /// Reports an audit create session event.
-        /// </summary>
-        /// <param name="auditEntryId">The audit entry id.</param>
-        /// <param name="session">The session object that was created.</param>
-        /// <param name="revisedSessionTimeout">The revised session timeout</param>
-        /// <param name="exception">The exception received during create session request</param> 
-        public void ReportAuditCreateSessionEvent(string auditEntryId, Session session, double revisedSessionTimeout, Exception exception = null)
-        {
-            if (EventManager?.ServerAuditing != true)
-            {
-                // current server does not support auditing
-                return;
-            }
-
-            try
-            {
-                ServerSystemContext systemContext = DefaultSystemContext.Copy();
-
-                // raise an audit event.
-                AuditCreateSessionEventState e = new AuditCreateSessionEventState(null);
-
-                TranslationInfo message = null;
-                if (exception == null)
-                {
-                    message = new TranslationInfo(
-                      "AuditCreateSessionEvent",
-                      "en-US",
-                      $"Session with ID:{session?.Id} was created.");
-                }
-                else
-                {
-                    message = new TranslationInfo(
-                      "AuditCreateSessionEvent",
-                      "en-US",
-                      $"Error while creating session with ID:{session?.Id}: Exception: {exception.Message}.");
-                }
-
-                InitializeAuditSessionEvent(systemContext, e, message, exception == null, session, auditEntryId);
-
-                e.SetChildValue(systemContext, BrowseNames.SourceName, "Session/CreateSession", false);
-
-                // set AuditCreateSessionEventState fields
-                e.SetChildValue(systemContext, BrowseNames.ClientCertificate, session?.ClientCertificate?.RawData, false);
-                e.SetChildValue(systemContext, BrowseNames.ClientCertificateThumbprint, session?.ClientCertificate?.Thumbprint, false);
-                e.SetChildValue(systemContext, BrowseNames.RevisedSessionTimeout, revisedSessionTimeout, false);
-
-                ReportEvent(systemContext, e);
-            }
-            catch (Exception ex)
-            {
-                Utils.LogError(ex, "Error while reporting AuditCreateSessionEvent event for SessionId {0}.", session?.Id);
-            }
-        }
-
-        /// <summary>
-        /// Reports an audit activate session event.
-        /// </summary>
-        /// <param name="auditEntryId">The audit entry id.</param>
-        /// <param name="session">The session that is activated.</param>
-        /// <param name="softwareCertificates">The software certificates</param>
-        /// <param name="exception">The exception received during activate session request</param> 
-        public void ReportAuditActivateSessionEvent(string auditEntryId, Session session, List<SoftwareCertificate> softwareCertificates, Exception exception = null)
-        {
-            if (EventManager?.ServerAuditing != true)
-            {
-                // current server does not support auditing
-                return;
-            }
-
-            try
-            {
-                ServerSystemContext systemContext = DefaultSystemContext.Copy();
-
-                AuditActivateSessionEventState e = new AuditActivateSessionEventState(null);
-
-                TranslationInfo message = null;
-                if (exception == null)
-                {
-                    message = new TranslationInfo(
-                     "AuditActivateSessionEvent",
-                    "en-US",
-                    $"Session with Id:{session.Id} was activated.");
-                }
-                else
-                {
-                    message = new TranslationInfo(
-                      "AuditActivateSessionEvent",
-                      "en-US",
-                      $"Error while activate session with ID:{session?.Id}. Exception: {exception.Message}.");
-                }
-
-                InitializeAuditSessionEvent(systemContext, e, message, exception == null, session, auditEntryId);
-
-                e.SetChildValue(systemContext, BrowseNames.SourceName, "Session/ActivateSession", false);
-                e.SetChildValue(systemContext, BrowseNames.UserIdentityToken, Utils.Clone(session?.IdentityToken), false);
-
-                if (softwareCertificates != null)
-                {
-                    // build the list of SignedSoftwareCertificate
-                    List<SignedSoftwareCertificate> signedSoftwareCertificates = new List<SignedSoftwareCertificate>();
-                    foreach (SoftwareCertificate softwareCertificate in softwareCertificates)
-                    {
-                        SignedSoftwareCertificate item = new SignedSoftwareCertificate();
-                        item.CertificateData = softwareCertificate.SignedCertificate.RawData;
-                        signedSoftwareCertificates.Add(item);
-                    }
-                    e.SetChildValue(systemContext, BrowseNames.ClientSoftwareCertificates, signedSoftwareCertificates.ToArray(), false);
-                }
-
-                ReportEvent(systemContext, e);
-            }
-            catch (Exception e)
-            {
-                Utils.LogError(e, "Error while reporting AuditActivateSessionEvent event for SessionId {0}.", session?.Id);
-            }
-        }
-
-        /// <summary>
-        /// Reports an audit Url Mismatch event.
-        /// </summary>
-        /// <param name="auditEntryId">The audit entry id.</param>
-        /// <param name="session">The session object that was created.</param>
-        /// <param name="revisedSessionTimeout">The revised session timeout</param>
-        /// <param name="endpointUrl">The invalid endpoint url</param> 
-        public void ReportAuditUrlMismatchEvent(string auditEntryId, Session session, double revisedSessionTimeout, string endpointUrl)
-        {
-            if (EventManager?.ServerAuditing != true)
-            {
-                // current server does not support auditing
-                return;
-            }
-
-            try
-            {
-                ServerSystemContext systemContext = DefaultSystemContext.Copy();
-
-                AuditUrlMismatchEventState e = new AuditUrlMismatchEventState(null);
-
-                TranslationInfo message = new TranslationInfo(
-                     "AuditUrlMismatchEvent",
-                     "en-US",
-                     $"Session with ID:{session.Id} was cannot be created because endpoint URL does not match the Server’s HostNames.");
-
-                InitializeAuditSessionEvent(systemContext, e, message, false, session, auditEntryId);
-
-                e.SetChildValue(systemContext, BrowseNames.SourceName, "Session/CreateSession", false);
-
-                // set AuditCreateSessionEventState fields
-                e.SetChildValue(systemContext, BrowseNames.ClientCertificate, session?.ClientCertificate?.RawData, false);
-                e.SetChildValue(systemContext, BrowseNames.ClientCertificateThumbprint, session?.ClientCertificate?.Thumbprint, false);
-                e.SetChildValue(systemContext, BrowseNames.RevisedSessionTimeout, revisedSessionTimeout, false);
-
-                // set AuditUrlMismatchEventState
-                e.SetChildValue(systemContext, BrowseNames.EndpointUrl, endpointUrl, false);
-
-                ReportEvent(systemContext, e);
-            }
-            catch (Exception e)
-            {
-                Utils.LogError(e, "Error while reporting AuditUrlMismatchEvent event for SessionId {0}.", session?.Id);
-            }
-        }
-
-        /// <summary>
-        /// Reports an audit close session event.
-        /// </summary>
-        /// <param name="auditEntryId">The audit entry id.</param>
-        /// <param name="session">The session object that was created.</param>
-        /// <param name="sourceName">Session/CloseSession when the session is closed by request
-        /// “Session/Timeout” for a Session timeout
-        /// “Session/Terminated” for all other cases.</param>
-        public void ReportAuditCloseSessionEvent(string auditEntryId, Session session, string sourceName = "Session/Terminated")
-        {
-            if (EventManager?.ServerAuditing != true)
-            {
-                // current server does not support auditing
-                return;
-            }
-
-            try
-            {
-                ServerSystemContext systemContext = DefaultSystemContext.Copy();
-
-                // raise an audit event.
-                AuditSessionEventState e = new AuditSessionEventState(null);
-
-                TranslationInfo message = new TranslationInfo(
-                    "AuditCloseSessionEvent",
-                    "en-US",
-                    $"Session with ID:{session?.Id} was closed.");
-
-                InitializeAuditSessionEvent(systemContext, e, message, true, session, auditEntryId);
-
-                e.SetChildValue(systemContext, BrowseNames.SourceName, sourceName, false);
-
-                ReportEvent(systemContext, e);
-            }
-            catch (Exception ex)
-            {
-                Utils.LogError(ex, "Error while reporting AuditSessionEventState close event for SessionId {0}.", session?.Id);
-            }
-        }
-
-        /// <summary>
-        /// Reports an audit session event for the transfer subscription.
-        /// </summary>
-        /// <param name="auditEntryId">The audit entry id.</param>
-        /// <param name="session">The session object that was created.</param>
-        /// <param name="statusCode">The status code resulting .</param>
-        public void ReportAuditTransferSubscriptionEvent(string auditEntryId, Session session, StatusCode statusCode)
-        {
-            if (EventManager?.ServerAuditing != true)
-            {
-                // current server does not support auditing
-                return;
-            }
-
-            try
-            {
-                ServerSystemContext systemContext = DefaultSystemContext.Copy();
-
-                // raise an audit event.
-                AuditSessionEventState e = new AuditSessionEventState(null);
-
-                TranslationInfo message = new TranslationInfo(
-                    "AuditSessionEventState",
-                    "en-US",
-                    $"Transfer subscription for session ID:{session?.Id} has statusCode {statusCode}.");
-
-                InitializeAuditSessionEvent(systemContext, e, message, StatusCode.IsGood(statusCode), session, auditEntryId);
-
-                e.SetChildValue(systemContext, BrowseNames.SourceNode, session.Id, false);
-                e.SetChildValue(systemContext, BrowseNames.SourceName, "Session/TransferSubscriptions", false);
-
-                ReportEvent(systemContext, e);
-            }
-            catch (Exception ex)
-            {
-                Utils.LogError(ex, "Error while reporting AuditSessionEventState close event for SessionId {0}.", session?.Id);
-            }
-        }
-
-        /// <summary>
-        /// Initializes a session audit event.
-        /// </summary>
-        private void InitializeAuditSessionEvent(ServerSystemContext systemContext, AuditEventState e, TranslationInfo message, bool status, Session session, string auditEntryId)
-        {
-            e.Initialize(
-                systemContext,
-                null,
-                EventSeverity.Min,
-                new LocalizedText(message),
-                status,
-                DateTime.UtcNow);
-
-            e.SetChildValue(systemContext, BrowseNames.SourceNode, ObjectIds.Server, false);
-
-            // set AuditEventType properties
-            e.SetChildValue(systemContext, BrowseNames.ClientUserId, session?.Identity?.DisplayName, false);
-            e.SetChildValue(systemContext, BrowseNames.ClientAuditEntryId, auditEntryId, false);
-            // set AuditCreateSessionEventType & AuditActivateSessionsEventType properties
-            e.SetChildValue(systemContext, BrowseNames.SecureChannelId, session?.SecureChannelId, false);
-            // set AuditSessionEventType 
-            e.SetChildValue(systemContext, BrowseNames.SessionId, session?.Id, false);
-        }
-
-        #endregion Report Audit Events
+        #endregion
 
         #region Private Methods
         /// <summary>
@@ -1178,20 +669,20 @@ namespace Opc.Ua.Server
                 m_serverStatus.OnBeforeRead = OnReadServerStatus;
 
                 // initialize diagnostics.
-                m_serverDiagnostics = new ServerDiagnosticsSummaryDataType();
-
-                m_serverDiagnostics.ServerViewCount = 0;
-                m_serverDiagnostics.CurrentSessionCount = 0;
-                m_serverDiagnostics.CumulatedSessionCount = 0;
-                m_serverDiagnostics.SecurityRejectedSessionCount = 0;
-                m_serverDiagnostics.RejectedSessionCount = 0;
-                m_serverDiagnostics.SessionTimeoutCount = 0;
-                m_serverDiagnostics.SessionAbortCount = 0;
-                m_serverDiagnostics.PublishingIntervalCount = 0;
-                m_serverDiagnostics.CurrentSubscriptionCount = 0;
-                m_serverDiagnostics.CumulatedSubscriptionCount = 0;
-                m_serverDiagnostics.SecurityRejectedRequestsCount = 0;
-                m_serverDiagnostics.RejectedRequestsCount = 0;
+                m_serverDiagnostics = new ServerDiagnosticsSummaryDataType {
+                    ServerViewCount = 0,
+                    CurrentSessionCount = 0,
+                    CumulatedSessionCount = 0,
+                    SecurityRejectedSessionCount = 0,
+                    RejectedSessionCount = 0,
+                    SessionTimeoutCount = 0,
+                    SessionAbortCount = 0,
+                    PublishingIntervalCount = 0,
+                    CurrentSubscriptionCount = 0,
+                    CumulatedSubscriptionCount = 0,
+                    SecurityRejectedRequestsCount = 0,
+                    RejectedRequestsCount = 0
+                };
 
                 m_diagnosticsNodeManager.CreateServerDiagnostics(
                     m_defaultSystemContext,
@@ -1207,6 +698,18 @@ namespace Opc.Ua.Server
                 configurationNodeManager?.CreateServerConfiguration(
                     m_defaultSystemContext,
                     m_configuration);
+
+                m_auditing = m_configuration.ServerConfiguration.AuditingEnabled;
+                BaseVariableState auditing = (BaseVariableState)m_diagnosticsNodeManager.FindPredefinedNode(VariableIds.Server_Auditing, typeof(BaseVariableState));
+                if (auditing != null)
+                {
+                    auditing.OnSimpleWriteValue += OnWriteAuditing;
+                    auditing.OnSimpleReadValue += OnReadAuditing;
+                    auditing.Value = m_auditing;
+// TODO: admin only
+                    auditing.AccessLevel = AccessLevels.CurrentReadOrWrite;
+                    auditing.UserAccessLevel = AccessLevels.CurrentReadOrWrite;
+                }
             }
         }
 
@@ -1224,6 +727,36 @@ namespace Opc.Ua.Server
                 m_serverStatus.Timestamp = now;
                 m_serverStatus.Value.CurrentTime = now;
             }
+        }
+
+        /// <summary>
+        /// Updates the server auditing value.
+        /// </summary>
+        private ServiceResult OnWriteAuditing(
+            ISystemContext context,
+            NodeState node,
+            ref object value)
+        {
+            lock (m_dataLock)
+            {
+                m_auditing = Convert.ToBoolean(value, CultureInfo.InvariantCulture);
+            }
+            return ServiceResult.Good;
+        }
+
+        /// <summary>
+        /// Updates the server auditing value.
+        /// </summary>
+        private ServiceResult OnReadAuditing(
+            ISystemContext context,
+            NodeState node,
+            ref object value)
+        {
+            lock (m_dataLock)
+            {
+                value = m_auditing;
+            }
+            return ServiceResult.Good;
         }
 
         /// <summary>
@@ -1335,6 +868,7 @@ namespace Opc.Ua.Server
         private object m_dataLock = new object();
         private ServerObjectState m_serverObject;
         private ServerStatusValue m_serverStatus;
+        private bool m_auditing;
         private ServerDiagnosticsSummaryDataType m_serverDiagnostics;
         #endregion
     }

--- a/Libraries/Opc.Ua.Server/Server/StandardServer.cs
+++ b/Libraries/Opc.Ua.Server/Server/StandardServer.cs
@@ -267,38 +267,29 @@ namespace Opc.Ua.Server
         }
 
         #region Report Audit Events
-        /// <summary>
-        /// Report the open secure channel audit event
-        /// </summary>
-        /// <param name="channel">The <see cref="TcpServerChannel"/> that processes the open secure channel request.</param>
-        /// <param name="request">The incoming <see cref="OpenSecureChannelRequest"/></param>
-        /// <param name="clientCertificate">The client certificate.</param>
-        /// <param name="exception">The exception resulted from the open secure channel request.</param>
+        /// <inheritdoc/>
         public override void ReportAuditOpenSecureChannelEvent(
-            TcpServerChannel channel,
+            string globalChannelId,
+            EndpointDescription endpointDescription,
             OpenSecureChannelRequest request,
             X509Certificate2 clientCertificate,
             Exception exception)
         {
-            ServerInternal?.ReportAuditOpenSecureChannelEvent(channel, request, clientCertificate, exception);
+            ServerInternal?.ReportAuditOpenSecureChannelEvent(globalChannelId, endpointDescription, request, clientCertificate, exception);
         }
 
-        /// <summary>
-        /// Report the close secure channel audit event
-        /// </summary>
-        /// <param name="channel"></param>
-        /// <param name="exception">The exception resulted from the open secure channel request.</param>
-        public override void ReportAuditCloseSecureChannelEvent(TcpServerChannel channel, Exception exception)
+        /// <inheritdoc/>
+        public override void ReportAuditCloseSecureChannelEvent(
+            string globalChannelId,
+            Exception exception)
         {
-            ServerInternal?.ReportAuditCloseSecureChannelEvent(channel, exception);
+            ServerInternal?.ReportAuditCloseSecureChannelEvent(globalChannelId, exception);
         }
 
-        /// <summary>
-        /// Reports all audit events for client certificate ServiceResultException.
-        /// </summary>
-        /// <param name="clientCertificate">The client certificate.</param>
-        /// <param name="exception">The Exception that triggers a certificate audit event.</param>
-        public override void ReportAuditCertificateEvent(X509Certificate2 clientCertificate, Exception exception)
+        /// <inheritdoc/>
+        public override void ReportAuditCertificateEvent(
+            X509Certificate2 clientCertificate,
+            Exception exception)
         {
             ServerInternal?.ReportAuditCertificateEvent(clientCertificate, exception);
         }

--- a/Libraries/Opc.Ua.Server/Server/StandardServer.cs
+++ b/Libraries/Opc.Ua.Server/Server/StandardServer.cs
@@ -274,88 +274,13 @@ namespace Opc.Ua.Server
         /// <param name="request">The incoming <see cref="OpenSecureChannelRequest"/></param>
         /// <param name="clientCertificate">The client certificate.</param>
         /// <param name="exception">The exception resulted from the open secure channel request.</param>
-        public override void ReportAuditOpenSecureChannelEvent(TcpServerChannel channel,
+        public override void ReportAuditOpenSecureChannelEvent(
+            TcpServerChannel channel,
             OpenSecureChannelRequest request,
             X509Certificate2 clientCertificate,
             Exception exception)
         {
-            if (ServerInternal?.EventManager?.ServerAuditing != true)
-            {
-                // current server does not support auditing
-                return;
-            }
-
-            try
-            {
-                // raise an audit event.
-                AuditOpenSecureChannelEventState e = new AuditOpenSecureChannelEventState(null);
-                TranslationInfo message = null;
-                if (exception == null)
-                {
-                    message = new TranslationInfo(
-                        "AuditOpenSecureChannelEvent",
-                        "en-US",
-                        "AuditOpenSecureChannelEvent");
-                }
-                else
-                {
-                    message = new TranslationInfo(
-                        "AuditOpenSecureChannelEvent",
-                        "en-US",
-                        $"AuditOpenSecureChannelEvent - Exception: {exception.Message}.");
-                }
-
-                StatusCode statusCode = StatusCodes.Good;
-                while (exception != null && !(exception is ServiceResultException))
-                {
-                    exception = exception.InnerException;
-                }
-                if (exception is ServiceResultException sre)
-                {
-                    statusCode = sre.InnerResult.StatusCode;
-                }
-
-                ServerSystemContext systemContext = ServerInternal?.DefaultSystemContext.Copy();
-
-                DateTime actionTimestamp = DateTime.UtcNow;
-                if (request?.RequestHeader?.Timestamp != null)
-                {
-                    actionTimestamp = request.RequestHeader.Timestamp;
-                }
-
-                e.Initialize(
-                    systemContext,
-                    null,
-                    EventSeverity.Min,
-                    new LocalizedText(message),
-                    exception == null,
-                    actionTimestamp);  // initializes Status, ActionTimeStamp, ServerId, ClientAuditEntryId, ClientUserId
-
-                e.SetChildValue(systemContext, BrowseNames.SourceName, "SecureChannel/OpenSecureChannel", false);
-                e.SetChildValue(systemContext, BrowseNames.ClientUserId, "System/OpenSecureChannel", false);
-                e.SetChildValue(systemContext, BrowseNames.SourceNode, ObjectIds.Server, false);
-                e.SetChildValue(systemContext, BrowseNames.LocalTime, Utils.GetTimeZoneInfo(), false);
-               
-                // set AuditSecurityEventType fields
-                e.SetChildValue(systemContext, BrowseNames.StatusCodeId, statusCode, false);
-
-                // set AuditChannelEventType fields
-                e.SetChildValue(systemContext, BrowseNames.SecureChannelId, channel.GlobalChannelId, false);
-
-                // set AuditOpenSecureChannelEventType fields
-                e.SetChildValue(systemContext, BrowseNames.ClientCertificate, clientCertificate?.RawData, false);
-                e.SetChildValue(systemContext, BrowseNames.ClientCertificateThumbprint, clientCertificate?.Thumbprint, false);
-                e.SetChildValue(systemContext, BrowseNames.RequestType, request?.RequestType, false);
-                e.SetChildValue(systemContext, BrowseNames.SecurityPolicyUri, channel.EndpointDescription?.SecurityPolicyUri, false);
-                e.SetChildValue(systemContext, BrowseNames.SecurityMode, channel.EndpointDescription?.SecurityMode, false);
-                e.SetChildValue(systemContext, BrowseNames.RequestedLifetime, request?.RequestedLifetime, false);
-
-                ServerInternal?.ReportEvent(systemContext, e);
-            }
-            catch (Exception ex)
-            {
-                Utils.LogError(ex, "Error while reporting AuditOpenSecureChannelEvent event.");
-            }
+            ServerInternal?.ReportAuditOpenSecureChannelEvent(channel, request, clientCertificate, exception);
         }
 
         /// <summary>
@@ -365,78 +290,11 @@ namespace Opc.Ua.Server
         /// <param name="exception">The exception resulted from the open secure channel request.</param>
         public override void ReportAuditCloseSecureChannelEvent(TcpServerChannel channel, Exception exception)
         {
-            if (ServerInternal?.EventManager?.ServerAuditing != true)
-            {
-                // current server does not support auditing
-                return;
-            }
-
-            try
-            {
-                // raise an audit event.
-                AuditChannelEventState e = new AuditChannelEventState(null);
-
-                TranslationInfo message = null;
-                if (exception == null)
-                {
-                    message = new TranslationInfo(
-                        "AuditCloseSecureChannelEvent",
-                        "en-US",
-                        "AuditCloseSecureChannelEvent");
-                }
-                else
-                {
-                    message = new TranslationInfo(
-                        "AuditCloseSecureChannelEvent",
-                        "en-US",
-                        $"AuditCloseSecureChannelEvent - Exception: {exception.Message}.");
-                }
-
-                StatusCode statusCode = StatusCodes.Good;
-                while (exception != null && !(exception is ServiceResultException))
-                {
-                    exception = exception.InnerException;
-                }
-                if (exception is ServiceResultException sre)
-                {
-                    statusCode = sre.InnerResult.StatusCode;
-                }
-
-                ServerSystemContext systemContext = ServerInternal?.DefaultSystemContext.Copy();
-
-                e.Initialize(
-                    systemContext,
-                    null,
-                    EventSeverity.Min,
-                    new LocalizedText(message),
-                    exception == null,
-                    DateTime.UtcNow);  // initializes Status, ActionTimeStamp, ServerId, ClientAuditEntryId, ClientUserId
-
-                e.SetChildValue(systemContext, BrowseNames.SourceName, "SecureChannel/CloseSecureChannel", false);
-
-                string clientUserId = "System/CloseSecureChannel";
-                //operationContext.UserIdentity?.DisplayName, or ”System/CloseSecureChannel”
-
-                e.SetChildValue(systemContext, BrowseNames.ClientUserId, clientUserId, false);
-                e.SetChildValue(systemContext, BrowseNames.SourceNode, ObjectIds.Server, false);
-                e.SetChildValue(systemContext, BrowseNames.LocalTime, Utils.GetTimeZoneInfo(), false);
-
-                // set AuditSecurityEventType fields
-                e.SetChildValue(systemContext, BrowseNames.StatusCodeId, statusCode, false);
-
-                // set AuditChannelEventType fields
-                e.SetChildValue(systemContext, BrowseNames.SecureChannelId, channel.GlobalChannelId, false);
-
-                ServerInternal?.ReportEvent(systemContext, e);
-            }
-            catch (Exception ex)
-            {
-                Utils.LogError(ex, "Error while reporting AuditOpenSecureChannelEvent event.");
-            }
+            ServerInternal?.ReportAuditCloseSecureChannelEvent(channel, exception);
         }
 
         /// <summary>
-        /// Reports all audit events for client certificate ServiceResultException. It goes recursively for all service results stored in the exception
+        /// Reports all audit events for client certificate ServiceResultException.
         /// </summary>
         /// <param name="clientCertificate">The client certificate.</param>
         /// <param name="exception">The Exception that triggers a certificate audit event.</param>
@@ -444,60 +302,6 @@ namespace Opc.Ua.Server
         {
             ServerInternal?.ReportAuditCertificateEvent(clientCertificate, exception);
         }
-
-        #region Private Report Audit Event Methods        
-
-        /// <summary>
-        /// Report Audit event
-        /// </summary>
-        /// <param name="operationContext">Client operation info</param>
-        /// <param name="methodName">Audit method name</param>
-        /// <param name="serviceResultException">The service exception that includes also a status code</param>
-        private void ReportAuditEvent(OperationContext operationContext,
-            string methodName,
-            ServiceResultException serviceResultException)
-        {
-            if (ServerInternal?.EventManager?.ServerAuditing != true)
-            {
-                // current server does not support auditing
-                return;
-            }
-
-            try
-            {
-                ServerSystemContext systemContext = ServerInternal?.DefaultSystemContext.Copy();
-
-                AuditEventState e = new AuditEventState(null);
-
-                TranslationInfo message = new TranslationInfo(
-                   "AuditEvent",
-                   "en-US",
-                   $"Method {methodName} failed. Result: {serviceResultException.Message}.");
-
-                e.Initialize(
-                   systemContext,
-                   null,
-                   EventSeverity.Min,
-                   new LocalizedText(message),
-                   StatusCode.IsGood(serviceResultException.StatusCode),
-                   DateTime.UtcNow);  // initializes Status, ActionTimeStamp, ServerId, ClientAuditEntryId, ClientUserId
-
-                e.SetChildValue(systemContext, BrowseNames.SourceNode, ObjectIds.Server, false);
-                e.SetChildValue(systemContext, BrowseNames.SourceName, $"Attribute/{methodName}", false);
-                e.SetChildValue(systemContext, BrowseNames.LocalTime, Utils.GetTimeZoneInfo(), false);
-
-                e.SetChildValue(systemContext, BrowseNames.ClientUserId, operationContext?.UserIdentity?.DisplayName, false);
-                e.SetChildValue(systemContext, BrowseNames.ClientAuditEntryId, operationContext?.AuditEntryId, false);
-
-                ServerInternal?.ReportEvent(systemContext, e);
-            }
-            catch (Exception ex)
-            {
-                Utils.LogError(ex, "Error while reporting AuditEvent event.");
-            }
-        }
-        #endregion
-
         #endregion Report Audit Events
 
         /// <summary>
@@ -563,7 +367,7 @@ namespace Opc.Ua.Server
                     {
                         throw new ServiceResultException(StatusCodes.BadServerUriInvalid);
                     }
-                }               
+                }
 
                 bool requireEncryption = ServerBase.RequireEncryption(context?.ChannelContext?.EndpointDescription);
 
@@ -592,7 +396,7 @@ namespace Opc.Ua.Server
                                 certificateApplicationUri != clientDescription.ApplicationUri)
                             {
                                 // report the AuditCertificateDataMismatch event for invalid uri
-                                ServerInternal?.ReportAuditCertificateDataMismatchEvent( parsedClientCertificate, null, clientDescription.ApplicationUri, StatusCodes.BadCertificateUriInvalid);
+                                ServerInternal?.ReportAuditCertificateDataMismatchEvent(parsedClientCertificate, null, clientDescription.ApplicationUri, StatusCodes.BadCertificateUriInvalid);
 
                                 throw ServiceResultException.Create(
                                     StatusCodes.BadCertificateUriInvalid,
@@ -600,7 +404,7 @@ namespace Opc.Ua.Server
                                     clientDescription.ApplicationUri, certificateApplicationUri);
                             }
 
-                            CertificateValidator.Validate(clientCertificateChain);                            
+                            CertificateValidator.Validate(clientCertificateChain);
                         }
                     }
                     catch (Exception e)
@@ -858,7 +662,7 @@ namespace Opc.Ua.Server
 
                 // report the audit event for session activate
                 Session session = ServerInternal.SessionManager.GetSession(requestHeader.AuthenticationToken);
-                ServerInternal.ReportAuditActivateSessionEvent(context?.AuditEntryId, session, softwareCertificates);                
+                ServerInternal.ReportAuditActivateSessionEvent(context?.AuditEntryId, session, softwareCertificates);
 
                 return CreateResponse(requestHeader, StatusCodes.Good);
             }
@@ -1355,7 +1159,7 @@ namespace Opc.Ua.Server
                     }
                 }
 
-                ReportAuditEvent(context, "Read", e);
+                ServerInternal.ReportAuditEvent(context, "Read", e);
 
                 throw TranslateException(context, e);
             }
@@ -1423,7 +1227,7 @@ namespace Opc.Ua.Server
                     }
                 }
 
-                ReportAuditEvent(context, "HistoryRead", e);
+                ServerInternal.ReportAuditEvent(context, "HistoryRead", e);
 
                 throw TranslateException(context, e);
             }
@@ -3287,7 +3091,7 @@ namespace Opc.Ua.Server
                 lock (m_lock)
                 {
                     if (m_serverInternal != null)
-                    { 
+                    {
                         m_serverInternal.SubscriptionManager.Shutdown();
                         m_serverInternal.SessionManager.Shutdown();
                         m_serverInternal.NodeManager.Shutdown();
@@ -3328,7 +3132,7 @@ namespace Opc.Ua.Server
                     ServerInternal.Status.Variable.State.Value = ServerState.Shutdown;
                     ServerInternal.Status.Variable.ClearChangeMasks(ServerInternal.DefaultSystemContext, true);
 
-                    foreach(Session session in currentessions)
+                    foreach (Session session in currentessions)
                     {
                         // raise close session audit event
                         ServerInternal.ReportAuditCloseSessionEvent(null, session, "Session/Terminated");

--- a/Stack/Opc.Ua.Core/Schema/ApplicationConfiguration.cs
+++ b/Stack/Opc.Ua.Core/Schema/ApplicationConfiguration.cs
@@ -1464,6 +1464,7 @@ namespace Opc.Ua
             m_supportedPrivateKeyFormats = new string[] { "PFX", "PEM" };
             m_maxTrustListSize = 0;
             m_multicastDnsEnabled = false;
+            m_auditingEnabled = false;
         }
 
         /// <summary>
@@ -1875,6 +1876,17 @@ namespace Opc.Ua
             get { return m_operationLimits; }
             set { m_operationLimits = value; }
         }
+
+        /// <summary>
+        /// Whether auditing is enabled.
+        /// </summary>
+        /// <value><c>true</c> if auditing is enabled; otherwise, <c>false</c>.</value>
+        [DataMember(IsRequired = false, Order = 36)]
+        public bool AuditingEnabled
+        {
+            get { return m_auditingEnabled; }
+            set { m_auditingEnabled = value; }
+        }
         #endregion
 
         #region Private Members
@@ -1911,6 +1923,7 @@ namespace Opc.Ua
         private bool m_multicastDnsEnabled;
         private ReverseConnectServerConfiguration m_reverseConnect;
         private OperationLimits m_operationLimits;
+        private bool m_auditingEnabled;
         #endregion
     }
     #endregion

--- a/Stack/Opc.Ua.Core/Schema/ApplicationConfiguration.xsd
+++ b/Stack/Opc.Ua.Core/Schema/ApplicationConfiguration.xsd
@@ -162,6 +162,7 @@
           <xs:element name="MultiCastDnsEnabled" type="xs:boolean" minOccurs="0" />
           <xs:element name="ReverseConnect" type="ReverseConnectServerConfiguration" minOccurs="0" />
           <xs:element name="OperationLimits" type="OperationLimits" minOccurs="0" />
+          <xs:element name="AuditingEnabled" type="xs:boolean" minOccurs="0" />
         </xs:sequence>
       </xs:extension>
     </xs:complexContent>

--- a/Stack/Opc.Ua.Core/Stack/Server/EndpointBase.cs
+++ b/Stack/Opc.Ua.Core/Stack/Server/EndpointBase.cs
@@ -128,49 +128,34 @@ namespace Opc.Ua
         }
         #endregion
 
-        // TODO: refactor callbacks
         #region IAuditEventCallback Members
-        /// <summary>
-        /// Report the open secure channel audit event
-        /// </summary>
-        /// <param name="channel">The <see cref="TcpServerChannel"/> that processes the open secure channel request.</param>
-        /// <param name="request">The incoming <see cref="OpenSecureChannelRequest"/></param>
-        /// <param name="clientCertificate">The client certificate.</param>
-        /// <param name="exception">The exception resulted from the open secure channel request.</param>
+        /// <inheritdoc/>
         public void ReportAuditOpenSecureChannelEvent(
-            TcpServerChannel channel,
+            string globalChannelId,
+            EndpointDescription endpointDescription,
             OpenSecureChannelRequest request,
             X509Certificate2 clientCertificate,
             Exception exception)
         {
             // trigger the reporting of AuditOpenSecureChannelEventType
-            ServerForContext?.ReportAuditOpenSecureChannelEvent(channel, request, clientCertificate, exception);
+            ServerForContext?.ReportAuditOpenSecureChannelEvent(globalChannelId, endpointDescription, request, clientCertificate, exception);
         }
 
-        /// <summary>
-        /// Report the close secure channel audit event
-        /// </summary>
-        /// <param name="channel"></param>
-        /// <param name="exception">The exception resulted from the open secure channel request.</param>
+        /// <inheritdoc/>
         public void ReportAuditCloseSecureChannelEvent(
-            TcpServerChannel channel,
+            string globalChannelId,
             Exception exception)
         {
             // trigger the reporting of close AuditChannelEventType
-            ServerForContext?.ReportAuditCloseSecureChannelEvent(channel, exception);
+            ServerForContext?.ReportAuditCloseSecureChannelEvent(globalChannelId, exception);
         }
 
-        /// <summary>
-        /// Reports all audit events for client certificate ServiceResultException. It goes recursively for all service results stored in the exception
-        /// </summary>
-        /// <param name="clientCertificate">The client certificate.</param>
-        /// <param name="exception">The Exception that triggers a certificate audit event.</param>
+        /// <inheritdoc/>
         public void ReportAuditCertificateEvent(X509Certificate2 clientCertificate, Exception exception)
         {
             // trigger the reporting of OpenSecureChannelAuditEvent
             ServerForContext?.ReportAuditCertificateEvent(clientCertificate, exception);
         }
-
         #endregion
 
         #region Public Methods

--- a/Stack/Opc.Ua.Core/Stack/Server/EndpointBase.cs
+++ b/Stack/Opc.Ua.Core/Stack/Server/EndpointBase.cs
@@ -13,6 +13,7 @@
 using System;
 using System.Collections.Generic;
 using System.Security.Cryptography.X509Certificates;
+// TODO remove dependency on TcpServerChannel
 using Opc.Ua.Bindings;
 
 namespace Opc.Ua
@@ -125,9 +126,9 @@ namespace Opc.Ua
         {
             return ProcessRequestAsyncResult.WaitForComplete(result, false);
         }
-
         #endregion
 
+        // TODO: refactor callbacks
         #region IAuditEventCallback Members
         /// <summary>
         /// Report the open secure channel audit event
@@ -136,7 +137,8 @@ namespace Opc.Ua
         /// <param name="request">The incoming <see cref="OpenSecureChannelRequest"/></param>
         /// <param name="clientCertificate">The client certificate.</param>
         /// <param name="exception">The exception resulted from the open secure channel request.</param>
-        public void ReportAuditOpenSecureChannelEvent(TcpServerChannel channel,
+        public void ReportAuditOpenSecureChannelEvent(
+            TcpServerChannel channel,
             OpenSecureChannelRequest request,
             X509Certificate2 clientCertificate,
             Exception exception)
@@ -150,7 +152,9 @@ namespace Opc.Ua
         /// </summary>
         /// <param name="channel"></param>
         /// <param name="exception">The exception resulted from the open secure channel request.</param>
-        public void ReportAuditCloseSecureChannelEvent(TcpServerChannel channel, Exception exception)
+        public void ReportAuditCloseSecureChannelEvent(
+            TcpServerChannel channel,
+            Exception exception)
         {
             // trigger the reporting of close AuditChannelEventType
             ServerForContext?.ReportAuditCloseSecureChannelEvent(channel, exception);

--- a/Stack/Opc.Ua.Core/Stack/Server/IAuditEventCallback.cs
+++ b/Stack/Opc.Ua.Core/Stack/Server/IAuditEventCallback.cs
@@ -22,26 +22,36 @@ namespace Opc.Ua
     public interface IAuditEventCallback
     {
         /// <summary>
-        /// Report the open secure channel audit event
+        /// Report the open secure channel audit event.
         /// </summary>
-        /// <param name="channel">The <see cref="TcpServerChannel"/> that processes the open secure channel request.</param>
+        /// <param name="globalChannelId">The global unique channel id.</param>
+        /// <param name="endpointDescription">The endpoint description used for the request.</param>
         /// <param name="request">The incoming <see cref="OpenSecureChannelRequest"/></param>
         /// <param name="clientCertificate">The client certificate.</param>
         /// <param name="exception">The exception resulted from the open secure channel request.</param>
-        void ReportAuditOpenSecureChannelEvent(TcpServerChannel channel, OpenSecureChannelRequest request, X509Certificate2 clientCertificate, Exception exception);
-        
-        /// <summary>
-        /// Report the close secure channel audit event
-        /// </summary>
-        /// <param name="channel"></param>
-        /// <param name="exception">The exception resulted from the open secure channel request.</param>
-        void ReportAuditCloseSecureChannelEvent(TcpServerChannel channel, Exception exception);
+        void ReportAuditOpenSecureChannelEvent(
+            string globalChannelId,
+            EndpointDescription endpointDescription,
+            OpenSecureChannelRequest request,
+            X509Certificate2 clientCertificate,
+            Exception exception);
 
         /// <summary>
-        /// Report certificate audit event 
+        /// Report the close secure channel audit event.
+        /// </summary>
+        /// <param name="globalChannelId">The global unique channel id.</param>
+        /// <param name="exception">The exception resulted from the open secure channel request.</param>
+        void ReportAuditCloseSecureChannelEvent(
+            string globalChannelId,
+            Exception exception);
+
+        /// <summary>
+        /// Report certificate audit event. 
         /// </summary>
         /// <param name="clientCertificate">The client certificate.</param>
         /// <param name="exception">The Exception that triggers a certificate audit event.</param>
-        void ReportAuditCertificateEvent(X509Certificate2 clientCertificate, Exception exception);
+        void ReportAuditCertificateEvent(
+            X509Certificate2 clientCertificate,
+            Exception exception);
     }
 }

--- a/Stack/Opc.Ua.Core/Stack/Server/ServerBase.cs
+++ b/Stack/Opc.Ua.Core/Stack/Server/ServerBase.cs
@@ -153,15 +153,11 @@ namespace Opc.Ua
             m_requestQueue.ScheduleIncomingRequest(request);
         }
 
-        #region ITransportListenerCallback Members
-        /// <summary>
-        /// Report the open secure channel audit event
-        /// </summary>
-        /// <param name="channel">The <see cref="TcpServerChannel"/> that processes the open secure channel request.</param>
-        /// <param name="request">The incoming <see cref="OpenSecureChannelRequest"/></param>
-        /// <param name="clientCertificate">The client certificate.</param>
-        /// <param name="exception">The exception resulted from the open secure channel request.</param>
-        public virtual void ReportAuditOpenSecureChannelEvent(TcpServerChannel channel,
+        #region IAuditEventCallback Members
+        /// <inheritdoc/>
+        public virtual void ReportAuditOpenSecureChannelEvent(
+            string globalChannelId,
+            EndpointDescription endpointDescription,
             OpenSecureChannelRequest request,
             X509Certificate2 clientCertificate,
             Exception exception)
@@ -169,22 +165,18 @@ namespace Opc.Ua
             // raise an audit open secure channel event.            
         }
 
-        /// <summary>
-        /// Report the close secure channel audit event
-        /// </summary>
-        /// <param name="channel"></param>
-        /// <param name="exception">The exception resulted from the open secure channel request.</param>
-        public virtual void ReportAuditCloseSecureChannelEvent(TcpServerChannel channel, Exception exception)
+        /// <inheritdoc/>
+        public virtual void ReportAuditCloseSecureChannelEvent(
+            string globalChannelId,
+            Exception exception)
         {
             // raise an audit close secure channel event.    
         }
 
-        /// <summary>
-        /// Reports the audit event for client certificate error
-        /// </summary>
-        /// <param name="clientCertificate">The Client certificate</param>
-        /// <param name="exception">The <see cref="Exception"/> that triggers a certificate audit event.</param>
-        public virtual void ReportAuditCertificateEvent(X509Certificate2 clientCertificate, Exception exception)
+        /// <inheritdoc/>
+        public virtual void ReportAuditCertificateEvent(
+            X509Certificate2 clientCertificate,
+            Exception exception)
         {
             // raise the audit certificate
         }

--- a/Stack/Opc.Ua.Core/Stack/Tcp/TcpServerChannel.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/TcpServerChannel.cs
@@ -275,7 +275,7 @@ namespace Opc.Ua.Bindings
                     // process open secure channel repsonse.
                     if (TcpMessageType.IsType(messageType, TcpMessageType.Open))
                     {
-                        Utils.LogTrace(TraceMasks.ServiceDetail, "ChannelId {0}: ProcessOpenSecureChannelRequest", ChannelId);                       
+                        Utils.LogTrace(TraceMasks.ServiceDetail, "ChannelId {0}: ProcessOpenSecureChannelRequest", ChannelId);
                         return ProcessOpenSecureChannelRequest(messageType, messageChunk);
                     }
 
@@ -517,7 +517,7 @@ namespace Opc.Ua.Bindings
                 // If the certificate structure, signature and trust list checks pass,
                 // return the other specific validation errors instead of BadSecurityChecksFailed
                 if (innerException != null)
-                {       
+                {
                     if (innerException.StatusCode == StatusCodes.BadCertificateUntrusted ||
                         innerException.StatusCode == StatusCodes.BadCertificateChainIncomplete ||
                         innerException.StatusCode == StatusCodes.BadCertificateRevoked ||
@@ -845,7 +845,7 @@ namespace Opc.Ua.Bindings
                 {
                     throw ServiceResultException.Create(StatusCodes.BadStructureMissing, "Could not parse CloseSecureChannel request body.");
                 }
-                
+
                 // send the response.
                 // SendCloseSecureChannelResponse(requestId, token, request);
 

--- a/Stack/Opc.Ua.Core/Stack/Tcp/TcpTransportListener.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/TcpTransportListener.cs
@@ -260,6 +260,9 @@ namespace Opc.Ua.Bindings
                 if (m_callback != null)
                 {
                     channel.SetRequestReceivedCallback(new TcpChannelRequestEventHandler(OnRequestReceived));
+                    channel.SetReportOpenSecureChannellAuditCalback(new ReportAuditOpenSecureChannelEventHandler(OnReportAuditOpenSecureChannelEvent));
+                    channel.SetReportCloseSecureChannellAuditCalback(new ReportAuditCloseSecureChannelEventHandler(OnReportAuditCloseSecureChannelEvent));
+                    channel.SetReportCertificateAuditCalback(new ReportAuditCertificateEventHandler(OnReportAuditCertificateEvent));
                 }
             }
             catch (Exception e)
@@ -576,7 +579,7 @@ namespace Opc.Ua.Bindings
             {
                 if (m_callback != null)
                 {
-                    m_callback.ReportAuditOpenSecureChannelEvent(channel, request, clientCertificate, exception);
+                    m_callback.ReportAuditOpenSecureChannelEvent(channel.GlobalChannelId, channel.EndpointDescription, request, clientCertificate, exception);
                 }
             }
             catch (Exception e)
@@ -594,7 +597,7 @@ namespace Opc.Ua.Bindings
             {
                 if (m_callback != null)
                 {
-                    m_callback.ReportAuditCloseSecureChannelEvent(channel, exception);
+                    m_callback.ReportAuditCloseSecureChannelEvent(channel.GlobalChannelId, exception);
                 }
             }
             catch (Exception e)
@@ -602,8 +605,6 @@ namespace Opc.Ua.Bindings
                 Utils.LogError(e, "TCPLISTENER - Unexpected error sending CloseSecureChannel Audit event.");
             }
         }
-
-
 
         /// <summary>
         /// Callback for reporting the certificate audit events
@@ -622,6 +623,7 @@ namespace Opc.Ua.Bindings
                 Utils.LogError(e, "TCPLISTENER - Unexpected error sending Certificate Audit event.");
             }
         }
+
         private void OnProcessRequestComplete(IAsyncResult result)
         {
             try

--- a/Stack/Opc.Ua.Core/Stack/Transport/ITransportListenerCallback.cs
+++ b/Stack/Opc.Ua.Core/Stack/Transport/ITransportListenerCallback.cs
@@ -11,16 +11,13 @@
 */
 
 using System;
-using System.Collections.Generic;
-using System.Security.Cryptography.X509Certificates;
-using System.Text;
-using Opc.Ua.Bindings;
 
 namespace Opc.Ua
 {
     /// <summary>
     /// This is an interface to a object that receives notifications from the listener when a message arrives.
     /// </summary>
+    // TODO: why is audit event plugged in here?
     public interface ITransportListenerCallback : IAuditEventCallback
     {
         /// <summary>

--- a/Stack/Opc.Ua.Core/Stack/Transport/ITransportListenerCallback.cs
+++ b/Stack/Opc.Ua.Core/Stack/Transport/ITransportListenerCallback.cs
@@ -15,9 +15,9 @@ using System;
 namespace Opc.Ua
 {
     /// <summary>
-    /// This is an interface to a object that receives notifications from the listener when a message arrives.
+    /// This is an interface to a object that receives notifications
+    /// from the listener when a message arrives.
     /// </summary>
-    // TODO: why is audit event plugged in here?
     public interface ITransportListenerCallback : IAuditEventCallback
     {
         /// <summary>

--- a/Tests/Opc.Ua.Server.Tests/ServerFixture.cs
+++ b/Tests/Opc.Ua.Server.Tests/ServerFixture.cs
@@ -103,7 +103,8 @@ namespace Opc.Ua.Server.Tests
                 });
             }
 
-            serverConfig.SetDiagnosticsEnabled(true).SetAuditingEnabled(true);
+            serverConfig.SetDiagnosticsEnabled(true);
+            serverConfig.SetAuditingEnabled(true);
 
             if (ReverseConnectTimeout != 0)
             {

--- a/Tests/Opc.Ua.Server.Tests/ServerFixture.cs
+++ b/Tests/Opc.Ua.Server.Tests/ServerFixture.cs
@@ -103,7 +103,7 @@ namespace Opc.Ua.Server.Tests
                 });
             }
 
-            serverConfig.SetAuditingEnabled(true);
+            serverConfig.SetDiagnosticsEnabled(true).SetAuditingEnabled(true);
 
             if (ReverseConnectTimeout != 0)
             {

--- a/Tests/Opc.Ua.Server.Tests/ServerFixture.cs
+++ b/Tests/Opc.Ua.Server.Tests/ServerFixture.cs
@@ -103,6 +103,8 @@ namespace Opc.Ua.Server.Tests
                 });
             }
 
+            serverConfig.SetAuditingEnabled(true);
+
             if (ReverseConnectTimeout != 0)
             {
                 serverConfig.SetReverseConnect(new ReverseConnectServerConfiguration() {


### PR DESCRIPTION
## Proposed changes

- Move the auditing flag to server internal
- Hook up new configuration setting to the Auditing node
- A Security Admin can change the Audit setting.
- Refactor audit events to be extensions in one class.
- enable auditing and diagnostics by default for higher test coverage.
- refactor dependency of some events to bindings, e.g. TcpServerChannel should not be used as reportevent parameter

## Related Issues

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- [x] Test enhancement (non-breaking change to increase test coverage)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [x] I ran tests locally with my changes, all passed.
- [x] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

