### PR TITLE
Use EphemeralKeySet for certificates with private key on supporting platforms

### DIFF
--- a/Libraries/Opc.Ua.Gds.Server.Common/CertificateGroup.cs
+++ b/Libraries/Opc.Ua.Gds.Server.Common/CertificateGroup.cs
@@ -302,7 +302,7 @@ namespace Opc.Ua.Gds.Server
             }
         
             DateTime yesterday = DateTime.Today.AddDays(-1);
-            X509Certificate2 newCertificate = CertificateFactory.CreateCertificate(subjectName)
+            using (X509Certificate2 newCertificate = CertificateFactory.CreateCertificate(subjectName)
                 .SetNotBefore(yesterday)
                 .SetLifeTime(Configuration.CACertificateLifetime)
                 .SetHashAlgorithm(X509Utils.GetRSAHashAlgorithmName(Configuration.CACertificateHashSize))
@@ -311,17 +311,19 @@ namespace Opc.Ua.Gds.Server
                 .CreateForRSA()
                 .AddToStore(
                     AuthoritiesStoreType,
-                    AuthoritiesStorePath);
+                    AuthoritiesStorePath))
+            {
 
-            // save only public key
-            Certificate = new X509Certificate2(newCertificate.RawData);
+                // save only public key
+                Certificate = new X509Certificate2(newCertificate.RawData);
 
-            // initialize revocation list
-            await RevokeCertificateAsync(AuthoritiesStorePath, newCertificate, null).ConfigureAwait(false);
+                // initialize revocation list
+                await RevokeCertificateAsync(AuthoritiesStorePath, newCertificate, null).ConfigureAwait(false);
 
-            await UpdateAuthorityCertInTrustedList().ConfigureAwait(false);
+                await UpdateAuthorityCertInTrustedList().ConfigureAwait(false);
 
-            return Certificate;
+                return Certificate;
+            }
         }
 
         #endregion

--- a/Libraries/Opc.Ua.Gds.Server.Common/LinqUsersDatabase.cs
+++ b/Libraries/Opc.Ua.Gds.Server.Common/LinqUsersDatabase.cs
@@ -182,8 +182,8 @@ namespace Opc.Ua.Gds.Server.Database.Linq
                 queryCounterResetTime = DateTime.UtcNow;
                 // assign IDs to new users
                 var queryNewUsers = from x in Users
-                                   where x.ID == Guid.Empty
-                                   select x;
+                                    where x.ID == Guid.Empty
+                                    select x;
                 if (Users.Count > 0)
                 {
                     foreach (var user in queryNewUsers)
@@ -199,18 +199,20 @@ namespace Opc.Ua.Gds.Server.Database.Linq
         #region IPasswordHasher
         private string Hash(string password)
         {
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0 || NET462
+#pragma warning disable CA5379 // Ensure Key Derivation Function algorithm is sufficiently strong
             using (var algorithm = new Rfc2898DeriveBytes(
-              password,
-              kSaltSize,
-              kIterations))
+                password,
+                kSaltSize,
+                kIterations))
             {
+#pragma warning restore CA5379 // Ensure Key Derivation Function algorithm is sufficiently strong
 #else
             using (var algorithm = new Rfc2898DeriveBytes(
-              password,
-              kSaltSize,
-              kIterations,
-              HashAlgorithmName.SHA512))
+                password,
+                kSaltSize,
+                kIterations,
+                HashAlgorithmName.SHA512))
             {
 #endif
                 var key = Convert.ToBase64String(algorithm.GetBytes(kKeySize));
@@ -235,18 +237,20 @@ namespace Opc.Ua.Gds.Server.Database.Linq
             var salt = Convert.FromBase64String(parts[1]);
             var key = Convert.FromBase64String(parts[2]);
 
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0 || NET462
+#pragma warning disable CA5379 // Ensure Key Derivation Function algorithm is sufficiently strong
             using (var algorithm = new Rfc2898DeriveBytes(
-              password,
-              salt,
-              iterations))
+                password,
+                salt,
+                iterations))
             {
+#pragma warning restore CA5379 // Ensure Key Derivation Function algorithm is sufficiently strong
 #else
             using (var algorithm = new Rfc2898DeriveBytes(
-              password,
-              salt,
-              iterations,
-              HashAlgorithmName.SHA512))
+                password,
+                salt,
+                iterations,
+                HashAlgorithmName.SHA512))
             {
 #endif
                 var keyToCheck = algorithm.GetBytes(kKeySize);
@@ -256,8 +260,8 @@ namespace Opc.Ua.Gds.Server.Database.Linq
                 return verified;
             }
         }
