### PR TITLE
Added events BadSessionClosed and BadSecureChannelClosed

### DIFF
--- a/Libraries/Opc.Ua.Client/ISession.cs
+++ b/Libraries/Opc.Ua.Client/ISession.cs
@@ -102,6 +102,16 @@ namespace Opc.Ua.Client
         /// Raised to indicate the session is closing.
         /// </summary>
         event EventHandler SessionClosing;
+
+        /// <summary>
+        /// Raised to indicate the session has been closed unexpectedly.
+        /// </summary>
+        event EventHandler BadSessionClosed;
+
+        /// <summary>
+        /// Raised to indicate the secure channel has been closed unexpectedly.
+        /// </summary>
+        event EventHandler BadSecureChannelClosed;
         #endregion
 
         #region Public Properties

--- a/Libraries/Opc.Ua.Client/Session.cs
+++ b/Libraries/Opc.Ua.Client/Session.cs
@@ -391,6 +391,16 @@ namespace Opc.Ua.Client
 
         #region Events
         /// <summary>
+        /// Raised before a reconnect operation completes.
+        /// </summary>
+        public event RenewUserIdentityEventHandler RenewUserIdentity
+        {
+            add { m_RenewUserIdentity += value; }
+            remove { m_RenewUserIdentity -= value; }
+        }
+
+        private event RenewUserIdentityEventHandler m_RenewUserIdentity;
+        /// <summary>
         /// Raised when a keep alive arrives from the server or an error is detected.
         /// </summary>
         /// <remarks>
@@ -1194,20 +1204,7 @@ namespace Opc.Ua.Client
 
             return session;
         }
-        #endregion
-
-        #region Events
-        /// <summary>
-        /// Raised before a reconnect operation completes.
-        /// </summary>
-        public event RenewUserIdentityEventHandler RenewUserIdentity
-        {
-            add { m_RenewUserIdentity += value; }
-            remove { m_RenewUserIdentity -= value; }
-        }
-
-        private event RenewUserIdentityEventHandler m_RenewUserIdentity;
-        #endregion
+        #endregion      
 
         #region Public Methods
         /// <summary>
@@ -5256,10 +5253,16 @@ namespace Opc.Ua.Client
                         }
                         return;
                     case StatusCodes.BadSessionClosed:
-                        m_BadSessionClosed(this, null);
+                        if (m_BadSessionClosed != null)
+                        {
+                            m_BadSessionClosed(this, null);
+                        }
                         return;
                     case StatusCodes.BadSecureChannelClosed:
-                        m_BadSecureChannelClosed(this, null);
+                        if (m_BadSecureChannelClosed != null)
+                        {
+                            m_BadSecureChannelClosed(this, null);
+                        }
                         return;
                     case StatusCodes.BadNoSubscription:
                     case StatusCodes.BadSessionIdInvalid:

--- a/Libraries/Opc.Ua.Client/Session.cs
+++ b/Libraries/Opc.Ua.Client/Session.cs
@@ -132,6 +132,8 @@ namespace Opc.Ua.Client
                 m_PublishError = template.m_PublishError;
                 m_SubscriptionsChanged = template.m_SubscriptionsChanged;
                 m_SessionClosing = template.m_SessionClosing;
+                m_BadSessionClosed = template.m_BadSessionClosed;
+                m_BadSecureChannelClosed = template.m_BadSecureChannelClosed;
             }
 
             foreach (Subscription subscription in template.Subscriptions)
@@ -503,6 +505,38 @@ namespace Opc.Ua.Client
             remove
             {
                 m_SessionClosing -= value;
+            }
+        }
+
+        /// <summary>
+        /// Raised to indicate the session has been closed unexpectedly.
+        /// </summary>
+        public event EventHandler BadSessionClosed
+        {
+            add
+            {
+                m_BadSessionClosed += value;
+            }
+
+            remove
+            {
+                m_BadSessionClosed -= value;
+            }
+        }
+
+        /// <summary>
+        /// Raised to indicate the secure channel has been closed unexpectedly.
+        /// </summary>
+        public event EventHandler BadSecureChannelClosed
+        {
+            add
+            {
+                m_BadSecureChannelClosed += value;
+            }
+
+            remove
+            {
+                m_BadSecureChannelClosed -= value;
             }
         }
         #endregion
@@ -5221,11 +5255,15 @@ namespace Opc.Ua.Client
                             Utils.LogInfo("PUBLISH - Too many requests, set limit to GoodPublishRequestCount={0}.", m_tooManyPublishRequests);
                         }
                         return;
-                    case StatusCodes.BadNoSubscription:
                     case StatusCodes.BadSessionClosed:
+                        m_BadSessionClosed(this, null);
+                        return;
+                    case StatusCodes.BadSecureChannelClosed:
+                        m_BadSecureChannelClosed(this, null);
+                        return;
+                    case StatusCodes.BadNoSubscription:
                     case StatusCodes.BadSessionIdInvalid:
                     case StatusCodes.BadSecureChannelIdInvalid:
-                    case StatusCodes.BadSecureChannelClosed:
                     case StatusCodes.BadServerHalted:
                         return;
                 }
@@ -5768,6 +5806,8 @@ namespace Opc.Ua.Client
         private event PublishErrorEventHandler m_PublishError;
         private event EventHandler m_SubscriptionsChanged;
         private event EventHandler m_SessionClosing;
+        private event EventHandler m_BadSessionClosed;
+        private event EventHandler m_BadSecureChannelClosed;
         #endregion
     }
 


### PR DESCRIPTION
## Proposed changes

The existing _SessionClosing_ event is being raised only if the session has been intentionally closed.
I added events _BadSessionClosed_ and _BadSecureChannelClosed_ to detect unexpected connection lost. This could happen in several circumstances, like under a really slow VPN connection or when using an unreliable network service. These new events allow library's user to properly handle these issues and taking necessary actions (e.g. recreating the session).


## Related Issues

- Fixes #

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [x] I ran tests locally with my changes, all passed. 
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments
