### PR TITLE
Add Pubsub uadp discovery for Publisher Server Endpoints and DataSetWriter configuration 

### DIFF
--- a/Libraries/Opc.Ua.PubSub/DataSetWriterConfigurationResponse.cs
+++ b/Libraries/Opc.Ua.PubSub/DataSetWriterConfigurationResponse.cs
@@ -1,0 +1,54 @@
+/* ========================================================================
+ * Copyright (c) 2005-2021 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ * 
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ * 
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+namespace Opc.Ua.PubSub
+{
+    /// <summary>
+    /// Data Set Writer Configuration message
+    /// </summary>
+    public class DataSetWriterConfigurationResponse
+    {
+        /// <summary>
+        /// DataSetWriterIds contained in the configuration information.
+        /// </summary>
+        public ushort[] DataSetWriterIds { get; set; }
+
+        /// <summary>
+        /// The field shall contain only the entry for the requested or changed DataSetWriters in the WriterGroup.
+        /// </summary>
+        public WriterGroupDataType DataSetWriterConfig { get; set; }
+
+        /// <summary>
+        /// Status codes indicating the capability of the Publisher to provide 
+        /// configuration information for the DataSetWriterIds.The size of the array
+        /// shall match the size of the DataSetWriterIds array.
+        /// </summary>
+        public StatusCode[] StatusCodes { get; set; }
+    }
+}

--- a/Libraries/Opc.Ua.PubSub/DatasetWriterConfigurationEventArgs.cs
+++ b/Libraries/Opc.Ua.PubSub/DatasetWriterConfigurationEventArgs.cs
@@ -1,0 +1,64 @@
+/* ========================================================================
+ * Copyright (c) 2005-2021 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ * 
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ * 
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+
+namespace Opc.Ua.PubSub
+{
+    /// <summary>
+    /// Class that contains data related to DatasetWriterConfigurationReceived event
+    /// </summary>
+    public class DataSetWriterConfigurationEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Get the ids of the DataSetWriters
+        /// </summary>
+        public ushort[] DataSetWriterIds { get; internal set; }
+
+        /// <summary>
+        /// Get the received configuration.
+        /// </summary>
+        public WriterGroupDataType DataSetWriterConfiguration { get; internal set; }
+
+        /// <summary>
+        /// Get the source information
+        /// </summary>
+        public string Source { get; internal set; }
+
+        /// <summary>
+        /// Get the publisher Id
+        /// </summary>
+        public object PublisherId { get; internal set; }
+
+        /// <summary>
+        /// Get the statuses code of the DataSetWriter
+        /// </summary>
+        public StatusCode[] StatusCodes { get; internal set; }
+    }
+}

--- a/Libraries/Opc.Ua.PubSub/Encoding/UadpNetworkMessage.cs
+++ b/Libraries/Opc.Ua.PubSub/Encoding/UadpNetworkMessage.cs
@@ -550,13 +550,13 @@ namespace Opc.Ua.PubSub.Encoding
             }
             else
             {
-                Utils.Trace("The UADP DiscoveryResponse DataSetMetaData message cannot be encoded: The DataSetWriterId property is missing. Value 0 will be used.");
+                Trace("The UADP DiscoveryResponse DataSetMetaData message cannot be encoded: The DataSetWriterId property is missing. Value 0 will be used.");
                 binaryEncoder.WriteUInt16("DataSetWriterId", 0);
             }
 
             if (m_metadata == null)
             {
-                Utils.Trace("The UADP DiscoveryResponse DataSetMetaData message cannot be encoded: The MetaData property is missing. Value null will be used.");
+                Trace("The UADP DiscoveryResponse DataSetMetaData message cannot be encoded: The MetaData property is missing. Value null will be used.");
             }
             binaryEncoder.WriteEncodeable("MetaData", m_metadata, typeof(DataSetMetaDataType));
 
@@ -900,7 +900,7 @@ namespace Opc.Ua.PubSub.Encoding
             catch (Exception ex)
             {
                 // Unexpected exception in DecodeSubscribedDataSets
-                Utils.Trace(ex, "UadpNetworkMessage.DecodeSubscribedDataSets");
+                Trace(ex, "UadpNetworkMessage.DecodeSubscribedDataSets");
             }
         }
 
@@ -915,7 +915,7 @@ namespace Opc.Ua.PubSub.Encoding
 
             // temporary write StatusCode.Good 
             StatusCode statusCode = binaryDecoder.ReadStatusCode("StatusCode");
-            Utils.Trace("DecodeMetaDataMessage returned: ", statusCode);
+            Trace("DecodeMetaDataMessage returned: ", statusCode);
 
         }
 
@@ -929,7 +929,7 @@ namespace Opc.Ua.PubSub.Encoding
 
             PublisherProvideEndpoints = binaryDecoder.ReadStatusCode("statusCode");
 
-            Utils.Trace("DecodePublisherEndpointsMessage returned: ", PublisherProvideEndpoints);
+            Trace("DecodePublisherEndpointsMessage returned: ", PublisherProvideEndpoints);
         }
 
         /// <summary>
@@ -975,7 +975,7 @@ namespace Opc.Ua.PubSub.Encoding
             {
                 if (PublisherId == null)
                 {
-                    Utils.Trace(TraceMasks.Error, "NetworkMessageHeader cannot be encoded. PublisherId is null but it is expected to be encoded.");
+                    Trace(TraceMasks.Error, "NetworkMessageHeader cannot be encoded. PublisherId is null but it is expected to be encoded.");
                 }
                 else
                 {

--- a/Libraries/Opc.Ua.PubSub/PublisherEndpointsEventArgs.cs
+++ b/Libraries/Opc.Ua.PubSub/PublisherEndpointsEventArgs.cs
@@ -1,0 +1,59 @@
+/* ========================================================================
+ * Copyright (c) 2005-2021 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ * 
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ * 
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+
+namespace Opc.Ua.PubSub
+{
+    /// <summary>
+    /// Class that contains data related to PublisherEndpoints event
+    /// </summary>
+    public class PublisherEndpointsEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Get the received Publisher identifier.
+        /// </summary>
+        public object PublisherId { get; internal set; }
+
+        /// <summary>
+        /// Get the source information
+        /// </summary>
+        public string Source { get; internal set; }
+
+        /// <summary>
+        /// Get the received Publisher Endpoints.
+        /// </summary>
+        public EndpointDescription[] PublisherEndpoints { get; internal set; }
+
+        /// <summary>
+        /// Get the status code of the DataSetWriter
+        /// </summary>
+        public StatusCode StatusCode { get; internal set; }
+    }
+}

--- a/Libraries/Opc.Ua.PubSub/Transport/IUadpDiscoveryMessages.cs
+++ b/Libraries/Opc.Ua.PubSub/Transport/IUadpDiscoveryMessages.cs
@@ -1,0 +1,103 @@
+/* ========================================================================
+ * Copyright (c) 2005-2021 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ * 
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ * 
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using System.Collections.Generic;
+
+namespace Opc.Ua.PubSub
+{
+    /// <summary>
+    /// UADP Discovery messages interface
+    /// </summary>
+    public interface IUadpDiscoveryMessages
+    {
+        /// <summary>
+        /// Set GetPublisherEndpoints callback used by the subscriber to receive PublisherEndpoints data from publisher
+        /// </summary>
+        /// <param name="eventHandler"></param>
+        void GetPublisherEndpointsCallback(GetPublisherEndpointsEventHandler eventHandler);
+
+        /// <summary>
+        /// Set GetDataSetWriterIds callback used by the subscriber to receive DataSetWriter ids from publisher
+        /// </summary>
+        /// <param name="eventHandler"></param>
+        void GetDataSetWriterConfigurationCallback(GetDataSetWriterIdsEventHandler eventHandler);
+
+        /// <summary>
+        /// Create and return the list of EndpointDescription to be used only by UADP Discovery response messages
+        /// </summary>
+        /// <param name="endpoints"></param>
+        /// <param name="publisherProvideEndpointsStatusCode"></param>
+        /// <param name="publisherId"></param>
+        /// <returns></returns>
+        UaNetworkMessage CreatePublisherEndpointsNetworkMessage(EndpointDescription[] endpoints,
+            StatusCode publisherProvideEndpointsStatusCode, object publisherId);
+
+        /// <summary>
+        /// Create and return the list of DataSetMetaData response messages 
+        /// </summary>
+        /// <param name="dataSetWriterIds"></param>
+        /// <returns></returns>
+        IList<UaNetworkMessage> CreateDataSetMetaDataNetworkMessages(UInt16[] dataSetWriterIds);
+
+        /// <summary>
+        /// Create and return the list of DataSetWriterConfiguration response message
+        /// </summary>
+        /// <param name="dataSetWriterIds">DatasetWriter ids</param>
+        /// <returns></returns>
+        IList<UaNetworkMessage> CreateDataSetWriterCofigurationMessage(UInt16[] dataSetWriterIds);
+
+        /// <summary>
+        /// Request UADP Discovery DataSetWriterConfiguration messages
+        /// </summary>
+        void RequestDataSetWriterConfiguration();
+
+        /// <summary>
+        /// Request UADP Discovery DataSetMetaData messages
+        /// </summary>
+        void RequestDataSetMetaData();
+
+        /// <summary>
+        /// Request UADP Discovery Publisher endpoints only
+        /// </summary>
+        void RequestPublisherEndpoints();
+    }
+
+    /// <summary>
+    /// Get PublisherEndpoints event handler
+    /// </summary>
+    /// <returns></returns>
+    public delegate IList<EndpointDescription> GetPublisherEndpointsEventHandler();
+
+    /// <summary>
+    /// Get DataSetWriterConfiguration ids event handler
+    /// </summary>
+    /// <returns></returns>
+    public delegate IList<UInt16> GetDataSetWriterIdsEventHandler(UaPubSubApplication uaPubSubApplication);
+}

--- a/Libraries/Opc.Ua.PubSub/Transport/UdpDiscoveryPublisher.cs
+++ b/Libraries/Opc.Ua.PubSub/Transport/UdpDiscoveryPublisher.cs
@@ -33,6 +33,7 @@ using System.Net;
 using System.Net.Sockets;
 using System.Threading.Tasks;
 using Opc.Ua.PubSub.Encoding;
+using System.Linq;
 
 namespace Opc.Ua.PubSub.Transport
 {
@@ -41,11 +42,13 @@ namespace Opc.Ua.PubSub.Transport
     /// </summary>
     internal class UdpDiscoveryPublisher : UdpDiscovery
     {
+        #region Private fields 
+        // Minimum response interval
         private const int kMinimumResponseInterval = 500;
 
         // The list that will store the WriterIds that shall be set as DataSetMetaData Response message
         private readonly List<UInt16> m_metadataWriterIdsToSend;
-        private int m_responseInterval = kMinimumResponseInterval;
+        #endregion
 
         #region Constructor
         /// <summary>
@@ -86,7 +89,6 @@ namespace Opc.Ua.PubSub.Transport
                 }
             }
         }
-
         #endregion
 
         #region Private Methods
@@ -97,8 +99,9 @@ namespace Opc.Ua.PubSub.Transport
         private void OnUadpDiscoveryReceive(IAsyncResult result)
         {
             // this is what had been passed into BeginReceive as the second parameter:
+            UdpClient socket = result.AsyncState as UdpClient;
 
-            if (!(result.AsyncState is UdpClient socket))
+            if (socket == null)
             {
                 return;
             }
@@ -174,14 +177,30 @@ namespace Opc.Ua.PubSub.Transport
                     }
                 }
 
-                Task.Run(SendResponseDataSetMetaDataAsync).ConfigureAwait(false);
+                Task.Run(SendResponseDataSetMetaData).ConfigureAwait(false);
+            }
+
+            else if (networkMessage.UADPNetworkMessageType == UADPNetworkMessageType.DiscoveryRequest
+                    && networkMessage.UADPDiscoveryType == UADPNetworkMessageDiscoveryType.PublisherEndpoint)
+            {
+                Task.Run(SendResponsePublisherEndpoints).ConfigureAwait(false);
+            }
+
+            else if (networkMessage.UADPNetworkMessageType == UADPNetworkMessageType.DiscoveryRequest
+                && networkMessage.UADPDiscoveryType == UADPNetworkMessageDiscoveryType.DataSetWriterConfiguration
+                && networkMessage.DataSetWriterIds != null)
+            {
+                Task.Run(SendResponseDataSetWriterConfiguration).ConfigureAwait(false);
             }
         }
 
-        private async Task SendResponseDataSetMetaDataAsync()
-        {
-            await Task.Delay(m_responseInterval).ConfigureAwait(false);
 
+        /// <summary>
+        /// Sends a DataSetMetadata discovery response message
+        /// </summary>
+        private async Task SendResponseDataSetMetaData()
+        {
+            await Task.Delay(kMinimumResponseInterval).ConfigureAwait(false);
             lock (m_lock)
             {
                 if (m_metadataWriterIdsToSend.Count > 0)
@@ -190,12 +209,67 @@ namespace Opc.Ua.PubSub.Transport
 
                     foreach (UaNetworkMessage message in responseMessages)
                     {
-                        Utils.Trace("UdpDiscoveryPublisher.SendResponseDataSetMetaData Before sending message for DataSetWriterId:{0}", message.DataSetWriterId);
+                        Utils.Trace("UdpDiscoveryPublisher.SendResponseDataSetMetaData before sending message for DataSetWriterId:{0}", message.DataSetWriterId);
 
                         m_udpConnection.PublishNetworkMessage(message);
                     }
                     m_metadataWriterIdsToSend.Clear();
                 }
+            }
+        }
+
+        /// <summary>
+        /// Sends a DataSetWriterConfiguration discovery response message
+        /// </summary>
+        private async Task SendResponseDataSetWriterConfiguration()
+        {
+            await Task.Delay(kMinimumResponseInterval).ConfigureAwait(false);
+            lock (m_lock)
+            {
+                IList<UInt16> dataSetWriterIdsToSend = new List<UInt16>();
+                if (GetDataSetWriterIds != null)
+                {
+                    dataSetWriterIdsToSend = GetDataSetWriterIds.Invoke(m_udpConnection.Application);
+                }
+
+                if (dataSetWriterIdsToSend.Count > 0)
+                {
+                    IList<UaNetworkMessage> responsesMessages = m_udpConnection.CreateDataSetWriterCofigurationMessage(
+                        dataSetWriterIdsToSend.ToArray());
+
+                    foreach (var responsesMessage in responsesMessages)
+                    {
+                        Utils.Trace("UdpDiscoveryPublisher.SendResponseDataSetWriterConfiguration Before sending message for DataSetWriterId:{0}", responsesMessage.DataSetWriterId);
+
+                        m_udpConnection.PublishNetworkMessage(responsesMessage);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        ///  Send response PublisherEndpoints
+        /// </summary>
+        private async Task SendResponsePublisherEndpoints()
+        {
+            await Task.Delay(kMinimumResponseInterval).ConfigureAwait(false);
+
+            lock (m_lock)
+            {
+                IList<EndpointDescription> publisherEndpointsToSend = new List<EndpointDescription>();
+                if (GetPublisherEndpoints != null)
+                {
+                    publisherEndpointsToSend = GetPublisherEndpoints.Invoke();
+                }
+
+                UaNetworkMessage message = m_udpConnection.CreatePublisherEndpointsNetworkMessage(
+                    publisherEndpointsToSend.ToArray(),
+                    publisherEndpointsToSend.Count > 0 ? StatusCodes.Good : StatusCodes.BadNotFound,
+                    m_udpConnection.PubSubConnectionConfiguration.PublisherId.Value);
+
+                Utils.Trace("UdpDiscoveryPublisher.SendResponsePublisherEndpoints before sending message for PublisherEndpoints.");
+
+                m_udpConnection.PublishNetworkMessage(message);
             }
         }
 
@@ -229,6 +303,20 @@ namespace Opc.Ua.PubSub.Transport
                 newsocket.BeginReceive(OnUadpDiscoveryReceive, newsocket);
             }
         }
+        #endregion
+
+        #region Public Properties
+
+        /// <summary>
+        /// The GetPublisherEndpoints event callback reference to store the EndpointDescription[] to be set as PublisherEndpoints Response message 
+        /// </summary>
+        public GetPublisherEndpointsEventHandler GetPublisherEndpoints { get; set; }
+
+        /// <summary>
+        ///  The GetDataSetWriterIds event callback reference to store the DataSetWriter ids to be set as PublisherEndpoints Response message
+        /// </summary>
+        public GetDataSetWriterIdsEventHandler GetDataSetWriterIds { get; set; }
+
         #endregion
     }
 }

--- a/Libraries/Opc.Ua.PubSub/Transport/UdpDiscoverySubscriber.cs
+++ b/Libraries/Opc.Ua.PubSub/Transport/UdpDiscoverySubscriber.cs
@@ -29,6 +29,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Net.Sockets;
 using System.Threading.Tasks;
 using Opc.Ua.PubSub.Encoding;
 
@@ -39,6 +41,7 @@ namespace Opc.Ua.PubSub.Transport
     /// </summary>
     internal class UdpDiscoverySubscriber : UdpDiscovery
     {
+        #region  Private Fields
         private const int kInitialRequestInterval = 5000;
 
         // The list that will store the WriterIds that shall be included in a DataSetMetaData Request message
@@ -46,6 +49,7 @@ namespace Opc.Ua.PubSub.Transport
 
         // the component that triggers the publish request messages
         private readonly IntervalRunner m_intervalRunner;
+        #endregion
 
         #region Constructor
         /// <summary>
@@ -57,12 +61,12 @@ namespace Opc.Ua.PubSub.Transport
             m_metadataWriterIdsToSend = new List<ushort>();
 
             m_intervalRunner = new IntervalRunner(udpConnection.PubSubConnectionConfiguration.Name,
-                kInitialRequestInterval, CanPublish, SendDiscoveryRequestDataSetMetaData);
+                kInitialRequestInterval, CanPublish, RequestDiscoveryMessages);
 
         }
         #endregion
 
-        #region Start/Stop Method Overides
+        #region Start/Stop Method Overrides
 
         /// <summary>
         /// Implementation of StartAsync for the subscriber Discovery
@@ -105,7 +109,7 @@ namespace Opc.Ua.PubSub.Transport
         }
 
         /// <summary>
-        /// Removes the specfoed DataSetWriterId for DataSetInformation to be requested 
+        /// Removes the specified DataSetWriterId for DataSetInformation to be requested 
         /// </summary>
         /// <param name="writerId"></param>
         public void RemoveWriterIdForDataSetMetadata(UInt16 writerId)
@@ -118,33 +122,91 @@ namespace Opc.Ua.PubSub.Transport
                 }
             }
         }
-        #endregion
+        /// <summary>
+        /// Send a discovery Request for DataSetWriterConfiguration
+        /// </summary>
+        public void SendDiscoveryRequestDataSetWriterConfiguration()
+        {
+            ushort[] dataSetWriterIds = m_udpConnection.PubSubConnectionConfiguration.ReaderGroups?
+                .SelectMany(group => group.DataSetReaders)?
+                .Select(group => group.DataSetWriterId)?
+                .ToArray();
 
-        #region Private Methods
+            UadpNetworkMessage discoveryRequestDataSetWriterConfiguration = new UadpNetworkMessage(UADPNetworkMessageDiscoveryType.DataSetWriterConfiguration) {
+                DataSetWriterIds = dataSetWriterIds,
+                PublisherId = m_udpConnection.PubSubConnectionConfiguration.PublisherId.Value,
+            };
+
+            byte[] bytes = discoveryRequestDataSetWriterConfiguration.Encode(MessageContext);
+
+            // send the Discovery request message to all open UADPClient 
+            foreach (UdpClient udpClient in m_discoveryUdpClients)
+            {
+                try
+                {
+                    Utils.Trace("UdpDiscoverySubscriber.SendDiscoveryRequestDataSetWriterConfiguration message");
+                    udpClient.Send(bytes, bytes.Length, DiscoveryNetworkAddressEndPoint);
+                }
+                catch (Exception ex)
+                {
+                    Utils.Trace(ex, "UdpDiscoverySubscriber.SendDiscoveryRequestDataSetWriterConfiguration");
+                }
+            }
+
+            // double the time between requests
+            m_intervalRunner.Interval = m_intervalRunner.Interval * 2;
+        }
 
         /// <summary>
-        /// Decide if there is anything to publish
+        /// Updates the dataset writer configuration
         /// </summary>
-        /// <returns></returns>
-        private bool CanPublish()
+        /// <param name="writerConfig">the configuration</param>
+        public void UpdateDataSetWriterConfiguration(WriterGroupDataType writerConfig)
         {
-            lock (m_lock)
+            WriterGroupDataType writerGroup = m_udpConnection.PubSubConnectionConfiguration.WriterGroups?
+                .Find(x => x.WriterGroupId == writerConfig.WriterGroupId);
+            if (writerGroup != null)
             {
-                if (m_metadataWriterIdsToSend.Count == 0)
-                {
-                    // reset the interval for publisher if there is nothing to send
-                    m_intervalRunner.Interval = kInitialRequestInterval;
-                }
-
-                return m_metadataWriterIdsToSend.Count > 0;
+                int index = m_udpConnection.PubSubConnectionConfiguration.WriterGroups.IndexOf(writerGroup);
+                m_udpConnection.PubSubConnectionConfiguration.WriterGroups[index] = writerConfig;
             }
+        }
+
+        /// <summary>
+        /// Send a discovery Request for PublisherEndpoints
+        /// </summary>
+        public void SendDiscoveryRequestPublisherEndpoints()
+        {
+            UadpNetworkMessage discoveryRequestPublisherEndpoints = new UadpNetworkMessage(UADPNetworkMessageDiscoveryType.PublisherEndpoint);
+            discoveryRequestPublisherEndpoints.PublisherId = m_udpConnection.PubSubConnectionConfiguration.PublisherId.Value;
+
+            byte[] bytes = discoveryRequestPublisherEndpoints.Encode(MessageContext);
+
+            // send the PublisherEndpoints DiscoveryRequest message to all open UdpClients
+            foreach (var udpClient in m_discoveryUdpClients)
+            {
+                try
+                {
+                    Utils.Trace("UdpDiscoverySubscriber.SendDiscoveryRequestPublisherEndpoints message for PublisherId: {0}",
+                        discoveryRequestPublisherEndpoints.PublisherId);
+
+                    udpClient.Send(bytes, bytes.Length, DiscoveryNetworkAddressEndPoint);
+                }
+                catch (Exception ex)
+                {
+                    Utils.Trace(ex, "UdpDiscoverySubscriber.SendDiscoveryRequestPublisherEndpoints");
+                }
+            }
+
+            // double the time between requests
+            m_intervalRunner.Interval *= 2;
         }
 
 
         /// <summary>
         /// Create and Send the DiscoveryRequest messages for DataSetMetaData
         /// </summary>
-        private void SendDiscoveryRequestDataSetMetaData()
+        public void SendDiscoveryRequestDataSetMetaData()
         {
             UInt16[] dataSetWriterIds = null;
             lock (m_lock)
@@ -184,6 +246,35 @@ namespace Opc.Ua.PubSub.Transport
 
             // double the time between requests
             m_intervalRunner.Interval = m_intervalRunner.Interval * 2;
+        }
+        #endregion
+
+        #region Private Methods
+        /// <summary>
+        /// Decide if there is anything to publish
+        /// </summary>
+        /// <returns></returns>
+        private bool CanPublish()
+        {
+            lock (m_lock)
+            {
+                if (m_metadataWriterIdsToSend.Count == 0)
+                {
+                    // reset the interval for publisher if there is nothing to send
+                    m_intervalRunner.Interval = kInitialRequestInterval;
+                }
+
+                return m_metadataWriterIdsToSend.Count > 0;
+            }
+        }
+
+        /// <summary>
+        /// Joint task to request discovery messages
+        /// </summary>
+        private void RequestDiscoveryMessages()
+        {
+            SendDiscoveryRequestDataSetMetaData();
+            SendDiscoveryRequestDataSetWriterConfiguration();
         }
         #endregion
     }

--- a/Libraries/Opc.Ua.PubSub/Transport/UdpPubSubConnection.cs
+++ b/Libraries/Opc.Ua.PubSub/Transport/UdpPubSubConnection.cs
@@ -654,7 +654,7 @@ namespace Opc.Ua.PubSub.Transport
         /// <summary>
         /// Resets SequenceNumber 
         /// </summary>
-        internal void ResetSequenceNumber()
+        internal static void ResetSequenceNumber()
         {
             s_sequenceNumber = 0;
             s_dataSetSequenceNumber = 0;

--- a/Libraries/Opc.Ua.PubSub/UaPubSubApplication.cs
+++ b/Libraries/Opc.Ua.PubSub/UaPubSubApplication.cs
@@ -65,10 +65,21 @@ namespace Opc.Ua.PubSub
         public event EventHandler<SubscribedDataEventArgs> MetaDataReceived;
 
         /// <summary>
+        /// Event that is triggered when the <see cref="UaPubSubApplication"/> receives and decodes subscribed DataSet PublisherEndpoints
+        /// </summary>
+        public event EventHandler<PublisherEndpointsEventArgs> PublisherEndpointsReceived;
+
+        /// <summary>
         /// Event that is triggered before the configuration is updated with a new MetaData 
         /// The configuration will not be updated if <see cref="ConfigurationUpdatingEventArgs.Cancel"/> flag is set on true.
         /// </summary>
         public event EventHandler<ConfigurationUpdatingEventArgs> ConfigurationUpdating;
+
+        /// <summary>
+        /// Event that is triggered when the <see cref="UaPubSubApplication"/> receives and decodes subscribed DataSet MetaData
+        /// </summary>
+        public event EventHandler<DataSetWriterConfigurationEventArgs> DataSetWriterConfigurationReceived;
+
         #endregion
 
         #region Event Callbacks
@@ -307,6 +318,43 @@ namespace Opc.Ua.PubSub
             catch (Exception ex)
             {
                 Utils.Trace(ex, "UaPubSubApplication.RaiseMetaDataReceivedEvent");
+            }
+        }
+        /// <summary>
+        /// Raise DatasetWriterConfigurationReceived event
+        /// </summary>
+        /// <param name="e"></param>
+        internal void RaiseDatasetWriterConfigurationReceivedEvent(DataSetWriterConfigurationEventArgs e)
+        {
+            try
+            {
+                if (DataSetWriterConfigurationReceived != null)
+                {
+                    DataSetWriterConfigurationReceived(this, e);
+                }
+            }
+            catch (Exception ex)
+            {
+                Utils.Trace(ex, "UaPubSubApplication.DatasetWriterConfigurationReceivedEvent");
+            }
+        }
+
+        /// <summary>
+        /// Raise PublisherEndpointsReceived event
+        /// </summary>
+        /// <param name="e"></param>
+        internal void RaisePublisherEndpointsReceivedEvent(PublisherEndpointsEventArgs e)
+        {
+            try
+            {
+                if (PublisherEndpointsReceived != null)
+                {
+                    PublisherEndpointsReceived(this, e);
+                }
+            }
+            catch (Exception ex)
+            {
+                Utils.Trace(ex, "UaPubSubApplication.RaisePublisherEndpointsReceivedEvent");
             }
         }
 

--- a/Libraries/Opc.Ua.PubSub/UaPublisher.cs
+++ b/Libraries/Opc.Ua.PubSub/UaPublisher.cs
@@ -39,7 +39,7 @@ namespace Opc.Ua.PubSub
     {
         #region Fields
         private readonly object m_lock = new object();
-
+        
         private readonly IUaPubSubConnection m_pubSubConnection;
         private readonly WriterGroupDataType m_writerGroupConfiguration;
         private readonly WriterGroupPublishState m_writerGroupPublishState;
@@ -69,7 +69,7 @@ namespace Opc.Ua.PubSub
             m_writerGroupPublishState = new WriterGroupPublishState();
 
             m_intervalRunner = new IntervalRunner(m_writerGroupConfiguration.Name, m_writerGroupConfiguration.PublishingInterval, CanPublish, PublishMessages);
-
+            
         }
 
         #endregion
@@ -141,7 +141,7 @@ namespace Opc.Ua.PubSub
         #endregion
 
         #region Private Methods
-
+        
         /// <summary>
         /// Decide if the connection can publish
         /// </summary>
@@ -155,7 +155,7 @@ namespace Opc.Ua.PubSub
         }
 
         /// <summary>
-        /// Generate and publish a messages
+        /// Generate and publish the messages
         /// </summary>
         private void PublishMessages()
         {
@@ -174,6 +174,7 @@ namespace Opc.Ua.PubSub
                         }
                     }
                 }
+               
             }
             catch (Exception e)
             {

--- a/Tests/Opc.Ua.PubSub.Tests/Transport/UdpPubSubConnectionTests.Publisher.cs
+++ b/Tests/Opc.Ua.PubSub.Tests/Transport/UdpPubSubConnectionTests.Publisher.cs
@@ -28,8 +28,6 @@
  * ======================================================================*/
 
 using NUnit.Framework;
