### PR TITLE
Fix session reconnect exponential backoff

### DIFF
--- a/Applications/ConsoleReferenceClient/Program.cs
+++ b/Applications/ConsoleReferenceClient/Program.cs
@@ -104,6 +104,8 @@ namespace Quickstarts.ConsoleReferenceClient
                 { "rc|reverseconnect=", "Connect using the reverse connect endpoint. (e.g. opc.tcp://localhost:65300)", (string url) => reverseConnectUrlString = url},
             };
 
+            ReverseConnectManager reverseConnectManager = null;
+
             try
             {
                 // parse command line and set options
@@ -161,7 +163,6 @@ namespace Quickstarts.ConsoleReferenceClient
                     throw new ErrorExitException("Application instance certificate invalid!", ExitCode.ErrorCertificate);
                 }
 
-                ReverseConnectManager reverseConnectManager = null;
                 if (reverseConnectUrlString != null)
                 {
                     // start the reverse connection manager
@@ -318,6 +319,11 @@ namespace Quickstarts.ConsoleReferenceClient
             catch (Exception ex)
             {
                 output.WriteLine(ex.Message);
+            }
+            finally
+            {
+                Utils.SilentDispose(reverseConnectManager);
+                output.Close();
             }
         }
     }

--- a/Applications/ConsoleReferenceClient/Program.cs
+++ b/Applications/ConsoleReferenceClient/Program.cs
@@ -78,7 +78,7 @@ namespace Quickstarts.ConsoleReferenceClient
             bool jsonvalues = false;
             bool verbose = false;
             bool subscribe = false;
-            bool useSecurity = true;
+            bool noSecurity = false;
             string password = null;
             int timeout = Timeout.Infinite;
             string logFile = null;
@@ -88,7 +88,7 @@ namespace Quickstarts.ConsoleReferenceClient
                 usage,
                 { "h|help", "show this message and exit", h => showHelp = h != null },
                 { "a|autoaccept", "auto accept certificates (for testing only)", a => autoAccept = a != null },
-                { "nsec|nosecurity", "select endpoint with security NONE, if available", s => useSecurity = !(s != null) },
+                { "nsec|nosecurity", "select endpoint with security NONE, least secure if unavailable", s => noSecurity = s != null },
                 { "un|username=", "the name of the user identity for the connection", (string u) => username = u },
                 { "up|userpassword=", "the password of the user identity for the connection", (string u) => userpassword = u },
                 { "c|console", "log to console", c => logConsole = c != null },
@@ -175,7 +175,8 @@ namespace Quickstarts.ConsoleReferenceClient
                 }
 
                 // wait for timeout or Ctrl-C
-                var quitEvent = ConsoleUtils.CtrlCHandler();
+                var quitCTS = new CancellationTokenSource();
+                var quitEvent = ConsoleUtils.CtrlCHandler(quitCTS);
 
                 // connect to a server until application stops
                 bool quit = false;
@@ -204,7 +205,7 @@ namespace Quickstarts.ConsoleReferenceClient
                             uaClient.UserIdentity = new UserIdentity(username, userpassword ?? string.Empty);
                         }
 