-    
-#endregion
+
+        #endregion
 
         #region Internal Members
         [OnDeserialized]

--- a/Libraries/Opc.Ua.Security.Certificates/X509Certificate/X509PfxUtils.cs
+++ b/Libraries/Opc.Ua.Security.Certificates/X509Certificate/X509PfxUtils.cs
@@ -29,6 +29,7 @@
 
 using System;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 
@@ -130,16 +131,16 @@ namespace Opc.Ua.Security.Certificates
             // By default keys are not persisted
             X509KeyStorageFlags defaultStorageSet = X509KeyStorageFlags.Exportable;
 #if NETSTANDARD2_1_OR_GREATER || NET472_OR_GREATER || NET5_0_OR_GREATER
-            if (!noEphemeralKeySet)
+            if (!noEphemeralKeySet && !RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
                 defaultStorageSet |= X509KeyStorageFlags.EphemeralKeySet;
             }
 #endif
 
             X509KeyStorageFlags[] storageFlags = {
-                            defaultStorageSet | X509KeyStorageFlags.MachineKeySet,
-                            defaultStorageSet | X509KeyStorageFlags.UserKeySet
-                        };
+                defaultStorageSet | X509KeyStorageFlags.MachineKeySet,
+                defaultStorageSet | X509KeyStorageFlags.UserKeySet
+            };
 
             // try some combinations of storage flags, support is platform dependent
             foreach (X509KeyStorageFlags flag in storageFlags)

--- a/Libraries/Opc.Ua.Security.Certificates/X509Certificate/X509PfxUtils.cs
+++ b/Libraries/Opc.Ua.Security.Certificates/X509Certificate/X509PfxUtils.cs
@@ -116,21 +116,26 @@ namespace Opc.Ua.Security.Certificates
         /// </summary>
         /// <param name="rawData">The raw PKCS #12 store data.</param>
         /// <param name="password">The password to use to access the store.</param>
