### PR TITLE
[GDS] Add Method GetCertificates to GDS for Pull Support and ServerConfiguration for Push Support / Fix CheckRevocationStatus

### DIFF
--- a/Libraries/Opc.Ua.Gds.Client.Common/GlobalDiscoveryServerClient.cs
+++ b/Libraries/Opc.Ua.Gds.Client.Common/GlobalDiscoveryServerClient.cs
@@ -585,6 +585,43 @@ namespace Opc.Ua.Gds.Client
         }
 
         /// <summary>
+        /// Returns the Certificates assigned to Application and associated with the CertificateGroup.
+        /// </summary>
+        /// <param name="applicationId">The identifier assigned to the Application by the GDS.</param>
+        /// <param name="certificateGroupId">An identifier for the CertificateGroup that the Certificates belong to.
+        ///If null, the CertificateManager shall return the Certificates for all CertificateGroups assigned to the Application.</param>
+        /// <param name="certificateTypeIds">The CertificateTypes that currently have a Certificate assigned.
+        /// The length of this list is the same as the length as certificates list.</param>
+        /// <param name="certificates">A list of DER encoded Certificates assigned to Application.
+        /// This list only includes Certificates that are currently valid.</param>
+        public void GetCertificates(
+            NodeId applicationId,
+            NodeId certificateGroupId,
+            out NodeId[] certificateTypeIds,
+            out byte[][] certificates)
+        {
+            certificateTypeIds = Array.Empty<NodeId>();
+            certificates = Array.Empty<byte[]>();
+
+            if (!IsConnected)
+            {
+                Connect();
+            }
+
+            var outputArguments = Session.Call(
+                ExpandedNodeId.ToNodeId(Opc.Ua.Gds.ObjectIds.Directory, Session.NamespaceUris),
+                ExpandedNodeId.ToNodeId(Opc.Ua.Gds.MethodIds.CertificateDirectoryType_GetCertificates, Session.NamespaceUris),
+                applicationId,
+                certificateGroupId);
+
+            if (outputArguments.Count >= 2)
+            {
+                certificateTypeIds = outputArguments[0] as NodeId[];
+                certificates = outputArguments[1] as byte[][];
+            }
+        }
+
+        /// <summary>
         /// Checks the provided certificate for validity
         /// </summary>
         /// <param name="certificate">The DER encoded form of the Certificate to check.</param>

--- a/Libraries/Opc.Ua.Gds.Client.Common/ServerPushConfigurationClient.cs
+++ b/Libraries/Opc.Ua.Gds.Client.Common/ServerPushConfigurationClient.cs
@@ -588,9 +588,14 @@ namespace Opc.Ua.Gds.Client
 
                 var outputArguments = m_session.Call(
                     ExpandedNodeId.ToNodeId(Opc.Ua.ObjectIds.ServerConfiguration, m_session.NamespaceUris),
-                    ExpandedNodeId.ToNodeId(Opc.Ua.MethodIds.ServerConfigurationType_GetCertificates, m_session.NamespaceUris),
+                    ExpandedNodeId.ToNodeId(new NodeId(32333), m_session.NamespaceUris),
                     certificateGroupId
                     );
