### PR TITLE
JsonDecoder: ReadExtensionObject returns partial JSON for some types

### DIFF
--- a/Stack/Opc.Ua.Core/Types/Encoders/JsonDecoder.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/JsonDecoder.cs
@@ -1450,8 +1450,9 @@ namespace Opc.Ua
                 using (JsonTextWriter writer = new JsonTextWriter(stream))
                 {
                     EncodeAsJson(writer, token);
-                    return new ExtensionObject(typeId, ostrm.ToArray());
                 }
+                // Close the writer before retrieving the data
+                return new ExtensionObject(typeId, ostrm.ToArray());
             }
             finally
             {
@@ -1463,7 +1464,7 @@ namespace Opc.Ua
         /// Reads an encodeable object from the stream.
         /// </summary>
         /// <param name="fieldName">The encodeable object field name</param>
-        /// <param name="systemType">The system type of the encopdeable object to be read</param>
+        /// <param name="systemType">The system type of the encodeable object to be read</param>
         /// <param name="encodeableTypeId">The TypeId for the <see cref="IEncodeable"/> instance that will be read.</param>
         /// <returns>An <see cref="IEncodeable"/> object that was read from the stream.</returns>
         public IEncodeable ReadEncodeable(string fieldName, System.Type systemType, ExpandedNodeId encodeableTypeId = null)

--- a/Stack/Opc.Ua.Core/Types/Encoders/JsonDecoder.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/JsonDecoder.cs
@@ -1445,14 +1445,16 @@ namespace Opc.Ua
                     return new ExtensionObject(typeId, encodeable);
                 }
 
-                var ostrm = new MemoryStream();
-                using (var stream = new StreamWriter(ostrm))
-                using (JsonTextWriter writer = new JsonTextWriter(stream))
+                using (var ostrm = new MemoryStream())
                 {
-                    EncodeAsJson(writer, token);
+                    using (var stream = new StreamWriter(ostrm))
+                    using (JsonTextWriter writer = new JsonTextWriter(stream))
+                    {
+                        EncodeAsJson(writer, token);
+                    }
+                    // Close the writer before retrieving the data
+                    return new ExtensionObject(typeId, ostrm.ToArray());
                 }
-                // Close the writer before retrieving the data
-                return new ExtensionObject(typeId, ostrm.ToArray());
             }
             finally
             {


### PR DESCRIPTION
## Proposed changes

Cherry pick bugfix from #2146:
ReadExtensionObject returns partial JSON for some types.
It appears that this is due to the JSON being read before the JsonTextWriter is closed.

see also: https://github.com/OPCFoundation/UA-.NETStandard/pull/2146/commits/2a4ba56e079b317aae6fd10de158daada1453191

Co-authored-by: @MarkusHorstmann 

## Related Issues

- Fixes #2145 

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