+        /// <param name="noEphemeralKeySet">Set to true if the key should not use the ephemeral key set.</param>
         /// <returns>The certificate with a private key.</returns>
         public static X509Certificate2 CreateCertificateFromPKCS12(
             byte[] rawData,
-            string password
+            string password,
+            bool noEphemeralKeySet = false
             )
         {
             Exception ex = null;
             X509Certificate2 certificate = null;
 
             // By default keys are not persisted
+            X509KeyStorageFlags defaultStorageSet = X509KeyStorageFlags.Exportable;
 #if NETSTANDARD2_1_OR_GREATER || NET472_OR_GREATER || NET5_0_OR_GREATER
-            const X509KeyStorageFlags defaultStorageSet = X509KeyStorageFlags.Exportable | X509KeyStorageFlags.EphemeralKeySet;
-#else
-            const X509KeyStorageFlags defaultStorageSet = X509KeyStorageFlags.Exportable;
+            if (!noEphemeralKeySet)
+            {
+                defaultStorageSet |= X509KeyStorageFlags.EphemeralKeySet;
+            }
 #endif
+
             X509KeyStorageFlags[] storageFlags = {
                             defaultStorageSet | X509KeyStorageFlags.MachineKeySet,
                             defaultStorageSet | X509KeyStorageFlags.UserKeySet

--- a/Libraries/Opc.Ua.Server/Configuration/ConfigurationNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/Configuration/ConfigurationNodeManager.cs
@@ -469,12 +469,13 @@ namespace Opc.Ua.Server
                         case "":
                         {
                             X509Certificate2 certWithPrivateKey = certificateGroup.ApplicationCertificate.LoadPrivateKeyEx(passwordProvider).Result;
-                            updateCertificate.CertificateWithPrivateKey = CertificateFactory.CreateCertificateWithPrivateKey(newCert, certWithPrivateKey);
+                            var exportableKey = X509Utils.CreateCopyWithStorageFlags(certWithPrivateKey, false);
+                            updateCertificate.CertificateWithPrivateKey = CertificateFactory.CreateCertificateWithPrivateKey(newCert, exportableKey);
                             break;
                         }
                         case "PFX":
                         {
-                            X509Certificate2 certWithPrivateKey = X509Utils.CreateCertificateFromPKCS12(privateKey, passwordProvider?.GetPassword(certificateGroup.ApplicationCertificate));
+                            X509Certificate2 certWithPrivateKey = X509Utils.CreateCertificateFromPKCS12(privateKey, passwordProvider?.GetPassword(certificateGroup.ApplicationCertificate), true);
                             updateCertificate.CertificateWithPrivateKey = CertificateFactory.CreateCertificateWithPrivateKey(newCert, certWithPrivateKey);
                             break;
                         }

--- a/Libraries/Opc.Ua.Server/Configuration/ConfigurationNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/Configuration/ConfigurationNodeManager.cs
@@ -469,7 +469,7 @@ namespace Opc.Ua.Server
                         case "":
                         {
                             X509Certificate2 certWithPrivateKey = certificateGroup.ApplicationCertificate.LoadPrivateKeyEx(passwordProvider).Result;
-                            var exportableKey = X509Utils.CreateCopyWithStorageFlags(certWithPrivateKey, false);
+                            var exportableKey = X509Utils.CreateCopyWithPrivateKey(certWithPrivateKey, false);
                             updateCertificate.CertificateWithPrivateKey = CertificateFactory.CreateCertificateWithPrivateKey(newCert, exportableKey);
                             break;
                         }

--- a/Stack/Opc.Ua.Bindings.Https/Stack/Https/HttpsTransportListener.cs
+++ b/Stack/Opc.Ua.Bindings.Https/Stack/Https/HttpsTransportListener.cs
@@ -256,7 +256,7 @@ namespace Opc.Ua.Bindings
 #if NETCOREAPP3_1_OR_GREATER || NETSTANDARD2_1 || NET472_OR_GREATER || NET5_0_OR_GREATER
                 // Create a copy of the certificate with the private key on platforms
                 // which default to the ephemeral KeySet.
-                ServerCertificate = X509Utils.CreateCopyWithStorageFlags(m_serverCertificate, false)
+                ServerCertificate = X509Utils.CreateCopyWithPrivateKey(m_serverCertificate, false)
 #else
                 ServerCertificate = m_serverCertificate
 #endif

--- a/Stack/Opc.Ua.Bindings.Https/Stack/Https/HttpsTransportListener.cs
+++ b/Stack/Opc.Ua.Bindings.Https/Stack/Https/HttpsTransportListener.cs
@@ -253,12 +253,12 @@ namespace Opc.Ua.Bindings
                 CheckCertificateRevocation = false,
                 ClientCertificateMode = ClientCertificateMode.NoCertificate,
                 // note: this is the TLS certificate!
-#if NETSTANDARD2_1 || NET472_OR_GREATER || NET5_0_OR_GREATER
+#if NETCOREAPP3_1_OR_GREATER || NETSTANDARD2_1 || NET472_OR_GREATER || NET5_0_OR_GREATER
                 // Create a copy of the certificate with the private key on platforms
                 // which default to the ephemeral KeySet.
                 ServerCertificate = X509Utils.CreateCopyWithStorageFlags(m_serverCertificate, false)
 #else
-                ServerCertificate = m_serverCertificate;
+                ServerCertificate = m_serverCertificate
 #endif
             };
 

--- a/Stack/Opc.Ua.Core/Security/Certificates/CertificateValidator.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/CertificateValidator.cs
@@ -451,9 +451,9 @@ namespace Opc.Ua
         }
 
         /// <inheritdoc/>
-        public virtual Task ValidateAsync(X509Certificate2Collection chain, CancellationToken ct)
+        public virtual Task ValidateAsync(X509Certificate2Collection certificateChain, CancellationToken ct)
         {
-            return ValidateAsync(chain, null, ct);
+            return ValidateAsync(certificateChain, null, ct);
         }
 
         /// <summary>

--- a/Stack/Opc.Ua.Core/Security/Certificates/DirectoryCertificateStore.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/DirectoryCertificateStore.cs
@@ -14,6 +14,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Threading.Tasks;
@@ -402,11 +403,15 @@ namespace Opc.Ua
                             .Append(Path.DirectorySeparatorChar)
                             .Append(fileRoot);
 
+                        // By default keys are not persisted
+                        X509KeyStorageFlags defaultStorageSet = X509KeyStorageFlags.Exportable;
 #if NETSTANDARD2_1_OR_GREATER || NET472_OR_GREATER || NET5_0_OR_GREATER
-                        const X509KeyStorageFlags defaultStorageSet = X509KeyStorageFlags.Exportable | X509KeyStorageFlags.EphemeralKeySet;
-#else
-                        const X509KeyStorageFlags defaultStorageSet = X509KeyStorageFlags.Exportable;
+                        if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                        {
+                            defaultStorageSet |= X509KeyStorageFlags.EphemeralKeySet;
+                        }
 #endif
