### PR TITLE
Do not dispose BinaryEncoder stream if leaveOpen is set

### DIFF
--- a/Stack/Opc.Ua.Core/Types/Encoders/BinaryEncoder.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/BinaryEncoder.cs
@@ -88,10 +88,7 @@ namespace Opc.Ua
                     m_writer.Dispose();
                 }
 
-                if (!m_leaveOpen)
-                {
-                    m_ostrm?.Dispose();
-                }
+                m_ostrm?.Dispose();
             }
         }
         #endregion
@@ -1643,17 +1640,17 @@ namespace Opc.Ua
                         WriteXmlElementArray(null, (XmlElement[])array);
                         break;
                     case BuiltInType.Variant:
+                    {
+                        // try to write IEncodeable Array
+                        IEncodeable[] encodeableArray = array as IEncodeable[];
+                        if (encodeableArray != null)
                         {
-                            // try to write IEncodeable Array
-                            IEncodeable[] encodeableArray = array as IEncodeable[];
-                            if (encodeableArray != null)
-                            {
-                                WriteEncodeableArray(fieldName, encodeableArray, array.GetType().GetElementType());
-                                return;
-                            }
-                            WriteVariantArray(null, (Variant[])array);
-                            break;
+                            WriteEncodeableArray(fieldName, encodeableArray, array.GetType().GetElementType());
+                            return;
                         }
+                        WriteVariantArray(null, (Variant[])array);
+                        break;
+                    }
                     case BuiltInType.Enumeration:
                         int[] ints = array as int[];
                         if (ints == null)
@@ -1689,25 +1686,25 @@ namespace Opc.Ua
                         WriteDataValueArray(null, (DataValue[])array);
                         break;
                     default:
+                    {
+                        // try to write IEncodeable Array
+                        IEncodeable[] encodeableArray = array as IEncodeable[];
+                        if (encodeableArray != null)
                         {
-                            // try to write IEncodeable Array
-                            IEncodeable[] encodeableArray = array as IEncodeable[];
-                            if (encodeableArray != null)
-                            {
-                                WriteEncodeableArray(fieldName, encodeableArray, array.GetType().GetElementType());
-                                break;
-                            }
-                            if (array == null)
-                            {
-                                // write zero dimension
-                                WriteInt32(null, -1);
-                                return;
-                            }
-                            throw ServiceResultException.Create(
-                                StatusCodes.BadEncodingError,
-                                "Unexpected type encountered while encoding an Array with BuiltInType: {0}",
-                                builtInType);
+                            WriteEncodeableArray(fieldName, encodeableArray, array.GetType().GetElementType());
+                            break;
                         }
+                        if (array == null)
+                        {
+                            // write zero dimension
+                            WriteInt32(null, -1);
+                            return;
+                        }
+                        throw ServiceResultException.Create(
+                            StatusCodes.BadEncodingError,
+                            "Unexpected type encountered while encoding an Array with BuiltInType: {0}",
+                            builtInType);
+                    }
                 }
             }
             else if (valueRank > ValueRanks.OneDimension)
