### PR TITLE
Add missing DataTypes.Decimal to AttributeExtensions

### DIFF
--- a/Libraries/Opc.Ua.Client.ComplexTypes/TypeBuilder/AttributeExtensions.cs
+++ b/Libraries/Opc.Ua.Client.ComplexTypes/TypeBuilder/AttributeExtensions.cs
@@ -282,7 +282,8 @@ namespace Opc.Ua.Client.ComplexTypes
                 // supertypes of numbers
                 case DataTypes.Integer:
                 case DataTypes.UInteger:
-                case DataTypes.Number: return BuiltInType.Variant;
+                case DataTypes.Number: 
+                case DataTypes.Decimal: return BuiltInType.Variant;
             }
 
             return TypeInfo.GetBuiltInType(datatypeId);


### PR DESCRIPTION
## Proposed changes

Opc.Ua.Client.ComplexTypes.AttributeExtensions should handle DataTypes.Decimal

## Related Issues

- Fixes #2425

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.
