### PR TITLE
Fixed a bug in the calculation of StandardDeviationSample and VariancePopulation

### DIFF
--- a/Libraries/Opc.Ua.Server/Aggregates/StdDevAggregateCalculator.cs
+++ b/Libraries/Opc.Ua.Server/Aggregates/StdDevAggregateCalculator.cs
@@ -74,6 +74,8 @@ namespace Opc.Ua.Server
             {
                 switch (id.Value)
                 {
+                    // StandardDeviation: valueType == 1, Variance: valueType == 2
+                    // includeBounds == true: smples, includeBounds == false: population (this is a strange relationship)
                     case Objects.AggregateFunction_StandardDeviationPopulation:
                     {
                         return ComputeStdDev(slice, false, 1);
@@ -81,12 +83,12 @@ namespace Opc.Ua.Server
 
                     case Objects.AggregateFunction_StandardDeviationSample:
                     {
-                        return ComputeStdDev(slice, false, 2);
+                        return ComputeStdDev(slice, true, 1);
                     }
 
                     case Objects.AggregateFunction_VariancePopulation:
                     {
-                        return ComputeStdDev(slice, true, 1);
+                        return ComputeStdDev(slice, false, 2);
                     }
 
                     case Objects.AggregateFunction_VarianceSample:
@@ -289,7 +291,15 @@ namespace Opc.Ua.Server
             // use the sample variance if bounds are included.
             if (includeBounds)
             {
-                variance /= (xData.Count + 1);
+                // Spec part 13 v105 section 5.4.3.37 
+                if (xData.Count == 0)
+                {                    
+                    variance = 0;
+                }
+                else
+                {
+                    variance /= (xData.Count - 1);
+                }
             }
             
            // use the population variance if bounds are not included.

--- a/Libraries/Opc.Ua.Server/Aggregates/StdDevAggregateCalculator.cs
+++ b/Libraries/Opc.Ua.Server/Aggregates/StdDevAggregateCalculator.cs
@@ -74,8 +74,11 @@ namespace Opc.Ua.Server
             {
                 switch (id.Value)
                 {
-                    // StandardDeviation: valueType == 1, Variance: valueType == 2
-                    // includeBounds == true: smples, includeBounds == false: population (this is a strange relationship)
+                    // valueType == 1: StandardDeviation, valueType == 2: Variance
+
+                    // includeBounds == true: smples, includeBounds == false: population
+                    // (this is a strange way to distinguish between sample and population)
+
                     case Objects.AggregateFunction_StandardDeviationPopulation:
                     {
                         return ComputeStdDev(slice, false, 1);
@@ -291,8 +294,8 @@ namespace Opc.Ua.Server
             // use the sample variance if bounds are included.
             if (includeBounds)
             {
-                // Spec part 13 v105 section 5.4.3.37 
-                if (xData.Count == 0)
+                // Spec part 13 v105 section 5.4.3.37 and subsequent
+                if (xData.Count <= 1)
                 {                    
                     variance = 0;
                 }

--- a/Libraries/Opc.Ua.Server/Aggregates/StdDevAggregateCalculator.cs
+++ b/Libraries/Opc.Ua.Server/Aggregates/StdDevAggregateCalculator.cs
@@ -76,7 +76,7 @@ namespace Opc.Ua.Server
                 {
                     // valueType == 1: StandardDeviation, valueType == 2: Variance
 
-                    // includeBounds == true: smples, includeBounds == false: population
+                    // includeBounds == true: sample, includeBounds == false: population
                     // (this is a strange way to distinguish between sample and population)
 
                     case Objects.AggregateFunction_StandardDeviationPopulation:


### PR DESCRIPTION
## Proposed changes

There are two obvious errors in the calculation of the StandardDeviationSample and VariancePopulation aggregates which are fixed with this PR. The linked issue #2360 also claims that there is a further issue with the way the bounds are included. This needs further investigation. As this may need more time, I preferred to fix the obvious errors immediately.

## Related Issues

- Fixes #2360 

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