@@ -1736,287 +1733,287 @@ namespace Opc.Ua
                 switch (matrix.TypeInfo.BuiltInType)
                 {
                     case BuiltInType.Boolean:
+                    {
+                        bool[] values = (bool[])matrix.Elements;
+                        for (int ii = 0; ii < values.Length; ii++)
                         {
-                            bool[] values = (bool[])matrix.Elements;
-                            for (int ii = 0; ii < values.Length; ii++)
-                            {
-                                WriteBoolean(null, values[ii]);
-                            }
-                            break;
+                            WriteBoolean(null, values[ii]);
                         }
+                        break;
+                    }
                     case BuiltInType.SByte:
+                    {
+                        sbyte[] values = (sbyte[])matrix.Elements;
+                        for (int ii = 0; ii < values.Length; ii++)
                         {
-                            sbyte[] values = (sbyte[])matrix.Elements;
-                            for (int ii = 0; ii < values.Length; ii++)
-                            {
-                                WriteSByte(null, values[ii]);
-                            }
-                            break;
+                            WriteSByte(null, values[ii]);
                         }
+                        break;
+                    }
                     case BuiltInType.Byte:
+                    {
+                        byte[] values = (byte[])matrix.Elements;
+                        for (int ii = 0; ii < values.Length; ii++)
                         {
-                            byte[] values = (byte[])matrix.Elements;
-                            for (int ii = 0; ii < values.Length; ii++)
-                            {
-                                WriteByte(null, values[ii]);
-                            }
-                            break;
+                            WriteByte(null, values[ii]);
                         }
+                        break;
+                    }
                     case BuiltInType.Int16:
+                    {
+                        Int16[] values = (Int16[])matrix.Elements;
+                        for (int ii = 0; ii < values.Length; ii++)
                         {
-                            Int16[] values = (Int16[])matrix.Elements;
-                            for (int ii = 0; ii < values.Length; ii++)
-                            {
-                                WriteInt16(null, values[ii]);
-                            }
-                            break;
+                            WriteInt16(null, values[ii]);
                         }
+                        break;
+                    }
                     case BuiltInType.UInt16:
+                    {
+                        UInt16[] values = (UInt16[])matrix.Elements;
+                        for (int ii = 0; ii < values.Length; ii++)
                         {
-                            UInt16[] values = (UInt16[])matrix.Elements;
-                            for (int ii = 0; ii < values.Length; ii++)
-                            {
-                                WriteUInt16(null, values[ii]);
-                            }
-                            break;
+                            WriteUInt16(null, values[ii]);
                         }
+                        break;
+                    }
                     case BuiltInType.Enumeration:
+                    {
+                        Enum[] values = matrix.Elements as Enum[];
+                        if (values != null)
                         {
-                            Enum[] values = matrix.Elements as Enum[];
-                            if (values != null)
+                            for (int ii = 0; ii < values.Length; ii++)
                             {
-                                for (int ii = 0; ii < values.Length; ii++)
-                                {
-                                    WriteEnumerated(null, values[ii]);
-                                }
-                                break;
+                                WriteEnumerated(null, values[ii]);
                             }
-                            goto case BuiltInType.Int32;
+                            break;
                         }
+                        goto case BuiltInType.Int32;
+                    }
                     case BuiltInType.Int32:
+                    {
+                        Int32[] values = (Int32[])matrix.Elements;
+                        for (int ii = 0; ii < values.Length; ii++)
                         {
-                            Int32[] values = (Int32[])matrix.Elements;
-                            for (int ii = 0; ii < values.Length; ii++)
-                            {
-                                WriteInt32(null, values[ii]);
-                            }
-                            break;
+                            WriteInt32(null, values[ii]);
                         }
+                        break;
+                    }
                     case BuiltInType.UInt32:
+                    {
+                        UInt32[] values = (UInt32[])matrix.Elements;
+                        for (int ii = 0; ii < values.Length; ii++)
                         {
-                            UInt32[] values = (UInt32[])matrix.Elements;
-                            for (int ii = 0; ii < values.Length; ii++)
-                            {
-                                WriteUInt32(null, values[ii]);
-                            }
-                            break;
+                            WriteUInt32(null, values[ii]);
                         }
+                        break;
+                    }
                     case BuiltInType.Int64:
+                    {
+                        Int64[] values = (Int64[])matrix.Elements;
+                        for (int ii = 0; ii < values.Length; ii++)
                         {
-                            Int64[] values = (Int64[])matrix.Elements;
-                            for (int ii = 0; ii < values.Length; ii++)
-                            {
-                                WriteInt64(null, values[ii]);
-                            }
-                            break;
+                            WriteInt64(null, values[ii]);
                         }
+                        break;
+                    }
                     case BuiltInType.UInt64:
+                    {
+                        UInt64[] values = (UInt64[])matrix.Elements;
+                        for (int ii = 0; ii < values.Length; ii++)
                         {
-                            UInt64[] values = (UInt64[])matrix.Elements;
-                            for (int ii = 0; ii < values.Length; ii++)
-                            {
-                                WriteUInt64(null, values[ii]);
-                            }
-                            break;
+                            WriteUInt64(null, values[ii]);
                         }
+                        break;
+                    }
                     case BuiltInType.Float:
+                    {
+                        float[] values = (float[])matrix.Elements;
+                        for (int ii = 0; ii < values.Length; ii++)
                         {
-                            float[] values = (float[])matrix.Elements;
-                            for (int ii = 0; ii < values.Length; ii++)
-                            {
-                                WriteFloat(null, values[ii]);
-                            }
-                            break;
+                            WriteFloat(null, values[ii]);
                         }
+                        break;
+                    }
                     case BuiltInType.Double:
+                    {
+                        double[] values = (double[])matrix.Elements;
+                        for (int ii = 0; ii < values.Length; ii++)
                         {
-                            double[] values = (double[])matrix.Elements;
-                            for (int ii = 0; ii < values.Length; ii++)
-                            {
-                                WriteDouble(null, values[ii]);
-                            }
-                            break;
+                            WriteDouble(null, values[ii]);
                         }
+                        break;
+                    }
                     case BuiltInType.String:
+                    {
+                        string[] values = (string[])matrix.Elements;
+                        for (int ii = 0; ii < values.Length; ii++)
                         {
-                            string[] values = (string[])matrix.Elements;
-                            for (int ii = 0; ii < values.Length; ii++)
-                            {
-                                WriteString(null, values[ii]);
-                            }
-                            break;
+                            WriteString(null, values[ii]);
                         }
+                        break;
+                    }
                     case BuiltInType.DateTime:
+                    {
+                        DateTime[] values = (DateTime[])matrix.Elements;
+                        for (int ii = 0; ii < values.Length; ii++)
                         {
-                            DateTime[] values = (DateTime[])matrix.Elements;
-                            for (int ii = 0; ii < values.Length; ii++)
-                            {
-                                WriteDateTime(null, values[ii]);
-                            }
-                            break;
+                            WriteDateTime(null, values[ii]);
                         }
+                        break;
+                    }
                     case BuiltInType.Guid:
+                    {
+                        Uuid[] values = (Uuid[])matrix.Elements;
+                        for (int ii = 0; ii < values.Length; ii++)
                         {
-                            Uuid[] values = (Uuid[])matrix.Elements;
-                            for (int ii = 0; ii < values.Length; ii++)
-                            {
-                                WriteGuid(null, values[ii]);
-                            }
-                            break;
+                            WriteGuid(null, values[ii]);
                         }
+                        break;
+                    }
                     case BuiltInType.ByteString:
+                    {
+                        byte[][] values = (byte[][])matrix.Elements;
+                        for (int ii = 0; ii < values.Length; ii++)
                         {
-                            byte[][] values = (byte[][])matrix.Elements;
-                            for (int ii = 0; ii < values.Length; ii++)
-                            {
-                                WriteByteString(null, values[ii]);
-                            }
-                            break;
+                            WriteByteString(null, values[ii]);
                         }
+                        break;
+                    }
                     case BuiltInType.XmlElement:
+                    {
+                        XmlElement[] values = (XmlElement[])matrix.Elements;
+                        for (int ii = 0; ii < values.Length; ii++)
                         {
-                            XmlElement[] values = (XmlElement[])matrix.Elements;
-                            for (int ii = 0; ii < values.Length; ii++)
-                            {
-                                WriteXmlElement(null, values[ii]);
-                            }
-                            break;
+                            WriteXmlElement(null, values[ii]);
                         }
+                        break;
+                    }
                     case BuiltInType.NodeId:
+                    {
+                        NodeId[] values = (NodeId[])matrix.Elements;
+                        for (int ii = 0; ii < values.Length; ii++)
                         {
-                            NodeId[] values = (NodeId[])matrix.Elements;
-                            for (int ii = 0; ii < values.Length; ii++)
-                            {
-                                WriteNodeId(null, values[ii]);
-                            }
-                            break;
+                            WriteNodeId(null, values[ii]);
                         }
+                        break;
+                    }
                     case BuiltInType.ExpandedNodeId:
+                    {
+                        ExpandedNodeId[] values = (ExpandedNodeId[])matrix.Elements;
+                        for (int ii = 0; ii < values.Length; ii++)
                         {
-                            ExpandedNodeId[] values = (ExpandedNodeId[])matrix.Elements;
-                            for (int ii = 0; ii < values.Length; ii++)
-                            {
-                                WriteExpandedNodeId(null, values[ii]);
-                            }
-                            break;
+                            WriteExpandedNodeId(null, values[ii]);
                         }
+                        break;
+                    }
                     case BuiltInType.StatusCode:
+                    {
+                        StatusCode[] values = (StatusCode[])matrix.Elements;
+                        for (int ii = 0; ii < values.Length; ii++)
                         {
-                            StatusCode[] values = (StatusCode[])matrix.Elements;
-                            for (int ii = 0; ii < values.Length; ii++)
-                            {
-                                WriteStatusCode(null, values[ii]);
-                            }
-                            break;
+                            WriteStatusCode(null, values[ii]);
                         }
+                        break;
+                    }
                     case BuiltInType.QualifiedName:
+                    {
+                        QualifiedName[] values = (QualifiedName[])matrix.Elements;
+                        for (int ii = 0; ii < values.Length; ii++)
                         {
-                            QualifiedName[] values = (QualifiedName[])matrix.Elements;
-                            for (int ii = 0; ii < values.Length; ii++)
-                            {
-                                WriteQualifiedName(null, values[ii]);
-                            }
-                            break;
+                            WriteQualifiedName(null, values[ii]);
                         }
+                        break;
+                    }
                     case BuiltInType.LocalizedText:
+                    {
+                        LocalizedText[] values = (LocalizedText[])matrix.Elements;
+                        for (int ii = 0; ii < values.Length; ii++)
                         {
-                            LocalizedText[] values = (LocalizedText[])matrix.Elements;
-                            for (int ii = 0; ii < values.Length; ii++)
-                            {
-                                WriteLocalizedText(null, values[ii]);
-                            }
-                            break;
+                            WriteLocalizedText(null, values[ii]);
                         }
+                        break;
+                    }
                     case BuiltInType.ExtensionObject:
+                    {
+                        ExtensionObject[] values = (ExtensionObject[])matrix.Elements;
+                        for (int ii = 0; ii < values.Length; ii++)
                         {
-                            ExtensionObject[] values = (ExtensionObject[])matrix.Elements;
-                            for (int ii = 0; ii < values.Length; ii++)
-                            {
-                                WriteExtensionObject(null, values[ii]);
-                            }
-                            break;
+                            WriteExtensionObject(null, values[ii]);
                         }
+                        break;
+                    }
                     case BuiltInType.DataValue:
+                    {
+                        DataValue[] values = (DataValue[])matrix.Elements;
+                        for (int ii = 0; ii < values.Length; ii++)
                         {
-                            DataValue[] values = (DataValue[])matrix.Elements;
-                            for (int ii = 0; ii < values.Length; ii++)
-                            {
-                                WriteDataValue(null, values[ii]);
-                            }
-                            break;
+                            WriteDataValue(null, values[ii]);
                         }
+                        break;
+                    }
                     case BuiltInType.Variant:
+                    {
+                        Variant[] variants = matrix.Elements as Variant[];
+                        if (variants != null)
                         {
-                            Variant[] variants = matrix.Elements as Variant[];
-                            if (variants != null)
+                            for (int ii = 0; ii < variants.Length; ii++)
                             {
-                                for (int ii = 0; ii < variants.Length; ii++)
-                                {
-                                    WriteVariant(null, variants[ii]);
-                                }
-                                break;
-                            }
-
-                            // try to write IEncodeable Array
-                            IEncodeable[] encodeableArray = matrix.Elements as IEncodeable[];
-                            if (encodeableArray != null)
-                            {
-                                for (int ii = 0; ii < encodeableArray.Length; ii++)
-                                {
-                                    WriteEncodeable(null, encodeableArray[ii], null);
-                                }
-                                break;
-                            }
-
-                            object[] objects = matrix.Elements as object[];
-                            if (objects != null)
-                            {
-                                for (int ii = 0; ii < objects.Length; ii++)
-                                {
-                                    WriteVariant(null, new Variant(objects[ii]));
-                                }
-                                break;
-                            }
-                            throw ServiceResultException.Create(
-                                StatusCodes.BadEncodingError,
-                                "Unexpected type encountered while encoding a Matrix.");
-                        }
-                    case BuiltInType.DiagnosticInfo:
-                        {
-                            DiagnosticInfo[] values = (DiagnosticInfo[])matrix.Elements;
-                            for (int ii = 0; ii < values.Length; ii++)
-                            {
-                                WriteDiagnosticInfo(null, values[ii]);
+                                WriteVariant(null, variants[ii]);
                             }
                             break;
                         }
-                    default:
+
+                        // try to write IEncodeable Array
+                        IEncodeable[] encodeableArray = matrix.Elements as IEncodeable[];
+                        if (encodeableArray != null)
                         {
-                            // try to write IEncodeable Array
-                            IEncodeable[] encodeableArray = matrix.Elements as IEncodeable[];
-                            if (encodeableArray != null)
+                            for (int ii = 0; ii < encodeableArray.Length; ii++)
                             {
-                                for (int ii = 0; ii < encodeableArray.Length; ii++)
-                                {
-                                    WriteEncodeable(null, encodeableArray[ii], null);
-                                }
-                                break;
+                                WriteEncodeable(null, encodeableArray[ii], null);
                             }
-                            throw ServiceResultException.Create(
-                                StatusCodes.BadEncodingError,
-                                "Unexpected type encountered while encoding a Matrix with BuiltInType: {0}",
-                                matrix.TypeInfo.BuiltInType);
+                            break;
                         }
+
+                        object[] objects = matrix.Elements as object[];
+                        if (objects != null)
+                        {
+                            for (int ii = 0; ii < objects.Length; ii++)
+                            {
+                                WriteVariant(null, new Variant(objects[ii]));
+                            }
+                            break;
+                        }
+                        throw ServiceResultException.Create(
+                            StatusCodes.BadEncodingError,
+                            "Unexpected type encountered while encoding a Matrix.");
+                    }
+                    case BuiltInType.DiagnosticInfo:
+                    {
+                        DiagnosticInfo[] values = (DiagnosticInfo[])matrix.Elements;
+                        for (int ii = 0; ii < values.Length; ii++)
+                        {
+                            WriteDiagnosticInfo(null, values[ii]);
+                        }
+                        break;
+                    }
+                    default:
+                    {
+                        // try to write IEncodeable Array
+                        IEncodeable[] encodeableArray = matrix.Elements as IEncodeable[];
+                        if (encodeableArray != null)
+                        {
+                            for (int ii = 0; ii < encodeableArray.Length; ii++)
+                            {
+                                WriteEncodeable(null, encodeableArray[ii], null);
+                            }
+                            break;
+                        }
+                        throw ServiceResultException.Create(
+                            StatusCodes.BadEncodingError,
+                            "Unexpected type encountered while encoding a Matrix with BuiltInType: {0}",
+                            matrix.TypeInfo.BuiltInType);
+                    }
                 }
             }
         }