+
                         X509KeyStorageFlags[] storageFlags = {
                             defaultStorageSet | X509KeyStorageFlags.MachineKeySet,
                             defaultStorageSet | X509KeyStorageFlags.UserKeySet

--- a/Stack/Opc.Ua.Core/Security/Certificates/X509CertificateStore.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/X509CertificateStore.cs
@@ -143,8 +143,8 @@ namespace Opc.Ua
                     if (certificate.HasPrivateKey && !m_noPrivateKeys)
                     {
                         // X509Store needs a persisted private key
-                        var persistableCertificate = X509Utils.CreateCopyWithStorageFlags(certificate, true);
-                        store.Add(persistableCertificate);
+                        var persistedCertificate = X509Utils.CreateCopyWithPrivateKey(certificate, true);
+                        store.Add(persistedCertificate);
                     }
                     else if (certificate.HasPrivateKey && m_noPrivateKeys)
                     {

--- a/Stack/Opc.Ua.Core/Security/Certificates/X509CertificateStore.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/X509CertificateStore.cs
@@ -146,8 +146,7 @@ namespace Opc.Ua
                         var persistableCertificate = X509Utils.CreateCopyWithStorageFlags(certificate, true);
                         store.Add(persistableCertificate);
                     }
-                    else
-                    if (certificate.HasPrivateKey && m_noPrivateKeys)
+                    else if (certificate.HasPrivateKey && m_noPrivateKeys)
                     {
                         // ensure no private key is added to store
                         using (var publicKey = new X509Certificate2(certificate.RawData))

--- a/Stack/Opc.Ua.Core/Security/Certificates/X509Utils.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/X509Utils.cs
@@ -491,6 +491,24 @@ namespace Opc.Ua
         }
 
         /// <summary>
+        /// Creates a copy of a certificate with a private key, if required by0 the platform.
+        /// </summary>
+        /// <returns>The certificate</returns>
+        public static X509Certificate2 CreateCopyWithStorageFlags(X509Certificate2 certificate, bool persisted)
+        {
+            // a copy is only necessary on windows
+            if (certificate.HasPrivateKey &&
+                Environment.OSVersion.Platform == PlatformID.Win32NT)
+            {
+                // see https://github.com/dotnet/runtime/issues/29144
+                string passcode = GeneratePasscode();
+                X509KeyStorageFlags storageFlags = persisted ? X509KeyStorageFlags.PersistKeySet : X509KeyStorageFlags.DefaultKeySet;
+                return new X509Certificate2(certificate.Export(X509ContentType.Pfx, passcode), passcode, storageFlags);
+            }
+            return certificate;
+        }
+
+        /// <summary>
         /// Creates a certificate from a PKCS #12 store with a private key.
         /// </summary>
         /// <param name="rawData">The raw PKCS #12 store data.</param>

--- a/Stack/Opc.Ua.Core/Security/Certificates/X509Utils.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/X509Utils.cs
@@ -500,8 +500,11 @@ namespace Opc.Ua
         public static X509Certificate2 CreateCopyWithPrivateKey(X509Certificate2 certificate, bool persisted)
         {
             // a copy is only necessary on windows
-            if (certificate.HasPrivateKey &&
-                RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            if (certificate.HasPrivateKey
+#if !NETFRAMEWORK
+                && RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+#endif
+                )
             {
                 // see https://github.com/dotnet/runtime/issues/29144
                 string passcode = GeneratePasscode();

--- a/Stack/Opc.Ua.Core/Security/Certificates/X509Utils.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/X509Utils.cs
@@ -14,6 +14,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
@@ -491,14 +492,16 @@ namespace Opc.Ua
         }
 
         /// <summary>
-        /// Creates a copy of a certificate with a private key, if required by0 the platform.
+        /// Creates a copy of a certificate with a private key.
+        /// If the platform defaults to an ephemeral key set,
+        /// the private key requires an extra copy.
         /// </summary>
         /// <returns>The certificate</returns>
-        public static X509Certificate2 CreateCopyWithStorageFlags(X509Certificate2 certificate, bool persisted)
+        public static X509Certificate2 CreateCopyWithPrivateKey(X509Certificate2 certificate, bool persisted)
         {
             // a copy is only necessary on windows
             if (certificate.HasPrivateKey &&
-                Environment.OSVersion.Platform == PlatformID.Win32NT)
+                RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 // see https://github.com/dotnet/runtime/issues/29144
                 string passcode = GeneratePasscode();

--- a/Stack/Opc.Ua.Core/Security/Certificates/X509Utils.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/X509Utils.cs
@@ -502,7 +502,7 @@ namespace Opc.Ua
             {
                 // see https://github.com/dotnet/runtime/issues/29144
                 string passcode = GeneratePasscode();
-                X509KeyStorageFlags storageFlags = persisted ? X509KeyStorageFlags.PersistKeySet : X509KeyStorageFlags.DefaultKeySet;
+                X509KeyStorageFlags storageFlags = persisted ? X509KeyStorageFlags.PersistKeySet : X509KeyStorageFlags.Exportable;
                 return new X509Certificate2(certificate.Export(X509ContentType.Pfx, passcode), passcode, storageFlags);
             }
             return certificate;
@@ -513,13 +513,15 @@ namespace Opc.Ua
         /// </summary>
         /// <param name="rawData">The raw PKCS #12 store data.</param>
         /// <param name="password">The password to use to access the store.</param>
+        /// <param name="noEphemeralKeySet">Set to true if the key should not use the ephemeral key set.</param>
         /// <returns>The certificate with a private key.</returns>
         public static X509Certificate2 CreateCertificateFromPKCS12(
             byte[] rawData,
-            string password
+            string password,
+            bool noEphemeralKeySet = false
             )
         {
-            return X509PfxUtils.CreateCertificateFromPKCS12(rawData, password);
+            return X509PfxUtils.CreateCertificateFromPKCS12(rawData, password, noEphemeralKeySet);
         }
 
         /// <summary>

--- a/Tests/Opc.Ua.Configuration.Tests/ApplicationInstanceTests.cs
+++ b/Tests/Opc.Ua.Configuration.Tests/ApplicationInstanceTests.cs
@@ -565,7 +565,7 @@ namespace Opc.Ua.Configuration.Tests
 
                 //Act
                 await applicationInstance.AddOwnCertificateToTrustedStoreAsync(cert, new CancellationToken()).ConfigureAwait(false);
-                ICertificateStore store = configuration.SecurityConfiguration.TrustedPeerCertificates.OpenStore()
+                ICertificateStore store = configuration.SecurityConfiguration.TrustedPeerCertificates.OpenStore();
                 var storedCertificates = await store.FindByThumbprint(cert.Thumbprint).ConfigureAwait(false);
 
                 //Assert

--- a/Tests/Opc.Ua.Configuration.Tests/ApplicationInstanceTests.cs
+++ b/Tests/Opc.Ua.Configuration.Tests/ApplicationInstanceTests.cs
@@ -536,7 +536,7 @@ namespace Opc.Ua.Configuration.Tests
         }
 
         /// <summary>
-        /// Tests that a supplied certifiacte is stored in the Trusted store of the Server after calling method AddOwnCertificateToTrustedStoreAsync
+        /// Tests that a supplied certificate is stored in the Trusted store of the Server after calling method AddOwnCertificateToTrustedStoreAsync
         /// </summary>
         /// <returns></returns>
         [Test]
@@ -556,21 +556,23 @@ namespace Opc.Ua.Configuration.Tests
             DateTime notBefore = DateTime.Today.AddDays(-30);
             DateTime notAfter = DateTime.Today.AddDays(30);
 
-            var cert = CertificateFactory.CreateCertificate(SubjectName)
+            using (var cert = CertificateFactory.CreateCertificate(SubjectName)
                 .SetNotBefore(notBefore)
                 .SetNotAfter(notAfter)
                 .SetCAConstraint(-1)
-                .CreateForRSA();
+                .CreateForRSA())
+            {
 
-            //Act
-            await applicationInstance.AddOwnCertificateToTrustedStoreAsync(cert, new CancellationToken()).ConfigureAwait(false);
-            ICertificateStore store = configuration.SecurityConfiguration.TrustedPeerCertificates.OpenStore();
-            var storedCertificates = await store.FindByThumbprint(cert.Thumbprint).ConfigureAwait(false);
+                //Act
+                await applicationInstance.AddOwnCertificateToTrustedStoreAsync(cert, new CancellationToken()).ConfigureAwait(false);
+                ICertificateStore store = configuration.SecurityConfiguration.TrustedPeerCertificates.OpenStore()
+                var storedCertificates = await store.FindByThumbprint(cert.Thumbprint).ConfigureAwait(false);
 
-            //Assert
-            Assert.IsTrue(storedCertificates.Contains(cert));
+                //Assert
+                Assert.IsTrue(storedCertificates.Contains(cert));
+            }
         }
-      
+
         /// <summary>
         /// Test to verify that a new cert is not recreated/replaced if DisableCertificateAutoCreation is set.
         /// </summary>
@@ -692,28 +694,31 @@ namespace Opc.Ua.Configuration.Tests
             }
 
             string rootCASubjectName = "CN=Root CA Test, O=OPC Foundation, C=US, S=Arizona";
-            var rootCA = CertificateFactory.CreateCertificate(rootCASubjectName)
+            using (var rootCA = CertificateFactory.CreateCertificate(rootCASubjectName)
                 .SetNotBefore(issuerNotBefore)
                 .SetNotAfter(issuerNotAfter)
                 .SetCAConstraint(-1)
-                .CreateForRSA();
+                .CreateForRSA())
+            {
 
-            var appCert = CertificateFactory.CreateCertificate(
-                ApplicationUri,
-                ApplicationName,
-                SubjectName,
-                domainNames)
-                .SetNotBefore(notBefore)
-                .SetNotAfter(notAfter)
-                .SetIssuer(rootCA)
-                .SetRSAKeySize(keySize)
-                .CreateForRSA();
+                var appCert = CertificateFactory.CreateCertificate(
+                    ApplicationUri,
+                    ApplicationName,
+                    SubjectName,
+                    domainNames)
+                    .SetNotBefore(notBefore)
+                    .SetNotAfter(notAfter)
+                    .SetIssuer(rootCA)
+                    .SetRSAKeySize(keySize)
+                    .CreateForRSA();
 
-            var result = new X509Certificate2Collection {
-                appCert,
-                new X509Certificate2(rootCA.RawData)
-            };
-            return result;
+                var result = new X509Certificate2Collection {
+                    appCert,
+                    new X509Certificate2(rootCA.RawData)
+                };
+
+                return result;
+            }
         }
         #endregion
 

--- a/Tests/Opc.Ua.Core.Tests/Security/Certificates/CertificateFactoryTest.cs
+++ b/Tests/Opc.Ua.Core.Tests/Security/Certificates/CertificateFactoryTest.cs
@@ -73,6 +73,10 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
         [OneTimeTearDown]
         protected void OneTimeTearDown()
         {
+            foreach (var cert in m_rootCACertificate.Values)
+            {
+                Utils.SilentDispose(cert);
+            }
         }
         #endregion
 
@@ -89,26 +93,28 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
             ApplicationTestData app = appTestGenerator
                 .ApplicationTestSet(1)
                 .First();
-            var cert = CertificateFactory.CreateCertificate(app.ApplicationUri, app.ApplicationName, app.Subject, app.DomainNames)
+            using (var cert = CertificateFactory.CreateCertificate(app.ApplicationUri, app.ApplicationName, app.Subject, app.DomainNames)
                 .SetHashAlgorithm(keyHashPair.HashAlgorithmName)
                 .SetRSAKeySize(keyHashPair.KeySize)
-                .CreateForRSA();
-            Assert.NotNull(cert);
-            Assert.NotNull(cert.RawData);
-            Assert.True(cert.HasPrivateKey);
-            using (RSA rsa = cert.GetRSAPrivateKey())
+                .CreateForRSA())
             {
-                rsa.ExportParameters(true);
+                Assert.NotNull(cert);
+                Assert.NotNull(cert.RawData);
+                Assert.True(cert.HasPrivateKey);
+                using (RSA rsa = cert.GetRSAPrivateKey())
+                {
+                    rsa.ExportParameters(true);
+                }
+                using (RSA rsa = cert.GetRSAPublicKey())
+                {
+                    rsa.ExportParameters(false);
+                }
+                var plainCert = new X509Certificate2(cert.RawData);
+                Assert.NotNull(plainCert);
+                VerifyApplicationCert(app, plainCert);
+                X509Utils.VerifyRSAKeyPair(cert, cert, true);
+                Assert.True(X509Utils.VerifySelfSigned(cert), "Verify Self signed.");
             }
