### PR TITLE
Use the request queue to return GoodSubscriptionTransferred immediately

### DIFF
--- a/Libraries/Opc.Ua.Client/Subscription.cs
+++ b/Libraries/Opc.Ua.Client/Subscription.cs
@@ -2267,13 +2267,8 @@ namespace Opc.Ua.Client
 
                                 if (statusChanged != null)
                                 {
-                                    Utils.LogWarning("StatusChangeNotification received with Status = {0} for SubscriptionId={1} Session = {2}.",
-                                        statusChanged.Status.ToString(), Id, Session.SessionId);
-
-                                    if (statusChanged.Status == StatusCodes.GoodSubscriptionTransferred)
-                                    {
-
-                                    }
+                                    Utils.LogWarning("StatusChangeNotification received with Status = {0} for SubscriptionId={1}.",
+                                        statusChanged.Status.ToString(), Id);
                                 }
                             }
                         }

--- a/Libraries/Opc.Ua.Client/Subscription.cs
+++ b/Libraries/Opc.Ua.Client/Subscription.cs
@@ -42,7 +42,7 @@ namespace Opc.Ua.Client
     /// A subscription.
     /// </summary>
     [DataContract(Namespace = Namespaces.OpcUaXsd)]
-    public partial class Subscription : IDisposable
+    public partial class Subscription : IDisposable, ICloneable
     {
         #region Constructors
         /// <summary>
@@ -197,6 +197,21 @@ namespace Opc.Ua.Client
                 m_messageWorkerEvent.Set();
                 m_messageWorkerTask = null;
             }
+        }
+        #endregion
+
+        #region ICloneable Members
+        /// <summary cref="ICloneable.Clone" />
+        public virtual object Clone()
+        {
+            return this.MemberwiseClone();
+        }
+
+        /// <summary cref="Object.MemberwiseClone" />
+        public new object MemberwiseClone()
+        {
+            var clone = new Subscription(this);
+            return clone;
         }
         #endregion
 
@@ -2252,7 +2267,13 @@ namespace Opc.Ua.Client
 
                                 if (statusChanged != null)
                                 {
-                                    Utils.LogWarning("StatusChangeNotification received with Status = {0} for SubscriptionId={1}.", statusChanged.Status.ToString(), Id);
+                                    Utils.LogWarning("StatusChangeNotification received with Status = {0} for SubscriptionId={1} Session = {2}.",
+                                        statusChanged.Status.ToString(), Id, Session.SessionId);
+
+                                    if (statusChanged.Status == StatusCodes.GoodSubscriptionTransferred)
+                                    {
+
+                                    }
                                 }
                             }
                         }
@@ -2880,7 +2901,7 @@ namespace Opc.Ua.Client
     /// A collection of subscriptions.
     /// </summary>
     [CollectionDataContract(Name = "ListOfSubscription", Namespace = Namespaces.OpcUaXsd, ItemName = "Subscription")]
-    public partial class SubscriptionCollection : List<Subscription>
+    public partial class SubscriptionCollection : List<Subscription>, ICloneable
     {
         #region Constructors
         /// <summary>
@@ -2899,6 +2920,22 @@ namespace Opc.Ua.Client
         /// </summary>
         /// <param name="capacity">The max. capacity of the collection</param>
         public SubscriptionCollection(int capacity) : base(capacity) { }
+        #endregion
+
+        #region ICloneable Members
+        /// <summary cref="ICloneable.Clone" />
+        public virtual object Clone()
+        {
+            return (SubscriptionCollection)this.MemberwiseClone();
+        }
+
+        /// <summary cref="Object.MemberwiseClone" />
+        public new object MemberwiseClone()
+        {
+            SubscriptionCollection clone = new SubscriptionCollection();
+            clone.AddRange(this.Select(item => (Subscription)item.Clone()));
+            return clone;
+        }
         #endregion
     }
 }

--- a/Libraries/Opc.Ua.Server/Subscription/SessionPublishQueue.cs
+++ b/Libraries/Opc.Ua.Server/Subscription/SessionPublishQueue.cs
@@ -163,7 +163,7 @@ namespace Opc.Ua.Server
         /// <summary>
         /// Removes a subscription from the publish queue.
         /// </summary>
