### PR TITLE
Expose hiresclock ticks and benchmark

### DIFF
--- a/Stack/Opc.Ua.Core/Types/Utils/HiResClock.cs
+++ b/Stack/Opc.Ua.Core/Types/Utils/HiResClock.cs
@@ -58,6 +58,17 @@ namespace Opc.Ua
         }
 
         /// <summary>
+        /// Returns a monotonic increasing tick count based on the frequency of the underlying timer.
+        /// </summary>
+        public static long Ticks
+        {
+            get
+            {
+                return s_Default.m_disabled ? DateTime.UtcNow.Ticks : Stopwatch.GetTimestamp();
+            }
+        }
+
+        /// <summary>
         /// Return the frequency of the ticks.
         /// </summary>
         public static long Frequency => s_Default.m_disabled ?

--- a/Stack/Opc.Ua.Core/Types/Utils/HiResClock.cs
+++ b/Stack/Opc.Ua.Core/Types/Utils/HiResClock.cs
@@ -86,16 +86,11 @@ namespace Opc.Ua
                     // check if already initialized.
                     if (!s_Default.m_initialized)
                     {
-                        if (s_Default.m_disabled && !value)
+                        if (s_Default.m_disabled != value)
                         {
                             // reset baseline
-                            s_Default = new HiResClock();
+                            s_Default = new HiResClock(value);
                         }
-                        else
-                        {
-                            s_Default.m_disabled = value;
-                        }
-
                         s_Default.m_initialized = true;
                     }
                     else
@@ -113,17 +108,17 @@ namespace Opc.Ua
         public static void Reset()
         {
             // reset baseline
-            s_Default = new HiResClock();
+            s_Default = new HiResClock(s_Default.m_disabled);
         }
 
         /// <summary>
         /// Constructs a HiRes clock class.
         /// </summary>
-        private HiResClock()
+        private HiResClock(bool disabled)
         {
             m_initialized = false;
             m_offset = DateTime.UtcNow.Ticks;
-            if (!Stopwatch.IsHighResolution)
+            if (!Stopwatch.IsHighResolution || disabled)
             {
                 m_ticksDelegate = UtcNowTicks;
                 m_frequency = TimeSpan.TicksPerSecond;
@@ -137,6 +132,7 @@ namespace Opc.Ua
                 m_ticksDelegate = Stopwatch.GetTimestamp;
                 m_frequency = Stopwatch.Frequency;
                 m_ticksPerMillisecond = m_frequency / 1000.0;
+                m_disabled = false;
             }
             m_ratio = ((decimal)TimeSpan.TicksPerSecond) / m_frequency;
         }
@@ -150,7 +146,7 @@ namespace Opc.Ua
         /// <summary>
         /// Defines a global instance.
         /// </summary>
-        private static HiResClock s_Default = new HiResClock();
+        private static HiResClock s_Default = new HiResClock(false);
         private TicksDelegate m_ticksDelegate;
         private long m_frequency;
         private long m_baseline;

--- a/Tests/Opc.Ua.Core.Tests/Types/Utils/HiResClock.cs
+++ b/Tests/Opc.Ua.Core.Tests/Types/Utils/HiResClock.cs
@@ -204,6 +204,12 @@ namespace Opc.Ua.Core.Tests.Types.UtilsTests
             _ = HiResClock.Ticks;
         }
 
+        [Benchmark]
+        public void HiResTickCount64()
+        {
+            _ = HiResClock.TickCount64;
+        }
+
         /// <summary>
         /// Resolution of the following ticks is limited
         /// to 1ms and the timer tick, e.g. 16ms on windows.

--- a/Tests/Opc.Ua.Core.Tests/Types/Utils/HiResClock.cs
+++ b/Tests/Opc.Ua.Core.Tests/Types/Utils/HiResClock.cs
@@ -30,6 +30,7 @@
 using System;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+using BenchmarkDotNet.Attributes;
 using NUnit.Framework;
 
 namespace Opc.Ua.Core.Tests.Types.UtilsTests
@@ -178,6 +179,29 @@ namespace Opc.Ua.Core.Tests.Types.UtilsTests
             {
                 Assert.Inconclusive(ex.Message);
             }
+        }
+        #endregion
+
+        #region Benchmarks
+        /// <summary>
+        /// Test the overhead and perf of the Stopwatch timer.
+        /// </summary>
+        [Benchmark]
+        public void DateTimeTicks()
+        {
+            _ = DateTime.UtcNow.Ticks;
+        }
+
+        [Benchmark]
+        public void StopwatchGetTimestamp()
+        {
+            _ = Stopwatch.GetTimestamp();
+        }
+
+        [Benchmark]
+        public void HiResClockTicks()
+        {
+            _ = HiResClock.Ticks;
         }
         #endregion
     }

--- a/Tests/Opc.Ua.Core.Tests/Types/Utils/HiResClock.cs
+++ b/Tests/Opc.Ua.Core.Tests/Types/Utils/HiResClock.cs
@@ -203,6 +203,33 @@ namespace Opc.Ua.Core.Tests.Types.UtilsTests
         {
             _ = HiResClock.Ticks;
         }
