### PR TITLE
GDS: automatically add all created CAs to TrustedIssuerStore

### DIFF
--- a/Libraries/Opc.Ua.Gds.Server.Common/ApplicationsNodeManager.cs
+++ b/Libraries/Opc.Ua.Gds.Server.Common/ApplicationsNodeManager.cs
@@ -71,20 +71,21 @@ namespace Opc.Ua.Gds.Server
 
             SystemContext.NodeIdFactory = this;
 
+            m_configuration = configuration;
             // get the configuration for the node manager.
-            m_configuration = configuration.ParseExtension<GlobalDiscoveryServerConfiguration>();
+            m_GlobalDiscoveryServerConfiguration = configuration.ParseExtension<GlobalDiscoveryServerConfiguration>();
 
             // use suitable defaults if no configuration exists.
-            if (m_configuration == null)
+            if (m_GlobalDiscoveryServerConfiguration == null)
             {
-                m_configuration = new GlobalDiscoveryServerConfiguration();
+                m_GlobalDiscoveryServerConfiguration = new GlobalDiscoveryServerConfiguration();
             }
 
-            if (!String.IsNullOrEmpty(m_configuration.DefaultSubjectNameContext))
+            if (!String.IsNullOrEmpty(m_GlobalDiscoveryServerConfiguration.DefaultSubjectNameContext))
             {
-                if (m_configuration.DefaultSubjectNameContext[0] != ',')
+                if (m_GlobalDiscoveryServerConfiguration.DefaultSubjectNameContext[0] != ',')
                 {
-                    m_configuration.DefaultSubjectNameContext = "," + m_configuration.DefaultSubjectNameContext;
+                    m_GlobalDiscoveryServerConfiguration.DefaultSubjectNameContext = "," + m_GlobalDiscoveryServerConfiguration.DefaultSubjectNameContext;
                 }
             }
 
@@ -304,7 +305,7 @@ namespace Opc.Ua.Gds.Server
             }
 
             ICertificateGroup certificateGroup = m_certificateGroupFactory.Create(
-                m_configuration.AuthoritiesStorePath, certificateGroupConfiguration);
+                m_GlobalDiscoveryServerConfiguration.AuthoritiesStorePath, certificateGroupConfiguration, m_configuration);
             SetCertificateGroupNodes(certificateGroup);
             await certificateGroup.Init().ConfigureAwait(false);
 
@@ -330,7 +331,7 @@ namespace Opc.Ua.Gds.Server
                 m_database.NamespaceIndex = this.NamespaceIndexes[0];
                 m_request.NamespaceIndex = this.NamespaceIndexes[0];
 
-                foreach (var certificateGroupConfiguration in m_configuration.CertificateGroups)
+                foreach (var certificateGroupConfiguration in m_GlobalDiscoveryServerConfiguration.CertificateGroups)
                 {
                     try
                     {
@@ -706,9 +707,9 @@ namespace Opc.Ua.Gds.Server
 
             if (!contextFound)
             {
-                if (!String.IsNullOrEmpty(m_configuration.DefaultSubjectNameContext))
+                if (!String.IsNullOrEmpty(m_GlobalDiscoveryServerConfiguration.DefaultSubjectNameContext))
                 {
-                    builder.Append(m_configuration.DefaultSubjectNameContext);
+                    builder.Append(m_GlobalDiscoveryServerConfiguration.DefaultSubjectNameContext);
                 }
             }
 
@@ -821,9 +822,9 @@ namespace Opc.Ua.Gds.Server
                     buffer.Append(GetDefaultUserToken());
                 }
 
-                if (!String.IsNullOrEmpty(m_configuration.DefaultSubjectNameContext))
+                if (!String.IsNullOrEmpty(m_GlobalDiscoveryServerConfiguration.DefaultSubjectNameContext))
                 {
-                    buffer.Append(m_configuration.DefaultSubjectNameContext);
+                    buffer.Append(m_GlobalDiscoveryServerConfiguration.DefaultSubjectNameContext);
                 }
 
                 subjectName = buffer.ToString();
@@ -1107,7 +1108,7 @@ namespace Opc.Ua.Gds.Server
             issuerCertificates[0] = certificateGroup.Certificate.RawData;
 
             // store new app certificate
-            using (ICertificateStore store = CertificateStoreIdentifier.OpenStore(m_configuration.ApplicationCertificatesStorePath))
+            using (ICertificateStore store = CertificateStoreIdentifier.OpenStore(m_GlobalDiscoveryServerConfiguration.ApplicationCertificatesStorePath))
             {
                 store.Add(certificate).Wait();
             }
@@ -1378,7 +1379,8 @@ namespace Opc.Ua.Gds.Server
         #region Private Fields
         private bool m_autoApprove;
         private uint m_nextNodeId;
-        private GlobalDiscoveryServerConfiguration m_configuration;
+        private ApplicationConfiguration m_configuration;
+        private GlobalDiscoveryServerConfiguration m_GlobalDiscoveryServerConfiguration;
         private IApplicationsDatabase m_database;
         private ICertificateRequest m_request;
         private ICertificateGroup m_certificateGroupFactory;

--- a/Libraries/Opc.Ua.Gds.Server.Common/ICertificateGroup.cs
+++ b/Libraries/Opc.Ua.Gds.Server.Common/ICertificateGroup.cs
@@ -27,6 +27,7 @@
  * http://opcfoundation.org/License/MIT/1.00/
  * ======================================================================*/
 
+using System.Runtime.InteropServices;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 using Opc.Ua.Security.Certificates;
@@ -59,13 +60,15 @@ namespace Opc.Ua.Gds.Server
         NodeId Id { get; set; }
         NodeId CertificateType { get; set; }
         CertificateGroupConfiguration Configuration { get; }
+        ApplicationConfiguration ApplicationConfiguration { get; }
         X509Certificate2 Certificate { get; set; }
         TrustListState DefaultTrustList { get; set; }
         bool UpdateRequired { get; set; }
 
         ICertificateGroup Create(
             string path,
-            CertificateGroupConfiguration certificateGroupConfiguration);
+            CertificateGroupConfiguration certificateGroupConfiguration,
+            [Optional] ApplicationConfiguration applicationConfiguration);
 
         Task Init();
 