-using Opc.Ua;
-using Opc.Ua.PubSub;
 using Opc.Ua.PubSub.Configuration;
 using Opc.Ua.PubSub.Transport;
 using System;
@@ -51,7 +49,7 @@ namespace Opc.Ua.PubSub.Tests.Transport
 #endif
         public void ValidateUdpPubSubConnectionNetworkMessagePublishUnicast()
         {
-            //Arrange 
+           //Arrange 
             var localhost = GetFirstNic();
             Assert.IsNotNull(localhost, "localhost is null");
             Assert.IsNotNull(localhost.Address, "localhost.Address is null");
@@ -92,7 +90,7 @@ namespace Opc.Ua.PubSub.Tests.Transport
             Assert.IsNotNull(networkMessages, "connection.CreateNetworkMessages shall not return null");
 
             //Act
-            publisherConnection.Start();
+           publisherConnection.Start();
 
             if (networkMessages != null)
             {
@@ -271,11 +269,93 @@ namespace Opc.Ua.PubSub.Tests.Transport
             }
         }
 
-        [Test(Description = "Validate discovery request PublishNetworkMessage"), Order(4)]
+        [Test(Description = "Validate discovery request PublishNetworkMessage for a DataSetMetaData"), Order(4)]
 #if !CUSTOM_TESTS
         [Ignore("A network interface controller is necessary in order to run correctly.")]
 #endif
