### PR TITLE
Improve handling of bad chunk headers, reduce log output

### DIFF
--- a/Stack/Opc.Ua.Core/Security/Certificates/CertificateValidator.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/CertificateValidator.cs
@@ -1301,11 +1301,12 @@ namespace Opc.Ua
                 }
             }
 
-            if (endpoint != null && !FindDomain(certificate, endpoint))
+            Uri endpointUrl = endpoint?.EndpointUrl;
+            if (endpointUrl != null && !FindDomain(certificate, endpointUrl))
             {
                 string message = Utils.Format(
                     "The domain '{0}' is not listed in the server certificate.",
-                    endpoint.EndpointUrl.DnsSafeHost);
+                    endpointUrl.DnsSafeHost);
                 sresult = new ServiceResult(StatusCodes.BadCertificateHostNameInvalid,
                     null, null, message, null, sresult
                     );
@@ -1462,13 +1463,12 @@ namespace Opc.Ua
                 }
             }
 
-            bool domainFound = FindDomain(serverCertificate, endpoint);
-
-            if (!domainFound)
+            Uri endpointUrl = endpoint?.EndpointUrl;
+            if (endpointUrl != null && !FindDomain(serverCertificate, endpointUrl))
             {
                 bool accept = false;
                 const string message = "The domain '{0}' is not listed in the server certificate.";
-                var serviceResult = ServiceResultException.Create(StatusCodes.BadCertificateHostNameInvalid, message, endpoint.EndpointUrl.DnsSafeHost);
+                var serviceResult = ServiceResultException.Create(StatusCodes.BadCertificateHostNameInvalid, message, endpointUrl.DnsSafeHost);
                 if (m_CertificateValidation != null)
                 {
                     var args = new CertificateValidationEventArgs(new ServiceResult(serviceResult), serverCertificate);
@@ -1480,7 +1480,7 @@ namespace Opc.Ua
                 {
                     if (serverValidation)
                     {
-                        Utils.LogError(message, endpoint.EndpointUrl.DnsSafeHost);
+                        Utils.LogError(message, endpointUrl.DnsSafeHost);
                     }
                     else
                     {
@@ -1689,9 +1689,9 @@ namespace Opc.Ua
         /// endpoint that was used to connect a session.
         /// </summary>
         /// <param name="serverCertificate">The server certificate which is tested for domain names.</param>
-        /// <param name="endpoint">The endpoint which was used to connect.</param>
+        /// <param name="endpointUrl">The endpoint Url which was used to connect.</param>
         /// <returns>True if domain was found.</returns>
-        private bool FindDomain(X509Certificate2 serverCertificate, ConfiguredEndpoint endpoint)
+        private bool FindDomain(X509Certificate2 serverCertificate, Uri endpointUrl)
         {
             bool domainFound = false;
 
@@ -1701,9 +1701,9 @@ namespace Opc.Ua
             if (domains != null && domains.Count > 0)
             {
                 string hostname;
-                string dnsHostName = hostname = endpoint.EndpointUrl.DnsSafeHost;
+                string dnsHostName = hostname = endpointUrl.DnsSafeHost;
                 bool isLocalHost = false;
-                if (endpoint.EndpointUrl.HostNameType == UriHostNameType.Dns)
+                if (endpointUrl.HostNameType == UriHostNameType.Dns)
                 {
                     if (String.Equals(dnsHostName, "localhost", StringComparison.OrdinalIgnoreCase))
                     {

--- a/Stack/Opc.Ua.Core/Stack/Tcp/TcpListenerChannel.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/TcpListenerChannel.cs
@@ -150,7 +150,7 @@ namespace Opc.Ua.Bindings
 
                 Socket = new TcpMessageSocket(this, socket, BufferManager, Quotas.MaxBufferSize);
 
-                Utils.LogInfo("{0} SOCKET ATTACHED: {1:X8}, ChannelId={2}", ChannelName, Socket.Handle, ChannelId);
+                Utils.LogTrace("{0} SOCKET ATTACHED: {1:X8}, ChannelId={2}", ChannelName, Socket.Handle, ChannelId);
 
                 Socket.ReadNextMessage();
 
@@ -206,13 +206,6 @@ namespace Opc.Ua.Bindings
         {
             lock (DataLock)
             {
-                Utils.LogError(
-                    "{0} ForceChannelFault Socket={1:X8}, ChannelId={2}, TokenId={3}, Reason={4}",
-                    ChannelName,
-                    (Socket != null) ? Socket.Handle : 0,
-                    (CurrentToken != null) ? CurrentToken.ChannelId : 0,
-                    (CurrentToken != null) ? CurrentToken.TokenId : 0,
-                    reason);
 
                 CompleteReverseHello(new ServiceResultException(reason));
 
@@ -220,6 +213,23 @@ namespace Opc.Ua.Bindings
                 if (State == TcpChannelState.Faulted)
                 {
                     return;
+                }
+
+                bool close = false;
+                if (State != TcpChannelState.Connecting)
+                {
+                    Utils.LogError(
+                        "{0} ForceChannelFault Socket={1:X8}, ChannelId={2}, TokenId={3}, Reason={4}",
+                        ChannelName,
+                        (Socket != null) ? Socket.Handle : 0,
+                        (CurrentToken != null) ? CurrentToken.ChannelId : 0,
+                        (CurrentToken != null) ? CurrentToken.TokenId : 0,
+                        reason);
+                }
+                else
+                {
+                    // Close immediately if the client never got out of connecting state
+                    close = true;
                 }
 
                 // send error and close response.
@@ -234,11 +244,19 @@ namespace Opc.Ua.Bindings
                 State = TcpChannelState.Faulted;
                 m_responseRequired = false;
 
-                // notify any monitors.
-                NotifyMonitors(reason, false);
+                if (close)
+                {
+                    // close channel immediately.
+                    ChannelClosed();
+                }
+                else
+                {
+                    // notify any monitors.
+                    NotifyMonitors(reason, false);
 
-                // ensure the channel will be cleaned up if the client does not reconnect.
-                StartCleanupTimer(reason);
+                    // ensure the channel will be cleaned up if the client does not reconnect.
+                    StartCleanupTimer(reason);
+                }
             }
         }
 
@@ -256,11 +274,8 @@ namespace Opc.Ua.Bindings
         /// </summary>
         protected void CleanupTimer()
         {
-            if (m_cleanupTimer != null)
-            {
-                m_cleanupTimer.Dispose();
-                m_cleanupTimer = null;
-            }
+            Utils.SilentDispose(m_cleanupTimer);
+            m_cleanupTimer = null;
         }
 
         /// <summary>
@@ -271,6 +286,7 @@ namespace Opc.Ua.Bindings
             lock (DataLock)
             {
                 CleanupTimer();
+
                 // nothing to do if the channel is now open or closed.
                 if (State == TcpChannelState.Closed || State == TcpChannelState.Open)
                 {
@@ -284,7 +300,7 @@ namespace Opc.Ua.Bindings
                     reason = new ServiceResult(StatusCodes.BadTimeout);
                 }
 
-                Utils.LogInfo(
+                Utils.LogTrace(
                     "{0} Cleanup Socket={1:X8}, ChannelId={2}, TokenId={3}, Reason={4}",
                     ChannelName,
                     (Socket != null) ? Socket.Handle : 0,

--- a/Stack/Opc.Ua.Core/Stack/Tcp/TcpMessageSocket.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/TcpMessageSocket.cs
@@ -301,7 +301,7 @@ namespace Opc.Ua.Bindings
         {
             if (disposing)
             {
-                m_socket.Dispose();
+                m_socket?.Dispose();
             }
         }
         #endregion
@@ -311,7 +311,7 @@ namespace Opc.Ua.Bindings
         /// Gets the socket handle.
         /// </summary>
         /// <value>The socket handle.</value>
-        public int Handle => m_socket != null ? m_socket.GetHashCode() : -1;
+        public int Handle => m_socket?.GetHashCode() ?? -1;
 
         /// <summary>
         /// Gets the local endpoint.
@@ -320,7 +320,16 @@ namespace Opc.Ua.Bindings
         /// See the Remarks section for more information.</exception>
         /// <exception cref="System.ObjectDisposedException">The System.Net.Sockets.Socket has been closed.</exception>
         /// <returns>The System.Net.EndPoint that the System.Net.Sockets.Socket is using for communications.</returns>
-        public EndPoint LocalEndpoint => m_socket.LocalEndPoint;
+        public EndPoint LocalEndpoint => m_socket?.LocalEndPoint;
+
+        /// <summary>
+        /// Gets the local endpoint.
+        /// </summary>
+        /// <exception cref="System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.
+        /// See the Remarks section for more information.</exception>
+        /// <exception cref="System.ObjectDisposedException">The System.Net.Sockets.Socket has been closed.</exception>
+        /// <returns>The System.Net.EndPoint that the System.Net.Sockets.Socket is using for communications.</returns>
+        public EndPoint RemoteEndpoint => m_socket?.RemoteEndPoint;
 
         /// <summary>
         /// Gets the transport channel features implemented by this message socket.
@@ -611,15 +620,20 @@ namespace Opc.Ua.Bindings
             // start reading the message body.
             if (m_incomingMessageSize < 0)
             {
-                m_incomingMessageSize = BitConverter.ToInt32(m_receiveBuffer, 4);
+                UInt32 messageType = BitConverter.ToUInt32(m_receiveBuffer, 0);
+                if (!TcpMessageType.IsValid(messageType))
+                {
+                    m_readState = ReadState.Error;
 
+                    return ServiceResult.Create(
+                        StatusCodes.BadTcpMessageTypeInvalid,
+                        "Message type {0:X8} is invalid.",
+                        messageType);
+                }
+
+                m_incomingMessageSize = BitConverter.ToInt32(m_receiveBuffer, 4);
                 if (m_incomingMessageSize <= 0 || m_incomingMessageSize > m_receiveBufferSize)
                 {
-                    Utils.LogError(
-                        "BadTcpMessageTooLarge: BufferSize={0}; MessageSize={1}",
-                        m_receiveBufferSize,
-                        m_incomingMessageSize);
-
                     m_readState = ReadState.Error;
 
                     return ServiceResult.Create(

--- a/Stack/Opc.Ua.Core/Stack/Tcp/TcpMessageType.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/TcpMessageType.cs
@@ -129,7 +129,8 @@ namespace Opc.Ua.Bindings
                 }
             }
 
-            if (((messageType & ChunkTypeMask) != Final) && ((messageType & ChunkTypeMask) != Intermediate))
+            uint chunkTypeMask = messageType & ChunkTypeMask;
+            if ((chunkTypeMask != Final) && (chunkTypeMask != Intermediate))
             {
                 return false;
             }

--- a/Stack/Opc.Ua.Core/Stack/Tcp/UaSCBinaryChannel.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/UaSCBinaryChannel.cs
@@ -744,7 +744,7 @@ namespace Opc.Ua.Bindings
             {
                 if (m_state != value)
                 {
-                    Utils.LogInfo("ChannelId {0}: in {1} state.", ChannelId, value);
+                    Utils.LogTrace("ChannelId {0}: in {1} state.", ChannelId, value);
                 }
 
                 m_state = value;

--- a/Stack/Opc.Ua.Core/Stack/Transport/IMessageSocket.cs
+++ b/Stack/Opc.Ua.Core/Stack/Transport/IMessageSocket.cs
@@ -12,6 +12,7 @@
 
 
 using System;
+using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -148,7 +149,16 @@ namespace Opc.Ua.Bindings
         /// See the Remarks section for more information.</exception>
         /// <exception cref="System.ObjectDisposedException">The Socket has been closed.</exception>
         /// <returns>The System.Net.EndPoint that the Socket is using for communications.</returns>
-        System.Net.EndPoint LocalEndpoint { get; }
+        EndPoint LocalEndpoint { get; }
+
+        /// <summary>
+        /// Gets the remote endpoint.
+        /// </summary>
+        /// <exception cref="System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.
+        /// See the Remarks section for more information.</exception>
+        /// <exception cref="System.ObjectDisposedException">The Socket has been closed.</exception>
+        /// <returns>The System.Net.EndPoint that the Socket is using for communications.</returns>
+        EndPoint RemoteEndpoint { get; }
 
         /// <summary>
         /// Returns the features implemented by the message socket.


### PR DESCRIPTION
## Proposed changes

- Reduce socket log output and demote to Trace
- Check for invalid chunk header and reduce log output
- Close socket immediately if a bad chunk header is detected (e.g. if socket is opened by another protocol)
- Expose Remote endpoint for application

## Related Issues

- Fixes #

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
