### PR TITLE
Session.Load doesn't create the monitored items

### DIFF
--- a/Libraries/Opc.Ua.Client/ISession.cs
+++ b/Libraries/Opc.Ua.Client/ISession.cs
@@ -296,15 +296,17 @@ namespace Opc.Ua.Client
         /// Load the list of subscriptions saved in a file.
         /// </summary>
         /// <param name="stream">The stream.</param>
+        /// <param name="transferSubscriptions">Load the subscriptions for transfer after load.</param>
         /// <returns>The list of loaded subscriptions</returns>
-        IEnumerable<Subscription> Load(Stream stream);
+        IEnumerable<Subscription> Load(Stream stream, bool transferSubscriptions = false);
 
         /// <summary>
         /// Load the list of subscriptions saved in a file.
         /// </summary>
         /// <param name="filePath">The file path.</param>
+        /// <param name="transferSubscriptions">Load the subscriptions for transfer after load.</param>
         /// <returns>The list of loaded subscriptions</returns>
-        IEnumerable<Subscription> Load(string filePath);
+        IEnumerable<Subscription> Load(string filePath, bool transferSubscriptions = false);
 
         /// <summary>
         /// Updates the local copy of the server's namespace uri and server uri tables.

--- a/Libraries/Opc.Ua.Client/Session.cs
+++ b/Libraries/Opc.Ua.Client/Session.cs
@@ -1412,8 +1412,9 @@ namespace Opc.Ua.Client
         /// Load the list of subscriptions saved in a stream.
         /// </summary>
         /// <param name="stream">The stream.</param>
+        /// <param name="transferSubscriptions">Load the subscriptions for transfer after load.</param>
         /// <returns>The list of loaded subscriptions</returns>
-        public IEnumerable<Subscription> Load(Stream stream)
+        public IEnumerable<Subscription> Load(Stream stream, bool transferSubscriptions = false)
         {
             // secure settings
             XmlReaderSettings settings = Utils.DefaultXmlReaderSettings();
@@ -1425,6 +1426,15 @@ namespace Opc.Ua.Client
                 SubscriptionCollection subscriptions = (SubscriptionCollection)serializer.ReadObject(reader);
                 foreach (Subscription subscription in subscriptions)
                 {
+                    if (!transferSubscriptions)
+                    {
+                        // ServerId must be reset if the saved list of subscriptions
+                        // is not used to transfer a subscription
+                        foreach (var monitoredItem in subscription.MonitoredItems)
+                        {
+                            monitoredItem.ServerId = 0;
+                        }
+                    }
                     AddSubscription(subscription);
                 }
                 return subscriptions;
@@ -1435,12 +1445,13 @@ namespace Opc.Ua.Client
         /// Load the list of subscriptions saved in a file.
         /// </summary>
         /// <param name="filePath">The file path.</param>
+        /// <param name="transferSubscriptions">Load the subscriptions for transfer after load.</param>
         /// <returns>The list of loaded subscriptions</returns>
-        public IEnumerable<Subscription> Load(string filePath)
+        public IEnumerable<Subscription> Load(string filePath, bool transferSubscriptions = false)
         {
             using (FileStream stream = File.OpenRead(filePath))
             {
-                return Load(stream);
+                return Load(stream, transferSubscriptions);
             }
         }
 

--- a/Tests/Opc.Ua.Client.Tests/SubscriptionTest.cs
+++ b/Tests/Opc.Ua.Client.Tests/SubscriptionTest.cs
@@ -35,7 +35,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using NUnit.Framework;
-using Opc.Ua.Server.Tests;
 
 namespace Opc.Ua.Client.Tests
 {
@@ -46,7 +45,7 @@ namespace Opc.Ua.Client.Tests
     [SetCulture("en-us"), SetUICulture("en-us")]
     public class SubscriptionTest : ClientTestFramework
     {
-        private readonly string m_subscriptionTestXml = Path.Combine("D:\\", "SubscriptionTest.xml");
+        private readonly string m_subscriptionTestXml = Path.Combine(Path.GetTempPath(), "SubscriptionTest.xml");
 
         #region Test Setup
         /// <summary>


### PR DESCRIPTION
## Proposed changes

- Issue: The monitored items are not created on the server because the serverId is now saved with the monitored items to allow to transfer a subscription after a session reconnect. However, by loading the serverId from file there is a regression that the monitored items are not recreated on a server in the normal use case, when somebody is not trying to transfer a subscription.

- Fix: to support both use cases added a flag to the Load function to indicate that a session transfer should be supported. Otherwise the serverId is reset after load. A user has to opt-in to get the transfer session support.

## Related Issues

- Fixes #2073 

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- [x] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [x] I ran tests locally with my changes, all passed.
- [x] I fixed all failing tests in the CI pipelines. 
- [x] I fixed all introduced issues with CodeQL and LGTM.
- [x] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