-                        bool connected = await uaClient.ConnectAsync(serverUrl.ToString(), useSecurity).ConfigureAwait(false);
+                        bool connected = await uaClient.ConnectAsync(serverUrl.ToString(), !noSecurity, quitCTS.Token).ConfigureAwait(false);
                         if (connected)
                         {
                             output.WriteLine("Connected! Ctrl-C to quit.");

--- a/Applications/ConsoleReferenceClient/UAClient.cs
+++ b/Applications/ConsoleReferenceClient/UAClient.cs
@@ -126,7 +126,7 @@ namespace Quickstarts
         /// <summary>
         /// Creates a session with the UA server
         /// </summary>
-        public async Task<bool> ConnectAsync(string serverUrl, bool useSecurity = true)
+        public async Task<bool> ConnectAsync(string serverUrl, bool useSecurity = true, CancellationToken ct = default)
         {
             if (serverUrl == null) throw new ArgumentNullException(nameof(serverUrl));
 
@@ -146,8 +146,9 @@ namespace Quickstarts
                         do
                         {
                             using (var cts = new CancellationTokenSource(30_000))
+                            using (var linkedCTS = CancellationTokenSource.CreateLinkedTokenSource(ct, cts.Token))
                             {
-                                connection = await m_reverseConnectManager.WaitForConnection(new Uri(serverUrl), null, cts.Token);
+                                connection = await m_reverseConnectManager.WaitForConnection(new Uri(serverUrl), null, linkedCTS.Token);
                                 if (connection == null)
                                 {
                                     throw new ServiceResultException(StatusCodes.BadTimeout, "Waiting for a reverse connection timed out.");

--- a/Applications/ConsoleReferenceClient/UAClient.cs
+++ b/Applications/ConsoleReferenceClient/UAClient.cs
@@ -276,7 +276,7 @@ namespace Quickstarts
                         return;
                     }
 
-                    var state = m_reconnectHandler.BeginReconnect(m_session, ReconnectPeriod, Client_ReconnectComplete);
+                    var state = m_reconnectHandler.BeginReconnect(m_session, m_reverseConnectManager, ReconnectPeriod, Client_ReconnectComplete);
                     if (state == SessionReconnectHandler.ReconnectState.Triggered)
                     {
                         Utils.LogInfo("KeepAlive status {0}, reconnect status {1}, reconnect period {2}ms.", e.Status, state, ReconnectPeriod);

--- a/Applications/ConsoleReferenceClient/UAClient.cs
+++ b/Applications/ConsoleReferenceClient/UAClient.cs
@@ -276,9 +276,7 @@ namespace Quickstarts
                     {
                         m_output.WriteLine("--- RECONNECTED TO NEW SESSION --- {0}", m_reconnectHandler.Session.SessionId);
                         var session = m_session;
-                        session.KeepAlive -= Session_KeepAlive;
-                        m_session = m_reconnectHandler.Session as Session;
-                        m_session.KeepAlive += Session_KeepAlive;
+                        m_session = m_reconnectHandler.Session;
                         Utils.SilentDispose(session);
                     }
                     else
@@ -332,7 +330,7 @@ namespace Quickstarts
         private object m_lock = new object();
         private ApplicationConfiguration m_configuration;
         private SessionReconnectHandler m_reconnectHandler;
-        private Session m_session;
+        private ISession m_session;
         private readonly TextWriter m_output;
         private readonly Action<IList, IList> m_validateResponse;
         #endregion

--- a/Applications/ConsoleReferenceServer/ConsoleUtils.cs
+++ b/Applications/ConsoleReferenceServer/ConsoleUtils.cs
@@ -395,12 +395,13 @@ namespace Quickstarts
         /// Create an event which is set if a user
         /// enters the Ctrl-C key combination.
         /// </summary>
-        public static ManualResetEvent CtrlCHandler()
+        public static ManualResetEvent CtrlCHandler(CancellationTokenSource cts = default)
         {
             var quitEvent = new ManualResetEvent(false);
             try
             {
                 Console.CancelKeyPress += (_, eArgs) => {
+                    cts.Cancel();
                     quitEvent.Set();
                     eArgs.Cancel = true;
                 };

--- a/Docs/ReverseConnect.md
+++ b/Docs/ReverseConnect.md
@@ -11,8 +11,8 @@ The Reverse Connect option consists of the following elements:
 * Updated client library which support to 
   - Configure a client endpoint to accept *ReverseHello* messages using a *ReverseConnectManager*.
   - A client API extension to allow applications to register for reverse connections either by callback or by waiting for the *ReverseHello* message for a specific server endpoint and application Uri combination. An optional filter for server Uris or endpoint Urls can be applied to allow multiple clients to use the same endpoint.
-* The updated C# [Reference Server](../Applications/ConsoleReferenceServer) with reverse connect support.
-* The C# Core [Client](https://github.com/OPCFoundation/UA-.NETStandard-Samples/tree/master/Samples/NetCoreComplexClient) and [Server](https://github.com/OPCFoundation/UA-.NETStandard-Samples/tree/master/Samples/NetCoreConsoleServer) samples that can initiate a Reverse connection with command line options.
+* The C# [Console Reference Server](../Applications/ConsoleReferenceServer) with reverse connect support in the configuration xml.
+* The C# Core [Console Reference Client](../Applications/ConsoleReferenceClient) that can initiate a Reverse connection with command line options.
 * A modified C# [Aggregation Server](https://github.com/OPCFoundation/UA-.NETStandard-Samples/tree/master/Workshop/Aggregation) that supports incoming and outgoing reverse connections.
 
 ## Reverse Connect Handshake ##

--- a/Libraries/Opc.Ua.Client/ReverseConnectManager.cs
+++ b/Libraries/Opc.Ua.Client/ReverseConnectManager.cs
@@ -340,24 +340,21 @@ namespace Opc.Ua.Client
         {
             lock (m_lock)
             {
-                if (m_endpointUrls != null)
+                foreach (var host in m_endpointUrls)
                 {
-                    foreach (var host in m_endpointUrls)
+                    var value = host.Value;
+                    try
                     {
-                        var value = host.Value;
-                        try
+                        if (value.State == ReverseConnectHostState.Open)
                         {
-                            if (value.State == ReverseConnectHostState.Open)
-                            {
-                                value.ReverseConnectHost.Close();
-                                value.State = ReverseConnectHostState.Closed;
-                            }
+                            value.ReverseConnectHost.Close();
+                            value.State = ReverseConnectHostState.Closed;
                         }
-                        catch (Exception e)
-                        {
-                            Utils.LogError(e, "Failed to Close {0}.", host.Key);
-                            value.State = ReverseConnectHostState.Errored;
-                        }
+                    }
+                    catch (Exception e)
+                    {
+                        Utils.LogError(e, "Failed to Close {0}.", host.Key);
+                        value.State = ReverseConnectHostState.Errored;
                     }
                 }
             }

--- a/Libraries/Opc.Ua.Client/ReverseConnectManager.cs
+++ b/Libraries/Opc.Ua.Client/ReverseConnectManager.cs
@@ -340,21 +340,24 @@ namespace Opc.Ua.Client
         {
             lock (m_lock)
             {
-                foreach (var host in m_endpointUrls)
+                if (m_endpointUrls != null)
                 {
-                    var value = host.Value;
-                    try
+                    foreach (var host in m_endpointUrls)
                     {
-                        if (value.State == ReverseConnectHostState.Open)
+                        var value = host.Value;
+                        try
                         {
-                            value.ReverseConnectHost.Close();
-                            value.State = ReverseConnectHostState.Closed;
+                            if (value.State == ReverseConnectHostState.Open)
+                            {
+                                value.ReverseConnectHost.Close();
+                                value.State = ReverseConnectHostState.Closed;
+                            }
                         }
-                    }
-                    catch (Exception e)
-                    {
-                        Utils.LogError(e, "Failed to Close {0}.", host.Key);
-                        value.State = ReverseConnectHostState.Errored;
+                        catch (Exception e)
+                        {
+                            Utils.LogError(e, "Failed to Close {0}.", host.Key);
+                            value.State = ReverseConnectHostState.Errored;
+                        }
                     }
                 }
             }

--- a/Libraries/Opc.Ua.Client/Session.cs
+++ b/Libraries/Opc.Ua.Client/Session.cs
@@ -5316,7 +5316,7 @@ namespace Opc.Ua.Client
                     // Servers may return this error when overloaded
                     case StatusCodes.BadTooManyOperations:
                     case StatusCodes.BadTcpServerTooBusy:
-                        // throttle the resend to lower server load
+                        // throttle the resend to reduce server load
                         Thread.Sleep(100);
                         break;
                 }

--- a/Libraries/Opc.Ua.Client/Session.cs
+++ b/Libraries/Opc.Ua.Client/Session.cs
@@ -387,6 +387,17 @@ namespace Opc.Ua.Client
             }
 
             base.Dispose(disposing);
+
+            if (disposing)
+            {
+                // suppress spurious events
+                m_KeepAlive = null;
+                m_Publish = null;
+                m_PublishError = null;
+                m_PublishSequenceNumbersToAcknowledge = null;
+                m_SubscriptionsChanged = null;
+                m_SessionClosing = null;
+            }
         }
         #endregion
 

--- a/Libraries/Opc.Ua.Client/Session.cs
+++ b/Libraries/Opc.Ua.Client/Session.cs
@@ -5293,7 +5293,8 @@ namespace Opc.Ua.Client
                     }
                 }
 
-                // don't send another publish for these errors.
+                // don't send another publish for these errors,
+                // or throttle to avoid server overload.
                 switch (error.Code)
                 {
                     case StatusCodes.BadTooManyPublishRequests:
@@ -5311,6 +5312,12 @@ namespace Opc.Ua.Client
                     case StatusCodes.BadSecureChannelClosed:
                     case StatusCodes.BadServerHalted:
                         return;
+
+                    // Servers may return this error when overloaded
+                    case StatusCodes.BadTooManyOperations:
+                    case StatusCodes.BadTcpServerTooBusy:
+                        Thread.Sleep(100);
+                        break;
                 }
 
                 Utils.LogError(e, "PUBLISH #{0} - Unhandled error {1} during Publish.", requestHeader.RequestHandle, error.StatusCode);

--- a/Libraries/Opc.Ua.Client/Session.cs
+++ b/Libraries/Opc.Ua.Client/Session.cs
@@ -5316,6 +5316,7 @@ namespace Opc.Ua.Client
                     // Servers may return this error when overloaded
                     case StatusCodes.BadTooManyOperations:
                     case StatusCodes.BadTcpServerTooBusy:
+                        // throttle the resend to lower server load
                         Thread.Sleep(100);
                         break;
                 }

--- a/Libraries/Opc.Ua.Client/SessionObsolete.cs
+++ b/Libraries/Opc.Ua.Client/SessionObsolete.cs
@@ -99,6 +99,24 @@ namespace Opc.Ua.Client
             RequestHeader requestHeader,
             bool deleteSubscriptions,
             CancellationToken ct) => base.CloseSessionAsync(requestHeader, deleteSubscriptions, ct);
+
+        /// <inheritdoc/>
+        [Obsolete("Call ISession.TransferSubscriptions(SubscriptionIds, bool) instead.")]
+        public override ResponseHeader TransferSubscriptions(
+            RequestHeader requestHeader,
+            UInt32Collection subscriptionIds,
+            bool sendInitialValues,
+            out TransferResultCollection results,
+            out DiagnosticInfoCollection diagnosticInfos) => base.TransferSubscriptions(
+                requestHeader, subscriptionIds, sendInitialValues, out results, out diagnosticInfos);
+
+        /// <inheritdoc/>
+        [Obsolete("Call ISession.TransferSubscriptionsAsync(SubscriptionIds, bool) instead.")]
+        public override Task<TransferSubscriptionsResponse> TransferSubscriptionsAsync(
+            RequestHeader requestHeader,
+            UInt32Collection subscriptionIds,
+            bool sendInitialValues,
+            CancellationToken ct) => TransferSubscriptionsAsync(requestHeader, subscriptionIds, sendInitialValues, ct);
     }
 }
 #endif

