### PR TITLE
Check DiscoveryOnly before the message is parsed.

### DIFF
--- a/Stack/Opc.Ua.Bindings.Https/Stack/Https/HttpsTransportListener.cs
+++ b/Stack/Opc.Ua.Bindings.Https/Stack/Https/HttpsTransportListener.cs
@@ -365,9 +365,9 @@ namespace Opc.Ua.Bindings
                     input.TypeId != DataTypeIds.GetEndpointsRequest &&
                     input.TypeId != DataTypeIds.FindServersRequest)
                 {
-                    message = "Connection refused, invalid security policy.";
-                    Utils.LogError(message);
-                    await WriteResponseAsync(context.Response, message, HttpStatusCode.Unauthorized).ConfigureAwait(false);
+                    var serviceResultException = new ServiceResultException(StatusCodes.BadSecurityPolicyRejected, "Channel can only be used for discovery.");
+                    IServiceResponse serviceResponse = EndpointBase.CreateFault(null, serviceResultException);
+                    await WriteServiceResponseAsync(context, serviceResponse, ct).ConfigureAwait(false);
                     return;
                 }
 
@@ -381,15 +381,8 @@ namespace Opc.Ua.Bindings
 
                 IServiceResponse output = m_callback.EndProcessRequest(result);
 
-                byte[] response = BinaryEncoder.EncodeMessage(output, m_quotas.MessageContext);
-                context.Response.ContentLength = response.Length;
-                context.Response.ContentType = context.Request.ContentType;
-                context.Response.StatusCode = (int)HttpStatusCode.OK;
-#if NETSTANDARD2_1 || NET5_0_OR_GREATER || NETCOREAPP3_1_OR_GREATER
-                await context.Response.Body.WriteAsync(response.AsMemory(0, response.Length), ct).ConfigureAwait(false);
-#else
-                await context.Response.Body.WriteAsync(response, 0, response.Length, ct).ConfigureAwait(false);
-#endif
+                await WriteServiceResponseAsync(context, output, ct).ConfigureAwait(false);
+
                 return;
             }
             catch (Exception e)
@@ -438,6 +431,22 @@ namespace Opc.Ua.Bindings
             Start();
         }
 
+        /// <summary>
+        /// Encodes a service response and writes it back.
+        /// </summary>
+        private async Task WriteServiceResponseAsync(HttpContext context, IServiceResponse response, CancellationToken ct)
+        {
+            byte[] encodedResponse = BinaryEncoder.EncodeMessage(response, m_quotas.MessageContext);
+            context.Response.ContentLength = encodedResponse.Length;
+            context.Response.ContentType = context.Request.ContentType;
+            context.Response.StatusCode = (int)HttpStatusCode.OK;
+#if NETSTANDARD2_1 || NET5_0_OR_GREATER || NETCOREAPP3_1_OR_GREATER
+            await context.Response.Body.WriteAsync(encodedResponse.AsMemory(0, encodedResponse.Length), ct).ConfigureAwait(false);
+#else
+            await context.Response.Body.WriteAsync(encodedResponse, 0, encodedResponse.Length, ct).ConfigureAwait(false);
+#endif
+        }
+
         private static Task WriteResponseAsync(HttpResponse response, string message, HttpStatusCode status)
         {
             response.ContentLength = message.Length;
@@ -455,7 +464,7 @@ namespace Opc.Ua.Bindings
                 return memory.ToArray();
             }
         }
-        #endregion
+#endregion
 
         #region Private Fields
         private string m_listenerId;

--- a/Stack/Opc.Ua.Core/Stack/Server/EndpointBase.cs
+++ b/Stack/Opc.Ua.Core/Stack/Server/EndpointBase.cs
@@ -395,7 +395,7 @@ namespace Opc.Ua
         /// <param name="request">The request.</param>
         /// <param name="exception">The exception.</param>
         /// <returns>A fault message.</returns>
