### PR TITLE
'#' is not treated as a reserved character in RelativePath's text format

### DIFF
--- a/Stack/Opc.Ua.Core/Types/Utils/RelativePath.cs
+++ b/Stack/Opc.Ua.Core/Types/Utils/RelativePath.cs
@@ -740,7 +740,7 @@ namespace Opc.Ua
 
                 int last = reader.Peek();
 
-                for (int next = last; next != -1; next = reader.Peek(), last=next)
+                for (int next = last; next != -1; next = reader.Peek(), last = next)
                 {
                     if (!Char.IsDigit((char)next))
                     {
@@ -783,27 +783,20 @@ namespace Opc.Ua
                         }
                     }
 
-                    // check for invalid character.            
-                    if (next == '!' || next == ':' || next == '<' || next == '>' || next == '/' || next == '.')
-                    {
-                        throw new ServiceResultException(
-                            StatusCodes.BadSyntaxError,
-                            Utils.Format("Unexpected character '{0}' in browse path.", next));
-
-                    }
-
                     // check for escape character.
                     if (next == '&')
                     {
-                        // remove '&'
-                        next = reader.Read(); 
-                        // get escaped character without removing it
-                        next = reader.Peek();
+                        next = reader.Read();
+                        if (next == -1)
+                        {
+                            throw new ServiceResultException(
+                                StatusCodes.BadSyntaxError,
+                                "Unexpected end after escape character '&'.");
+                        }
+                        next = reader.Read();
 
                         if (next == '!' || next == ':' || next == '<' || next == '>' || next == '/' || next == '.' || next == '#' || next == '&')
                         {
-                            // if valid, then remove it
-                            reader.Read(); 
                             buffer.Append((char)next);
                             continue;
                         }
@@ -811,15 +804,16 @@ namespace Opc.Ua
                         {
                             throw new ServiceResultException(
                                 StatusCodes.BadSyntaxError,
-                                Utils.Format("Invalid escape character '{0}' in browse path.", next));
+                                Utils.Format("Invalid escape sequence '&{0}' in browse path.", next));
                         }
                     }
-                    // handle non-escaped '#' character
-                    else if (next == '#') 
+
+                    // check for invalid character.
+                    if (next == '!' || next == ':' || next == '<' || next == '>' || next == '/' || next == '.' || next == '#' || next == '&')
                     {
                         throw new ServiceResultException(
                             StatusCodes.BadSyntaxError,
-                            Utils.Format("Unexpected non-escaped character '{0}' in browse path.", next));
+                            Utils.Format("Unexpected character '{0}' in browse path.", next));
                     }
 
                     // append character.
@@ -833,8 +827,8 @@ namespace Opc.Ua
                     if (last != '>')
                     {
                         throw new ServiceResultException(
-                            StatusCodes.BadSyntaxError,
-                            Utils.Format("Missing file '>' for reference type name in browse path."));
+                        StatusCodes.BadSyntaxError,
+                        Utils.Format("Missing closing '>' for reference type name in browse path."));
                     }
                 }
 

--- a/Stack/Opc.Ua.Core/Types/Utils/RelativePath.cs
+++ b/Stack/Opc.Ua.Core/Types/Utils/RelativePath.cs
@@ -795,10 +795,31 @@ namespace Opc.Ua
                     // check for escape character.
                     if (next == '&')
                     {
-                        next = reader.Read();
-                        next = reader.Read();
-                        buffer.Append((char)next);
-                        continue;
+                        // remove '&'
+                        next = reader.Read(); 
+                        // get escaped character without removing it
+                        next = reader.Peek();
+
+                        if (next == '!' || next == ':' || next == '<' || next == '>' || next == '/' || next == '.' || next == '#' || next == '&')
+                        {
+                            // if valid, then remove it
+                            reader.Read(); 
+                            buffer.Append((char)next);
+                            continue;
+                        }
+                        else
+                        {
+                            throw new ServiceResultException(
+                                StatusCodes.BadSyntaxError,
+                                Utils.Format("Invalid escape character '{0}' in browse path.", next));
+                        }
+                    }
+                    // handle non-escaped '#' character
+                    else if (next == '#') 
+                    {
+                        throw new ServiceResultException(
+                            StatusCodes.BadSyntaxError,
+                            Utils.Format("Unexpected non-escaped character '{0}' in browse path.", next));
                     }
 
                     // append character.

--- a/Tests/Opc.Ua.Core.Tests/Types/Utils/UtilTests.cs
+++ b/Tests/Opc.Ua.Core.Tests/Types/Utils/UtilTests.cs
@@ -290,6 +290,68 @@ namespace Opc.Ua.Core.Tests.Types.UtilsTests
             Assert.AreEqual(false, settings.CloseInput);
         }
         #endregion
+
+        #region RelativePath.Parse Escaping
+
+        /// <summary>
+        /// Parse a path containing non-escaped hash character.
+        /// </summary>
+        [Test]
+        public void RelativePathParseNonEscapedHash()
+        {
+            TypeTable typeTable = new TypeTable(new NamespaceTable());
+            string str = "/abc#def";
+            Assert.Throws<ServiceResultException>(() => RelativePath.Parse(str, typeTable).Format(typeTable));
+        }
+
+        /// <summary>
+        /// Parse a path containing correctly escaped hash character.
+        /// </summary>
+        [Test]
+        public void RelativePathParseEscapedHash()
+        {
+            TypeTable typeTable = new TypeTable(new NamespaceTable());
+            string str = "/abc&#def";
+            string expected = "/abc#def";
+            Assert.AreEqual(expected, RelativePath.Parse(str, typeTable).Format(typeTable));
+        }
+
+        /// <summary>
+        /// Parse a path containing correctly escaped hash character folowed by exclamation.
+        /// </summary>
+        [Test]
+        public void RelativePathParseEscapedHashFollowedByExclamation()
+        {
+            TypeTable typeTable = new TypeTable(new NamespaceTable());
+            string str = "/abc&#!def";
+            Assert.Throws<ServiceResultException>(() => RelativePath.Parse(str, typeTable).Format(typeTable));
+        }
+
+        /// <summary>
+        /// Parse a path containing correctly escaped hash character by exclamation within the reference type delimeters.
+        /// </summary>
+        [Test]
+        public void RelativePathParseEscapedHashFollowedByExclamationInReferenceType()
+        {
+            TypeTable typeTable = new TypeTable(new NamespaceTable());
+            string str = "<abc&#!def>";
+            Assert.Throws<ServiceResultException>(() => RelativePath.Parse(str, typeTable).Format(typeTable));
+        }
+
+        /// <summary>
+        /// Parse a path containing incorrectly escaped character sequence.
+        /// </summary>
+        [Test]
+        public void RelativePathParseInvalidEscapeSequence()
+        {
+            TypeTable typeTable = new TypeTable(new NamespaceTable());
+            string str = "/abc&$!def";
+            Assert.Throws<ServiceResultException>(() => RelativePath.Parse(str, typeTable).Format(typeTable));
+        }
+
+
+        #endregion
+
     }
 
 }


### PR DESCRIPTION
## Proposed changes

Raise a ServiceResultException if the formatter faces a non-escaped #.

## Related Issues

- Fixes #
https://github.com/OPCFoundation/UA-.NETStandard/issues/2250

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [x] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
