### PR TITLE
Fix for sending PublishRequest after reconnect and explain session dispose in sample

### DIFF
--- a/Applications/ConsoleReferenceClient/Program.cs
+++ b/Applications/ConsoleReferenceClient/Program.cs
@@ -130,7 +130,7 @@ namespace Quickstarts.ConsoleReferenceClient
                 };
 
                 // load the application configuration.
-                var config = await application.LoadApplicationConfiguration(silent: false);
+                var config = await application.LoadApplicationConfiguration(silent: false).ConfigureAwait(false);
 
                 // override logfile
                 if (logFile != null)
@@ -189,7 +189,7 @@ namespace Quickstarts.ConsoleReferenceClient
                             uaClient.UserIdentity = new UserIdentity(username, userpassword ?? string.Empty);
                         }
 
-                        bool connected = await uaClient.ConnectAsync(serverUrl.ToString(), false);
+                        bool connected = await uaClient.ConnectAsync(serverUrl.ToString(), false).ConfigureAwait(false);
                         if (connected)
                         {
                             output.WriteLine("Connected! Ctrl-C to quit.");
@@ -229,7 +229,7 @@ namespace Quickstarts.ConsoleReferenceClient
 
                                 if (jsonvalues && variableIds != null)
                                 {
-                                    await samples.ReadAllValuesAsync(uaClient, variableIds);
+                                    await samples.ReadAllValuesAsync(uaClient, variableIds).ConfigureAwait(false);
                                 }
 
                                 if (subscribe)
@@ -262,7 +262,7 @@ namespace Quickstarts.ConsoleReferenceClient
                                         publishingInterval: 5000,
                                         queueSize: 10,
                                         lifetimeCount: 12,
-                                        keepAliveCount: 2);
+                                        keepAliveCount: 2).ConfigureAwait(false);
 
                                     // Wait for DataChange notifications from MonitoredItems
                                     quit = quitEvent.WaitOne(timeout > 0 ? waitTime : Timeout.Infinite);

--- a/Applications/ConsoleReferenceClient/UAClient.cs
+++ b/Applications/ConsoleReferenceClient/UAClient.cs
@@ -270,11 +270,27 @@ namespace Quickstarts
                 // if session recovered, Session property is null
                 if (m_reconnectHandler.Session != null)
                 {
-                    m_session = m_reconnectHandler.Session as Session;
+                    // ensure only a new instance is disposed
+                    // after reactivate, the same session instance may be returned
+                    if (!Object.ReferenceEquals(m_session, m_reconnectHandler.Session))
+                    {
+                        m_output.WriteLine("--- RECONNECTED TO NEW SESSION --- {0}", m_reconnectHandler.Session.SessionId);
+                        var session = m_session;
+                        session.KeepAlive -= Session_KeepAlive;
+                        m_session = m_reconnectHandler.Session as Session;
+                        m_session.KeepAlive += Session_KeepAlive;
+                        Utils.SilentDispose(session);
+                    }
+                    else
+                    {
+                        m_output.WriteLine("--- REACTIVATED SESSION --- {0}", m_reconnectHandler.Session.SessionId);
+                    }
+                }
+                else
+                {
+                    m_output.WriteLine("--- RECONNECT KeepAlive recovered ---");
                 }
             }
-
-            m_output.WriteLine("--- RECONNECTED ---");
         }
         #endregion
 

--- a/Libraries/Opc.Ua.Client/Session.cs
+++ b/Libraries/Opc.Ua.Client/Session.cs
@@ -5766,10 +5766,17 @@ namespace Opc.Ua.Client
         /// <summary>
         /// Returns the minimum number of active publish request that should be used.
         /// </summary>
+        /// <remarks>
+        /// Returns 0 if there are no subscriptions.
+        /// </remarks>
         private int GetMinPublishRequestCount()
         {
             lock (SyncRoot)
             {
+                if (m_subscriptions.Count == 0)
+                {
+                    return 0;
+                }
                 return Math.Max(m_subscriptions.Count, m_minPublishRequestCount);
             }
         }


### PR DESCRIPTION
## Proposed changes

- due to the new `MinPublishRequestCount` property publish requests are being sent after reconnect even if no subscription is active
- Improve sample code to show how to dispose the old session after reconnect

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
