### PR TITLE
JSON objects cannot have the DataTypeEncodingId

### DIFF
--- a/Stack/Opc.Ua.Core/Types/Encoders/JsonEncoder.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/JsonEncoder.cs
@@ -2498,6 +2498,25 @@ namespace Opc.Ua
             ref int index,
             TypeInfo typeInfo)
         {
+            ulong sizeFromDimensions = 1;
+            // check if matrix is well formed
+            for (int ii = 0; ii < matrix.Dimensions.Length; ii++)
+            {
+                if (matrix.Dimensions[ii] > m_context.MaxArrayLength)
+                {
+                    throw ServiceResultException.Create(
+                            StatusCodes.BadEncodingLimitsExceeded,
+                            "Maximum MaxArrayLength of {0} was exceeded while in matrix dimensions",
+                            m_context.MaxArrayLength);
+                }
+
+                sizeFromDimensions *= (ulong)matrix.Dimensions[ii];
+            }
+            if (sizeFromDimensions != (ulong)matrix.Elements.Length)
+            {
+                throw new ArgumentException("The number of elements in the matrix does not match the dimensions.");
+            }
+
             // check the nesting level for avoiding a stack overflow.
             if (m_nestingLevel > m_context.MaxEncodingNestingLevels)
             {

--- a/Stack/Opc.Ua.Core/Types/Encoders/JsonEncoder.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/JsonEncoder.cs
@@ -1301,6 +1301,7 @@ namespace Opc.Ua
             }
 
             var encodeable = value.Body as IEncodeable;
+
             if (!UseReversibleEncoding && encodeable != null)
             {
                 // non reversible encoding, only the content of the Body field is encoded
@@ -1320,14 +1321,27 @@ namespace Opc.Ua
 
             PushStructure(fieldName);
 
+            var typeId = value.TypeId;
+                     
+            if (encodeable != null)
+            {
+                switch (value.Encoding)
+                {
+                    case ExtensionObjectEncoding.Binary: { typeId = encodeable.BinaryEncodingId; break; }
+                    case ExtensionObjectEncoding.Xml: { typeId = encodeable.XmlEncodingId; break; }
+                    default: { typeId = encodeable.TypeId; break; }
+                }
+            }
+
+            var localTypeId = ExpandedNodeId.ToNodeId(typeId, Context.NamespaceUris);
+
             if (UseReversibleEncoding)
             {
-                var nodeId = ExpandedNodeId.ToNodeId(value.TypeId, Context.NamespaceUris);
-                WriteNodeId("TypeId", nodeId);
+                WriteNodeId("TypeId", localTypeId);
             }
             else
             {
-                WriteExpandedNodeId("TypeId", value.TypeId);
+                WriteExpandedNodeId("TypeId", typeId);
             }
 
             if (encodeable != null)
@@ -2484,25 +2498,6 @@ namespace Opc.Ua
             ref int index,
             TypeInfo typeInfo)
         {
-            ulong sizeFromDimensions = 1;
-            // check if matrix is well formed
-            for (int ii = 0; ii < matrix.Dimensions.Length; ii++)
-            {
-                if (matrix.Dimensions[ii] > m_context.MaxArrayLength)
-                {
-                    throw ServiceResultException.Create(
-                            StatusCodes.BadEncodingLimitsExceeded,
-                            "Maximum MaxArrayLength of {0} was exceeded while in matrix dimensions",
-                            m_context.MaxArrayLength);
-                }
-
-                sizeFromDimensions *= (ulong)matrix.Dimensions[ii];
-            }
-            if (sizeFromDimensions != (ulong)matrix.Elements.Length)
-            {
-                throw new ArgumentException("The number of elements in the matrix does not match the dimensions.");
-            }
-
             // check the nesting level for avoiding a stack overflow.
             if (m_nestingLevel > m_context.MaxEncodingNestingLevels)
             {


### PR DESCRIPTION
Found a less invasive way to get the JSON encoding ids.