### PR TITLE
Support custom cert store with flat directory structure

### DIFF
--- a/Libraries/Opc.Ua.Configuration/ApplicationConfigurationBuilder.cs
+++ b/Libraries/Opc.Ua.Configuration/ApplicationConfigurationBuilder.cs
@@ -141,15 +141,8 @@ namespace Opc.Ua.Configuration
                     StoreType = rejectedRootType,
                     StorePath = DefaultCertificateStorePath(TrustlistType.Rejected, rejectedRoot)
                 },
-                // ensure secure default settings
-                AutoAcceptUntrustedCertificates = false,
-                AddAppCertToTrustedStore = false,
-                RejectSHA1SignedCertificates = true,
-                RejectUnknownRevocationStatus = true,
-                SuppressNonceValidationErrors = false,
-                SendCertificateChain = true,
-                MinimumCertificateKeySize = CertificateFactory.DefaultKeySize
             };
+            SetSecureDefaults(ApplicationConfiguration.SecurityConfiguration);
 
             return this;
         }
@@ -189,15 +182,8 @@ namespace Opc.Ua.Configuration
                     StoreType = rejectedRootType,
                     StorePath = DefaultCertificateStorePath(TrustlistType.Rejected, rejectedRoot)
                 },
-                // ensure secure default settings
-                AutoAcceptUntrustedCertificates = false,
-                AddAppCertToTrustedStore = false,
-                RejectSHA1SignedCertificates = true,
-                RejectUnknownRevocationStatus = true,
-                SuppressNonceValidationErrors = false,
-                SendCertificateChain = true,
-                MinimumCertificateKeySize = CertificateFactory.DefaultKeySize
             };
+            SetSecureDefaults(ApplicationConfiguration.SecurityConfiguration);
 
             return this;
         }
@@ -995,6 +981,21 @@ namespace Opc.Ua.Configuration
                     }
                 }
             }
+        }
+
+        /// <summary>
+        /// Set secure defaults for flags.
+        /// </summary>
+        private void SetSecureDefaults(SecurityConfiguration securityConfiguration)
+        {
+            // ensure secure default settings
+            securityConfiguration.AutoAcceptUntrustedCertificates = false;
+            securityConfiguration.AddAppCertToTrustedStore = false;
+            securityConfiguration.RejectSHA1SignedCertificates = true;
+            securityConfiguration.RejectUnknownRevocationStatus = true;
+            securityConfiguration.SuppressNonceValidationErrors = false;
+            securityConfiguration.SendCertificateChain = true;
+            securityConfiguration.MinimumCertificateKeySize = CertificateFactory.DefaultKeySize;
         }
 
         /// <summary>

--- a/Libraries/Opc.Ua.Configuration/ApplicationConfigurationBuilder.cs
+++ b/Libraries/Opc.Ua.Configuration/ApplicationConfigurationBuilder.cs
@@ -934,7 +934,7 @@ namespace Opc.Ua.Configuration
             }
             else
             {
-                // return custom root store, the 
+                // return custom root store
                 return pkiRoot;
             }
             throw new NotSupportedException("Unsupported store type.");

--- a/Libraries/Opc.Ua.Configuration/IApplicationConfigurationBuilder.cs
+++ b/Libraries/Opc.Ua.Configuration/IApplicationConfigurationBuilder.cs
@@ -44,6 +44,7 @@ namespace Opc.Ua.Configuration
         IApplicationConfigurationBuilderClientSelected,
         IApplicationConfigurationBuilderSecurity,
         IApplicationConfigurationBuilderSecurityOptions,
+        IApplicationConfigurationBuilderSecurityOptionStores,
         IApplicationConfigurationBuilderServerPolicies,
         IApplicationConfigurationBuilderCreate
     {
@@ -380,6 +381,52 @@ namespace Opc.Ua.Configuration
             string pkiRoot = null,
             string appRoot = null,
             string rejectedRoot = null
+            );
+
+        /// <summary>
+        /// Add the security configuration for mandatory application, issuer and trusted stores.
+        /// </summary>
+        /// <param name="subjectName">Application certificate subject name as distinguished name.
+        /// A DC=localhost entry is converted to the hostname. The common name CN= is mandatory.</param>
+        /// <param name="appRoot">The path to the app cert store.</param>
+        /// <param name="trustedRoot">The path to the trusted cert store.</param>
+        /// <param name="issuerRoot">The path to the issuer cert store.</param>
+        /// <param name="rejectedRoot">The path to the rejected certificate store.</param>
+        IApplicationConfigurationBuilderSecurityOptionStores AddSecurityConfigurationStores(
+            string subjectName,
+            string appRoot,
+            string trustedRoot,
+            string issuerRoot,
+            string rejectedRoot = null
+            );
+    }
+
+    /// <summary>
+    /// Add security options to the configuration.
+    /// </summary>
+    public interface IApplicationConfigurationBuilderSecurityOptionStores :
+        IApplicationConfigurationBuilderTraceConfiguration,
+        IApplicationConfigurationBuilderExtension,
+        IApplicationConfigurationBuilderCreate
+    {
+        /// <summary>
+        /// Add the security configuration for the user certificate issuer and trusted stores.
+        /// </summary>
+        /// <param name="trustedRoot">The path to the trusted cert store.</param>
+        /// <param name="issuerRoot">The path to the issuer cert store.</param>
+        IApplicationConfigurationBuilderSecurityOptionStores AddSecurityConfigurationUserStore(
+            string trustedRoot,
+            string issuerRoot
+            );
+
+        /// <summary>
+        /// Add the security configuration for the https certificate issuer and trusted stores.
+        /// </summary>
+        /// <param name="trustedRoot">The path to the trusted cert store.</param>
+        /// <param name="issuerRoot">The path to the issuer cert store.</param>
+        IApplicationConfigurationBuilderSecurityOptionStores AddSecurityConfigurationHttpsStore(
+            string trustedRoot,
+            string issuerRoot
             );
     }
 