--- a/Tests/Opc.Ua.Gds.Tests/CertificateGroupTests.cs
+++ b/Tests/Opc.Ua.Gds.Tests/CertificateGroupTests.cs
@@ -51,6 +51,26 @@ namespace Opc.Ua.Gds.Tests
                 Assert.IsTrue(certs.Count == 1);
             }
         }
+
+        [Test]
+        public async Task TestCreateCACertificateAsyncCertIsInTrustedIssuerStoreAsync()
+        {
+            var applicatioConfiguration = new ApplicationConfiguration();
+            applicatioConfiguration.SecurityConfiguration = new SecurityConfiguration();
+            applicatioConfiguration.SecurityConfiguration.TrustedIssuerCertificates.StorePath = _path + "/issuers";
+            applicatioConfiguration.SecurityConfiguration.TrustedIssuerCertificates.StoreType = "Directory";
+            var cgConfiguration = new CertificateGroupConfiguration();
+            cgConfiguration.SubjectName = "CN=GDS Test CA, O=OPC Foundation";
+            cgConfiguration.BaseStorePath = _path;
+            var certificateGroup = new CertificateGroup().Create(_path + "/authorities", cgConfiguration, applicatioConfiguration);
+            var certificate = await certificateGroup.CreateCACertificateAsync(cgConfiguration.SubjectName).ConfigureAwait(false);
+            Assert.NotNull(certificate);
+            using (ICertificateStore trustedStore = CertificateStoreIdentifier.OpenStore(applicatioConfiguration.SecurityConfiguration.TrustedIssuerCertificates.StorePath))
+            {
+                X509Certificate2Collection certs = await trustedStore.FindByThumbprint(certificate.Thumbprint).ConfigureAwait(false);
+                Assert.IsTrue(certs.Count == 1);
+            }
+        }
         #endregion
     }
 }


### PR DESCRIPTION
## Proposed changes

For the GDS to work with Application Self Admin privilege all Certs singed by the GDS own CA need to be allowed by teh Certificate Validator, as a workaround previously the Method AddOwnCertificateToTrustedStoreAsync was added:
https://github.com/OPCFoundation/UA-.NETStandard/blob/7867a6fa7ea6dd2e0fe4e04d86d7e3cc6c358ddd/Libraries/Opc.Ua.Configuration/ApplicationInstance.cs#L574

The better solution is to store all CAs of the GDS automatically in the TrusitedIssuer Cert Store.

## Related Issues

- Needed for #2338
## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist



- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [x] I ran tests locally with my changes, all passed.
- [x] I fixed all failing tests in the CI pipelines. 
- [x] I fixed all introduced issues with CodeQL and LGTM.
- [x] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [x] I have added necessary documentation (if appropriate).
- [x] Any dependent changes have been merged and published in downstream modules.

