### PR TITLE
Improve Utils.IsEqual for byte compare

### DIFF
--- a/Stack/Opc.Ua.Core/Types/Utils/Utils.cs
+++ b/Stack/Opc.Ua.Core/Types/Utils/Utils.cs
@@ -1875,6 +1875,88 @@ namespace Opc.Ua
         }
 
         /// <summary>
+        /// Checks if two T values are equal based on IEquatable compare.
+        /// </summary>
+        public static bool IsEqual<T>(T value1, T value2) where T : IEquatable<T>
+        {
+            // check for reference equality.
+            if (Object.ReferenceEquals(value1, value2))
+            {
+                return true;
+            }
+
+            if (Object.ReferenceEquals(value1, null))
+            {
+                if (!Object.ReferenceEquals(value2, null))
+                {
+                    return value2.Equals(value1);
+                }
+
+                return true;
+            }
+
+            // use IEquatable comparer
+            return value1.Equals(value2);
+        }
+
+        /// <summary>
+        /// Checks if two IEnumerable T values are equal.
+        /// </summary>
+        public static bool IsEqual<T>(IEnumerable<T> value1, IEnumerable<T> value2) where T : IEquatable<T>
+        {
+            // check for reference equality.
+            if (Object.ReferenceEquals(value1, value2))
+            {
+                return true;
+            }
+
+            if (Object.ReferenceEquals(value1, null) || Object.ReferenceEquals(value2, null))
+            {
+                return false;
+            }
+
+            return value1.SequenceEqual(value2);
+        }
+
+        /// <summary>
+        /// Checks if two T[] values are equal.
+        /// </summary>
+        public static bool IsEqualB<T>(T[] value1, T[] value2) where T : unmanaged, IEquatable<T>
+        {
+            // check for reference equality.
+            if (Object.ReferenceEquals(value1, value2))
+            {
+                return true;
+            }
+
+            if (Object.ReferenceEquals(value1, null) || Object.ReferenceEquals(value2, null))
+            {
+                return false;
+            }
+
+            return value1.SequenceEqual(value2);
+        }
+
+        /// <summary>
+        /// Checks if two T[] values are equal.
+        /// </summary>
+        public static bool IsEqual(byte[] value1, byte[] value2)
+        {
+            // check for reference equality.
+            if (Object.ReferenceEquals(value1, value2))
+            {
+                return true;
+            }
+
+            if (Object.ReferenceEquals(value1, null) || Object.ReferenceEquals(value2, null))
+            {
+                return false;
+            }
+
+            return value1.SequenceEqual(value2);
+        }
+
+        /// <summary>
         /// Checks if two values are equal.
         /// </summary>
         public static bool IsEqual(object value1, object value2)
@@ -1886,9 +1968,9 @@ namespace Opc.Ua
             }
 
             // check for null values.
-            if (value1 == null)
+            if (Object.ReferenceEquals(value1, null))
             {
-                if (value2 != null)
+                if (!Object.ReferenceEquals(value2, null))
                 {
                     return value2.Equals(value1);
                 }
@@ -1897,12 +1979,12 @@ namespace Opc.Ua
             }
 
             // check for null values.
-            if (value2 == null)
+            if (Object.ReferenceEquals(value2, null))
             {
                 return value1.Equals(value2);
             }
 
-            // check that data types are the same.
+            // check that data types are not the same.
             if (value1.GetType() != value2.GetType())
             {
                 return value1.Equals(value2);
@@ -1915,14 +1997,12 @@ namespace Opc.Ua
             }
 
             // check for compareable objects.
-
             if (value1 is IComparable comparable1)
             {
                 return comparable1.CompareTo(value2) == 0;
             }
 
             // check for encodeable objects.
-
             if (value1 is IEncodeable encodeable1)
             {
                 if (!(value2 is IEncodeable encodeable2))
@@ -1934,7 +2014,6 @@ namespace Opc.Ua
             }
 
             // check for XmlElement objects.
-
             if (value1 is XmlElement element1)
             {
                 if (!(value2 is XmlElement element2))
@@ -1946,7 +2025,6 @@ namespace Opc.Ua
             }
 
             // check for arrays.
-
             if (value1 is Array array1)
             {
                 // arrays are greater than non-arrays.
@@ -1975,6 +2053,12 @@ namespace Opc.Ua
                     {
                         return false;
                     }
+                }
+
+                // handle byte[] special case fast
+                if (array1 is byte[] byteArray1 && array2 is byte[] byteArray2)
+                {
+                    return byteArray1.SequenceEqual(byteArray2);
                 }
 
                 IEnumerator enumerator1 = array1.GetEnumerator();

--- a/Stack/Opc.Ua.Core/Types/Utils/Utils.cs
+++ b/Stack/Opc.Ua.Core/Types/Utils/Utils.cs
@@ -1937,6 +1937,32 @@ namespace Opc.Ua
             return value1.SequenceEqual(value2);
         }
 