--- a/Stack/Opc.Ua.Core/Security/Certificates/DirectoryCertificateStore.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/DirectoryCertificateStore.cs
@@ -725,7 +725,8 @@ namespace Opc.Ua
 
                 // check if cache is still good.
                 if ((m_certificateSubdir.LastWriteTimeUtc < m_lastDirectoryCheck) &&
-                    (NoPrivateKeys || m_privateKeySubdir == null || m_privateKeySubdir.Exists || m_privateKeySubdir.LastWriteTimeUtc < m_lastDirectoryCheck))
+                    (NoPrivateKeys || m_privateKeySubdir == null || !m_privateKeySubdir.Exists ||
+                    m_privateKeySubdir.LastWriteTimeUtc < m_lastDirectoryCheck))
                 {
                     return m_certificates;
                 }

--- a/Tests/Opc.Ua.Configuration.Tests/CertificateStoreTypeTest.cs
+++ b/Tests/Opc.Ua.Configuration.Tests/CertificateStoreTypeTest.cs
@@ -1,0 +1,229 @@
+/* ========================================================================
+ * Copyright (c) 2005-2023 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ * 
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ * 
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+
+using System;
+using System.IO;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Opc.Ua.Security.Certificates;
+
+namespace Opc.Ua.Configuration.Tests
+{
+    /// <summary>
+    /// Tests for the CertificateFactory class.
+    /// </summary>
+    [TestFixture, Category("CertificateStore")]
+    [SetCulture("en-us")]
+    public class CertificateStoreTypeTest
+    {
+        [OneTimeSetUp]
+        protected void OneTimeSetUp()
+        {
+            CertificateStoreType.RegisterCertificateStoreType(TestCertStore.StoreTypePrefix, new TestStoreType());
+        }
+
+        [SetUp]
+        public void SetUp()
+        {
+            m_tempPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            Directory.CreateDirectory(m_tempPath);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            Directory.Delete(m_tempPath, true);
+        }
+
+        #region Test Methods
+        [Test]
+        public async Task CertifcateStoreTypeNoConfigTest()
+        {
+            ApplicationInstance application = new ApplicationInstance() {
+                ApplicationName = "Application",
+            };
+
+            var appConfigBuilder = application.Build(
+                applicationUri: "urn:localhost:CertStoreTypeTest",
+                productUri: "uri:opcfoundation.org:Tests:CertStoreTypeTest")
+                .AsClient()
+                .AddSecurityConfigurationStores(
+                    subjectName: "CN=CertStoreTypeTest, O=OPC Foundation",
+                    appRoot: TestCertStore.StoreTypePrefix + m_tempPath + Path.DirectorySeparatorChar + "own",
+                    trustedRoot: TestCertStore.StoreTypePrefix + m_tempPath + Path.DirectorySeparatorChar + "trusted",
+                    issuerRoot: TestCertStore.StoreTypePrefix + m_tempPath + Path.DirectorySeparatorChar + "issuer"
+                    )
+                .AddSecurityConfigurationUserStore(
+                    trustedRoot: TestCertStore.StoreTypePrefix + m_tempPath + Path.DirectorySeparatorChar + "trustedUser",
+                    issuerRoot: TestCertStore.StoreTypePrefix + m_tempPath + Path.DirectorySeparatorChar + "userIssuer"
+                );
+
+            // patch custom stores before creating the config
+            ApplicationConfiguration appConfig = await appConfigBuilder.Create().ConfigureAwait(false);
+
+            bool certOK = await application.CheckApplicationInstanceCertificate(true, 0).ConfigureAwait(false);
+            Assert.True(certOK);
+
+            int instancesCreatedWhileLoadingConfig = TestCertStore.InstancesCreated;
+            Assert.IsTrue(instancesCreatedWhileLoadingConfig > 0);
+            var trustedIssuers = appConfig.SecurityConfiguration.TrustedIssuerCertificates;
+            ICertificateStore trustedIssuersStore = trustedIssuers.OpenStore();
+            trustedIssuersStore.Close();
+            int instancesCreatedWhileOpeningAuthRootStore = TestCertStore.InstancesCreated;
+            Assert.IsTrue(instancesCreatedWhileLoadingConfig < instancesCreatedWhileOpeningAuthRootStore);
+            CertificateStoreIdentifier.OpenStore(TestCertStore.StoreTypePrefix + m_tempPath + Path.DirectorySeparatorChar + "trustedUser");
+            Assert.IsTrue(instancesCreatedWhileOpeningAuthRootStore < TestCertStore.InstancesCreated);
+        }
+        #endregion Test Methods
+
+        #region Private members
+        private string m_tempPath;
+        #endregion
+    }
+
+    internal sealed class TestStoreType : ICertificateStoreType
+    {
+        public ICertificateStore CreateStore()
+        {
+            return new TestCertStore();
+        }
+
+        public bool SupportsStorePath(string storePath)
+        {
+            return storePath != null && storePath.StartsWith(TestCertStore.StoreTypePrefix);
+        }
+    }
+
+    internal sealed class TestCertStore : ICertificateStore
+    {
+        public const string StoreTypePrefix = "testStoreType:";
+
+        public TestCertStore()
+        {
+            s_instancesCreated++;
+            m_innerStore = new DirectoryCertificateStore(true);
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            m_innerStore.Dispose();
+        }
+
+        /// <inheritdoc/>
+        public void Open(string location, bool noPrivateKeys)
+        {
+            if (location == null)
+            {
+                throw new ArgumentNullException(nameof(location));
+            }
+            if (!location.StartsWith(StoreTypePrefix, StringComparison.Ordinal))
+            {
+                throw new ArgumentException($"Expected argument {nameof(location)} starting with {StoreTypePrefix}");
+            }
+            m_innerStore.Open(location.Substring(StoreTypePrefix.Length), noPrivateKeys);
+        }
+
+        /// <inheritdoc/>
+        public void Close()
+        {
+            m_innerStore.Close();
+        }
+
+        /// <inheritdoc/>
+        public string StoreType => StoreTypePrefix.Substring(0, StoreTypePrefix.Length - 1);
+
+        /// <inheritdoc/>
+        public string StorePath => m_innerStore.StorePath;
+
+        /// <inheritdoc/>
+        public Task Add(X509Certificate2 certificate, string password = null)
+        {
+            return m_innerStore.Add(certificate, password);
+        }
+
+        /// <inheritdoc/>
+        public Task<bool> Delete(string thumbprint)
+        {
+            return m_innerStore.Delete(thumbprint);
+        }
+
+        /// <inheritdoc/>
+        public Task<X509Certificate2Collection> Enumerate()
+        {
+            return m_innerStore.Enumerate();
+        }
+
+        /// <inheritdoc/>
+        public Task<X509Certificate2Collection> FindByThumbprint(string thumbprint)
+        {
+            return m_innerStore.FindByThumbprint(thumbprint);
+        }
+
+        /// <inheritdoc/>
+        public bool SupportsCRLs
+            => m_innerStore.SupportsCRLs;
+
+        /// <inheritdoc/>
+        public Task AddCRL(X509CRL crl)
+            => m_innerStore.AddCRL(crl);
+
+        /// <inheritdoc/>
+        public Task<bool> DeleteCRL(X509CRL crl)
+            => m_innerStore.DeleteCRL(crl);
+
+        /// <inheritdoc/>
+        public Task<X509CRLCollection> EnumerateCRLs()
+            => m_innerStore.EnumerateCRLs();
+
+        /// <inheritdoc/>
+        public Task<X509CRLCollection> EnumerateCRLs(X509Certificate2 issuer, bool validateUpdateTime = true)
+            => m_innerStore.EnumerateCRLs(issuer, validateUpdateTime);
+
+        /// <inheritdoc/>
+        public Task<StatusCode> IsRevoked(X509Certificate2 issuer, X509Certificate2 certificate)
+            => m_innerStore.IsRevoked(issuer, certificate);
+
+        /// <inheritdoc/>
+        public bool SupportsLoadPrivateKey => m_innerStore.SupportsLoadPrivateKey;
+
+        /// <inheritdoc/>
+        public Task<X509Certificate2> LoadPrivateKey(string thumbprint, string subjectName, string password)
+            => m_innerStore.LoadPrivateKey(thumbprint, subjectName, password);
+
+        public static int InstancesCreated => s_instancesCreated;
+
+        #region Private Members
+        private static int s_instancesCreated = 0;
+        private readonly DirectoryCertificateStore m_innerStore;
+        #endregion 
+    }
+}


### PR DESCRIPTION
## Proposed changes

In some use cases (e.g. Kubernetes secrets) it would be beneficial to store the certificates, private keys, crl etc. in a flat directory instead of having a root which contains a hierarchy with certs/crl/private etc. 
- Modify the `DirectoryCertificateStore` to allow it to use a flat structure by adding a special constructor.
- Add the configuration builder functions to allow to specify custom certificate stores for app/user/https.
- Add a test sample which shows how to use the 'flat store' with a custom cert store wrapper.
- By default, behavior of `DirectoryCertificateStore` is unchanged. Needs an external wrapper to expose the flat mode.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- [x] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [x] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