-        public void ValidateUdpPubSubConnectionNetworkMessageDiscoveryPublish()
+        public void ValidateUdpPubSubConnectionNetworkMessageDiscoveryPublish_DataSetMetadata()
+        {
+            //Arrange 
+            var localhost = GetFirstNic();
+            Assert.IsNotNull(localhost, "localhost is null");
+            Assert.IsNotNull(localhost.Address, "localhost.Address is null");
+
+            //create publisher configuration object with modified port
+            string configurationFile = Utils.GetAbsoluteFilePath(m_publisherConfigurationFileName, true, true, false);
+            PubSubConfigurationDataType publisherConfiguration = UaPubSubConfigurationHelper.LoadConfiguration(configurationFile);
+            Assert.IsNotNull(publisherConfiguration, "publisherConfiguration is null");
+            Assert.Greater(publisherConfiguration.Connections.Count, 1, "publisherConfiguration.Connection should be > 0");
+
+            //discovery IP adress 224.0.2.14
+            IPAddress[] multicastIPAddresses =  Dns.GetHostAddresses(kUdpDiscoveryIp);
+            IPAddress multicastIPAddress = multicastIPAddresses.First();
+            Assert.IsNotNull(multicastIPAddress, "multicastIPAddress is null");
+
+            NetworkAddressUrlDataType publisherAddress = new NetworkAddressUrlDataType();
+            publisherAddress.Url = string.Format(kUdpUrlFormat, Utils.UriSchemeOpcUdp, multicastIPAddress.ToString());
+            publisherConfiguration.Connections[0].Address = new ExtensionObject(publisherAddress);
+
+            //create publisher UaPubSubApplication with changed configuration settings
+            UaPubSubApplication publisherApplication = UaPubSubApplication.Create(publisherConfiguration);
+            Assert.IsNotNull(publisherApplication, "publisherApplication is null");
+                        
+            UdpPubSubConnection publisherConnection = publisherApplication.PubSubConnections.First() as UdpPubSubConnection;
+            Assert.IsNotNull(publisherConnection, "publisherConnection is null");
+
+            // will signal that the uadp message was received from local ip
+            m_shutdownEvent = new ManualResetEvent(false);
+
+            //setup uadp client for receiving from multicast (simulate a subscriber multicast)
+            UdpClient udpMulticastClient = new UdpClientMulticast(localhost.Address, multicastIPAddress, kDiscoveryPortNo);
+            udpMulticastClient.BeginReceive(new AsyncCallback(OnReceive), udpMulticastClient);
+
+            // prepare a network message
+            WriterGroupDataType writerGroup0 = publisherConnection.PubSubConnectionConfiguration.WriterGroups.First();
+            List<UInt16> dataSetWriterIds = new List<UInt16>();
+            foreach (DataSetWriterDataType dataSetWriterDataType in writerGroup0.DataSetWriters)
+            {
+                dataSetWriterIds.Add(dataSetWriterDataType.DataSetWriterId);
+            }
+            IList<UaNetworkMessage> networkMessages = publisherConnection.CreateDataSetMetaDataNetworkMessages(dataSetWriterIds.ToArray());
+            Assert.IsNotNull(networkMessages, "connection.CreateNetworkMessages shall not return null");
+
+            //Act  
+            publisherConnection.Start();
+
+            if (networkMessages != null)
+            {
+                foreach (UaNetworkMessage uaNetworkMessage in networkMessages)
+                {
+                    if (uaNetworkMessage != null)
+                    {
+                        publisherConnection.PublishNetworkMessage(uaNetworkMessage);
+                    }
+                }
+            }
+
+            //Assert
+            bool noMessageReceived = false;
+            if (!m_shutdownEvent.WaitOne(kEstimatedPublishingTime))
+            {
+                noMessageReceived = true;
+            }
+
+            publisherConnection.Stop();
+            udpMulticastClient.Close();
+            udpMulticastClient.Dispose();
+            
+            if (noMessageReceived)
+            {
+                Assert.Fail("The UDP message was not received");
+            }
+        }
+
+
+        [Test(Description = "Validate discovery DataSetWriterConfigurationMessage response"), Order(4)]
+#if !CUSTOM_TESTS
+        [Ignore("A network interface controller is necessary in order to run correctly.")]
+#endif
+        public void ValidateUdpPubSubConnectionNetworkMessageDiscoveryPublish_DataSetWriterConfiguration()
         {
             //Arrange 
             var localhost = GetFirstNic();
@@ -318,21 +398,15 @@ namespace Opc.Ua.PubSub.Tests.Transport
             {
                 dataSetWriterIds.Add(dataSetWriterDataType.DataSetWriterId);
             }
-            IList<UaNetworkMessage> networkMessages = publisherConnection.CreateDataSetMetaDataNetworkMessages(dataSetWriterIds.ToArray());
-            Assert.IsNotNull(networkMessages, "connection.CreateNetworkMessages shall not return null");
+            UaNetworkMessage networkMessage = publisherConnection.CreateDataSetWriterCofigurationMessage(dataSetWriterIds.ToArray()).First();
+            Assert.IsNotNull(networkMessage, "connection.CreateDataSetWriterCofigurationMessages shall not return null");
 
             //Act  
             publisherConnection.Start();
 
-            if (networkMessages != null)
+            if (networkMessage != null)
             {
-                foreach (UaNetworkMessage uaNetworkMessage in networkMessages)
-                {
-                    if (uaNetworkMessage != null)
-                    {
-                        publisherConnection.PublishNetworkMessage(uaNetworkMessage);
-                    }
-                }
+                publisherConnection.PublishNetworkMessage(networkMessage);
             }
 
             //Assert
@@ -342,6 +416,96 @@ namespace Opc.Ua.PubSub.Tests.Transport
                 noMessageReceived = true;
             }
 
