### PR TITLE
Add Session.CloseAsync, fix UANodesetHelper.Save

### DIFF
--- a/Libraries/Opc.Ua.Client/ISession.cs
+++ b/Libraries/Opc.Ua.Client/ISession.cs
@@ -56,6 +56,20 @@ namespace Opc.Ua.Client
     public delegate void PublishErrorEventHandler(ISession session, PublishErrorEventArgs e);
 
     /// <summary>
+    /// Interfaces for session internal use.
+    /// </summary>
+    internal interface ISessionInternal
+    {
+        /// <summary>
+        /// Removes a transferred subscription from the session.
+        /// Called by the session to which the subscription
+        /// is transferred to obtain ownership. Internal.
+        /// </summary>
+        /// <param name="subscription">The subscription to remove.</param>
+        bool RemoveTransferredSubscription(Subscription subscription);
+    }
+
+    /// <summary>
     /// Manages a session with a server.
     /// </summary>
     public interface ISession : ISessionClient, IDisposable
@@ -403,21 +417,6 @@ namespace Opc.Ua.Client
         void ReadNodes(IList<NodeId> nodeIds, NodeClass nodeClass, out IList<Node> nodeCollection, out IList<ServiceResult> errors, bool optionalAttributes = false);
 
         /// <summary>
-        /// Reads the values for the node attributes and returns a node object collection.
-        /// </summary>
-        /// <remarks>
-        /// If the nodeclass for the nodes in nodeIdCollection is already known
-        /// and passed as nodeClass, reads only values of required attributes.
-        /// Otherwise NodeClass.Unspecified should be used.
-        /// </remarks>
-        /// <param name="nodeIds">The nodeId collection to read.</param>
-        /// <param name="nodeClass">The nodeClass of all nodes in the collection. Set to <c>NodeClass.Unspecified</c> if the nodeclass is unknown.</param>
-        /// <param name="optionalAttributes">Set to <c>true</c> if optional attributes should not be omitted.</param>
-        /// <param name="ct">The cancellation token.</param>
-        /// <returns>The node collection and associated errors.</returns>
-        Task<(IList<Node>, IList<ServiceResult>)> ReadNodesAsync(IList<NodeId> nodeIds, NodeClass nodeClass, bool optionalAttributes = false, CancellationToken ct = default);
-
-        /// <summary>
         /// Reads the value for a node.
         /// </summary>
         /// <param name="nodeId">The node Id.</param>
@@ -431,55 +430,12 @@ namespace Opc.Ua.Client
         object ReadValue(NodeId nodeId, Type expectedType);
 
         /// <summary>
-        /// Reads the value for a node.
-        /// </summary>
-        /// <param name="nodeId">The node Id.</param>
-        /// <param name="ct">The cancellation token for the request.</param>
-        Task<DataValue> ReadValueAsync(NodeId nodeId, CancellationToken ct = default);
-
-        /// <summary>
         /// Reads the values for a node collection. Returns diagnostic errors.
         /// </summary>
         /// <param name="nodeIds">The node Id.</param>
         /// <param name="values">The data values read from the server.</param>
         /// <param name="errors">The errors reported by the server.</param>
         void ReadValues(IList<NodeId> nodeIds, out DataValueCollection values, out IList<ServiceResult> errors);
-
-        /// <summary>
-        /// Reads the values for the node attributes and returns a node object.
-        /// </summary>
-        /// <param name="nodeId">The nodeId.</param>
-        /// <param name="ct">The cancellation token for the request.</param>
-        Task<Node> ReadNodeAsync(NodeId nodeId, CancellationToken ct = default);
-
-        /// <summary>
-        /// Reads the values for the node attributes and returns a node object.
-        /// </summary>
-        /// <remarks>
-        /// If the nodeclass is known, only the supported attribute values are read.
-        /// </remarks>
-        /// <param name="nodeId">The nodeId.</param>
-        /// <param name="nodeClass">The nodeclass of the node to read.</param>
-        /// <param name="optionalAttributes">Read optional attributes.</param>
-        /// <param name="ct">The cancellation token for the request.</param>
-        Task<Node> ReadNodeAsync(NodeId nodeId, NodeClass nodeClass, bool optionalAttributes = true, CancellationToken ct = default);
-
-        /// <summary>
-        /// Reads the values for the node attributes and returns a node object collection.
-        /// Reads the nodeclass of the nodeIds, then reads
-        /// the values for the node attributes and returns a node collection.
-        /// </summary>
-        /// <param name="nodeIds">The nodeId collection.</param>
-        /// <param name="optionalAttributes">If optional attributes to read.</param>
-        /// <param name="ct">The cancellation token.</param>
-        Task<(IList<Node>, IList<ServiceResult>)> ReadNodesAsync(IList<NodeId> nodeIds, bool optionalAttributes = false, CancellationToken ct = default);
-
-        /// <summary>
-        /// Reads the values for a node collection. Returns diagnostic errors.
-        /// </summary>
-        /// <param name="nodeIds">The node Id.</param>
-        /// <param name="ct">The cancellation token for the request.</param>
-        Task<(DataValueCollection, IList<ServiceResult>)> ReadValuesAsync(IList<NodeId> nodeIds, CancellationToken ct = default);
 
         /// <summary>
         /// Fetches all references for the specified node.
