### PR TITLE
Encode and decode CRL time values as UTC or GeneralizedTime depending on the value of the year

### DIFF
--- a/Libraries/Opc.Ua.Security.Certificates/X509Crl/CrlBuilder.cs
+++ b/Libraries/Opc.Ua.Security.Certificates/X509Crl/CrlBuilder.cs
@@ -327,13 +327,13 @@ namespace Opc.Ua.Security.Certificates
                 crlWriter.WriteEncodedValue((ReadOnlySpan<byte>)IssuerName.RawData);
 
                 // this update
-                crlWriter.WriteUtcTime(this.ThisUpdate);
+                WriteTime(crlWriter, ThisUpdate);
 
                 if (NextUpdate != DateTime.MinValue &&
                     NextUpdate > ThisUpdate)
                 {
                     // next update
-                    crlWriter.WriteUtcTime(NextUpdate);
+                    WriteTime(crlWriter, NextUpdate);
                 }
 
                 // sequence to start the revoked certificates.
@@ -382,6 +382,23 @@ namespace Opc.Ua.Security.Certificates
                 crlWriter.PopSequence();
 
                 return crlWriter.Encode();
+            }
+        }
+
+        /// <summary>
+        /// Write either a UTC time or a Generalized time depending if DataTime is before or after 2050.
+        /// </summary>
+        /// <param name="writer">The writer to write to.</param>
+        /// <param name="dateTime">The date time to write.</param>
+        private static void WriteTime(AsnWriter writer, DateTime dateTime)
+        {
+            if (dateTime.Year < 2050)
+            {
+                writer.WriteUtcTime(dateTime);
+            }
+            else
+            {
+                writer.WriteGeneralizedTime(dateTime);
             }
         }
         #endregion


### PR DESCRIPTION


## Proposed changes

Encode and decode CRL time values as UTC or GeneralizedTime depending on the value of the year.

## Related Issues

- Fixes #1930 

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [x] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.