-            using (RSA rsa = cert.GetRSAPublicKey())
-            {
-                rsa.ExportParameters(false);
-            }
-            var plainCert = new X509Certificate2(cert.RawData);
-            Assert.NotNull(plainCert);
-            VerifyApplicationCert(app, plainCert);
-            X509Utils.VerifyRSAKeyPair(cert, cert, true);
-            Assert.True(X509Utils.VerifySelfSigned(cert), "Verify Self signed.");
         }
 
         /// <summary>
@@ -125,20 +131,22 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
             Assert.True(issuerCertificate.HasPrivateKey);
             var appTestGenerator = new ApplicationTestDataGenerator(keyHashPair.KeySize);
             ApplicationTestData app = appTestGenerator.ApplicationTestSet(1).First();
-            var cert = CertificateFactory.CreateCertificate(
+            using (var cert = CertificateFactory.CreateCertificate(
                 app.ApplicationUri, app.ApplicationName, app.Subject, app.DomainNames)
                 .SetHashAlgorithm(keyHashPair.HashAlgorithmName)
                 .SetIssuer(issuerCertificate)
                 .SetRSAKeySize(keyHashPair.KeySize)
-                .CreateForRSA();
-            Assert.NotNull(cert);
-            Assert.NotNull(cert.RawData);
-            Assert.True(cert.HasPrivateKey);
-            using (var plainCert = new X509Certificate2(cert.RawData))
+                .CreateForRSA())
             {
-                Assert.NotNull(plainCert);
-                VerifyApplicationCert(app, plainCert, issuerCertificate);
-                X509Utils.VerifyRSAKeyPair(plainCert, cert, true);
+                Assert.NotNull(cert);
+                Assert.NotNull(cert.RawData);
+                Assert.True(cert.HasPrivateKey);
+                using (var plainCert = new X509Certificate2(cert.RawData))
+                {
+                    Assert.NotNull(plainCert);
+                    VerifyApplicationCert(app, plainCert, issuerCertificate);
+                    X509Utils.VerifyRSAKeyPair(plainCert, cert, true);
+                }
             }
         }
 
