### PR TITLE
GDS: add ArgumentException to Method CreateCACertificateAsync

### DIFF
--- a/Libraries/Opc.Ua.Gds.Server.Common/CertificateGroup.cs
+++ b/Libraries/Opc.Ua.Gds.Server.Common/CertificateGroup.cs
@@ -286,6 +286,12 @@ namespace Opc.Ua.Gds.Server
             string subjectName
             )
         {
+            if(!SubjectName.Equals(subjectName))
+            {
+                throw new ArgumentException("SubjectName provided does not match the SubjectName property of the CertificateGroup \n" +
+                    "CA Certificate is not created until the subjectName " + SubjectName " is provided", subjectName);
+            }
+        
             DateTime yesterday = DateTime.Today.AddDays(-1);
             X509Certificate2 newCertificate = CertificateFactory.CreateCertificate(subjectName)
                 .SetNotBefore(yesterday)
@@ -304,11 +310,6 @@ namespace Opc.Ua.Gds.Server
             // initialize revocation list
             await RevokeCertificateAsync(AuthoritiesStorePath, newCertificate, null).ConfigureAwait(false);
 
-            if(SubjectName != subjectName)
-            {
-                throw new ArgumentException("Subject Name of CA does not match the Subject Name Property of the Certificate Group \n" +
-                    "CA Certificate is created but only placed in the Issuer Certificate Store & not in the Trusted Store", subjectName);
-            }
             await UpdateAuthorityCertInTrustedList().ConfigureAwait(false);
 
             return Certificate;

--- a/Libraries/Opc.Ua.Gds.Server.Common/CertificateGroup.cs
+++ b/Libraries/Opc.Ua.Gds.Server.Common/CertificateGroup.cs
@@ -289,7 +289,7 @@ namespace Opc.Ua.Gds.Server
             if(!SubjectName.Equals(subjectName))
             {
                 throw new ArgumentException("SubjectName provided does not match the SubjectName property of the CertificateGroup \n" +
-                    "CA Certificate is not created until the subjectName " + SubjectName " is provided", subjectName);
+                    "CA Certificate is not created until the subjectName " + SubjectName + " is provided", subjectName);
             }
         
             DateTime yesterday = DateTime.Today.AddDays(-1);

--- a/Libraries/Opc.Ua.Gds.Server.Common/CertificateGroup.cs
+++ b/Libraries/Opc.Ua.Gds.Server.Common/CertificateGroup.cs
@@ -286,7 +286,11 @@ namespace Opc.Ua.Gds.Server
             string subjectName
             )
         {
-            if(!SubjectName.Equals(subjectName))
+            // validate new subjectName matches the previous subject
+            // TODO: An issuer may modify the subject of the CA certificate,
+            // but then the configuration must be updated too!
+            // NOTE: not a strict requirement here for ASN.1 byte compare
+            if (!X509Utils.CompareDistinguishedName(subjectName, SubjectName))
             {
                 throw new ArgumentException("SubjectName provided does not match the SubjectName property of the CertificateGroup \n" +
                     "CA Certificate is not created until the subjectName " + SubjectName + " is provided", subjectName);

--- a/Libraries/Opc.Ua.Gds.Server.Common/CertificateGroup.cs
+++ b/Libraries/Opc.Ua.Gds.Server.Common/CertificateGroup.cs
@@ -304,6 +304,11 @@ namespace Opc.Ua.Gds.Server
             // initialize revocation list
             await RevokeCertificateAsync(AuthoritiesStorePath, newCertificate, null).ConfigureAwait(false);
 
+            if(SubjectName != subjectName)
+            {
+                throw new ArgumentException("Subject Name of CA does not match the Subject Name Property of the Certificate Group \n" +
+                    "CA Certificate is created but only placed in the Issuer Certificate Store & not in the Trusted Store", subjectName);
+            }
             await UpdateAuthorityCertInTrustedList().ConfigureAwait(false);
 
             return Certificate;


### PR DESCRIPTION
## Proposed changes

Introduces an exception, to notify the user when supplying an invalid argument to the method CreateCACertificateAsync
This exception was introduced, as in the current implementation the same subject name has to be used as in the configuration or else the certificate is not copied to the trusted store.


## Related Issues

- Fixes #2325

## Types of changes

What types of changes does your code introduce?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [x] I ran tests locally with my changes, all passed.
- [x] I fixed all failing tests in the CI pipelines. 
- [x] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [x] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments
This only affects the GDS Server Project

