### PR TITLE
Fix potential deadlocks with WaitAsync on a SemaphoreSlim

### DIFF
--- a/Libraries/Opc.Ua.Client/SessionAsync.cs
+++ b/Libraries/Opc.Ua.Client/SessionAsync.cs
@@ -385,9 +385,9 @@ namespace Opc.Ua.Client
 
             if (subscriptionIds.Count > 0)
             {
+                await m_reconnectLock.WaitAsync(ct).ConfigureAwait(false);
                 try
                 {
-                    await m_reconnectLock.WaitAsync(ct).ConfigureAwait(false);
                     m_reconnecting = true;
 
                     for (int ii = 0; ii < subscriptions.Count; ii++)
@@ -485,9 +485,9 @@ namespace Opc.Ua.Client
 
             if (subscriptionIds.Count > 0)
             {
+                await m_reconnectLock.WaitAsync(ct).ConfigureAwait(false);
                 try
                 {
-                    await m_reconnectLock.WaitAsync(ct).ConfigureAwait(false);
                     m_reconnecting = true;
 
                     TransferSubscriptionsResponse response = await base.TransferSubscriptionsAsync(null, subscriptionIds, sendInitialValues, ct).ConfigureAwait(false);
@@ -1491,9 +1491,9 @@ namespace Opc.Ua.Client
         private async Task ReconnectAsync(ITransportWaitingConnection connection, ITransportChannel transportChannel, CancellationToken ct)
         {
             bool resetReconnect = false;
+            await m_reconnectLock.WaitAsync(ct).ConfigureAwait(false);
             try
             {
-                await m_reconnectLock.WaitAsync(ct).ConfigureAwait(false);
                 bool reconnecting = m_reconnecting;
                 m_reconnecting = true;
                 resetReconnect = true;

--- a/Stack/Opc.Ua.Core/Security/Certificates/CertificateValidator.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/CertificateValidator.cs
@@ -466,10 +466,10 @@ namespace Opc.Ua
 
             try
             {
+                await m_semaphore.WaitAsync(ct).ConfigureAwait(false);
+
                 try
                 {
-                    await m_semaphore.WaitAsync(ct).ConfigureAwait(false);
-
                     await InternalValidateAsync(chain, endpoint, ct).ConfigureAwait(false);
 
                     // add to list of validated certificates.
@@ -488,10 +488,9 @@ namespace Opc.Ua
             }
 
             // add to list of peers.
+            await m_semaphore.WaitAsync(ct).ConfigureAwait(false);
             try
             {
-                await m_semaphore.WaitAsync(ct).ConfigureAwait(false);
-
                 Utils.LogCertificate(LogLevel.Warning, "Validation errors suppressed: ", certificate);
                 m_validatedCertificates[certificate.Thumbprint] = new X509Certificate2(certificate.RawData);
             }


### PR DESCRIPTION
## Proposed changes

Fix cases where a cancellable `WaitAsync(ct)` on a `SemaphoreSlim` within a try/finally could end up in a deadlock.

Fix: The WaitAsync must be outside the try/finally block. if the WaitAsync is cancelled, it should not release the semaphore

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