@@ -2103,49 +2100,49 @@ namespace Opc.Ua
             switch (idType)
             {
                 case IdType.Numeric:
+                {
+                    uint id = Convert.ToUInt32(identifier, CultureInfo.InvariantCulture);
+
+                    if (id <= Byte.MaxValue && namespaceIndex == 0)
                     {
-                        uint id = Convert.ToUInt32(identifier, CultureInfo.InvariantCulture);
-
-                        if (id <= Byte.MaxValue && namespaceIndex == 0)
-                        {
-                            encoding = NodeIdEncodingBits.TwoByte;
-                            break;
-                        }
-
-                        if (id <= UInt16.MaxValue && namespaceIndex <= Byte.MaxValue)
-                        {
-                            encoding = NodeIdEncodingBits.FourByte;
-                            break;
-                        }
-
-                        encoding = NodeIdEncodingBits.Numeric;
+                        encoding = NodeIdEncodingBits.TwoByte;
                         break;
                     }
+
+                    if (id <= UInt16.MaxValue && namespaceIndex <= Byte.MaxValue)
+                    {
+                        encoding = NodeIdEncodingBits.FourByte;
+                        break;
+                    }
+
+                    encoding = NodeIdEncodingBits.Numeric;
+                    break;
+                }
 
                 case IdType.String:
-                    {
-                        encoding = NodeIdEncodingBits.String;
-                        break;
-                    }
+                {
+                    encoding = NodeIdEncodingBits.String;
+                    break;
+                }
 
                 case IdType.Guid:
-                    {
-                        encoding = NodeIdEncodingBits.Guid;
-                        break;
-                    }
+                {
+                    encoding = NodeIdEncodingBits.Guid;
+                    break;
+                }
 
                 case IdType.Opaque:
-                    {
-                        encoding = NodeIdEncodingBits.ByteString;
-                        break;
-                    }
+                {
+                    encoding = NodeIdEncodingBits.ByteString;
+                    break;
+                }
 
                 default:
-                    {
-                        throw new ServiceResultException(
-                            StatusCodes.BadEncodingError,
-                            Utils.Format("NodeId identifier type '{0}' not supported.", idType));
-                    }
+                {
+                    throw new ServiceResultException(
+                        StatusCodes.BadEncodingError,
+                        Utils.Format("NodeId identifier type '{0}' not supported.", idType));
+                }
             }
 
             return Convert.ToByte(encoding, CultureInfo.InvariantCulture);
@@ -2160,45 +2157,45 @@ namespace Opc.Ua
             switch ((NodeIdEncodingBits)(0x3F & encoding))
             {
                 case NodeIdEncodingBits.TwoByte:
-                    {
-                        WriteByte(null, Convert.ToByte(identifier, CultureInfo.InvariantCulture));
-                        break;
-                    }
+                {
+                    WriteByte(null, Convert.ToByte(identifier, CultureInfo.InvariantCulture));
+                    break;
+                }
 
                 case NodeIdEncodingBits.FourByte:
-                    {
-                        WriteByte(null, Convert.ToByte(namespaceIndex));
-                        WriteUInt16(null, Convert.ToUInt16(identifier, CultureInfo.InvariantCulture));
-                        break;
-                    }
+                {
+                    WriteByte(null, Convert.ToByte(namespaceIndex));
+                    WriteUInt16(null, Convert.ToUInt16(identifier, CultureInfo.InvariantCulture));
+                    break;
+                }
 
                 case NodeIdEncodingBits.Numeric:
-                    {
-                        WriteUInt16(null, namespaceIndex);
-                        WriteUInt32(null, Convert.ToUInt32(identifier, CultureInfo.InvariantCulture));
-                        break;
-                    }
+                {
+                    WriteUInt16(null, namespaceIndex);
+                    WriteUInt32(null, Convert.ToUInt32(identifier, CultureInfo.InvariantCulture));
+                    break;
+                }
 
                 case NodeIdEncodingBits.String:
-                    {
-                        WriteUInt16(null, namespaceIndex);
-                        WriteString(null, (string)identifier);
-                        break;
-                    }
+                {
+                    WriteUInt16(null, namespaceIndex);
+                    WriteString(null, (string)identifier);
+                    break;
+                }
 
                 case NodeIdEncodingBits.Guid:
-                    {
-                        WriteUInt16(null, namespaceIndex);
-                        WriteGuid(null, new Uuid((Guid)identifier));
-                        break;
-                    }
+                {
+                    WriteUInt16(null, namespaceIndex);
+                    WriteGuid(null, new Uuid((Guid)identifier));
+                    break;
+                }
 
                 case NodeIdEncodingBits.ByteString:
-                    {
-                        WriteUInt16(null, namespaceIndex);
-                        WriteByteString(null, (byte[])identifier);
-                        break;
-                    }
+                {
+                    WriteUInt16(null, namespaceIndex);
+                    WriteByteString(null, (byte[])identifier);
+                    break;
+                }
             }
         }
 