@@ -552,6 +508,66 @@ namespace Opc.Ua.Client
         /// Reads the display name for a set of Nodes.
         /// </summary>
         void ReadDisplayName(IList<NodeId> nodeIds, out IList<string> displayNames, out IList<ServiceResult> errors);
+
+#if (CLIENT_ASYNC)
+        /// <summary>
+        /// Reads the values for the node attributes and returns a node object collection.
+        /// </summary>
+        /// <remarks>
+        /// If the nodeclass for the nodes in nodeIdCollection is already known
+        /// and passed as nodeClass, reads only values of required attributes.
+        /// Otherwise NodeClass.Unspecified should be used.
+        /// </remarks>
+        /// <param name="nodeIds">The nodeId collection to read.</param>
+        /// <param name="nodeClass">The nodeClass of all nodes in the collection. Set to <c>NodeClass.Unspecified</c> if the nodeclass is unknown.</param>
+        /// <param name="optionalAttributes">Set to <c>true</c> if optional attributes should not be omitted.</param>
+        /// <param name="ct">The cancellation token.</param>
+        /// <returns>The node collection and associated errors.</returns>
+        Task<(IList<Node>, IList<ServiceResult>)> ReadNodesAsync(IList<NodeId> nodeIds, NodeClass nodeClass, bool optionalAttributes = false, CancellationToken ct = default);
+
+        /// <summary>
+        /// Reads the value for a node.
+        /// </summary>
+        /// <param name="nodeId">The node Id.</param>
+        /// <param name="ct">The cancellation token for the request.</param>
+        Task<DataValue> ReadValueAsync(NodeId nodeId, CancellationToken ct = default);
+
+        /// <summary>
+        /// Reads the values for the node attributes and returns a node object.
+        /// </summary>
+        /// <param name="nodeId">The nodeId.</param>
+        /// <param name="ct">The cancellation token for the request.</param>
+        Task<Node> ReadNodeAsync(NodeId nodeId, CancellationToken ct = default);
+
+        /// <summary>
+        /// Reads the values for the node attributes and returns a node object.
+        /// </summary>
+        /// <remarks>
+        /// If the nodeclass is known, only the supported attribute values are read.
+        /// </remarks>
+        /// <param name="nodeId">The nodeId.</param>
+        /// <param name="nodeClass">The nodeclass of the node to read.</param>
+        /// <param name="optionalAttributes">Read optional attributes.</param>
+        /// <param name="ct">The cancellation token for the request.</param>
+        Task<Node> ReadNodeAsync(NodeId nodeId, NodeClass nodeClass, bool optionalAttributes = true, CancellationToken ct = default);
+
+        /// <summary>
+        /// Reads the values for the node attributes and returns a node object collection.
+        /// Reads the nodeclass of the nodeIds, then reads
+        /// the values for the node attributes and returns a node collection.
+        /// </summary>
+        /// <param name="nodeIds">The nodeId collection.</param>
+        /// <param name="optionalAttributes">If optional attributes to read.</param>
+        /// <param name="ct">The cancellation token.</param>
+        Task<(IList<Node>, IList<ServiceResult>)> ReadNodesAsync(IList<NodeId> nodeIds, bool optionalAttributes = false, CancellationToken ct = default);
+
+        /// <summary>
+        /// Reads the values for a node collection. Returns diagnostic errors.
+        /// </summary>
+        /// <param name="nodeIds">The node Id.</param>
+        /// <param name="ct">The cancellation token for the request.</param>
+        Task<(DataValueCollection, IList<ServiceResult>)> ReadValuesAsync(IList<NodeId> nodeIds, CancellationToken ct = default);
+#endif
         #endregion
 
         #region Close Methods
@@ -570,6 +586,7 @@ namespace Opc.Ua.Client
         /// </summary>
         StatusCode Close(int timeout, bool closeChannel);
 
+#if (CLIENT_ASYNC)
         /// <summary>
         /// Disconnects from the server and frees any network resources with the default timeout.
         /// </summary>
@@ -589,6 +606,7 @@ namespace Opc.Ua.Client
         /// Disconnects from the server and frees any network resources with the specified timeout.
         /// </summary>
         Task<StatusCode> CloseAsync(int timeout, bool closeChannel, CancellationToken ct = default);
+#endif
         #endregion
 
         #region Subscription Methods
@@ -611,18 +629,11 @@ namespace Opc.Ua.Client
         bool RemoveSubscriptions(IEnumerable<Subscription> subscriptions);
 
         /// <summary>
-        /// Removes a transferred subscription from the session.
-        /// Called by the session to which the subscription
-        /// is transferred to obtain ownership. Internal.
-        /// </summary>
-        /// <param name="subscription">The subscription to remove.</param>
-        bool RemoveTransferredSubscription(Subscription subscription);
-
-        /// <summary>
         /// Transfers a list of Subscriptions from another session.
         /// </summary>
         bool TransferSubscriptions(SubscriptionCollection subscriptions, bool sendInitialValues);
 
+#if (CLIENT_ASYNC)
         /// <summary>
         /// Removes a subscription from the session.
         /// </summary>
@@ -634,6 +645,7 @@ namespace Opc.Ua.Client
         /// </summary>
         /// <param name="subscriptions">The list of subscriptions to remove.</param>
         Task<bool> RemoveSubscriptionsAsync(IEnumerable<Subscription> subscriptions);
+#endif
         #endregion
 
         #region Browse Methods
@@ -750,6 +762,6 @@ namespace Opc.Ua.Client
         /// Sends a republish request.
         /// </summary>
         bool Republish(uint subscriptionId, uint sequenceNumber);
-        #endregion      
+        #endregion
     }
 }

--- a/Libraries/Opc.Ua.Client/ISession.cs
+++ b/Libraries/Opc.Ua.Client/ISession.cs
@@ -56,20 +56,6 @@ namespace Opc.Ua.Client
     public delegate void PublishErrorEventHandler(ISession session, PublishErrorEventArgs e);
 
     /// <summary>
-    /// Interfaces for session internal use.
-    /// </summary>
-    internal interface ISessionInternal
-    {
-        /// <summary>
-        /// Removes a transferred subscription from the session.
-        /// Called by the session to which the subscription
-        /// is transferred to obtain ownership. Internal.
-        /// </summary>
-        /// <param name="subscription">The subscription to remove.</param>
-        bool RemoveTransferredSubscription(Subscription subscription);
-    }
-
-    /// <summary>
     /// Manages a session with a server.
     /// </summary>
     public interface ISession : ISessionClient, IDisposable
@@ -632,6 +618,14 @@ namespace Opc.Ua.Client
         /// Transfers a list of Subscriptions from another session.
         /// </summary>
         bool TransferSubscriptions(SubscriptionCollection subscriptions, bool sendInitialValues);
+
+        /// <summary>
+        /// Removes a transferred subscription from the session.
+        /// Called by the session to which the subscription
+        /// is transferred to obtain ownership. Internal.
+        /// </summary>
+        /// <param name="subscription">The subscription to remove.</param>
+        bool RemoveTransferredSubscription(Subscription subscription);
 
 #if (CLIENT_ASYNC)
         /// <summary>

--- a/Libraries/Opc.Ua.Client/ISession.cs
+++ b/Libraries/Opc.Ua.Client/ISession.cs
@@ -28,7 +28,6 @@
  * ======================================================================*/
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading;
@@ -560,6 +559,36 @@ namespace Opc.Ua.Client
         /// Disconnects from the server and frees any network resources with the specified timeout.
         /// </summary>
         StatusCode Close(int timeout);
