### PR TITLE
SHA-1 signatures will no longer be trusted by default 

### DIFF
--- a/Libraries/Opc.Ua.Security.Certificates/X509Certificate/X509PfxUtils.cs
+++ b/Libraries/Opc.Ua.Security.Certificates/X509Certificate/X509PfxUtils.cs
@@ -174,8 +174,8 @@ namespace Opc.Ua.Security.Certificates
             byte[] testBlock = new byte[TestBlockSize];
             var rnd = new Random();
             rnd.NextBytes(testBlock);
-            byte[] encryptedBlock = rsaPublicKey.Encrypt(testBlock, RSAEncryptionPadding.OaepSHA1);
-            byte[] decryptedBlock = rsaPrivateKey.Decrypt(encryptedBlock, RSAEncryptionPadding.OaepSHA1);
+            byte[] encryptedBlock = rsaPublicKey.Encrypt(testBlock, RSAEncryptionPadding.OaepSHA256);
+            byte[] decryptedBlock = rsaPrivateKey.Decrypt(encryptedBlock, RSAEncryptionPadding.OaepSHA256);
             if (decryptedBlock != null)
             {
                 return testBlock.SequenceEqual(decryptedBlock);
@@ -193,8 +193,8 @@ namespace Opc.Ua.Security.Certificates
             byte[] testBlock = new byte[TestBlockSize];
             var rnd = new Random();
             rnd.NextBytes(testBlock);
-            byte[] signature = rsaPrivateKey.SignData(testBlock, HashAlgorithmName.SHA1, RSASignaturePadding.Pkcs1);
-            return rsaPublicKey.VerifyData(testBlock, signature, HashAlgorithmName.SHA1, RSASignaturePadding.Pkcs1);
+            byte[] signature = rsaPrivateKey.SignData(testBlock, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+            return rsaPublicKey.VerifyData(testBlock, signature, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
         }
 
 #if ECC_SUPPORT

--- a/Libraries/Opc.Ua.Security.Certificates/X509Certificate/X509PfxUtils.cs
+++ b/Libraries/Opc.Ua.Security.Certificates/X509Certificate/X509PfxUtils.cs
@@ -174,8 +174,8 @@ namespace Opc.Ua.Security.Certificates
             byte[] testBlock = new byte[TestBlockSize];
             var rnd = new Random();
             rnd.NextBytes(testBlock);
-            byte[] encryptedBlock = rsaPublicKey.Encrypt(testBlock, RSAEncryptionPadding.OaepSHA256);
-            byte[] decryptedBlock = rsaPrivateKey.Decrypt(encryptedBlock, RSAEncryptionPadding.OaepSHA256);
+            byte[] encryptedBlock = rsaPublicKey.Encrypt(testBlock, RSAEncryptionPadding.OaepSHA1);
+            byte[] decryptedBlock = rsaPrivateKey.Decrypt(encryptedBlock, RSAEncryptionPadding.OaepSHA1);
             if (decryptedBlock != null)
             {
                 return testBlock.SequenceEqual(decryptedBlock);

--- a/Stack/Opc.Ua.Core/Security/Certificates/RsaUtils.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/RsaUtils.cs
@@ -330,8 +330,8 @@ namespace Opc.Ua
                 int blockSize = 0x10;
                 byte[] testBlock = new byte[blockSize];
                 randomSource.NextBytes(testBlock, 0, blockSize);
-                byte[] signature = privateKey.SignData(testBlock, HashAlgorithmName.SHA1, RSASignaturePadding.Pss);
-                return publicKey.VerifyData(testBlock, signature, HashAlgorithmName.SHA1, RSASignaturePadding.Pss);
+                byte[] signature = privateKey.SignData(testBlock, HashAlgorithmName.SHA256, RSASignaturePadding.Pss);
+                return publicKey.VerifyData(testBlock, signature, HashAlgorithmName.SHA256, RSASignaturePadding.Pss);
             }
             catch
             {

--- a/Tests/Opc.Ua.Security.Certificates.Tests/CertificateTestsForECDsa.cs
+++ b/Tests/Opc.Ua.Security.Certificates.Tests/CertificateTestsForECDsa.cs
@@ -378,8 +378,10 @@ namespace Opc.Ua.Security.Certificates.Tests
             PEMWriter.ExportCertificateAsPEM(certificate);
             if (certificate.HasPrivateKey)
             {
+#if !NETFRAMEWORK
                 PEMWriter.ExportPrivateKeyAsPEM(certificate, password);
                 PEMWriter.ExportECDsaPrivateKeyAsPEM(certificate);
+#endif
             }
         }
         #endregion

--- a/Tests/Opc.Ua.Security.Certificates.Tests/Opc.Ua.Security.Certificates.Tests.csproj
+++ b/Tests/Opc.Ua.Security.Certificates.Tests/Opc.Ua.Security.Certificates.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -15,6 +15,10 @@
     <DefineConstants>$(DefineConstants);ECC_SUPPORT</DefineConstants>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net48'">
+    <DefineConstants>$(DefineConstants);ECC_SUPPORT</DefineConstants>
+  </PropertyGroup>
+  
   <PropertyGroup Condition="'$(TargetFramework)' == 'net5.0'">
     <DefineConstants>$(DefineConstants);ECC_SUPPORT</DefineConstants>
   </PropertyGroup>
@@ -22,7 +26,11 @@
   <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <DefineConstants>$(DefineConstants);ECC_SUPPORT</DefineConstants>
   </PropertyGroup>
-  
+
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <DefineConstants>$(DefineConstants);ECC_SUPPORT</DefineConstants>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="3.14.0" />


### PR DESCRIPTION
## Proposed changes

- Since some distributions stop to trust SHA1 signatures by default, replace some internal algorithm checks with SHA256 versions.
- The test case to force signature check also reenables ECC tests for .NET 4.8 which had been previously disabled.

## Related Issues

- Fixes #2405 

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
