### PR TITLE
Fix possible memory leak of CancellationTokenSource

### DIFF
--- a/Libraries/Opc.Ua.Client/ReverseConnectManager.cs
+++ b/Libraries/Opc.Ua.Client/ReverseConnectManager.cs
@@ -216,6 +216,11 @@ namespace Opc.Ua.Client
                 Utils.SilentDispose(m_configurationWatcher);
                 m_configurationWatcher = null;
             }
+            if (m_configurationWatcher != null)
+            {
+                Utils.SilentDispose(m_cts);
+                m_cts = null;
+            }
             DisposeHosts();
         }
         #endregion
@@ -725,6 +730,7 @@ namespace Opc.Ua.Client
             CancellationTokenSource cts = m_cts;
             m_cts = new CancellationTokenSource();
             cts.Cancel();
+            cts.Dispose();
         }
         #endregion
 

--- a/Libraries/Opc.Ua.Client/ReverseConnectManager.cs
+++ b/Libraries/Opc.Ua.Client/ReverseConnectManager.cs
@@ -216,7 +216,7 @@ namespace Opc.Ua.Client
                 Utils.SilentDispose(m_configurationWatcher);
                 m_configurationWatcher = null;
             }
-            if (m_configurationWatcher != null)
+            if (m_cts != null)
             {
                 Utils.SilentDispose(m_cts);
                 m_cts = null;

--- a/Stack/Opc.Ua.Core/Stack/Tcp/UaSCBinaryClientChannel.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/UaSCBinaryClientChannel.cs
@@ -155,13 +155,15 @@ namespace Opc.Ua.Bindings
                 else
                 {
                     Socket = m_socketFactory.Create(this, BufferManager, Quotas.MaxBufferSize);
-                    task = Task.Run(async () =>
-                        await (Socket?.BeginConnect(
-                            m_via, m_ConnectCallback, operation,
-                            new CancellationTokenSource(timeout).Token) ?? Task.FromResult(false)).ConfigureAwait(false));
+                    task = Task.Run(async () => {
+                        using (var cts = new CancellationTokenSource(timeout))
+                        {
+                            await (Socket?.BeginConnect(m_via, m_ConnectCallback, operation, cts.Token) ?? Task.FromResult(false)).ConfigureAwait(false);
+
+                        }
+                    });
                 }
             }
-
             return m_handshakeOperation;
         }
 
@@ -1272,7 +1274,7 @@ namespace Opc.Ua.Bindings
                 m_queuedOperations = null;
             }
         }
-        #endregion 
+        #endregion
 
         #region Message Processing
         /// <summary>

--- a/Stack/Opc.Ua.Core/Stack/Transport/AsyncResultBase.cs
+++ b/Stack/Opc.Ua.Core/Stack/Transport/AsyncResultBase.cs
@@ -76,6 +76,13 @@ namespace Opc.Ua
 
                 // signal any waiting threads.
                 DisposeWaitHandle(true);
+
+                // dispose the cancellation token.
+                if (m_cts != null)
+                {
+                    Utils.SilentDispose(m_cts);
+                    m_cts = null;
+                }
             }
         }
         #endregion


### PR DESCRIPTION
## Proposed changes

Fix a few cases (not all) where TCS are not properly disposed. Specifically BeginConnect, which may cause resource leaks.

## Related Issues

- Fixes #2138

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