@@ -181,67 +189,80 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
             X509Certificate2 issuerCertificate = GetIssuer(keyHashPair);
             Assert.True(X509Utils.VerifySelfSigned(issuerCertificate));
 
-            var otherIssuerCertificate = CertificateFactory.CreateCertificate(issuerCertificate.Subject)
+            using (var otherIssuerCertificate = CertificateFactory.CreateCertificate(issuerCertificate.Subject)
                 .SetLifeTime(TimeSpan.FromDays(180))
                 .SetHashAlgorithm(keyHashPair.HashAlgorithmName)
                 .SetCAConstraint(pathLengthConstraint)
-                .CreateForRSA();
-            Assert.True(X509Utils.VerifySelfSigned(otherIssuerCertificate));
-
-            X509Certificate2Collection revokedCerts = new X509Certificate2Collection();
-            for (int i = 0; i < 10; i++)
+                .CreateForRSA())
             {
-                var cert = CertificateFactory.CreateCertificate($"CN=Test Cert {i}, O=Contoso")
-                    .SetIssuer(issuerCertificate)
-                    .SetRSAKeySize((ushort)(keyHashPair.KeySize <= 2048 ? keyHashPair.KeySize : 2048))
-                    .CreateForRSA();
-                revokedCerts.Add(cert);
-                Assert.False(X509Utils.VerifySelfSigned(cert));
-            }
+                Assert.True(X509Utils.VerifySelfSigned(otherIssuerCertificate));
 
