### PR TITLE
- Refactor the ReceiveEvents permission type validation to be taken into account also when ConditionRefresh method is called.

### DIFF
--- a/Libraries/Opc.Ua.Server/Diagnostics/MonitoredNode.cs
+++ b/Libraries/Opc.Ua.Server/Diagnostics/MonitoredNode.cs
@@ -241,22 +241,8 @@ namespace Opc.Ua.Server
                 }
                 #endregion
 
-
-                NodeId sourceNode = null;
-                if (e is BaseEventState baseEventState)
-                {
-                    sourceNode = baseEventState.NodeId;
-                }
-                else if (e is InstanceStateSnapshot snapshot)
-                {
-                    BaseEventState eventState = snapshot.Handle as BaseEventState;
-                    sourceNode = eventState?.NodeId;
-                }
-                OperationContext operationContext = new OperationContext(monitoredItem);
-
-                ServiceResult validationResult = NodeManager.ValidateRolePermissions(operationContext,
-                        sourceNode, PermissionType.ReceiveEvents);
-
+                // validate if the monitored item has the required role permissions to receive the event
+                ServiceResult validationResult = NodeManager.ValidateEventRolePermissions(monitoredItem, e);
 
                 if (ServiceResult.IsBad(validationResult))
                 {
@@ -270,7 +256,7 @@ namespace Opc.Ua.Server
                     monitoredItem?.QueueEvent(e);
                 }
             }
-        }
+        }        
 
         /// <summary>
         /// Called when the state of a Node changes.


### PR DESCRIPTION
## Proposed changes

- Fix error in validating PermissionType.ReceiveEvents.
The specs state that "A Client only receives an Event if this bit is set on the Node identified by the EventTypeId field and on the Node identified by the SourceNode field.
This Permission is only valid for EventType Nodes or SourceNodes."
The previous code was only checking the Node id of event state instance.

## Related Issues

- Fixes #

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [x] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