--- a/Libraries/Opc.Ua.Client/SessionObsolete.cs
+++ b/Libraries/Opc.Ua.Client/SessionObsolete.cs
@@ -116,7 +116,7 @@ namespace Opc.Ua.Client
             RequestHeader requestHeader,
             UInt32Collection subscriptionIds,
             bool sendInitialValues,
-            CancellationToken ct) => TransferSubscriptionsAsync(requestHeader, subscriptionIds, sendInitialValues, ct);
+            CancellationToken ct) => base.TransferSubscriptionsAsync(requestHeader, subscriptionIds, sendInitialValues, ct);
     }
 }
 #endif

--- a/Libraries/Opc.Ua.Client/SessionReconnectHandler.cs
+++ b/Libraries/Opc.Ua.Client/SessionReconnectHandler.cs
@@ -213,12 +213,13 @@ namespace Opc.Ua.Client
                 }
 
                 // set reconnect period within boundaries
-                m_baseReconnectPeriod = reconnectPeriod = CheckedReconnectPeriod(reconnectPeriod);
+                reconnectPeriod = CheckedReconnectPeriod(reconnectPeriod);
 
                 // ignore subsequent trigger requests
                 if (m_state == ReconnectState.Ready)
                 {
                     m_session = session;
+                    m_baseReconnectPeriod = reconnectPeriod;
                     m_reconnectFailed = false;
                     m_cancelReconnect = false;
                     m_callback = callback;
@@ -230,8 +231,9 @@ namespace Opc.Ua.Client
                 }
 
                 // if triggered, reset timer if requested reconnect period is smaller
