### PR TITLE
Fixes to support structures with allowsubtypes

### DIFF
--- a/Libraries/Opc.Ua.Client.ComplexTypes/TypeBuilder/ComplexTypeBuilder.cs
+++ b/Libraries/Opc.Ua.Client.ComplexTypes/TypeBuilder/ComplexTypeBuilder.cs
@@ -109,9 +109,11 @@ namespace Opc.Ua.Client.ComplexTypes
             switch (structureDefinition.StructureType)
             {
                 case StructureType.StructureWithOptionalFields: baseType = typeof(OptionalFieldsComplexType); break;
+                case StructureType.UnionWithSubtypedValues:
                 case StructureType.Union: baseType = typeof(UnionComplexType); break;
-                case StructureType.Structure:
-                default: baseType = typeof(BaseComplexType); break;
+                case StructureType.StructureWithSubtypedValues:
+                case StructureType.Structure: baseType = typeof(BaseComplexType); break;
+                default: throw new DataTypeNotSupportedException("Unsupported structure type");
             }
             var structureBuilder = m_moduleBuilder.DefineType(
                 GetFullQualifiedTypeName(name),

--- a/Libraries/Opc.Ua.Client.ComplexTypes/TypeBuilder/ComplexTypeFieldBuilder.cs
+++ b/Libraries/Opc.Ua.Client.ComplexTypes/TypeBuilder/ComplexTypeFieldBuilder.cs
@@ -87,7 +87,8 @@ namespace Opc.Ua.Client.ComplexTypes
             setIl.Emit(OpCodes.Ldarg_0);
             setIl.Emit(OpCodes.Ldarg_1);
             setIl.Emit(OpCodes.Stfld, fieldBuilder);
-            if (m_structureType == StructureType.Union)
+            if (m_structureType == StructureType.Union ||
+                m_structureType == StructureType.UnionWithSubtypedValues)
             {
                 // set the union selector to the new field index
                 FieldInfo unionField = typeof(UnionComplexType).GetField(

--- a/Libraries/Opc.Ua.Client.ComplexTypes/Types/StructureFieldAttribute.cs
+++ b/Libraries/Opc.Ua.Client.ComplexTypes/Types/StructureFieldAttribute.cs
@@ -34,7 +34,7 @@ namespace Opc.Ua.Client.ComplexTypes
     /// <summary>
     /// Attribute for a base complex type field definition.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct)]
+    [AttributeUsage(AttributeTargets.Property)]
     public class StructureFieldAttribute : Attribute
     {
         #region Constructors

--- a/Stack/Opc.Ua.Core/Types/Encoders/BinaryDecoder.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/BinaryDecoder.cs
@@ -2120,8 +2120,17 @@ namespace Opc.Ua
                 {
                     // decode body.
                     encodeable.Decode(this);
-
                     m_nestingLevel--;
+
+                    // verify the decoder did not exceeded the length of the encodeable object
+                    int used = Position - start;
+                    if (length < used)
+                    {
+                        throw ServiceResultException.Create(
+                            StatusCodes.BadEncodingLimitsExceeded,
+                            "The encodeable.Decoder operation exceeded the length of the extension object. {0} > {1}",
+                            used, length);
+                    }
                 }
                 catch (ServiceResultException sre) when (sre.StatusCode == StatusCodes.BadEncodingLimitsExceeded)
                 {

--- a/Tests/Opc.Ua.Client.ComplexTypes.Tests/Types/ComplexTypesTests.cs
+++ b/Tests/Opc.Ua.Client.ComplexTypes.Tests/Types/ComplexTypesTests.cs
@@ -115,7 +115,8 @@ namespace Opc.Ua.Client.ComplexTypes.Tests.Types
             for (int i = 0; i < baseType.GetPropertyCount(); i++)
             {
                 var obj = baseType[i];
-                if (structureType == StructureType.Union)
+                if (structureType == StructureType.Union ||
+                    structureType == StructureType.UnionWithSubtypedValues)
                 {
                     if (((UnionComplexType)baseType).SwitchField == i + 1)
                     {

--- a/Tests/Opc.Ua.Client.ComplexTypes.Tests/Types/MockResolverTests.cs
+++ b/Tests/Opc.Ua.Client.ComplexTypes.Tests/Types/MockResolverTests.cs
@@ -31,6 +31,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.Serialization;
 using System.Text;
 using System.Threading.Tasks;
 using NUnit.Framework;
@@ -614,6 +615,31 @@ namespace Opc.Ua.Client.ComplexTypes.Tests.Types
             Assert.AreEqual(1, definitions.Count);
             Assert.AreEqual(structure, definitions[dataTypeNode.NodeId]);
         }
+
+        [Test]
+        public void CreateBaseComplexTypeTest()
+        {
+            var testDataComplexType = new TestDataComplexType() {
+                PropertyInt8 = 1,
+                PropertyInt16 = 2,
+                PropertyInt32 = 3,
+                PropertyInt64 = 4,
+                PropertyInt32Array = new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 },
+                PropertyInt322DArray = new[,] { { 1, 2, 3, }, { 4, 5, 6 } },
+                PropertyInt325DArray = new[, , , ,] {
+                    {
+                        { { { 1, 2, 3, }, { 4, 5, 6 } }, { { 7, 8, 9 }, { 10, 11, 12 } } },
+                        { { { 111, 112, 113, }, { 114, 115, 116 } }, { { 117, 118, 119 }, { 1110, 1111, 1112 } } },
+                        { { { 311, 312, 313, }, { 314, 315, 316 } }, { { 317, 318, 319 }, { 3110, 3111, 3112 } } },
+                    },
+                    {
+                        { { { 71, 72, 73, }, { 74, 75, 76 } }, { { 77, 78, 79 }, { 710, 711, 712 } } },
+                        { { { 7111, 7112, 7113, }, { 7114, 7115, 7116 } }, { { 7117, 7118, 7119 }, { 71110, 71111, 71112 } } },
+                        { { { 7311, 7312, 7313, }, { 7314, 7315, 7316 } }, { { 7317, 7318, 7319 }, { 73110, 73111, 73112 } } },
+                    }
+                },
+            };
+        }
         #endregion
 
         #region Private Methods
@@ -675,4 +701,43 @@ namespace Opc.Ua.Client.ComplexTypes.Tests.Types
         }
         #endregion Private Methods
     }
+
+    #region TestDataComplexType
+    [StructureDefinition(BaseDataType = StructureBaseDataType.Structure)]
+    [StructureTypeId(ComplexTypeId = "i=10000", BinaryEncodingId = "i=10001", XmlEncodingId = "i=10002")]
+    public class TestDataComplexType : BaseComplexType
+    {
+        public TestDataComplexType()
+        {
+        }
+
+        [DataMember(Order =0)]
+        [StructureField(BuiltInType = (int)BuiltInType.SByte)]
+        public SByte PropertyInt8 { get; set; }
+
+        [DataMember(Order = 1)]
+        [StructureField(BuiltInType = (int)BuiltInType.Int16)]
+        public Int16 PropertyInt16 { get; set; }
+
+        [DataMember(Order = 2)]
+        [StructureField(BuiltInType = (int)BuiltInType.Int32)]
+        public Int32 PropertyInt32 { get; set; }
+
+        [DataMember(Order = 3)]
+        [StructureField(BuiltInType = (int)BuiltInType.Int64)]
+        public Int64 PropertyInt64 { get; set; }
+
+        [DataMember(Order = 4)]
+        [StructureField(BuiltInType = (int)BuiltInType.Int32, ValueRank = 1, IsOptional = false)]
+        public Int32[] PropertyInt32Array { get; set; }
+
+        [DataMember(Order = 5)]
+        [StructureField(BuiltInType = (int)BuiltInType.Int32, ValueRank = 2, IsOptional = false)]
+        public Int32[,] PropertyInt322DArray { get; set; }
+
+        [DataMember(Order = 6)]
+        [StructureField(BuiltInType = (int)BuiltInType.Int32, ValueRank = 5, IsOptional = false)]
+        public Int32[,,,,] PropertyInt325DArray { get; set; }
+    }
+    #endregion
 }


### PR DESCRIPTION
## Proposed changes

The latest errata supports complex types with allowsubtypes, e.g. `UnionWithSubtypedValues`/`StructureWithSubtypedValues`. 
If allowsubtypes is set for a structure type, a known complex type as member of the structure is encoded as ExtensionObject to allow fo a subtype to be used in the structure.

## Related Issues

- Fixes an issue found with a server with an address model that implements structures with abstract complex types and with structures which allow subtypes. The client could hang endless when building the complex type system in this case.
- The StructureFieldAttribute has the wrong AttributeTypeIds set. 

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [x] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