+            publisherConnection.Stop();
+            udpMulticastClient.Close();
+            udpMulticastClient.Dispose();
+
+            if (noMessageReceived)
+            {
+                Assert.Fail("The UDP message was not received");
+            }
+        }
+
+        [Test(Description = "Validate discovery request PublishNetworkMessage for PublisherEndpoints"), Order(4)]
+#if !CUSTOM_TESTS
+        [Ignore("A network interface controller is necessary in order to run correctly.")]
+#endif
+        public void ValidateUdpPubSubConnectionNetworkMessageDiscoveryPublish_PublisherEndpoints()
+        {
+            //Arrange 
+            var localhost = GetFirstNic();
+            Assert.IsNotNull(localhost, "localhost is null");
+            Assert.IsNotNull(localhost.Address, "localhost.Address is null");
+
+            //create publisher configuration object with modified port
+            string configurationFile = Utils.GetAbsoluteFilePath(m_publisherConfigurationFileName, true, true, false);
+            PubSubConfigurationDataType publisherConfiguration = UaPubSubConfigurationHelper.LoadConfiguration(configurationFile);
+            Assert.IsNotNull(publisherConfiguration, "publisherConfiguration is null");
+            Assert.Greater(publisherConfiguration.Connections.Count, 1, "publisherConfiguration.Connection should be > 0");
+
+            //discovery IP adress 224.0.2.14
+            IPAddress[] multicastIPAddresses = Dns.GetHostAddresses(kUdpDiscoveryIp);
+            IPAddress multicastIPAddress = multicastIPAddresses.First();
+            Assert.IsNotNull(multicastIPAddress, "multicastIPAddress is null");
+
+            NetworkAddressUrlDataType publisherAddress = new NetworkAddressUrlDataType();
+            publisherAddress.Url = string.Format(kUdpUrlFormat, Utils.UriSchemeOpcUdp, multicastIPAddress.ToString());
+            publisherConfiguration.Connections[0].Address = new ExtensionObject(publisherAddress);
+
+            //create publisher UaPubSubApplication with changed configuration settings
+            UaPubSubApplication publisherApplication = UaPubSubApplication.Create(publisherConfiguration);
+            Assert.IsNotNull(publisherApplication, "publisherApplication is null");
+
+            UdpPubSubConnection publisherConnection = publisherApplication.PubSubConnections.First() as UdpPubSubConnection;
+            Assert.IsNotNull(publisherConnection, "publisherConnection is null");
+
+            // will signal that the uadp message was received from local ip
+            m_shutdownEvent = new ManualResetEvent(false);
+
+            //setup uadp client for receiving from multicast (simulate a subscriber multicast)
+            UdpClient udpMulticastClient = new UdpClientMulticast(localhost.Address, multicastIPAddress, kDiscoveryPortNo);
+            udpMulticastClient.BeginReceive(new AsyncCallback(OnReceive), udpMulticastClient);
+
+            List<EndpointDescription> endpointDescriptions = new List<EndpointDescription>()
+            {
+                new EndpointDescription() {
+                    EndpointUrl = "opc.tcp://server1:4840/Test",
+                    SecurityMode = MessageSecurityMode.None,
+                    SecurityPolicyUri = "http://opcfoundation.org/UA/SecurityPolicy#None",
+                    Server = new ApplicationDescription() { ApplicationName = "Test security mode None", ApplicationUri = "urn:localhost:Server" }
+                },
+                new EndpointDescription()
+                {
+                    EndpointUrl = "opc.tcp://server1:4840/Test",
+                    SecurityMode = MessageSecurityMode.Sign,
+                    SecurityPolicyUri = "http://opcfoundation.org/UA/SecurityPolicy#Basic256Sha256",
+                    Server = new ApplicationDescription() { ApplicationName = "Test security mode Sign", ApplicationUri = "urn:localhost:Server" }
+                },
+                new EndpointDescription()
+                {
+                    EndpointUrl = "opc.tcp://server1:4840/Test",
+                    SecurityMode = MessageSecurityMode.SignAndEncrypt,
+                    SecurityPolicyUri = "http://opcfoundation.org/UA/SecurityPolicy#Basic256Sha256",
+                    Server = new ApplicationDescription() { ApplicationName = "Test security mode SignAndEncrypt", ApplicationUri = "urn:localhost:Server" }
+                }
+            };
+
+            UaNetworkMessage uaNetworkMessage = publisherConnection.CreatePublisherEndpointsNetworkMessage(endpointDescriptions.ToArray(), 
+                StatusCodes.Good, publisherConnection.PubSubConnectionConfiguration.PublisherId.Value);
+            Assert.IsNotNull(uaNetworkMessage, "uaNetworkMessage shall not return null");
+
+            //Act  
+            publisherConnection.Start();
+
+            publisherConnection.PublishNetworkMessage(uaNetworkMessage);
+
+            // Assert
+            bool noMessageReceived = false;
+            if (!m_shutdownEvent.WaitOne(kEstimatedPublishingTime))
+            {
+                noMessageReceived = true;
+            }
+           
             publisherConnection.Stop();
             udpMulticastClient.Close();
             udpMulticastClient.Dispose();

--- a/Tests/Opc.Ua.PubSub.Tests/Transport/UdpPubSubConnectionTests.Subscriber.cs
+++ b/Tests/Opc.Ua.PubSub.Tests/Transport/UdpPubSubConnectionTests.Subscriber.cs
@@ -98,7 +98,7 @@ namespace Opc.Ua.PubSub.Tests.Transport
             IPEndPoint remoteEndPoint = new IPEndPoint(localhost.Address, kDiscoveryPortNo);
             Assert.IsNotNull(remoteEndPoint, "remoteEndPoint is null");
 
-            m_sentBytes = PrepareData(publisherConnection);
+            m_sentBytes = BuildNetworkMessages(publisherConnection);
             int sentBytesLen = udpUnicastClient.Send(m_sentBytes, m_sentBytes.Length, remoteEndPoint);
             Assert.AreEqual(sentBytesLen, m_sentBytes.Length, "Sent bytes size not equal to published bytes size!");
 
@@ -159,7 +159,7 @@ namespace Opc.Ua.PubSub.Tests.Transport
             //Act  
             subscriberConnection.Start();
             m_shutdownEvent = new ManualResetEvent(false);
-            m_sentBytes = PrepareData(publisherConnection);
+            m_sentBytes = BuildNetworkMessages(publisherConnection);
 
             // first physical network ip is mandatory on UdpClientBroadcast as parameter
             UdpClient udpBroadcastClient = new UdpClientBroadcast(localhost.Address, kDiscoveryPortNo, UsedInContext.Publisher);
@@ -227,7 +227,7 @@ namespace Opc.Ua.PubSub.Tests.Transport
             //Act  
             subscriberConnection.Start();
             m_shutdownEvent = new ManualResetEvent(false);
-            m_sentBytes = PrepareData(publisherConnection);
+            m_sentBytes = BuildNetworkMessages(publisherConnection);
 
             // first physical network ip is mandatory on UdpClientMulticast as parameter, for multicast publisher the port must not be 4840
             UdpClient udpMulticastClient = new UdpClientMulticast(localhost.Address, multicastIPAddress, 0);
@@ -254,7 +254,177 @@ namespace Opc.Ua.PubSub.Tests.Transport
 #if !CUSTOM_TESTS
         [Ignore("A network interface controller is necessary in order to run correctly.")]
 #endif
-        public void ValidateUdpPubSubConnectionNetworkMessageReceiveFromDiscoveryResponse()
+        public void ValidateUdpPubSubConnectionNetworkMessageReceiveFromDiscoveryResponse_DataSetMetadata()
+        {
+            // Arrange
+            var localhost = GetFirstNic();
+            Assert.IsNotNull(localhost, "localhost is null");
+            Assert.IsNotNull(localhost.Address, "localhost.Address is null");
+
+            //discovery IP address 224.0.2.14
+            IPAddress multicastIPAddress = new IPAddress(new byte[4] { 224, 0, 2, 14 });
+            Assert.IsNotNull(multicastIPAddress, "multicastIPAddress is null");
+
+            //set subscriber configuration
+            string configurationFile = Utils.GetAbsoluteFilePath(m_subscriberConfigurationFileName, true, true, false);
+            PubSubConfigurationDataType subscriberConfiguration = UaPubSubConfigurationHelper.LoadConfiguration(configurationFile);
+            Assert.IsNotNull(subscriberConfiguration, "subscriberConfiguration is null");
+
+            //set address and create subscriber
+            NetworkAddressUrlDataType subscriberAddress = new NetworkAddressUrlDataType();
+            subscriberAddress.Url = string.Format(kUdpUrlFormat, Utils.UriSchemeOpcUdp, multicastIPAddress.ToString());
+            subscriberConfiguration.Connections[0].Address = new ExtensionObject(subscriberAddress);
+            UaPubSubApplication subscriberApplication = UaPubSubApplication.Create(subscriberConfiguration);
+            Assert.IsNotNull(subscriberApplication, "subscriberApplication is null");
+
+            UdpPubSubConnection subscriberConnection = subscriberApplication.PubSubConnections.First() as UdpPubSubConnection;
+            Assert.IsNotNull(subscriberConnection, "subscriberConnection is null");
+
+            //subscribe to event handlers
+            subscriberApplication.RawDataReceived += RawDataReceived_NoRequests;
+            subscriberApplication.MetaDataReceived += MetaDataReceived;
+
+            //set publisher cofiguration
+            configurationFile = Utils.GetAbsoluteFilePath(m_publisherConfigurationFileName, true, true, false);
+            PubSubConfigurationDataType publisherConfiguration = UaPubSubConfigurationHelper.LoadConfiguration(configurationFile);
+            Assert.IsNotNull(publisherConfiguration, "publisherConfiguration is null");
+
+            //set address and create publisher
+            NetworkAddressUrlDataType publisherAddress = new NetworkAddressUrlDataType();
+            publisherAddress.Url = string.Format(kUdpUrlFormat, Utils.UriSchemeOpcUdp, multicastIPAddress.ToString());
+            publisherConfiguration.Connections.First().Address = new ExtensionObject(publisherAddress);
+            UaPubSubApplication publisherApplication = UaPubSubApplication.Create(publisherConfiguration);
+            Assert.IsNotNull(publisherApplication, "publisherApplication is null");
+
+            UdpPubSubConnection publisherConnection = publisherApplication.PubSubConnections.First() as UdpPubSubConnection;
+            Assert.IsNotNull(publisherConnection, "publisherConnection is null");
+
+            //start subcriber and prepare the message
+            subscriberConnection.Start();
+            m_shutdownEvent = new ManualResetEvent(false);
+            m_sentBytes = BuildNetworkMessages(publisherConnection, UdpConnectionType.Discovery);
+
+            subscriberConnection.RequestDataSetMetaData();
+
+            //create multicast client
+            // first physical network ip is mandatory on UdpClientMulticast as parameter, for multicast publisher the port must not be 4840
+            UdpClient udpMulticastClient = new UdpClientMulticast(localhost.Address, multicastIPAddress, 0);
+            Assert.IsNotNull(udpMulticastClient, "udpMulticastClient is null");
+
+            //set endpoint and send message
+            IPEndPoint remoteEndPoint = new IPEndPoint(multicastIPAddress, kDiscoveryPortNo);
+            int sentBytesLen = udpMulticastClient.Send(m_sentBytes, m_sentBytes.Length, remoteEndPoint);
+
+            //manually create dataset metadata message and trigger metadata reveived event for test
+            DataSetMetaDataType metaData = m_uaPublisherApplication.DataCollector.GetPublishedDataSet(m_uaPublisherApplication.UaPubSubConfigurator.PubSubConfiguration.PublishedDataSets.First().Name)?.DataSetMetaData;
+            WriterGroupDataType writerConfig = m_uaPublisherApplication.PubSubConnections.First().PubSubConnectionConfiguration.WriterGroups.First();
+            UadpNetworkMessage networkMessage = new UadpNetworkMessage(writerConfig, metaData) { PublisherId = m_uaPublisherApplication.ApplicationId, DataSetWriterId = writerConfig.DataSetWriters.First().DataSetWriterId };
+            SubscribedDataEventArgs subscribedDataEventArgs = new SubscribedDataEventArgs()
+            {
+                NetworkMessage = networkMessage,
+            };
+            subscriberApplication.RaiseMetaDataReceivedEvent(subscribedDataEventArgs);
+
+
+            Assert.AreEqual(sentBytesLen, m_sentBytes.Length, "Sent bytes size not equal to published bytes size!");
+
+            Thread.Sleep(kEstimatedPublishingTime);
+
+            // Assert
+            if (!m_shutdownEvent.WaitOne(kEstimatedPublishingTime))
+            {
+                Assert.Fail("Subscriber multicast error ... published data not received");
+            }
+
+            subscriberConnection.Stop();
+        }
+
+        [Test(Description = "Validate subscriber data on first nic;" +
+                           "Subscriber multicast ip - Publisher multicast ip;" +
+                           "Setting Subscriber as unicast or broadcast not functional. Just discovery request to multicast and response works fine;"), Order(4)]
+#if !CUSTOM_TESTS
+        [Ignore("A network interface controller is necessary in order to run correctly.")]
+#endif
+        public void ValidateUadpPubSubConnectionNetworkMessageReceiveFromDiscoveryResponse_DataSetWriterConfig()
+        {
+            // Arrange
+            var localhost = GetFirstNic();
+            Assert.IsNotNull(localhost, "localhost is null");
+            Assert.IsNotNull(localhost.Address, "localhost.Address is null");
+
+            //discovery IP address 224.0.2.14
+            IPAddress multicastIPAddress = new IPAddress(new byte[4] { 224, 0, 2, 14 });
+            Assert.IsNotNull(multicastIPAddress, "multicastIPAddress is null");
+
+            //set configuration
+            string configurationFile = Utils.GetAbsoluteFilePath(m_subscriberConfigurationFileName, true, true, false);
+            PubSubConfigurationDataType subscriberConfiguration = UaPubSubConfigurationHelper.LoadConfiguration(configurationFile);
+            Assert.IsNotNull(subscriberConfiguration, "subscriberConfiguration is null");
+
+            //set address and create subscriber
+            NetworkAddressUrlDataType subscriberAddress = new NetworkAddressUrlDataType();
+            subscriberAddress.Url = string.Format(kUdpUrlFormat, Utils.UriSchemeOpcUdp, multicastIPAddress.ToString());
+            subscriberConfiguration.Connections[0].Address = new ExtensionObject(subscriberAddress);
+            UaPubSubApplication subscriberApplication = UaPubSubApplication.Create(subscriberConfiguration);
+            Assert.IsNotNull(subscriberApplication, "subscriberApplication is null");
+
+            UdpPubSubConnection subscriberConnection = subscriberApplication.PubSubConnections.First() as UdpPubSubConnection;
+            Assert.IsNotNull(subscriberConnection, "subscriberConnection is null");
+
+            //subscribe the event handlers
+            subscriberApplication.RawDataReceived += RawDataReceived_NoRequests;
+            subscriberApplication.DataSetWriterConfigurationReceived += DatasetWriterConfigurationReceived;
+
+            //set publisher configuration an create publisher
+            configurationFile = Utils.GetAbsoluteFilePath(m_publisherConfigurationFileName, true, true, false);
+            PubSubConfigurationDataType publisherConfiguration = UaPubSubConfigurationHelper.LoadConfiguration(configurationFile);
+            Assert.IsNotNull(publisherConfiguration, "publisherConfiguration is null");
+
+            NetworkAddressUrlDataType publisherAddress = new NetworkAddressUrlDataType();
+            publisherAddress.Url = string.Format(kUdpUrlFormat, Utils.UriSchemeOpcUdp, multicastIPAddress.ToString());
+            publisherConfiguration.Connections.First().Address = new ExtensionObject(publisherAddress);
+            UaPubSubApplication publisherApplication = UaPubSubApplication.Create(publisherConfiguration);
+            Assert.IsNotNull(publisherApplication, "publisherApplication is null");
+
+            UdpPubSubConnection publisherConnection = publisherApplication.PubSubConnections.First() as UdpPubSubConnection;
+            Assert.IsNotNull(publisherConnection, "publisherConnection is null");
+
+            //start the subscriber and prepare message
+            subscriberConnection.Start();
+            m_shutdownEvent = new ManualResetEvent(false);
+            m_sentBytes = PrepareDataSetWriterConfigurationMessage(publisherConnection);
+
+            //prepare multicast client
+            UdpClient udpMulticastClient = new UdpClientMulticast(localhost.Address, multicastIPAddress, 0);
+            Assert.IsNotNull(udpMulticastClient, "udpMulticastClient is null");
+
+            //set endpoint and send message
+            IPEndPoint remoteEndPoint = new IPEndPoint(multicastIPAddress, kDiscoveryPortNo);
+            int sentBytesLen = udpMulticastClient.Send(m_sentBytes, m_sentBytes.Length, remoteEndPoint);
+
+            Assert.AreEqual(sentBytesLen, m_sentBytes.Length, "Sent bytes size not equal to published bytes size!");
+
+            Thread.Sleep(kEstimatedPublishingTime);
+
+            // Assert
+            if (!m_shutdownEvent.WaitOne(kEstimatedPublishingTime))
+            {
+                Assert.Fail("Subscriber multicast error ... published data not received");
+            }
+
+            subscriberApplication.DataSetWriterConfigurationReceived -= DatasetWriterConfigurationReceived;
+            subscriberConnection.Stop();
+            publisherConnection.Stop();
+        }
+
+        [Test(Description = "Validate subscriber data on first nic;" +
+                            "Subscriber multicast ip - Publisher multicast ip;" +
+                            "Publisher holds a DataSetWriterConfiguration, Subscriber requests the configuration;" +
+                            "Setting Subscriber as unicast or broadcast not functional. Just discovery request to multicast and response works fine;"), Order(4)]
+#if !CUSTOM_TESTS
+        [Ignore("A network interface controller is necessary in order to run correctly.")]
+#endif
+        public void ValidateUdpPubSubConnectionNetworkMessageReceiveFromDiscoveryResponse_SubscriberRequestDataSetWriterConfiguration()
         {
             // Arrange
             var localhost = GetFirstNic();
@@ -278,7 +448,157 @@ namespace Opc.Ua.PubSub.Tests.Transport
             UdpPubSubConnection subscriberConnection = subscriberApplication.PubSubConnections.First() as UdpPubSubConnection;
             Assert.IsNotNull(subscriberConnection, "subscriberConnection is null");
 
-            subscriberApplication.RawDataReceived += RawDataReceived;
+            subscriberApplication.DataSetWriterConfigurationReceived += DatasetWriterConfigurationReceived;
+
+            configurationFile = Utils.GetAbsoluteFilePath(m_publisherConfigurationFileName, true, true, false);
+            PubSubConfigurationDataType publisherConfiguration = UaPubSubConfigurationHelper.LoadConfiguration(configurationFile);
+            Assert.IsNotNull(publisherConfiguration, "publisherConfiguration is null");
+
+            NetworkAddressUrlDataType publisherAddress = new NetworkAddressUrlDataType();
+            publisherAddress.Url = string.Format(kUdpUrlFormat, Utils.UriSchemeOpcUdp, multicastIPAddress.ToString());
+            publisherConfiguration.Connections.First().Address = new ExtensionObject(publisherAddress);
+            UaPubSubApplication publisherApplication = UaPubSubApplication.Create(publisherConfiguration);
+            Assert.IsNotNull(publisherApplication, "publisherApplication is null");
+
+            UdpPubSubConnection publisherConnection = publisherApplication.PubSubConnections.First() as UdpPubSubConnection;
+            Assert.IsNotNull(publisherConnection, "publisherConnection is null");
+
+            m_shutdownEvent = new ManualResetEvent(false);
+
+            publisherConnection.Start();
+            // Add DataSetWriterConfiguration on Publisher
+            if (publisherConnection is IUadpDiscoveryMessages)
+            {
+                // set the DataSetWriterConfiguration callback waiting for a Subscriber request to grab them
+                ((IUadpDiscoveryMessages)publisherConnection).GetDataSetWriterConfigurationCallback(GetDataSetWriterConfiguration);
+            }
+
+            //Act 
+            subscriberConnection.Start();
+
+            subscriberConnection.RequestDataSetWriterConfiguration();
+
+            Thread.Sleep(kEstimatedPublishingTime);
+
+            // Assert
+            if (!m_shutdownEvent.WaitOne(kEstimatedPublishingTime))
+            {
+                Assert.Fail("Subscriber multicast error ... published data not received");
+            }
+
+            subscriberApplication.DataSetWriterConfigurationReceived -= DatasetWriterConfigurationReceived;
+
+            subscriberConnection.Stop();
+            publisherConnection.Stop();
+        }
+
+        [Test(Description = "Validate subscriber data on first nic;" +
+                            "Subscriber multicast ip - Publisher multicast ip;" +
+                            "Publisher holds a PublisherEndpoints collection, Subscriber request available PublisherEndpoints;" +
+                            "Setting Subscriber as unicast or broadcast not functional. Just discovery request to multicast and response works fine;"), Order(4)]
+#if !CUSTOM_TESTS
+        [Ignore("A network interface controller is necessary in order to run correctly.")]
+#endif
+        public void ValidateUdpPubSubConnectionNetworkMessageReceiveFromDiscoveryResponse_SubscriberRequestPublisherEndpoints()
+        {
+            // Arrange
+            var localhost = GetFirstNic();
+            Assert.IsNotNull(localhost, "localhost is null");
+            Assert.IsNotNull(localhost.Address, "localhost.Address is null");
+
+            //discovery IP address 224.0.2.14
+            IPAddress multicastIPAddress = new IPAddress(new byte[4] { 224, 0, 2, 14 });
+            Assert.IsNotNull(multicastIPAddress, "multicastIPAddress is null");
+
+            string configurationFile = Utils.GetAbsoluteFilePath(m_subscriberConfigurationFileName, true, true, false);
+            PubSubConfigurationDataType subscriberConfiguration = UaPubSubConfigurationHelper.LoadConfiguration(configurationFile);
+            Assert.IsNotNull(subscriberConfiguration, "subscriberConfiguration is null");
+
+            NetworkAddressUrlDataType subscriberAddress = new NetworkAddressUrlDataType();
+            subscriberAddress.Url = string.Format(kUdpUrlFormat, Utils.UriSchemeOpcUdp, multicastIPAddress.ToString());
+            subscriberConfiguration.Connections[0].Address = new ExtensionObject(subscriberAddress);
+            UaPubSubApplication subscriberApplication = UaPubSubApplication.Create(subscriberConfiguration);
+            Assert.IsNotNull(subscriberApplication, "subscriberApplication is null");
+
+            UdpPubSubConnection subscriberConnection = subscriberApplication.PubSubConnections.First() as UdpPubSubConnection;
+            Assert.IsNotNull(subscriberConnection, "subscriberConnection is null");
+
+            subscriberApplication.PublisherEndpointsReceived += PublisherEndpointsReceived;
+
+            configurationFile = Utils.GetAbsoluteFilePath(m_publisherConfigurationFileName, true, true, false);
+            PubSubConfigurationDataType publisherConfiguration = UaPubSubConfigurationHelper.LoadConfiguration(configurationFile);
+            Assert.IsNotNull(publisherConfiguration, "publisherConfiguration is null");
+
+            NetworkAddressUrlDataType publisherAddress = new NetworkAddressUrlDataType();
+            publisherAddress.Url = string.Format(kUdpUrlFormat, Utils.UriSchemeOpcUdp, multicastIPAddress.ToString());
+            publisherConfiguration.Connections.First().Address = new ExtensionObject(publisherAddress);
+            UaPubSubApplication publisherApplication = UaPubSubApplication.Create(publisherConfiguration);
+            Assert.IsNotNull(publisherApplication, "publisherApplication is null");
+
+            UdpPubSubConnection publisherConnection = publisherApplication.PubSubConnections.First() as UdpPubSubConnection;
+            Assert.IsNotNull(publisherConnection, "publisherConnection is null");
+
+            m_shutdownEvent = new ManualResetEvent(false);
+                        
+            publisherConnection.Start();
+            // Add several PublisherEndpoints on Publisher
+            if (publisherConnection is IUadpDiscoveryMessages)
+            {
+                // set the publisher callback (feed with several demo PublisherEndpoints) waiting for a Subscriber request to grab them
+                ((IUadpDiscoveryMessages)publisherConnection).GetPublisherEndpointsCallback(GetPublisherEndpoints);
+            }
+            
+            //Act 
+            subscriberConnection.Start();
+
+            subscriberConnection.RequestPublisherEndpoints();
+
+            Thread.Sleep(kEstimatedPublishingTime);
+
+            // Assert
+            if (!m_shutdownEvent.WaitOne(kEstimatedPublishingTime))
+            {
+                Assert.Fail("Subscriber multicast error ... published data not received");
+            }
+
+            subscriberApplication.PublisherEndpointsReceived -= PublisherEndpointsReceived;
+
+            subscriberConnection.Stop();
+            publisherConnection.Stop();
+        }
+
+        [Test(Description = "Validate subscriber data on first nic;" +
+                            "Subscriber multicast ip - Publisher multicast ip;" +
+                            "Publisher send a PublisherEndpoints collection to the Subscriber, Subscriber only listen for PublisherEndpoints;" +
+                            "Setting Subscriber as unicast or broadcast not functional. Just discovery request to multicast and response works fine;"), Order(4)]
+#if !CUSTOM_TESTS
+        [Ignore("A network interface controller is necessary in order to run correctly.")]
+#endif
+        public void ValidateUdpPubSubConnectionNetworkMessageReceiveFromDiscoveryResponse_PublisherTriggerEndpoints()
+        {
+            // Arrange
+            var localhost = GetFirstNic();
+            Assert.IsNotNull(localhost, "localhost is null");
+            Assert.IsNotNull(localhost.Address, "localhost.Address is null");
+
+            //discovery IP address 224.0.2.14
+            IPAddress multicastIPAddress = new IPAddress(new byte[4] { 224, 0, 2, 14 });
+            Assert.IsNotNull(multicastIPAddress, "multicastIPAddress is null");
+
+            string configurationFile = Utils.GetAbsoluteFilePath(m_subscriberConfigurationFileName, true, true, false);
+            PubSubConfigurationDataType subscriberConfiguration = UaPubSubConfigurationHelper.LoadConfiguration(configurationFile);
+            Assert.IsNotNull(subscriberConfiguration, "subscriberConfiguration is null");
+
+            NetworkAddressUrlDataType subscriberAddress = new NetworkAddressUrlDataType();
+            subscriberAddress.Url = string.Format(kUdpUrlFormat, Utils.UriSchemeOpcUdp, multicastIPAddress.ToString());
+            subscriberConfiguration.Connections[0].Address = new ExtensionObject(subscriberAddress);
+            UaPubSubApplication subscriberApplication = UaPubSubApplication.Create(subscriberConfiguration);
+            Assert.IsNotNull(subscriberApplication, "subscriberApplication is null");
+
+            UdpPubSubConnection subscriberConnection = subscriberApplication.PubSubConnections.First() as UdpPubSubConnection;
+            Assert.IsNotNull(subscriberConnection, "subscriberConnection is null");
+
+            subscriberApplication.PublisherEndpointsReceived += PublisherEndpointsReceived;
 
             configurationFile = Utils.GetAbsoluteFilePath(m_publisherConfigurationFileName, true, true, false);
             PubSubConfigurationDataType publisherConfiguration = UaPubSubConfigurationHelper.LoadConfiguration(configurationFile);
@@ -295,14 +615,18 @@ namespace Opc.Ua.PubSub.Tests.Transport
 
             //Act  
             subscriberConnection.Start();
+            
             m_shutdownEvent = new ManualResetEvent(false);
-            m_sentBytes = PrepareData(publisherConnection, UdpConnectionType.Discovery);
 
-            // first physical network ip is mandatory on UdpClientMulticast as parameter, for multicast publisher the port must not be 4840
+            // Prepare NetworkMessage with PublisherEndpoints 
+            m_sentBytes = PreparePublisherEndpointsMessage(publisherConnection, UdpConnectionType.Discovery);
+
+            // Publisher: first physical network ip is mandatory on UdpClientMulticast as parameter, for multicast publisher the port must not be 4840
             UdpClient udpMulticastClient = new UdpClientMulticast(localhost.Address, multicastIPAddress, 0);
             Assert.IsNotNull(udpMulticastClient, "udpMulticastClient is null");
 
             IPEndPoint remoteEndPoint = new IPEndPoint(multicastIPAddress, kDiscoveryPortNo);
+            // Publisher: trigger PublishNetworkMessage including PublisherEndpoints data
             int sentBytesLen = udpMulticastClient.Send(m_sentBytes, m_sentBytes.Length, remoteEndPoint);
             Assert.AreEqual(sentBytesLen, m_sentBytes.Length, "Sent bytes size not equal to published bytes size!");
 
@@ -313,6 +637,8 @@ namespace Opc.Ua.PubSub.Tests.Transport
             {
                 Assert.Fail("Subscriber multicast error ... published data not received");
             }
+
+            subscriberApplication.PublisherEndpointsReceived -= PublisherEndpointsReceived;
 
             subscriberConnection.Stop();
         }
@@ -343,6 +669,7 @@ namespace Opc.Ua.PubSub.Tests.Transport
 
                 string sentBytesStr = BitConverter.ToString(m_sentBytes);
                 string bytesStr = BitConverter.ToString(bytes);
+
                 Assert.AreEqual(sentBytesStr, bytesStr, "Sent bytes: {0} and received bytes: {1} content are not equal", sentBytesStr, bytesStr);
 
                 m_shutdownEvent.Set();
@@ -350,11 +677,113 @@ namespace Opc.Ua.PubSub.Tests.Transport
         }
 
         /// <summary>
