### PR TITLE
Fix for references that may cause a memory leak

### DIFF
--- a/Stack/Opc.Ua.Core/Stack/State/NodeState.cs
+++ b/Stack/Opc.Ua.Core/Stack/State/NodeState.cs
@@ -4489,11 +4489,25 @@ namespace Opc.Ua
                 return false;
             }
 
-            if (m_references.Remove(new NodeStateReference(referenceTypeId, isInverse, targetId)))
+            NodeStateReference sourceRef = null;
+
+            foreach (var m_refKey in m_references.Keys)
             {
-                m_changeMasks |= NodeStateChangeMasks.References;
-                OnReferenceRemoved?.Invoke(this, referenceTypeId, isInverse, targetId);
-                return true;
+                if (m_refKey.TargetId != null && m_refKey.TargetId.IdentifierText.Equals(targetId.IdentifierText))
+                {
+                    sourceRef = m_refKey as NodeStateReference;
+                    break;
+                }
+            }
+
+            if (sourceRef != null)
+            {
+                if (m_references.Remove(sourceRef))
+                {
+                    m_changeMasks |= NodeStateChangeMasks.References;
+                    OnReferenceRemoved?.Invoke(this, referenceTypeId, isInverse, targetId);
+                    return true;
+                }
             }
 
             return false;


### PR DESCRIPTION
References can not be removed after session closes and may cause a memory leak.

## Proposed changes

Root cause: Target's IsInverse flag which has incorrect value is used during the removal of source's reference 
Fix: Retrieve the source's reference by the targetId first and remove it.

## Related Issues

- Fixes #2343

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

