### PR TITLE
Truncate inner diagnostics if nested depth too high

### DIFF
--- a/Libraries/Opc.Ua.Client/SessionClientBatched.cs
+++ b/Libraries/Opc.Ua.Client/SessionClientBatched.cs
@@ -1871,9 +1871,8 @@ namespace Opc.Ua
             DiagnosticInfo diagnosticInfo,
             int stringTableOffset)
         {
-            const int MaxDepth = 10;
             int depth = 0;
-            while (diagnosticInfo != null && depth++ < MaxDepth)
+            while (diagnosticInfo != null && depth++ < DiagnosticInfo.MaxInnerDepth)
             {
                 if (diagnosticInfo.LocalizedText >= 0)
                 {

--- a/Libraries/Opc.Ua.Server/NodeManager/MasterNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/NodeManager/MasterNodeManager.cs
@@ -834,7 +834,8 @@ namespace Opc.Ua.Server
                 {
                     DiagnosticInfo diagnosticInfo = diagnosticInfos[ii];
 
-                    while (diagnosticInfo != null)
+                    int depth = 0;
+                    while (diagnosticInfo != null && depth++ < DiagnosticInfo.MaxInnerDepth)
                     {
                         if (!String.IsNullOrEmpty(diagnosticInfo.AdditionalInfo))
                         {

--- a/Stack/Opc.Ua.Core/Types/BuiltIn/DiagnosticInfo.cs
+++ b/Stack/Opc.Ua.Core/Types/BuiltIn/DiagnosticInfo.cs
@@ -30,8 +30,13 @@ namespace Opc.Ua
     /// <br/></para>
     /// </remarks>
     [DataContract(Namespace = Namespaces.OpcUaXsd)]
-    public class DiagnosticInfo : ICloneable, IFormattable
+    public sealed class DiagnosticInfo : ICloneable, IFormattable
     {
+        /// <summary>
+        /// Limits the recursion depth for the InnerDiagnosticInfo field.
+        /// </summary>
+        public const int MaxInnerDepth = 5;
+
         #region Constructors
         /// <summary>
         /// Initializes the object with default values.
@@ -46,10 +51,18 @@ namespace Opc.Ua
         /// </summary>
         /// <remarks>
         /// Creates a new instance of the object while copying the value passed in.
+        /// If InnerDiagnosticInfo exceeds the recursion limit, it is not copied.
         /// </remarks>
         /// <param name="value">The value to copy</param>
         /// <exception cref="ArgumentNullException">Thrown when the value is null</exception>
-        public DiagnosticInfo(DiagnosticInfo value)
+        public DiagnosticInfo(DiagnosticInfo value) : this(value, 0)
+        {
+        }
+
+        /// <summary>
+        /// Creates a deep copy of the value, but limits the recursion depth.
+        /// </summary>
+        private DiagnosticInfo(DiagnosticInfo value, int depth)
         {
             if (value == null) throw new ArgumentNullException(nameof(value));
 
@@ -60,9 +73,9 @@ namespace Opc.Ua
             m_additionalInfo = value.m_additionalInfo;
             m_innerStatusCode = value.m_innerStatusCode;
 
-            if (value.m_innerDiagnosticInfo != null)
+            if (value.m_innerDiagnosticInfo != null && depth < MaxInnerDepth)
             {
-                m_innerDiagnosticInfo = new DiagnosticInfo(value.m_innerDiagnosticInfo);
+                m_innerDiagnosticInfo = new DiagnosticInfo(value.m_innerDiagnosticInfo, depth + 1);
             }
         }
 
@@ -89,7 +102,7 @@ namespace Opc.Ua
         }
 
         /// <summary>
-        /// Initializes the object with an exception.
+        /// Initializes the object with a ServiceResult.
         /// </summary>
         /// <param name="diagnosticsMask">The bitmask describing the diagnostic data</param>
         /// <param name="result">The overall transaction result</param>
@@ -100,6 +113,25 @@ namespace Opc.Ua
             DiagnosticsMasks diagnosticsMask,
             bool serviceLevel,
             StringTable stringTable)
+            : this(result, diagnosticsMask, serviceLevel, stringTable, 0)
+        {
+        }
+
+        /// <summary>
+        /// Initializes the object with a ServiceResult.
+        /// Limits the recursion depth for the InnerDiagnosticInfo field.
+        /// </summary>
+        /// <param name="diagnosticsMask">The bitmask describing the diagnostic data</param>
+        /// <param name="result">The overall transaction result</param>
+        /// <param name="serviceLevel">The service level</param>
+        /// <param name="stringTable">A table of strings carrying more diagnostic data</param>
+        /// <param name="depth">The recursion depth of the inner diagnostics field</param>
+        private DiagnosticInfo(
+            ServiceResult result,
+            DiagnosticsMasks diagnosticsMask,
+            bool serviceLevel,
+            StringTable stringTable,
+            int depth)
         {
             uint mask = (uint)diagnosticsMask;
 
@@ -110,7 +142,7 @@ namespace Opc.Ua
 
             diagnosticsMask = (DiagnosticsMasks)mask;
 
-            Initialize(result, diagnosticsMask, stringTable);
+            Initialize(result, diagnosticsMask, stringTable, depth);
         }
 
         /// <summary>
@@ -135,7 +167,7 @@ namespace Opc.Ua
 
             diagnosticsMask = (DiagnosticsMasks)mask;
 
-            Initialize(new ServiceResult(exception), diagnosticsMask, stringTable);
+            Initialize(new ServiceResult(exception), diagnosticsMask, stringTable, 0);
         }
 
         /// <summary>
@@ -172,10 +204,12 @@ namespace Opc.Ua
         /// <param name="diagnosticsMask">The bitmask describing the type of diagnostic data</param>
         /// <param name="result">The transaction result</param>
         /// <param name="stringTable">An array of strings that may be used to provide additional diagnostic details</param>
+        /// <param name="depth">The depth of the inner diagnostics property</param>
         private void Initialize(
             ServiceResult result,
             DiagnosticsMasks diagnosticsMask,
-            StringTable stringTable)
+            StringTable stringTable,
+            int depth)
         {
             if (stringTable == null) throw new ArgumentNullException(nameof(stringTable));
 
@@ -250,11 +284,21 @@ namespace Opc.Ua
                 // recursively append the inner diagnostics.
                 if ((DiagnosticsMasks.ServiceInnerDiagnostics & diagnosticsMask) != 0)
                 {
-                    m_innerDiagnosticInfo = new DiagnosticInfo(
-                        result.InnerResult,
-                        diagnosticsMask,
-                        true,
-                        stringTable);
+                    if (depth < MaxInnerDepth)
+                    {
+                        m_innerDiagnosticInfo = new DiagnosticInfo(
+                            result.InnerResult,
+                            diagnosticsMask,
+                            true,
+                            stringTable,
+                            depth + 1);
+                    }
+                    else
+                    {
+                        Utils.LogWarning(
+                            "Inner diagnostics truncated. Max depth of {0} exceeded.",
+                            MaxInnerDepth);
+                    }
                 }
             }
         }
@@ -359,6 +403,99 @@ namespace Opc.Ua
         /// </summary>
         public override bool Equals(object obj)
         {
+            return Equals(obj, 0);
+        }
+
+        /// <summary>
+        /// Returns a unique hashcode for the object.
+        /// </summary>
+        public override int GetHashCode()
+        {
+            var hash = new HashCode();
+            GetHashCode(ref hash, 0);
+            return hash.ToHashCode();
+        }
+
+        /// <summary>
+        /// Converts the value to a human readable string.
+        /// </summary>
+        /// <remarks>
+        /// Converts the value to a human readable string.
+        /// </remarks>
+        public override string ToString()
+        {
+            return ToString(null, null);
+        }
+        #endregion
+
+        #region IFormattable Members
+        /// <summary>
+        /// Returns the string representation of the object.
+        /// </summary>
+        /// <remarks>
+        /// Returns the string representation of the object.
+        /// </remarks>
+        /// <param name="format">(Unused). Always pass a null</param>
+        /// <param name="formatProvider">(Unused) The provider.</param>
+        /// <exception cref="FormatException">Thrown if the <i>format</i> parameter is NOT null</exception>
+        public string ToString(string format, IFormatProvider formatProvider)
+        {
+            if (format == null)
+            {
+                return Utils.Format("{0}:{1}:{2}:{3}", m_symbolicId, m_namespaceUri, m_locale, m_localizedText);
+            }
+
+            throw new FormatException(Utils.Format("Invalid format string: '{0}'.", format));
+        }
+        #endregion
+
+        #region ICloneable Members
+        /// <inheritdoc/>
+        public object Clone()
+        {
+            return this.MemberwiseClone();
+        }
+
+        /// <summary>
+        /// Makes a deep copy of the object.
+        /// </summary>
+        public new object MemberwiseClone()
+        {
+            return new DiagnosticInfo(this);
+        }
+        #endregion
+
+        #region Private Methods
+        /// <summary>
+        /// Adds the hashcodes for the object.
+        /// Limits the recursion depth to prevent stack overflow.
+        /// </summary>
+        private void GetHashCode(ref HashCode hash, int depth)
+        {
+            hash.Add(this.m_symbolicId);
+            hash.Add(this.m_namespaceUri);
+            hash.Add(this.m_locale);
+            hash.Add(this.m_localizedText);
+
+            if (this.m_additionalInfo != null)
+            {
+                hash.Add(this.m_additionalInfo);
+            }
+
+            hash.Add(this.m_innerStatusCode);
+
+            if (this.m_innerDiagnosticInfo != null && depth < MaxInnerDepth)
+            {
+                this.m_innerDiagnosticInfo.GetHashCode(ref hash, depth + 1);
+            }
+        }
+
+        /// <summary>
+        /// Determines if the specified object is equal to this object.
+        /// Limits the depth of the comparison to avoid infinite recursion.
+        /// </summary>
+        private bool Equals(object obj, int depth)
+        {
             if (Object.ReferenceEquals(this, obj))
             {
                 return true;
@@ -406,87 +543,21 @@ namespace Opc.Ua
 
                 if (this.m_innerDiagnosticInfo != null)
                 {
-                    return this.m_innerDiagnosticInfo.Equals(value.m_innerDiagnosticInfo);
+                    if (depth < MaxInnerDepth)
+                    {
+                        return this.m_innerDiagnosticInfo.Equals(value.m_innerDiagnosticInfo, depth + 1);
+                    }
+                    else
+                    {
+                        // ignore the remaining inner diagnostic info and consider it equal.
+                        return true;
+                    }
                 }
 
                 return value.m_innerDiagnosticInfo == null;
             }
 
             return false;
-        }
-
-        /// <summary>
-        /// Returns a unique hashcode for the object.
-        /// </summary>
-        public override int GetHashCode()
-        {
-            var hash = new HashCode();
-            hash.Add(this.m_symbolicId);
-            hash.Add(this.m_namespaceUri);
-            hash.Add(this.m_locale);
-            hash.Add(this.m_localizedText);
-
-            if (this.m_additionalInfo != null)
-            {
-                hash.Add(this.m_additionalInfo);
-            }
-
-            hash.Add(this.m_innerStatusCode);
-
-            if (this.m_innerDiagnosticInfo != null)
-            {
-                hash.Add(this.m_innerDiagnosticInfo);
-            }
-
-            return hash.ToHashCode();
-        }
-
-        /// <summary>
-        /// Converts the value to a human readable string.
-        /// </summary>
-        /// <remarks>
-        /// Converts the value to a human readable string.
-        /// </remarks>
-        public override string ToString()
-        {
-            return ToString(null, null);
-        }
-        #endregion
-
-        #region IFormattable Members
-        /// <summary>
-        /// Returns the string representation of the object.
-        /// </summary>
-        /// <remarks>
-        /// Returns the string representation of the object.
-        /// </remarks>
-        /// <param name="format">(Unused). Always pass a null</param>
-        /// <param name="formatProvider">(Unused) The provider.</param>
-        /// <exception cref="FormatException">Thrown if the <i>format</i> parameter is NOT null</exception>
-        public string ToString(string format, IFormatProvider formatProvider)
-        {
-            if (format == null)
-            {
-                return Utils.Format("{0}:{1}:{2}:{3}", m_symbolicId, m_namespaceUri, m_locale, m_localizedText);
-            }
-
-            throw new FormatException(Utils.Format("Invalid format string: '{0}'.", format));
-        }
-        #endregion
-
-        #region ICloneable Members
-        /// <inheritdoc/>
-        public virtual object Clone()
-        {
-            return this.MemberwiseClone();
-        }
-
-        /// <summary>
-        /// Makes a deep copy of the object.
-        /// </summary>
-        public new object MemberwiseClone()
-        {
-            return new DiagnosticInfo(this);
         }
         #endregion
 

--- a/Stack/Opc.Ua.Core/Types/Encoders/XmlEncoder.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/XmlEncoder.cs
@@ -629,16 +629,15 @@ namespace Opc.Ua
         /// </summary>
         public void WriteDiagnosticInfo(string fieldName, DiagnosticInfo value)
         {
-            // check the nesting level for avoiding a stack overflow.
-            if (m_nestingLevel > m_context.MaxEncodingNestingLevels)
-            {
-                throw ServiceResultException.Create(
-                    StatusCodes.BadEncodingLimitsExceeded,
-                    "Maximum nesting level of {0} was exceeded",
-                    m_context.MaxEncodingNestingLevels);
-            }
+            WriteDiagnosticInfo(fieldName, value, 0);
+        }
 
-            m_nestingLevel++;
+        /// <summary>
+        /// Writes a DiagnosticInfo to the stream.
+        /// </summary>
+        private void WriteDiagnosticInfo(string fieldName, DiagnosticInfo value, int depth)
+        {
+            CheckAndIncrementNestingLevel();
 
             if (BeginField(fieldName, value == null, true))
             {
@@ -652,7 +651,15 @@ namespace Opc.Ua
                     WriteInt32("LocalizedText", value.LocalizedText);
                     WriteString("AdditionalInfo", value.AdditionalInfo);
                     WriteStatusCode("InnerStatusCode", value.InnerStatusCode);
-                    WriteDiagnosticInfo("InnerDiagnosticInfo", value.InnerDiagnosticInfo);
+                    if (depth < DiagnosticInfo.MaxInnerDepth)
+                    {
+                        WriteDiagnosticInfo("InnerDiagnosticInfo", value.InnerDiagnosticInfo, depth + 1);
+                    }
+                    else
+                    {
+                        Utils.LogWarning("InnerDiagnosticInfo dropped because nesting exceeds maximum of {0}.",
+                            DiagnosticInfo.MaxInnerDepth);
+                    }
                 }
 
                 PopNamespace();
@@ -724,31 +731,27 @@ namespace Opc.Ua
         /// </summary>
         public void WriteVariant(string fieldName, Variant value)
         {
-            // check the nesting level for avoiding a stack overflow.
-            if (m_nestingLevel > m_context.MaxEncodingNestingLevels)
+            CheckAndIncrementNestingLevel();
+
+            try
             {
-                throw ServiceResultException.Create(
-                    StatusCodes.BadEncodingLimitsExceeded,
-                    "Maximum nesting level of {0} was exceeded",
-                    m_context.MaxEncodingNestingLevels);
+                if (BeginField(fieldName, false, false))
+                {
+                    PushNamespace(Namespaces.OpcUaXsd);
+
+                    m_writer.WriteStartElement("Value", Namespaces.OpcUaXsd);
+                    WriteVariantContents(value.Value, value.TypeInfo);
+                    m_writer.WriteEndElement();
+
+                    PopNamespace();
+
+                    EndField(fieldName);
+                }
             }
-
-            m_nestingLevel++;
-
-            if (BeginField(fieldName, false, false))
+            finally
             {
-                PushNamespace(Namespaces.OpcUaXsd);
-
-                m_writer.WriteStartElement("Value", Namespaces.OpcUaXsd);
-                WriteVariantContents(value.Value, value.TypeInfo);
-                m_writer.WriteEndElement();
-
-                PopNamespace();
-
-                EndField(fieldName);
+                m_nestingLevel--;
             }
-
-            m_nestingLevel--;
         }
 
         /// <summary>
@@ -855,16 +858,7 @@ namespace Opc.Ua
         /// </summary>
         public void WriteEncodeable(string fieldName, IEncodeable value, System.Type systemType)
         {
-            // check the nesting level for avoiding a stack overflow.
-            if (m_nestingLevel > m_context.MaxEncodingNestingLevels)
-            {
-                throw ServiceResultException.Create(
-                    StatusCodes.BadEncodingLimitsExceeded,
-                    "Maximum nesting level of {0} was exceeded",
-                    m_context.MaxEncodingNestingLevels);
-            }
-
-            m_nestingLevel++;
+            CheckAndIncrementNestingLevel();
 
             if (BeginField(fieldName, value == null, true))
             {
@@ -1973,16 +1967,7 @@ namespace Opc.Ua
         /// </summary>
         public void WriteArray(string fieldName, object array, int valueRank, BuiltInType builtInType)
         {
-            // check the nesting level for avoiding a stack overflow.
-            if (m_nestingLevel > m_context.MaxEncodingNestingLevels)
-            {
-                throw ServiceResultException.Create(
-                    StatusCodes.BadEncodingLimitsExceeded,
-                    "Maximum nesting level of {0} was exceeded",
-                    m_context.MaxEncodingNestingLevels);
-            }
-
-            m_nestingLevel++;
+            CheckAndIncrementNestingLevel();
 
             try
             {
@@ -2148,25 +2133,15 @@ namespace Opc.Ua
                 m_nestingLevel--;
             }
         }
-
         #endregion
 
         #region Private Methods
         /// <summary>
-        /// Writes an DataValue array to the stream.
+        /// Writes a DataValue array to the stream.
         /// </summary>
         private void WriteMatrix(string fieldName, Matrix value)
         {
-            // check the nesting level for avoiding a stack overflow.
-            if (m_nestingLevel > m_context.MaxEncodingNestingLevels)
-            {
-                throw ServiceResultException.Create(
-                    StatusCodes.BadEncodingLimitsExceeded,
-                    "Maximum nesting level of {0} was exceeded",
-                    m_context.MaxEncodingNestingLevels);
-            }
-
-            m_nestingLevel++;
+            CheckAndIncrementNestingLevel();
 
             if (BeginField(fieldName, value == null, true, true))
             {
@@ -2228,6 +2203,21 @@ namespace Opc.Ua
             {
                 m_writer.WriteEndElement();
             }
+        }
+
+        /// <summary>
+        /// Test and increment the nesting level.
+        /// </summary>
+        private void CheckAndIncrementNestingLevel()
+        {
+            if (m_nestingLevel > m_context.MaxEncodingNestingLevels)
+            {
+                throw ServiceResultException.Create(
+                    StatusCodes.BadEncodingLimitsExceeded,
+                    "Maximum nesting level of {0} was exceeded",
+                    m_context.MaxEncodingNestingLevels);
+            }
+            m_nestingLevel++;
         }
         #endregion
 

--- a/Tests/Opc.Ua.Core.Tests/Types/BuiltIn/BuiltInTests.cs
+++ b/Tests/Opc.Ua.Core.Tests/Types/BuiltIn/BuiltInTests.cs
@@ -256,7 +256,6 @@ namespace Opc.Ua.Core.Tests.Types.BuiltIn
             Assert.AreEqual(null, diagnosticInfo.InnerDiagnosticInfo);
 
             Assert.IsTrue(diagnosticInfo.Equals(null));
-            Assert.IsTrue(diagnosticInfo.GetHashCode() == 0);
             Assert.IsTrue(diagnosticInfo.IsNullDiagnosticInfo);
         }
 

--- a/Tests/Opc.Ua.Core.Tests/Types/Encoders/JsonEncoderTests.cs
+++ b/Tests/Opc.Ua.Core.Tests/Types/Encoders/JsonEncoderTests.cs
@@ -242,7 +242,9 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
             {   BuiltInType.StatusCode, new StatusCode(StatusCodes.BadCertificateInvalid),
                 $"{StatusCodes.BadCertificateInvalid}", $"{{\"Code\":{StatusCodes.BadCertificateInvalid}, \"Symbol\":\"{nameof(StatusCodes.BadCertificateInvalid)}\"}}"},
 
-            {   BuiltInType.DiagnosticInfo, new DiagnosticInfo(), "{}", null},
+            {   BuiltInType.DiagnosticInfo, new DiagnosticInfo(), null, null},
+            {   BuiltInType.DiagnosticInfo, new DiagnosticInfo(-1,-1,-1,-1,null), null, null},
+            {   BuiltInType.DiagnosticInfo, new DiagnosticInfo(1,2,3,4,"AdditionalInfo"), "{\"SymbolicId\":1,\"NamespaceUri\":2,\"Locale\":3,\"LocalizedText\":4,\"AdditionalInfo\":\"AdditionalInfo\"}", null},
 
             {   BuiltInType.QualifiedName, QualifiedName.Null, null, null},
             {   BuiltInType.QualifiedName, new QualifiedName(kQualifiedName), $"{{\"Name\":\"{kQualifiedName}\"}}", null},


### PR DESCRIPTION
## Proposed changes

- `DiagnosticInfo` contains the `InnerDiagnosticInfo` which can be nested. Limit the recursion to `MaxInnerDepth` in multiple places to prevent stack overflow / endless loops.
- The default value for MaxInnerDepth should not be more than 5.

Encoder/Decoder improvements:
- Decorate all nesting level counters in Encoders/Decoders with try/finally. Simplify check/increment with helper function.
- Truncate encoded DiagnosticInfo if nesting level is exceeded. 
- throw `BadEncodingLimitExceeded` if the decoded DiagnosticInfo contains InnerDiagnosticInfo which exceeds the limit. 

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- [x] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [x] I ran tests locally with my changes, all passed.
- [x] I fixed all failing tests in the CI pipelines. 
- [x] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

