### PR TITLE
Fixes an issue in Session.LoadDataTypeSystem.

### DIFF
--- a/Libraries/Opc.Ua.Client/Session.cs
+++ b/Libraries/Opc.Ua.Client/Session.cs
@@ -1860,6 +1860,10 @@ namespace Opc.Ua.Client
                 {
                     namespaces[((NodeId)referenceNodeIds[ii])] = (string)nameSpaceValues[ii];
                 }
+                else
+                {
+                    Utils.LogWarning("Failed to load namespace {0}: {1}", namespaceNodeIds[ii], errors[ii]);
+                }
             }
 
             // build the namespace/schema import dictionary
@@ -1867,9 +1871,9 @@ namespace Opc.Ua.Client
             foreach (var r in references)
             {
                 NodeId nodeId = ExpandedNodeId.ToNodeId(r.NodeId, NamespaceUris);
-                if (schemas.TryGetValue(nodeId, out var schema))
+                if (schemas.TryGetValue(nodeId, out var schema) && namespaces.TryGetValue(nodeId, out var ns))
                 {
-                    imports[namespaces[nodeId]] = schema;
+                    imports[ns] = schema;
                 }
             }
 


### PR DESCRIPTION
## Proposed changes

Starting with line 1857 a dictionary of namespaces is populated in an defensive manner. If a namespace value can't be read, it is silently ignored. If this happens, it will result in a KeyNotFoundException when populating the imports dictionary. This fix adds a warning if a namespace value can't be read and populates the imports dictionary also defensivly.

## Related Issues

- Fixes #

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [x] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

We noticed the problem when communicating with a server that hat a namespace value wich was not of type string.