-                if (m_state == ReconnectState.Triggered && reconnectPeriod < m_reconnectPeriod)
+                if (m_state == ReconnectState.Triggered && reconnectPeriod < m_baseReconnectPeriod)
                 {
+                    m_baseReconnectPeriod = reconnectPeriod;
                     m_reconnectTimer.Change(JitteredReconnectPeriod(reconnectPeriod), Timeout.Infinite);
                     m_reconnectPeriod = CheckedReconnectPeriod(reconnectPeriod, true);
                 }

--- a/Libraries/Opc.Ua.Client/SessionReconnectHandler.cs
+++ b/Libraries/Opc.Ua.Client/SessionReconnectHandler.cs
@@ -235,7 +235,7 @@ namespace Opc.Ua.Client
                     return m_state;
                 }
 
-                // if triggered, reset timer if requested reconnect period is smaller
+                // if triggered, reset timer if requested reconnect period is shorter
                 if (m_state == ReconnectState.Triggered && reconnectPeriod < m_baseReconnectPeriod)
                 {
                     m_baseReconnectPeriod = reconnectPeriod;
@@ -351,8 +351,8 @@ namespace Opc.Ua.Client
                     {
                         int elapsed = (int)DateTime.UtcNow.Subtract(reconnectStart).TotalMilliseconds;
                         Utils.LogInfo("Reconnect period is {0} ms, {1} ms elapsed in reconnect.", m_reconnectPeriod, elapsed);
-                        int adjustedReconnectPeriod = JitteredReconnectPeriod(m_reconnectPeriod) - elapsed;
-                        adjustedReconnectPeriod = CheckedReconnectPeriod(adjustedReconnectPeriod);
+                        int adjustedReconnectPeriod = CheckedReconnectPeriod(m_reconnectPeriod - elapsed);
+                        adjustedReconnectPeriod = JitteredReconnectPeriod(adjustedReconnectPeriod);
                         m_reconnectTimer.Change(adjustedReconnectPeriod, Timeout.Infinite);
                         Utils.LogInfo("Next adjusted reconnect scheduled in {0} ms.", adjustedReconnectPeriod);
                         m_reconnectPeriod = CheckedReconnectPeriod(m_reconnectPeriod, true);

--- a/Libraries/Opc.Ua.Client/SessionReconnectHandler.cs
+++ b/Libraries/Opc.Ua.Client/SessionReconnectHandler.cs
@@ -54,6 +54,11 @@ namespace Opc.Ua.Client
         public const int DefaultReconnectPeriod = 1000;
 
         /// <summary>
+        /// The default reconnect operation limit in ms.
+        /// </summary>
+        public const int MinReconnectOperationLimit = 5000;
+
+        /// <summary>
         /// The internal state of the reconnect handler.
         /// </summary>
         public enum ReconnectState
@@ -361,8 +366,7 @@ namespace Opc.Ua.Client
         {
             // helper to override operation timeout
             int operationTimeout = m_session.OperationTimeout;
-            int reconnectOperationTimeout = m_reconnectPeriod >= DefaultReconnectPeriod ?
-                m_reconnectPeriod : DefaultReconnectPeriod;
+            int reconnectOperationTimeout = Math.Max(m_reconnectPeriod, MinReconnectOperationLimit);
 
             // try a reconnect.
             if (!m_reconnectFailed)

--- a/Libraries/Opc.Ua.Client/SessionReconnectHandler.cs
+++ b/Libraries/Opc.Ua.Client/SessionReconnectHandler.cs
@@ -235,7 +235,7 @@ namespace Opc.Ua.Client
                     return m_state;
                 }
 
-                // if triggered, reset timer if requested reconnect period is shorter
+                // if triggered, reset timer only if requested reconnect period is shorter
                 if (m_state == ReconnectState.Triggered && reconnectPeriod < m_baseReconnectPeriod)
                 {
                     m_baseReconnectPeriod = reconnectPeriod;


### PR DESCRIPTION
## Proposed changes

- With exponential backoff enabled, a KeepAlive calling `BeginReconnect` could retrigger the timer in a way that a reconnect would never occur.
- Throttle `ISession.BeginPublish` on `BadTooManyOperations` error.
- Add reverse connect option to console client to test reconnect with reverse connect manager.
- null events in session on dispose to suppress spurious events.
- mark `TransferSubscription` service calls obsolete to avoid accidential use by applications.
- for reverse connection testing of session reconnect handler, add option to console client

## Related Issues

- Fixes #2169 

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [x] I ran tests locally with my changes, all passed.
- [x] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