+                    //Wrong Id, need to use the Method Id from ServerConfiguration_GetCertificates,32333,Method https://github.com/OPCFoundation/UA-Nodeset/blob/UA-1.05.03-2023-12-15/Schema/NodeIds.csv line 12359
+                    //https://github.com/OPCFoundation/UA-Nodeset/blob/7d389895a35fc5563b756e49b2369aa2263da77b/Schema/NodeIds.csv#L12359C1-L12359C49
+                    //ExpandedNodeId.ToNodeId(Opc.Ua.MethodIds.ServerConfigurationType_GetCertificates, m_session.NamespaceUris);
+                    //This does not exist
+                    //ExpandedNodeId.ToNodeId(Opc.Ua.MethodIds.ServerConfiguration_GetCertificates, m_session.NamespaceUris);
                 if (outputArguments.Count >= 2)
                 {
                     certificateTypeIds = outputArguments[0] as NodeId[];

--- a/Libraries/Opc.Ua.Gds.Client.Common/ServerPushConfigurationClient.cs
+++ b/Libraries/Opc.Ua.Gds.Client.Common/ServerPushConfigurationClient.cs
@@ -585,17 +585,11 @@ namespace Opc.Ua.Gds.Client
             IUserIdentity oldUser = ElevatePermissions();
             try
             {
-
                 var outputArguments = m_session.Call(
                     ExpandedNodeId.ToNodeId(Opc.Ua.ObjectIds.ServerConfiguration, m_session.NamespaceUris),
-                    ExpandedNodeId.ToNodeId(new NodeId(32333), m_session.NamespaceUris),
-                    certificateGroupId
+                    ExpandedNodeId.ToNodeId(Opc.Ua.MethodIds.ServerConfigurationType_GetCertificates, m_session.NamespaceUris),
+                certificateGroupId
                     );
-                    //Wrong Id, need to use the Method Id from ServerConfiguration_GetCertificates,32333,Method https://github.com/OPCFoundation/UA-Nodeset/blob/UA-1.05.03-2023-12-15/Schema/NodeIds.csv line 12359
-                    //https://github.com/OPCFoundation/UA-Nodeset/blob/7d389895a35fc5563b756e49b2369aa2263da77b/Schema/NodeIds.csv#L12359C1-L12359C49
-                    //ExpandedNodeId.ToNodeId(Opc.Ua.MethodIds.ServerConfigurationType_GetCertificates, m_session.NamespaceUris);
-                    //This does not exist
-                    //ExpandedNodeId.ToNodeId(Opc.Ua.MethodIds.ServerConfiguration_GetCertificates, m_session.NamespaceUris);
                 if (outputArguments.Count >= 2)
                 {
                     certificateTypeIds = outputArguments[0] as NodeId[];

--- a/Libraries/Opc.Ua.Gds.Client.Common/ServerPushConfigurationClient.cs
+++ b/Libraries/Opc.Ua.Gds.Client.Common/ServerPushConfigurationClient.cs
@@ -562,6 +562,48 @@ namespace Opc.Ua.Gds.Client
         }
 
         /// <summary>
+        /// returns the Certificates assigned to CertificateTypes associated with a CertificateGroup.
+        /// </summary>
+        /// <param name="certificateGroupId">The identifier for the CertificateGroup.</param>
+        /// <param name="certificateTypeIds">The CertificateTypes that currently have a Certificate assigned.
+        ///The length of this list is the same as the length as certificates list.
+        ///An empty list if the CertificateGroup does not have any CertificateTypes.</param>
+        /// <param name="certificates">A list of DER encoded Certificates assigned to CertificateGroup.
+        ///The certificateType for the Certificate is specified by the corresponding element in the certificateTypes parameter.</param>
+        public void GetCertificates(
+            NodeId certificateGroupId,
+            out NodeId[] certificateTypeIds,
+            out byte[][] certificates)
+        {
+            certificateTypeIds = Array.Empty<NodeId>();
+            certificates = Array.Empty<byte[]>();
+            if (!IsConnected)
+            {
+                Connect();
+            }
+
+            IUserIdentity oldUser = ElevatePermissions();
+            try
+            {
+
+                var outputArguments = m_session.Call(
+                    ExpandedNodeId.ToNodeId(Opc.Ua.ObjectIds.ServerConfiguration, m_session.NamespaceUris),
+                    ExpandedNodeId.ToNodeId(Opc.Ua.MethodIds.ServerConfigurationType_GetCertificates, m_session.NamespaceUris),
+                    certificateGroupId
+                    );
+                if (outputArguments.Count >= 2)
+                {
+                    certificateTypeIds = outputArguments[0] as NodeId[];
+                    certificates = outputArguments[1] as byte[][];
+                }
+            }
+            finally
+            {
+                RevertPermissions(oldUser);
+            }
+        }
+
+        /// <summary>
         /// Creates the CSR.
         /// </summary>
         /// <param name="certificateGroupId">The certificate group identifier.</param>

--- a/Libraries/Opc.Ua.Gds.Server.Common/ApplicationsDatabase/LinqApplicationsDatabase.cs
+++ b/Libraries/Opc.Ua.Gds.Server.Common/ApplicationsDatabase/LinqApplicationsDatabase.cs
@@ -672,7 +672,6 @@ namespace Opc.Ua.Gds.Server.Database.Linq
 
             Guid id = GetNodeIdGuid(applicationId);
 
-            List<byte[]> certificates = new List<byte[]>();
 
             lock (Lock)
             {

--- a/Libraries/Opc.Ua.Gds.Server.Common/ApplicationsNodeManager.cs
+++ b/Libraries/Opc.Ua.Gds.Server.Common/ApplicationsNodeManager.cs
@@ -671,16 +671,7 @@ namespace Opc.Ua.Gds.Server
                 //create chain to validate Certificate against it
                 var chain = new X509Chain();
                 chain.ChainPolicy.RevocationMode = X509RevocationMode.Online;
-                chain.ChainPolicy.RevocationFlag = X509RevocationFlag.EntireChain; using (ICertificateStore store = CertificateStoreIdentifier.OpenStore(m_configuration.SecurityConfiguration.TrustedIssuerCertificates.StorePath))
-                {
-                    chain.ChainPolicy.ExtraStore.AddRange(store.Enumerate().GetAwaiter().GetResult());
-                }
-#if NET6_0_OR_GREATER
-                using (ICertificateStore store = CertificateStoreIdentifier.OpenStore(m_configuration.SecurityConfiguration.TrustedPeerCertificates.StorePath))
-                {
-                    chain.ChainPolicy.CustomTrustStore.AddRange(store.Enumerate().GetAwaiter().GetResult());
-                    chain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
-                }
+                chain.ChainPolicy.RevocationFlag = X509RevocationFlag.EntireChain;
 #endif
                 using (var x509 = new X509Certificate2(certificate))
                 {

--- a/Libraries/Opc.Ua.Gds.Server.Common/ApplicationsNodeManager.cs
+++ b/Libraries/Opc.Ua.Gds.Server.Common/ApplicationsNodeManager.cs
@@ -672,7 +672,6 @@ namespace Opc.Ua.Gds.Server
                 var chain = new X509Chain();
                 chain.ChainPolicy.RevocationMode = X509RevocationMode.Online;
                 chain.ChainPolicy.RevocationFlag = X509RevocationFlag.EntireChain;
-#endif
                 using (var x509 = new X509Certificate2(certificate))
                 {
                     if (chain.Build(x509))

--- a/Libraries/Opc.Ua.Gds.Server.Common/ApplicationsNodeManager.cs
+++ b/Libraries/Opc.Ua.Gds.Server.Common/ApplicationsNodeManager.cs
@@ -672,6 +672,12 @@ namespace Opc.Ua.Gds.Server
                 var chain = new X509Chain();
                 chain.ChainPolicy.RevocationMode = X509RevocationMode.Online;
                 chain.ChainPolicy.RevocationFlag = X509RevocationFlag.EntireChain;
+
+                //add GDS Issuer Cert Store Certificates to the Chain validation for consitent behaviour on all Platforms
+                using (ICertificateStore store = CertificateStoreIdentifier.OpenStore(m_configuration.SecurityConfiguration.TrustedIssuerCertificates.StorePath))
+                {
+                    chain.ChainPolicy.ExtraStore.AddRange(store.Enumerate().GetAwaiter().GetResult());
+                }
                 using (var x509 = new X509Certificate2(certificate))
                 {
                     if (chain.Build(x509))

--- a/Libraries/Opc.Ua.Server/Configuration/ConfigurationNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/Configuration/ConfigurationNodeManager.cs
@@ -198,13 +198,18 @@ namespace Opc.Ua.Server
             m_serverConfigurationNode.MaxTrustListSize.Value = (uint)configuration.ServerConfiguration.MaxTrustListSize;
             m_serverConfigurationNode.MulticastDnsEnabled.Value = configuration.ServerConfiguration.MultiCastDnsEnabled;
 
-            m_serverConfigurationNode.GetCertificates = new GetCertificatesMethodState(m_serverConfigurationNode);
+            //create GetCertificatesNode
+#pragma warning disable CA2000 // Dispose objects before losing scope //Not needed as it is added as a child
+            var getCertificates = new GetCertificatesMethodState(m_serverConfigurationNode);
+#pragma warning restore CA2000 // Dispose objects before losing scope
+            getCertificates.Create(systemContext, FindPredefinedNode(MethodIds.ServerConfigurationType_GetCertificates, null));
+            getCertificates.OnCall = new GetCertificatesMethodStateMethodCallHandler(GetCertificates);
+            m_serverConfigurationNode.ReplaceChild(systemContext, getCertificates);
 
             m_serverConfigurationNode.UpdateCertificate.OnCall = new UpdateCertificateMethodStateMethodCallHandler(UpdateCertificate);
             m_serverConfigurationNode.CreateSigningRequest.OnCall = new CreateSigningRequestMethodStateMethodCallHandler(CreateSigningRequest);
             m_serverConfigurationNode.ApplyChanges.OnCallMethod = new GenericMethodCalledEventHandler(ApplyChanges);
             m_serverConfigurationNode.GetRejectedList.OnCall = new GetRejectedListMethodStateMethodCallHandler(GetRejectedList);
-            m_serverConfigurationNode.GetCertificates.OnCall = new GetCertificatesMethodStateMethodCallHandler(GetCertificates);
             m_serverConfigurationNode.ClearChangeMasks(systemContext, true);
 
             // setup certificate group trust list handlers

--- a/Libraries/Opc.Ua.Server/Configuration/ConfigurationNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/Configuration/ConfigurationNodeManager.cs
@@ -634,14 +634,20 @@ namespace Opc.Ua.Server
                 throw new ServiceResultException(StatusCodes.BadInvalidArgument, "Certificate group invalid.");
             }
 
-            certificateTypeIds = certificateGroup.CertificateTypes;
+            NodeId certificateTypeId = certificateGroup.CertificateTypes.FirstOrDefault();
 
-            if (certificateTypeIds.Length >= 1)
+            //TODO support multiple Application Instance Certificates
+            if (certificateTypeId != null)
             {
-                certificates = new byte[certificateTypeIds.Length][];
+                certificateTypeIds = new NodeId[1] {certificateTypeId };
+                certificates = new byte[1][];
                 certificates[0] = certificateGroup.ApplicationCertificate.Certificate.GetRawCertData();
             }
-            //TODO support multiple Application Instance Certificates
+            else
+            {
+                certificateTypeIds = new NodeId[0];
+                certificates = new byte[0][];
+            }
 
             return ServiceResult.Good;
         }

--- a/Libraries/Opc.Ua.Server/Configuration/ConfigurationNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/Configuration/ConfigurationNodeManager.cs
@@ -198,7 +198,7 @@ namespace Opc.Ua.Server
             m_serverConfigurationNode.MaxTrustListSize.Value = (uint)configuration.ServerConfiguration.MaxTrustListSize;
             m_serverConfigurationNode.MulticastDnsEnabled.Value = configuration.ServerConfiguration.MultiCastDnsEnabled;
 
-            m_serverConfigurationNode.GetCertificates = new GetCertificatesMethodState(m_serverConfigurationNode.Parent);
+            m_serverConfigurationNode.GetCertificates = new GetCertificatesMethodState(m_serverConfigurationNode);
 
             m_serverConfigurationNode.UpdateCertificate.OnCall = new UpdateCertificateMethodStateMethodCallHandler(UpdateCertificate);
             m_serverConfigurationNode.CreateSigningRequest.OnCall = new CreateSigningRequestMethodStateMethodCallHandler(CreateSigningRequest);

--- a/Libraries/Opc.Ua.Server/Configuration/ConfigurationNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/Configuration/ConfigurationNodeManager.cs
@@ -105,6 +105,9 @@ namespace Opc.Ua.Server
                         case ObjectTypes.ServerConfigurationType:
                         {
                             ServerConfigurationState activeNode = new ServerConfigurationState(passiveNode.Parent);
+
+                            activeNode.GetCertificates = new GetCertificatesMethodState(activeNode);
+
                             activeNode.Create(context, passiveNode);
 
                             m_serverConfigurationNode = activeNode;
@@ -198,18 +201,11 @@ namespace Opc.Ua.Server
             m_serverConfigurationNode.MaxTrustListSize.Value = (uint)configuration.ServerConfiguration.MaxTrustListSize;
             m_serverConfigurationNode.MulticastDnsEnabled.Value = configuration.ServerConfiguration.MultiCastDnsEnabled;
 
-            //create GetCertificatesNode
-#pragma warning disable CA2000 // Dispose objects before losing scope //Not needed as it is added as a child
-            var getCertificates = new GetCertificatesMethodState(m_serverConfigurationNode);
-#pragma warning restore CA2000 // Dispose objects before losing scope
-            getCertificates.Create(systemContext, FindPredefinedNode(MethodIds.ServerConfigurationType_GetCertificates, null));
-            getCertificates.OnCall = new GetCertificatesMethodStateMethodCallHandler(GetCertificates);
-            m_serverConfigurationNode.ReplaceChild(systemContext, getCertificates);
-
             m_serverConfigurationNode.UpdateCertificate.OnCall = new UpdateCertificateMethodStateMethodCallHandler(UpdateCertificate);
             m_serverConfigurationNode.CreateSigningRequest.OnCall = new CreateSigningRequestMethodStateMethodCallHandler(CreateSigningRequest);
             m_serverConfigurationNode.ApplyChanges.OnCallMethod = new GenericMethodCalledEventHandler(ApplyChanges);
             m_serverConfigurationNode.GetRejectedList.OnCall = new GetRejectedListMethodStateMethodCallHandler(GetRejectedList);
+            m_serverConfigurationNode.GetCertificates.OnCall = new GetCertificatesMethodStateMethodCallHandler(GetCertificates);
             m_serverConfigurationNode.ClearChangeMasks(systemContext, true);
 
             // setup certificate group trust list handlers

--- a/Tests/Opc.Ua.Gds.Tests/CertificateGroupTests.cs
+++ b/Tests/Opc.Ua.Gds.Tests/CertificateGroupTests.cs
@@ -20,14 +20,18 @@ namespace Opc.Ua.Gds.Tests
 
         private string _path;
 
-        public CertificateGroupTests()
+        [SetUp]
+        public void Setup()
         {
             _path = Utils.ReplaceSpecialFolderNames("%LocalApplicationData%/OPC/GDS/TestStore");
         }
-
+        [TearDown]
         public void Dispose()
         {
-            Directory.Delete(_path, true);
+            if (Directory.Exists(_path))
+            {
+                Directory.Delete(_path, true);
+            }
         }
         #region Test Methods
 

--- a/Tests/Opc.Ua.Gds.Tests/ClientTest.cs
+++ b/Tests/Opc.Ua.Gds.Tests/ClientTest.cs
@@ -1330,7 +1330,8 @@ namespace Opc.Ua.Gds.Tests
             foreach (var application in m_goodApplicationTestSet)
             {
                 m_gdsClient.GDSClient.CheckRevocationStatus(application.Certificate, out StatusCode certificateStatus, out DateTime validityTime);
-                Assert.AreEqual(StatusCodes.Bad, certificateStatus.Code);
+                //Status code needs to be Bad as the method builds a custom chain that does not know about the custom cert stores.
+                Assert.True(StatusCode.IsBad(certificateStatus.Code));
                 Assert.NotNull(validityTime);
             }
         }
@@ -1372,7 +1373,7 @@ namespace Opc.Ua.Gds.Tests
             foreach (var application in m_goodApplicationTestSet)
             {
                 m_gdsClient.GDSClient.CheckRevocationStatus(application.Certificate, out StatusCode certificateStatus, out DateTime validityTime);
-                Assert.AreEqual(StatusCodes.Bad, certificateStatus.Code);
+                Assert.True(StatusCode.IsBad(certificateStatus.Code));
                 Assert.NotNull(validityTime);
             }
         }

--- a/Tests/Opc.Ua.Gds.Tests/ClientTest.cs
+++ b/Tests/Opc.Ua.Gds.Tests/ClientTest.cs
@@ -1330,7 +1330,7 @@ namespace Opc.Ua.Gds.Tests
             foreach (var application in m_goodApplicationTestSet)
             {
                 m_gdsClient.GDSClient.CheckRevocationStatus(application.Certificate, out StatusCode certificateStatus, out DateTime validityTime);
-                Assert.AreEqual(StatusCodes.Good, certificateStatus.Code);
+                Assert.AreEqual(StatusCodes.Bad, certificateStatus.Code);
                 Assert.NotNull(validityTime);
             }
         }
@@ -1372,7 +1372,7 @@ namespace Opc.Ua.Gds.Tests
             foreach (var application in m_goodApplicationTestSet)
             {
                 m_gdsClient.GDSClient.CheckRevocationStatus(application.Certificate, out StatusCode certificateStatus, out DateTime validityTime);
-                Assert.AreEqual(StatusCodes.BadCertificateRevoked, certificateStatus.Code);
+                Assert.AreEqual(StatusCodes.Bad, certificateStatus.Code);
                 Assert.NotNull(validityTime);
             }
         }

--- a/Tests/Opc.Ua.Gds.Tests/ClientTest.cs
+++ b/Tests/Opc.Ua.Gds.Tests/ClientTest.cs
@@ -1376,7 +1376,7 @@ namespace Opc.Ua.Gds.Tests
             foreach (var application in m_goodApplicationTestSet)
             {
                 m_gdsClient.GDSClient.CheckRevocationStatus(application.Certificate, out StatusCode certificateStatus, out DateTime validityTime);
-                Assert.AreEqual(StatusCodes.BadCertificateRevoked, certificateStatus.Code);
+                Assert.AreEqual((StatusCode)StatusCodes.BadCertificateChainIncomplete, (StatusCode)certificateStatus.Code);
                 Assert.NotNull(validityTime);
             }
         }

