### PR TITLE
document role based user mangement

### DIFF
--- a/Docs/README.md
+++ b/Docs/README.md
@@ -10,6 +10,7 @@ UA Core stack related:
 * Using the [Reverse Connect](ReverseConnect.md) for the UA-TCP transport.
 * Support for the [TransferSubscriptions](TransferSubscription.md) service set.
 * Improved support for [Logging](Logging.md) with `ILogger` and `EventSource`.
+* Support for [WellKnownRoles & RoleBasedUserManagement](RoleBasedUserManagement.md).
 
 Reference application related:
 * [Reference Server](../Applications/ReferenceServer/README.md) documentation for running against CTT.

--- a/Docs/RoleBasedUserManagement.md
+++ b/Docs/RoleBasedUserManagement.md
@@ -38,7 +38,7 @@ To make it easier to implement a real user name / pw implementation, avoiding ha
 
 https://github.com/OPCFoundation/UA-.NETStandard/tree/61edad9d6361b566baa5fdd69a23e7ac58c3433d/Libraries/Opc.Ua.Server/RoleBasedUserManagement/UserDatabase
 
-'''
+```
 public interface IUserDatabase
     {
         /// <summary>
@@ -82,7 +82,7 @@ public interface IUserDatabase
         /// <returns>true if change was sucessfull</returns>
         bool ChangePassword(string userName, string oldPassword, string newPassword);
     }
-'''
+```
 
 An implementation targeting SQL Server using Entity Framework 6 is available in the Samples Repo:
 https://github.com/OPCFoundation/UA-.NETStandard-Samples/blob/e100ac787507988da95223a031af76fe57b5e11d/Samples/GDS/Server/SqlUsersDatabase.cs

--- a/Docs/RoleBasedUserManagement.md
+++ b/Docs/RoleBasedUserManagement.md
@@ -1,0 +1,127 @@
+# Role Based User Management
+
+## Overview
+
+OPC UA Supports role based user management in a way that assigns permissions to nodes.
+Those permissions are then assigned to a role.
+The role is assigned to one or multiple Identities by the Server.
+
+Since #2444 the OPC UA .NET Standard Stack implements the well known roles from:
+https://reference.opcfoundation.org/Core/Part3/v105/docs/4.9.2
+
+- Anonymous
+- AuthenticatedUser
+- Observer
+- Operator
+- Engineer
+- Supervisor
+- ConfigureAdmin
+- SecurityAdmin
+
+## Implementation
+
+To get started using well known roles in your server the first thing you have to do is returning a RoleBasedIdentity in the overriden SessionManager_ImpersonateUser Method.
+
+https://github.com/OPCFoundation/UA-.NETStandard/blob/61edad9d6361b566baa5fdd69a23e7ac58c3433d/Applications/Quickstarts.Servers/ReferenceServer/ReferenceServer.cs#L229C22-L229C52
+
+https://github.com/OPCFoundation/UA-.NETStandard/blob/61edad9d6361b566baa5fdd69a23e7ac58c3433d/Applications/Quickstarts.Servers/ReferenceServer/ReferenceServer.cs#L327
+
+You can add as many roles to your returned identity as needed.
+
+All well knwon roles are created as static properties in the Role class of the server:
+
+https://github.com/OPCFoundation/UA-.NETStandard/blob/61edad9d6361b566baa5fdd69a23e7ac58c3433d/Libraries/Opc.Ua.Server/RoleBasedUserManagement/RoleBasedIdentity.cs
+
+If you want to add additional roles you can refer to the GDS implementation which adds some user defined roles.
+
+To make it easier to implement a real user name / pw implementation, avoiding hardcoded passwords, the Server Library provides an interface and a sample implementation for a users database:
+
+https://github.com/OPCFoundation/UA-.NETStandard/tree/61edad9d6361b566baa5fdd69a23e7ac58c3433d/Libraries/Opc.Ua.Server/RoleBasedUserManagement/UserDatabase
+
+'''
+public interface IUserDatabase
+    {
+        /// <summary>
+        /// Initialize User Database
+        /// </summary>
+        void Initialize();
+        /// <summary>
+        /// Register new user
+        /// </summary>
+        /// <param name="userName">the username</param>
+        /// <param name="password">the password</param>
+        /// <param name="roles">the role of the new user</param>
+        /// <returns>true if registered sucessfull</returns>
+        bool CreateUser(string userName, string password, IEnumerable<Role> roles);
+        /// <summary>
+        /// Delete existring user
+        /// </summary>
+        /// <param name="userName">the user to delete</param>
+        /// <returns>true if deleted sucessfully</returns>
+        bool DeleteUser(string userName);
+        /// <summary>
+        /// checks if the provided credentials fit a user
+        /// </summary>
+        /// <param name="userName">the username</param>
+        /// <param name="password">the password</param>
+        /// <returns>true if userName + PW combination is correct</returns>
+        bool CheckCredentials(string userName, string password);
+        /// <summary>
+        /// returns the Role of the provided user
+        /// </summary>
+        /// <param name="userName"></param>
+        /// <returns>the Role of the provided users</returns>
+        /// <exception cref="ArgumentException">When the user is not found</exception>
+        IEnumerable<Role> GetUserRoles(string userName);
+        /// <summary>
+        /// changes the password of an existing users
+        /// </summary>
+        /// <param name="userName"></param>
+        /// <param name="oldPassword"></param>
+        /// <param name="newPassword"></param>
+        /// <returns>true if change was sucessfull</returns>
+        bool ChangePassword(string userName, string oldPassword, string newPassword);
+    }
+'''
+
+An implementation targeting SQL Server using Entity Framework 6 is available in the Samples Repo:
+https://github.com/OPCFoundation/UA-.NETStandard-Samples/blob/e100ac787507988da95223a031af76fe57b5e11d/Samples/GDS/Server/SqlUsersDatabase.cs
+
+To enable the authorization for your servers methods you can take a look at the HasApplicationSecureAdminAccess method of the ConfigurationNodeManager:
+
+https://github.com/OPCFoundation/UA-.NETStandard/blob/61edad9d6361b566baa5fdd69a23e7ac58c3433d/Libraries/Opc.Ua.Server/Configuration/ConfigurationNodeManager.cs#L300C9-L319C10
+
+This method verifies the current session has the needed roles to access the methods.
+
+## GDS
+
+The GDS supports some additional well known roles starting with #2338
+
+https://reference.opcfoundation.org/GDS/v105/docs/6.2
+https://reference.opcfoundation.org/GDS/v105/docs/7.2
+
+- DiscoveryAdmin
+- SecurityAdmin
+- CertificateAuthorityAdmin
+- RegistrationAuthorityAdmin
+
+https://github.com/OPCFoundation/UA-.NETStandard/blob/61edad9d6361b566baa5fdd69a23e7ac58c3433d/Libraries/Opc.Ua.Gds.Server.Common/GdsRole.cs
+
+
+Additionally the ApplicationSelfAdmin privilege is supported.
+In the UA .NET Standard Stack the ApplicationSelfAdmin privilege is implemented using a user defined role.
+
+To store its users the GDS implements the IUserDatabase interface from the server library.
+
+https://github.com/OPCFoundation/UA-.NETStandard/tree/61edad9d6361b566baa5fdd69a23e7ac58c3433d/Libraries/Opc.Ua.Server/RoleBasedUserManagement/UserDatabase
+
+The JsonUserDatabase path is stored in the GDS Configuration:
+https://github.com/OPCFoundation/UA-.NETStandard/blob/61edad9d6361b566baa5fdd69a23e7ac58c3433d/Libraries/Opc.Ua.Gds.Server.Common/GlobalDiscoveryServerConfiguration.cs#L91
+
+The GDS allows library users to supply their own implementation using the constructor:
+https://github.com/OPCFoundation/UA-.NETStandard/blob/61edad9d6361b566baa5fdd69a23e7ac58c3433d/Libraries/Opc.Ua.Gds.Server.Common/GlobalDiscoverySampleServer.cs#L55C2-L63C10
+
+## Limitations
+
+- Does not really make use of the permissions <-> roles 
+- Does not implement the RoleBasedSecurity Information Model from: https://reference.opcfoundation.org/Core/Part18/v105/docs/

--- a/Docs/RoleBasedUserManagement.md
+++ b/Docs/RoleBasedUserManagement.md
@@ -7,7 +7,7 @@ Those permissions are then assigned to a role.
 The role is assigned to one or multiple Identities by the Server.
 
 Since #2444 the OPC UA .NET Standard Stack implements the well known roles from:
-https://reference.opcfoundation.org/Core/Part3/v105/docs/4.9.2
+[UA Part 3: Address Space Model - 4.9.2 Well Known Roles](https://reference.opcfoundation.org/Core/Part3/v105/docs/4.9.2)
 
 - Anonymous
 - AuthenticatedUser
@@ -22,23 +22,23 @@ https://reference.opcfoundation.org/Core/Part3/v105/docs/4.9.2
 
 To get started using well known roles in your server the first thing you have to do is returning a RoleBasedIdentity in the overriden SessionManager_ImpersonateUser Method.
 
-https://github.com/OPCFoundation/UA-.NETStandard/blob/61edad9d6361b566baa5fdd69a23e7ac58c3433d/Applications/Quickstarts.Servers/ReferenceServer/ReferenceServer.cs#L229C22-L229C52
+[ReferenceServer.cs (SessionManager_ImpersonateUser)](https://github.com/OPCFoundation/UA-.NETStandard/blob/61edad9d6361b566baa5fdd69a23e7ac58c3433d/Applications/Quickstarts.Servers/ReferenceServer/ReferenceServer.cs#L229C22-L229C52)
 
-https://github.com/OPCFoundation/UA-.NETStandard/blob/61edad9d6361b566baa5fdd69a23e7ac58c3433d/Applications/Quickstarts.Servers/ReferenceServer/ReferenceServer.cs#L327
+[ReferenceServer.cs (new RoleBasedIdentity)](https://github.com/OPCFoundation/UA-.NETStandard/blob/61edad9d6361b566baa5fdd69a23e7ac58c3433d/Applications/Quickstarts.Servers/ReferenceServer/ReferenceServer.cs#L327)
 
 You can add as many roles to your returned identity as needed.
 
 All well knwon roles are created as static properties in the Role class of the server:
 
-https://github.com/OPCFoundation/UA-.NETStandard/blob/61edad9d6361b566baa5fdd69a23e7ac58c3433d/Libraries/Opc.Ua.Server/RoleBasedUserManagement/RoleBasedIdentity.cs
+[RoleBasedIdentity.cs](https://github.com/OPCFoundation/UA-.NETStandard/blob/61edad9d6361b566baa5fdd69a23e7ac58c3433d/Libraries/Opc.Ua.Server/RoleBasedUserManagement/RoleBasedIdentity.cs)
 
 If you want to add additional roles you can refer to the GDS implementation which adds some user defined roles.
 
 To make it easier to implement a real user name / pw implementation, avoiding hardcoded passwords, the Server Library provides an interface and a sample implementation for a users database:
 
-https://github.com/OPCFoundation/UA-.NETStandard/tree/61edad9d6361b566baa5fdd69a23e7ac58c3433d/Libraries/Opc.Ua.Server/RoleBasedUserManagement/UserDatabase
+[RoleBasedUserManagement/UserDatabase](https://github.com/OPCFoundation/UA-.NETStandard/tree/61edad9d6361b566baa5fdd69a23e7ac58c3433d/Libraries/Opc.Ua.Server/RoleBasedUserManagement/UserDatabase)
 
-```
+```C#
 public interface IUserDatabase
     {
         /// <summary>
@@ -85,27 +85,28 @@ public interface IUserDatabase
 ```
 
 An implementation targeting SQL Server using Entity Framework 6 is available in the Samples Repo:
