### PR TITLE
Default self signed certificates to set CA flag to false

### DIFF
--- a/Libraries/Opc.Ua.Security.Certificates/Org.BouncyCastle/CertificateBuilder.cs
+++ b/Libraries/Opc.Ua.Security.Certificates/Org.BouncyCastle/CertificateBuilder.cs
@@ -317,8 +317,10 @@ namespace Opc.Ua.Security.Certificates
                 basicConstraints = new BasicConstraints(m_pathLengthConstraint);
             }
             else if (!m_isCA && IssuerCAKeyCert == null)
-            {   // self-signed
-                basicConstraints = new BasicConstraints(0);
+            {
+                // see Mantis https://mantis.opcfoundation.org/view.php?id=8370
+                // self signed application certificates shall set the CA bit to false
+                basicConstraints = new BasicConstraints(false);
             }
 
             if (X509Extensions.FindExtension<X509BasicConstraintsExtension>(m_extensions) == null)

--- a/Libraries/Opc.Ua.Security.Certificates/X509Certificate/CertificateBuilder.cs
+++ b/Libraries/Opc.Ua.Security.Certificates/X509Certificate/CertificateBuilder.cs
@@ -432,8 +432,9 @@ namespace Opc.Ua.Security.Certificates
             // Basic constraints
             if (!m_isCA && IssuerCAKeyCert == null)
             {
-                // self signed
-                return new X509BasicConstraintsExtension(true, true, 0, true);
+                // see Mantis https://mantis.opcfoundation.org/view.php?id=8370
+                // self signed application certificates shall set the CA bit to false
+                return new X509BasicConstraintsExtension(false, false, 0, true);
             }
             else if (m_isCA && m_pathLengthConstraint >= 0)
             {

--- a/Tests/Opc.Ua.Core.Tests/Security/Certificates/CertificateFactoryTest.cs
+++ b/Tests/Opc.Ua.Core.Tests/Security/Certificates/CertificateFactoryTest.cs
@@ -297,9 +297,8 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
             }
             else
             {
-                Assert.True(constraints.CertificateAuthority);
-                Assert.True(constraints.HasPathLengthConstraint);
-                Assert.AreEqual(0, constraints.PathLengthConstraint);
+                Assert.False(constraints.CertificateAuthority);
+                Assert.False(constraints.HasPathLengthConstraint);
             }
 
             // key usage

--- a/Tests/Opc.Ua.Security.Certificates.Tests/CertificateTestsForECDsa.cs
+++ b/Tests/Opc.Ua.Security.Certificates.Tests/CertificateTestsForECDsa.cs
@@ -132,10 +132,7 @@ namespace Opc.Ua.Security.Certificates.Tests
             Assert.AreEqual(X509Defaults.HashAlgorithmName, Oids.GetHashAlgorithmName(cert.SignatureAlgorithm.Value));
             Assert.GreaterOrEqual(DateTime.UtcNow, cert.NotBefore);
             Assert.GreaterOrEqual(DateTime.UtcNow.AddMonths(X509Defaults.LifeTime), cert.NotAfter.ToUniversalTime());
-            var basicConstraintsExtension = X509Extensions.FindExtension<X509BasicConstraintsExtension>(cert.Extensions);
-            Assert.NotNull(basicConstraintsExtension);
-            Assert.True(basicConstraintsExtension.CertificateAuthority);
-            Assert.AreEqual(0, basicConstraintsExtension.PathLengthConstraint);
+            TestUtils.ValidateSelSignedBasicConstraints(cert);
             var keyUsage = X509Extensions.FindExtension<X509KeyUsageExtension>(cert.Extensions);
             Assert.NotNull(keyUsage);
             X509PfxUtils.VerifyECDsaKeyPair(cert, cert, true);
@@ -173,9 +170,7 @@ namespace Opc.Ua.Security.Certificates.Tests
                 publicKey.ExportParameters(false);
             }
             Assert.AreEqual(ecCurveHashPair.HashAlgorithmName, Oids.GetHashAlgorithmName(cert.SignatureAlgorithm.Value));
-            var basicConstraintsExtension = X509Extensions.FindExtension<X509BasicConstraintsExtension>(cert.Extensions);
-            Assert.NotNull(basicConstraintsExtension);
-            Assert.True(basicConstraintsExtension.CertificateAuthority);
+            TestUtils.ValidateSelSignedBasicConstraints(cert);
             X509PfxUtils.VerifyECDsaKeyPair(cert, cert, true);
             Assert.True(X509Utils.VerifySelfSigned(cert));
             CheckPEMWriter(cert);

--- a/Tests/Opc.Ua.Security.Certificates.Tests/CertificateTestsForRSA.cs
+++ b/Tests/Opc.Ua.Security.Certificates.Tests/CertificateTestsForRSA.cs
@@ -136,9 +136,7 @@ namespace Opc.Ua.Security.Certificates.Tests
             Assert.AreEqual(X509Defaults.HashAlgorithmName, Oids.GetHashAlgorithmName(cert.SignatureAlgorithm.Value));
             Assert.GreaterOrEqual(DateTime.UtcNow, cert.NotBefore);
             Assert.GreaterOrEqual(DateTime.UtcNow.AddMonths(X509Defaults.LifeTime), cert.NotAfter.ToUniversalTime());