@@ -2305,61 +2302,61 @@ namespace Opc.Ua
                     case BuiltInType.DataValue: { WriteDataValueArray(null, (DataValue[])valueToEncode); break; }
 
                     case BuiltInType.Enumeration:
+                    {
+                        // Check whether the value to encode is int array.
+                        int[] ints = valueToEncode as int[];
+                        if (ints == null)
                         {
-                            // Check whether the value to encode is int array.
-                            int[] ints = valueToEncode as int[];
-                            if (ints == null)
+                            Enum[] enums = valueToEncode as Enum[];
+                            if (enums == null)
                             {
-                                Enum[] enums = valueToEncode as Enum[];
-                                if (enums == null)
-                                {
-                                    throw new ServiceResultException(
-                                        StatusCodes.BadEncodingError,
-                                        Utils.Format("Type '{0}' is not allowed in an Enumeration.", value.GetType().FullName));
-                                }
-                                ints = new int[enums.Length];
-                                for (int ii = 0; ii < enums.Length; ii++)
-                                {
-                                    ints[ii] = (int)(object)enums[ii];
-                                }
+                                throw new ServiceResultException(
+                                    StatusCodes.BadEncodingError,
+                                    Utils.Format("Type '{0}' is not allowed in an Enumeration.", value.GetType().FullName));
                             }
+                            ints = new int[enums.Length];
+                            for (int ii = 0; ii < enums.Length; ii++)
+                            {
+                                ints[ii] = (int)(object)enums[ii];
+                            }
+                        }
 
-                            WriteInt32Array(null, ints);
+                        WriteInt32Array(null, ints);
+                        break;
+                    }
+
+                    case BuiltInType.Variant:
+                    {
+                        Variant[] variants = valueToEncode as Variant[];
+
+                        if (variants != null)
+                        {
+                            WriteVariantArray(null, variants);
                             break;
                         }
 
-                    case BuiltInType.Variant:
+                        object[] objects = valueToEncode as object[];
+
+                        if (objects != null)
                         {
-                            Variant[] variants = valueToEncode as Variant[];
-
-                            if (variants != null)
-                            {
-                                WriteVariantArray(null, variants);
-                                break;
-                            }
-
-                            object[] objects = valueToEncode as object[];
-
-                            if (objects != null)
-                            {
-                                WriteObjectArray(null, objects);
-                                break;
-                            }
-
-                            throw ServiceResultException.Create(
-                                StatusCodes.BadEncodingError,
-                                "Unexpected type encountered while encoding a Matrix: {0}",
-                                valueToEncode.GetType());
+                            WriteObjectArray(null, objects);
+                            break;
                         }
+
+                        throw ServiceResultException.Create(
+                            StatusCodes.BadEncodingError,
+                            "Unexpected type encountered while encoding a Matrix: {0}",
+                            valueToEncode.GetType());
+                    }
 
                     case BuiltInType.DiagnosticInfo: { WriteDiagnosticInfoArray(null, (DiagnosticInfo[])valueToEncode); break; }
                     default:
-                        {
-                            throw ServiceResultException.Create(
-                                StatusCodes.BadEncodingError,
-                                "Unexpected type encountered while encoding a Variant: {0}",
-                                value.TypeInfo.BuiltInType);
-                        }
+                    {
+                        throw ServiceResultException.Create(
+                            StatusCodes.BadEncodingError,
+                            "Unexpected type encountered while encoding a Variant: {0}",
+                            value.TypeInfo.BuiltInType);
+                    }
                 }
 
                 // write the dimensions.

--- a/Stack/Opc.Ua.Core/Types/Encoders/BinaryEncoder.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/BinaryEncoder.cs
@@ -88,7 +88,10 @@ namespace Opc.Ua
                     m_writer.Dispose();
                 }
 
-                m_ostrm?.Dispose();
+                if (!m_leaveOpen)
+                {
+                    m_ostrm?.Dispose();
+                }
             }
         }
         #endregion

--- a/Stack/Opc.Ua.Core/Types/Encoders/BinaryEncoder.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/BinaryEncoder.cs
@@ -88,7 +88,10 @@ namespace Opc.Ua
                     m_writer.Dispose();
                 }
 
-                m_ostrm?.Dispose();
+                if (!m_leaveOpen)
+                {
+                    m_ostrm?.Dispose();
+                }
             }
         }
         #endregion
@@ -1640,17 +1643,17 @@ namespace Opc.Ua
                         WriteXmlElementArray(null, (XmlElement[])array);
                         break;
                     case BuiltInType.Variant:
-                    {
-                        // try to write IEncodeable Array
-                        IEncodeable[] encodeableArray = array as IEncodeable[];
-                        if (encodeableArray != null)
                         {
-                            WriteEncodeableArray(fieldName, encodeableArray, array.GetType().GetElementType());
-                            return;
+                            // try to write IEncodeable Array
+                            IEncodeable[] encodeableArray = array as IEncodeable[];
+                            if (encodeableArray != null)
+                            {
+                                WriteEncodeableArray(fieldName, encodeableArray, array.GetType().GetElementType());
+                                return;
+                            }
+                            WriteVariantArray(null, (Variant[])array);
+                            break;
                         }
-                        WriteVariantArray(null, (Variant[])array);
-                        break;
-                    }
                     case BuiltInType.Enumeration:
                         int[] ints = array as int[];
                         if (ints == null)
@@ -1686,25 +1689,25 @@ namespace Opc.Ua
                         WriteDataValueArray(null, (DataValue[])array);
                         break;
                     default:
-                    {
-                        // try to write IEncodeable Array
-                        IEncodeable[] encodeableArray = array as IEncodeable[];
-                        if (encodeableArray != null)
                         {
-                            WriteEncodeableArray(fieldName, encodeableArray, array.GetType().GetElementType());
-                            break;
+                            // try to write IEncodeable Array
+                            IEncodeable[] encodeableArray = array as IEncodeable[];
+                            if (encodeableArray != null)
+                            {
+                                WriteEncodeableArray(fieldName, encodeableArray, array.GetType().GetElementType());
+                                break;
+                            }
+                            if (array == null)
+                            {
+                                // write zero dimension
+                                WriteInt32(null, -1);
+                                return;
+                            }
+                            throw ServiceResultException.Create(
+                                StatusCodes.BadEncodingError,
+                                "Unexpected type encountered while encoding an Array with BuiltInType: {0}",
+                                builtInType);
                         }
-                        if (array == null)
-                        {
-                            // write zero dimension
-                            WriteInt32(null, -1);
-                            return;
-                        }
-                        throw ServiceResultException.Create(
-                            StatusCodes.BadEncodingError,
-                            "Unexpected type encountered while encoding an Array with BuiltInType: {0}",
-                            builtInType);
-                    }
                 }
             }
             else if (valueRank > ValueRanks.OneDimension)
