### PR TITLE
Make the use of validated certificates opt-in.

### DIFF
--- a/Libraries/Opc.Ua.Configuration/ApplicationConfigurationBuilder.cs
+++ b/Libraries/Opc.Ua.Configuration/ApplicationConfigurationBuilder.cs
@@ -325,6 +325,13 @@ namespace Opc.Ua.Configuration
         }
 
         /// <inheritdoc/>
+        public IApplicationConfigurationBuilderSecurityOptions SetUseValidatedCertificates(bool useValidatedCertificates)
+        {
+            ApplicationConfiguration.SecurityConfiguration.UseValidatedCertificates = useValidatedCertificates;
+            return this;
+        }
+
+        /// <inheritdoc/>
         public IApplicationConfigurationBuilderSecurityOptions SetSuppressNonceValidationErrors(bool suppressNonceValidationErrors)
         {
             ApplicationConfiguration.SecurityConfiguration.SuppressNonceValidationErrors = suppressNonceValidationErrors;

--- a/Libraries/Opc.Ua.Configuration/IApplicationConfigurationBuilder.cs
+++ b/Libraries/Opc.Ua.Configuration/IApplicationConfigurationBuilder.cs
@@ -419,6 +419,12 @@ namespace Opc.Ua.Configuration
         IApplicationConfigurationBuilderSecurityOptions SetRejectUnknownRevocationStatus(bool rejectUnknownRevocationStatus);
 
         /// <summary>
+        /// Use the validated certificates for fast Validation.
+        /// </summary>
+        /// <param name="useValidatedCertificates"><see langword="true"/> to use the validated certificates.</param>
+        IApplicationConfigurationBuilderSecurityOptions SetUseValidatedCertificates(bool useValidatedCertificates);
+
+        /// <summary>
         /// Whether to suppress errors which are caused by clients and servers which provide
         /// zero nonce values or nonce with insufficient entropy.
         /// Suppressing this error is a security risk and may allow an attacker to decrypt user tokens.

--- a/Stack/Opc.Ua.Core/Schema/ApplicationConfiguration.cs
+++ b/Stack/Opc.Ua.Core/Schema/ApplicationConfiguration.cs
@@ -923,12 +923,26 @@ namespace Opc.Ua
         }
 
         /// <summary>
+        /// Gets or sets a value indicating whether the Validator skips the full chain validation
+        /// for already validated or accepted certificates.
+        /// </summary>
+        /// <remarks>
+        /// This flag can be set to true by applications.
+        /// </remarks>
+        [DataMember(IsRequired = false, EmitDefaultValue = false, Order = 13)]
+        public bool UseValidatedCertificates
+        {
+            get { return m_useValidatedCertificates; }
+            set { m_useValidatedCertificates = value; }
+        }
+
+        /// <summary>
         /// Gets or sets a value indicating whether the application cert should be copied to the trusted store.
         /// </summary>
         /// <remarks>
         /// It is useful for client/server applications running on the same host  and sharing the cert store to autotrust.
         /// </remarks>
