### PR TITLE
Fix stringtables for diagnostic results when service calls are batched 

### DIFF
--- a/Applications/Quickstarts.Servers/TestData/NodeStateComparer.cs
+++ b/Applications/Quickstarts.Servers/TestData/NodeStateComparer.cs
@@ -1,0 +1,72 @@
+/* ========================================================================
+ * Copyright (c) 2005-2019 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ * 
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ * 
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System.Collections.Generic;
+using Opc.Ua;
+
+namespace TestData
+{
+    /// <summary>
+    /// Helper which implements IEqualityComparer for Linq queries.
+    /// </summary>
+    public class NodeStateComparer : IEqualityComparer<NodeState>
+    {
+        /// <inheritdoc/>
+        public bool Equals(NodeState x, NodeState y)
+        {
+            if (ReferenceEquals(x, y))
+            {
+                return true;
+            }
+
+            if (ReferenceEquals(x, null) || ReferenceEquals(y, null))
+            {
+                return false;
+            }
+
+            if (x.NodeId == y.NodeId)
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <inheritdoc/>
+        public int GetHashCode(NodeState node)
+        {
+            if (ReferenceEquals(node, null))
+            {
+                return 0;
+            }
+
+            return node.NodeId.GetHashCode();
+        }
+    }
+}

--- a/Libraries/Opc.Ua.Client/SessionClientBatched.cs
+++ b/Libraries/Opc.Ua.Client/SessionClientBatched.cs
@@ -85,7 +85,7 @@ namespace Opc.Ua
 
             uint operationLimit = OperationLimits.MaxNodesPerNodeManagement;
             InitResponseCollections<AddNodesResult, AddNodesResultCollection>(
-                out results, out diagnosticInfos,
+                out results, out diagnosticInfos, out var stringTable,
                 nodesToAdd.Count, operationLimit
                 );
 
@@ -106,9 +106,10 @@ namespace Opc.Ua
                 ClientBase.ValidateDiagnosticInfos(batchDiagnosticInfos, batchNodesToAdd);
 
                 AddResponses<AddNodesResult, AddNodesResultCollection>(
-                    ref results, ref diagnosticInfos, batchResults, batchDiagnosticInfos);
+                    ref results, ref diagnosticInfos, ref stringTable, batchResults, batchDiagnosticInfos, responseHeader.StringTable);
             }
 
+            responseHeader.StringTable = stringTable;
             return responseHeader;
         }
 
@@ -123,7 +124,7 @@ namespace Opc.Ua
 
             uint operationLimit = OperationLimits.MaxNodesPerNodeManagement;
             InitResponseCollections<AddNodesResult, AddNodesResultCollection>(
-                out var results, out var diagnosticInfos,
+                out var results, out var diagnosticInfos, out var stringTable,
                 nodesToAdd.Count, operationLimit
                 );
 
@@ -144,11 +145,12 @@ namespace Opc.Ua
                 ClientBase.ValidateDiagnosticInfos(batchDiagnosticInfos, batchNodesToAdd);
 
                 AddResponses<AddNodesResult, AddNodesResultCollection>(
-                    ref results, ref diagnosticInfos, batchResults, batchDiagnosticInfos);
+                    ref results, ref diagnosticInfos, ref stringTable, batchResults, batchDiagnosticInfos, response.ResponseHeader.StringTable);
             }
 
             response.Results = results;
             response.DiagnosticInfos = diagnosticInfos;
+            response.ResponseHeader.StringTable = stringTable;
 
             return response;
         }
@@ -167,7 +169,7 @@ namespace Opc.Ua
 
             uint operationLimit = OperationLimits.MaxNodesPerNodeManagement;
             InitResponseCollections<StatusCode, StatusCodeCollection>(
-                out results, out diagnosticInfos,
+                out results, out diagnosticInfos, out var stringTable,
                 referencesToAdd.Count, operationLimit
                 );
 
@@ -188,9 +190,10 @@ namespace Opc.Ua
                 ClientBase.ValidateDiagnosticInfos(batchDiagnosticInfos, batchReferencesToAdd);
 
                 AddResponses<StatusCode, StatusCodeCollection>(
-                    ref results, ref diagnosticInfos, batchResults, batchDiagnosticInfos);
+                    ref results, ref diagnosticInfos, ref stringTable, batchResults, batchDiagnosticInfos, responseHeader.StringTable);
             }
 
+            responseHeader.StringTable = stringTable;
             return responseHeader;
         }
 
@@ -205,7 +208,7 @@ namespace Opc.Ua
 
             uint operationLimit = OperationLimits.MaxNodesPerNodeManagement;
             InitResponseCollections<StatusCode, StatusCodeCollection>(
-                out var results, out var diagnosticInfos,
+                out var results, out var diagnosticInfos, out var stringTable,
                 referencesToAdd.Count, operationLimit
                 );
 
@@ -226,11 +229,12 @@ namespace Opc.Ua
                 ClientBase.ValidateDiagnosticInfos(batchDiagnosticInfos, batchReferencesToAdd);
 
                 AddResponses<StatusCode, StatusCodeCollection>(
-                    ref results, ref diagnosticInfos, batchResults, batchDiagnosticInfos);
+                    ref results, ref diagnosticInfos, ref stringTable, batchResults, batchDiagnosticInfos, response.ResponseHeader.StringTable);
             }
 
             response.Results = results;
             response.DiagnosticInfos = diagnosticInfos;
+            response.ResponseHeader.StringTable = stringTable;
 
             return response;
         }
@@ -249,7 +253,7 @@ namespace Opc.Ua
 
             uint operationLimit = OperationLimits.MaxNodesPerNodeManagement;
             InitResponseCollections<StatusCode, StatusCodeCollection>(
-                out results, out diagnosticInfos,
+                out results, out diagnosticInfos, out var stringTable,
                 nodesToDelete.Count, operationLimit
                 );
 
@@ -270,9 +274,10 @@ namespace Opc.Ua
                 ClientBase.ValidateDiagnosticInfos(batchDiagnosticInfos, batchNodesToDelete);
 
                 AddResponses<StatusCode, StatusCodeCollection>(
-                    ref results, ref diagnosticInfos, batchResults, batchDiagnosticInfos);
+                    ref results, ref diagnosticInfos, ref stringTable, batchResults, batchDiagnosticInfos, responseHeader.StringTable);
             }
 
+            responseHeader.StringTable = stringTable;
             return responseHeader;
         }
 
@@ -287,7 +292,7 @@ namespace Opc.Ua
 
             uint operationLimit = OperationLimits.MaxNodesPerNodeManagement;
             InitResponseCollections<StatusCode, StatusCodeCollection>(
-                out var results, out var diagnosticInfos,
+                out var results, out var diagnosticInfos, out var stringTable,
                 nodesToDelete.Count, operationLimit
                 );
 
@@ -309,11 +314,12 @@ namespace Opc.Ua
                 ClientBase.ValidateDiagnosticInfos(batchDiagnosticInfos, batchNodesToDelete);
 
                 AddResponses<StatusCode, StatusCodeCollection>(
-                    ref results, ref diagnosticInfos, batchResults, batchDiagnosticInfos);
+                    ref results, ref diagnosticInfos, ref stringTable, batchResults, batchDiagnosticInfos, response.ResponseHeader.StringTable);
             }
 
             response.Results = results;
             response.DiagnosticInfos = diagnosticInfos;
+            response.ResponseHeader.StringTable = stringTable;
 
             return response;
         }
@@ -332,7 +338,7 @@ namespace Opc.Ua
 
             uint operationLimit = OperationLimits.MaxNodesPerNodeManagement;
             InitResponseCollections<StatusCode, StatusCodeCollection>(
-                out results, out diagnosticInfos,
+                out results, out diagnosticInfos, out var stringTable,
                 referencesToDelete.Count, operationLimit
                 );
 
@@ -353,9 +359,10 @@ namespace Opc.Ua
                 ClientBase.ValidateDiagnosticInfos(batchDiagnosticInfos, batchReferencesToDelete);
 
                 AddResponses<StatusCode, StatusCodeCollection>(
-                    ref results, ref diagnosticInfos, batchResults, batchDiagnosticInfos);
+                    ref results, ref diagnosticInfos, ref stringTable, batchResults, batchDiagnosticInfos, responseHeader.StringTable);
             }
 
+            responseHeader.StringTable = stringTable;
             return responseHeader;
         }
 
@@ -370,7 +377,7 @@ namespace Opc.Ua
 
             uint operationLimit = OperationLimits.MaxNodesPerNodeManagement;
             InitResponseCollections<StatusCode, StatusCodeCollection>(
-                out var results, out var diagnosticInfos,
+                out var results, out var diagnosticInfos, out var stringTable,
                 referencesToDelete.Count, operationLimit
                 );
 
@@ -392,11 +399,12 @@ namespace Opc.Ua
                 ClientBase.ValidateDiagnosticInfos(batchDiagnosticInfos, batchReferencesToDelete);
 
                 AddResponses<StatusCode, StatusCodeCollection>(
-                    ref results, ref diagnosticInfos, batchResults, batchDiagnosticInfos);
+                    ref results, ref diagnosticInfos, ref stringTable, batchResults, batchDiagnosticInfos, response.ResponseHeader.StringTable);
             }
 
             response.Results = results;
             response.DiagnosticInfos = diagnosticInfos;
+            response.ResponseHeader.StringTable = stringTable;
 
             return response;
         }
@@ -417,7 +425,7 @@ namespace Opc.Ua
 
             uint operationLimit = OperationLimits.MaxNodesPerBrowse;
             InitResponseCollections<BrowseResult, BrowseResultCollection>(
-                out results, out diagnosticInfos,
+                out results, out diagnosticInfos, out var stringTable,
                 nodesToBrowse.Count, operationLimit
                 );
 
@@ -440,9 +448,10 @@ namespace Opc.Ua
                 ClientBase.ValidateDiagnosticInfos(batchDiagnosticInfos, nodesToBrowseBatch);
 
                 AddResponses<BrowseResult, BrowseResultCollection>(
-                    ref results, ref diagnosticInfos, batchResults, batchDiagnosticInfos);
+                    ref results, ref diagnosticInfos, ref stringTable, batchResults, batchDiagnosticInfos, responseHeader.StringTable);
             }
 
+            responseHeader.StringTable = stringTable;
             return responseHeader;
         }
 
@@ -459,7 +468,7 @@ namespace Opc.Ua
 
             uint operationLimit = OperationLimits.MaxNodesPerBrowse;
             InitResponseCollections<BrowseResult, BrowseResultCollection>(
-                out var results, out var diagnosticInfos,
+                out var results, out var diagnosticInfos, out var stringTable,
                 nodesToBrowse.Count, operationLimit
                 );
 
@@ -484,11 +493,12 @@ namespace Opc.Ua
                 ClientBase.ValidateDiagnosticInfos(batchDiagnosticInfos, nodesToBrowseBatch);
 
                 AddResponses<BrowseResult, BrowseResultCollection>(
-                    ref results, ref diagnosticInfos, batchResults, batchDiagnosticInfos);
+                    ref results, ref diagnosticInfos, ref stringTable, batchResults, batchDiagnosticInfos, response.ResponseHeader.StringTable);
             }
 
             response.Results = results;
             response.DiagnosticInfos = diagnosticInfos;
+            response.ResponseHeader.StringTable = stringTable;
 
             return response;
         }
@@ -507,7 +517,7 @@ namespace Opc.Ua
 
             uint operationLimit = OperationLimits.MaxNodesPerTranslateBrowsePathsToNodeIds;
             InitResponseCollections<BrowsePathResult, BrowsePathResultCollection>(
-                out results, out diagnosticInfos,
+                out results, out diagnosticInfos, out var stringTable,
                 browsePaths.Count, operationLimit
                 );
 
@@ -528,9 +538,10 @@ namespace Opc.Ua
                 ClientBase.ValidateDiagnosticInfos(batchDiagnosticInfos, batchBrowsePaths);
 
                 AddResponses<BrowsePathResult, BrowsePathResultCollection>(
-                    ref results, ref diagnosticInfos, batchResults, batchDiagnosticInfos);
+                    ref results, ref diagnosticInfos, ref stringTable, batchResults, batchDiagnosticInfos, responseHeader.StringTable);
             }
 
+            responseHeader.StringTable = stringTable;
             return responseHeader;
         }
 
@@ -545,7 +556,7 @@ namespace Opc.Ua
 
             uint operationLimit = OperationLimits.MaxNodesPerTranslateBrowsePathsToNodeIds;
             InitResponseCollections<BrowsePathResult, BrowsePathResultCollection>(
-                out var results, out var diagnosticInfos,
+                out var results, out var diagnosticInfos, out var stringTable,
                 browsePaths.Count, operationLimit
                 );
 
@@ -569,11 +580,12 @@ namespace Opc.Ua
                 ClientBase.ValidateDiagnosticInfos(batchDiagnosticInfos, batchBrowsePaths);
 
                 AddResponses<BrowsePathResult, BrowsePathResultCollection>(
-                    ref results, ref diagnosticInfos, batchResults, batchDiagnosticInfos);
+                    ref results, ref diagnosticInfos, ref stringTable, batchResults, batchDiagnosticInfos, response.ResponseHeader.StringTable);
             }
 
             response.Results = results;
             response.DiagnosticInfos = diagnosticInfos;
+            response.ResponseHeader.StringTable = stringTable;
 
             return response;
         }
@@ -708,7 +720,7 @@ namespace Opc.Ua
 
             uint operationLimit = OperationLimits.MaxNodesPerRead;
             InitResponseCollections<DataValue, DataValueCollection>(
-                out results, out diagnosticInfos,
+                out results, out diagnosticInfos, out var stringTable,
                 nodesToRead.Count, operationLimit
                 );
 
@@ -732,9 +744,10 @@ namespace Opc.Ua
                 ClientBase.ValidateDiagnosticInfos(batchDiagnosticInfos, batchAttributesToRead);
 
                 AddResponses<DataValue, DataValueCollection>(
-                    ref results, ref diagnosticInfos, batchResults, batchDiagnosticInfos);
+                    ref results, ref diagnosticInfos, ref stringTable, batchResults, batchDiagnosticInfos, responseHeader.StringTable);
             }
 
+            responseHeader.StringTable = stringTable;
             return responseHeader;
         }
 
@@ -751,7 +764,7 @@ namespace Opc.Ua
 
             uint operationLimit = OperationLimits.MaxNodesPerRead;
             InitResponseCollections<DataValue, DataValueCollection>(
-                out var results, out var diagnosticInfos,
+                out var results, out var diagnosticInfos, out var stringTable,
                 nodesToRead.Count, operationLimit
                 );
 
@@ -776,11 +789,12 @@ namespace Opc.Ua
                 ClientBase.ValidateDiagnosticInfos(batchDiagnosticInfos, batchAttributesToRead);
 
                 AddResponses<DataValue, DataValueCollection>(
-                    ref results, ref diagnosticInfos, batchResults, batchDiagnosticInfos);
+                    ref results, ref diagnosticInfos, ref stringTable, batchResults, batchDiagnosticInfos, response.ResponseHeader.StringTable);
             }
 
             response.Results = results;
             response.DiagnosticInfos = diagnosticInfos;
+            response.ResponseHeader.StringTable = stringTable;
 
             return response;
         }
@@ -807,7 +821,7 @@ namespace Opc.Ua
             }
 
             InitResponseCollections<HistoryReadResult, HistoryReadResultCollection>(
-                out results, out diagnosticInfos,
+                out results, out diagnosticInfos, out var stringTable,
                 nodesToRead.Count, operationLimit
                 );
 
@@ -831,9 +845,10 @@ namespace Opc.Ua
                 ClientBase.ValidateDiagnosticInfos(batchDiagnosticInfos, batchNodesToRead);
 
                 AddResponses<HistoryReadResult, HistoryReadResultCollection>(
-                    ref results, ref diagnosticInfos, batchResults, batchDiagnosticInfos);
+                    ref results, ref diagnosticInfos, ref stringTable, batchResults, batchDiagnosticInfos, responseHeader.StringTable);
             }
 
+            responseHeader.StringTable = stringTable;
             return responseHeader;
         }
 
@@ -856,7 +871,7 @@ namespace Opc.Ua
             }
 
             InitResponseCollections<HistoryReadResult, HistoryReadResultCollection>(
-                out var results, out var diagnosticInfos,
+                out var results, out var diagnosticInfos, out var stringTable,
                 nodesToRead.Count, operationLimit
                 );
 
@@ -881,11 +896,12 @@ namespace Opc.Ua
                 ClientBase.ValidateDiagnosticInfos(batchDiagnosticInfos, batchNodesToRead);
 
                 AddResponses<HistoryReadResult, HistoryReadResultCollection>(
-                    ref results, ref diagnosticInfos, batchResults, batchDiagnosticInfos);
+                    ref results, ref diagnosticInfos, ref stringTable, batchResults, batchDiagnosticInfos, response.ResponseHeader.StringTable);
             }
 
             response.Results = results;
             response.DiagnosticInfos = diagnosticInfos;
+            response.ResponseHeader.StringTable = stringTable;
 
             return response;
         }
@@ -904,7 +920,7 @@ namespace Opc.Ua
 
             uint operationLimit = OperationLimits.MaxNodesPerWrite;
             InitResponseCollections<StatusCode, StatusCodeCollection>(
-                out results, out diagnosticInfos,
+                out results, out diagnosticInfos, out var stringTable,
                 nodesToWrite.Count, operationLimit
                 );
 
@@ -925,9 +941,10 @@ namespace Opc.Ua
                 ClientBase.ValidateDiagnosticInfos(batchDiagnosticInfos, batchNodesToWrite);
 
                 AddResponses<StatusCode, StatusCodeCollection>(
-                    ref results, ref diagnosticInfos, batchResults, batchDiagnosticInfos);
+                    ref results, ref diagnosticInfos, ref stringTable, batchResults, batchDiagnosticInfos, responseHeader.StringTable);
             }
 
+            responseHeader.StringTable = stringTable;
             return responseHeader;
         }
 
@@ -942,7 +959,7 @@ namespace Opc.Ua
 
             uint operationLimit = OperationLimits.MaxNodesPerWrite;
             InitResponseCollections<StatusCode, StatusCodeCollection>(
-                out var results, out var diagnosticInfos,
+                out var results, out var diagnosticInfos, out var stringTable,
                 nodesToWrite.Count, operationLimit
                 );
 
@@ -964,11 +981,12 @@ namespace Opc.Ua
                 ClientBase.ValidateDiagnosticInfos(batchDiagnosticInfos, batchNodesToWrite);
 
                 AddResponses<StatusCode, StatusCodeCollection>(
-                    ref results, ref diagnosticInfos, batchResults, batchDiagnosticInfos);
+                    ref results, ref diagnosticInfos, ref stringTable, batchResults, batchDiagnosticInfos, response.ResponseHeader.StringTable);
             }
 
             response.Results = results;
             response.DiagnosticInfos = diagnosticInfos;
+            response.ResponseHeader.StringTable = stringTable;
 
             return response;
         }
@@ -997,7 +1015,7 @@ namespace Opc.Ua
             }
 
             InitResponseCollections<HistoryUpdateResult, HistoryUpdateResultCollection>(
-                out results, out diagnosticInfos,
+                out results, out diagnosticInfos, out var stringTable,
                 historyUpdateDetails.Count, operationLimit
                 );
 
@@ -1018,9 +1036,10 @@ namespace Opc.Ua
                 ClientBase.ValidateDiagnosticInfos(batchDiagnosticInfos, batchHistoryUpdateDetails);
 
                 AddResponses<HistoryUpdateResult, HistoryUpdateResultCollection>(
-                    ref results, ref diagnosticInfos, batchResults, batchDiagnosticInfos);
+                    ref results, ref diagnosticInfos, ref stringTable, batchResults, batchDiagnosticInfos, responseHeader.StringTable);
             }
 
+            responseHeader.StringTable = stringTable;
             return responseHeader;
         }
 
@@ -1041,7 +1060,7 @@ namespace Opc.Ua
             }
 
             InitResponseCollections<HistoryUpdateResult, HistoryUpdateResultCollection>(
-                out var results, out var diagnosticInfos,
+                out var results, out var diagnosticInfos, out var stringTable,
                 historyUpdateDetails.Count, operationLimit
                 );
 
@@ -1062,11 +1081,12 @@ namespace Opc.Ua
                 ClientBase.ValidateDiagnosticInfos(batchDiagnosticInfos, batchHistoryUpdateDetails);
 
                 AddResponses<HistoryUpdateResult, HistoryUpdateResultCollection>(
-                    ref results, ref diagnosticInfos, batchResults, batchDiagnosticInfos);
+                    ref results, ref diagnosticInfos, ref stringTable, batchResults, batchDiagnosticInfos, response.ResponseHeader.StringTable);
             }
 
             response.Results = results;
             response.DiagnosticInfos = diagnosticInfos;
+            response.ResponseHeader.StringTable = stringTable;
 
             return response;
         }
@@ -1085,7 +1105,7 @@ namespace Opc.Ua
 
             uint operationLimit = OperationLimits.MaxNodesPerMethodCall;
             InitResponseCollections<CallMethodResult, CallMethodResultCollection>(
-                out results, out diagnosticInfos,
+                out results, out diagnosticInfos, out var stringTable,
                 methodsToCall.Count, operationLimit
                 );
 
@@ -1106,9 +1126,10 @@ namespace Opc.Ua
                 ClientBase.ValidateDiagnosticInfos(batchDiagnosticInfos, batchMethodsToCall);
 
                 AddResponses<CallMethodResult, CallMethodResultCollection>(
-                    ref results, ref diagnosticInfos, batchResults, batchDiagnosticInfos);
+                    ref results, ref diagnosticInfos, ref stringTable, batchResults, batchDiagnosticInfos, responseHeader.StringTable);
             }
 
+            responseHeader.StringTable = stringTable;
             return responseHeader;
         }
 
@@ -1123,7 +1144,7 @@ namespace Opc.Ua
 
             uint operationLimit = OperationLimits.MaxNodesPerMethodCall;
             InitResponseCollections<CallMethodResult, CallMethodResultCollection>(
-                out var results, out var diagnosticInfos,
+                out var results, out var diagnosticInfos, out var stringTable,
                 methodsToCall.Count, operationLimit
                 );
 
@@ -1145,11 +1166,12 @@ namespace Opc.Ua
                 ClientBase.ValidateDiagnosticInfos(batchDiagnosticInfos, batchMethodsToCall);
 
                 AddResponses<CallMethodResult, CallMethodResultCollection>(
-                    ref results, ref diagnosticInfos, batchResults, batchDiagnosticInfos);
+                    ref results, ref diagnosticInfos, ref stringTable, batchResults, batchDiagnosticInfos, response.ResponseHeader.StringTable);
             }
 
             response.Results = results;
             response.DiagnosticInfos = diagnosticInfos;
+            response.ResponseHeader.StringTable = stringTable;
 
             return response;
         }
@@ -1170,7 +1192,7 @@ namespace Opc.Ua
 
             uint operationLimit = OperationLimits.MaxMonitoredItemsPerCall;
             InitResponseCollections<MonitoredItemCreateResult, MonitoredItemCreateResultCollection>(
-                out results, out diagnosticInfos,
+                out results, out diagnosticInfos, out var stringTable,
                 itemsToCreate.Count, operationLimit
                 );
 
@@ -1193,9 +1215,10 @@ namespace Opc.Ua
                 ClientBase.ValidateDiagnosticInfos(batchDiagnosticInfos, batchItemsToCreate);
 
                 AddResponses<MonitoredItemCreateResult, MonitoredItemCreateResultCollection>(
-                    ref results, ref diagnosticInfos, batchResults, batchDiagnosticInfos);
+                    ref results, ref diagnosticInfos, ref stringTable, batchResults, batchDiagnosticInfos, responseHeader.StringTable);
             }
 
+            responseHeader.StringTable = stringTable;
             return responseHeader;
         }
 
@@ -1212,7 +1235,7 @@ namespace Opc.Ua
 
             uint operationLimit = OperationLimits.MaxMonitoredItemsPerCall;
             InitResponseCollections<MonitoredItemCreateResult, MonitoredItemCreateResultCollection>(
-                out var results, out var diagnosticInfos,
+                out var results, out var diagnosticInfos, out var stringTable,
                 itemsToCreate.Count, operationLimit
                 );
 
@@ -1236,11 +1259,12 @@ namespace Opc.Ua
                 ClientBase.ValidateDiagnosticInfos(batchDiagnosticInfos, batchItemsToCreate);
 
                 AddResponses<MonitoredItemCreateResult, MonitoredItemCreateResultCollection>(
-                    ref results, ref diagnosticInfos, batchResults, batchDiagnosticInfos);
+                    ref results, ref diagnosticInfos, ref stringTable, batchResults, batchDiagnosticInfos, response.ResponseHeader.StringTable);
             }
 
             response.Results = results;
             response.DiagnosticInfos = diagnosticInfos;
+            response.ResponseHeader.StringTable = stringTable;
 
             return response;
         }
@@ -1261,7 +1285,7 @@ namespace Opc.Ua
 
             uint operationLimit = OperationLimits.MaxMonitoredItemsPerCall;
             InitResponseCollections<MonitoredItemModifyResult, MonitoredItemModifyResultCollection>(
-                out results, out diagnosticInfos,
+                out results, out diagnosticInfos, out var stringTable,
                 itemsToModify.Count, operationLimit
                 );
 
@@ -1284,9 +1308,10 @@ namespace Opc.Ua
                 ClientBase.ValidateDiagnosticInfos(batchDiagnosticInfos, batchItemsToModify);
 
                 AddResponses<MonitoredItemModifyResult, MonitoredItemModifyResultCollection>(
-                    ref results, ref diagnosticInfos, batchResults, batchDiagnosticInfos);
+                    ref results, ref diagnosticInfos, ref stringTable, batchResults, batchDiagnosticInfos, responseHeader.StringTable);
             }
 
+            responseHeader.StringTable = stringTable;
             return responseHeader;
         }
 
@@ -1303,7 +1328,7 @@ namespace Opc.Ua
 
             uint operationLimit = OperationLimits.MaxMonitoredItemsPerCall;
             InitResponseCollections<MonitoredItemModifyResult, MonitoredItemModifyResultCollection>(
-                out var results, out var diagnosticInfos,
+                out var results, out var diagnosticInfos, out var stringTable,
                 itemsToModify.Count, operationLimit
                 );
 
@@ -1327,11 +1352,12 @@ namespace Opc.Ua
                 ClientBase.ValidateDiagnosticInfos(batchDiagnosticInfos, batchItemsToModify);
 
                 AddResponses<MonitoredItemModifyResult, MonitoredItemModifyResultCollection>(
-                    ref results, ref diagnosticInfos, batchResults, batchDiagnosticInfos);
+                    ref results, ref diagnosticInfos, ref stringTable, batchResults, batchDiagnosticInfos, response.ResponseHeader.StringTable);
             }
 
             response.Results = results;
             response.DiagnosticInfos = diagnosticInfos;
+            response.ResponseHeader.StringTable = stringTable;
 
             return response;
         }
@@ -1352,7 +1378,7 @@ namespace Opc.Ua
 
             uint operationLimit = OperationLimits.MaxMonitoredItemsPerCall;
             InitResponseCollections<StatusCode, StatusCodeCollection>(
-                out results, out diagnosticInfos,
+                out results, out diagnosticInfos, out var stringTable,
                 monitoredItemIds.Count, operationLimit
                 );
 
@@ -1375,9 +1401,10 @@ namespace Opc.Ua
                 ClientBase.ValidateDiagnosticInfos(batchDiagnosticInfos, batchMonitoredItemIds);
 
                 AddResponses<StatusCode, StatusCodeCollection>(
-                    ref results, ref diagnosticInfos, batchResults, batchDiagnosticInfos);
+                    ref results, ref diagnosticInfos, ref stringTable, batchResults, batchDiagnosticInfos, responseHeader.StringTable);
             }
 
+            responseHeader.StringTable = stringTable;
             return responseHeader;
         }
 
@@ -1394,7 +1421,7 @@ namespace Opc.Ua
 
             uint operationLimit = OperationLimits.MaxMonitoredItemsPerCall;
             InitResponseCollections<StatusCode, StatusCodeCollection>(
-                out var results, out var diagnosticInfos,
+                out var results, out var diagnosticInfos, out var stringTable,
                 monitoredItemIds.Count, operationLimit
                 );
 
@@ -1418,11 +1445,12 @@ namespace Opc.Ua
                 ClientBase.ValidateDiagnosticInfos(batchDiagnosticInfos, batchMonitoredItemIds);
 
                 AddResponses<StatusCode, StatusCodeCollection>(
-                    ref results, ref diagnosticInfos, batchResults, batchDiagnosticInfos);
+                    ref results, ref diagnosticInfos, ref stringTable, batchResults, batchDiagnosticInfos, response.ResponseHeader.StringTable);
             }
 
             response.Results = results;
             response.DiagnosticInfos = diagnosticInfos;
+            response.ResponseHeader.StringTable = stringTable;
 
             return response;
         }
@@ -1446,12 +1474,12 @@ namespace Opc.Ua
 
             uint operationLimit = OperationLimits.MaxMonitoredItemsPerCall;
             InitResponseCollections<StatusCode, StatusCodeCollection>(
-                out addResults, out addDiagnosticInfos,
+                out addResults, out addDiagnosticInfos, out var stringTable,
                 linksToAdd.Count, operationLimit
                 );
 
             InitResponseCollections<StatusCode, StatusCodeCollection>(
-                out removeResults, out removeDiagnosticInfos,
+                out removeResults, out removeDiagnosticInfos, out _,
                 linksToRemove.Count, operationLimit
                 );
 
@@ -1496,10 +1524,10 @@ namespace Opc.Ua
                 ClientBase.ValidateDiagnosticInfos(batchRemoveDiagnosticInfos, batchLinksToRemove);
 
                 AddResponses<StatusCode, StatusCodeCollection>(
-                    ref addResults, ref addDiagnosticInfos, batchAddResults, batchAddDiagnosticInfos);
+                    ref addResults, ref addDiagnosticInfos, ref stringTable, batchAddResults, batchAddDiagnosticInfos, responseHeader.StringTable);
 
                 AddResponses<StatusCode, StatusCodeCollection>(
-                    ref removeResults, ref removeDiagnosticInfos, batchRemoveResults, batchRemoveDiagnosticInfos);
+                    ref removeResults, ref removeDiagnosticInfos, ref stringTable, batchRemoveResults, batchRemoveDiagnosticInfos, responseHeader.StringTable);
             }
 
             if (linksToRemove.Count > 0)
@@ -1530,12 +1558,14 @@ namespace Opc.Ua
                     ClientBase.ValidateDiagnosticInfos(batchRemoveDiagnosticInfos, batchLinksToRemove);
 
                     AddResponses<StatusCode, StatusCodeCollection>(
-                        ref addResults, ref addDiagnosticInfos, batchAddResults, batchAddDiagnosticInfos);
+                        ref addResults, ref addDiagnosticInfos, ref stringTable, batchAddResults, batchAddDiagnosticInfos, responseHeader.StringTable);
 
                     AddResponses<StatusCode, StatusCodeCollection>(
-                        ref removeResults, ref removeDiagnosticInfos, batchRemoveResults, batchRemoveDiagnosticInfos);
+                        ref removeResults, ref removeDiagnosticInfos, ref stringTable, batchRemoveResults, batchRemoveDiagnosticInfos, responseHeader.StringTable);
                 }
             }
+
+            responseHeader.StringTable = stringTable;
             return responseHeader;
         }
 #if (CLIENT_ASYNC)
@@ -1552,12 +1582,12 @@ namespace Opc.Ua
 
             uint operationLimit = OperationLimits.MaxMonitoredItemsPerCall;
             InitResponseCollections<StatusCode, StatusCodeCollection>(
-                out var addResults, out var addDiagnosticInfos,
+                out var addResults, out var addDiagnosticInfos, out var stringTable,
                 linksToAdd.Count, operationLimit
                 );
 
             InitResponseCollections<StatusCode, StatusCodeCollection>(
-                out var removeResults, out var removeDiagnosticInfos,
+                out var removeResults, out var removeDiagnosticInfos, out _,
                 linksToRemove.Count, operationLimit
                 );
 
@@ -1603,10 +1633,10 @@ namespace Opc.Ua
                 ClientBase.ValidateDiagnosticInfos(batchRemoveDiagnosticInfos, batchLinksToRemove);
 
                 AddResponses<StatusCode, StatusCodeCollection>(
-                    ref addResults, ref addDiagnosticInfos, batchAddResults, batchAddDiagnosticInfos);
+                    ref addResults, ref addDiagnosticInfos, ref stringTable, batchAddResults, batchAddDiagnosticInfos, response.ResponseHeader.StringTable);
 
                 AddResponses<StatusCode, StatusCodeCollection>(
-                    ref removeResults, ref removeDiagnosticInfos, batchRemoveResults, batchRemoveDiagnosticInfos);
+                    ref removeResults, ref removeDiagnosticInfos, ref stringTable, batchRemoveResults, batchRemoveDiagnosticInfos, response.ResponseHeader.StringTable);
             }
 
             if (linksToRemove.Count > 0)
@@ -1638,10 +1668,10 @@ namespace Opc.Ua
                     ClientBase.ValidateDiagnosticInfos(batchRemoveDiagnosticInfos, batchLinksToRemove);
 
                     AddResponses<StatusCode, StatusCodeCollection>(
-                        ref addResults, ref addDiagnosticInfos, batchAddResults, batchAddDiagnosticInfos);
+                        ref addResults, ref addDiagnosticInfos, ref stringTable, batchAddResults, batchAddDiagnosticInfos, response.ResponseHeader.StringTable);
 
                     AddResponses<StatusCode, StatusCodeCollection>(
-                        ref removeResults, ref removeDiagnosticInfos, batchRemoveResults, batchRemoveDiagnosticInfos);
+                        ref removeResults, ref removeDiagnosticInfos, ref stringTable, batchRemoveResults, batchRemoveDiagnosticInfos, response.ResponseHeader.StringTable);
                 }
             }
 
@@ -1649,6 +1679,7 @@ namespace Opc.Ua
             response.AddDiagnosticInfos = addDiagnosticInfos;
             response.RemoveResults = removeResults;
             response.RemoveDiagnosticInfos = removeDiagnosticInfos;
+            response.ResponseHeader.StringTable = stringTable;
 
             return response;
         }
@@ -1668,7 +1699,7 @@ namespace Opc.Ua
 
             uint operationLimit = OperationLimits.MaxMonitoredItemsPerCall;
             InitResponseCollections<StatusCode, StatusCodeCollection>(
-                out results, out diagnosticInfos,
+                out results, out diagnosticInfos, out var stringTable,
                 monitoredItemIds.Count, operationLimit
                 );
 
@@ -1690,9 +1721,10 @@ namespace Opc.Ua
                 ClientBase.ValidateDiagnosticInfos(batchDiagnosticInfos, batchMonitoredItemIds);
 
                 AddResponses<StatusCode, StatusCodeCollection>(
-                    ref results, ref diagnosticInfos, batchResults, batchDiagnosticInfos);
+                    ref results, ref diagnosticInfos, ref stringTable, batchResults, batchDiagnosticInfos, responseHeader.StringTable);
             }
 
+            responseHeader.StringTable = stringTable;
             return responseHeader;
         }
 
@@ -1708,7 +1740,7 @@ namespace Opc.Ua
 
             uint operationLimit = OperationLimits.MaxMonitoredItemsPerCall;
             InitResponseCollections<StatusCode, StatusCodeCollection>(
-                out var results, out var diagnosticInfos,
+                out var results, out var diagnosticInfos, out var stringTable,
                 monitoredItemIds.Count, operationLimit
                 );
 
@@ -1732,11 +1764,12 @@ namespace Opc.Ua
                 ClientBase.ValidateDiagnosticInfos(batchDiagnosticInfos, batchMonitoredItemIds);
 
                 AddResponses<StatusCode, StatusCodeCollection>(
-                    ref results, ref diagnosticInfos, batchResults, batchDiagnosticInfos);
+                    ref results, ref diagnosticInfos, ref stringTable, batchResults, batchDiagnosticInfos, response.ResponseHeader.StringTable);
             }
 
             response.Results = results;
             response.DiagnosticInfos = diagnosticInfos;
+            response.ResponseHeader.StringTable = stringTable;
 
             return response;
         }
@@ -1754,18 +1787,23 @@ namespace Opc.Ua
         private static void InitResponseCollections<T, C>(
             out C results,
             out DiagnosticInfoCollection diagnosticInfos,
+            out StringCollection stringTable,
             int count,
             uint operationLimit) where C : List<T>, new()
         {
-            results = null;
-            diagnosticInfos = null;
-
-            if (count > operationLimit)
+            if (count <= operationLimit)
+            {
+                results = null;
+                diagnosticInfos = null;
+                stringTable = null;
+            }
+            else
             {
                 results = new C() {
                     Capacity = count
                 };
                 diagnosticInfos = new DiagnosticInfoCollection(count);
+                stringTable = new StringCollection();
             }
         }
 
@@ -1776,17 +1814,21 @@ namespace Opc.Ua
         /// Assigns the batched collection result to the result if the result
         /// collection is not initialized, adds the range to the result
         /// collections otherwise.
+        /// The string table indexes are updated in the diagnostic infos if necessary.
         /// </remarks>
         private static void AddResponses<T, C>(
             ref C results,
             ref DiagnosticInfoCollection diagnosticInfos,
+            ref StringCollection stringTable,
             C batchedResults,
-            DiagnosticInfoCollection batchedDiagnosticInfos) where C : List<T>
+            DiagnosticInfoCollection batchedDiagnosticInfos,
+            StringCollection batchedStringTable) where C : List<T>
         {
             if (results == null)
             {
                 results = batchedResults;
                 diagnosticInfos = batchedDiagnosticInfos;
+                stringTable = batchedStringTable;
             }
             else
             {
@@ -1804,14 +1846,52 @@ namespace Opc.Ua
                 }
                 if (correctionCount > 0)
                 {
-                    // fill missing diagnostics infos with empty ones
+                    // fill missing diagnostics infos with null entries
                     for (int i = 0; i < correctionCount; i++)
                     {
-                        diagnosticInfos.Add(new DiagnosticInfo());
+                        diagnosticInfos.Add(null);
+                    }
+                }
+                else if (batchedStringTable.Count > 0)
+                {
+                    // correct indexes in the string table
+                    int stringTableOffset = stringTable.Count;
+                    foreach (DiagnosticInfo diagnosticInfo in batchedDiagnosticInfos)
+                    {
+                        UpdateDiagnosticInfoIndexes(diagnosticInfo, stringTableOffset);
                     }
                 }
                 results.AddRange(batchedResults);
                 diagnosticInfos.AddRange(batchedDiagnosticInfos);
+                stringTable.AddRange(batchedStringTable);
+            }
+        }
+
+        private static void UpdateDiagnosticInfoIndexes(
+            DiagnosticInfo diagnosticInfo,
+            int stringTableOffset)
+        {
+            const int MaxDepth = 10;
+            int depth = 0;
+            while (diagnosticInfo != null && depth++ < MaxDepth)
+            {
+                if (diagnosticInfo.LocalizedText >= 0)
+                {
+                    diagnosticInfo.LocalizedText += stringTableOffset;
+                }
+                if (diagnosticInfo.Locale >= 0)
+                {
+                    diagnosticInfo.Locale += stringTableOffset;
+                }
+                if (diagnosticInfo.NamespaceUri >= 0)
+                {
+                    diagnosticInfo.NamespaceUri += stringTableOffset;
+                }
+                if (diagnosticInfo.SymbolicId >= 0)
+                {
+                    diagnosticInfo.SymbolicId += stringTableOffset;
+                }
+                diagnosticInfo = diagnosticInfo.InnerDiagnosticInfo;
             }
         }
         #endregion

--- a/Libraries/Opc.Ua.Configuration/IApplicationConfigurationBuilder.cs
+++ b/Libraries/Opc.Ua.Configuration/IApplicationConfigurationBuilder.cs
@@ -405,9 +405,7 @@ namespace Opc.Ua.Configuration
     /// Add security options to the configuration.
     /// </summary>
     public interface IApplicationConfigurationBuilderSecurityOptionStores :
-        IApplicationConfigurationBuilderTraceConfiguration,
-        IApplicationConfigurationBuilderExtension,
-        IApplicationConfigurationBuilderCreate
+        IApplicationConfigurationBuilderSecurityOptions
     {
         /// <summary>
         /// Add the security configuration for the user certificate issuer and trusted stores.

--- a/Stack/Opc.Ua.Core/Types/BuiltIn/DiagnosticInfo.cs
+++ b/Stack/Opc.Ua.Core/Types/BuiltIn/DiagnosticInfo.cs
@@ -330,6 +330,27 @@ namespace Opc.Ua
             get { return m_innerDiagnosticInfo; }
             set { m_innerDiagnosticInfo = value; }
         }
+
+        /// <summary>
+        /// Whether the object represents a Null DiagnosticInfo.
+        /// </summary>
+        public bool IsNullDiagnosticInfo
+        {
+            get
+            {
+                if (m_symbolicId == -1 &&
+                    m_locale == -1 &&
+                    m_localizedText == -1 &&
+                    m_namespaceUri == -1 &&
+                    m_additionalInfo == null &&
+                    m_innerDiagnosticInfo == null &&
+                    m_innerStatusCode == StatusCodes.Good)
+                {
+                    return true;
+                }
+                return false;
+            }
+        }
         #endregion
 
         #region Overridden Methods
@@ -339,6 +360,11 @@ namespace Opc.Ua
         public override bool Equals(object obj)
         {
             if (Object.ReferenceEquals(this, obj))
+            {
+                return true;
+            }
+
+            if (obj == null && IsNullDiagnosticInfo)
             {
                 return true;
             }

--- a/Stack/Opc.Ua.Core/Types/BuiltIn/DiagnosticInfo.cs
+++ b/Stack/Opc.Ua.Core/Types/BuiltIn/DiagnosticInfo.cs
@@ -36,9 +36,6 @@ namespace Opc.Ua
         /// <summary>
         /// Initializes the object with default values.
         /// </summary>
-        /// <remarks>
-        /// Initializes the object with default values.
-        /// </remarks>
         public DiagnosticInfo()
         {
             Initialize();
@@ -72,9 +69,6 @@ namespace Opc.Ua
         /// <summary>
         /// Initializes the object with specific values.
         /// </summary>
-        /// <remarks>
-        /// Initializes the object with specific values.
-        /// </remarks>
         /// <param name="symbolicId">The symbolic ID</param>
         /// <param name="namespaceUri">The namespace URI applicable</param>
         /// <param name="locale">The locale for the localized text value</param>
@@ -97,9 +91,6 @@ namespace Opc.Ua
         /// <summary>
         /// Initializes the object with an exception.
         /// </summary>
-        /// <remarks>
-        /// Initializes the object with an exception.
-        /// </remarks>
         /// <param name="diagnosticsMask">The bitmask describing the diagnostic data</param>
         /// <param name="result">The overall transaction result</param>
         /// <param name="serviceLevel">The service level</param>
@@ -125,9 +116,6 @@ namespace Opc.Ua
         /// <summary>
         /// Initializes the object with an exception.
         /// </summary>
-        /// <remarks>
-        /// Initializes the object with an exception.
-        /// </remarks>
         /// <param name="diagnosticsMask">A bitmask describing the type of diagnostic data</param>
         /// <param name="exception">The exception to associated with the diagnostic data</param>
         /// <param name="serviceLevel">The service level</param>
@@ -153,9 +141,6 @@ namespace Opc.Ua
         /// <summary>
         /// Initializes the object during deserialization.
         /// </summary>
-        /// <remarks>
-        /// Initializes the object during deserialization.
-        /// </remarks>
         /// <param name="context">The context information of an underlying data-stream</param>
         [OnDeserializing()]
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "context")]
@@ -184,9 +169,6 @@ namespace Opc.Ua
         /// <summary>
         /// Initializes the object with a service result.
         /// </summary>
-        /// <remarks>
-        /// Initializes the object with a service result.
-        /// </remarks>
         /// <param name="diagnosticsMask">The bitmask describing the type of diagnostic data</param>
         /// <param name="result">The transaction result</param>
         /// <param name="stringTable">An array of strings that may be used to provide additional diagnostic details</param>
@@ -197,13 +179,7 @@ namespace Opc.Ua
         {
             if (stringTable == null) throw new ArgumentNullException(nameof(stringTable));
 
-            m_symbolicId = -1;
-            m_namespaceUri = -1;
-            m_locale = -1;
-            m_localizedText = -1;
-            m_additionalInfo = null;
-            m_innerStatusCode = StatusCodes.Good;
-            m_innerDiagnosticInfo = null;
+            Initialize();
 
             if ((DiagnosticsMasks.ServiceSymbolicId & diagnosticsMask) != 0)
             {
@@ -288,9 +264,6 @@ namespace Opc.Ua
         /// <summary>
         /// The index of the symbolic id in the string table.
         /// </summary>
-        /// <remarks>
-        /// The index of the symbolic id in the string table.
-        /// </remarks>
         [DataMember(Order = 1, IsRequired = false)]
         public int SymbolicId
         {
@@ -301,9 +274,6 @@ namespace Opc.Ua
         /// <summary>
         /// The index of the namespace uri in the string table.
         /// </summary>
-        /// <remarks>
-        /// The index of the namespace uri in the string table.
-        /// </remarks>
         [DataMember(Order = 2, IsRequired = false)]
         public int NamespaceUri
         {
@@ -334,9 +304,6 @@ namespace Opc.Ua
         /// <summary>
         /// The additional debugging or trace information.
         /// </summary>
-        /// <remarks>
-        /// The additional debugging or trace information.
-        /// </remarks>
         [DataMember(Order = 5, IsRequired = false, EmitDefaultValue = false)]
         public string AdditionalInfo
         {
@@ -347,9 +314,6 @@ namespace Opc.Ua
         /// <summary>
         /// The status code returned from an underlying system.
         /// </summary>
-        /// <remarks>
-        /// The status code returned from an underlying system.
-        /// </remarks>
         [DataMember(Order = 6, IsRequired = false)]
         public StatusCode InnerStatusCode
         {
@@ -360,9 +324,6 @@ namespace Opc.Ua
         /// <summary>
         /// The diagnostic info returned from a underlying system.
         /// </summary>
-        /// <remarks>
-        /// The diagnostic info returned from a underlying system.
-        /// </remarks>
         [DataMember(Order = 7, IsRequired = false, EmitDefaultValue = false)]
         public DiagnosticInfo InnerDiagnosticInfo
         {
@@ -375,9 +336,6 @@ namespace Opc.Ua
         /// <summary>
         /// Determines if the specified object is equal to the object.
         /// </summary>
-        /// <remarks>
-        /// Determines if the specified object is equal to the object.
-        /// </remarks>
         public override bool Equals(object obj)
         {
             if (Object.ReferenceEquals(this, obj))
@@ -389,6 +347,7 @@ namespace Opc.Ua
 
             if (value != null)
             {
+
                 if (this.m_symbolicId != value.m_symbolicId)
                 {
                     return false;
@@ -499,9 +458,6 @@ namespace Opc.Ua
         /// <summary>
         /// Makes a deep copy of the object.
         /// </summary>
-        /// <remarks>
-        /// Makes a deep copy of this object.
-        /// </remarks>
         public new object MemberwiseClone()
         {
             return new DiagnosticInfo(this);
@@ -609,6 +565,7 @@ namespace Opc.Ua
             return clone;
         }
         #endregion
+
     }//class
     #endregion
 

--- a/Stack/Opc.Ua.Core/Types/Encoders/BinaryDecoder.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/BinaryDecoder.cs
@@ -611,6 +611,13 @@ namespace Opc.Ua
             // read the encoding byte.
             byte encodingByte = m_reader.ReadByte();
 
+            // check if the diagnostic info is null.
+            if (encodingByte == 0)
+            {
+                m_nestingLevel--;
+                return null;// DiagnosticInfo.Default;
+            }
+
             DiagnosticInfo value = new DiagnosticInfo();
 
             // read the fields of the diagnostic info structure.
@@ -1914,6 +1921,7 @@ namespace Opc.Ua
                     array = values;
                     break;
                 }
+
                 case BuiltInType.DiagnosticInfo:
                 {
                     DiagnosticInfo[] values = new DiagnosticInfo[length];

--- a/Stack/Opc.Ua.Core/Types/Encoders/BinaryDecoder.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/BinaryDecoder.cs
@@ -615,7 +615,7 @@ namespace Opc.Ua
             if (encodingByte == 0)
             {
                 m_nestingLevel--;
-                return null;// DiagnosticInfo.Default;
+                return null;
             }
 
             DiagnosticInfo value = new DiagnosticInfo();

--- a/Stack/Opc.Ua.Core/Types/Encoders/JsonDecoder.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/JsonDecoder.cs
@@ -1099,42 +1099,50 @@ namespace Opc.Ua
 
                 DiagnosticInfo di = new DiagnosticInfo();
 
+                bool hasDiagnosticInfo = false;
                 if (value.ContainsKey("SymbolicId"))
                 {
                     di.SymbolicId = ReadInt32("SymbolicId");
+                    hasDiagnosticInfo = true;
                 }
 
                 if (value.ContainsKey("NamespaceUri"))
                 {
                     di.NamespaceUri = ReadInt32("NamespaceUri");
+                    hasDiagnosticInfo = true;
                 }
 
                 if (value.ContainsKey("Locale"))
                 {
                     di.Locale = ReadInt32("Locale");
+                    hasDiagnosticInfo = true;
                 }
 
                 if (value.ContainsKey("LocalizedText"))
                 {
                     di.LocalizedText = ReadInt32("LocalizedText");
+                    hasDiagnosticInfo = true;
                 }
 
                 if (value.ContainsKey("AdditionalInfo"))
                 {
                     di.AdditionalInfo = ReadString("AdditionalInfo");
+                    hasDiagnosticInfo = true;
                 }
 
                 if (value.ContainsKey("InnerStatusCode"))
                 {
                     di.InnerStatusCode = ReadStatusCode("InnerStatusCode");
+                    hasDiagnosticInfo = true;
                 }
 
                 if (value.ContainsKey("InnerDiagnosticInfo"))
                 {
                     di.InnerDiagnosticInfo = ReadDiagnosticInfo("InnerDiagnosticInfo");
+                    hasDiagnosticInfo = true;
                 }
 
-                return di;
+                return hasDiagnosticInfo ? di : null;
             }
             finally
             {

--- a/Stack/Opc.Ua.Core/Types/Encoders/XmlDecoder.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/XmlDecoder.cs
@@ -1196,43 +1196,50 @@ namespace Opc.Ua
             m_nestingLevel++;
 
             DiagnosticInfo value = new DiagnosticInfo();
-
+            bool hasDiagnosticInfo = false;
             if (BeginField("SymbolicId", true))
             {
                 value.SymbolicId = ReadInt32(null);
                 EndField("SymbolicId");
+                hasDiagnosticInfo = true;
             }
 
             if (BeginField("NamespaceUri", true))
             {
                 value.NamespaceUri = ReadInt32(null);
                 EndField("NamespaceUri");
+                hasDiagnosticInfo = true;
             }
 
             if (BeginField("Locale", true))
             {
                 value.Locale = ReadInt32(null);
                 EndField("Locale");
+                hasDiagnosticInfo = true;
             }
 
             if (BeginField("LocalizedText", true))
             {
                 value.LocalizedText = ReadInt32(null);
                 EndField("LocalizedText");
+                hasDiagnosticInfo = true;
             }
 
             value.AdditionalInfo = ReadString("AdditionalInfo");
             value.InnerStatusCode = ReadStatusCode("InnerStatusCode");
 
+            hasDiagnosticInfo = hasDiagnosticInfo || value.AdditionalInfo != null || value.InnerStatusCode != StatusCodes.Good;
+
             if (BeginField("InnerDiagnosticInfo", true))
             {
                 value.InnerDiagnosticInfo = ReadDiagnosticInfo();
                 EndField("InnerDiagnosticInfo");
+                hasDiagnosticInfo = true;
             }
 
             m_nestingLevel--;
 
-            return value;
+            return hasDiagnosticInfo ? value : null;
         }
 
         /// <summary>

--- a/Tests/Opc.Ua.Client.Tests/ClientTest.cs
+++ b/Tests/Opc.Ua.Client.Tests/ClientTest.cs
@@ -535,6 +535,8 @@ namespace Opc.Ua.Client.Tests
                 var dataValue = Session.ReadValue(nodeId);
                 Assert.NotNull(dataValue);
                 Assert.NotNull(dataValue.Value);
+                Assert.AreNotEqual(DateTime.MinValue, dataValue.SourceTimestamp);
+                Assert.AreNotEqual(DateTime.MinValue, dataValue.ServerTimestamp);
             }
         }
 
@@ -543,7 +545,7 @@ namespace Opc.Ua.Client.Tests
         {
             var namespaceUris = Session.NamespaceUris;
             var testSet = new NodeIdCollection(GetTestSetStatic(namespaceUris));
-            testSet.AddRange(GetTestSetSimulation(namespaceUris));
+            testSet.AddRange(GetTestSetFullSimulation(namespaceUris));
             Session.ReadValues(testSet, out DataValueCollection values, out IList<ServiceResult> errors);
             Assert.AreEqual(testSet.Count, values.Count);
             Assert.AreEqual(testSet.Count, errors.Count);
@@ -554,7 +556,7 @@ namespace Opc.Ua.Client.Tests
         {
             var namespaceUris = Session.NamespaceUris;
             var testSet = GetTestSetStatic(namespaceUris).ToList();
-            testSet.AddRange(GetTestSetSimulation(namespaceUris));
+            testSet.AddRange(GetTestSetFullSimulation(namespaceUris));
             DataValueCollection values;
             IList<ServiceResult> errors;
             (values, errors) = await Session.ReadValuesAsync(new NodeIdCollection(testSet)).ConfigureAwait(false);

--- a/Tests/Opc.Ua.Client.Tests/ClientTestFramework.cs
+++ b/Tests/Opc.Ua.Client.Tests/ClientTestFramework.cs
@@ -72,12 +72,13 @@ namespace Opc.Ua.Client.Tests
         public Uri ServerUrl { get; private set; }
         public ExpandedNodeId[] TestSetStatic { get; private set; }
         public ExpandedNodeId[] TestSetSimulation { get; private set; }
-
+        public ExpandedNodeId[] TestSetHistory { get; private set; }
         public ClientTestFramework(string uriScheme = Utils.UriSchemeOpcTcp)
         {
             UriScheme = uriScheme;
             TestSetStatic = CommonTestWorkers.NodeIdTestSetStatic;
             TestSetSimulation = CommonTestWorkers.NodeIdTestSetSimulation;
+            TestSetHistory = CommonTestWorkers.NodeIdTestDataHistory;
         }
 
         #region DataPointSources
@@ -259,6 +260,16 @@ namespace Opc.Ua.Client.Tests
         public IList<NodeId> GetTestSetSimulation(NamespaceTable namespaceUris)
         {
             return TestSetSimulation.Select(n => ExpandedNodeId.ToNodeId(n, namespaceUris)).Where(n => n != null).ToList();
+        }
+
+        /// <summary>
+        /// Return a test set of nodes with history values.
+        /// </summary>
+        /// <param name="namespaceUris">The namesapce table used in the session.</param>
+        /// <returns>The list of test nodes.</returns>
+        public IList<NodeId> GetTestSetHistory(NamespaceTable namespaceUris)
+        {
+            return TestSetHistory.Select(n => ExpandedNodeId.ToNodeId(n, namespaceUris)).Where(n => n != null).ToList();
         }
         #endregion
 

--- a/Tests/Opc.Ua.Client.Tests/ClientTestFramework.cs
+++ b/Tests/Opc.Ua.Client.Tests/ClientTestFramework.cs
@@ -72,12 +72,14 @@ namespace Opc.Ua.Client.Tests
         public Uri ServerUrl { get; private set; }
         public ExpandedNodeId[] TestSetStatic { get; private set; }
         public ExpandedNodeId[] TestSetSimulation { get; private set; }
+        public ExpandedNodeId[] TestSetDataSimulation { get; private set; }
         public ExpandedNodeId[] TestSetHistory { get; private set; }
         public ClientTestFramework(string uriScheme = Utils.UriSchemeOpcTcp)
         {
             UriScheme = uriScheme;
             TestSetStatic = CommonTestWorkers.NodeIdTestSetStatic;
             TestSetSimulation = CommonTestWorkers.NodeIdTestSetSimulation;
+            TestSetDataSimulation = CommonTestWorkers.NodeIdTestSetDataSimulation;
             TestSetHistory = CommonTestWorkers.NodeIdTestDataHistory;
         }
 
@@ -260,6 +262,28 @@ namespace Opc.Ua.Client.Tests
         public IList<NodeId> GetTestSetSimulation(NamespaceTable namespaceUris)
         {
             return TestSetSimulation.Select(n => ExpandedNodeId.ToNodeId(n, namespaceUris)).Where(n => n != null).ToList();
+        }
+
+        /// <summary>
+        /// Return a test set of nodes all nodes with simulated values.
+        /// </summary>
+        /// <param name="namespaceUris">The namesapce table used in the session.</param>
+        /// <returns>The list of simulated test nodes.</returns>
+        public IList<NodeId> GetTestSetFullSimulation(NamespaceTable namespaceUris)
+        {
+            var simulation = TestSetSimulation.Select(n => ExpandedNodeId.ToNodeId(n, namespaceUris)).Where(n => n != null).ToList();
+            simulation.AddRange(TestSetDataSimulation.Select(n => ExpandedNodeId.ToNodeId(n, namespaceUris)).Where(n => n != null));
+            return simulation;
+        }
+
+        /// <summary>
+        /// Return a test data set of nodes with simulated values.
+        /// </summary>
+        /// <param name="namespaceUris">The namesapce table used in the session.</param>
+        /// <returns>The list of simulated test nodes.</returns>
+        public IList<NodeId> GetTestSetDataSimulation(NamespaceTable namespaceUris)
+        {
+            return TestSetDataSimulation.Select(n => ExpandedNodeId.ToNodeId(n, namespaceUris)).Where(n => n != null).ToList();
         }
 
         /// <summary>

--- a/Tests/Opc.Ua.Client.Tests/SessionClientBatchTest.cs
+++ b/Tests/Opc.Ua.Client.Tests/SessionClientBatchTest.cs
@@ -637,6 +637,13 @@ namespace Opc.Ua.Client.Tests
                     NodeId = nodeId
                 }));
 
+            // add a some real history nodes
+            testSet = GetTestSetHistory(Session.NamespaceUris);
+            nodesToRead.AddRange(
+                testSet.Select(nodeId => new HistoryReadValueId {
+                    NodeId = nodeId
+                }));
+
             var response = await Session.HistoryReadAsync(
                 null,
                 eventDetails ? ReadEventDetails() : ReadRawModifiedDetails(),

--- a/Tests/Opc.Ua.Client.Tests/SessionClientBatchTest.cs
+++ b/Tests/Opc.Ua.Client.Tests/SessionClientBatchTest.cs
@@ -62,7 +62,7 @@ namespace Opc.Ua.Client.Tests
         {
             SupportsExternalServerUrl = true;
             await base.OneTimeSetUp().ConfigureAwait(false);
-            if(Session is Session session)
+            if (Session is Session session)
             {
                 session.OperationLimits = null;
                 session.OperationLimits = new OperationLimits() {
@@ -160,7 +160,7 @@ namespace Opc.Ua.Client.Tests
                 Assert.AreEqual(diagnosticInfos.Count, diagnosticInfos.Count);
             });
 
-            Assert.AreEqual(StatusCodes.BadServiceUnsupported, sre.StatusCode);
+            Assert.AreEqual(StatusCodes.BadServiceUnsupported, sre.StatusCode, sre.ToString());
         }
 #endif
 
@@ -355,8 +355,8 @@ namespace Opc.Ua.Client.Tests
                     out BrowseResultCollection results,
                     out DiagnosticInfoCollection diagnosticInfos);
 
-                ServerFixtureUtils.ValidateResponse(responseHeader);
-                ServerFixtureUtils.ValidateDiagnosticInfos(diagnosticInfos, browseDescriptionCollection);
+                ServerFixtureUtils.ValidateResponse(responseHeader, results, browseDescriptionCollection);
+                ServerFixtureUtils.ValidateDiagnosticInfos(diagnosticInfos, browseDescriptionCollection, responseHeader.StringTable);
 
                 allResults.AddRange(results);
 
@@ -366,8 +366,8 @@ namespace Opc.Ua.Client.Tests
                     TestContext.Out.WriteLine("BrowseNext {0} Nodes...", continuationPoints.Count);
                     responseHeader = Session.BrowseNext(requestHeader, false, continuationPoints,
                         out var browseNextResultCollection, out diagnosticInfos);
-                    ServerFixtureUtils.ValidateResponse(responseHeader);
-                    ServerFixtureUtils.ValidateDiagnosticInfos(diagnosticInfos, continuationPoints);
+                    ServerFixtureUtils.ValidateResponse(responseHeader, browseNextResultCollection, continuationPoints);
+                    ServerFixtureUtils.ValidateDiagnosticInfos(diagnosticInfos, continuationPoints, responseHeader.StringTable);
                     allResults.AddRange(browseNextResultCollection);
                     continuationPoints = ServerFixtureUtils.PrepareBrowseNext(browseNextResultCollection);
                 }
@@ -472,8 +472,8 @@ namespace Opc.Ua.Client.Tests
                     var nextResponse = await Session.BrowseNextAsync(requestHeader, false, continuationPoints, CancellationToken.None).ConfigureAwait(false);
                     BrowseResultCollection browseNextResultCollection = nextResponse.Results;
                     diagnosticInfos = nextResponse.DiagnosticInfos;
-                    ServerFixtureUtils.ValidateResponse(response.ResponseHeader);
-                    ServerFixtureUtils.ValidateDiagnosticInfos(diagnosticInfos, continuationPoints);
+                    ServerFixtureUtils.ValidateResponse(response.ResponseHeader, nextResponse.Results, continuationPoints);
+                    ServerFixtureUtils.ValidateDiagnosticInfos(diagnosticInfos, continuationPoints, nextResponse.ResponseHeader.StringTable);
                     allResults.AddRange(browseNextResultCollection);
                     continuationPoints = ServerFixtureUtils.PrepareBrowseNext(browseNextResultCollection);
                 }
@@ -559,8 +559,8 @@ namespace Opc.Ua.Client.Tests
                     out BrowsePathResultCollection results,
                     out DiagnosticInfoCollection diagnosticInfos);
 
-            ClientBase.ValidateResponse(results, browsePaths);
-            ClientBase.ValidateDiagnosticInfos(diagnosticInfos, browsePaths);
+            ServerFixtureUtils.ValidateResponse(responseHeader, results, browsePaths);
+            ServerFixtureUtils.ValidateDiagnosticInfos(diagnosticInfos, browsePaths, responseHeader.StringTable);
             Assert.NotNull(responseHeader);
         }
 
@@ -585,8 +585,8 @@ namespace Opc.Ua.Client.Tests
             BrowsePathResultCollection results = response.Results;
             DiagnosticInfoCollection diagnosticInfos = response.DiagnosticInfos;
 
-            ClientBase.ValidateResponse(results, browsePaths);
-            ClientBase.ValidateDiagnosticInfos(diagnosticInfos, browsePaths);
+            ServerFixtureUtils.ValidateResponse(response.ResponseHeader, results, browsePaths);
+            ServerFixtureUtils.ValidateDiagnosticInfos(diagnosticInfos, browsePaths, response.ResponseHeader.StringTable);
             Assert.NotNull(response.ResponseHeader);
         }
 #endif
@@ -597,12 +597,22 @@ namespace Opc.Ua.Client.Tests
             HistoryReadResultCollection results = null;
             DiagnosticInfoCollection diagnosticInfos = null;
 
-            // there are no historizing nodes, but create some real ones
+            // create a mix of historizing and dynamic nodes
             var testSet = GetTestSetSimulation(Session.NamespaceUris);
             HistoryReadValueIdCollection nodesToRead = new HistoryReadValueIdCollection(
                 testSet.Select(nodeId => new HistoryReadValueId {
                     NodeId = nodeId
                 }));
+
+            // add a some real history nodes
+            testSet = GetTestSetHistory(Session.NamespaceUris);
+            nodesToRead.AddRange(
+                testSet.Select(nodeId => new HistoryReadValueId {
+                    NodeId = nodeId
+                }));
+
+            // add the server object for events
+            nodesToRead.Add(new HistoryReadValueId { NodeId = ObjectIds.Server });
 
             var responseHeader = Session.HistoryRead(
                 null,
@@ -613,8 +623,8 @@ namespace Opc.Ua.Client.Tests
                 out results,
                 out diagnosticInfos);
 
-            ClientBase.ValidateResponse(results, nodesToRead);
-            ClientBase.ValidateDiagnosticInfos(diagnosticInfos, nodesToRead);
+            ServerFixtureUtils.ValidateResponse(responseHeader, results, nodesToRead);
+            ServerFixtureUtils.ValidateDiagnosticInfos(diagnosticInfos, nodesToRead, responseHeader.StringTable);
         }
 
         [Theory]
@@ -634,8 +644,8 @@ namespace Opc.Ua.Client.Tests
                 false,
                 nodesToRead, CancellationToken.None).ConfigureAwait(false);
 
-            ClientBase.ValidateResponse(response.Results, nodesToRead);
-            ClientBase.ValidateDiagnosticInfos(response.DiagnosticInfos, nodesToRead);
+            ServerFixtureUtils.ValidateResponse(response.ResponseHeader, response.Results, nodesToRead);
+            ServerFixtureUtils.ValidateDiagnosticInfos(response.DiagnosticInfos, nodesToRead, response.ResponseHeader.StringTable);
         }
 
         [Theory]
@@ -674,8 +684,8 @@ namespace Opc.Ua.Client.Tests
                 out results,
                 out diagnosticInfos);
 
-            ClientBase.ValidateResponse(results, historyUpdateDetails);
-            ClientBase.ValidateDiagnosticInfos(diagnosticInfos, historyUpdateDetails);
+            ServerFixtureUtils.ValidateResponse(responseHeader, results, historyUpdateDetails);
+            ServerFixtureUtils.ValidateDiagnosticInfos(diagnosticInfos, historyUpdateDetails, responseHeader.StringTable);
         }
 
         [Theory]
@@ -710,8 +720,8 @@ namespace Opc.Ua.Client.Tests
                 historyUpdateDetails,
                 CancellationToken.None).ConfigureAwait(false);
 
-            ClientBase.ValidateResponse(response.Results, historyUpdateDetails);
-            ClientBase.ValidateDiagnosticInfos(response.DiagnosticInfos, historyUpdateDetails);
+            ServerFixtureUtils.ValidateResponse(response.ResponseHeader, response.Results, historyUpdateDetails);
+            ServerFixtureUtils.ValidateDiagnosticInfos(response.DiagnosticInfos, historyUpdateDetails, response.ResponseHeader.StringTable);
         }
         #endregion
 
@@ -734,10 +744,28 @@ namespace Opc.Ua.Client.Tests
         {
             ReadEventDetails details = new ReadEventDetails {
                 NumValuesPerNode = 10,
+                Filter = DefaultEventFilter(),
                 StartTime = DateTime.UtcNow.AddSeconds(30),
                 EndTime = DateTime.UtcNow.AddHours(-1),
             };
             return new ExtensionObject(details);
+        }
+
+        private EventFilter DefaultEventFilter()
+        {
+            EventFilter filter = filter = new EventFilter();
+
+            filter.AddSelectClause(ObjectTypes.BaseEventType, BrowseNames.EventId);
+            filter.AddSelectClause(ObjectTypes.BaseEventType, BrowseNames.EventType);
+            filter.AddSelectClause(ObjectTypes.BaseEventType, BrowseNames.SourceNode);
+            filter.AddSelectClause(ObjectTypes.BaseEventType, BrowseNames.SourceName);
+            filter.AddSelectClause(ObjectTypes.BaseEventType, BrowseNames.Time);
+            filter.AddSelectClause(ObjectTypes.BaseEventType, BrowseNames.ReceiveTime);
+            filter.AddSelectClause(ObjectTypes.BaseEventType, BrowseNames.LocalTime);
+            filter.AddSelectClause(ObjectTypes.BaseEventType, BrowseNames.Message);
+            filter.AddSelectClause(ObjectTypes.BaseEventType, BrowseNames.Severity);
+
+            return filter;
         }
     }
     #endregion

--- a/Tests/Opc.Ua.Client.Tests/SubscriptionTest.cs
+++ b/Tests/Opc.Ua.Client.Tests/SubscriptionTest.cs
@@ -283,7 +283,7 @@ namespace Opc.Ua.Client.Tests
                 list.ForEach(i => i.Notification += (MonitoredItem item, MonitoredItemNotificationEventArgs e) => {
                     foreach (var value in item.DequeueValues())
                     {
-                        valueChanges++; 
+                        valueChanges++;
                         TestContext.Out.WriteLine("{0}: {1}, {2}, {3}", item.DisplayName, value.Value, value.SourceTimestamp, value.StatusCode);
                     }
                 });
@@ -308,6 +308,7 @@ namespace Opc.Ua.Client.Tests
         }
 
         [Theory, Order(300)]
+        [Timeout(30_000)]
         /// <remarks>
         /// This test doesn't deterministically prove sequential publishing,
         /// but rather relies on a subscription not being able to handle the message load.
@@ -415,6 +416,7 @@ namespace Opc.Ua.Client.Tests
         }
 
         [Test, Order(400)]
+        [Timeout(30_000)]
         public async Task PublishRequestCount()
         {
             var subscriptionList = new List<Subscription>();
@@ -439,9 +441,9 @@ namespace Opc.Ua.Client.Tests
                 };
 
                 subscriptionList.Add(subscription);
-                var simulatedNodes = GetTestSetSimulation(Session.NamespaceUris);
                 var list = new List<MonitoredItem>();
-                var nodeSet = simulatedNodes;
+                var nodeSet = GetTestSetFullSimulation(Session.NamespaceUris);
+
                 for (int ii = 0; ii < monitoredItemsPerSubscription; ii++)
                 {
                     var nextNode = nodeSet[ii % nodeSet.Count];
@@ -470,7 +472,7 @@ namespace Opc.Ua.Client.Tests
             while (stopwatch.ElapsedMilliseconds < testWaitTime)
             {
                 // use the sample server default for max publish request count
-                Assert.GreaterOrEqual(maxServerPublishRequest, Session.GoodPublishRequestCount);
+                Assert.GreaterOrEqual(Math.Max(maxServerPublishRequest, subscriptions), Session.GoodPublishRequestCount);
                 await Task.Delay(100).ConfigureAwait(false);
             }
 
@@ -510,7 +512,7 @@ namespace Opc.Ua.Client.Tests
         [Theory, Order(810)]
         public async Task TransferSubscription(TransferType transferType, bool sendInitialValues)
         {
-            const int kTestSubscriptions = 2;
+            const int kTestSubscriptions = 5;
             const int kDelay = 2_000;
             const int kQueueSize = 10;
 
@@ -550,7 +552,7 @@ namespace Opc.Ua.Client.Tests
                 }
                 else
                 {
-                    testSet.AddRange(GetTestSetSimulation(namespaceUris));
+                    testSet.AddRange(GetTestSetFullSimulation(namespaceUris));
                 }
 
                 subscription.Handle = ii;

--- a/Tests/Opc.Ua.Core.Tests/Types/BuiltIn/BuiltInTests.cs
+++ b/Tests/Opc.Ua.Core.Tests/Types/BuiltIn/BuiltInTests.cs
@@ -254,6 +254,9 @@ namespace Opc.Ua.Core.Tests.Types.BuiltIn
             Assert.AreEqual(null, diagnosticInfo.AdditionalInfo);
             Assert.AreEqual(ServiceResult.Good.StatusCode, diagnosticInfo.InnerStatusCode);
             Assert.AreEqual(null, diagnosticInfo.InnerDiagnosticInfo);
+
+            Assert.IsTrue(diagnosticInfo.Equals(null));
+            Assert.IsTrue(diagnosticInfo.IsNullDiagnosticInfo);
         }
 
         /// <summary>
@@ -317,54 +320,7 @@ namespace Opc.Ua.Core.Tests.Types.BuiltIn
             Assert.Throws<ArgumentException>(() => _ = new NodeId((object)(int)123, 123));
             Assert.Throws<ServiceResultException>(() => _ = NodeId.Create((uint)123, "urn:xyz", null));
             Assert.Throws<ServiceResultException>(() => _ = NodeId.Parse("ns="));
-            Assert.Throws<ServiceResultException>(() => _ = NodeId.Parse("nsu="));
             Assert.IsNull(NodeId.ToExpandedNodeId(null, null));
-        }
-
-        [Test]
-        public void NodeIdHashCode()
-        {
-            // ensure that the hash code is the same for the same node id
-            IList<NodeId> nodeIds = new List<NodeId>();
-
-            // Null NodeIds
-            nodeIds.Add(NodeId.Null);
-            nodeIds.Add(new NodeId(0));
-            nodeIds.Add(new NodeId(Guid.Empty));
-            nodeIds.Add(new NodeId(""));
-            nodeIds.Add(new NodeId(new byte[0]));
-
-            foreach (NodeId nodeId in nodeIds)
-            {
-                Assert.AreEqual(NodeId.Null.GetHashCode(), nodeId.GetHashCode(), $"NodeId={nodeId}");
-                Assert.IsTrue(nodeId.IsNullNodeId);
-            }
-
-            nodeIds.Insert(0, new NodeId(123));
-            nodeIds.Insert(0, new NodeId(123, 0));
-            Assert.AreEqual(nodeIds[0].GetHashCode(), nodeIds[1].GetHashCode());
-            Assert.AreEqual(nodeIds[0], nodeIds[1]);
-
-            nodeIds.Insert(0, new NodeId(123, 1));
-            Assert.AreNotEqual(nodeIds[0].GetHashCode(), nodeIds[1].GetHashCode());
-
-            nodeIds.Insert(0, new NodeId("Test"));
-            Assert.AreNotEqual(nodeIds[0].GetHashCode(), nodeIds[2].GetHashCode());
-
-            TestContext.Out.WriteLine("NodeIds:");
-            foreach (NodeId nodeId in nodeIds)
-            {
-                TestContext.Out.WriteLine($"NodeId={nodeId}, HashCode={nodeId.GetHashCode():x8}");
-            }
-
-            TestContext.Out.WriteLine("Distinct NodeIds:");
-            var distinctNodeIds = nodeIds.Distinct();
-            foreach (NodeId nodeId in distinctNodeIds)
-            {
-                TestContext.Out.WriteLine($"NodeId={nodeId}, HashCode={nodeId.GetHashCode():x8}");
-            }
-
-            Assert.AreEqual(4, distinctNodeIds.Count());
         }
 
         [Theory]

--- a/Tests/Opc.Ua.Server.Tests/CommonTestWorkers.cs
+++ b/Tests/Opc.Ua.Server.Tests/CommonTestWorkers.cs
@@ -66,6 +66,7 @@ namespace Opc.Ua.Server.Tests
             new ExpandedNodeId(TestData.Variables.Data_Static_Scalar_UInt32Value, TestData.Namespaces.TestData),
         };
 
+        // CTT simulation data
         public static readonly ExpandedNodeId[] NodeIdTestSetSimulation =
         {
             new ExpandedNodeId("Scalar_Simulation_SByte", Quickstarts.ReferenceServer.Namespaces.ReferenceServer),
@@ -80,8 +81,28 @@ namespace Opc.Ua.Server.Tests
             new ExpandedNodeId("Scalar_Simulation_Variant", Quickstarts.ReferenceServer.Namespaces.ReferenceServer),
         };
 
-        public static readonly ExpandedNodeId[] NodeIdMemoryBufferSimulation =
+        /// <summary>
+        /// Ref server test data node manager.
+        /// </summary>
+        public static readonly ExpandedNodeId[] NodeIdTestDataSetSimulation =
         {
+            new ExpandedNodeId(TestData.Variables.Data_Dynamic_Scalar_Int16Value, TestData.Namespaces.TestData),
+            new ExpandedNodeId(TestData.Variables.Data_Dynamic_Scalar_Int32Value, TestData.Namespaces.TestData),
+            new ExpandedNodeId(TestData.Variables.Data_Dynamic_Scalar_UInt16Value, TestData.Namespaces.TestData),
+            new ExpandedNodeId(TestData.Variables.Data_Dynamic_Scalar_UInt32Value, TestData.Namespaces.TestData),
+            new ExpandedNodeId(TestData.Variables.Data_Dynamic_AnalogArray_ByteValue, TestData.Namespaces.TestData),
+            new ExpandedNodeId(TestData.Variables.Data_Dynamic_Scalar_VectorValue, TestData.Namespaces.TestData),
+            new ExpandedNodeId(TestData.Variables.Data_Dynamic_Scalar_VectorValue_X, TestData.Namespaces.TestData),
+            new ExpandedNodeId(TestData.Variables.Data_Dynamic_Scalar_StructureValue, TestData.Namespaces.TestData),
+        };
+
+        public static readonly ExpandedNodeId[] NodeIdTestDataHistory =
+        {
+            new ExpandedNodeId(TestData.Variables.Data_Dynamic_Scalar_Int32Value, TestData.Namespaces.TestData),
+        };
+
+        public static readonly ExpandedNodeId[] NodeIdMemoryBufferSimulation =
+            {
             // dynamic variables from namespace MemoryBuffer
             new ExpandedNodeId("UInt32[64]", MemoryBuffer.Namespaces.MemoryBuffer + "/Instance"),
             new ExpandedNodeId("Double[40]", MemoryBuffer.Namespaces.MemoryBuffer + "/Instance"),
@@ -171,8 +192,8 @@ namespace Opc.Ua.Server.Tests
                         response = services.Browse(requestHeader, null,
                             requestedMaxReferencesPerNode, browseCollection,
                             out browseResultCollection, out diagnosticsInfoCollection);
-                        ServerFixtureUtils.ValidateResponse(response);
-                        ServerFixtureUtils.ValidateDiagnosticInfos(diagnosticsInfoCollection, browseCollection);
+                        ServerFixtureUtils.ValidateResponse(response, browseResultCollection, browseCollection);
+                        ServerFixtureUtils.ValidateDiagnosticInfos(diagnosticsInfoCollection, browseCollection, response.StringTable);
 
                         allResults.AddRange(browseResultCollection);
                     }
@@ -209,8 +230,8 @@ namespace Opc.Ua.Server.Tests
                     requestHeader.Timestamp = DateTime.UtcNow;
                     response = services.BrowseNext(requestHeader, false, continuationPoints,
                         out var browseNextResultCollection, out diagnosticsInfoCollection);
-                    ServerFixtureUtils.ValidateResponse(response);
-                    ServerFixtureUtils.ValidateDiagnosticInfos(diagnosticsInfoCollection, continuationPoints);
+                    ServerFixtureUtils.ValidateResponse(response, browseNextResultCollection, continuationPoints);
+                    ServerFixtureUtils.ValidateDiagnosticInfos(diagnosticsInfoCollection, continuationPoints, response.StringTable);
                     allResults.AddRange(browseNextResultCollection);
                     continuationPoints = ServerFixtureUtils.PrepareBrowseNext(browseNextResultCollection);
                 }
@@ -272,8 +293,8 @@ namespace Opc.Ua.Server.Tests
                     browsePaths.Take((int)operationLimits.MaxNodesPerTranslateBrowsePathsToNodeIds).ToArray() :
                     browsePaths;
                 ResponseHeader response = services.TranslateBrowsePathsToNodeIds(requestHeader, browsePathSnippet, out var browsePathResults, out var diagnosticInfos);
-                ServerFixtureUtils.ValidateResponse(response);
-                ServerFixtureUtils.ValidateDiagnosticInfos(diagnosticInfos, browsePathSnippet);
+                ServerFixtureUtils.ValidateResponse(response, browsePathResults, browsePathSnippet);
+                ServerFixtureUtils.ValidateDiagnosticInfos(diagnosticInfos, browsePathSnippet, response.StringTable);
                 allBrowsePaths.AddRange(browsePathResults);
                 foreach (var result in browsePathResults)
                 {
@@ -350,8 +371,8 @@ namespace Opc.Ua.Server.Tests
             });
             response = services.CreateMonitoredItems(requestHeader, id, TimestampsToReturn.Neither, itemsToCreate,
                 out MonitoredItemCreateResultCollection itemCreateResults, out DiagnosticInfoCollection diagnosticInfos);
-            ServerFixtureUtils.ValidateResponse(response);
-            ServerFixtureUtils.ValidateDiagnosticInfos(diagnosticInfos, itemsToCreate);
+            ServerFixtureUtils.ValidateResponse(response, itemCreateResults, itemsToCreate);
+            ServerFixtureUtils.ValidateDiagnosticInfos(diagnosticInfos, itemsToCreate, response.StringTable);
 
             // modify subscription
             response = services.ModifySubscription(requestHeader, id,
@@ -374,8 +395,8 @@ namespace Opc.Ua.Server.Tests
             };
             response = services.ModifyMonitoredItems(requestHeader, id, TimestampsToReturn.Both, itemsToModify,
                         out MonitoredItemModifyResultCollection modifyResults, out diagnosticInfos);
-            ServerFixtureUtils.ValidateResponse(response);
-            ServerFixtureUtils.ValidateDiagnosticInfos(diagnosticInfos, itemsToModify);
+            ServerFixtureUtils.ValidateResponse(response, modifyResults, itemsToModify);
+            ServerFixtureUtils.ValidateDiagnosticInfos(diagnosticInfos, itemsToModify, response.StringTable);
 
             // publish request
             var acknoledgements = new SubscriptionAcknowledgementCollection();
@@ -383,8 +404,8 @@ namespace Opc.Ua.Server.Tests
                         out uint subscriptionId, out UInt32Collection availableSequenceNumbers,
                         out bool moreNotifications, out NotificationMessage notificationMessage,
                         out StatusCodeCollection statuses, out diagnosticInfos);
-            ServerFixtureUtils.ValidateResponse(response);
-            ServerFixtureUtils.ValidateDiagnosticInfos(diagnosticInfos, acknoledgements);
+            ServerFixtureUtils.ValidateResponse(response, statuses, acknoledgements);
+            ServerFixtureUtils.ValidateDiagnosticInfos(diagnosticInfos, acknoledgements, response.StringTable);
             Assert.AreEqual(id, subscriptionId);
             Assert.AreEqual(0, availableSequenceNumbers.Count);
 
@@ -393,8 +414,8 @@ namespace Opc.Ua.Server.Tests
             var subscriptions = new UInt32Collection() { id };
             response = services.SetPublishingMode(requestHeader, enabled, subscriptions,
                         out statuses, out diagnosticInfos);
-            ServerFixtureUtils.ValidateResponse(response);
-            ServerFixtureUtils.ValidateDiagnosticInfos(diagnosticInfos, subscriptions);
+            ServerFixtureUtils.ValidateResponse(response, statuses, subscriptions);
+            ServerFixtureUtils.ValidateDiagnosticInfos(diagnosticInfos, subscriptions, response.StringTable);
 
             // wait some time to fill queue
             int loopCounter = (int)queueSize;
@@ -408,8 +429,8 @@ namespace Opc.Ua.Server.Tests
                     out subscriptionId, out availableSequenceNumbers,
                     out moreNotifications, out notificationMessage,
                     out statuses, out diagnosticInfos);
-                ServerFixtureUtils.ValidateResponse(response);
-                ServerFixtureUtils.ValidateDiagnosticInfos(diagnosticInfos, acknoledgements);
+                ServerFixtureUtils.ValidateResponse(response, statuses, acknoledgements);
+                ServerFixtureUtils.ValidateDiagnosticInfos(diagnosticInfos, acknoledgements, response.StringTable);
                 Assert.AreEqual(id, subscriptionId);
 
                 var dataChangeNotification = notificationMessage.NotificationData[0].Body as DataChangeNotification;
@@ -434,13 +455,13 @@ namespace Opc.Ua.Server.Tests
             enabled = false;
             response = services.SetPublishingMode(requestHeader, enabled, subscriptions,
                 out statuses, out diagnosticInfos);
-            ServerFixtureUtils.ValidateResponse(response);
-            ServerFixtureUtils.ValidateDiagnosticInfos(diagnosticInfos, subscriptions);
+            ServerFixtureUtils.ValidateResponse(response, statuses, subscriptions);
+            ServerFixtureUtils.ValidateDiagnosticInfos(diagnosticInfos, subscriptions, response.StringTable);
 
             // delete subscription
             response = services.DeleteSubscriptions(requestHeader, subscriptions, out statuses, out diagnosticInfos);
-            ServerFixtureUtils.ValidateResponse(response);
-            ServerFixtureUtils.ValidateDiagnosticInfos(diagnosticInfos, subscriptions);
+            ServerFixtureUtils.ValidateResponse(response, statuses, subscriptions);
+            ServerFixtureUtils.ValidateDiagnosticInfos(diagnosticInfos, subscriptions, response.StringTable);
         }
 
         /// <summary>
@@ -469,20 +490,23 @@ namespace Opc.Ua.Server.Tests
             // enable publishing
             var response = services.SetPublishingMode(requestHeader, true, subscriptionIds,
                         out var statuses, out var diagnosticInfos);
-            ServerFixtureUtils.ValidateResponse(response);
-            ServerFixtureUtils.ValidateDiagnosticInfos(diagnosticInfos, subscriptionIds);
+            ServerFixtureUtils.ValidateResponse(response, statuses, subscriptionIds);
+            ServerFixtureUtils.ValidateDiagnosticInfos(diagnosticInfos, subscriptionIds, response.StringTable);
 
             // wait some time to settle
             Thread.Sleep(1000);
 
-            // publish request
-            var acknoledgements = new SubscriptionAcknowledgementCollection();
+            // publish request (use invalid sequence number for status)
+            var acknoledgements = new SubscriptionAcknowledgementCollection() {
+                new SubscriptionAcknowledgement()
+                    { SubscriptionId = subscriptionId, SequenceNumber=123 }
+                };
             response = services.Publish(requestHeader, acknoledgements,
                 out uint publishedId, out UInt32Collection availableSequenceNumbers,
                 out bool moreNotifications, out NotificationMessage notificationMessage,
-                out StatusCodeCollection _, out diagnosticInfos);
-            ServerFixtureUtils.ValidateResponse(response);
-            ServerFixtureUtils.ValidateDiagnosticInfos(diagnosticInfos, acknoledgements);
+                out statuses, out diagnosticInfos);
+            ServerFixtureUtils.ValidateResponse(response, statuses, acknoledgements);
+            ServerFixtureUtils.ValidateDiagnosticInfos(diagnosticInfos, acknoledgements, response.StringTable);
             Assert.AreEqual(subscriptionId, publishedId);
 
             // static node, do not acknoledge
@@ -508,7 +532,8 @@ namespace Opc.Ua.Server.Tests
                 out TransferResultCollection transferResults, out DiagnosticInfoCollection diagnosticInfos);
             Assert.AreEqual(StatusCodes.Good, response.ServiceResult.Code);
             Assert.AreEqual(subscriptionIds.Count, transferResults.Count);
-            ServerFixtureUtils.ValidateDiagnosticInfos(diagnosticInfos, subscriptionIds);
+            ServerFixtureUtils.ValidateResponse(response, transferResults, subscriptionIds);
+            ServerFixtureUtils.ValidateDiagnosticInfos(diagnosticInfos, subscriptionIds, response.StringTable);
 
             foreach (var transferResult in transferResults)
             {
@@ -537,7 +562,7 @@ namespace Opc.Ua.Server.Tests
                 out StatusCodeCollection _, out diagnosticInfos);
             Assert.AreEqual(StatusCodes.Good, response.ServiceResult.Code);
             ServerFixtureUtils.ValidateResponse(response);
-            ServerFixtureUtils.ValidateDiagnosticInfos(diagnosticInfos, acknoledgements);
+            ServerFixtureUtils.ValidateDiagnosticInfos(diagnosticInfos, acknoledgements, response.StringTable);
             Assert.AreEqual(subscriptionIds[0], publishedId);
             Assert.AreEqual(sendInitialData ? 1 : 0, notificationMessage.NotificationData.Count);
             if (sendInitialData)
@@ -576,7 +601,7 @@ namespace Opc.Ua.Server.Tests
                 out bool moreNotifications, out NotificationMessage notificationMessage,
                 out StatusCodeCollection _, out var diagnosticInfos);
             ServerFixtureUtils.ValidateResponse(response);
-            ServerFixtureUtils.ValidateDiagnosticInfos(diagnosticInfos, acknoledgements);
+            ServerFixtureUtils.ValidateDiagnosticInfos(diagnosticInfos, acknoledgements, response.StringTable);
             Assert.IsFalse(moreNotifications);
             Assert.IsTrue(subscriptionIds.Contains(publishedId));
             Assert.AreEqual(1, notificationMessage.NotificationData.Count);
@@ -591,9 +616,9 @@ namespace Opc.Ua.Server.Tests
 
             if (deleteSubscriptions)
             {
-                response = services.DeleteSubscriptions(requestHeader, subscriptionIds, out var _, out diagnosticInfos);
-                ServerFixtureUtils.ValidateResponse(response);
-                ServerFixtureUtils.ValidateDiagnosticInfos(diagnosticInfos, subscriptionIds);
+                response = services.DeleteSubscriptions(requestHeader, subscriptionIds, out var statuses, out diagnosticInfos);
+                ServerFixtureUtils.ValidateResponse(response, statuses, subscriptionIds);
+                ServerFixtureUtils.ValidateDiagnosticInfos(diagnosticInfos, subscriptionIds, response.StringTable);
             }
         }
         #endregion
@@ -648,8 +673,8 @@ namespace Opc.Ua.Server.Tests
             };
             var response = services.CreateMonitoredItems(requestHeader, subscriptionId, TimestampsToReturn.Neither, itemsToCreate,
                 out MonitoredItemCreateResultCollection itemCreateResults, out DiagnosticInfoCollection diagnosticInfos);
-            ServerFixtureUtils.ValidateResponse(response);
-            ServerFixtureUtils.ValidateDiagnosticInfos(diagnosticInfos, itemsToCreate);
+            ServerFixtureUtils.ValidateResponse(response, itemCreateResults, itemsToCreate);
+            ServerFixtureUtils.ValidateDiagnosticInfos(diagnosticInfos, itemsToCreate, response.StringTable);
         }
         #endregion
 

--- a/Tests/Opc.Ua.Server.Tests/CommonTestWorkers.cs
+++ b/Tests/Opc.Ua.Server.Tests/CommonTestWorkers.cs
@@ -84,16 +84,17 @@ namespace Opc.Ua.Server.Tests
         /// <summary>
         /// Ref server test data node manager.
         /// </summary>
-        public static readonly ExpandedNodeId[] NodeIdTestDataSetSimulation =
+        public static readonly ExpandedNodeId[] NodeIdTestSetDataSimulation =
         {
             new ExpandedNodeId(TestData.Variables.Data_Dynamic_Scalar_Int16Value, TestData.Namespaces.TestData),
             new ExpandedNodeId(TestData.Variables.Data_Dynamic_Scalar_Int32Value, TestData.Namespaces.TestData),
             new ExpandedNodeId(TestData.Variables.Data_Dynamic_Scalar_UInt16Value, TestData.Namespaces.TestData),
             new ExpandedNodeId(TestData.Variables.Data_Dynamic_Scalar_UInt32Value, TestData.Namespaces.TestData),
+            new ExpandedNodeId(TestData.Variables.AnalogScalarValueObjectType_UInt32Value, TestData.Namespaces.TestData),
             new ExpandedNodeId(TestData.Variables.Data_Dynamic_AnalogArray_ByteValue, TestData.Namespaces.TestData),
             new ExpandedNodeId(TestData.Variables.Data_Dynamic_Scalar_VectorValue, TestData.Namespaces.TestData),
             new ExpandedNodeId(TestData.Variables.Data_Dynamic_Scalar_VectorValue_X, TestData.Namespaces.TestData),
-            new ExpandedNodeId(TestData.Variables.Data_Dynamic_Scalar_StructureValue, TestData.Namespaces.TestData),
+            new ExpandedNodeId(TestData.Variables.Data_Dynamic_Structure_ScalarStructure, TestData.Namespaces.TestData),
         };
 
         public static readonly ExpandedNodeId[] NodeIdTestDataHistory =

--- a/Tests/Opc.Ua.Server.Tests/ReferenceServerTest.cs
+++ b/Tests/Opc.Ua.Server.Tests/ReferenceServerTest.cs
@@ -184,8 +184,8 @@ namespace Opc.Ua.Server.Tests
             var requestHeader = m_requestHeader;
             requestHeader.Timestamp = DateTime.UtcNow;
             var response = m_server.Read(requestHeader, kMaxAge, TimestampsToReturn.Neither, readIdCollection, out var results, out var diagnosticInfos);
-            ServerFixtureUtils.ValidateResponse(response);
-            ServerFixtureUtils.ValidateDiagnosticInfos(diagnosticInfos, results);
+            ServerFixtureUtils.ValidateResponse(response, results, readIdCollection);
+            ServerFixtureUtils.ValidateDiagnosticInfos(diagnosticInfos, results, response.StringTable);
 
             Assert.NotNull(results);
             Assert.AreEqual(readIdCollection.Count, results.Count);
@@ -224,8 +224,8 @@ namespace Opc.Ua.Server.Tests
             }
             var response = m_server.Read(requestHeader, kMaxAge, TimestampsToReturn.Neither, nodesToRead,
                 out var dataValues, out var diagnosticInfos);
-            ServerFixtureUtils.ValidateResponse(response);
-            ServerFixtureUtils.ValidateDiagnosticInfos(diagnosticInfos, dataValues);
+            ServerFixtureUtils.ValidateResponse(response, dataValues, nodesToRead);
+            ServerFixtureUtils.ValidateDiagnosticInfos(diagnosticInfos, dataValues, response.StringTable);
         }
 
         /// <summary>
@@ -258,8 +258,8 @@ namespace Opc.Ua.Server.Tests
                 TestContext.Out.WriteLine("NodeId {0} {1}", reference.NodeId, reference.BrowseName);
                 var response = m_server.Read(requestHeader, kMaxAge, TimestampsToReturn.Both, nodesToRead,
                     out var dataValues, out var diagnosticInfos);
-                ServerFixtureUtils.ValidateResponse(response);
-                ServerFixtureUtils.ValidateDiagnosticInfos(diagnosticInfos, dataValues);
+                ServerFixtureUtils.ValidateResponse(response, dataValues, nodesToRead);
+                ServerFixtureUtils.ValidateDiagnosticInfos(diagnosticInfos, dataValues, response.StringTable);
 
                 foreach (var dataValue in dataValues)
                 {
@@ -283,8 +283,8 @@ namespace Opc.Ua.Server.Tests
             nodesToWrite.Add(new WriteValue() { NodeId = nodeId, AttributeId = Attributes.Value, Value = new DataValue(1234) });
             var response = m_server.Write(requestHeader, nodesToWrite,
                 out var dataValues, out var diagnosticInfos);
-            ServerFixtureUtils.ValidateResponse(response);
-            ServerFixtureUtils.ValidateDiagnosticInfos(diagnosticInfos, dataValues);
+            ServerFixtureUtils.ValidateResponse(response, dataValues, nodesToWrite);
+            ServerFixtureUtils.ValidateDiagnosticInfos(diagnosticInfos, dataValues, response.StringTable);
         }
 
         /// <summary>
@@ -479,7 +479,7 @@ namespace Opc.Ua.Server.Tests
 
                 Assert.AreEqual(StatusCodes.Good, response.ServiceResult.Code);
                 ServerFixtureUtils.ValidateResponse(response);
-                ServerFixtureUtils.ValidateDiagnosticInfos(diagnosticInfos, acknoledgements);
+                ServerFixtureUtils.ValidateDiagnosticInfos(diagnosticInfos, acknoledgements, response.StringTable);
                 Assert.AreEqual(subscriptionIds[0], publishedId);
                 Assert.AreEqual(1, notificationMessage.NotificationData.Count);
 
@@ -495,7 +495,7 @@ namespace Opc.Ua.Server.Tests
 
                     Assert.AreEqual(StatusCodes.Good, response.ServiceResult.Code);
                     ServerFixtureUtils.ValidateResponse(response);
-                    ServerFixtureUtils.ValidateDiagnosticInfos(diagnosticInfos, acknoledgements);
+                    ServerFixtureUtils.ValidateDiagnosticInfos(diagnosticInfos, acknoledgements, response.StringTable);
                     Assert.AreEqual(subscriptionIds[0], publishedId);
                     Assert.AreEqual(0, notificationMessage.NotificationData.Count);
                 }
@@ -513,7 +513,8 @@ namespace Opc.Ua.Server.Tests
                 SecureChannelContext.Current = securityContext;
 
                 Assert.AreEqual(StatusCodes.BadUserAccessDenied, results[0].StatusCode.Code);
-                ServerFixtureUtils.ValidateResponse(response);
+                ServerFixtureUtils.ValidateResponse(response, results, nodesToCall);
+                ServerFixtureUtils.ValidateDiagnosticInfos(diagnosticInfos, nodesToCall, response.StringTable);
 
                 // Still nothing to publish since previous ResendData call did not execute
                 m_requestHeader.Timestamp = DateTime.UtcNow;
@@ -524,7 +525,7 @@ namespace Opc.Ua.Server.Tests
 
                 Assert.AreEqual(StatusCodes.Good, response.ServiceResult.Code);
                 ServerFixtureUtils.ValidateResponse(response);
-                ServerFixtureUtils.ValidateDiagnosticInfos(diagnosticInfos, acknoledgements);
+                ServerFixtureUtils.ValidateDiagnosticInfos(diagnosticInfos, acknoledgements, response.StringTable);
                 Assert.AreEqual(subscriptionIds[0], publishedId);
                 Assert.AreEqual(0, notificationMessage.NotificationData.Count);
 
@@ -551,7 +552,7 @@ namespace Opc.Ua.Server.Tests
 
                 Assert.AreEqual(StatusCodes.Good, response.ServiceResult.Code);
                 ServerFixtureUtils.ValidateResponse(response);
-                ServerFixtureUtils.ValidateDiagnosticInfos(diagnosticInfos, acknoledgements);
+                ServerFixtureUtils.ValidateDiagnosticInfos(diagnosticInfos, acknoledgements, response.StringTable);
                 Assert.AreEqual(subscriptionIds[0], publishedId);
                 Assert.AreEqual(1, notificationMessage.NotificationData.Count);
                 var items = notificationMessage.NotificationData.FirstOrDefault();
@@ -572,7 +573,7 @@ namespace Opc.Ua.Server.Tests
 
                     Assert.AreEqual(StatusCodes.Good, response.ServiceResult.Code);
                     ServerFixtureUtils.ValidateResponse(response);
-                    ServerFixtureUtils.ValidateDiagnosticInfos(diagnosticInfos, acknoledgements);
+                    ServerFixtureUtils.ValidateDiagnosticInfos(diagnosticInfos, acknoledgements, response.StringTable);
                     Assert.AreEqual(subscriptionIds[0], publishedId);
                     Assert.AreEqual(1, notificationMessage.NotificationData.Count);
                     items = notificationMessage.NotificationData.FirstOrDefault();
@@ -593,7 +594,7 @@ namespace Opc.Ua.Server.Tests
 
                 Assert.AreEqual(StatusCodes.Good, response.ServiceResult.Code);
                 ServerFixtureUtils.ValidateResponse(response);
-                ServerFixtureUtils.ValidateDiagnosticInfos(diagnosticInfos, acknoledgements);
+                ServerFixtureUtils.ValidateDiagnosticInfos(diagnosticInfos, acknoledgements, response.StringTable);
                 Assert.AreEqual(subscriptionIds[0], publishedId);
                 Assert.AreEqual(0, notificationMessage.NotificationData.Count);
 
@@ -631,7 +632,8 @@ namespace Opc.Ua.Server.Tests
                 out var diagnosticInfos);
 
             Assert.AreEqual(expectedStatus, results[0].StatusCode.Code);
-            ServerFixtureUtils.ValidateResponse(response);
+            ServerFixtureUtils.ValidateResponse(response, results, nodesToCall);
+            ServerFixtureUtils.ValidateDiagnosticInfos(diagnosticInfos, nodesToCall, response.StringTable);
 
             return nodesToCall;
         }
@@ -652,8 +654,8 @@ namespace Opc.Ua.Server.Tests
             var response = m_server.Read(requestHeader, kMaxAge, TimestampsToReturn.Neither, nodesToRead,
                 out var readDataValues, out var diagnosticInfos);
 
-            ServerFixtureUtils.ValidateResponse(response);
-            ServerFixtureUtils.ValidateDiagnosticInfos(diagnosticInfos, readDataValues);
+            ServerFixtureUtils.ValidateResponse(response, readDataValues, nodesToRead);
+            ServerFixtureUtils.ValidateDiagnosticInfos(diagnosticInfos, readDataValues, response.StringTable);
             Assert.AreEqual(testSet.Length, readDataValues.Count);
 
             var modifiedValues = new DataValueCollection();
@@ -677,8 +679,8 @@ namespace Opc.Ua.Server.Tests
             requestHeader.Timestamp = DateTime.UtcNow;
             response = m_server.Write(requestHeader, nodesToWrite,
                 out var writeDataValues, out diagnosticInfos);
-            ServerFixtureUtils.ValidateResponse(response);
-            ServerFixtureUtils.ValidateDiagnosticInfos(diagnosticInfos, writeDataValues);
+            ServerFixtureUtils.ValidateResponse(response, writeDataValues, nodesToWrite);
+            ServerFixtureUtils.ValidateDiagnosticInfos(diagnosticInfos, writeDataValues, response.StringTable);
         }
         #endregion
     }


### PR DESCRIPTION
## Proposed changes

- Issue fix: Currently when diagnostics is enabled in client calls, the string table in the response header is not updated when a service call is split into multiple service calls.  In this case the stringtables from all calls must be appended and the index in the diagnosticinfo must be updated to match the updated string list.
- To reduce the number of 'null' DiagnosticInfo allocations, the decoders now try to return null instead of a default DiagnosticInfo. A new property ÌsNullDiagnosticInfo' can be used to check for unused DiagnosticInfo entries.
- The tests were slightly improved to use test set data from the generated TestData namespace, which contains also a historical node.
- All `ServerFixtureUtils.ValidateXXX` checks were updated to include the check for diagnosticInfos and the string tables to catch issues.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [x] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [x] I ran tests locally with my changes, all passed.
- [x] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