-            Assert.NotNull(issuerCertificate);
-            Assert.NotNull(issuerCertificate.RawData);
-            Assert.True(issuerCertificate.HasPrivateKey);
-            using (var rsa = issuerCertificate.GetRSAPrivateKey())
-            {
-                Assert.NotNull(rsa);
-            }
+                X509Certificate2Collection revokedCerts = new X509Certificate2Collection();
+                try
+                {
+                    for (int i = 0; i < 10; i++)
+                    {
+                        var cert = CertificateFactory.CreateCertificate($"CN=Test Cert {i}, O=Contoso")
+                            .SetIssuer(issuerCertificate)
+                            .SetRSAKeySize((ushort)(keyHashPair.KeySize <= 2048 ? keyHashPair.KeySize : 2048))
+                            .CreateForRSA();
+                        revokedCerts.Add(cert);
+                        Assert.False(X509Utils.VerifySelfSigned(cert));
+                    }
 
-            using (var plainCert = new X509Certificate2(issuerCertificate.RawData))
-            {
-                Assert.NotNull(plainCert);
-                VerifyCACert(plainCert, issuerCertificate.Subject, pathLengthConstraint);
-            }
-            Assert.True(X509Utils.VerifySelfSigned(issuerCertificate));
-            X509Utils.VerifyRSAKeyPair(issuerCertificate, issuerCertificate, true);
+                    Assert.NotNull(issuerCertificate);
+                    Assert.NotNull(issuerCertificate.RawData);
+                    Assert.True(issuerCertificate.HasPrivateKey);
+                    using (var rsa = issuerCertificate.GetRSAPrivateKey())
+                    {
+                        Assert.NotNull(rsa);
+                    }
 
-            var crl = CertificateFactory.RevokeCertificate(issuerCertificate, null, null);
-            Assert.NotNull(crl);
-            Assert.True(crl.VerifySignature(issuerCertificate, true));
-            var extension = crl.CrlExtensions.FindExtension<X509CrlNumberExtension>();
-            var crlCounter = new BigInteger(1);
-            Assert.AreEqual(crlCounter, extension.CrlNumber);
-            var revokedList = new X509CRLCollection {
-                crl
-            };
-            foreach (var cert in revokedCerts)
-            {
-                Assert.Throws<CryptographicException>(() => crl.VerifySignature(otherIssuerCertificate, true));
-                Assert.False(crl.IsRevoked(cert));
-                var nextCrl = CertificateFactory.RevokeCertificate(issuerCertificate, revokedList, new X509Certificate2Collection(cert));
-                crlCounter++;
-                Assert.NotNull(nextCrl);
-                Assert.True(nextCrl.IsRevoked(cert));
-                extension = nextCrl.CrlExtensions.FindExtension<X509CrlNumberExtension>();
-                Assert.AreEqual(crlCounter, extension.CrlNumber);
-                Assert.True(crl.VerifySignature(issuerCertificate, true));
-                revokedList.Add(nextCrl);
-                crl = nextCrl;
-            }
+                    using (var plainCert = new X509Certificate2(issuerCertificate.RawData))
+                    {
+                        Assert.NotNull(plainCert);
+                        VerifyCACert(plainCert, issuerCertificate.Subject, pathLengthConstraint);
+                    }
+                    Assert.True(X509Utils.VerifySelfSigned(issuerCertificate));
+                    X509Utils.VerifyRSAKeyPair(issuerCertificate, issuerCertificate, true);
 
-            foreach (var cert in revokedCerts)
-            {
-                Assert.True(crl.IsRevoked(cert));
+                    var crl = CertificateFactory.RevokeCertificate(issuerCertificate, null, null);
+                    Assert.NotNull(crl);
+                    Assert.True(crl.VerifySignature(issuerCertificate, true));
+                    var extension = crl.CrlExtensions.FindExtension<X509CrlNumberExtension>();
+                    var crlCounter = new BigInteger(1);
+                    Assert.AreEqual(crlCounter, extension.CrlNumber);
+                    var revokedList = new X509CRLCollection {
+                        crl
+                    };
+
+                    foreach (var cert in revokedCerts)
+                    {
+                        Assert.Throws<CryptographicException>(() => crl.VerifySignature(otherIssuerCertificate, true));
+                        Assert.False(crl.IsRevoked(cert));
+                        var nextCrl = CertificateFactory.RevokeCertificate(issuerCertificate, revokedList, new X509Certificate2Collection(cert));
+                        crlCounter++;
+                        Assert.NotNull(nextCrl);
+                        Assert.True(nextCrl.IsRevoked(cert));
+                        extension = nextCrl.CrlExtensions.FindExtension<X509CrlNumberExtension>();
+                        Assert.AreEqual(crlCounter, extension.CrlNumber);
+                        Assert.True(crl.VerifySignature(issuerCertificate, true));
+                        revokedList.Add(nextCrl);
+                        crl = nextCrl;
+                    }
+
+                    foreach (var cert in revokedCerts)
+                    {
+                        Assert.True(crl.IsRevoked(cert));
+                    }
+                }
+                finally
+                {
+                    foreach (var cert in revokedCerts)
+                    {
+                        Utils.SilentDispose(cert);
+                    }
+                }
             }
         }
 
@@ -252,8 +273,7 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
         public void ParseCertificateBlob()
         {
             // check if complete chain should be sent.
-            if (m_rootCACertificate != null &&
-                m_rootCACertificate.Count > 0)
+            if (m_rootCACertificate != null && !m_rootCACertificate.IsEmpty)
             {
                 var byteServerCertificateChain = new List<byte>();
                 var certArray = m_rootCACertificate.Values.ToArray();
@@ -285,7 +305,6 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
                     TestContext.Out.WriteLine(certChain[i]);
                     Assert.AreEqual(certChain[i].RawData, certArray[i].RawData);
                 }
-
             }
             else
             {

--- a/Tests/Opc.Ua.Core.Tests/Security/Certificates/CertificateStoreTest.cs
+++ b/Tests/Opc.Ua.Core.Tests/Security/Certificates/CertificateStoreTest.cs
@@ -74,6 +74,7 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
                     }
                 }
             }
+            Utils.SilentDispose(m_testCertificate);
         }
         #endregion
 


### PR DESCRIPTION
## Proposed changes

- In order to reduce leaking private key files on windows, `EphemeralKeySet`  is used on supporting platforms.
- Keys from the Ephemeral Keyset can not be used with `CopyWithPrivateKey`, add support to copy these keys, e.g. for GDS push support.
- MacOS throws PlatformNotSupported when ephemeral keyset is used.
- Kestrel needs a dedicated key without the ephemeral keyset flag.
- Dispose private keys where possible to reduce number of leaked files in tests.
- For bouncy castle legacy support, do not use the `PersistKey` flag by default on netstandard2.0 and net462. However keys may still leak.

## Related Issues

- Fixes #2136 
- Fixes #1950 

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