-        public void Remove(Subscription subscription)
+        public void Remove(Subscription subscription, bool removeQueuedRequests)
         {
             if (subscription == null) throw new ArgumentNullException(nameof(subscription));
 
@@ -179,6 +179,22 @@ namespace Opc.Ua.Server
                     }
                 }
 
+                if (removeQueuedRequests)
+                {
+                    RemoveQueuedRequests();
+                }
+
+                // TraceState("SUBSCRIPTION REMOVED");
+            }
+        }
+
+        /// <summary>
+        /// Removes outstanding requests if no 
+        /// </summary>
+        public void RemoveQueuedRequests()
+        {
+            lock (m_lock)
+            {
                 // remove any outstanding publishes.
                 if (m_queuedSubscriptions.Count == 0)
                 {
@@ -190,8 +206,27 @@ namespace Opc.Ua.Server
                         m_queuedRequests.RemoveFirst();
                     }
                 }
+            }
+        }
 
-                // TraceState("SUBSCRIPTION REMOVED");
+        /// <summary>
+        /// Try to publish the subscription transferred
+        /// status change using a queued publish request.
+        /// </summary>
+        public bool TryPublishCustomStatus(StatusCode statusCode)
+        {
+            lock (m_lock)
+            {
+                if (m_queuedRequests.Count > 0)
+                {
+                    QueuedRequest request = m_queuedRequests.Last.Value;
+                    request.Error = statusCode;
+                    request.Set();
+                    m_queuedRequests.RemoveLast();
+                    return true;
+                }
+
+                return false;
             }
         }
 
@@ -451,6 +486,20 @@ namespace Opc.Ua.Server
 
                 // TraceState("REQUEST #{0} PUBLISH ERROR ({1})", clientHandle, error.StatusCode);
                 throw new ServiceResultException(request.Error);
+            }
+            // special case to force a status message is handled correctly
+            else if (request.Error == StatusCodes.GoodSubscriptionTransferred)
+            {
+                if (request.Subscription != null)
+                {
+                    lock (m_lock)
+                    {
+                        request.Subscription.Publishing = false;
+                        AssignSubscriptionToRequest(request.Subscription);
+                    }
+                    request.Subscription = null;
+                }
+                return null;
             }
 
             // must be shuting down if this is null but no error.

--- a/Libraries/Opc.Ua.Server/Subscription/SessionPublishQueue.cs
+++ b/Libraries/Opc.Ua.Server/Subscription/SessionPublishQueue.cs
@@ -210,8 +210,8 @@ namespace Opc.Ua.Server
         }
 
         /// <summary>
-        /// Try to publish the subscription transferred
-        /// status change using a queued publish request.
+        /// Try to publish a custom status message
+        /// using a queued publish request.
         /// </summary>
         public bool TryPublishCustomStatus(StatusCode statusCode)
         {

--- a/Libraries/Opc.Ua.Server/Subscription/SubscriptionManager.cs
+++ b/Libraries/Opc.Ua.Server/Subscription/SubscriptionManager.cs
@@ -490,7 +490,7 @@ namespace Opc.Ua.Server
 
                         if (m_publishQueues.TryGetValue(sessionId, out queue))
                         {
-                            queue.Remove(subscription);
+                            queue.Remove(subscription, true);
                         }
                     }
                 }
@@ -960,20 +960,9 @@ namespace Opc.Ua.Server
             {
                 Utils.LogTrace("Publish #{0} ReceivedFromClient", context.ClientHandle);
 
-                // check for status messages.
-                lock (m_statusMessagesLock)
+                if (ReturnPendingStatusMessage(context, out message, out subscriptionId))
                 {
-                    Queue<StatusMessage> statusQueue = null;
-
-                    if (m_statusMessages.TryGetValue(context.SessionId, out statusQueue))
-                    {
-                        if (statusQueue.Count > 0)
-                        {
-                            StatusMessage status = statusQueue.Dequeue();
-                            subscriptionId = status.SubscriptionId;
-                            return status.Message;
-                        }
-                    }
+                    return message;
                 }
 
                 bool requeue = false;
@@ -989,6 +978,12 @@ namespace Opc.Ua.Server
 
                     if (subscription == null)
                     {
+                        // check for pending status message.
+                        if (ReturnPendingStatusMessage(context, out message, out subscriptionId))
+                        {
+                            return message;
+                        }
+
                         Utils.LogTrace("Publish #{0} Timeout", context.ClientHandle);
                         return null;
                     }
@@ -1268,7 +1263,8 @@ namespace Opc.Ua.Server
                             if (m_publishQueues.TryGetValue(ownerSession.Id, out var ownerPublishQueue) &&
                                 ownerPublishQueue != null)
                             {
-                                ownerPublishQueue.Remove(subscription);
+                                // keep the queued requests for the status message
+                                ownerPublishQueue.Remove(subscription, false);
                             }
                         }
 
