### PR TITLE
CSR doesn't preserve ASN.1 encoding of the Subject for GDS push

### DIFF
--- a/Libraries/Opc.Ua.Gds.Client.Common/GlobalDiscoveryServerClient.cs
+++ b/Libraries/Opc.Ua.Gds.Client.Common/GlobalDiscoveryServerClient.cs
@@ -318,7 +318,7 @@ namespace Opc.Ua.Gds.Client
             if (Session != null)
             {
                 KeepAlive?.Invoke(Session, null);
-                Session.Close();
+                Session?.Close();
                 Session = null;
             }
         }
@@ -334,8 +334,7 @@ namespace Opc.Ua.Gds.Client
 
         private void Session_SessionClosing(object sender, EventArgs e)
         {
-            Session.Dispose();
-            Session = null;
+            Utils.LogInfo("The GDS Client session is closing.");
         }
 
         /// <summary>

--- a/Libraries/Opc.Ua.Gds.Server.Common/CertificateGroup.cs
+++ b/Libraries/Opc.Ua.Gds.Server.Common/CertificateGroup.cs
@@ -256,15 +256,13 @@ namespace Opc.Ua.Gds.Server
                         domainNames = domainNameList.ToArray();
                     }
                 }
-                
+
                 DateTime yesterday = DateTime.Today.AddDays(-1);
                 using (var signingKey = await LoadSigningKeyAsync(Certificate, string.Empty).ConfigureAwait(false))
                 {
-                    return CertificateFactory.CreateCertificate(
-                            application.ApplicationUri,
-                            null,
-                            info.Subject.ToString(true, (IDictionary)Org.BouncyCastle.Asn1.X509.X509Name.DefaultSymbols),
-                            domainNames)
+                    X500DistinguishedName subjectName = new X500DistinguishedName(info.Subject.GetEncoded());
+                    return CertificateBuilder.Create(subjectName)
+                        .AddExtension(new X509SubjectAltNameExtension(application.ApplicationUri, domainNames))
                         .SetNotBefore(yesterday)
                         .SetLifeTime(Configuration.DefaultCertificateLifetime)
                         .SetHashAlgorithm(X509Utils.GetRSAHashAlgorithmName(Configuration.DefaultCertificateHashSize))

--- a/Libraries/Opc.Ua.Security.Certificates/Org.BouncyCastle/CertificateBuilder.cs
+++ b/Libraries/Opc.Ua.Security.Certificates/Org.BouncyCastle/CertificateBuilder.cs
@@ -231,7 +231,7 @@ namespace Opc.Ua.Security.Certificates
 
                 var pkcs10CertificationRequest = new Pkcs10CertificationRequest(
                     signatureFactory,
-                    new CertificateFactoryX509Name(true, certificate.Subject),
+                    new CertificateFactoryX509Name(certificate.SubjectName),
                     publicKey,
                     attributes);
 
@@ -262,14 +262,14 @@ namespace Opc.Ua.Security.Certificates
         /// <param name="cg">The cert generator</param>
         private void CreateMandatoryFields(X509V3CertificateGenerator cg)
         {
-            m_subjectDN = new CertificateFactoryX509Name(SubjectName.Name);
+            m_subjectDN = new CertificateFactoryX509Name(SubjectName);
             // subject and issuer DN, issuer of issuer for AKI
             m_issuerDN = null;
             m_issuerIssuerAKI = null;
             if (IssuerCAKeyCert != null)
             {
-                m_issuerDN = new CertificateFactoryX509Name(IssuerCAKeyCert.Subject);
-                m_issuerIssuerAKI = new CertificateFactoryX509Name(IssuerCAKeyCert.Issuer);
+                m_issuerDN = new CertificateFactoryX509Name(IssuerCAKeyCert.SubjectName);
+                m_issuerIssuerAKI = new CertificateFactoryX509Name(IssuerCAKeyCert.IssuerName);
             }
             else
             {

--- a/Libraries/Opc.Ua.Security.Certificates/Org.BouncyCastle/CertificateFactoryX509Name.cs
+++ b/Libraries/Opc.Ua.Security.Certificates/Org.BouncyCastle/CertificateFactoryX509Name.cs
@@ -1,5 +1,5 @@
 /* ========================================================================
- * Copyright (c) 2005-2021 The OPC Foundation, Inc. All rights reserved.
+ * Copyright (c) 2005-2022 The OPC Foundation, Inc. All rights reserved.
  *
  * OPC Foundation MIT License 1.00
  * 
@@ -29,6 +29,9 @@
 
 #if !NETSTANDARD2_1 && !NET472_OR_GREATER && !NET5_0_OR_GREATER
 
+using System;
+using System.Security.Cryptography.X509Certificates;
+using Org.BouncyCastle.Asn1;
 using Org.BouncyCastle.Asn1.X509;
 
 namespace Opc.Ua.Security.Certificates.BouncyCastle
@@ -44,9 +47,20 @@ namespace Opc.Ua.Security.Certificates.BouncyCastle
     public class CertificateFactoryX509Name : X509Name
     {
         /// <summary>
+        /// Create the X509Name from a X500DistinguishedName
+        /// ASN.1 encoded distinguished name.
+        /// </summary>
+        /// <param name="distinguishedName">The distinguished name.</param>
+        public CertificateFactoryX509Name(X500DistinguishedName distinguishedName) :
+            base((Asn1Sequence)Asn1Object.FromByteArray(distinguishedName.RawData))
+        {
+        }
+
+        /// <summary>
         /// Create the X509Name from a distinguished name.
         /// </summary>
         /// <param name="distinguishedName">The distinguished name.</param>
+        [Obsolete("Use constructor with X500DistinguishedName instead.")]
         public CertificateFactoryX509Name(string distinguishedName) :
             base(true, ConvertToX509Name(distinguishedName))
         {
@@ -57,6 +71,7 @@ namespace Opc.Ua.Security.Certificates.BouncyCastle
         /// </summary>
         /// <param name="reverse">Reverse the order of the names.</param>
         /// <param name="distinguishedName">The distinguished name.</param>
+        [Obsolete("Use constructor with X500DistinguishedName instead.")]
         public CertificateFactoryX509Name(bool reverse, string distinguishedName) :
             base(reverse, ConvertToX509Name(distinguishedName))
         {

--- a/Libraries/Opc.Ua.Security.Certificates/X509Certificate/CertificateBuilder.cs
+++ b/Libraries/Opc.Ua.Security.Certificates/X509Certificate/CertificateBuilder.cs
@@ -30,10 +30,10 @@
 #if NETSTANDARD2_1 || NET472_OR_GREATER || NET5_0_OR_GREATER
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
-using System.Linq;
-using System.Collections.Generic;
 
 namespace Opc.Ua.Security.Certificates
 {
@@ -105,7 +105,6 @@ namespace Opc.Ua.Security.Certificates
             var serialNumber = m_serialNumber.Reverse().ToArray();
             if (IssuerCAKeyCert != null)
             {
-                var issuerSubjectName = IssuerCAKeyCert.SubjectName;
                 using (RSA rsaIssuerKey = IssuerCAKeyCert.GetRSAPrivateKey())
                 {
                     signedCert = request.Create(

--- a/Libraries/Opc.Ua.Server/Configuration/ConfigurationNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/Configuration/ConfigurationNodeManager.cs
@@ -420,8 +420,12 @@ namespace Opc.Ua.Server
                     throw new ServiceResultException(StatusCodes.BadCertificateInvalid, "Certificate data is invalid.");
                 }
 
-                // validate new subject matches the previous subject
-                if (!X509Utils.CompareDistinguishedName(certificateGroup.ApplicationCertificate.Certificate.SubjectName, newCert.SubjectName))
+                // validate new subject matches the previous subject,
+                // otherwise application may not be able to find it after restart
+                // TODO: An issuer may modify the subject of an issued certificate,
+                // but then the configuration must be updated too!
+                // NOTE: not a strict requirement here for ASN.1 byte compare 
+                if (!X509Utils.CompareDistinguishedName(certificateGroup.ApplicationCertificate.Certificate.Subject, newCert.Subject))
                 {
                     throw new ServiceResultException(StatusCodes.BadSecurityChecksFailed, "Subject Name of new certificate doesn't match the application.");
                 }

--- a/Stack/Opc.Ua.Core/Stack/Tcp/UaSCBinaryClientChannel.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/UaSCBinaryClientChannel.cs
@@ -1007,6 +1007,12 @@ namespace Opc.Ua.Bindings
         {
             lock (DataLock)
             {
+                // channel may already be closed
+                if (State == TcpChannelState.Closed)
+                {
+                    return;
+                }
+
                 // clear an unprocessed chunks.
                 SaveIntermediateChunk(0, new ArraySegment<byte>(), false);
 


### PR DESCRIPTION
## Proposed changes

- Preserve the ASN.1 encoding of a CSR Subject in the issued certificate.
- However, a certificate issuer is allowed to change the Subject. Make the check on GDS Push only check the Subject string, to ensure the app config can still find the pushed cert after restart.
- found an issue during debugging the session disconnect may run into unnecessary exceptions as `ChannelShutdown` may be  called twice.

## Related Issues

- Fixes #2014 

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [x] I ran tests locally with my changes, all passed.
- [x] I fixed all failing tests in the CI pipelines. 
- [x] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