@@ -1733,287 +1736,287 @@ namespace Opc.Ua
                 switch (matrix.TypeInfo.BuiltInType)
                 {
                     case BuiltInType.Boolean:
-                    {
-                        bool[] values = (bool[])matrix.Elements;
-                        for (int ii = 0; ii < values.Length; ii++)
                         {
-                            WriteBoolean(null, values[ii]);
-                        }
-                        break;
-                    }
-                    case BuiltInType.SByte:
-                    {
-                        sbyte[] values = (sbyte[])matrix.Elements;
-                        for (int ii = 0; ii < values.Length; ii++)
-                        {
-                            WriteSByte(null, values[ii]);
-                        }
-                        break;
-                    }
-                    case BuiltInType.Byte:
-                    {
-                        byte[] values = (byte[])matrix.Elements;
-                        for (int ii = 0; ii < values.Length; ii++)
-                        {
-                            WriteByte(null, values[ii]);
-                        }
-                        break;
-                    }
-                    case BuiltInType.Int16:
-                    {
-                        Int16[] values = (Int16[])matrix.Elements;
-                        for (int ii = 0; ii < values.Length; ii++)
-                        {
-                            WriteInt16(null, values[ii]);
-                        }
-                        break;
-                    }
-                    case BuiltInType.UInt16:
-                    {
-                        UInt16[] values = (UInt16[])matrix.Elements;
-                        for (int ii = 0; ii < values.Length; ii++)
-                        {
-                            WriteUInt16(null, values[ii]);
-                        }
-                        break;
-                    }
-                    case BuiltInType.Enumeration:
-                    {
-                        Enum[] values = matrix.Elements as Enum[];
-                        if (values != null)
-                        {
+                            bool[] values = (bool[])matrix.Elements;
                             for (int ii = 0; ii < values.Length; ii++)
                             {
-                                WriteEnumerated(null, values[ii]);
+                                WriteBoolean(null, values[ii]);
                             }
                             break;
                         }
-                        goto case BuiltInType.Int32;
-                    }
+                    case BuiltInType.SByte:
+                        {
+                            sbyte[] values = (sbyte[])matrix.Elements;
+                            for (int ii = 0; ii < values.Length; ii++)
+                            {
+                                WriteSByte(null, values[ii]);
+                            }
+                            break;
+                        }
+                    case BuiltInType.Byte:
+                        {
+                            byte[] values = (byte[])matrix.Elements;
+                            for (int ii = 0; ii < values.Length; ii++)
+                            {
+                                WriteByte(null, values[ii]);
+                            }
+                            break;
+                        }
+                    case BuiltInType.Int16:
+                        {
+                            Int16[] values = (Int16[])matrix.Elements;
+                            for (int ii = 0; ii < values.Length; ii++)
+                            {
+                                WriteInt16(null, values[ii]);
+                            }
+                            break;
+                        }
+                    case BuiltInType.UInt16:
+                        {
+                            UInt16[] values = (UInt16[])matrix.Elements;
+                            for (int ii = 0; ii < values.Length; ii++)
+                            {
+                                WriteUInt16(null, values[ii]);
+                            }
+                            break;
+                        }
+                    case BuiltInType.Enumeration:
+                        {
+                            Enum[] values = matrix.Elements as Enum[];
+                            if (values != null)
+                            {
+                                for (int ii = 0; ii < values.Length; ii++)
+                                {
+                                    WriteEnumerated(null, values[ii]);
+                                }
+                                break;
+                            }
+                            goto case BuiltInType.Int32;
+                        }
                     case BuiltInType.Int32:
-                    {
-                        Int32[] values = (Int32[])matrix.Elements;
-                        for (int ii = 0; ii < values.Length; ii++)
                         {
-                            WriteInt32(null, values[ii]);
+                            Int32[] values = (Int32[])matrix.Elements;
+                            for (int ii = 0; ii < values.Length; ii++)
+                            {
+                                WriteInt32(null, values[ii]);
+                            }
+                            break;
                         }
-                        break;
-                    }
                     case BuiltInType.UInt32:
-                    {
-                        UInt32[] values = (UInt32[])matrix.Elements;
-                        for (int ii = 0; ii < values.Length; ii++)
                         {
-                            WriteUInt32(null, values[ii]);
+                            UInt32[] values = (UInt32[])matrix.Elements;
+                            for (int ii = 0; ii < values.Length; ii++)
+                            {
+                                WriteUInt32(null, values[ii]);
+                            }
+                            break;
                         }
-                        break;
-                    }
                     case BuiltInType.Int64:
-                    {
-                        Int64[] values = (Int64[])matrix.Elements;
-                        for (int ii = 0; ii < values.Length; ii++)
                         {
-                            WriteInt64(null, values[ii]);
+                            Int64[] values = (Int64[])matrix.Elements;
+                            for (int ii = 0; ii < values.Length; ii++)
+                            {
+                                WriteInt64(null, values[ii]);
+                            }
+                            break;
                         }
-                        break;
-                    }
                     case BuiltInType.UInt64:
-                    {
-                        UInt64[] values = (UInt64[])matrix.Elements;
-                        for (int ii = 0; ii < values.Length; ii++)
                         {
-                            WriteUInt64(null, values[ii]);
+                            UInt64[] values = (UInt64[])matrix.Elements;
+                            for (int ii = 0; ii < values.Length; ii++)
+                            {
+                                WriteUInt64(null, values[ii]);
+                            }
+                            break;
                         }
-                        break;
-                    }
                     case BuiltInType.Float:
-                    {
-                        float[] values = (float[])matrix.Elements;
-                        for (int ii = 0; ii < values.Length; ii++)
                         {
-                            WriteFloat(null, values[ii]);
+                            float[] values = (float[])matrix.Elements;
+                            for (int ii = 0; ii < values.Length; ii++)
+                            {
+                                WriteFloat(null, values[ii]);
+                            }
+                            break;
                         }
-                        break;
-                    }
                     case BuiltInType.Double:
-                    {
-                        double[] values = (double[])matrix.Elements;
-                        for (int ii = 0; ii < values.Length; ii++)
                         {
-                            WriteDouble(null, values[ii]);
+                            double[] values = (double[])matrix.Elements;
+                            for (int ii = 0; ii < values.Length; ii++)
+                            {
+                                WriteDouble(null, values[ii]);
+                            }
+                            break;
                         }
-                        break;
-                    }
                     case BuiltInType.String:
-                    {
-                        string[] values = (string[])matrix.Elements;
-                        for (int ii = 0; ii < values.Length; ii++)
                         {
-                            WriteString(null, values[ii]);
+                            string[] values = (string[])matrix.Elements;
+                            for (int ii = 0; ii < values.Length; ii++)
+                            {
+                                WriteString(null, values[ii]);
+                            }
+                            break;
                         }
-                        break;
-                    }
                     case BuiltInType.DateTime:
-                    {
-                        DateTime[] values = (DateTime[])matrix.Elements;
-                        for (int ii = 0; ii < values.Length; ii++)
                         {
-                            WriteDateTime(null, values[ii]);
+                            DateTime[] values = (DateTime[])matrix.Elements;
+                            for (int ii = 0; ii < values.Length; ii++)
+                            {
+                                WriteDateTime(null, values[ii]);
+                            }
+                            break;
                         }
-                        break;
-                    }
                     case BuiltInType.Guid:
-                    {
-                        Uuid[] values = (Uuid[])matrix.Elements;
-                        for (int ii = 0; ii < values.Length; ii++)
                         {
-                            WriteGuid(null, values[ii]);
+                            Uuid[] values = (Uuid[])matrix.Elements;
+                            for (int ii = 0; ii < values.Length; ii++)
+                            {
+                                WriteGuid(null, values[ii]);
+                            }
+                            break;
                         }
-                        break;
-                    }
                     case BuiltInType.ByteString:
-                    {
-                        byte[][] values = (byte[][])matrix.Elements;
-                        for (int ii = 0; ii < values.Length; ii++)
                         {
-                            WriteByteString(null, values[ii]);
+                            byte[][] values = (byte[][])matrix.Elements;
+                            for (int ii = 0; ii < values.Length; ii++)
+                            {
+                                WriteByteString(null, values[ii]);
+                            }
+                            break;
                         }
-                        break;
-                    }
                     case BuiltInType.XmlElement:
-                    {
-                        XmlElement[] values = (XmlElement[])matrix.Elements;
-                        for (int ii = 0; ii < values.Length; ii++)
                         {
-                            WriteXmlElement(null, values[ii]);
+                            XmlElement[] values = (XmlElement[])matrix.Elements;
+                            for (int ii = 0; ii < values.Length; ii++)
+                            {
+                                WriteXmlElement(null, values[ii]);
+                            }
+                            break;
                         }
-                        break;
-                    }
                     case BuiltInType.NodeId:
-                    {
-                        NodeId[] values = (NodeId[])matrix.Elements;
-                        for (int ii = 0; ii < values.Length; ii++)
                         {
-                            WriteNodeId(null, values[ii]);
+                            NodeId[] values = (NodeId[])matrix.Elements;
+                            for (int ii = 0; ii < values.Length; ii++)
+                            {
+                                WriteNodeId(null, values[ii]);
+                            }
+                            break;
                         }
-                        break;
-                    }
                     case BuiltInType.ExpandedNodeId:
-                    {
-                        ExpandedNodeId[] values = (ExpandedNodeId[])matrix.Elements;
-                        for (int ii = 0; ii < values.Length; ii++)
                         {
-                            WriteExpandedNodeId(null, values[ii]);
+                            ExpandedNodeId[] values = (ExpandedNodeId[])matrix.Elements;
+                            for (int ii = 0; ii < values.Length; ii++)
+                            {
+                                WriteExpandedNodeId(null, values[ii]);
+                            }
+                            break;
                         }
-                        break;
-                    }
                     case BuiltInType.StatusCode:
-                    {
-                        StatusCode[] values = (StatusCode[])matrix.Elements;
-                        for (int ii = 0; ii < values.Length; ii++)
                         {
-                            WriteStatusCode(null, values[ii]);
+                            StatusCode[] values = (StatusCode[])matrix.Elements;
+                            for (int ii = 0; ii < values.Length; ii++)
+                            {
+                                WriteStatusCode(null, values[ii]);
+                            }
+                            break;
                         }
-                        break;
-                    }
                     case BuiltInType.QualifiedName:
-                    {
-                        QualifiedName[] values = (QualifiedName[])matrix.Elements;
-                        for (int ii = 0; ii < values.Length; ii++)
                         {
-                            WriteQualifiedName(null, values[ii]);
+                            QualifiedName[] values = (QualifiedName[])matrix.Elements;
+                            for (int ii = 0; ii < values.Length; ii++)
+                            {
+                                WriteQualifiedName(null, values[ii]);
+                            }
+                            break;
                         }
-                        break;
-                    }
                     case BuiltInType.LocalizedText:
-                    {
-                        LocalizedText[] values = (LocalizedText[])matrix.Elements;
-                        for (int ii = 0; ii < values.Length; ii++)
                         {
-                            WriteLocalizedText(null, values[ii]);
+                            LocalizedText[] values = (LocalizedText[])matrix.Elements;
+                            for (int ii = 0; ii < values.Length; ii++)
+                            {
+                                WriteLocalizedText(null, values[ii]);
+                            }
+                            break;
                         }
-                        break;
-                    }
                     case BuiltInType.ExtensionObject:
-                    {
-                        ExtensionObject[] values = (ExtensionObject[])matrix.Elements;
-                        for (int ii = 0; ii < values.Length; ii++)
                         {
-                            WriteExtensionObject(null, values[ii]);
+                            ExtensionObject[] values = (ExtensionObject[])matrix.Elements;
+                            for (int ii = 0; ii < values.Length; ii++)
+                            {
+                                WriteExtensionObject(null, values[ii]);
+                            }
+                            break;
                         }
-                        break;
-                    }
                     case BuiltInType.DataValue:
-                    {
-                        DataValue[] values = (DataValue[])matrix.Elements;
-                        for (int ii = 0; ii < values.Length; ii++)
                         {
-                            WriteDataValue(null, values[ii]);
+                            DataValue[] values = (DataValue[])matrix.Elements;
+                            for (int ii = 0; ii < values.Length; ii++)
+                            {
+                                WriteDataValue(null, values[ii]);
+                            }
+                            break;
                         }
-                        break;
-                    }
                     case BuiltInType.Variant:
-                    {
-                        Variant[] variants = matrix.Elements as Variant[];
-                        if (variants != null)
                         {
-                            for (int ii = 0; ii < variants.Length; ii++)
+                            Variant[] variants = matrix.Elements as Variant[];
+                            if (variants != null)
                             {
-                                WriteVariant(null, variants[ii]);
+                                for (int ii = 0; ii < variants.Length; ii++)
+                                {
+                                    WriteVariant(null, variants[ii]);
+                                }
+                                break;
                             }
-                            break;
-                        }
 
-                        // try to write IEncodeable Array
-                        IEncodeable[] encodeableArray = matrix.Elements as IEncodeable[];
-                        if (encodeableArray != null)
-                        {
-                            for (int ii = 0; ii < encodeableArray.Length; ii++)
+                            // try to write IEncodeable Array
+                            IEncodeable[] encodeableArray = matrix.Elements as IEncodeable[];
+                            if (encodeableArray != null)
                             {
-                                WriteEncodeable(null, encodeableArray[ii], null);
+                                for (int ii = 0; ii < encodeableArray.Length; ii++)
+                                {
+                                    WriteEncodeable(null, encodeableArray[ii], null);
+                                }
+                                break;
                             }
-                            break;
-                        }
 
-                        object[] objects = matrix.Elements as object[];
-                        if (objects != null)
-                        {
-                            for (int ii = 0; ii < objects.Length; ii++)
+                            object[] objects = matrix.Elements as object[];
+                            if (objects != null)
                             {
-                                WriteVariant(null, new Variant(objects[ii]));
+                                for (int ii = 0; ii < objects.Length; ii++)
+                                {
+                                    WriteVariant(null, new Variant(objects[ii]));
+                                }
+                                break;
                             }
-                            break;
+                            throw ServiceResultException.Create(
+                                StatusCodes.BadEncodingError,
+                                "Unexpected type encountered while encoding a Matrix.");
                         }
-                        throw ServiceResultException.Create(
-                            StatusCodes.BadEncodingError,
-                            "Unexpected type encountered while encoding a Matrix.");
-                    }
                     case BuiltInType.DiagnosticInfo:
-                    {
-                        DiagnosticInfo[] values = (DiagnosticInfo[])matrix.Elements;
-                        for (int ii = 0; ii < values.Length; ii++)
                         {
-                            WriteDiagnosticInfo(null, values[ii]);
-                        }
-                        break;
-                    }
-                    default:
-                    {
-                        // try to write IEncodeable Array
-                        IEncodeable[] encodeableArray = matrix.Elements as IEncodeable[];
-                        if (encodeableArray != null)
-                        {
-                            for (int ii = 0; ii < encodeableArray.Length; ii++)
+                            DiagnosticInfo[] values = (DiagnosticInfo[])matrix.Elements;
+                            for (int ii = 0; ii < values.Length; ii++)
                             {
-                                WriteEncodeable(null, encodeableArray[ii], null);
+                                WriteDiagnosticInfo(null, values[ii]);
                             }
                             break;
                         }
-                        throw ServiceResultException.Create(
-                            StatusCodes.BadEncodingError,
-                            "Unexpected type encountered while encoding a Matrix with BuiltInType: {0}",
-                            matrix.TypeInfo.BuiltInType);
-                    }
+                    default:
+                        {
+                            // try to write IEncodeable Array
+                            IEncodeable[] encodeableArray = matrix.Elements as IEncodeable[];
+                            if (encodeableArray != null)
+                            {
+                                for (int ii = 0; ii < encodeableArray.Length; ii++)
+                                {
+                                    WriteEncodeable(null, encodeableArray[ii], null);
+                                }
+                                break;
+                            }
+                            throw ServiceResultException.Create(
+                                StatusCodes.BadEncodingError,
+                                "Unexpected type encountered while encoding a Matrix with BuiltInType: {0}",
+                                matrix.TypeInfo.BuiltInType);
+                        }
                 }
             }
         }