-            var basicConstraintsExtension = X509Extensions.FindExtension<X509BasicConstraintsExtension>(cert.Extensions);
-            Assert.NotNull(basicConstraintsExtension);
-            Assert.True(basicConstraintsExtension.CertificateAuthority);
+            TestUtils.ValidateSelSignedBasicConstraints(cert);
             X509Utils.VerifyRSAKeyPair(cert, cert, true);
             Assert.True(X509Utils.VerifySelfSigned(cert));
         }
@@ -156,9 +154,7 @@ namespace Opc.Ua.Security.Certificates.Tests
             Assert.AreEqual(Subject, cert.Subject);
             Assert.AreEqual(keyHashPair.KeySize, cert.GetRSAPublicKey().KeySize);
             Assert.AreEqual(X509Defaults.HashAlgorithmName, Oids.GetHashAlgorithmName(cert.SignatureAlgorithm.Value));
-            var basicConstraintsExtension = X509Extensions.FindExtension<X509BasicConstraintsExtension>(cert.Extensions);
-            Assert.NotNull(basicConstraintsExtension);
-            Assert.True(basicConstraintsExtension.CertificateAuthority);
+            TestUtils.ValidateSelSignedBasicConstraints(cert);
             Assert.AreEqual(cert.SubjectName.Name, cert.IssuerName.Name);
             Assert.AreEqual(cert.SubjectName.RawData, cert.IssuerName.RawData);
             X509Utils.VerifyRSAKeyPair(cert, cert, true);
@@ -179,9 +175,7 @@ namespace Opc.Ua.Security.Certificates.Tests
             Assert.AreEqual(Subject, cert.Subject);
             Assert.AreEqual(X509Defaults.RSAKeySize, cert.GetRSAPublicKey().KeySize);
             Assert.AreEqual(keyHashPair.HashAlgorithmName, Oids.GetHashAlgorithmName(cert.SignatureAlgorithm.Value));
-            var basicConstraintsExtension = X509Extensions.FindExtension<X509BasicConstraintsExtension>(cert.Extensions);
-            Assert.NotNull(basicConstraintsExtension);
-            Assert.True(basicConstraintsExtension.CertificateAuthority);
+            TestUtils.ValidateSelSignedBasicConstraints(cert);
             X509Utils.VerifyRSAKeyPair(cert, cert, true);
             Assert.True(X509Utils.VerifySelfSigned(cert));
         }
@@ -217,9 +211,7 @@ namespace Opc.Ua.Security.Certificates.Tests
             }
             Assert.AreEqual(keyHashPair.KeySize, cert.GetRSAPublicKey().KeySize);
             Assert.AreEqual(keyHashPair.HashAlgorithmName, Oids.GetHashAlgorithmName(cert.SignatureAlgorithm.Value));
-            var basicConstraintsExtension = X509Extensions.FindExtension<X509BasicConstraintsExtension>(cert.Extensions);
-            Assert.NotNull(basicConstraintsExtension);
-            Assert.True(basicConstraintsExtension.CertificateAuthority);
+            TestUtils.ValidateSelSignedBasicConstraints(cert);
             X509Utils.VerifyRSAKeyPair(cert, cert, true);
             Assert.True(X509Utils.VerifySelfSigned(cert));
             CheckPEMWriter(cert);

--- a/Tests/Opc.Ua.Security.Certificates.Tests/TestUtils.cs
+++ b/Tests/Opc.Ua.Security.Certificates.Tests/TestUtils.cs
@@ -32,6 +32,9 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Security.Cryptography.X509Certificates;
+using NUnit.Framework;
+using Opc.Ua.Security.Certificates;
 
 namespace Opc.Ua.Tests
 {
@@ -89,6 +92,15 @@ namespace Opc.Ua.Tests
                 return Directory.EnumerateFiles(assetsPath, searchPattern).ToArray();
             }
             return Array.Empty<string>();
+        }
+
+        public static void ValidateSelSignedBasicConstraints(X509Certificate2 certificate)
+        {
+            var basicConstraintsExtension = X509Extensions.FindExtension<X509BasicConstraintsExtension>(certificate.Extensions);
+            Assert.NotNull(basicConstraintsExtension);
+            Assert.False(basicConstraintsExtension.CertificateAuthority);
+            Assert.True(basicConstraintsExtension.Critical);
+            Assert.False(basicConstraintsExtension.HasPathLengthConstraint);
         }
     }
     #endregion


### PR DESCRIPTION
## Proposed changes

Change the default for the CA flag of self signed application certificates to false.

## Related Issues

- follow guidance in [Mantis 8370](https://mantis.opcfoundation.org/view.php?id=8370)

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [x] I ran tests locally with my changes, all passed.
- [x] I fixed all failing tests in the CI pipelines. 
- [x] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

The default for the CA flag of self signed certificates had been a moving target. For spec release V1.05 spec mandates to set CA flag to false for application certificates, follow this guidance here ...