### PR TITLE
Remove lock from IServiceMessageContext

### DIFF
--- a/Stack/Opc.Ua.Core/Types/Utils/IServiceMessageContext.cs
+++ b/Stack/Opc.Ua.Core/Types/Utils/IServiceMessageContext.cs
@@ -21,11 +21,6 @@ namespace Opc.Ua
     {
         #region Public Properties
         /// <summary>
-        /// Returns the object used to synchronize access to the context.
-        /// </summary>
-        object SyncRoot { get; }
-
-        /// <summary>
         /// The maximum length for any string, byte string or xml element.
         /// </summary>
         int MaxStringLength { get; }

--- a/Stack/Opc.Ua.Core/Types/Utils/ServiceMessageContext.cs
+++ b/Stack/Opc.Ua.Core/Types/Utils/ServiceMessageContext.cs
@@ -60,10 +60,7 @@ namespace Opc.Ua
         /// </summary>
         public static ServiceMessageContext ThreadContext
         {
-            get
-            {
-                return s_globalContext;
-            }
+            get => s_globalContext;
 
             set
             {
@@ -73,17 +70,12 @@ namespace Opc.Ua
 
         #region Public Properties
         /// <summary>
-        /// Returns the object used to synchronize access to the context.
-        /// </summary>
-        public object SyncRoot => m_lock;
-
-        /// <summary>
         /// The maximum length for any string, byte string or xml element.
         /// </summary>
         public int MaxStringLength
         {
-            get { lock (m_lock) { return m_maxStringLength; } }
-            set { lock (m_lock) { m_maxStringLength = value; } }
+            get => m_maxStringLength;
+            set { m_maxStringLength = value; }
         }
 
         /// <summary>
@@ -91,8 +83,8 @@ namespace Opc.Ua
         /// </summary>
         public int MaxArrayLength
         {
-            get { lock (m_lock) { return m_maxArrayLength; } }
-            set { lock (m_lock) { m_maxArrayLength = value; } }
+            get => m_maxArrayLength;
+            set { m_maxArrayLength = value; }
         }
 
         /// <summary>
@@ -100,8 +92,8 @@ namespace Opc.Ua
         /// </summary>
         public int MaxByteStringLength
         {
-            get { lock (m_lock) { return m_maxByteStringLength; } }
-            set { lock (m_lock) { m_maxByteStringLength = value; } }
+            get => m_maxByteStringLength;
+            set { m_maxByteStringLength = value; }
         }
 
         /// <summary>
@@ -109,8 +101,8 @@ namespace Opc.Ua
         /// </summary>
         public int MaxMessageSize
         {
-            get { lock (m_lock) { return m_maxMessageSize; } }
-            set { lock (m_lock) { m_maxMessageSize = value; } }
+            get => m_maxMessageSize;
+            set { m_maxMessageSize = value; }
         }
 
         /// <summary>
@@ -118,7 +110,7 @@ namespace Opc.Ua
         /// </summary>
         public uint MaxEncodingNestingLevels
         {
-            get { lock (m_lock) { return m_maxEncodingNestingLevels; } }
+            get => m_maxEncodingNestingLevels;
         }
 
         /// <summary>
@@ -126,23 +118,16 @@ namespace Opc.Ua
         /// </summary>
         public NamespaceTable NamespaceUris
         {
-            get
-            {
-                return m_namespaceUris;
-            }
+            get => m_namespaceUris;
 
             set
             {
-                lock (m_lock)
+                if (value == null)
                 {
-                    if (value == null)
-                    {
-                        m_namespaceUris = ServiceMessageContext.GlobalContext.NamespaceUris;
-                        return;
-                    }
-
-                    m_namespaceUris = value;
+                    m_namespaceUris = ServiceMessageContext.GlobalContext.NamespaceUris;
+                    return;
                 }
+                m_namespaceUris = value;
             }
         }
 
@@ -151,23 +136,17 @@ namespace Opc.Ua
         /// </summary>
         public StringTable ServerUris
         {
-            get
-            {
-                return m_serverUris;
-            }
+            get => m_serverUris;
 
             set
             {
-                lock (m_lock)
+                if (value == null)
                 {
-                    if (value == null)
-                    {
-                        m_serverUris = ServiceMessageContext.GlobalContext.ServerUris;
-                        return;
-                    }
-
-                    m_serverUris = value;
+                    m_serverUris = ServiceMessageContext.GlobalContext.ServerUris;
+                    return;
                 }
+
+                m_serverUris = value;
             }
         }
 
@@ -176,29 +155,22 @@ namespace Opc.Ua
         /// </summary>
         public IEncodeableFactory Factory
         {
-            get
-            {
-                return m_factory;
-            }
+            get => m_factory;
 
             set
             {
-                lock (m_lock)
+                if (value == null)
                 {
-                    if (value == null)
-                    {
-                        m_factory = ServiceMessageContext.GlobalContext.Factory;
-                        return;
-                    }
-
-                    m_factory = value;
+                    m_factory = ServiceMessageContext.GlobalContext.Factory;
+                    return;
                 }
+
+                m_factory = value;
             }
         }
         #endregion
 
         #region Private Fields
-        private readonly object m_lock = new object();
         private int m_maxStringLength;
         private int m_maxByteStringLength;
         private int m_maxArrayLength;

--- a/version.json
+++ b/version.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.5.373-preview",
-  "versionHeightOffset": 106,
+  "version": "1.5.374-preview",
+  "versionHeightOffset": 10,
   "nugetPackageVersion": {
     "semVer": 2
   },


### PR DESCRIPTION
## Proposed changes

Reduce lock contention for encoders/decoders.

The IServiceMessageContext locks all properties without really a need, because assigning/reading int and objects are transaction safe.

## Related Issues

- Fixes #

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