-        [DataMember(IsRequired = false, EmitDefaultValue = false, Order = 13)]
+        [DataMember(IsRequired = false, EmitDefaultValue = false, Order = 14)]
         public bool AddAppCertToTrustedStore
         {
             get { return m_addAppCertToTrustedStore; }
@@ -941,7 +955,7 @@ namespace Opc.Ua
         /// <remarks>
         /// If set to true the complete certificate chain will be sent for CA signed certificates.
         /// </remarks>
-        [DataMember(IsRequired = false, EmitDefaultValue = false, Order = 14)]
+        [DataMember(IsRequired = false, EmitDefaultValue = false, Order = 15)]
         public bool SendCertificateChain
         {
             get { return m_sendCertificateChain; }
@@ -951,7 +965,7 @@ namespace Opc.Ua
         /// <summary>
         /// The store containing additional user issuer certificates.
         /// </summary>
-        [DataMember(IsRequired = false, EmitDefaultValue = false, Order = 15)]
+        [DataMember(IsRequired = false, EmitDefaultValue = false, Order = 16)]
         public CertificateTrustList UserIssuerCertificates
         {
             get
@@ -973,7 +987,7 @@ namespace Opc.Ua
         /// <summary>
         /// The store containing trusted user certificates.
         /// </summary>
-        [DataMember(IsRequired = false, EmitDefaultValue = false, Order = 16)]
+        [DataMember(IsRequired = false, EmitDefaultValue = false, Order = 17)]
         public CertificateTrustList TrustedUserCertificates
         {
             get
@@ -995,7 +1009,7 @@ namespace Opc.Ua
         /// <summary>
         /// The store containing additional Https issuer certificates.
         /// </summary>
-        [DataMember(IsRequired = false, EmitDefaultValue = false, Order = 17)]
+        [DataMember(IsRequired = false, EmitDefaultValue = false, Order = 18)]
         public CertificateTrustList HttpsIssuerCertificates
         {
             get
@@ -1017,7 +1031,7 @@ namespace Opc.Ua
         /// <summary>
         /// The store containing trusted Https certificates.
         /// </summary>
-        [DataMember(IsRequired = false, EmitDefaultValue = false, Order = 18)]
+        [DataMember(IsRequired = false, EmitDefaultValue = false, Order = 19)]
         public CertificateTrustList TrustedHttpsCertificates
         {
             get
@@ -1044,7 +1058,7 @@ namespace Opc.Ua
         /// If set to true the server nonce validation errors are suppressed.
         /// Please set this flag to true only in close and secured networks since it can cause security vulnerabilities.
         /// </remarks>
-        [DataMember(IsRequired = false, EmitDefaultValue = false, Order = 19)]
+        [DataMember(IsRequired = false, EmitDefaultValue = false, Order = 20)]
         public bool SuppressNonceValidationErrors
         {
             get { return m_suppressNonceValidationErrors; }
@@ -1067,6 +1081,7 @@ namespace Opc.Ua
         private bool m_rejectSHA1SignedCertificates;
         private bool m_rejectUnknownRevocationStatus;
         private ushort m_minCertificateKeySize;
+        private bool m_useValidatedCertificates;
         private bool m_addAppCertToTrustedStore;
         private bool m_sendCertificateChain;
         private bool m_suppressNonceValidationErrors;

--- a/Stack/Opc.Ua.Core/Schema/ApplicationConfiguration.xsd
+++ b/Stack/Opc.Ua.Core/Schema/ApplicationConfiguration.xsd
@@ -51,6 +51,7 @@
       <xs:element name="RejectSHA1SignedCertificates" type="xs:boolean" minOccurs="0" />
       <xs:element name="RejectUnknownRevocationStatus" type="xs:boolean" minOccurs="0" />
       <xs:element name="MinimumCertificateKeySize" type="xs:unsignedShort" minOccurs="0" />
+      <xs:element name="UseValidatedCertificates" type="xs:boolean" minOccurs="0" />
       <xs:element name="AddAppCertToTrustedStore" type="xs:boolean" minOccurs="0" />
       <xs:element name="SendCertificateChain" type="xs:boolean" minOccurs="0" />
       <xs:element name="UserIssuerCertificates" type="CertificateTrustList" minOccurs="0" />

--- a/Stack/Opc.Ua.Core/Security/Certificates/CertificateValidator.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/CertificateValidator.cs
@@ -39,6 +39,7 @@ namespace Opc.Ua
             m_rejectSHA1SignedCertificates = CertificateFactory.DefaultHashSize >= 256;
             m_rejectUnknownRevocationStatus = false;
             m_minimumCertificateKeySize = CertificateFactory.DefaultKeySize;
+            m_useValidatedCertificates = false;
         }
         #endregion
 
@@ -191,6 +192,10 @@ namespace Opc.Ua
                 {
                     m_minimumCertificateKeySize = configuration.MinimumCertificateKeySize;
                 }
+                if ((m_protectFlags & ProtectFlags.UseValidatedCertificates) == 0)
+                {
+                    m_useValidatedCertificates = configuration.UseValidatedCertificates;
+                }
             }
 
             if (configuration.ApplicationCertificate != null)
@@ -320,16 +325,21 @@ namespace Opc.Ua
         }
 
         /// <summary>
-        /// Opt-In to use the cache for validated certificates.
+        /// Opt-In to use the already validated certificates for validation.
         /// </summary>
-        public bool EnableValidatedCertificates
+        public bool UseValidatedCertificates
         {
-            get => m_enableValidatedCertificates;
+            get => m_useValidatedCertificates;
             set
             {
                 lock (m_lock)
                 {
-                    m_enableValidatedCertificates = value;
+                    m_protectFlags |= ProtectFlags.UseValidatedCertificates;
+                    if (m_useValidatedCertificates != value)
+                    {
+                        m_useValidatedCertificates = value;
+                        ResetValidatedCertificates();
+                    }
                 }
             }
         }
@@ -936,7 +946,7 @@ namespace Opc.Ua
             // check for previously validated certificate.
             X509Certificate2 certificate2 = null;
 
-            if (m_enableValidatedCertificates &&
+            if (m_useValidatedCertificates &&
                 m_validatedCertificates.TryGetValue(certificate.Thumbprint, out certificate2))
             {
                 if (Utils.IsEqual(certificate2.RawData, certificate.RawData))
@@ -956,8 +966,7 @@ namespace Opc.Ua
             ServiceResult sresult = PopulateSresultWithValidationErrors(validationErrors);
 
             // setup policy chain
-            X509ChainPolicy policy = new X509ChainPolicy()
-            {
+            X509ChainPolicy policy = new X509ChainPolicy() {
                 RevocationFlag = X509RevocationFlag.EntireChain,
                 RevocationMode = X509RevocationMode.NoCheck,
                 VerificationFlags = X509VerificationFlags.NoFlag,
@@ -1280,7 +1289,7 @@ namespace Opc.Ua
         {
             if (!serverValidation)
             {
-                if (m_enableValidatedCertificates &&
+                if (m_useValidatedCertificates &&
                     m_validatedCertificates.TryGetValue(serverCertificate.Thumbprint, out X509Certificate2 certificate2))
                 {
                     if (Utils.IsEqual(certificate2.RawData, serverCertificate.RawData))
@@ -1334,123 +1343,123 @@ namespace Opc.Ua
             switch (status.Status)
             {
                 case X509ChainStatusFlags.NotValidForUsage:
-                    {
-                        return ServiceResult.Create(
-                            (isIssuer) ? StatusCodes.BadCertificateUseNotAllowed : StatusCodes.BadCertificateIssuerUseNotAllowed,
-                            "Certificate may not be used as an application instance certificate. {0}: {1}",
-                            status.Status,
-                            status.StatusInformation);
-                    }
+                {
+                    return ServiceResult.Create(
+                        (isIssuer) ? StatusCodes.BadCertificateUseNotAllowed : StatusCodes.BadCertificateIssuerUseNotAllowed,
+                        "Certificate may not be used as an application instance certificate. {0}: {1}",
+                        status.Status,
+                        status.StatusInformation);
+                }
 
                 case X509ChainStatusFlags.NoError:
                 case X509ChainStatusFlags.OfflineRevocation:
                 case X509ChainStatusFlags.InvalidBasicConstraints:
-                    {
-                        break;
-                    }
+                {
+                    break;
+                }
 
                 case X509ChainStatusFlags.PartialChain:
                     goto case X509ChainStatusFlags.UntrustedRoot;
                 case X509ChainStatusFlags.UntrustedRoot:
+                {
+                    // self signed cert signature validation 
+                    // .NET Core ChainStatus returns NotSignatureValid only on Windows, 
+                    // so we have to do the extra cert signature check on all platforms
+                    if (issuer == null && id.Certificate != null &&
+                        X509Utils.IsSelfSigned(id.Certificate))
                     {
-                        // self signed cert signature validation 
-                        // .NET Core ChainStatus returns NotSignatureValid only on Windows, 
-                        // so we have to do the extra cert signature check on all platforms
-                        if (issuer == null && id.Certificate != null &&
-                            X509Utils.IsSelfSigned(id.Certificate))
+                        if (!IsSignatureValid(id.Certificate))
                         {
-                            if (!IsSignatureValid(id.Certificate))
-                            {
-                                goto case X509ChainStatusFlags.NotSignatureValid;
-                            }
-                            break;
+                            goto case X509ChainStatusFlags.NotSignatureValid;
                         }
-
-                        return ServiceResult.Create(
-                            StatusCodes.BadCertificateChainIncomplete,
-                            "Certificate chain validation failed. {0}: {1}",
-                            status.Status,
-                            status.StatusInformation);
+                        break;
                     }
+
+                    return ServiceResult.Create(
+                        StatusCodes.BadCertificateChainIncomplete,
+                        "Certificate chain validation failed. {0}: {1}",
+                        status.Status,
+                        status.StatusInformation);
+                }
 
                 case X509ChainStatusFlags.RevocationStatusUnknown:
+                {
+                    if (issuer != null)
                     {
-                        if (issuer != null)
+                        if ((issuer.ValidationOptions & CertificateValidationOptions.SuppressRevocationStatusUnknown) != 0)
                         {
-                            if ((issuer.ValidationOptions & CertificateValidationOptions.SuppressRevocationStatusUnknown) != 0)
-                            {
-                                Utils.LogWarning(Utils.TraceMasks.Security,
-                                    "Error suppressed: {0}: {1}",
-                                    status.Status, status.StatusInformation);
-                                break;
-                            }
-                        }
-
-                        // check for meaning less errors for self-signed certificates.
-                        if (id.Certificate != null && X509Utils.IsSelfSigned(id.Certificate))
-                        {
+                            Utils.LogWarning(Utils.TraceMasks.Security,
+                                "Error suppressed: {0}: {1}",
+                                status.Status, status.StatusInformation);
                             break;
                         }
-
-                        return ServiceResult.Create(
-                            (isIssuer) ? StatusCodes.BadCertificateIssuerRevocationUnknown : StatusCodes.BadCertificateRevocationUnknown,
-                            "Certificate revocation status cannot be verified. {0}: {1}",
-                            status.Status,
-                            status.StatusInformation);
                     }
+
+                    // check for meaning less errors for self-signed certificates.
+                    if (id.Certificate != null && X509Utils.IsSelfSigned(id.Certificate))
+                    {
+                        break;
+                    }
+
+                    return ServiceResult.Create(
+                        (isIssuer) ? StatusCodes.BadCertificateIssuerRevocationUnknown : StatusCodes.BadCertificateRevocationUnknown,
+                        "Certificate revocation status cannot be verified. {0}: {1}",
+                        status.Status,
+                        status.StatusInformation);
+                }
 
                 case X509ChainStatusFlags.Revoked:
-                    {
-                        return ServiceResult.Create(
-                            (isIssuer) ? StatusCodes.BadCertificateIssuerRevoked : StatusCodes.BadCertificateRevoked,
-                            "Certificate has been revoked. {0}: {1}",
-                            status.Status,
-                            status.StatusInformation);
-                    }
+                {
+                    return ServiceResult.Create(
+                        (isIssuer) ? StatusCodes.BadCertificateIssuerRevoked : StatusCodes.BadCertificateRevoked,
+                        "Certificate has been revoked. {0}: {1}",
+                        status.Status,
+                        status.StatusInformation);
+                }
 
                 case X509ChainStatusFlags.NotTimeNested:
+                {
+                    if (id != null && ((id.ValidationOptions & CertificateValidationOptions.SuppressCertificateExpired) != 0))
                     {
-                        if (id != null && ((id.ValidationOptions & CertificateValidationOptions.SuppressCertificateExpired) != 0))
-                        {
-                            Utils.LogWarning(Utils.TraceMasks.Security,
-                                "Error suppressed: {0}: {1}",
-                                status.Status, status.StatusInformation);
-                            break;
-                        }
-
-                        return ServiceResult.Create(
-                            StatusCodes.BadCertificateIssuerTimeInvalid,
-                            "Issuer Certificate has expired or is not yet valid. {0}: {1}",
-                            status.Status,
-                            status.StatusInformation);
+                        Utils.LogWarning(Utils.TraceMasks.Security,
+                            "Error suppressed: {0}: {1}",
+                            status.Status, status.StatusInformation);
+                        break;
                     }
+
+                    return ServiceResult.Create(
+                        StatusCodes.BadCertificateIssuerTimeInvalid,
+                        "Issuer Certificate has expired or is not yet valid. {0}: {1}",
+                        status.Status,
+                        status.StatusInformation);
+                }
 
                 case X509ChainStatusFlags.NotTimeValid:
+                {
+                    if (id != null && ((id.ValidationOptions & CertificateValidationOptions.SuppressCertificateExpired) != 0))
                     {
-                        if (id != null && ((id.ValidationOptions & CertificateValidationOptions.SuppressCertificateExpired) != 0))
-                        {
-                            Utils.LogWarning(Utils.TraceMasks.Security,
-                                "Error suppressed: {0}: {1}",
-                                status.Status, status.StatusInformation);
-                            break;
-                        }
-
-                        return ServiceResult.Create(
-                            (isIssuer) ? StatusCodes.BadCertificateIssuerTimeInvalid : StatusCodes.BadCertificateTimeInvalid,
-                            "Certificate has expired or is not yet valid. {0}: {1}",
-                            status.Status,
-                            status.StatusInformation);
+                        Utils.LogWarning(Utils.TraceMasks.Security,
+                            "Error suppressed: {0}: {1}",
+                            status.Status, status.StatusInformation);
+                        break;
                     }
+
+                    return ServiceResult.Create(
+                        (isIssuer) ? StatusCodes.BadCertificateIssuerTimeInvalid : StatusCodes.BadCertificateTimeInvalid,
+                        "Certificate has expired or is not yet valid. {0}: {1}",
+                        status.Status,
+                        status.StatusInformation);
+                }
 
                 case X509ChainStatusFlags.NotSignatureValid:
                 default:
-                    {
-                        return ServiceResult.Create(
-                            StatusCodes.BadCertificateInvalid,
-                            "Certificate validation failed. {0}: {1}",
-                            status.Status,
-                            status.StatusInformation);
-                    }
+                {
+                    return ServiceResult.Create(
+                        StatusCodes.BadCertificateInvalid,
+                        "Certificate validation failed. {0}: {1}",
+                        status.Status,
+                        status.StatusInformation);
+                }
             }
 
             return null;
@@ -1583,7 +1592,8 @@ namespace Opc.Ua
             AutoAcceptUntrustedCertificates = 1,
             RejectSHA1SignedCertificates = 2,
             RejectUnknownRevocationStatus = 4,
-            MinimumCertificateKeySize = 8
+            MinimumCertificateKeySize = 8,
+            UseValidatedCertificates = 16
         };
         #endregion
 
@@ -1604,7 +1614,7 @@ namespace Opc.Ua
         private bool m_rejectSHA1SignedCertificates;
         private bool m_rejectUnknownRevocationStatus;
         private ushort m_minimumCertificateKeySize;
-        private bool m_enableValidatedCertificates;
+        private bool m_useValidatedCertificates;
         #endregion
     }
 

--- a/Stack/Opc.Ua.Core/Security/Certificates/CertificateValidator.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/CertificateValidator.cs
@@ -375,9 +375,12 @@ namespace Opc.Ua
                 // check for errors that may be suppressed.
                 if (ContainsUnsuppressibleSC(se.Result))
                 {
-                    SaveCertificate(certificate);
                     Utils.LogCertificate(LogLevel.Error, "Certificate rejected. Reason={0}.",
                         certificate, se.Result.StatusCode);
+
+                    // save the chain in rejected store to allow to add certs to a trusted or issuer store
+                    SaveCertificates(chain);
+
                     LogInnerServiceResults(LogLevel.Error, se.Result.InnerResult);
                     throw new ServiceResultException(se, StatusCodes.BadCertificateInvalid);
                 }
@@ -440,11 +443,12 @@ namespace Opc.Ua
                 // throw if rejected.
                 if (!accept)
                 {
-                    // write the invalid certificate to rejected store if specified.
+                    // write the invalid certificate chain to rejected store if specified.
                     Utils.LogCertificate(LogLevel.Error, "Certificate rejected. Reason={0}.",
                         certificate, serviceResult != null ? serviceResult.StatusCode.ToString() : "Unknown Error");
 
-                    SaveCertificate(certificate);
+                    // save the chain in rejected store to allow to add cert to a trusted or issuer store
+                    SaveCertificates(chain);
 
                     throw new ServiceResultException(se, StatusCodes.BadCertificateInvalid);
                 }
@@ -497,28 +501,45 @@ namespace Opc.Ua
         /// </summary>
         private void SaveCertificate(X509Certificate2 certificate)
         {
+            SaveCertificates(new X509Certificate2Collection { certificate });
+        }
+
+        /// <summary>
+        /// Saves the certificate chain in the rejected certificate store.
+        /// </summary>
+        private void SaveCertificates(X509Certificate2Collection certificateChain)
+        {
             lock (m_lock)
             {
                 if (m_rejectedCertificateStore != null)
                 {
-                    Utils.LogTrace("Writing rejected certificate to: {0}", m_rejectedCertificateStore);
+                    Utils.LogTrace("Writing rejected certificate chain to: {0}", m_rejectedCertificateStore);
                     try
                     {
                         ICertificateStore store = m_rejectedCertificateStore.OpenStore();
                         try
                         {
-                            store.Delete(certificate.Thumbprint);
-                            // save only public key
-                            if (certificate.HasPrivateKey)
+                            bool leafCertificate = true;
+                            foreach (var certificate in certificateChain)
                             {
-                                using (var cert = new X509Certificate2(certificate.RawData))
+                                if (!leafCertificate)
                                 {
-                                    store.Add(cert);
+                                    Utils.LogCertificate("Saved issuer certificate: ", certificate);
                                 }
-                            }
-                            else
-                            {
-                                store.Add(certificate);
+                                leafCertificate = false;
+                                store.Delete(certificate.Thumbprint);
+                                // save only public key
+                                if (certificate.HasPrivateKey)
+                                {
+                                    using (var cert = new X509Certificate2(certificate.RawData))
+                                    {
+                                        store.Add(cert);
+                                    }
+                                }
+                                else
+                                {
+                                    store.Add(certificate);
+                                }
                             }
                         }
                         finally
@@ -814,9 +835,6 @@ namespace Opc.Ua
                             {
                                 CertificateValidationOptions options = certificateStore.ValidationOptions;
 
-                                // already checked revocation for file based stores. windows based stores always suppress.
-                                options |= CertificateValidationOptions.SuppressRevocationStatusUnknown;
-
                                 if (checkRecovationStatus)
                                 {
                                     StatusCode status = await store.IsRevoked(issuer, certificate).ConfigureAwait(false);
@@ -830,7 +848,8 @@ namespace Opc.Ua
                                                 status.Code = StatusCodes.BadCertificateIssuerRevocationUnknown;
                                             }
 
-                                            if (m_rejectUnknownRevocationStatus)
+                                            if (m_rejectUnknownRevocationStatus &&
+                                                (options & CertificateValidationOptions.SuppressRevocationStatusUnknown) == 0)
                                             {
                                                 serviceResult = new ServiceResultException(status);
                                             }
@@ -845,6 +864,9 @@ namespace Opc.Ua
                                         }
                                     }
                                 }
+
+                                // already checked revocation for file based stores. windows based stores always suppress.
+                                options |= CertificateValidationOptions.SuppressRevocationStatusUnknown;
 
                                 return (new CertificateIdentifier(issuer, options), serviceResult);
                             }


### PR DESCRIPTION
## Proposed changes

Currently, the validated certificates are stored in a dictionary for fast compare of the certificate validation when an application reconnects, until manually cleared by e.g. `ResetValidatedCertificates()`. After discussion it was decided to make this function an opt-in feature to avoid use cases where changes in the trusted store or CRL are not reflected in the list of validated certificates.
The runtime penalty of a full check can be avoided if needed with the 'Opt-In' by configuration or by application setting the property. After opt-in it is the application responsibility to clear the list of validated certificates if needed.

#### Other cert validator improvements

- Setting the `ValidationOptions.SuppressRevocationStatusUnknown` on a trustlist (e.g. issuer) was ignored
- If another client/server connects with a chain, the whole chain is saved to the rejected store, not only the leaf certificate. 

## Related Issues

- Fixes #1564 

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [x] I ran tests locally with my changes, all passed.
- [x] I fixed all failing tests in the CI pipelines. 
- [x] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments


