### PR TITLE
Only load optional bindings assemblies if needed

### DIFF
--- a/Libraries/Opc.Ua.Client/CoreClientUtils.cs
+++ b/Libraries/Opc.Ua.Client/CoreClientUtils.cs
@@ -303,15 +303,16 @@ namespace Opc.Ua.Client
             // return the selected endpoint.
             return selectedEndpoint;
         }
-        #endregion
 
-        #region Private Methods
-        private static Uri GetDiscoveryUrl(string discoveryUrl)
+        /// <summary>
+        /// Convert the discoveryUrl to a Uri and modify endpoint as per connection scheme if required.
+        /// </summary>
+        public static Uri GetDiscoveryUrl(string discoveryUrl)
         {
             // needs to add the '/discovery' back onto non-UA TCP URLs.
-            if (discoveryUrl.StartsWith(Utils.UriSchemeHttp))
+            if (discoveryUrl.StartsWith(Utils.UriSchemeHttp, StringComparison.Ordinal))
             {
-                if (!discoveryUrl.EndsWith("/discovery"))
+                if (!discoveryUrl.EndsWith("/discovery", StringComparison.OrdinalIgnoreCase))
                 {
                     discoveryUrl += "/discovery";
                 }

--- a/Libraries/Opc.Ua.Server/Server/StandardServer.cs
+++ b/Libraries/Opc.Ua.Server/Server/StandardServer.cs
@@ -2827,18 +2827,21 @@ namespace Opc.Ua.Server
             }
 
             // set server description.
-            serverDescription = new ApplicationDescription();
-
-            serverDescription.ApplicationUri = configuration.ApplicationUri;
-            serverDescription.ApplicationName = new LocalizedText("en-US", configuration.ApplicationName);
-            serverDescription.ApplicationType = configuration.ApplicationType;
-            serverDescription.ProductUri = configuration.ProductUri;
-            serverDescription.DiscoveryUrls = GetDiscoveryUrls();
+            serverDescription = new ApplicationDescription {
+                ApplicationUri = configuration.ApplicationUri,
+                ApplicationName = new LocalizedText("en-US", configuration.ApplicationName),
+                ApplicationType = configuration.ApplicationType,
+                ProductUri = configuration.ProductUri,
+                DiscoveryUrls = GetDiscoveryUrls()
+            };
 
             endpoints = new EndpointDescriptionCollection();
             IList<EndpointDescription> endpointsForHost = null;
 
-            foreach (var scheme in Utils.DefaultUriSchemes)
+            var baseAddresses = configuration.ServerConfiguration.BaseAddresses;
+            var requiredSchemes = Utils.DefaultUriSchemes.Where(scheme => baseAddresses.Any(a => a.StartsWith(scheme, StringComparison.Ordinal)));
+
+            foreach (var scheme in requiredSchemes)
             {
                 var binding = bindingFactory.GetBinding(scheme);
                 if (binding != null)


### PR DESCRIPTION
## Proposed changes

- Currently the server startup tries to load bindings for all known schemes, even if no baseaddress was specified. 
Filter the required schemes to load only if necessary.
- Make GetDiscoveryUrl helper public

## Related Issues

- Fixes #1949 
- Fixes #1946 

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [x] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

