### PR TITLE
CRL revocation dates > 2050 use generalizedtime

### DIFF
--- a/Libraries/Opc.Ua.Security.Certificates/X509Crl/CrlBuilder.cs
+++ b/Libraries/Opc.Ua.Security.Certificates/X509Crl/CrlBuilder.cs
@@ -345,7 +345,7 @@ namespace Opc.Ua.Security.Certificates
 
                     BigInteger srlNumberValue = new BigInteger(revokedCert.UserCertificate);
                     crlWriter.WriteInteger(srlNumberValue);
-                    crlWriter.WriteUtcTime(revokedCert.RevocationDate);
+                    WriteTime(crlWriter, revokedCert.RevocationDate);
 
                     if (revokedCert.CrlEntryExtensions.Count > 0)
                     {
@@ -392,13 +392,14 @@ namespace Opc.Ua.Security.Certificates
         /// <param name="dateTime">The date time to write.</param>
         private static void WriteTime(AsnWriter writer, DateTime dateTime)
         {
-            if (dateTime.Year < 2050)
+            DateTime utcTime = dateTime.ToUniversalTime();
+            if (utcTime.Year < 2050)
             {
-                writer.WriteUtcTime(dateTime);
+                writer.WriteUtcTime(utcTime);
             }
             else
             {
-                writer.WriteGeneralizedTime(dateTime);
+                writer.WriteGeneralizedTime(utcTime, true);
             }
         }
         #endregion

--- a/Libraries/Opc.Ua.Security.Certificates/X509Crl/X509Crl.cs
+++ b/Libraries/Opc.Ua.Security.Certificates/X509Crl/X509Crl.cs
@@ -267,7 +267,6 @@ namespace Opc.Ua.Security.Certificates
                     // nextUpdate is OPTIONAL
                     m_nextUpdate = ReadTime(seqReader, optional: true);
 
-
                     var seqTag = new Asn1Tag(UniversalTagNumber.Sequence, true);
                     peekTag = seqReader.PeekTag();
                     if (peekTag == seqTag)
@@ -280,7 +279,7 @@ namespace Opc.Ua.Security.Certificates
                             var crlEntry = revReader.ReadSequence();
                             var serial = crlEntry.ReadInteger();
                             var revokedCertificate = new RevokedCertificate(serial.ToByteArray());
-                            revokedCertificate.RevocationDate = crlEntry.ReadUtcTime().UtcDateTime;
+                            revokedCertificate.RevocationDate = ReadTime(crlEntry, optional: false);
                             if (version == 1 &&
                                 crlEntry.HasData)
                             {
@@ -343,7 +342,7 @@ namespace Opc.Ua.Security.Certificates
             }
             else if (timeTag.TagValue == Asn1Tag.GeneralizedTime.TagValue)
             {
-                return asnReader.ReadGeneralizedTime().LocalDateTime;
+                return asnReader.ReadGeneralizedTime().UtcDateTime;
             }
             else if (optional)
             {


### PR DESCRIPTION
## Proposed changes

Also the revocation date must be encoded/decoded as generalized time if the UtcTime.Year >= 2050.

## Related Issues

- see #1959 

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [x] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

