### PR TITLE
Bump to MQTTnet v4.3.0.858 and replace deprecated call.

### DIFF
--- a/Libraries/Opc.Ua.PubSub/Opc.Ua.PubSub.csproj
+++ b/Libraries/Opc.Ua.PubSub/Opc.Ua.PubSub.csproj
@@ -36,7 +36,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="MQTTnet" Version="4.2.1.781" />
+    <PackageReference Include="MQTTnet" Version="4.3.0.858" />
     <PackageReference Include="System.Net.NetworkInformation" Version="4.3.0" />
   </ItemGroup>
 

--- a/Libraries/Opc.Ua.PubSub/Transport/MqttPubSubConnection.cs
+++ b/Libraries/Opc.Ua.PubSub/Transport/MqttPubSubConnection.cs
@@ -433,29 +433,38 @@ namespace Opc.Ua.PubSub.Transport
             var publisherMqttClient = m_publisherMqttClient;
             var subscriberMqttClient = m_subscriberMqttClient;
 
-            if (publisherMqttClient != null)
+            void DisposeCerts(X509CertificateCollection certificates)
             {
-                if (publisherMqttClient.IsConnected)
+                if (certificates != null)
                 {
-                    await publisherMqttClient.DisconnectAsync().ContinueWith((e) => publisherMqttClient.Dispose()).ConfigureAwait(false);
-                }
-                else
-                {
-                    publisherMqttClient.Dispose();
+                    // dispose certificates
+                    foreach (var cert in certificates)
+                    {
+                        Utils.SilentDispose(cert);
+                    }
                 }
             }
-
-            if (subscriberMqttClient != null)
+            async Task InternalStop(IMqttClient client)
             {
-                if (subscriberMqttClient.IsConnected)
+                if (client != null)
                 {
-                    await subscriberMqttClient.DisconnectAsync().ContinueWith((e) => subscriberMqttClient.Dispose()).ConfigureAwait(false);
-                }
-                else
-                {
-                    subscriberMqttClient.Dispose();
+                    X509CertificateCollection certificates = client.Options?.ChannelOptions?.TlsOptions?.ClientCertificatesProvider?.GetCertificates();
+                    if (client.IsConnected)
+                    {
+                        await client.DisconnectAsync().ContinueWith((e) => {
+                            DisposeCerts(certificates);
+                            Utils.SilentDispose(client);
+                        }).ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        DisposeCerts(certificates);
+                        Utils.SilentDispose(client);
+                    }
                 }
             }
+            await InternalStop(publisherMqttClient).ConfigureAwait(false);
+            await InternalStop(subscriberMqttClient).ConfigureAwait(false);
 
             if (m_metaDataPublishers != null)
             {
@@ -675,7 +684,7 @@ namespace Opc.Ua.PubSub.Transport
                     {
                         foreach (var x509cert in mqttTlsOptions?.Certificates.X509Certificates)
                         {
-                            x509Certificate2s.Add(new X509Certificate2(x509cert));
+                            x509Certificate2s.Add(new X509Certificate2(x509cert.Handle));
                         }
                     }
 


### PR DESCRIPTION
Bump to MQTTnet v4.3.0.858 and replaced obsolete WithTls method call with WithTlsOptions method cal.

## Proposed changes

MQTTnet v4.3.0.858 deprecated the WithTls method and recommends WithTlsOptions instead.

## Related Issues

Enables bump to MQTTnet v4.3.0.858

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [x] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