@@ -2100,49 +2103,49 @@ namespace Opc.Ua
             switch (idType)
             {
                 case IdType.Numeric:
-                {
-                    uint id = Convert.ToUInt32(identifier, CultureInfo.InvariantCulture);
-
-                    if (id <= Byte.MaxValue && namespaceIndex == 0)
                     {
-                        encoding = NodeIdEncodingBits.TwoByte;
+                        uint id = Convert.ToUInt32(identifier, CultureInfo.InvariantCulture);
+
+                        if (id <= Byte.MaxValue && namespaceIndex == 0)
+                        {
+                            encoding = NodeIdEncodingBits.TwoByte;
+                            break;
+                        }
+
+                        if (id <= UInt16.MaxValue && namespaceIndex <= Byte.MaxValue)
+                        {
+                            encoding = NodeIdEncodingBits.FourByte;
+                            break;
+                        }
+
+                        encoding = NodeIdEncodingBits.Numeric;
                         break;
                     }
-
-                    if (id <= UInt16.MaxValue && namespaceIndex <= Byte.MaxValue)
-                    {
-                        encoding = NodeIdEncodingBits.FourByte;
-                        break;
-                    }
-
-                    encoding = NodeIdEncodingBits.Numeric;
-                    break;
-                }
 
                 case IdType.String:
-                {
-                    encoding = NodeIdEncodingBits.String;
-                    break;
-                }
+                    {
+                        encoding = NodeIdEncodingBits.String;
+                        break;
+                    }
 
                 case IdType.Guid:
-                {
-                    encoding = NodeIdEncodingBits.Guid;
-                    break;
-                }
+                    {
+                        encoding = NodeIdEncodingBits.Guid;
+                        break;
+                    }
 
                 case IdType.Opaque:
-                {
-                    encoding = NodeIdEncodingBits.ByteString;
-                    break;
-                }
+                    {
+                        encoding = NodeIdEncodingBits.ByteString;
+                        break;
+                    }
 
                 default:
-                {
-                    throw new ServiceResultException(
-                        StatusCodes.BadEncodingError,
-                        Utils.Format("NodeId identifier type '{0}' not supported.", idType));
-                }
+                    {
+                        throw new ServiceResultException(
+                            StatusCodes.BadEncodingError,
+                            Utils.Format("NodeId identifier type '{0}' not supported.", idType));
+                    }
             }
 
             return Convert.ToByte(encoding, CultureInfo.InvariantCulture);