-        /// Prepare data 
+        /// Subscriber callback that listen for Publisher uadp notifications but does not test requests
         /// </summary>
-        /// <param name="publisherConnection"></param>
+        /// <param name="sender">the sender</param>
+        /// <param name="e">the event args</param>
+        private void RawDataReceived_NoRequests(object sender, RawDataReceivedEventArgs e)
+        {
+            lock (s_lock)
+            {
+                // Assert
+                var localhost = GetFirstNic();
+                Assert.IsNotNull(localhost, "localhost is null");
+                Assert.IsNotNull(localhost.Address, "localhost.Address is null");
+
+                Assert.IsNotNull(e.Source, "Udp address received should not be null");
+                if (localhost.Address.ToString() != e.Source.ToString())
+                {
+                    // the message comes from the network but was not initiated by test
+                    return;
+                }
+
+                byte[] bytes = e.Message;
+                if (bytes.Length > 12)
+                {
+                    Assert.AreEqual(m_sentBytes.Length, bytes.Length, "Sent bytes size: {0} does not match received bytes size: {1}", m_sentBytes.Length, bytes.Length);
+
+                    string sentBytesStr = BitConverter.ToString(m_sentBytes);
+                    string bytesStr = BitConverter.ToString(bytes);
+
+                    Assert.AreEqual(sentBytesStr, bytesStr, "Sent bytes: {0} and received bytes: {1} content are not equal", sentBytesStr, bytesStr);
+                }
+                m_shutdownEvent.Set();
+            }
+        }
+
+        /// <summary>
+        /// Handler for MetaDataDataReceived event.
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void MetaDataReceived(object sender, SubscribedDataEventArgs e)
+        {
+            lock (s_lock)
+            {
+                Console.WriteLine("Metadata received:");
+                bool isNetworkMessage = e.NetworkMessage is UadpNetworkMessage;
+                Assert.IsTrue(isNetworkMessage);
+                if (isNetworkMessage)
+                {
+                    if (e.NetworkMessage.IsMetaDataMessage)
+                    {
+                        UadpNetworkMessage message = (UadpNetworkMessage)e.NetworkMessage;
+
+                        Assert.IsNotNull(message.PublisherId);
+                        Assert.IsNotNull(message.DataSetWriterId);
+                        Assert.IsNotNull(message.DataSetMetaData);
+                        Assert.IsNotNull(message.DataSetMetaData.Fields);
+                        Assert.IsTrue(message.DataSetMetaData.Fields.Count > 0);
+
+
+                        Assert.IsNotNull(message.DataSetMetaData.Name);
+                        Assert.IsNotNull(message.DataSetMetaData.ConfigurationVersion);
+
+                        for (int i = 0; i < message.DataSetMetaData.Fields.Count; i++)
+                        {
+                            FieldMetaData field = message.DataSetMetaData.Fields[i];
+                            Assert.IsNotNull(field.Name);
+                            Assert.IsNotNull(field.DataType);
+                            Assert.IsNotNull(field.ValueRank);
+                            Assert.IsNotNull(field.TypeId);
+                            Assert.IsNotNull(field.Properties);
+                        }
+                    }
+                }
+                m_shutdownEvent.Set();
+            }
+        }
+
+        /// <summary>
+        /// Validate received publisher endpoints
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void PublisherEndpointsReceived(object sender, PublisherEndpointsEventArgs e)
+        {
+            lock (s_lock)
+            {
+                Assert.AreEqual(3, e.PublisherEndpoints.Length, "Send PublisherEndpoints: {0} and received PublisherEndpoints: {1} are not equal", 3, e.PublisherEndpoints.Length);
+
+                foreach (EndpointDescription ep in e.PublisherEndpoints)
+                {
+                    Assert.IsNotNull(ep.SecurityMode);
+                    Assert.IsNotEmpty(ep.SecurityPolicyUri);
+                    Assert.IsNotEmpty(ep.EndpointUrl);
+                    Assert.IsNotNull(ep.Server);
+                }
+                m_shutdownEvent.Set();
+            }
+        }
+
+        /// <summary>
+        /// Prepare data / metadata for network messages
+        /// </summary>
+        /// <param name="publisherConnection">the connection</param>
+        /// <param name="udpConnectionType">the connection's type</param>
+        /// <param name="networkMessageIndex">the network message index</param>
         /// <returns></returns>
