### PR TITLE
On discovery preserve IPv6 scopeid for local link addresses

### DIFF
--- a/Stack/Opc.Ua.Core/Stack/Client/DiscoveryClient.cs
+++ b/Stack/Opc.Ua.Core/Stack/Client/DiscoveryClient.cs
@@ -273,11 +273,12 @@ namespace Opc.Ua
                 foreach (EndpointDescription discoveryEndPoint in endpoints)
                 {
                     Uri discoveryEndPointUri = Utils.ParseUri(discoveryEndPoint.EndpointUrl);
-                    if  ( (endpointUrl.Scheme == discoveryEndPointUri.Scheme) && (endpointUrl.Port == discoveryEndPointUri.Port))
+                    if ((endpointUrl.Scheme == discoveryEndPointUri.Scheme) &&
+                        (endpointUrl.Port == discoveryEndPointUri.Port))
                     {
                         UriBuilder builder = new UriBuilder(discoveryEndPointUri);
                         builder.Host = endpointUrl.DnsSafeHost;
-                        discoveryEndPoint.EndpointUrl = builder.ToString();
+                        discoveryEndPoint.EndpointUrl = builder.Uri.OriginalString;
                     }
 
                     if (discoveryEndPoint.Server != null &&
@@ -313,12 +314,12 @@ namespace Opc.Ua
             IServiceMessageContext messageContext,
             X509Certificate2 clientCertificate = null)
         {
-            // create a dummy description.
-            EndpointDescription endpoint = new EndpointDescription();
-
-            endpoint.EndpointUrl = discoveryUrl.ToString();
-            endpoint.SecurityMode = MessageSecurityMode.None;
-            endpoint.SecurityPolicyUri = SecurityPolicies.None;
+            // create a default description.
+            EndpointDescription endpoint = new EndpointDescription {
+                EndpointUrl = discoveryUrl.OriginalString,
+                SecurityMode = MessageSecurityMode.None,
+                SecurityPolicyUri = SecurityPolicies.None
+            };
             endpoint.Server.ApplicationUri = endpoint.EndpointUrl;
             endpoint.Server.ApplicationType = ApplicationType.DiscoveryServer;
 
@@ -344,7 +345,7 @@ namespace Opc.Ua
         {
             // create a default description.
             var endpoint = new EndpointDescription {
-                EndpointUrl = connection.EndpointUrl.ToString(),
+                EndpointUrl = connection.EndpointUrl.OriginalString,
                 SecurityMode = MessageSecurityMode.None,
                 SecurityPolicyUri = SecurityPolicies.None
             };
@@ -375,7 +376,7 @@ namespace Opc.Ua
         {
             // create a default description.
             var endpoint = new EndpointDescription {
-                EndpointUrl = discoveryUrl.ToString(),
+                EndpointUrl = discoveryUrl.OriginalString,
                 SecurityMode = MessageSecurityMode.None,
                 SecurityPolicyUri = SecurityPolicies.None
             };

--- a/Tests/Opc.Ua.Core.Tests/Stack/Client/ClientTests.cs
+++ b/Tests/Opc.Ua.Core.Tests/Stack/Client/ClientTests.cs
@@ -1,0 +1,97 @@
+/* ========================================================================
+ * Copyright (c) 2005-2021 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ * 
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ * 
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+
+using System;
+using System.IO;
+using System.Text;
+using System.Xml;
+using NUnit.Framework;
+using Opc.Ua.Tests;
+
+namespace Opc.Ua.Core.Tests.Stack.Client
+{
+    /// <summary>
+    /// Tests for the UANodeSet helper.
+    /// </summary>
+    [TestFixture, Category("Client")]
+    [SetCulture("en-us"), SetUICulture("en-us")]
+    [Parallelizable]
+    public class ClientTests
+    {
+        #region Test Setup
+        [OneTimeSetUp]
+        protected void OneTimeSetUp()
+        {
+        }
+
+        [OneTimeTearDown]
+        protected void OneTimeTearDown()
+        {
+        }
+
+        [SetUp]
+        protected void SetUp()
+        {
+
+        }
+
+        [TearDown]
+        protected void TearDown()
+        {
+        }
+        #endregion
+
+        #region Test Methods
+        /// <summary>
+        /// Ensure that use of OriginalString preserves a scope id of a IPv6 address.
+        /// </summary>
+        [Test]
+        [TestCase("opc.tcp://another.server.com:4840/CustomEndpoint")]
+        [TestCase("opc.tcp://10.11.222.12:62541/ReferenceServer")]
+        [TestCase("opc.tcp://[2003:d9:1f40:bc00:a115:d9c7:6134:f347]:4840/AnEndpoint")]
+        [TestCase("opc.tcp://[fe80::280:deff:fa02:c63e%eth0]:4840/")]
+        [TestCase("opc.tcp://[fe80::de39:6fff:feae:c78%12]:4840/Endpoint1")]
+        public void DiscoveryEndPointUrls(string urlString)
+        {
+            Uri uri = new Uri(urlString);
+            Assert.True(uri.IsWellFormedOriginalString());
+
+            UriBuilder uriBuilder = new UriBuilder {
+                Scheme = uri.Scheme,
+                Host = uri.DnsSafeHost,
+                Port = uri.Port,
+                Path = uri.AbsolutePath
+            };
+
+            Assert.AreEqual(uri.OriginalString, uriBuilder.Uri.OriginalString);
+        }
+        #endregion
+    }
+}


### PR DESCRIPTION
## Proposed changes

Using the uri.OriginalString instead of the 'ToString()' preserves a scope id of a IPv6 local link address.

## Related Issues

- Fixes #1971 

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [x] I ran tests locally with my changes, all passed.
- [x] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [x] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
