### PR TITLE
On auto-trust setting: accept also CA-signed certificates.

### DIFF
--- a/Stack/Opc.Ua.Core/Security/Certificates/CertificateValidator.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/CertificateValidator.cs
@@ -440,7 +440,8 @@ namespace Opc.Ua
                             accept = args.Accept;
                         }
                         else if (m_autoAcceptUntrustedCertificates &&
-                            serviceResult.StatusCode == StatusCodes.BadCertificateUntrusted)
+                            (serviceResult.StatusCode == StatusCodes.BadCertificateUntrusted||
+                            serviceResult.StatusCode == StatusCodes.BadCertificateChainIncomplete))
                         {
                             accept = true;
                             Utils.LogCertificate("Auto accepted certificate: ", certificate);

--- a/Tests/Opc.Ua.Core.Tests/Security/Certificates/CertificateValidatorTest.cs
+++ b/Tests/Opc.Ua.Core.Tests/Security/Certificates/CertificateValidatorTest.cs
@@ -1161,6 +1161,29 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
             certValidator.CertificateValidation -= approver.OnCertificateValidation;
         }
 
+        [Test]
+        public async Task TestAutoAcceptChain()
+        {
+            var cert = m_appCerts[0];
+            var validator = TemporaryCertValidator.Create();
+            var certValidator = validator.Update();
+            // Set autoaccept to true, check that CA-signed is accepted.
+            certValidator.AutoAcceptUntrustedCertificates = true;
+            certValidator.Validate(cert);
+
+            // Set autoaccept to false, validate that CertValidationApprover will handle that BadCertChainIncomplete status.
+            await validator.TrustedStore.Add(cert).ConfigureAwait(false);
+            certValidator = validator.Update();
+            certValidator.AutoAcceptUntrustedCertificates = false;
+            CertValidationApprover approver;
+            approver = new CertValidationApprover(new StatusCode[] {
+                StatusCodes.BadCertificateChainIncomplete
+            });
+            certValidator.CertificateValidation += approver.OnCertificateValidation;
+            certValidator.Validate(cert);
+            certValidator.CertificateValidation -= approver.OnCertificateValidation;
+        }
+
         /// <summary>
         /// Test auto accept.
         /// </summary>


### PR DESCRIPTION
## Proposed changes

 The proposed change enables clients using also CA-issued certificates to be accepted by OPC UA servers configured with the `<AutoAcceptUntrustedCertificates>true</AutoAcceptUntrustedCertificates>`. Previously, only clients with self-signed certificates were accepted in this scenario.

## Related Issues

- Fixes #2020 

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [x] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [x] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

The provided change is really minor. I assume that the only question here is if this is the wanted behavior.