-        private byte[] PrepareData(UdpPubSubConnection publisherConnection, UdpConnectionType udpConnectionType = UdpConnectionType.Networking, int networkMessageIndex = 0)
+        private byte[] BuildNetworkMessages(UdpPubSubConnection publisherConnection, UdpConnectionType udpConnectionType = UdpConnectionType.Discovery, int networkMessageIndex = 0)
         {
             try
             {
@@ -384,10 +813,179 @@ namespace Opc.Ua.PubSub.Tests.Transport
 
                 return bytes;
             }
-            catch
+            catch (Exception ex)
             {
-                return Array.Empty<byte>();
+                Assert.Fail(ex.Message);
+                throw ex;
             }
+        }
+
+        /// <summary>
+        /// Prepare Publisher UADP Discovery request with PublisherEndpoints data
+        /// </summary>
+        /// <param name="publisherConnection"></param>
+        /// <param name="udpConnectionType"></param>
+        /// <returns></returns>
+        private byte[] PreparePublisherEndpointsMessage(UdpPubSubConnection publisherConnection, UdpConnectionType udpConnectionType = UdpConnectionType.Networking)
+        {
+            try
+            {
+                UaNetworkMessage networkMessage = null;
+                if (udpConnectionType == UdpConnectionType.Discovery)
+                {
+                    List<EndpointDescription> endpointDescriptions = CreatePublisherEndpoints();
+                    
+                    networkMessage = publisherConnection.CreatePublisherEndpointsNetworkMessage(endpointDescriptions.ToArray(),
+                        StatusCodes.Good, publisherConnection.PubSubConnectionConfiguration.PublisherId.Value);
+                    Assert.IsNotNull(networkMessage, "uaNetworkMessage shall not return null");
+
+                    return networkMessage.Encode(ServiceMessageContext.GlobalContext);
+                }
+
+                return null;
+            }
+            catch (Exception ex)
+            {
+                Assert.Fail(ex.Message);
+                throw ex;
+            }
+        }
+
+        /// <summary>
+        /// UADP Discovery: Provide Publisher demo PublisherEndpoints setting GetPublisherEndpointsCallback method to deliver them during a Subscriber request
+        /// </summary>
+        /// <returns></returns>
+        private List<EndpointDescription> GetPublisherEndpoints()
+        {
+            return CreatePublisherEndpoints();
+        }
+
+        /// <summary>
+        /// UADP Discovery: Create demo PublisherEndpoints
+        /// </summary>
+        /// <returns></returns>
+        private List<EndpointDescription> CreatePublisherEndpoints()
+        {
+            return new List<EndpointDescription>()
+            {
+                new EndpointDescription() {
+                    EndpointUrl = "opc.tcp://server1:4840/Test",
+                    SecurityMode = MessageSecurityMode.None,
+                    SecurityPolicyUri = "http://opcfoundation.org/UA/SecurityPolicy#None",
+                    Server = new ApplicationDescription() { ApplicationName = "Test security mode None", ApplicationUri = "urn:localhost:Server" }
+                },
+                new EndpointDescription()
+                {
+                    EndpointUrl = "opc.tcp://server1:4840/Test",
+                    SecurityMode = MessageSecurityMode.Sign,
+                    SecurityPolicyUri = "http://opcfoundation.org/UA/SecurityPolicy#Basic256Sha256",
+                    Server = new ApplicationDescription() { ApplicationName = "Test security mode Sign", ApplicationUri = "urn:localhost:Server" }
+                },
+                new EndpointDescription()
+                {
+                    EndpointUrl = "opc.tcp://server1:4840/Test",
+                    SecurityMode = MessageSecurityMode.SignAndEncrypt,
+                    SecurityPolicyUri = "http://opcfoundation.org/UA/SecurityPolicy#Basic256Sha256",
+                    Server = new ApplicationDescription() { ApplicationName = "Test security mode SignAndEncrypt", ApplicationUri = "urn:localhost:Server" }
+                }
+            };
+        }
+
+        /// <summary>
+        /// Prepare data for a DataSetWriterConfigurationMessage
+        /// </summary>
+        /// <param name="publisherConnection">Publisher connection</param>
+        /// <returns></returns>
+        private byte[] PrepareDataSetWriterConfigurationMessage(UdpPubSubConnection publisherConnection)
+        {
+            try
+            {
+                WriterGroupDataType writerGroup0 = publisherConnection.PubSubConnectionConfiguration.WriterGroups.First();
+
+                UaNetworkMessage networkMessage = null;
+
+                List<UInt16> dataSetWriterIds = new List<UInt16>();
+                foreach (DataSetWriterDataType dataSetWriterDataType in writerGroup0.DataSetWriters)
+                {
+                    dataSetWriterIds.Add(dataSetWriterDataType.DataSetWriterId);
+                }
+                networkMessage = publisherConnection.CreateDataSetWriterCofigurationMessage(dataSetWriterIds.ToArray()).First();
+
+                Assert.IsNotNull(networkMessage, "CreateDataSetWriterCofigurationMessages returned null");
+
+                byte[] bytes = networkMessage.Encode(ServiceMessageContext.GlobalContext);
+
+                return bytes;
+            }
+            catch (Exception ex)
+            {
+                Assert.Fail(ex.Message);
+                throw ex;
+            }
+        }
+
+        /// <summary>
+        /// Handler for DatasetWriterConfigurationReceived event.
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void DatasetWriterConfigurationReceived(object sender, DataSetWriterConfigurationEventArgs e)
+        {
+            lock (s_lock)
+            {
+                Console.WriteLine("DataSetWriterConfig received:");
+
+                if (e.DataSetWriterConfiguration != null)
+                {
+                    WriterGroupDataType config = e.DataSetWriterConfiguration;
+
+                    Assert.IsNotEmpty(config.Name);
+                    Assert.IsNotNull(config.SecurityKeyServices);
+                    Assert.IsNotNull(config.GroupProperties);
+                    Assert.IsNotNull(config.SecurityMode);
+                    Assert.IsNotNull(config.TransportSettings);
+                    Assert.IsNotNull(config.MessageSettings);
+                    Assert.IsNotEmpty(config.HeaderLayoutUri);
+                    Assert.IsTrue(config.DataSetWriters != null);
+
+                    foreach (DataSetWriterDataType writer in config.DataSetWriters)
+                    {
+                        Assert.IsNotEmpty(writer.Name);
+                        Assert.IsNotNull(writer.DataSetWriterProperties);
+                        Assert.IsNotNull(writer.MessageSettings);
+                        Assert.IsNotEmpty(writer.DataSetName);
+                    }
+                    m_shutdownEvent.Set();
+                }
+            }
+        }
+
+        /// <summary>
+        /// UADP Discovery: Provide DataSetWriterConfiguration setting GetDataSetWriterConfigurationCallback method to deliver them during a Subscriber request
+        /// </summary>
+        /// <returns></returns>
+        private IList<UInt16> GetDataSetWriterConfiguration(UaPubSubApplication uaPubSubApplication)
+        {
+            return CreateDataSetWriterIdsList(uaPubSubApplication);
+        }
+
+        /// <summary>
+        /// Create data set writer ids list from the PubSubConnectionDataType configuration
+        /// </summary>
+        /// <param name="uaPubSubApplication"></param>
+        /// <returns></returns>
+        private static IList<UInt16> CreateDataSetWriterIdsList(UaPubSubApplication uaPubSubApplication)
+        {
+            List<UInt16> ids = new List<UInt16>();
+
+            foreach (var connection in uaPubSubApplication.UaPubSubConfigurator.PubSubConfiguration.Connections)
+            {
+                ids.AddRange(connection.WriterGroups
+                    .Select(group => group.DataSetWriters)
+                    .SelectMany(writer => writer.Select(x => x.DataSetWriterId))
+                    .ToList());
+            }
+            return ids;
         }
     }
 }


### PR DESCRIPTION
## Proposed changes

Added the implementation of uadp discovery for Publisher Server Endpoints and DataSetWriter configuration.
Implementation includes now, additionally to the existing handling of the DataSetMetadata requests, both the handling of the Publisher Server Endpoints and of DataSetWriter configuration requests as described in the V 1.04 of the OPCUA specification.


## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- [x] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [x] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