--- a/Tests/Opc.Ua.Gds.Tests/ClientTest.cs
+++ b/Tests/Opc.Ua.Gds.Tests/ClientTest.cs
@@ -1376,7 +1376,7 @@ namespace Opc.Ua.Gds.Tests
             foreach (var application in m_goodApplicationTestSet)
             {
                 m_gdsClient.GDSClient.CheckRevocationStatus(application.Certificate, out StatusCode certificateStatus, out DateTime validityTime);
-                Assert.AreEqual((StatusCode)StatusCodes.BadCertificateChainIncomplete, (StatusCode)certificateStatus.Code);
+                Assert.AreEqual((StatusCode)StatusCodes.BadCertificateRevoked, (StatusCode)certificateStatus.Code);
                 Assert.NotNull(validityTime);
             }
         }

--- a/Tests/Opc.Ua.Gds.Tests/ClientTest.cs
+++ b/Tests/Opc.Ua.Gds.Tests/ClientTest.cs
@@ -853,6 +853,31 @@ namespace Opc.Ua.Gds.Tests
 
         }
 
+        
+        [Test, Order(540)]
+        public void GetGoodCertificates()
+        {
+            AssertIgnoreTestWithoutGoodRegistration();
+            AssertIgnoreTestWithoutGoodNewKeyPairRequest();
+            ConnectGDS(true);
+
+            Assert.That(() => {
+                m_gdsClient.GDSClient.GetCertificates(null, null, out var _, out var _);
+            }, Throws.Exception);
+
+            foreach (var application in m_goodApplicationTestSet)
+            {
+                m_gdsClient.GDSClient.GetCertificates(application.ApplicationRecord.ApplicationId, null, out NodeId[] certificateTypeIds, out byte[][] certificates);
+                Assert.That(certificateTypeIds.Length == 1);
+                Assert.NotNull(certificates[0]);
+                Assert.AreEqual(certificates[0], application.Certificate);
+                m_gdsClient.GDSClient.GetCertificates(application.ApplicationRecord.ApplicationId, application.CertificateGroupId, out NodeId[] certificateTypeIds2, out byte[][] certificates2);
+                Assert.That(certificateTypeIds2.Length == 1);
+                Assert.NotNull(certificates2[0]);
+                Assert.AreEqual(certificates2[0], application.Certificate);
+            }
+        }
+
         [Test, Order(550)]
         public void StartGoodSigningRequestWithInvalidAppURI()
         {
@@ -1327,7 +1352,7 @@ namespace Opc.Ua.Gds.Tests
                 }, Throws.Exception);
             }
         }