-        protected static ServiceFault CreateFault(IServiceRequest request, Exception exception)
+        public static ServiceFault CreateFault(IServiceRequest request, Exception exception)
         {
             DiagnosticsMasks diagnosticsMask = DiagnosticsMasks.ServiceNoInnerStatus;
 
@@ -452,7 +452,7 @@ namespace Opc.Ua
         /// <param name="request">The request.</param>
         /// <param name="exception">The exception.</param>
         /// <returns>A fault message.</returns>
-        protected static Exception CreateSoapFault(IServiceRequest request, Exception exception)
+        public static Exception CreateSoapFault(IServiceRequest request, Exception exception)
         {
             ServiceFault fault = CreateFault(request, exception);
 

--- a/Stack/Opc.Ua.Core/Stack/Tcp/TcpMessageType.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/TcpMessageType.cs
@@ -249,6 +249,11 @@ namespace Opc.Ua.Bindings
         public const int DefaultMaxMessageSize = DefaultMaxChunkCount * DefaultMaxBufferSize;
 
         /// <summary>
+        /// The default maximum message size for the discovery channel.
+        /// </summary>
+        public const int DefaultDiscoveryMaxMessageSize = DefaultMaxBufferSize;
+
+        /// <summary>
         /// How long a connection will remain in the server after it goes into a faulted state.
         /// </summary>
         public const int DefaultChannelLifetime = 60000;

--- a/Stack/Opc.Ua.Core/Types/Encoders/BinaryEncoder.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/BinaryEncoder.cs
@@ -179,13 +179,14 @@ namespace Opc.Ua
             if (context == null) throw new ArgumentNullException(nameof(context));
 
             // create encoder.
-            BinaryEncoder encoder = new BinaryEncoder(context);
+            using (BinaryEncoder encoder = new BinaryEncoder(context))
+            {
+                // encode message
+                encoder.EncodeMessage(message);
 
-            // encode message
-            encoder.EncodeMessage(message);
-
-            // close encoder.
-            return encoder.CloseAndReturnBuffer();
+                // close encoder.
+                return encoder.CloseAndReturnBuffer();
+            }
         }
 
         /// <summary>

--- a/Tests/Opc.Ua.Client.ComplexTypes.Tests/TypeSystemClientTest.cs
+++ b/Tests/Opc.Ua.Client.ComplexTypes.Tests/TypeSystemClientTest.cs
@@ -105,8 +105,7 @@ namespace Opc.Ua.Client.ComplexTypes.Tests
 
             m_clientFixture = new ClientFixture();
             await m_clientFixture.LoadClientConfiguration(m_pkiRoot).ConfigureAwait(false);
-            m_clientFixture.Config.TransportQuotas.MaxMessageSize =
-            m_clientFixture.Config.TransportQuotas.MaxBufferSize = 4 * 1024 * 1024;
+            m_clientFixture.Config.TransportQuotas.MaxMessageSize = 4 * 1024 * 1024;
             m_url = new Uri(m_uriScheme + "://localhost:" + m_serverFixture.Port.ToString());
             try
             {

--- a/Tests/Opc.Ua.Client.Tests/ClientTestFramework.cs
+++ b/Tests/Opc.Ua.Client.Tests/ClientTestFramework.cs
@@ -127,7 +127,7 @@ namespace Opc.Ua.Client.Tests
                 // start Ref server
                 ServerFixture = new ServerFixture<ReferenceServer> {
                     UriScheme = UriScheme,
-                    SecurityNone = true,
+                    SecurityNone = false,
                     AutoAccept = true,
                     AllNodeManagers = true,
                     OperationLimits = true
@@ -139,8 +139,7 @@ namespace Opc.Ua.Client.Tests
                 }
 
                 await ServerFixture.LoadConfiguration(PkiRoot).ConfigureAwait(false);
-                ServerFixture.Config.TransportQuotas.MaxMessageSize =
-                ServerFixture.Config.TransportQuotas.MaxBufferSize = TransportQuotaMaxMessageSize;
+                ServerFixture.Config.TransportQuotas.MaxMessageSize = TransportQuotaMaxMessageSize;
                 ServerFixture.Config.TransportQuotas.MaxByteStringLength =
                 ServerFixture.Config.TransportQuotas.MaxStringLength = TransportQuotaMaxStringLength;
                 ServerFixture.Config.ServerConfiguration.UserTokenPolicies.Add(
@@ -152,8 +151,7 @@ namespace Opc.Ua.Client.Tests
 
             ClientFixture = new ClientFixture();
             await ClientFixture.LoadClientConfiguration(PkiRoot).ConfigureAwait(false);
-            ClientFixture.Config.TransportQuotas.MaxMessageSize =
-            ClientFixture.Config.TransportQuotas.MaxBufferSize = TransportQuotaMaxMessageSize;
+            ClientFixture.Config.TransportQuotas.MaxMessageSize = TransportQuotaMaxMessageSize;
             ClientFixture.Config.TransportQuotas.MaxByteStringLength =
             ClientFixture.Config.TransportQuotas.MaxStringLength = TransportQuotaMaxStringLength;
 
@@ -171,6 +169,7 @@ namespace Opc.Ua.Client.Tests
                 try
                 {
                     Session = await ClientFixture.ConnectAsync(ServerUrl, SecurityPolicies.Basic256Sha256).ConfigureAwait(false);
+                    Session.ReturnDiagnostics = DiagnosticsMasks.All;
                 }
                 catch (Exception e)
                 {


### PR DESCRIPTION
## Proposed changes

A discovery only channel only accepts discovery service calls. The type of service call should be checked before the message is parsed. 
- Add a check for discovery message before the chunks are decoded.
- Add a check that discovery service call are below a restricted message size (e.g. 64k).
- Add a test case.

## Related Issues

- Fixes #2047

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.


