### PR TITLE
Adds server uri to CreateSessionRequest only if server is gateway

### DIFF
--- a/Libraries/Opc.Ua.Client/Session.cs
+++ b/Libraries/Opc.Ua.Client/Session.cs
@@ -2521,6 +2521,9 @@ namespace Opc.Ua.Client
                 sessionTimeout = (uint)m_configuration.ClientConfiguration.DefaultSessionTimeout;
             }
 
+            bool serverIsGateway = !string.IsNullOrEmpty(m_endpoint.Description.Server.GatewayServerUri);
+            string serverUri = serverIsGateway ? m_endpoint.Description.Server.ApplicationUri : null;
+
             bool successCreateSession = false;
             //if security none, first try to connect without certificate
             if (m_endpoint.Description.SecurityPolicyUri == SecurityPolicies.None)
@@ -2531,7 +2534,7 @@ namespace Opc.Ua.Client
                     base.CreateSession(
                         null,
                         clientDescription,
-                        m_endpoint.Description.Server.ApplicationUri,
+                        serverUri,
                         m_endpoint.EndpointUrl.ToString(),
                         sessionName,
                         clientNonce,
@@ -2562,7 +2565,7 @@ namespace Opc.Ua.Client
                 base.CreateSession(
                         null,
                         clientDescription,
-                        m_endpoint.Description.Server.ApplicationUri,
+                        serverUri,
                         m_endpoint.EndpointUrl.ToString(),
                         sessionName,
                         clientNonce,


### PR DESCRIPTION
## Proposed changes

The [specification](https://reference.opcfoundation.org/Core/Part4/v104/docs/5.6.2.2) states that the serverUri in a CreateSessionRequest should __only__ be set if the server is a gateway.

The current code sets the serverUri always. The changes introduced in this PR fixes this.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [x] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