+#if NETFRAMEWORK
+        [DllImport("msvcrt.dll", CallingConvention = CallingConvention.Cdecl)]
+        private static extern int memcmp(byte[] b1, byte[] b2, long count);
+
+        /// <summary>
+        /// Fast memcpy version of byte[] compare. 
+        /// </summary>
+        public static bool IsEqual(byte[] value1, byte[] value2)
+        {
+            // check for reference equality.
+            if (Object.ReferenceEquals(value1, value2))
+            {
+                return true;
+            }
+
+            if (Object.ReferenceEquals(value1, null) || Object.ReferenceEquals(value2, null))
+            {
+                return false;
+            }
+
+            // Validate buffers are the same length.
+            // This also ensures that the count does not exceed the length of either buffer.  
+            return value1.Length == value2.Length && memcmp(value1, value2, value1.Length) == 0;
+        }
+#endif
+
         /// <summary>
         /// Checks if two values are equal.
         /// </summary>
@@ -2039,7 +2065,11 @@ namespace Opc.Ua
                 // handle byte[] special case fast
                 if (array1 is byte[] byteArray1 && array2 is byte[] byteArray2)
                 {
+#if NETFRAMEWORK
+                    return memcmp(byteArray1, byteArray2, byteArray1.Length) == 0;
+#else
                     return byteArray1.SequenceEqual(byteArray2);
+#endif
                 }
 
                 IEnumerator enumerator1 = array1.GetEnumerator();
@@ -2499,7 +2529,7 @@ namespace Opc.Ua
                 extensions.Add(document.DocumentElement);
             }
         }
-        #endregion
+#endregion
 
         #region Reflection Helper Functions
         /// <summary>

--- a/Stack/Opc.Ua.Core/Types/Utils/Utils.cs
+++ b/Stack/Opc.Ua.Core/Types/Utils/Utils.cs
@@ -1921,26 +1921,7 @@ namespace Opc.Ua
         /// <summary>
         /// Checks if two T[] values are equal.
         /// </summary>
