### PR TITLE
Make sure always min publish requests are running when subscription publishing is started

### DIFF
--- a/Libraries/Opc.Ua.Client/ISession.cs
+++ b/Libraries/Opc.Ua.Client/ISession.cs
@@ -938,7 +938,7 @@ namespace Opc.Ua.Client
         /// <summary>
         /// Sends an additional publish request.
         /// </summary>
-        IAsyncResult BeginPublish(int timeout);
+        void StartPublish(int timeout);
 
         /// <summary>
         /// Sends a republish request.

--- a/Libraries/Opc.Ua.Client/Session.cs
+++ b/Libraries/Opc.Ua.Client/Session.cs
@@ -2412,7 +2412,7 @@ namespace Opc.Ua.Client
             // save session id.
             lock (SyncRoot)
             {
-                base.SessionCreated(sessionId, sessionCookie);
+                SessionCreated(sessionId, sessionCookie);
             }
 
             Utils.LogInfo("Revised session timeout value: {0}. ", m_sessionTimeout);

--- a/Libraries/Opc.Ua.Client/SessionAsync.cs
+++ b/Libraries/Opc.Ua.Client/SessionAsync.cs
@@ -184,7 +184,7 @@ namespace Opc.Ua.Client
             // save session id.
             lock (SyncRoot)
             {
-                base.SessionCreated(sessionId, sessionCookie);
+                SessionCreated(sessionId, sessionCookie);
             }
 
             Utils.LogInfo("Revised session timeout value: {0}. ", m_sessionTimeout);

--- a/Libraries/Opc.Ua.Client/SessionAsync.cs
+++ b/Libraries/Opc.Ua.Client/SessionAsync.cs
@@ -423,7 +423,7 @@ namespace Opc.Ua.Client
                     m_reconnectLock.Release();
                 }
 
-                RestartPublishing();
+                StartPublish(OperationTimeout);
             }
             else
             {
@@ -538,7 +538,7 @@ namespace Opc.Ua.Client
                     m_reconnectLock.Release();
                 }
 
-                RestartPublishing();
+                StartPublish(OperationTimeout);
             }
             else
             {
@@ -1520,15 +1520,12 @@ namespace Opc.Ua.Client
                     out certificateResults,
                     out certificateDiagnosticInfos);
 
-                int publishCount = 0;
-
                 Utils.LogInfo("Session RECONNECT {0} completed successfully.", SessionId);
 
                 lock (SyncRoot)
                 {
                     m_previousServerNonce = m_serverNonce;
                     m_serverNonce = serverNonce;
-                    publishCount = GetMinPublishRequestCount(true);
                 }
 
                 await m_reconnectLock.WaitAsync(ct).ConfigureAwait(false);
@@ -1536,12 +1533,7 @@ namespace Opc.Ua.Client
                 resetReconnect = false;
                 m_reconnectLock.Release();
 
-                // refill pipeline.
-                for (int ii = 0; ii < publishCount; ii++)
-                {
-                    BeginPublish(OperationTimeout);
-                }
-
+                StartPublish(OperationTimeout);
                 StartKeepAliveTimer();
 
                 IndicateSessionConfigurationChanged();

--- a/Libraries/Opc.Ua.Client/Subscription.cs
+++ b/Libraries/Opc.Ua.Client/Subscription.cs
@@ -132,7 +132,7 @@ namespace Opc.Ua.Client
         }
 
         /// <summary>
-        /// Resets the state of the publish timer and associated message worker. 
+        /// Resets the state of the publish timer and associated message worker.
         /// </summary>
         private void ResetPublishTimerAndWorkerState()
         {
@@ -434,13 +434,13 @@ namespace Opc.Ua.Client
 
         /// <summary>
         /// If the available sequence numbers of a subscription
-        /// are republished or acknowledged after a transfer. 
+        /// are republished or acknowledged after a transfer.
         /// </summary>
         /// <remarks>
         /// Default <c>false</c>, set to <c>true</c> if no data loss is important
         /// and available publish requests (sequence numbers) that were never acknowledged should be
         /// recovered with a republish. The setting is used after a subscription transfer.
-        /// </remarks>   
+        /// </remarks>
         [DataMember(Name = "RepublishAfterTransfer", Order = 15)]
         public bool RepublishAfterTransfer
         {
@@ -904,7 +904,7 @@ namespace Opc.Ua.Client
                 ModifyItems();
             }
 
-            // add available sequence numbers to incoming 
+            // add available sequence numbers to incoming
             ProcessTransferredSequenceNumbers(availableSequenceNumbers);
 
             m_changeMask |= SubscriptionChangeMask.Transferred;
@@ -982,7 +982,7 @@ namespace Opc.Ua.Client
                 await ModifyItemsAsync(ct).ConfigureAwait(false);
             }
 
-            // add available sequence numbers to incoming 
+            // add available sequence numbers to incoming
             ProcessTransferredSequenceNumbers(availableSequenceNumbers);
 
             m_changeMask |= SubscriptionChangeMask.Transferred;
@@ -1860,7 +1860,7 @@ namespace Opc.Ua.Client
             }
 
             // send initial publish.
-            m_session.BeginPublish(BeginPublishTimeout());
+            m_session.StartPublish(BeginPublishTimeout());
         }
 
 #if NET6_0_OR_GREATER
@@ -1919,7 +1919,7 @@ namespace Opc.Ua.Client
             }
 
             // try to send a publish to recover stopped publishing.
-            m_session?.BeginPublish(BeginPublishTimeout());
+            m_session?.StartPublish(BeginPublishTimeout());
         }
 
         /// <summary>
@@ -2410,7 +2410,7 @@ namespace Opc.Ua.Client
         /// </summary>
         private bool ValidSequentialPublishMessage(IncomingMessage message)
         {
-            // If sequential publishing is enabled, only release messages in perfect sequence. 
+            // If sequential publishing is enabled, only release messages in perfect sequence.
             return message.SequenceNumber <= m_lastSequenceNumberProcessed + 1 ||
                 // reconnect / transfer subscription case
                 m_resyncLastSequenceNumberProcessed ||

--- a/Libraries/Opc.Ua.Client/TraceableSession.cs
+++ b/Libraries/Opc.Ua.Client/TraceableSession.cs
@@ -920,9 +920,9 @@ namespace Opc.Ua.Client
         }
 
         /// <inheritdoc/>
-        public IAsyncResult BeginPublish(int timeout)
+        public void StartPublish(int timeout)
         {
-            return m_session.BeginPublish(timeout);
+            m_session.StartPublish(timeout);
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
## Proposed changes

When setting the minRequest property to 3 the expectation is that 3 requests are queued when publishing is started, but only 1 request is outstanding.  This only changes to 3 when an error occurs or the session is reconnected.  The change cleans up the queueing of publishing requests into a StartPublish method that wraps BeginPublish and ensures the minimum requests are queued.  In addition it now honors the "toomanyrequests" variable which was not used other than being set.

## Related Issues

- Fixes #

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [X] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

