### PR TITLE
Fix nodestate remove for diagnostic infos

### DIFF
--- a/Applications/Quickstarts.Servers/SampleNodeManager/SampleNodeManager.cs
+++ b/Applications/Quickstarts.Servers/SampleNodeManager/SampleNodeManager.cs
@@ -506,7 +506,7 @@ namespace Opc.Ua.Sample
                 LocalReference referenceToRemove = new LocalReference(
                     (NodeId)reference.TargetId,
                     reference.ReferenceTypeId,
-                    reference.IsInverse,
+                    !reference.IsInverse,
                     node.NodeId);
 
                 referencesToRemove.Add(referenceToRemove);

--- a/Libraries/Opc.Ua.Server/Diagnostics/CustomNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/Diagnostics/CustomNodeManager.cs
@@ -705,7 +705,7 @@ namespace Opc.Ua.Server
                 LocalReference referenceToRemove = new LocalReference(
                     (NodeId)reference.TargetId,
                     reference.ReferenceTypeId,
-                    reference.IsInverse,
+                    !reference.IsInverse,
                     node.NodeId);
 
                 referencesToRemove.Add(referenceToRemove);

--- a/Libraries/Opc.Ua.Server/NodeManager/MasterNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/NodeManager/MasterNodeManager.cs
@@ -665,7 +665,7 @@ namespace Opc.Ua.Server
                 }
 
                 // delete the reference.
-                nodeManager.DeleteReference(sourceHandle, reference.ReferenceTypeId, !reference.IsInverse, reference.TargetId, false);
+                nodeManager.DeleteReference(sourceHandle, reference.ReferenceTypeId, reference.IsInverse, reference.TargetId, false);
             }
         }
 

--- a/Libraries/Opc.Ua.Server/NodeManager/MasterNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/NodeManager/MasterNodeManager.cs
@@ -657,8 +657,7 @@ namespace Opc.Ua.Server
                 LocalReference reference = referencesToRemove[ii];
 
                 // find source node.
-                INodeManager nodeManager = null;
-                object sourceHandle = GetManagerHandle(reference.SourceId, out nodeManager);
+                object sourceHandle = GetManagerHandle(reference.SourceId, out INodeManager nodeManager);
 
                 if (sourceHandle == null)
                 {
@@ -666,7 +665,7 @@ namespace Opc.Ua.Server
                 }
 
                 // delete the reference.
-                nodeManager.DeleteReference(sourceHandle, reference.ReferenceTypeId, reference.IsInverse, reference.TargetId, false);
+                nodeManager.DeleteReference(sourceHandle, reference.ReferenceTypeId, !reference.IsInverse, reference.TargetId, false);
             }
         }
 

--- a/Stack/Opc.Ua.Core/Stack/State/NodeState.cs
+++ b/Stack/Opc.Ua.Core/Stack/State/NodeState.cs
@@ -4457,30 +4457,14 @@ namespace Opc.Ua
                 return false;
             }
 
-            bool success = m_references.Remove(new NodeStateReference(referenceTypeId, isInverse, targetId));
-            if (!success)
-            {
-                // try to remove target reference if it is still referenced
-                foreach (IReference m_refKey in m_references.Keys)
-                {
-                    if (m_refKey.TargetId != null &&
-                        m_refKey.TargetId.IdentifierText.Equals(targetId.IdentifierText, StringComparison.Ordinal) &&
-                        m_refKey.IsInverse != isInverse &&
-                        m_refKey is NodeStateReference sourceRef)
-                    {
-                        success = m_references.Remove(sourceRef);
-                        break;
-                    }
-                }
-            }
-
-            if (success)
+            if (m_references.Remove(new NodeStateReference(referenceTypeId, isInverse, targetId)))
             {
                 m_changeMasks |= NodeStateChangeMasks.References;
                 OnReferenceRemoved?.Invoke(this, referenceTypeId, isInverse, targetId);
+                return true;
             }
 
-            return success;
+            return false;
         }
 
         /// <summary>


### PR DESCRIPTION
## Proposed changes

Issue:
- In order to fix #2343, the change caused a regression pointed out by #2446.

Fix:

- First try to remove node, only then try to remove the reference to the target node.

Repro:
- connect/disconnect to the server with diagnostics enabled. Check Diagnostic nodes for leaking references.

## Related Issues

- Fixes #2446 , #2343

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.