+
+        /// <summary>
+        /// Close the session with the server and optionally closes the channel.
+        /// </summary>
+        StatusCode Close(bool closeChannel);
+
+        /// <summary>
+        /// Disconnects from the server and frees any network resources with the specified timeout.
+        /// </summary>
+        StatusCode Close(int timeout, bool closeChannel);
+
+        /// <summary>
+        /// Disconnects from the server and frees any network resources with the default timeout.
+        /// </summary>
+        Task<StatusCode> CloseAsync(CancellationToken ct = default);
+
+        /// <summary>
+        /// Close the session with the server and optionally closes the channel.
+        /// </summary>
+        Task<StatusCode> CloseAsync(bool closeChannel, CancellationToken ct = default);
+
+        /// <summary>
+        /// Disconnects from the server and frees any network resources with the specified timeout.
+        /// </summary>
+        Task<StatusCode> CloseAsync(int timeout, CancellationToken ct = default);
+
+        /// <summary>
+        /// Disconnects from the server and frees any network resources with the specified timeout.
+        /// </summary>
+        Task<StatusCode> CloseAsync(int timeout, bool closeChannel, CancellationToken ct = default);
         #endregion
 
         #region Subscription Methods

--- a/Libraries/Opc.Ua.Client/Session.cs
+++ b/Libraries/Opc.Ua.Client/Session.cs
@@ -3249,7 +3249,7 @@ namespace Opc.Ua.Client
         /// <summary>
         /// Disconnects from the server and frees any network resources with the specified timeout.
         /// </summary>
-        public virtual StatusCode Close(int timeout)
+        public StatusCode Close(int timeout)
             => Close(timeout, true);
 
         /// <summary>
@@ -3333,6 +3333,14 @@ namespace Opc.Ua.Client
 
             return result;
         }
+
+        /// <inheritdoc/>
+        [Obsolete("Call Close instead. Service Call doesn't clean up Session.")]
+#pragma warning disable CS0809 // Obsolete member overrides non-obsolete member
+        public override ResponseHeader CloseSession(
+#pragma warning restore CS0809 // Obsolete member overrides non-obsolete member
+            RequestHeader requestHeader,
+            bool deleteSubscriptions) => base.CloseSession(requestHeader, deleteSubscriptions);
         #endregion
 
         #region Subscription Methods

--- a/Libraries/Opc.Ua.Client/Session.cs
+++ b/Libraries/Opc.Ua.Client/Session.cs
@@ -46,7 +46,7 @@ namespace Opc.Ua.Client
     /// <summary>
     /// Manages a session with a server.
     /// </summary>