@@ -1323,7 +1319,9 @@ namespace Opc.Ua.Server
                             SessionDiagnosticsDataType diagnostics = ownerSession.SessionDiagnostics;
                             diagnostics.CurrentSubscriptionsCount--;
                         }
-                        // add the Good_SubscriptionTransferred
+
+                        // queue the Good_SubscriptionTransferred message
+                        bool statusQueued = false;
                         lock (m_statusMessagesLock)
                         {
                             if (!NodeId.IsNull(ownerSession.Id) && m_statusMessages.TryGetValue(ownerSession.Id, out var queue))
@@ -1333,6 +1331,24 @@ namespace Opc.Ua.Server
                                     Message = subscription.SubscriptionTransferred()
                                 };
                                 queue.Enqueue(message);
+                                statusQueued = true;
+                            }
+                        }
+
+                        if (statusQueued)
+                        {
+                            lock (m_lock)
+                            {
+                                // trigger publish response to return status immediately
+                                if (m_publishQueues.TryGetValue(ownerSession.Id, out var ownerPublishQueue) &&
+                                    ownerPublishQueue != null)
+                                {
+                                    // queue the status message
+                                    ownerPublishQueue.TryPublishCustomStatus(StatusCodes.GoodSubscriptionTransferred);
+
+                                    // remove queued requests if no subscriptions are active
+                                    ownerPublishQueue.RemoveQueuedRequests();
+                                }
                             }
                         }
                     }
@@ -1758,6 +1774,31 @@ namespace Opc.Ua.Server
         #endregion
 
         #region Private Methods
