### PR TITLE
Add Discovery Url null check in PatchEndpointUrl

### DIFF
--- a/Libraries/Opc.Ua.Configuration/ApplicationConfigurationBuilder.cs
+++ b/Libraries/Opc.Ua.Configuration/ApplicationConfigurationBuilder.cs
@@ -247,7 +247,8 @@ namespace Opc.Ua.Configuration
         {
             if (addPolicy)
             {
-                AddSecurityPolicies(false, false, true);
+                var policies = ApplicationConfiguration.ServerConfiguration.SecurityPolicies;
+                InternalAddPolicy(policies, MessageSecurityMode.None, SecurityPolicies.None);
             }
             return this;
         }

--- a/Stack/Opc.Ua.Bindings.Https/Stack/Https/HttpsTransportChannel.cs
+++ b/Stack/Opc.Ua.Bindings.Https/Stack/Https/HttpsTransportChannel.cs
@@ -116,13 +116,18 @@ namespace Opc.Ua.Bindings
 
                 // auto validate server cert, if supported
                 // if unsupported, the TLS server cert must be trusted by a root CA
-                var handler = new HttpClientHandler
-                {
+                var handler = new HttpClientHandler {
                     ClientCertificateOptions = ClientCertificateOption.Manual,
-                    MaxConnectionsPerServer = kMaxConnectionsPerServer,
                     AllowAutoRedirect = false,
                     MaxRequestContentBufferSize = m_quotas.MaxMessageSize,
                 };
+
+                // set property only if supported
+                var maxConnectionsPerServerProperty = handler.GetType().GetProperty("MaxConnectionsPerServer");
+                if (maxConnectionsPerServerProperty != null)
+                {
+                    maxConnectionsPerServerProperty.SetValue(handler, kMaxConnectionsPerServer);
+                }
 
                 // send client certificate for servers that require TLS client authentication
                 if (m_settings.ClientCertificate != null)
@@ -148,8 +153,7 @@ namespace Opc.Ua.Bindings
                         try
                         {
                             serverCertificateCustomValidationCallback =
-                                (httpRequestMessage, cert, chain, policyErrors) =>
-                                {
+                                (httpRequestMessage, cert, chain, policyErrors) => {
                                     try
                                     {
                                         var validationChain = new X509Certificate2Collection();
@@ -246,8 +250,7 @@ namespace Opc.Ua.Bindings
                 }
 
                 var result = new HttpsAsyncResult(callback, callbackData, m_operationTimeout, request, null);
-                Task.Run(async () =>
-                {
+                Task.Run(async () => {
                     try
                     {
                         var ct = new CancellationTokenSource(m_operationTimeout).Token;
@@ -416,15 +419,13 @@ namespace Opc.Ua.Bindings
             m_operationTimeout = settings.Configuration.OperationTimeout;
 
             // initialize the quotas.
-            m_quotas = new ChannelQuotas
-            {
+            m_quotas = new ChannelQuotas {
                 MaxBufferSize = m_settings.Configuration.MaxBufferSize,
                 MaxMessageSize = m_settings.Configuration.MaxMessageSize,
                 ChannelLifetime = m_settings.Configuration.ChannelLifetime,
                 SecurityTokenLifetime = m_settings.Configuration.SecurityTokenLifetime,
 
-                MessageContext = new ServiceMessageContext
-                {
+                MessageContext = new ServiceMessageContext {
                     MaxArrayLength = m_settings.Configuration.MaxArrayLength,
                     MaxByteStringLength = m_settings.Configuration.MaxByteStringLength,
                     MaxMessageSize = m_settings.Configuration.MaxMessageSize,

--- a/Stack/Opc.Ua.Core/Stack/Client/DiscoveryClient.cs
+++ b/Stack/Opc.Ua.Core/Stack/Client/DiscoveryClient.cs
@@ -273,6 +273,12 @@ namespace Opc.Ua
                 foreach (EndpointDescription discoveryEndPoint in endpoints)
                 {
                     Uri discoveryEndPointUri = Utils.ParseUri(discoveryEndPoint.EndpointUrl);
+                    if (discoveryEndPointUri == null)
+                    {
+                        Utils.LogWarning("Discovery endpoint contains invalid Url: {0}", discoveryEndPoint.EndpointUrl);
+                        continue;
+                    }
+
                     if ((endpointUrl.Scheme == discoveryEndPointUri.Scheme) &&
                         (endpointUrl.Port == discoveryEndPointUri.Port))
                     {


### PR DESCRIPTION
## Proposed changes

- Fix a null reference exception if an invalid discovery Url is returned by the server which cannot be parsed as Uri.
- Fix AddUnsecurePolicyNone to only add that policy.
- Fix a warning due to HttpHandler MaxConnectionsPerServer property

## Related Issues

- Fixes #2004 
- Fixes #1951 

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [x] I ran tests locally with my changes, all passed.
- [x] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

