### PR TITLE
Add event for the session configuration changed

### DIFF
--- a/Libraries/Opc.Ua.Client/ISession.cs
+++ b/Libraries/Opc.Ua.Client/ISession.cs
@@ -116,6 +116,15 @@ namespace Opc.Ua.Client
         /// Raised to indicate the session is closing.
         /// </summary>
         event EventHandler SessionClosing;
+
+        /// <summary>
+        /// Raised to indicate the session configuration changed.
+        /// </summary>
+        /// <remarks>
+        /// An example for a session configuration change is a new user identity,
+        /// a new server nonce, a new locale etc.
+        /// </remarks>
+        event EventHandler SessionConfigurationChanged;
         #endregion
 
         #region Public Properties

--- a/Libraries/Opc.Ua.Client/TraceableSession.cs
+++ b/Libraries/Opc.Ua.Client/TraceableSession.cs
@@ -114,6 +114,13 @@ namespace Opc.Ua.Client
         }
 
         /// <inheritdoc/>
+        public event EventHandler SessionConfigurationChanged
+        {
+            add => m_session.SessionConfigurationChanged += value;
+            remove => m_session.SessionConfigurationChanged -= value;
+        }
+
+        /// <inheritdoc/>
         public event RenewUserIdentityEventHandler RenewUserIdentity
         {
             add => m_session.RenewUserIdentity += value;

--- a/Tests/Opc.Ua.Client.Tests/SubscriptionTest.cs
+++ b/Tests/Opc.Ua.Client.Tests/SubscriptionTest.cs
@@ -186,6 +186,9 @@ namespace Opc.Ua.Client.Tests
             int keepAlive = 0;
             Session.KeepAlive += (ISession sender, KeepAliveEventArgs e) => { keepAlive++; };
 
+            int sessionConfigChanged = 0;
+            Session.SessionConfigurationChanged += (object sender, EventArgs e) => { sessionConfigChanged++; };
+
             // add current time
             var list = new List<MonitoredItem> {
                 new MonitoredItem(subscription.DefaultItem)
@@ -477,6 +480,9 @@ namespace Opc.Ua.Client.Tests
             ISession session1 = await ClientFixture.ConnectAsync(endpoint, userIdentity).ConfigureAwait(false);
             Assert.NotNull(session1);
 
+            int session1ConfigChanged = 0;
+            session1.SessionConfigurationChanged += (object sender, EventArgs e) => { session1ConfigChanged++; };
+
             ServerStatusDataType value1 = (ServerStatusDataType)session1.ReadValue(VariableIds.Server_ServerStatus, typeof(ServerStatusDataType));
             Assert.NotNull(value1);
 
@@ -525,6 +531,9 @@ namespace Opc.Ua.Client.Tests
 
             // prepare the inactive session with the new channel
             ISession session2 = ClientFixture.CreateSession(channel2, sessionConfiguration.ConfiguredEndpoint);
+
+            int session2ConfigChanged = 0;
+            session2.SessionConfigurationChanged += (object sender, EventArgs e) => { session2ConfigChanged++; };
 
             // apply the saved session configuration
             bool success = session2.ApplySessionConfiguration(sessionConfiguration);
@@ -632,6 +641,9 @@ namespace Opc.Ua.Client.Tests
             session2.DeleteSubscriptionsOnClose = true;
             session2.Close(1000);
             Utils.SilentDispose(session2);
+
+            Assert.AreEqual(0, session1ConfigChanged);
+            Assert.Less(0, session2ConfigChanged);
         }
 
         [Test, Order(400)]


### PR DESCRIPTION
## Proposed changes

- Add the event `SessionConfigurationChanged` which indicates that the `SaveSessionConfiguration` should be called again because some session configuration was changed, e.g. after a reconnect, locale, server nonce or the user impersonation changed.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [x] I ran tests locally with my changes, all passed.
- [x] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