+
+        /// <summary>
+        /// Resolution of the following ticks is limited
+        /// to 1ms and the timer tick, e.g. 16ms on windows.
+        /// </summary>
+        [Benchmark]
+        public void EnvironmentTicks()
+        {
+            _ = Environment.TickCount;
+        }
+
+        [DllImport("kernel32")]
+        private extern static UInt64 GetTickCount64();
+
+        [Benchmark]
+        public void WindowsGetTickCount64()
+        {
+            _ = GetTickCount64();
+        }
+
+        [Benchmark]
+        public void EnvironmentTickCount64()
+        {
+#if NET6_0_OR_GREATER
+            _ = Environment.TickCount64;
+#endif
+        }
         #endregion
     }
 }


### PR DESCRIPTION
## Proposed changes

HiResClock uses the strictly monotonic ticks of the Stopwatch. Expose the Ticks for use in client and server timer.
Add some benchmarks for overhead. Note that Environment Tick Count has lower resolution.

| Method                 | Runtime            | Mean        | Error     | StdDev    | Median      | Ratio | RatioSD |
|----------------------- |------------------- |------------:|----------:|----------:|------------:|------:|--------:|
| DateTimeTicks          | .NET 6.0           |  43.1452 ns | 0.7716 ns | 0.7218 ns |  42.7566 ns |  0.39 |    0.01 |
| DateTimeTicks          | .NET 8.0           |  42.3255 ns | 0.4176 ns | 0.3701 ns |  42.2631 ns |  0.38 |    0.01 |
| DateTimeTicks          | .NET Framework 4.8 | 110.7443 ns | 1.9313 ns | 1.8065 ns | 110.1187 ns |  1.00 |    0.00 |
|                        |                    |             |           |           |             |       |         |
| StopwatchGetTimestamp  | .NET 6.0           |  23.8582 ns | 0.1043 ns | 0.0924 ns |  23.8566 ns |  0.60 |    0.01 |
| StopwatchGetTimestamp  | .NET 8.0           |  23.7034 ns | 0.2796 ns | 0.2615 ns |  23.6207 ns |  0.59 |    0.01 |
| StopwatchGetTimestamp  | .NET Framework 4.8 |  40.1591 ns | 0.8476 ns | 1.0090 ns |  39.6571 ns |  1.00 |    0.00 |
|                        |                    |             |           |           |             |       |         |
| HiResClockTicks        | .NET 6.0           |  29.9222 ns | 0.2823 ns | 0.2358 ns |  29.9132 ns |  0.67 |    0.01 |
| HiResClockTicks        | .NET 8.0           |  29.8485 ns | 0.3524 ns | 0.3124 ns |  29.7525 ns |  0.67 |    0.01 |
| HiResClockTicks        | .NET Framework 4.8 |  44.4867 ns | 0.5793 ns | 0.5135 ns |  44.6219 ns |  1.00 |    0.00 |
|                        |                    |             |           |           |             |       |         |
| HiResTickCount64       | .NET 6.0           |  41.4106 ns | 0.8582 ns | 1.2308 ns |  41.1185 ns |  0.79 |    0.02 |
| HiResTickCount64       | .NET 8.0           |  40.0670 ns | 0.2551 ns | 0.2261 ns |  40.0233 ns |  0.77 |    0.01 |
| HiResTickCount64       | .NET Framework 4.8 |  52.0502 ns | 0.6347 ns | 0.5937 ns |  52.1837 ns |  1.00 |    0.00 |
|                        |                    |             |           |           |             |       |         |
| EnvironmentTicks       | .NET 6.0           |   3.7566 ns | 0.0833 ns | 0.0779 ns |   3.7483 ns |  1.14 |    0.03 |
| EnvironmentTicks       | .NET 8.0           |   3.9502 ns | 0.0713 ns | 0.0667 ns |   3.9555 ns |  1.20 |    0.02 |
| EnvironmentTicks       | .NET Framework 4.8 |   3.2891 ns | 0.0370 ns | 0.0309 ns |   3.2778 ns |  1.00 |    0.00 |
|                        |                    |             |           |           |             |       |         |
| WindowsGetTickCount64  | .NET 6.0           |  10.3288 ns | 0.2537 ns | 0.2373 ns |  10.3161 ns |  0.58 |    0.02 |
| WindowsGetTickCount64  | .NET 8.0           |   9.9404 ns | 0.2589 ns | 0.3714 ns |   9.8797 ns |  0.56 |    0.03 |
| WindowsGetTickCount64  | .NET Framework 4.8 |  17.7888 ns | 0.3816 ns | 0.3383 ns |  17.7877 ns |  1.00 |    0.00 |
|                        |                    |             |           |           |             |       |         |
| EnvironmentTickCount64 | .NET 6.0           |   3.5603 ns | 0.1239 ns | 0.1159 ns |   3.5662 ns |     ? |       ? |
| EnvironmentTickCount64 | .NET 8.0           |   3.4007 ns | 0.1305 ns | 0.1553 ns |   3.3434 ns |     ? |       ? |
| EnvironmentTickCount64 | .NET Framework 4.8 |   0.0035 ns | 0.0131 ns | 0.0123 ns |   0.0000 ns |     ? |       ? |

## Related Issues

Prep for #2055, #2457, #2458

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