-    public partial class Session : SessionClientBatched, ISession, ISessionInternal, IDisposable
+    public partial class Session : SessionClientBatched, ISession, IDisposable
     {
         #region Constructors
         /// <summary>

--- a/Libraries/Opc.Ua.Client/Session.cs
+++ b/Libraries/Opc.Ua.Client/Session.cs
@@ -2463,7 +2463,7 @@ namespace Opc.Ua.Client
                 //first try to connect with client certificate NULL
                 try
                 {
-                    CreateSession(
+                    base.CreateSession(
                         null,
                         clientDescription,
                         m_endpoint.Description.Server.ApplicationUri,
@@ -2494,7 +2494,7 @@ namespace Opc.Ua.Client
 
             if (!successCreateSession)
             {
-                CreateSession(
+                base.CreateSession(
                         null,
                         clientDescription,
                         m_endpoint.Description.Server.ApplicationUri,

--- a/Libraries/Opc.Ua.Client/Session.cs
+++ b/Libraries/Opc.Ua.Client/Session.cs
@@ -46,7 +46,7 @@ namespace Opc.Ua.Client
     /// <summary>
     /// Manages a session with a server.
     /// </summary>
-    public partial class Session : SessionClientBatched, ISession, IDisposable
+    public partial class Session : SessionClientBatched, ISession, ISessionInternal, IDisposable
     {
         #region Constructors
         /// <summary>
@@ -3333,14 +3333,6 @@ namespace Opc.Ua.Client
 
             return result;
         }
-
-        /// <inheritdoc/>
-        [Obsolete("Call Close instead. Service Call doesn't clean up Session.")]
-#pragma warning disable CS0809 // Obsolete member overrides non-obsolete member
-        public override ResponseHeader CloseSession(
-#pragma warning restore CS0809 // Obsolete member overrides non-obsolete member
-            RequestHeader requestHeader,
-            bool deleteSubscriptions) => base.CloseSession(requestHeader, deleteSubscriptions);
         #endregion
 
         #region Subscription Methods

--- a/Libraries/Opc.Ua.Client/SessionAsync.cs
+++ b/Libraries/Opc.Ua.Client/SessionAsync.cs
@@ -503,15 +503,6 @@ namespace Opc.Ua.Client
 
             return result;
         }
-
-        /// <inheritdoc/>
-        [Obsolete("Call CloseAsync instead. Service Call doesn't clean up Session.")]
-#pragma warning disable CS0809 // Obsolete member overrides non-obsolete member
-        public override Task<CloseSessionResponse> CloseSessionAsync(
-#pragma warning restore CS0809 // Obsolete member overrides non-obsolete member
-            RequestHeader requestHeader,
-            bool deleteSubscriptions,
-            CancellationToken ct) => base.CloseSessionAsync(requestHeader, deleteSubscriptions, ct);
         #endregion
     }
 }

--- a/Libraries/Opc.Ua.Client/SessionObsolete.cs
+++ b/Libraries/Opc.Ua.Client/SessionObsolete.cs
@@ -1,0 +1,104 @@
+/* ========================================================================
+ * Copyright (c) 2005-2020 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ * 
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ * 
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+#if CLIENT_ASYNC
+
+#pragma warning disable CS0809 // Obsolete member overrides non-obsolete member
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Opc.Ua.Client
+{
+    /// <summary>
+    /// Obsolete warnings for service calls which should not be used when using the Session API.
+    /// </summary>
+    public partial class Session : SessionClientBatched, ISession, IDisposable
+    {
+        /// <inheritdoc/>
+        [Obsolete("Call Create instead. Service Call doesn't create Session.")]
+        public override ResponseHeader CreateSession(
+            RequestHeader requestHeader,
+            ApplicationDescription clientDescription,
+            string serverUri,
+            string endpointUrl,
+            string sessionName,
+            byte[] clientNonce,
+            byte[] clientCertificate,
+            double requestedSessionTimeout,
+            uint maxResponseMessageSize,
+            out NodeId sessionId,
+            out NodeId authenticationToken,
+            out double revisedSessionTimeout,
+            out byte[] serverNonce,
+            out byte[] serverCertificate,
+            out EndpointDescriptionCollection serverEndpoints,
+            out SignedSoftwareCertificateCollection serverSoftwareCertificates,
+            out SignatureData serverSignature,
+            out uint maxRequestMessageSize) => CreateSession(
+                requestHeader, clientDescription, serverUri,
+                endpointUrl, sessionName, clientNonce,
+                clientCertificate, requestedSessionTimeout, maxResponseMessageSize,
+                out sessionId, out authenticationToken, out revisedSessionTimeout,
+                out serverNonce, out serverCertificate, out serverEndpoints,
+                out serverSoftwareCertificates, out serverSignature, out maxRequestMessageSize);
+
+        /// <inheritdoc/>
+        [Obsolete("Call Create instead. Service Call doesn't create Session.")]
+        public override Task<CreateSessionResponse> CreateSessionAsync(
+            RequestHeader requestHeader,
+            ApplicationDescription clientDescription,
+            string serverUri,
+            string endpointUrl,
+            string sessionName,
+            byte[] clientNonce,
+            byte[] clientCertificate,
+            double requestedSessionTimeout,
+            uint maxResponseMessageSize,
+            CancellationToken ct) => CreateSessionAsync(
+                requestHeader, clientDescription, serverUri,
+                endpointUrl, sessionName, clientNonce,
+                clientCertificate, requestedSessionTimeout, maxResponseMessageSize, ct);
+
+        /// <inheritdoc/>
+        [Obsolete("Call Close instead. Service Call doesn't clean up Session.")]
+        public override ResponseHeader CloseSession(
+            RequestHeader requestHeader,
+            bool deleteSubscriptions) => base.CloseSession(requestHeader, deleteSubscriptions);
+
+        /// <inheritdoc/>
+        [Obsolete("Call CloseAsync instead. Service Call doesn't clean up Session.")]
+        public override Task<CloseSessionResponse> CloseSessionAsync(
+            RequestHeader requestHeader,
+            bool deleteSubscriptions,
+            CancellationToken ct) => base.CloseSessionAsync(requestHeader, deleteSubscriptions, ct);
+    }
+}
+#endif

--- a/Libraries/Opc.Ua.Client/SessionObsolete.cs
+++ b/Libraries/Opc.Ua.Client/SessionObsolete.cs
@@ -62,7 +62,7 @@ namespace Opc.Ua.Client
             out EndpointDescriptionCollection serverEndpoints,
             out SignedSoftwareCertificateCollection serverSoftwareCertificates,
             out SignatureData serverSignature,
-            out uint maxRequestMessageSize) => CreateSession(
+            out uint maxRequestMessageSize) => base.CreateSession(
                 requestHeader, clientDescription, serverUri,
                 endpointUrl, sessionName, clientNonce,
                 clientCertificate, requestedSessionTimeout, maxResponseMessageSize,
@@ -82,7 +82,7 @@ namespace Opc.Ua.Client
             byte[] clientCertificate,
             double requestedSessionTimeout,
             uint maxResponseMessageSize,
-            CancellationToken ct) => CreateSessionAsync(
+            CancellationToken ct) => base.CreateSessionAsync(
                 requestHeader, clientDescription, serverUri,
                 endpointUrl, sessionName, clientNonce,
                 clientCertificate, requestedSessionTimeout, maxResponseMessageSize, ct);

--- a/Libraries/Opc.Ua.Client/Subscription.cs
+++ b/Libraries/Opc.Ua.Client/Subscription.cs
@@ -826,8 +826,7 @@ namespace Opc.Ua.Client
                 }
 
                 // remove the subscription from disconnected session
-                var sessionInternal = m_session as ISessionInternal;
-                if (sessionInternal?.RemoveTransferredSubscription(this) != true)
+                if (m_session?.RemoveTransferredSubscription(this) != true)
                 {
                     Utils.LogError("SubscriptionId {0}: Failed to remove transferred subscription from owner SessionId={1}.", Id, m_session?.SessionId);
                     return false;

--- a/Libraries/Opc.Ua.Client/Subscription.cs
+++ b/Libraries/Opc.Ua.Client/Subscription.cs
@@ -826,7 +826,8 @@ namespace Opc.Ua.Client
                 }
 
                 // remove the subscription from disconnected session
-                if (m_session?.RemoveTransferredSubscription(this) != true)
+                var sessionInternal = m_session as ISessionInternal;
+                if (sessionInternal?.RemoveTransferredSubscription(this) != true)
                 {
                     Utils.LogError("SubscriptionId {0}: Failed to remove transferred subscription from owner SessionId={1}.", Id, m_session?.SessionId);
                     return false;

--- a/Stack/Opc.Ua.Core/Schema/UANodeSetHelpers.cs
+++ b/Stack/Opc.Ua.Core/Schema/UANodeSetHelpers.cs
@@ -54,10 +54,8 @@ namespace Opc.Ua.Export
         /// <param name="istrm">The input stream.</param>
         public void Write(Stream istrm)
         {
-            var setting = Utils.DefaultXmlWriterSettings();
-            setting.CloseOutput = true;
-
-            var writer = XmlWriter.Create(istrm, setting);
+            XmlWriterSettings setting = Utils.DefaultXmlWriterSettings();
+            XmlWriter writer = XmlWriter.Create(istrm, setting);
 
             try
             {

--- a/Stack/Opc.Ua.Core/Stack/State/NodeStateCollection.cs
+++ b/Stack/Opc.Ua.Core/Stack/State/NodeStateCollection.cs
@@ -12,11 +12,10 @@
 
 using System;
 using System.Collections.Generic;
-using System.Xml;
-using System.Text;
 using System.IO;
 using System.Reflection;
 using System.Runtime.Serialization;
+using System.Xml;
 
 namespace Opc.Ua
 {
@@ -60,14 +59,14 @@ namespace Opc.Ua
         public void SaveAsNodeSet(ISystemContext context, Stream ostrm)
         {
             NodeTable nodeTable = new NodeTable(context.NamespaceUris, context.ServerUris, null);
-            
+
             for (int ii = 0; ii < this.Count; ii++)
             {
                 this[ii].Export(context, nodeTable);
             }
 
             NodeSet nodeSet = new NodeSet();
-            
+
             foreach (ILocalNode node in nodeTable)
             {
                 nodeSet.Add(node, nodeTable.NamespaceUris, nodeTable.ServerUris);
@@ -151,7 +150,7 @@ namespace Opc.Ua
             new AliasToUse(BrowseNames.HasInterface, ReferenceTypeIds.HasInterface)
         };
         #endregion
-        
+
         /// <summary>
         /// Writes the collection to a stream using the Opc.Ua.Schema.UANodeSet schema.
         /// </summary>
@@ -408,7 +407,7 @@ namespace Opc.Ua
             if (resourcePath == null) throw new ArgumentNullException(nameof(resourcePath));
 
             if (assembly == null) throw new ArgumentNullException(nameof(assembly));
-            
+
             Stream istrm = assembly.GetManifestResourceStream(resourcePath);
             if (istrm == null)
             {
@@ -436,7 +435,7 @@ namespace Opc.Ua
             if (resourcePath == null) throw new ArgumentNullException(nameof(resourcePath));
 
             if (assembly == null) throw new ArgumentNullException(nameof(assembly));
-            
+
             Stream istrm = assembly.GetManifestResourceStream(resourcePath);
             if (istrm == null)
             {
@@ -451,7 +450,7 @@ namespace Opc.Ua
 
             LoadFromBinary(context, istrm, updateTables);
         }
-#endregion
+        #endregion
     }
 
     /// <summary>
@@ -470,11 +469,11 @@ namespace Opc.Ua
         /// <param name="typeDefinitionId">The type definition.</param>
         /// <returns>Returns null if the type is not known.</returns>
         public virtual NodeState CreateInstance(
-            ISystemContext context, 
+            ISystemContext context,
             NodeState parent,
             NodeClass nodeClass,
-            QualifiedName browseName, 
-            NodeId referenceTypeId, 
+            QualifiedName browseName,
+            NodeId referenceTypeId,
             NodeId typeDefinitionId)
         {
             NodeState child = null;
@@ -564,7 +563,7 @@ namespace Opc.Ua
         {
             if (NodeId.IsNull(typeDefinitionId)) throw new ArgumentNullException(nameof(typeDefinitionId));
             if (type == null) throw new ArgumentNullException(nameof(type));
-            
+
             if (m_types == null)
             {
                 m_types = new NodeIdDictionary<Type>();
@@ -586,7 +585,7 @@ namespace Opc.Ua
                 m_types.Remove(typeDefinitionId);
             }
         }
-        
+
         private NodeIdDictionary<Type> m_types;
     }
 }

--- a/Tests/Opc.Ua.Core.Tests/Stack/Schema/UANodeSetHelpersTests.cs
+++ b/Tests/Opc.Ua.Core.Tests/Stack/Schema/UANodeSetHelpersTests.cs
@@ -165,12 +165,15 @@ namespace Opc.Ua.Core.Tests.Stack.Schema
                 Assert.AreEqual(256, dataType2.Definition.Field[5].MaxStringLength);
 
                 // export the nodeSet to a file, reimport it and re-test.
-                importedNodeStates.SaveAsNodeSet2(localContext, new FileStream(bufferPath, FileMode.Create));
+                using (var fileStream = new FileStream(bufferPath, FileMode.Create))
+                {
+                    importedNodeStates.SaveAsNodeSet2(localContext, fileStream);
+                }
                 try
                 {
                     using (var exportStream = new FileStream(bufferPath, FileMode.Open))
                     {
-                        var exportedNodeSet = Opc.Ua.Export.UANodeSet.Read(exportStream);
+                        var exportedNodeSet = Export.UANodeSet.Read(exportStream);
 
                         var exportedNodeStates = new NodeStateCollection();
                         localContext.NamespaceUris = new NamespaceTable();


### PR DESCRIPTION
## Proposed changes

- Add Session.CloseAsync methods.
- Add missing Close signatures to ISession
- Mark the CloseSession service call as obsolete to prevent invalid usage
- fix UANodeSetHelper.Save(stream), to not close the stream
- fix a deadlock in the sample app, due to the new default behavior of the cert validator not caching the approved certificates

## Related Issues

- Fixes #1943 

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [x] I ran tests locally with my changes, all passed.
- [x] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.