-        public static bool IsEqualB<T>(T[] value1, T[] value2) where T : unmanaged, IEquatable<T>
-        {
-            // check for reference equality.
-            if (Object.ReferenceEquals(value1, value2))
-            {
-                return true;
-            }
-
-            if (Object.ReferenceEquals(value1, null) || Object.ReferenceEquals(value2, null))
-            {
-                return false;
-            }
-
-            return value1.SequenceEqual(value2);
-        }
-
-        /// <summary>
-        /// Checks if two T[] values are equal.
-        /// </summary>
-        public static bool IsEqual(byte[] value1, byte[] value2)
+        public static bool IsEqual<T>(T[] value1, T[] value2) where T : unmanaged, IEquatable<T>
         {
             // check for reference equality.
             if (Object.ReferenceEquals(value1, value2))

--- a/Tests/Opc.Ua.Core.Tests/Opc.Ua.Core.Tests.csproj
+++ b/Tests/Opc.Ua.Core.Tests/Opc.Ua.Core.Tests.csproj
@@ -5,6 +5,7 @@
     <TargetFrameworks>$(TestsTargetFrameworks)</TargetFrameworks>
     <RootNamespace>Opc.Ua.Core.Tests</RootNamespace>
     <GenerateProgramFile>false</GenerateProgramFile>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Tests/Opc.Ua.Core.Tests/Types/Encoders/BinaryEncoderBenchmarks.cs
+++ b/Tests/Opc.Ua.Core.Tests/Types/Encoders/BinaryEncoderBenchmarks.cs
@@ -54,7 +54,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
         /// </summary>
         [Benchmark]
         [Test]
-        public void BinaryEncoder_Constructor2()
+        public void BinaryEncoderConstructor2()
         {
             using (var binaryEncoder = new BinaryEncoder(m_context))
             {
@@ -68,7 +68,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
         /// </summary>
         [Benchmark]
         [Test]
-        public void BinaryEncoder_Constructor3()
+        public void BinaryEncoderConstructor3()
         {
             using (var stream = new ArraySegmentStream(m_bufferManager, kBufferSize, 0, kBufferSize))
             {
@@ -85,7 +85,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
         /// </summary>
         [Benchmark]
         [Test]
-        public void BinaryEncoder_Constructor_Streamwriter2()
+        public void BinaryEncoderConstructorStreamwriter2()
         {
             using (IEncoder binaryEncoder = new BinaryEncoder(m_memoryStream, m_context, true))
             {
@@ -100,7 +100,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
         /// </summary>
         [Benchmark]
         [Test]
-        public void BinaryEncoder_StreamLeaveOpen_MemoryStream()
+        public void BinaryEncoderStreamLeaveOpenMemoryStream()
         {
             BinaryEncoder_StreamLeaveOpen(m_memoryStream);
         }
@@ -110,7 +110,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
         /// </summary>
         [Benchmark]
         [Test]
-        public void BinaryEncoder_StreamLeaveOpen_RecyclableMemoryStream()
+        public void BinaryEncoderStreamLeaveOpenRecyclableMemoryStream()
         {
             BinaryEncoder_StreamLeaveOpen(m_recyclableMemoryStream);
         }
@@ -120,7 +120,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
         /// </summary>
         [Benchmark]
         [Test]
-        public void BinaryEncoder_StreamLeaveOpen_ArraySegmentStream()
+        public void BinaryEncoderStreamLeaveOpenArraySegmentStream()
         {
             BinaryEncoder_StreamLeaveOpen(m_arraySegmentStream);
         }
@@ -131,7 +131,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
         /// </summary>
         [Benchmark]
         [Test]
-        public void BinaryEncoder_Constructor_Streamwriter_Reflection2()
+        public void BinaryEncoderConstructorStreamwriterReflection2()
         {
             using (var binaryEncoder = new BinaryEncoder(m_memoryStream, m_context, true))
             {

--- a/Tests/Opc.Ua.Core.Tests/Types/Utils/UtilsIsEqualTests.cs
+++ b/Tests/Opc.Ua.Core.Tests/Types/Utils/UtilsIsEqualTests.cs
@@ -31,7 +31,6 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Xml;
 using BenchmarkDotNet.Attributes;
@@ -67,16 +66,16 @@ namespace Opc.Ua.Core.Tests.Types.UtilsTests
         [Benchmark]
         public bool UtilsIsEqualByteArrayCompare()
         {
-            return Utils.IsEqual(m_bufferA, m_bufferB);
+            return IsEqual(m_bufferA, m_bufferB);
         }
 
         /// <summary>
-        /// Test IsEqual using the byte[] direct call.
+        /// Test IsEqual using the template T[] direct call.
         /// </summary>
         [Benchmark]
         public bool UtilsIsEqualTemplateByteArrayCompare()
         {
-            return Utils.IsEqualB(m_bufferA, m_bufferB);
+            return Utils.IsEqual(m_bufferA, m_bufferB);
         }
 
         /// <summary>
@@ -210,6 +209,27 @@ namespace Opc.Ua.Core.Tests.Types.UtilsTests
         [GlobalCleanup]
         public void GlobalCleanup()
         {
+        }
+        #endregion
+
+        #region IsEqualByteArray
+        /// <summary>
+        /// Checks if two byte[] values are equal.
+        /// </summary>
+        public static bool IsEqual(byte[] value1, byte[] value2)
+        {
+            // check for reference equality.
+            if (Object.ReferenceEquals(value1, value2))
+            {
+                return true;
+            }
+
+            if (Object.ReferenceEquals(value1, null) || Object.ReferenceEquals(value2, null))
+            {
+                return false;
+            }
+
+            return value1.SequenceEqual(value2);
         }
         #endregion
 

--- a/Tests/Opc.Ua.Core.Tests/Types/Utils/UtilsIsEqualTests.cs
+++ b/Tests/Opc.Ua.Core.Tests/Types/Utils/UtilsIsEqualTests.cs
@@ -57,7 +57,7 @@ namespace Opc.Ua.Core.Tests.Types.UtilsTests
         /// <summary>
         /// Test IsEqual using the generic IsEqual from previous versions.
         /// </summary>
-        [Benchmark]
+        [Benchmark(Baseline = true)]
         public bool UtilsIsEqualGenericByteArrayCompare()
         {
             return IsEqualGeneric(m_bufferA, m_bufferB);
@@ -127,27 +127,6 @@ namespace Opc.Ua.Core.Tests.Types.UtilsTests
         }
 
         /// <summary>
-        /// Compare the byte[] using a for loop with index, unsafe version.
-        /// </summary>
-        [Benchmark]
-        public bool ForLoopBinaryCompareUnsafe()
-        {
-            if (m_bufferA.Length != m_bufferB.Length) return false;
-            int payloadsize = m_bufferA.Length;
-            unsafe
-            {
-                for (int ii = 0; ii < payloadsize; ii++)
-                {
-                    if (m_bufferA[ii] != m_bufferB[ii])
-                    {
-                        return false;
-                    }
-                }
-                return true;
-            }
-        }
-
-        /// <summary>
         /// Test the memory compare using P/Invoke.
         /// </summary>
         [Benchmark]
@@ -161,7 +140,7 @@ namespace Opc.Ua.Core.Tests.Types.UtilsTests
             }
             else
             {
-                return ForLoopBinaryCompareUnsafe();
+                return ForLoopBinaryCompare();
             }
         }
 
@@ -196,6 +175,14 @@ namespace Opc.Ua.Core.Tests.Types.UtilsTests
             Assert.AreEqual(Utils.IsEqual((object)null, (object)m_bufferB), Utils.IsEqual(null, m_bufferB));
             Assert.AreEqual(Utils.IsEqual((object)m_bufferA, (object)null), Utils.IsEqual(m_bufferA, null));
             Assert.AreEqual(Utils.IsEqual((object)null, (object)null), Utils.IsEqual((byte[])null, (byte[])null));
+
+            Assert.AreEqual(Utils.IsEqual((object)m_bufferA, (object)m_bufferB), Utils.IsEqual((IEnumerable)m_bufferA, (IEnumerable)m_bufferB));
+            Assert.AreEqual(Utils.IsEqual((object)null, (object)m_bufferB), Utils.IsEqual((IEnumerable)null, (IEnumerable)m_bufferB));
+            Assert.AreEqual(Utils.IsEqual((object)m_bufferA, (object)null), Utils.IsEqual((IEnumerable)m_bufferA, (IEnumerable)null));
+
+            Assert.AreEqual(Utils.IsEqual((object)m_bufferA, (object)m_bufferB), Utils.IsEqual((Array)m_bufferA, (Array)m_bufferB));
+            Assert.AreEqual(Utils.IsEqual((object)null, (object)m_bufferB), Utils.IsEqual((Array)null, (Array)m_bufferB));
+            Assert.AreEqual(Utils.IsEqual((object)m_bufferA, (object)null), Utils.IsEqual((Array)m_bufferA, (Array)null));
 
             int i = 1;
             Assert.AreEqual(Utils.IsEqual((object)i, (object)m_bufferB), Utils.IsEqual(i, m_bufferB));

--- a/Tests/Opc.Ua.Core.Tests/Types/Utils/UtilsIsEqualTests.cs
+++ b/Tests/Opc.Ua.Core.Tests/Types/Utils/UtilsIsEqualTests.cs
@@ -1,0 +1,391 @@
+/* ========================================================================
+ * Copyright (c) 2005-2023 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ * 
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ * 
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Xml;
+using BenchmarkDotNet.Attributes;
+using NUnit.Framework;
+
+namespace Opc.Ua.Core.Tests.Types.UtilsTests
+{
+    [TestFixture, Category("Utils")]
+    [SetCulture("en-us"), SetUICulture("en-us")]
+    [Parallelizable]
+    [MemoryDiagnoser]
+    [DisassemblyDiagnoser]
+    public class UtilsIsEqualTests
+    {
+        [DllImport("msvcrt.dll", CallingConvention = CallingConvention.Cdecl)]
+        private static extern int memcmp(byte[] b1, byte[] b2, long count);
+
+        [Params(32, 128, 1024, 4096, 65536)]
+        public int PayLoadSize { get; set; } = 1024;
+
+        /// <summary>
+        /// Test IsEqual using the generic IsEqual from previous versions.
+        /// </summary>
+        [Benchmark]
+        public bool UtilsIsEqualGenericByteArrayCompare()
+        {
+            return IsEqualGeneric(m_bufferA, m_bufferB);
+        }
+
+        /// <summary>
+        /// Test IsEqual using the byte[] direct call.
+        /// </summary>
+        [Benchmark]
+        public bool UtilsIsEqualByteArrayCompare()
+        {
+            return Utils.IsEqual(m_bufferA, m_bufferB);
+        }
+
+        /// <summary>
+        /// Test IsEqual using the byte[] direct call.
+        /// </summary>
+        [Benchmark]
+        public bool UtilsIsEqualTemplateByteArrayCompare()
+        {
+            return Utils.IsEqualB(m_bufferA, m_bufferB);
+        }
+
+        /// <summary>
+        /// Test IsEqual using the latest generic implementation as object.
+        /// </summary>
+        [Benchmark]
+        public bool UtilsIsEqualObjectCompare()
+        {
+            return Utils.IsEqual((object)m_bufferA, (object)m_bufferB);
+        }
+
+        /// <summary>
+        /// Test IsEqual using the latest implementation as IEnumerable.
+        /// </summary>
+        [Benchmark]
+        public bool UtilsIsEqualIEnumerableCompare()
+        {
+            return Utils.IsEqual((IEnumerable<byte>)m_bufferA, (IEnumerable<byte>)m_bufferB);
+        }
+
+        /// <summary>
+        /// Directly compare a byte [] using SequenceEqual.
+        /// </summary>
+        [Benchmark]
+        public bool SequenceEqualsByteArrayCompare()
+        {
+            return m_bufferA.SequenceEqual(m_bufferB);
+        }
+
+        /// <summary>
+        /// Compare the byte[] using a for loop with index.
+        /// </summary>
+        [Benchmark]
+        public bool ForLoopBinaryCompare()
+        {
+            if (m_bufferA.Length != m_bufferB.Length) return false;
+            int payloadsize = m_bufferA.Length;
+            for (int ii = 0; ii < payloadsize; ii++)
+            {
+                if (m_bufferA[ii] != m_bufferB[ii])
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// Test the memory compare using P/Invoke.
+        /// </summary>
+        [Benchmark]
+        public bool MemCmpByteArrayCompare()
+        {
+            // Validate buffers are the same length.
+            // This also ensures that the count does not exceed the length of either buffer.  
+            return m_bufferA.Length == m_bufferB.Length && memcmp(m_bufferA, m_bufferB, m_bufferA.Length) == 0;
+        }
+
+        /// <summary>
+        /// Validate result of benchmark functions.
+        /// </summary>
+        [Test]
+        public void UtilsIsEqualObjectCompareTest()
+        {
+            bool result;
+            result = UtilsIsEqualGenericByteArrayCompare();
+            Assert.True(result);
+            result = UtilsIsEqualByteArrayCompare();
+            Assert.True(result);
+            result = UtilsIsEqualObjectCompare();
+            Assert.True(result);
+            result = UtilsIsEqualIEnumerableCompare();
+            Assert.True(result);
+            result = SequenceEqualsByteArrayCompare();
+            Assert.True(result);
+            result = ForLoopBinaryCompare();
+            Assert.True(result);
+            result = MemCmpByteArrayCompare();
+            Assert.True(result);
+        }
+
+        [Test]
+        public void UtilsIsEqualArrayEqualsByteArrayTest()
+        {
+            // byte arrays and null
+            Assert.AreEqual(Utils.IsEqual((object)m_bufferA, (object)m_bufferB), Utils.IsEqual(m_bufferA, m_bufferB));
+            Assert.AreEqual(Utils.IsEqual((object)null, (object)m_bufferB), Utils.IsEqual(null, m_bufferB));
+            Assert.AreEqual(Utils.IsEqual((object)m_bufferA, (object)null), Utils.IsEqual(m_bufferA, null));
+            Assert.AreEqual(Utils.IsEqual((object)null, (object)null), Utils.IsEqual((byte[])null, (byte[])null));
+
+            int i = 1;
+            Assert.AreEqual(Utils.IsEqual((object)i, (object)m_bufferB), Utils.IsEqual(i, m_bufferB));
+        }
+
+        #region Test Setup
+        [OneTimeSetUp]
+        public void OneTimeSetUp()
+        {
+            // for validating benchmark tests
+            m_random = new Random(0x62541);
+            m_bufferA = new byte[PayLoadSize];
+            m_bufferB = new byte[PayLoadSize];
+            m_random.NextBytes(m_bufferA);
+            Array.Copy(m_bufferA, m_bufferB, m_bufferA.Length);
+        }
+
+        [OneTimeTearDown]
+        public void OneTimeTearDown()
+        {
+        }
+        #endregion
+
+        #region Benchmark Setup
+        /// <summary>
+        /// Set up some variables for benchmarks.
+        /// </summary>
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            // for validating benchmark tests
+            m_random = new Random(0x62541);
+            m_bufferA = new byte[PayLoadSize];
+            m_bufferB = new byte[PayLoadSize];
+            m_random.NextBytes(m_bufferA);
+            Array.Copy(m_bufferA, m_bufferB, m_bufferA.Length);
+        }
+
+        /// <summary>
+        /// Tear down benchmark variables.
+        /// </summary>
+        [GlobalCleanup]
+        public void GlobalCleanup()
+        {
+        }
+        #endregion
+
+        #region IsEqual up to 1.4.372.106
+        /// <summary>
+        /// For backward comparison the original generic version of IsEqual up to release 1.4.372.106.
+        /// </summary>
+        public static bool IsEqualGeneric(object value1, object value2)
+        {
+            // check for reference equality.
+            if (Object.ReferenceEquals(value1, value2))
+            {
+                return true;
+            }
+
+            // check for null values.
+            if (value1 == null)
+            {
+                if (value2 != null)
+                {
+                    return value2.Equals(value1);
+                }
+
+                return true;
+            }
+
+            // check for null values.
+            if (value2 == null)
+            {
+                return value1.Equals(value2);
+            }
+
+            // check that data types are the same.
+            if (value1.GetType() != value2.GetType())
+            {
+                return value1.Equals(value2);
+            }
+
+            // check for DateTime objects
+            if (value1 is DateTime time1)
+            {
+                return Utils.IsEqual(time1, (DateTime)value2);
+            }
+
+            // check for compareable objects.
+
+            if (value1 is IComparable comparable1)
+            {
+                return comparable1.CompareTo(value2) == 0;
+            }
+
+            // check for encodeable objects.
+
+            if (value1 is IEncodeable encodeable1)
+            {
+                if (!(value2 is IEncodeable encodeable2))
+                {
+                    return false;
+                }
+
+                return encodeable1.IsEqual(encodeable2);
+            }
+
+            // check for XmlElement objects.
+
+            if (value1 is XmlElement element1)
+            {
+                if (!(value2 is XmlElement element2))
+                {
+                    return false;
+                }
+
+                return element1.OuterXml == element2.OuterXml;
+            }
+
+            // check for arrays.
+
+            if (value1 is Array array1)
+            {
+                // arrays are greater than non-arrays.
+                if (!(value2 is Array array2))
+                {
+                    return false;
+                }
+
+                // shorter arrays are less than longer arrays.
+                if (array1.Length != array2.Length)
+                {
+                    return false;
+                }
+
+                // compare the array dimension
+                if (array1.Rank != array2.Rank)
+                {
+                    return false;
+                }
+
+                // compare each rank.
+                for (int ii = 0; ii < array1.Rank; ii++)
+                {
+                    if (array1.GetLowerBound(ii) != array2.GetLowerBound(ii) ||
+                        array1.GetUpperBound(ii) != array2.GetUpperBound(ii))
+                    {
+                        return false;
+                    }
+                }
+
+                IEnumerator enumerator1 = array1.GetEnumerator();
+                IEnumerator enumerator2 = array2.GetEnumerator();
+
+                // compare each element.
+                while (enumerator1.MoveNext())
+                {
+                    // length is already checked
+                    enumerator2.MoveNext();
+
+                    bool result = Utils.IsEqual(enumerator1.Current, enumerator2.Current);
+
+                    if (!result)
+                    {
+                        return false;
+                    }
+                }
+
+                // arrays are identical.
+                return true;
+            }
+
+            // check enumerables.
+
+            if (value1 is IEnumerable enumerable1)
+            {
+                // collections are greater than non-collections.
+                if (!(value2 is IEnumerable enumerable2))
+                {
+                    return false;
+                }
+
+                IEnumerator enumerator1 = enumerable1.GetEnumerator();
+                IEnumerator enumerator2 = enumerable2.GetEnumerator();
+
+                while (enumerator1.MoveNext())
+                {
+                    // enumerable2 must be shorter. 
+                    if (!enumerator2.MoveNext())
+                    {
+                        return false;
+                    }
+
+                    bool result = Utils.IsEqual(enumerator1.Current, enumerator2.Current);
+
+                    if (!result)
+                    {
+                        return false;
+                    }
+                }
+
+                // enumerable2 must be longer.
+                if (enumerator2.MoveNext())
+                {
+                    return false;
+                }
+
+                // must be equal.
+                return true;
+            }
+
+            // check for objects that override the Equals function.
+            return value1.Equals(value2);
+        }
+        #endregion
+
+        #region Private Fields
+        private Random m_random;
+        private byte[] m_bufferA;
+        private byte[] m_bufferB;
+        #endregion
+    }
+}

--- a/Tests/Opc.Ua.Core.Tests/Types/Utils/UtilsTests.cs
+++ b/Tests/Opc.Ua.Core.Tests/Types/Utils/UtilsTests.cs
@@ -115,7 +115,7 @@ namespace Opc.Ua.Core.Tests.Types.UtilsTests
             Uri uri1 = new Uri("opc.tcp://host1:4840");
             Uri uri1_dupe = new Uri("opc.tcp://host1:4840");
             Uri uri2 = new Uri($"opc.tcp://localhost:4840");
-            Uri uri2_dupe = new Uri($"opc.tcp://{Dns.GetHostName()}:4840");
+            Uri uri2_dupe = new Uri($"opc.tcp://{Utils.GetHostName()}:4840");
 
             // uri compare resolves localhost
             Assert.True(Utils.AreDomainsEqual(uri1, uri1_dupe));

--- a/Tests/Opc.Ua.Core.Tests/Types/Utils/UtilsTests.cs
+++ b/Tests/Opc.Ua.Core.Tests/Types/Utils/UtilsTests.cs
@@ -27,9 +27,11 @@
  * http://opcfoundation.org/License/MIT/1.00/
  * ======================================================================*/
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Reflection;
 using System.Text;
 using System.Xml;
@@ -93,6 +95,137 @@ namespace Opc.Ua.Core.Tests.Types.UtilsTests
             string hex = "FF06050403020100";
             var hexutil = Utils.ToHexString(blob, true);
             Assert.AreEqual(hex, hexutil);
+        }
+
+        [Test]
+        public void Trace()
+        {
+            Utils.TraceDebug("");
+            Utils.TraceDebug(null);
+            Utils.Trace(new ServiceResultException(StatusCodes.BadAggregateConfigurationRejected), "Exception {0}", 1);
+            Utils.TraceExceptionMessage(new ServiceResultException(StatusCodes.BadEdited_OutOfRange), "Exception {0} {1}", 2, 3);
+            Utils.Trace(new ServiceResultException(StatusCodes.BadAggregateConfigurationRejected), "Exception {0} {1}", true, 2, 3);
+            Utils.Trace(new ServiceResultException(StatusCodes.BadEdited_OutOfRange), "Exception {0} {1}", false, 2, 3);
+            Utils.Trace(Utils.TraceMasks.Information, "Exception {0} {1}", 2, 3);
+        }
+
+        [Test]
+        public void AreDomainsEqual()
+        {
+            Uri uri1 = new Uri("opc.tcp://host1:4840");
+            Uri uri1_dupe = new Uri("opc.tcp://host1:4840");
+            Uri uri2 = new Uri($"opc.tcp://localhost:4840");
+            Uri uri2_dupe = new Uri($"opc.tcp://{Dns.GetHostName()}:4840");
+
+            // uri compare resolves localhost
+            Assert.True(Utils.AreDomainsEqual(uri1, uri1_dupe));
+            Assert.True(Utils.AreDomainsEqual(uri2, uri2_dupe));
+            Assert.True(Utils.AreDomainsEqual(uri2_dupe, uri2));
+            Assert.True(Utils.AreDomainsEqual(uri1, uri1));
+            Assert.True(Utils.AreDomainsEqual(uri2, uri2));
+
+            // string compare doesn't resolve localhost
+            Assert.True(Utils.AreDomainsEqual(uri1.ToString(), uri1_dupe.ToString()));
+            Assert.False(Utils.AreDomainsEqual(uri2.ToString(), uri2_dupe.ToString()));
+            Assert.False(Utils.AreDomainsEqual(uri1.ToString(), null));
+            Assert.False(Utils.AreDomainsEqual(uri2.ToString(), null));
+            Assert.False(Utils.AreDomainsEqual(uri1.ToString(), string.Empty));
+            Assert.False(Utils.AreDomainsEqual(uri2.ToString(), string.Empty));
+            Assert.False(Utils.AreDomainsEqual(null, uri1.ToString()));
+            Assert.False(Utils.AreDomainsEqual(null, uri2.ToString()));
+            Assert.False(Utils.AreDomainsEqual(string.Empty, uri1.ToString()));
+            Assert.False(Utils.AreDomainsEqual(string.Empty, uri2.ToString()));
+
+            Assert.False(Utils.AreDomainsEqual((Uri)null, null));
+            Assert.False(Utils.AreDomainsEqual((string)null, null));
+            Assert.False(Utils.AreDomainsEqual(uri1, uri2));
+            Assert.False(Utils.AreDomainsEqual(uri1.ToString(), uri2.ToString()));
+        }
+
+        public class TestClone
+        {
+            object m_object;
+
+            public TestClone(object value)
+            {
+                m_object = value;
+            }
+
+            public object Clone()
+            {
+                return new TestClone(m_object);
+            }
+        }
+
+        public class TestNoClone
+        {
+            object m_object;
+
+            public TestNoClone(object value)
+            {
+                m_object = value;
+            }
+
+            public object NoClone()
+            {
+                return new TestNoClone(m_object);
+            }
+        }
+
+        public class TestMemberwiseClone
+        {
+            object m_object;
+
+            public TestMemberwiseClone(object value)
+            {
+                m_object = value;
+            }
+
+            public object Clone()
+            {
+                return new TestMemberwiseClone(m_object);
+            }
+        }
+
+        [Test]
+        public void Clone()
+        {
+            var testClone = new TestClone(1);
+            Assert.NotNull(Utils.Clone(testClone));
+            var testMemberwiseClone = new TestMemberwiseClone(2);
+            Assert.NotNull(Utils.Clone(testMemberwiseClone));
+            var testNoClone = new TestNoClone(3);
+            Assert.Throws<NotSupportedException>(() => Utils.Clone(testNoClone));
+        }
+
+        [Test]
+        public void IsEqualUserIdentity()
+        {
+            var anonymousIdentity1 = new AnonymousIdentityToken();
+            var anonymousIdentity2 = new AnonymousIdentityToken();
+
+            Assert.True(Utils.IsEqualUserIdentity(anonymousIdentity1, anonymousIdentity1));
+            Assert.True(Utils.IsEqualUserIdentity(anonymousIdentity1, anonymousIdentity2));
+            Assert.False(Utils.IsEqualUserIdentity(anonymousIdentity1, null));
+            Assert.False(Utils.IsEqualUserIdentity(null, anonymousIdentity2));
+
+            var user1 = new UserNameIdentityToken() {
+                UserName = "user1",
+                Password = Encoding.ASCII.GetBytes("pass1".ToCharArray())
+            };
+            var user1_dupe = new UserNameIdentityToken() {
+                UserName = "user1",
+                Password = Encoding.ASCII.GetBytes("pass1".ToCharArray())
+            };
+            var user2 = new UserNameIdentityToken() {
+                UserName = "user2",
+                Password = Encoding.ASCII.GetBytes("pass2".ToCharArray())
+            };
+            Assert.True(Utils.IsEqualUserIdentity(user1, user1_dupe));
+            Assert.True(Utils.IsEqualUserIdentity(user1, user1));
+            Assert.False(Utils.IsEqualUserIdentity(user1, user2));
+            Assert.False(Utils.IsEqualUserIdentity(null, user2));
+            Assert.False(Utils.IsEqualUserIdentity(user1, null));
         }
         #endregion
 
@@ -292,7 +425,6 @@ namespace Opc.Ua.Core.Tests.Types.UtilsTests
         #endregion
 
         #region RelativePath.Parse Escaping
-
         /// <summary>
         /// Parse a path containing non-escaped hash character.
         /// </summary>
@@ -348,10 +480,7 @@ namespace Opc.Ua.Core.Tests.Types.UtilsTests
             string str = "/abc&$!def";
             Assert.Throws<ServiceResultException>(() => RelativePath.Parse(str, typeTable).Format(typeTable));
         }
-
-
         #endregion
-
     }
 
 }


### PR DESCRIPTION
## Proposed changes

- Improve the `Utils.IsEqual` helper for some special cases which compare byte[].
- In the actual implementation the compilers can not optimize for special cases, e.g. comparing a typical certificate as byte[] with 1k size on .NET8 took 167µs, the customized version needs only 69ns and is even faster than a P/Invoke to memc mp (80ns). 
- see benchmark result for improvements
- Due to the little difference between a custom byte[] and the T[] compare, the byte[] was moved back to the tests
- .NET Framework falls back on memcmp

see `UtilsIsEqualGenericByteArrayCompare` is a copy of the implementation up to V1.4.372.106 in the benchmark file.

| Method                               | Runtime            | PayLoadSize | Mean           | Error        | StdDev        | Median         | Ratio | RatioSD | Gen0    | Code Size | Allocated | Alloc Ratio |
|------------------------------------- |------------------- |------------ |---------------:|-------------:|--------------:|---------------:|------:|--------:|--------:|----------:|----------:|------------:|
| UtilsIsEqualGenericByteArrayCompare  | .NET 6.0           | 4096        |   865,245.1 ns | 42,327.84 ns | 124,804.58 ns |   859,613.3 ns | 0.778 |    0.11 | 23.4375 |   1,232 B |  196678 B |       0.997 |
| UtilsIsEqualByteArrayCompare         | .NET 6.0           | 4096        |       203.0 ns |      6.66 ns |      19.20 ns |       199.1 ns | 0.000 |    0.00 |       - |   1,213 B |         - |       0.000 |
| UtilsIsEqualTemplateByteArrayCompare | .NET 6.0           | 4096        |       185.6 ns |      3.69 ns |       3.63 ns |       185.5 ns | 0.000 |    0.00 |       - |   1,213 B |         - |       0.000 |
| UtilsIsEqualObjectCompare            | .NET 6.0           | 4096        |       335.3 ns |     17.84 ns |      52.60 ns |       327.1 ns | 0.000 |    0.00 |       - |   1,303 B |         - |       0.000 |
| UtilsIsEqualIEnumerableCompare       | .NET 6.0           | 4096        |       201.4 ns |      4.85 ns |      13.83 ns |       198.8 ns | 0.000 |    0.00 |       - |   1,213 B |         - |       0.000 |
| SequenceEqualsByteArrayCompare       | .NET 6.0           | 4096        |       194.3 ns |      4.54 ns |      13.10 ns |       192.2 ns | 0.000 |    0.00 |       - |   1,188 B |         - |       0.000 |
| ForLoopBinaryCompare                 | .NET 6.0           | 4096        |     6,537.8 ns |    130.73 ns |     214.79 ns |     6,556.9 ns | 0.006 |    0.00 |       - |     104 B |         - |       0.000 |
| MemCmpByteArrayCompare               | .NET 6.0           | 4096        |       310.2 ns |      6.24 ns |      16.87 ns |       304.5 ns | 0.000 |    0.00 |       - |      81 B |         - |       0.000 |
| UtilsIsEqualGenericByteArrayCompare  | .NET 8.0           | 4096        |   603,837.6 ns | 12,008.10 ns |  21,957.48 ns |   598,516.8 ns | 0.553 |    0.03 | 23.4375 |   1,763 B |  196678 B |       0.997 |
| UtilsIsEqualByteArrayCompare         | .NET 8.0           | 4096        |       187.7 ns |      4.77 ns |      13.92 ns |       185.3 ns | 0.000 |    0.00 |       - |     998 B |         - |       0.000 |
| UtilsIsEqualTemplateByteArrayCompare | .NET 8.0           | 4096        |       186.0 ns |      3.77 ns |       8.36 ns |       184.7 ns | 0.000 |    0.00 |       - |     998 B |         - |       0.000 |
| UtilsIsEqualObjectCompare            | .NET 8.0           | 4096        |       224.5 ns |      4.37 ns |       4.86 ns |       225.5 ns | 0.000 |    0.00 |       - |   1,693 B |         - |       0.000 |
| UtilsIsEqualIEnumerableCompare       | .NET 8.0           | 4096        |       175.9 ns |      3.57 ns |       3.50 ns |       175.3 ns | 0.000 |    0.00 |       - |     998 B |         - |       0.000 |
| SequenceEqualsByteArrayCompare       | .NET 8.0           | 4096        |       187.2 ns |      3.68 ns |       4.52 ns |       188.2 ns | 0.000 |    0.00 |       - |     968 B |         - |       0.000 |
| ForLoopBinaryCompare                 | .NET 8.0           | 4096        |     6,204.6 ns |    120.62 ns |     201.53 ns |     6,162.3 ns | 0.006 |    0.00 |       - |     104 B |         - |       0.000 |
| MemCmpByteArrayCompare               | .NET 8.0           | 4096        |       290.1 ns |      5.87 ns |       8.79 ns |       288.7 ns | 0.000 |    0.00 |       - |      79 B |         - |       0.000 |
| UtilsIsEqualGenericByteArrayCompare  | .NET Framework 4.8 | 4096        | 1,080,895.1 ns | 21,527.64 ns |  53,210.98 ns | 1,068,179.3 ns | 1.000 |    0.00 | 31.2500 |   1,294 B |  197266 B |       1.000 |
| UtilsIsEqualByteArrayCompare         | .NET Framework 4.8 | 4096        |    96,856.0 ns |  1,875.57 ns |   3,997.00 ns |    95,656.3 ns | 0.089 |    0.01 |       - |      84 B |      65 B |       0.000 |
| UtilsIsEqualTemplateByteArrayCompare | .NET Framework 4.8 | 4096        |       295.4 ns |      5.83 ns |       5.45 ns |       293.4 ns | 0.000 |    0.00 |       - |     105 B |         - |       0.000 |
| UtilsIsEqualObjectCompare            | .NET Framework 4.8 | 4096        |       534.9 ns |      7.94 ns |       7.04 ns |       535.8 ns | 0.001 |    0.00 |       - |   1,374 B |         - |       0.000 |
| UtilsIsEqualIEnumerableCompare       | .NET Framework 4.8 | 4096        |    97,511.8 ns |  1,894.10 ns |   2,948.88 ns |    97,664.6 ns | 0.089 |    0.01 |       - |      84 B |      65 B |       0.000 |
| SequenceEqualsByteArrayCompare       | .NET Framework 4.8 | 4096        |    94,807.6 ns |  1,889.00 ns |   1,939.86 ns |    94,856.6 ns | 0.089 |    0.00 |       - |     587 B |      65 B |       0.000 |
| ForLoopBinaryCompare                 | .NET Framework 4.8 | 4096        |     6,052.1 ns |    106.12 ns |      82.85 ns |     6,025.8 ns | 0.006 |    0.00 |       - |     104 B |         - |       0.000 |
| MemCmpByteArrayCompare               | .NET Framework 4.8 | 4096        |       298.7 ns |      6.03 ns |      13.23 ns |       294.1 ns | 0.000 |    0.00 |       - |      80 B |         - |       0.000 |

## Related Issues

- Fixes #2431

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