-https://github.com/OPCFoundation/UA-.NETStandard-Samples/blob/e100ac787507988da95223a031af76fe57b5e11d/Samples/GDS/Server/SqlUsersDatabase.cs
+[SqlUsersDatabase.cs](https://github.com/OPCFoundation/UA-.NETStandard-Samples/blob/e100ac787507988da95223a031af76fe57b5e11d/Samples/GDS/Server/SqlUsersDatabase.cs)
 
 To enable the authorization for your servers methods you can take a look at the HasApplicationSecureAdminAccess method of the ConfigurationNodeManager:
 
-https://github.com/OPCFoundation/UA-.NETStandard/blob/61edad9d6361b566baa5fdd69a23e7ac58c3433d/Libraries/Opc.Ua.Server/Configuration/ConfigurationNodeManager.cs#L300C9-L319C10
+[ConfigurationNodeManager.cs](https://github.com/OPCFoundation/UA-.NETStandard/blob/61edad9d6361b566baa5fdd69a23e7ac58c3433d/Libraries/Opc.Ua.Server/Configuration/ConfigurationNodeManager.cs#L300C9-L319C10)
 
 This method verifies the current session has the needed roles to access the methods.
 
 ## GDS
 
-The GDS supports some additional well known roles starting with #2338
+The GDS supports some additional well known roles starting with 
+[GDS: implement ApplicationSelfAdmin privilege in GlobalDiscoverySampleServer by romanett · Pull Request #2338](https://github.com/OPCFoundation/UA-.NETStandard/pull/2338)
 
-https://reference.opcfoundation.org/GDS/v105/docs/6.2
-https://reference.opcfoundation.org/GDS/v105/docs/7.2
+[UA Part 12: Discovery and Global Services - 6.2 Roles and Privileges](https://reference.opcfoundation.org/GDS/v105/docs/6.2)
+[UA Part 12: Discovery and Global Services - 7.2 Roles and Privileges](https://reference.opcfoundation.org/GDS/v105/docs/7.2)
 
 - DiscoveryAdmin
 - SecurityAdmin
 - CertificateAuthorityAdmin
 - RegistrationAuthorityAdmin
 
-https://github.com/OPCFoundation/UA-.NETStandard/blob/61edad9d6361b566baa5fdd69a23e7ac58c3433d/Libraries/Opc.Ua.Gds.Server.Common/GdsRole.cs
+[GdsRole.cs](https://github.com/OPCFoundation/UA-.NETStandard/blob/61edad9d6361b566baa5fdd69a23e7ac58c3433d/Libraries/Opc.Ua.Gds.Server.Common/GdsRole.cs)
 
 
 Additionally the ApplicationSelfAdmin privilege is supported.
@@ -113,15 +114,15 @@ In the UA .NET Standard Stack the ApplicationSelfAdmin privilege is implemented 
 
 To store its users the GDS implements the IUserDatabase interface from the server library.
 
-https://github.com/OPCFoundation/UA-.NETStandard/tree/61edad9d6361b566baa5fdd69a23e7ac58c3433d/Libraries/Opc.Ua.Server/RoleBasedUserManagement/UserDatabase
+[Opc.Ua.Server/RoleBasedUserManagement/UserDatabase](https://github.com/OPCFoundation/UA-.NETStandard/tree/61edad9d6361b566baa5fdd69a23e7ac58c3433d/Libraries/Opc.Ua.Server/RoleBasedUserManagement/UserDatabase)
 
 The JsonUserDatabase path is stored in the GDS Configuration:
-https://github.com/OPCFoundation/UA-.NETStandard/blob/61edad9d6361b566baa5fdd69a23e7ac58c3433d/Libraries/Opc.Ua.Gds.Server.Common/GlobalDiscoveryServerConfiguration.cs#L91
+[GlobalDiscoveryServerConfiguration.cs](https://github.com/OPCFoundation/UA-.NETStandard/blob/61edad9d6361b566baa5fdd69a23e7ac58c3433d/Libraries/Opc.Ua.Gds.Server.Common/GlobalDiscoveryServerConfiguration.cs#L91)
 
 The GDS allows library users to supply their own implementation using the constructor:
-https://github.com/OPCFoundation/UA-.NETStandard/blob/61edad9d6361b566baa5fdd69a23e7ac58c3433d/Libraries/Opc.Ua.Gds.Server.Common/GlobalDiscoverySampleServer.cs#L55C2-L63C10
+[GlobalDiscoverySampleServer.cs](https://github.com/OPCFoundation/UA-.NETStandard/blob/61edad9d6361b566baa5fdd69a23e7ac58c3433d/Libraries/Opc.Ua.Gds.Server.Common/GlobalDiscoverySampleServer.cs#L55C2-L63C10)
 
 ## Limitations
 
 - Does not really make use of the permissions <-> roles 
-- Does not implement the RoleBasedSecurity Information Model from: https://reference.opcfoundation.org/Core/Part18/v105/docs/
+- Does not implement the RoleBasedSecurity Information Model from: [](https://reference.opcfoundation.org/Core/Part18/v105/docs/)

--- a/Docs/RoleBasedUserManagement.md
+++ b/Docs/RoleBasedUserManagement.md
@@ -7,6 +7,7 @@ Those permissions are then assigned to a role.
 The role is assigned to one or multiple Identities by the Server.
 
 Since #2444 the OPC UA .NET Standard Stack implements the well known roles from:
+
 [UA Part 3: Address Space Model - 4.9.2 Well Known Roles](https://reference.opcfoundation.org/Core/Part3/v105/docs/4.9.2)
 
 - Anonymous
@@ -99,6 +100,7 @@ The GDS supports some additional well known roles starting with
 [GDS: implement ApplicationSelfAdmin privilege in GlobalDiscoverySampleServer by romanett · Pull Request #2338](https://github.com/OPCFoundation/UA-.NETStandard/pull/2338)
 
 [UA Part 12: Discovery and Global Services - 6.2 Roles and Privileges](https://reference.opcfoundation.org/GDS/v105/docs/6.2)
+
 [UA Part 12: Discovery and Global Services - 7.2 Roles and Privileges](https://reference.opcfoundation.org/GDS/v105/docs/7.2)
 
 - DiscoveryAdmin

--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ More samples based on the official [Nuget](https://www.nuget.org/packages/OPCFou
 * Sessions and Subscriptions.
 * A [PubSub](Docs/PubSub.md) library with samples.
 
+#### **New in 1.05.373**
+* 1.05 Nodeset
+* Support for [WellKnownRoles & RoleBasedUserManagement](Docs/RoleBasedUserManagement.md).
+
 #### **New in 1.4.368**
 * Improved support for [Logging](Docs/Logging.md) with `ILogger` and `EventSource`. 
 * Support for custom certificate stores with refactored `ICertificateStore` and `CertificateStoreType` interface.


### PR DESCRIPTION
## Proposed changes

Document the changes from #2444 


## Types of changes


- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [x] I ran tests locally with my changes, all passed.
- [x] I fixed all failing tests in the CI pipelines. 
- [x] I fixed all introduced issues with CodeQL and LGTM.
- [x] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [x] I have added necessary documentation (if appropriate).
- [x] Any dependent changes have been merged and published in downstream modules.

## Documentation added:

# Role Based User Management

## Overview

OPC UA Supports role based user management in a way that assigns permissions to nodes.
Those permissions are then assigned to a role.
The role is assigned to one or multiple Identities by the Server.

Since #2444 the OPC UA .NET Standard Stack implements the well known roles from:
https://reference.opcfoundation.org/Core/Part3/v105/docs/4.9.2

- Anonymous
- AuthenticatedUser
- Observer
- Operator
- Engineer
- Supervisor
- ConfigureAdmin
- SecurityAdmin

## Implementation

To get started using well known roles in your server the first thing you have to do is returning a RoleBasedIdentity in the overriden SessionManager_ImpersonateUser Method.

https://github.com/OPCFoundation/UA-.NETStandard/blob/61edad9d6361b566baa5fdd69a23e7ac58c3433d/Applications/Quickstarts.Servers/ReferenceServer/ReferenceServer.cs#L229C22-L229C52

https://github.com/OPCFoundation/UA-.NETStandard/blob/61edad9d6361b566baa5fdd69a23e7ac58c3433d/Applications/Quickstarts.Servers/ReferenceServer/ReferenceServer.cs#L327

You can add as many roles to your returned identity as needed.

All well knwon roles are created as static properties in the Role class of the server:

https://github.com/OPCFoundation/UA-.NETStandard/blob/61edad9d6361b566baa5fdd69a23e7ac58c3433d/Libraries/Opc.Ua.Server/RoleBasedUserManagement/RoleBasedIdentity.cs

If you want to add additional roles you can refer to the GDS implementation which adds some user defined roles.

To make it easier to implement a real user name / pw implementation, avoiding hardcoded passwords, the Server Library provides an interface and a sample implementation for a users database:

https://github.com/OPCFoundation/UA-.NETStandard/tree/61edad9d6361b566baa5fdd69a23e7ac58c3433d/Libraries/Opc.Ua.Server/RoleBasedUserManagement/UserDatabase


```
public interface IUserDatabase
    {
        /// <summary>
        /// Initialize User Database
        /// </summary>
        void Initialize();
        /// <summary>
        /// Register new user
        /// </summary>
        /// <param name="userName">the username</param>
        /// <param name="password">the password</param>
        /// <param name="roles">the role of the new user</param>
        /// <returns>true if registered sucessfull</returns>
        bool CreateUser(string userName, string password, IEnumerable<Role> roles);
        /// <summary>
        /// Delete existring user
        /// </summary>
        /// <param name="userName">the user to delete</param>
        /// <returns>true if deleted sucessfully</returns>
        bool DeleteUser(string userName);
        /// <summary>
        /// checks if the provided credentials fit a user
        /// </summary>
        /// <param name="userName">the username</param>
        /// <param name="password">the password</param>
        /// <returns>true if userName + PW combination is correct</returns>
        bool CheckCredentials(string userName, string password);
        /// <summary>
        /// returns the Role of the provided user
        /// </summary>
        /// <param name="userName"></param>
        /// <returns>the Role of the provided users</returns>
        /// <exception cref="ArgumentException">When the user is not found</exception>
        IEnumerable<Role> GetUserRoles(string userName);
        /// <summary>
        /// changes the password of an existing users
        /// </summary>
        /// <param name="userName"></param>
        /// <param name="oldPassword"></param>
        /// <param name="newPassword"></param>
        /// <returns>true if change was sucessfull</returns>
        bool ChangePassword(string userName, string oldPassword, string newPassword);
    }
```


An implementation targeting SQL Server using Entity Framework 6 is available in the Samples Repo:
https://github.com/OPCFoundation/UA-.NETStandard-Samples/blob/e100ac787507988da95223a031af76fe57b5e11d/Samples/GDS/Server/SqlUsersDatabase.cs

To enable the authorization for your servers methods you can take a look at the HasApplicationSecureAdminAccess method of the ConfigurationNodeManager:

https://github.com/OPCFoundation/UA-.NETStandard/blob/61edad9d6361b566baa5fdd69a23e7ac58c3433d/Libraries/Opc.Ua.Server/Configuration/ConfigurationNodeManager.cs#L300C9-L319C10

This method verifies the current session has the needed roles to access the methods.

## GDS

The GDS supports some additional well known roles starting with #2338

https://reference.opcfoundation.org/GDS/v105/docs/6.2
https://reference.opcfoundation.org/GDS/v105/docs/7.2

- DiscoveryAdmin
- SecurityAdmin
- CertificateAuthorityAdmin
- RegistrationAuthorityAdmin

https://github.com/OPCFoundation/UA-.NETStandard/blob/61edad9d6361b566baa5fdd69a23e7ac58c3433d/Libraries/Opc.Ua.Gds.Server.Common/GdsRole.cs


Additionally the ApplicationSelfAdmin privilege is supported.
In the UA .NET Standard Stack the ApplicationSelfAdmin privilege is implemented using a user defined role.

To store its users the GDS implements the IUserDatabase interface from the server library.

https://github.com/OPCFoundation/UA-.NETStandard/tree/61edad9d6361b566baa5fdd69a23e7ac58c3433d/Libraries/Opc.Ua.Server/RoleBasedUserManagement/UserDatabase

The JsonUserDatabase path is stored in the GDS Configuration:
https://github.com/OPCFoundation/UA-.NETStandard/blob/61edad9d6361b566baa5fdd69a23e7ac58c3433d/Libraries/Opc.Ua.Gds.Server.Common/GlobalDiscoveryServerConfiguration.cs#L91

The GDS allows library users to supply their own implementation using the constructor:
https://github.com/OPCFoundation/UA-.NETStandard/blob/61edad9d6361b566baa5fdd69a23e7ac58c3433d/Libraries/Opc.Ua.Gds.Server.Common/GlobalDiscoverySampleServer.cs#L55C2-L63C10

## Limitations

- Does not really make use of the permissions <-> roles 
- Does not implement the RoleBasedSecurity Information Model from: https://reference.opcfoundation.org/Core/Part18/v105/docs/