### PR TITLE
Implement a worker thread for condition refresh

### DIFF
--- a/Libraries/Opc.Ua.Server/NodeManager/ResourceManager.cs
+++ b/Libraries/Opc.Ua.Server/NodeManager/ResourceManager.cs
@@ -444,11 +444,18 @@ namespace Opc.Ua.Server
         {
             culture = null;
             TranslationTable match = null;
+
+            if (preferredLocales == null || preferredLocales.Count == 0) { return null; }
             
             for (int jj = 0; jj < preferredLocales.Count; jj++)
             {
                 // parse the locale.
                 string language = preferredLocales[jj];
+
+                if (language == null)
+                {
+                    continue;
+                }
 
                 int index = language.IndexOf('-');
 


### PR DESCRIPTION
## Proposed changes

Currently ConditionRefresh requests are queued and executed on tasks. This change adds requests to a queue and refresh is executed by a worker, limiting the amount of threads that can execute concurrently.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [x] I ran tests locally with my changes, all passed.
- [x] I fixed all failing tests in the CI pipelines. 
- [x] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.