@@ -2157,45 +2160,45 @@ namespace Opc.Ua
             switch ((NodeIdEncodingBits)(0x3F & encoding))
             {
                 case NodeIdEncodingBits.TwoByte:
-                {
-                    WriteByte(null, Convert.ToByte(identifier, CultureInfo.InvariantCulture));
-                    break;
-                }
+                    {
+                        WriteByte(null, Convert.ToByte(identifier, CultureInfo.InvariantCulture));
+                        break;
+                    }
 
                 case NodeIdEncodingBits.FourByte:
-                {
-                    WriteByte(null, Convert.ToByte(namespaceIndex));
-                    WriteUInt16(null, Convert.ToUInt16(identifier, CultureInfo.InvariantCulture));
-                    break;
-                }
+                    {
+                        WriteByte(null, Convert.ToByte(namespaceIndex));
+                        WriteUInt16(null, Convert.ToUInt16(identifier, CultureInfo.InvariantCulture));
+                        break;
+                    }
 
                 case NodeIdEncodingBits.Numeric:
-                {
-                    WriteUInt16(null, namespaceIndex);
-                    WriteUInt32(null, Convert.ToUInt32(identifier, CultureInfo.InvariantCulture));
-                    break;
-                }
+                    {
+                        WriteUInt16(null, namespaceIndex);
+                        WriteUInt32(null, Convert.ToUInt32(identifier, CultureInfo.InvariantCulture));
+                        break;
+                    }
 
                 case NodeIdEncodingBits.String:
-                {
-                    WriteUInt16(null, namespaceIndex);
-                    WriteString(null, (string)identifier);
-                    break;
-                }
+                    {
+                        WriteUInt16(null, namespaceIndex);
+                        WriteString(null, (string)identifier);
+                        break;
+                    }
 
                 case NodeIdEncodingBits.Guid:
-                {
-                    WriteUInt16(null, namespaceIndex);
-                    WriteGuid(null, new Uuid((Guid)identifier));
-                    break;
-                }
+                    {
+                        WriteUInt16(null, namespaceIndex);
+                        WriteGuid(null, new Uuid((Guid)identifier));
+                        break;
+                    }
 
                 case NodeIdEncodingBits.ByteString:
-                {
-                    WriteUInt16(null, namespaceIndex);
-                    WriteByteString(null, (byte[])identifier);
-                    break;
-                }
+                    {
+                        WriteUInt16(null, namespaceIndex);
+                        WriteByteString(null, (byte[])identifier);
+                        break;
+                    }
             }
         }
 
@@ -2302,61 +2305,61 @@ namespace Opc.Ua
                     case BuiltInType.DataValue: { WriteDataValueArray(null, (DataValue[])valueToEncode); break; }
 
                     case BuiltInType.Enumeration:
-                    {
-                        // Check whether the value to encode is int array.
-                        int[] ints = valueToEncode as int[];
-                        if (ints == null)
                         {
-                            Enum[] enums = valueToEncode as Enum[];
-                            if (enums == null)
+                            // Check whether the value to encode is int array.
+                            int[] ints = valueToEncode as int[];
+                            if (ints == null)
                             {
-                                throw new ServiceResultException(
-                                    StatusCodes.BadEncodingError,
-                                    Utils.Format("Type '{0}' is not allowed in an Enumeration.", value.GetType().FullName));
+                                Enum[] enums = valueToEncode as Enum[];
+                                if (enums == null)
+                                {
+                                    throw new ServiceResultException(
+                                        StatusCodes.BadEncodingError,
+                                        Utils.Format("Type '{0}' is not allowed in an Enumeration.", value.GetType().FullName));
+                                }
+                                ints = new int[enums.Length];
+                                for (int ii = 0; ii < enums.Length; ii++)
+                                {
+                                    ints[ii] = (int)(object)enums[ii];
+                                }
                             }
-                            ints = new int[enums.Length];
-                            for (int ii = 0; ii < enums.Length; ii++)
-                            {
-                                ints[ii] = (int)(object)enums[ii];
-                            }
-                        }
 
-                        WriteInt32Array(null, ints);
-                        break;
-                    }
+                            WriteInt32Array(null, ints);
+                            break;
+                        }
 
                     case BuiltInType.Variant:
