### PR TITLE
Async call to write cert to rejected store is not awaited

### DIFF
--- a/Stack/Opc.Ua.Core/Security/Certificates/CertificateValidator.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/CertificateValidator.cs
@@ -552,19 +552,7 @@ namespace Opc.Ua
                                     Utils.LogCertificate("Saved issuer certificate: ", certificate);
                                 }
                                 leafCertificate = false;
-                                store.Delete(certificate.Thumbprint);
-                                // save only public key
-                                if (certificate.HasPrivateKey)
-                                {
-                                    using (var cert = new X509Certificate2(certificate.RawData))
-                                    {
-                                        store.Add(cert);
-                                    }
-                                }
-                                else
-                                {
-                                    store.Add(certificate);
-                                }
+                                store.Add(certificate).GetAwaiter().GetResult();
                             }
                         }
                         finally


### PR DESCRIPTION
## Proposed changes

- Missing await on async call to write cert to rejected store. Found with analyzer `Microsoft.VisualStudio.Threading.Analyzers`
- Simplify the write by not deleting certificate with the same thumbprint, just override.
- Accidently writing a private key is not possible anymore, the cert stores are now flagged with noprivatekey support. Remove special handling.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [x] I ran tests locally with my changes, all passed.
- [x] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

