### PR TITLE
Set higher default client chunk count limit

### DIFF
--- a/Stack/Opc.Ua.Core/Stack/Tcp/UaSCBinaryChannel.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/UaSCBinaryChannel.cs
@@ -125,8 +125,8 @@ namespace Opc.Ua.Bindings
             m_maxRequestMessageSize = quotas.MaxMessageSize;
             m_maxResponseMessageSize = quotas.MaxMessageSize;
 
-            m_maxRequestChunkCount = CalculateChunkCount(m_maxRequestMessageSize, m_sendBufferSize);
-            m_maxResponseChunkCount = CalculateChunkCount(m_maxResponseMessageSize, m_receiveBufferSize);
+            m_maxRequestChunkCount = CalculateChunkCount(m_maxRequestMessageSize, TcpMessageLimits.MinBufferSize);
+            m_maxResponseChunkCount = CalculateChunkCount(m_maxResponseMessageSize, TcpMessageLimits.MinBufferSize);
 
             CalculateSymmetricKeySizes();
         }

--- a/Tests/Opc.Ua.Core.Tests/Types/Utils/HiResClock.cs
+++ b/Tests/Opc.Ua.Core.Tests/Types/Utils/HiResClock.cs
@@ -119,7 +119,10 @@ namespace Opc.Ua.Core.Tests.Types.UtilsTests
                 lastTickCount = tickCount;
                 counts++;
             }
-            Assert.LessOrEqual(1000, counts);
+            if (!disabled)
+            {
+                Assert.LessOrEqual(1000, counts);
+            }
             stopWatch.Stop();
             long elapsed = lastTickCount - firstTickCount;
             TestContext.Out.WriteLine("HiResClock counts: {0} resolution: {1}µs", counts, stopWatch.ElapsedMilliseconds * 1000 / counts);
@@ -159,7 +162,10 @@ namespace Opc.Ua.Core.Tests.Types.UtilsTests
                 lastTickCount = tickCount;
                 counts++;
             }
-            Assert.LessOrEqual(1000, counts);
+            if (!disabled)
+            {
+                Assert.LessOrEqual(1000, counts);
+            }
             stopWatch.Stop();
             long elapsed = (lastTickCount - firstTickCount) / TimeSpan.TicksPerMillisecond;
             TestContext.Out.WriteLine("HiResClock counts: {0} resolution: {1}µs", counts, stopWatch.ElapsedMilliseconds * 1000 / counts);


### PR DESCRIPTION
## Issue description

A server might return a much smaller send and receive buffer size than what was proposed in the hello message by a client. Given the current default max chunk count, which is based on the default buffer size, the response message size is also limited by the calculated max chunk count.

e.g. send/receive default: 65535 message size: 1Mb, default chunk counts: 17

now the server reduces the buffer sizes to 8192 bytes. The send chunk count can be adjusted by the server ack message, however the response message size is now limited to --> response message size = chunk count * buffer size
the effective response message size becomes: 17 * 8192 = 139264 bytes, which is much smaller than the requests 1MB message size.

- A second issue experienced is that a server may completely ignore the requested max response chunk count and return more chunks than anticipated, causing a dropped message by the client. 

## Proposed changes

- Calculate the default max chunk counts based on the TCP client min buffer size.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [x] I ran tests locally with my changes, all passed.
- [x] I fixed all failing tests in the CI pipelines. 
- [x] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

