### PR TITLE
Improvements for client keep alive timers and locks in subscriptions and sessions

### DIFF
--- a/Libraries/Opc.Ua.Client/TraceableSessionFactory.cs
+++ b/Libraries/Opc.Ua.Client/TraceableSessionFactory.cs
@@ -135,7 +135,7 @@ namespace Opc.Ua.Client
         }
 
         /// <inheritdoc/>
-        public override Task<ITransportChannel> CreateChannelAsync(
+        public override async Task<ITransportChannel> CreateChannelAsync(
             ApplicationConfiguration configuration,
             ITransportWaitingConnection connection,
             ConfiguredEndpoint endpoint,
@@ -145,7 +145,7 @@ namespace Opc.Ua.Client
         {
             using (Activity activity = TraceableSession.ActivitySource.StartActivity(nameof(CreateAsync)))
             {
-                return base.CreateChannelAsync(configuration, connection, endpoint, updateBeforeConnect, checkDomain, ct);
+                return await base.CreateChannelAsync(configuration, connection, endpoint, updateBeforeConnect, checkDomain, ct).ConfigureAwait(false);
             }
         }
 
@@ -177,32 +177,35 @@ namespace Opc.Ua.Client
         }
 
         /// <inheritdoc/>
-        public override Task<ISession> RecreateAsync(ISession sessionTemplate, CancellationToken ct = default)
+        public override async Task<ISession> RecreateAsync(ISession sessionTemplate, CancellationToken ct = default)
         {
             Session session = ValidateISession(sessionTemplate);
             using (Activity activity = TraceableSession.ActivitySource.StartActivity(nameof(RecreateAsync)))
             {
-                return Task.FromResult((ISession)new TraceableSession(Session.Recreate(session)));
+                ISession recreatedSession = await Session.RecreateAsync(session, ct).ConfigureAwait(false);
+                return new TraceableSession(recreatedSession);
             }
         }
 
         /// <inheritdoc/>
-        public override Task<ISession> RecreateAsync(ISession sessionTemplate, ITransportWaitingConnection connection, CancellationToken ct = default)
+        public override async Task<ISession> RecreateAsync(ISession sessionTemplate, ITransportWaitingConnection connection, CancellationToken ct = default)
         {
             Session session = ValidateISession(sessionTemplate);
             using (Activity activity = TraceableSession.ActivitySource.StartActivity(nameof(RecreateAsync)))
             {
-                return Task.FromResult((ISession)new TraceableSession(Session.Recreate(session, connection)));
+                ISession recreatedSession = await Session.RecreateAsync(session, connection, ct).ConfigureAwait(false);
+                return new TraceableSession(recreatedSession);
             }
         }
 
         /// <inheritdoc/>
-        public override Task<ISession> RecreateAsync(ISession sessionTemplate, ITransportChannel channel, CancellationToken ct = default)
+        public override async Task<ISession> RecreateAsync(ISession sessionTemplate, ITransportChannel channel, CancellationToken ct = default)
         {
             Session session = ValidateISession(sessionTemplate);
             using (Activity activity = TraceableSession.ActivitySource.StartActivity(nameof(RecreateAsync)))
             {
-                return Task.FromResult((ISession)new TraceableSession(Session.Recreate(session, channel)));
+                ISession recreatedSession = await Session.RecreateAsync(session, channel, ct).ConfigureAwait(false);
+                return new TraceableSession(recreatedSession);
             }
         }
         #endregion

--- a/Stack/Opc.Ua.Core/Types/Utils/AsyncAutoResetEvent.cs
+++ b/Stack/Opc.Ua.Core/Types/Utils/AsyncAutoResetEvent.cs
@@ -57,10 +57,9 @@ namespace Opc.Ua.Types.Utils
                 }
                 else
                 {
-                    // TaskCreationOptions.RunContinuationsAsynchronously is not necessary
-                    // unless the setting thread shares locks with the waiting thread.
-                    // Then dead locks may occur an the option is required.
-                    var tcs = new TaskCompletionSource<bool>();
+                    // TaskCreationOptions.RunContinuationsAsynchronously is needed
+                    // to decouple the reader thread from the processing in the subscriptions.
+                    var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
                     m_waits.Enqueue(tcs);
                     return tcs.Task;
                 }


### PR DESCRIPTION
## Proposed changes

Issue: 
- On high load, the keep alive timers keep firing and may get blocked in locks, leading to thread starvation.
- The `AsyncAutoResetEvent` for subscriptions is triggered from the reader loop inside a lock and the following execution on the subscription workload blocks the reader thread.

Fixes: 
- Use periodic timer for platforms supporting it
- Make the `PublishingStopped` and lastkeepalive non blocking by using interlocked variables.
- To decouple the reader loop from the subscription processing, create the TaskCompletionSource with `TaskCreationOptions.RunContinuationsAsynchronously` option.

## Related Issues

- Fixes #

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