+        /// <summary>
+        /// Checks if there is a status message to return.
+        /// </summary>
+        private bool ReturnPendingStatusMessage(OperationContext context, out NotificationMessage message, out uint subscriptionId)
+        {
+            message = null;
+            subscriptionId = 0;
+
+            // check for status messages.
+            lock (m_statusMessagesLock)
+            {
+                if (m_statusMessages.TryGetValue(context.SessionId, out Queue<StatusMessage> statusQueue))
+                {
+                    if (statusQueue.Count > 0)
+                    {
+                        StatusMessage status = statusQueue.Dequeue();
+                        subscriptionId = status.SubscriptionId;
+                        message = status.Message;
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+
         /// <summary>
         /// Periodically checks if the sessions have timed out.
         /// </summary>

--- a/Stack/Opc.Ua.Core/Security/Certificates/DirectoryCertificateStore.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/DirectoryCertificateStore.cs
@@ -98,7 +98,7 @@ namespace Opc.Ua
 
         #region ICertificateStore Members
         /// <inheritdoc/>
-        public void Open(string location, bool noPrivateKeys)
+        public void Open(string location, bool noPrivateKeys = false)
         {
             lock (m_lock)
             {

--- a/Stack/Opc.Ua.Core/Security/Certificates/DirectoryCertificateStore.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/DirectoryCertificateStore.cs
@@ -98,7 +98,7 @@ namespace Opc.Ua
 
         #region ICertificateStore Members
         /// <inheritdoc/>
-        public void Open(string location, bool noPrivateKeys = false)
+        public void Open(string location, bool noPrivateKeys)
         {
             lock (m_lock)
             {

--- a/Tests/Opc.Ua.Client.Tests/SubscriptionTest.cs
+++ b/Tests/Opc.Ua.Client.Tests/SubscriptionTest.cs
@@ -854,13 +854,29 @@ namespace Opc.Ua.Client.Tests
                 // wait
                 await Task.Delay(kDelay).ConfigureAwait(false);
 
-                transferSubscriptions.AddRange(originSubscriptions);
+                transferSubscriptions.AddRange((SubscriptionCollection)originSubscriptions.Clone());
                 int ii = 0;
                 transferSubscriptions.ForEach(s => {
+                    targetSession.AddSubscription(s);
                     s.Handle = ii++;
                     s.FastDataChangeCallback = (sub, n, _) => {
                         TestContext.Out.WriteLine($"FastDataChangeHandlerTarget: {sub.Id}-{n.SequenceNumber}-{n.MonitoredItems.Count}");
                         targetSubscriptionFastDataCounters[(int)s.Handle]++;
+                    };
+                    s.MonitoredItems.ToList().ForEach(i =>
+                        i.Notification += (MonitoredItem item, MonitoredItemNotificationEventArgs e) => {
+                            targetSubscriptionCounters[(int)s.Handle]++;
+                            foreach (var value in item.DequeueValues())
+                            {
+                                TestContext.Out.WriteLine("Tra:{0}: {1:20}, {2}, {3}, {4}", s.Id, item.DisplayName, value.Value, value.SourceTimestamp, value.StatusCode);
+                            }
+                        }
+                    );
+                    s.StateChanged += (su, e) => {
+                        TestContext.Out.WriteLine($"StateChanged: {su.Session.SessionId}-{su.Id}-{e.Status}");
+                    };
+                    s.PublishStatusChanged += (su, e) => {
+                        TestContext.Out.WriteLine($"PublishStatusChanged: {su.Session.SessionId}-{su.Id}-{e.Status}");
                     };
                 });
             }
@@ -904,8 +920,8 @@ namespace Opc.Ua.Client.Tests
                 TestContext.Out.WriteLine("-- Subscription {0}: OriginFastDataCounts {1}, TargetFastDataCounts {2} ",
                     jj, originSubscriptionFastDataCounters[jj], targetSubscriptionFastDataCounters[jj]);
                 var monitoredItemCount = transferSubscriptions[jj].MonitoredItemCount;
-                var originExpectedCount = sendInitialValues && originSessionOpen ? monitoredItemCount * 2 : monitoredItemCount;
-                var targetExpectedCount = sendInitialValues && !originSessionOpen ? monitoredItemCount : 0;
+                var originExpectedCount = monitoredItemCount;
+                var targetExpectedCount = sendInitialValues ? monitoredItemCount : 0;
                 if (jj == 0)
                 {
                     // correct for delayed ack and republish count
@@ -953,10 +969,6 @@ namespace Opc.Ua.Client.Tests
 
                 int[] testCounter = targetSubscriptionCounters;
                 int[] testFastDataCounter = targetSubscriptionFastDataCounters;
-                if (transferType == TransferType.KeepOpen)
-                {
-                    testCounter = originSubscriptionCounters;
-                }
 
                 if (jj == 0)
                 {
@@ -1119,11 +1131,11 @@ namespace Opc.Ua.Client.Tests
                 };
 
                 subscription.StateChanged += (s, e) => {
-                    TestContext.Out.WriteLine($"StateChanged: {s.Id}-{e.Status}");
+                    TestContext.Out.WriteLine($"StateChanged: {s.Session.SessionId}-{s.Id}-{e.Status}");
                 };
 
                 subscription.PublishStatusChanged += (s, e) => {
-                    TestContext.Out.WriteLine($"PublishStatusChanged: {s.Id}-{e.Status}");
+                    TestContext.Out.WriteLine($"PublishStatusChanged: {s.Session.SessionId}-{s.Id}-{e.Status}");
                 };
 
                 originSubscriptions.Add(subscription);


### PR DESCRIPTION
## Proposed changes

Issues:
- The expectation is for a client session to receive a `GoodSubscriptionTransferred` status after a subscription is transferred to another session. However there is a corner case exposed in our tests, when all subscriptions are transferred so that the client subscriptiona has no active subscriptions left, only `BadNoSubscription` is returned by the server for allpending requests, instead of the status. As a workaround, to get the status, the client session has to send an additional publish request which is unexpected after a `BadNoSubscription` error.
- The status message is only returned on the next publish request, which can lead to undesired delay of the notification.

Fix: Return the status message immediately if pending requests are available.

Other fixes:
- Make client subscription class cloneable
- Improve the test which didn't receive the status messages
- Use the publish request queue to return a status message immediately

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [x] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
