### PR TITLE
Make CertificateValidationEventArgs and CertificateUpdateEventArgs constructors public

### DIFF
--- a/Stack/Opc.Ua.Core/Security/Certificates/CertificateValidator.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/CertificateValidator.cs
@@ -1853,7 +1853,7 @@ namespace Opc.Ua
         /// <summary>
         /// Creates a new instance.
         /// </summary>
-        internal CertificateUpdateEventArgs(
+        public CertificateUpdateEventArgs(
             SecurityConfiguration configuration,
             ICertificateValidator validator)
         {

--- a/Stack/Opc.Ua.Core/Security/Certificates/CertificateValidator.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/CertificateValidator.cs
@@ -434,7 +434,7 @@ namespace Opc.Ua
         /// Validates a certificate.
         /// </summary>
         /// <remarks>
-        /// Each UA application may have a list of trusted certificates that is different from 
+        /// Each UA application may have a list of trusted certificates that is different from
         /// all other UA applications that may be running on the same machine. As a result, the
         /// certificate validator cannot rely completely on the Windows certificate store and
         /// user or machine specific CTLs (certificate trust lists).
@@ -547,7 +547,7 @@ namespace Opc.Ua
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="se"></param>
         /// <param name="certificate"></param>
@@ -1514,8 +1514,8 @@ namespace Opc.Ua
                     goto case X509ChainStatusFlags.UntrustedRoot;
                 case X509ChainStatusFlags.UntrustedRoot:
                 {
-                    // self signed cert signature validation 
-                    // .NET Core ChainStatus returns NotSignatureValid only on Windows, 
+                    // self signed cert signature validation
+                    // .NET Core ChainStatus returns NotSignatureValid only on Windows,
                     // so we have to do the extra cert signature check on all platforms
                     if (issuer == null && id.Certificate != null &&
                         X509Utils.IsSelfSigned(id.Certificate))
@@ -1780,7 +1780,7 @@ namespace Opc.Ua
         /// <summary>
         /// Creates a new instance.
         /// </summary>
-        internal CertificateValidationEventArgs(ServiceResult error, X509Certificate2 certificate)
+        public CertificateValidationEventArgs(ServiceResult error, X509Certificate2 certificate)
         {
             m_error = error;
             m_certificate = certificate;


### PR DESCRIPTION
## Proposed changes

Currently there is a way to implement CertificateValidationEventHandler and CertificateUpdateEventHandler but because of CertificateValidationEventArgs and CertificateUpdateEventArgs  have only internal constructors, there is no way to create these EventArgs objects for unit testing purposes.  Making these constructors public will unblock this important scenario. 

## Related Issues

- Fixes #2324 

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [x] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