-                    {
-                        Variant[] variants = valueToEncode as Variant[];
-
-                        if (variants != null)
                         {
-                            WriteVariantArray(null, variants);
-                            break;
+                            Variant[] variants = valueToEncode as Variant[];
+
+                            if (variants != null)
+                            {
+                                WriteVariantArray(null, variants);
+                                break;
+                            }
+
+                            object[] objects = valueToEncode as object[];
+
+                            if (objects != null)
+                            {
+                                WriteObjectArray(null, objects);
+                                break;
+                            }
+
+                            throw ServiceResultException.Create(
+                                StatusCodes.BadEncodingError,
+                                "Unexpected type encountered while encoding a Matrix: {0}",
+                                valueToEncode.GetType());
                         }
-
-                        object[] objects = valueToEncode as object[];
-
-                        if (objects != null)
-                        {
-                            WriteObjectArray(null, objects);
-                            break;
-                        }
-
-                        throw ServiceResultException.Create(
-                            StatusCodes.BadEncodingError,
-                            "Unexpected type encountered while encoding a Matrix: {0}",
-                            valueToEncode.GetType());
-                    }
 
                     case BuiltInType.DiagnosticInfo: { WriteDiagnosticInfoArray(null, (DiagnosticInfo[])valueToEncode); break; }
                     default:
-                    {
-                        throw ServiceResultException.Create(
-                            StatusCodes.BadEncodingError,
-                            "Unexpected type encountered while encoding a Variant: {0}",
-                            value.TypeInfo.BuiltInType);
-                    }
+                        {
+                            throw ServiceResultException.Create(
+                                StatusCodes.BadEncodingError,
+                                "Unexpected type encountered while encoding a Variant: {0}",
+                                value.TypeInfo.BuiltInType);
+                        }
                 }
 
                 // write the dimensions.

--- a/Tests/Opc.Ua.Core.Tests/Types/Encoders/BinaryEncoderBenchmarks.cs
+++ b/Tests/Opc.Ua.Core.Tests/Types/Encoders/BinaryEncoderBenchmarks.cs
@@ -1,0 +1,212 @@
+/* ========================================================================
+ * Copyright (c) 2005-2023 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ * 
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ * 
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using BenchmarkDotNet.Attributes;
+using NUnit.Framework;
+
+namespace Opc.Ua.Core.Tests.Types.Encoders
+{
+    [TestFixture, Category("JsonEncoder")]
+    [SetCulture("en-us"), SetUICulture("en-us")]
+    [NonParallelizable]
+    [MemoryDiagnoser]
+    [DisassemblyDiagnoser]
+    public class BinaryEncoderBenchmarks
+    {
+        [Params(1, 2, 8, 64)]
+        public int PayLoadSize { get; set; } = 64;
+
+        /// <summary>
+        /// Benchmark encoding with internal memory stream.
+        /// </summary>
+        [Benchmark]
+        [Test]
+        public void BinaryEncoder_Constructor2()
+        {
+            using (var binaryEncoder = new BinaryEncoder(m_context))
+            {
+                TestEncoding(binaryEncoder);
+                _ = binaryEncoder.CloseAndReturnBuffer();
+            }
+        }
+
+        /// <summary>
+        /// Benchmark encoding with memory stream kept open.
+        /// </summary>
+        [Benchmark]
+        [Test]
+        public void BinaryEncoder_Constructor_Recyclable_Streamwriter2()
+        {
+            using (var memoryStream = new Microsoft.IO.RecyclableMemoryStream(m_memoryManager))
+            {
+                int length1;
+                int length2;
+                using (var binaryEncoder = new BinaryEncoder(memoryStream, m_context, true))
+                {
+                    TestEncoding(binaryEncoder);
+                    length1 = binaryEncoder.Close();
+                }
+                using (var binaryEncoder = new BinaryEncoder(memoryStream, m_context, true))
+                {
+                    TestEncoding(binaryEncoder);
+                    length2 = binaryEncoder.Close();
+                    var result = Encoding.UTF8.GetString(memoryStream.ToArray());
+                    Assert.NotNull(result);
+                }
+                Assert.AreEqual(length1 * 2, length2);
+            }
+        }
+
+        /// <summary>
+        /// Benchmark encoding with memory stream kept open.
+        /// </summary>
+        [Benchmark]
+        [Test]
+        public void BinaryEncoder_Constructor_Streamwriter2()
+        {
+            using (var binaryEncoder = new BinaryEncoder(m_memoryStream, m_context, true))
+            {
+                TestEncoding(binaryEncoder);
+                int length = binaryEncoder.Close();
+                var result = Encoding.UTF8.GetString(m_memoryStream.ToArray());
+            }
+        }
+
+        /// <summary>
+        /// Encoding test with memory stream kept open.
+        /// </summary>
+        [Test]
+        public void BinaryEncoder_Constructor_StreamLeaveOpen()
+        {
+            int length1;
+            int length2;
+            using (var binaryEncoder = new BinaryEncoder(m_memoryStream, m_context, true))
+            {
+                TestEncoding(binaryEncoder);
+                length1 = binaryEncoder.Close();
+            }
+            using (var binaryEncoder = new BinaryEncoder(m_memoryStream, m_context, true))
+            {
+                TestEncoding(binaryEncoder);
+                length2 = binaryEncoder.Close();
+            }
+            Assert.AreEqual(length1 * 2, length2);
+            var result = Encoding.UTF8.GetString(m_memoryStream.ToArray());
+            Assert.NotNull(result);
+        }
+
+        /// <summary>
+        /// Benchmark encoding with memory stream kept open,
+        /// use internal reflection to get string from memory stream.
+        /// </summary>
+        [Benchmark]
+        [Test]
+        public void BinaryEncoder_Constructor_Streamwriter_Reflection2()
+        {
+            using (var binaryEncoder = new BinaryEncoder(m_memoryStream, m_context, true))
+            {
+                TestEncoding(binaryEncoder);
+                var result = binaryEncoder.CloseAndReturnBuffer();
+            }
+        }
+
+        #region Private Methods
+        private void TestEncoding(IEncoder encoder)
+        {
+            int payLoadSize = PayLoadSize;
+            encoder.WriteByte("Byte", 0);
+            while (--payLoadSize > 0)
+            {
+                encoder.WriteBoolean("Boolean", true);
+                encoder.WriteUInt64("UInt64", 1234566890);
+                encoder.WriteString("String", "The quick brown fox...");
+                encoder.WriteNodeId("NodeId", s_nodeId);
+                encoder.WriteInt32Array("Array", s_list);
+            }
+        }
+        #endregion
+
+        #region Test Setup
+        [OneTimeSetUp]
+        public void OneTimeSetUp()
+        {
+            // for validating benchmark tests
+            m_context = new ServiceMessageContext();
+            m_memoryManager = new Microsoft.IO.RecyclableMemoryStreamManager();
+            m_memoryStream = new MemoryStream();
+        }
+
+        [OneTimeTearDown]
+        public void OneTimeTearDown()
+        {
+            m_context = null;
+            m_memoryStream.Dispose();
+            m_memoryStream = null;
+            m_memoryManager = null;
+        }
+        #endregion
+
+        #region Benchmark Setup
+        /// <summary>
+        /// Set up some variables for benchmarks.
+        /// </summary>
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            m_context = new ServiceMessageContext();
+            m_memoryManager = new Microsoft.IO.RecyclableMemoryStreamManager();
+            m_memoryStream = new MemoryStream();
+        }
+
+        /// <summary>
+        /// Tear down benchmark variables.
+        /// </summary>
+        [GlobalCleanup]
+        public void GlobalCleanup()
+        {
+            m_context = null;
+            m_memoryStream.Dispose();
+            m_memoryStream = null;
+            m_memoryManager = null;
+        }
+        #endregion
+
+        #region Private Fields
+        private static NodeId s_nodeId = new NodeId(1234);
+        private static IList<Int32> s_list = new List<Int32>() { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+        private IServiceMessageContext m_context;
+        private MemoryStream m_memoryStream;
+        private Microsoft.IO.RecyclableMemoryStreamManager m_memoryManager;
+        #endregion
+    }
+}


### PR DESCRIPTION
## Proposed changes

Do not dispose the stream if the BinaryEncoder leaveopen flag is set in the constructor.

## Related Issues

- see PR https://github.com/Azure/Industrial-IoT/pull/1928

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [x] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [x] I ran tests locally with my changes, all passed.
- [x] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