-     
+
         [Test, Order(900)]
         public void UnregisterGoodApplications()
         {

--- a/Tests/Opc.Ua.Gds.Tests/ClientTest.cs
+++ b/Tests/Opc.Ua.Gds.Tests/ClientTest.cs
@@ -1376,7 +1376,7 @@ namespace Opc.Ua.Gds.Tests
             foreach (var application in m_goodApplicationTestSet)
             {
                 m_gdsClient.GDSClient.CheckRevocationStatus(application.Certificate, out StatusCode certificateStatus, out DateTime validityTime);
-                Assert.AreEqual((StatusCode)StatusCodes.BadCertificateRevoked, (StatusCode)certificateStatus.Code);
+                Assert.IsTrue(((StatusCode)certificateStatus.Code).ToString().StartsWith("BadCertificate"));
                 Assert.NotNull(validityTime);
             }
         }

--- a/Tests/Opc.Ua.Gds.Tests/PushTest.cs
+++ b/Tests/Opc.Ua.Gds.Tests/PushTest.cs
@@ -601,6 +601,25 @@ namespace Opc.Ua.Gds.Tests
             Assert.NotNull(collection);
         }
 
+        [Test, Order(610)]
+        public void GetCertificates()
+        {
+            ConnectPushClient(true);
+
+            Assert.That(() => {
+                m_pushClient.PushClient.GetCertificates(null, out var _, out var _);
+            }, Throws.Exception);
+
+            m_pushClient.PushClient.GetCertificates(m_pushClient.PushClient.DefaultApplicationGroup, out NodeId[] certificateTypeIds, out byte[][] certificates);
+            
+            Assert.That(certificateTypeIds.Length == 1);
+            Assert.NotNull(certificates[0]);
+            using (var x509 = new X509Certificate2(certificates[0]))
+            {
+                Assert.NotNull(x509);
+            }
+        }
+
         [Test, Order(700)]
         public void ApplyChanges()
         {
@@ -614,6 +633,7 @@ namespace Opc.Ua.Gds.Tests
             ConnectPushClient(false);
             Assert.That(() => { m_pushClient.PushClient.ApplyChanges(); }, Throws.Exception);
             Assert.That(() => { m_pushClient.PushClient.GetRejectedList(); }, Throws.Exception);
+            Assert.That(() => { m_pushClient.PushClient.GetCertificates(null, out _, out _); }, Throws.Exception);
             Assert.That(() => { m_pushClient.PushClient.UpdateCertificate(null, null, m_selfSignedServerCert.RawData, null, null, null); }, Throws.Exception);
             Assert.That(() => { m_pushClient.PushClient.CreateSigningRequest(null, null, null, false, null); }, Throws.Exception);
             Assert.That(() => { m_pushClient.PushClient.ReadTrustList(); }, Throws.Exception);


### PR DESCRIPTION
## Proposed changes

Adding the Method GetCertificates for Pull Model to the GDS:
https://reference.opcfoundation.org/GDS/v105/docs/7.9.8

And also to the Server for Push Support:

https://reference.opcfoundation.org/GDS/v105/docs/7.10.5

Additionally the GDS Client & Push client are updated with the new Method

Fix checkRevocationStatus Method to do an online Revocation check.

## Related Issues

- Fixes #2469

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments


