### PR TITLE
GDS: Add Audit Events to GDS and missing Events to ServerConfigurationNode

### DIFF
--- a/Libraries/Opc.Ua.Gds.Server.Common/ApplicationsNodeManager.cs
+++ b/Libraries/Opc.Ua.Gds.Server.Common/ApplicationsNodeManager.cs
@@ -508,6 +508,11 @@ namespace Opc.Ua.Gds.Server
 
             applicationId = m_database.RegisterApplication(application);
 
+            if(applicationId != null)
+            {
+                
+            }
+
             return ServiceResult.Good;
         }
 

--- a/Libraries/Opc.Ua.Gds.Server.Common/ApplicationsNodeManager.cs
+++ b/Libraries/Opc.Ua.Gds.Server.Common/ApplicationsNodeManager.cs
@@ -35,7 +35,10 @@ using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Threading.Tasks;
 using Opc.Ua.Gds.Server.Database;
+using Opc.Ua.Gds.Server.Diagnostics;
 using Opc.Ua.Server;
+using Org.BouncyCastle.Ocsp;
+using Org.BouncyCastle.Tls;
 
 namespace Opc.Ua.Gds.Server
 {
@@ -508,9 +511,10 @@ namespace Opc.Ua.Gds.Server
 
             applicationId = m_database.RegisterApplication(application);
 
-            if(applicationId != null)
+            if (applicationId != null)
             {
-                
+                object[] inputArguments = new object[] { application, applicationId };
+                Server.ReportApplicationRegistrationChangedAuditEvent(context, objectId, method, inputArguments);
             }
 
             return ServiceResult.Good;
@@ -534,6 +538,9 @@ namespace Opc.Ua.Gds.Server
             }
 
             m_database.RegisterApplication(application);
+
+            object[] inputArguments = new object[] { application };
+            Server.ReportApplicationRegistrationChangedAuditEvent(context, objectId, method, inputArguments);
 
             return ServiceResult.Good;
         }
@@ -568,6 +575,9 @@ namespace Opc.Ua.Gds.Server
             }
 
             m_database.UnregisterApplication(applicationId);
+
+            object[] inputArguments = new object[] { applicationId };
+            Server.ReportApplicationRegistrationChangedAuditEvent(context, objectId, method, inputArguments);
 
             return ServiceResult.Good;
         }
@@ -830,6 +840,9 @@ namespace Opc.Ua.Gds.Server
             string privateKeyPassword,
             ref NodeId requestId)
         {
+            object[] inputArguments = new object[] { applicationId, certificateGroupId, certificateTypeId, subjectName, domainNames, privateKeyFormat, privateKeyPassword };
+            Server.ReportCertificateRequestedAuditEvent(context, objectId, method, inputArguments, certificateGroupId, certificateTypeId);
+
             AuthorizationHelper.HasAuthorization(context, AuthorizationHelper.CertificateAuthorityAdminOrSelfAdmin, applicationId); ;
 
             var application = m_database.GetApplication(applicationId);
@@ -1187,6 +1200,9 @@ namespace Opc.Ua.Gds.Server
             m_database.SetApplicationTrustLists(applicationId, m_certTypeMap[certificateGroup.CertificateType], certificateGroup.Configuration.TrustedListPath);
 
             m_request.AcceptRequest(requestId, signedCertificate);
+
+            object[] inputArguments = new object[] { applicationId, requestId, signedCertificate, privateKey, issuerCertificates };
+            Server.ReportCertificateDeliveredAuditEvent(context, objectId, method, inputArguments);
 
             return ServiceResult.Good;
         }

--- a/Libraries/Opc.Ua.Gds.Server.Common/ApplicationsNodeManager.cs
+++ b/Libraries/Opc.Ua.Gds.Server.Common/ApplicationsNodeManager.cs
@@ -1,5 +1,5 @@
 /* ========================================================================
- * Copyright (c) 2005-2020 The OPC Foundation, Inc. All rights reserved.
+ * Copyright (c) 2005-2024 The OPC Foundation, Inc. All rights reserved.
  *
  * OPC Foundation MIT License 1.00
  * 
@@ -37,8 +37,6 @@ using System.Threading.Tasks;
 using Opc.Ua.Gds.Server.Database;
 using Opc.Ua.Gds.Server.Diagnostics;
 using Opc.Ua.Server;
-using Org.BouncyCastle.Ocsp;
-using Org.BouncyCastle.Tls;
 
 namespace Opc.Ua.Gds.Server
 {

--- a/Libraries/Opc.Ua.Gds.Server.Common/Diagnostics/AuditEvents.cs
+++ b/Libraries/Opc.Ua.Gds.Server.Common/Diagnostics/AuditEvents.cs
@@ -1,0 +1,173 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Opc.Ua.Server;
+
+namespace Opc.Ua.Gds.Server.Diagnostics
+{
+    public static class AuditEvents
+    {
+        /// <summary>
+        /// Raise CertificateDeliveredAudit event
+        /// </summary>
+        /// <param name="server">The server which reports audit events.</param>
+        /// <param name="systemContext">The current system context.</param>
+        /// <param name="objectId">The id of the object used for the method</param>
+        /// <param name="method">The method that triggered the audit event.</param>
+        /// <param name="inputArguments">The input arguments used to call the method that triggered the audit event.</param>
+        public static void ReportCertificateDeliveredAuditEvent(
+            this IAuditEventServer server,
+            ISystemContext systemContext,
+            NodeId objectId,
+            MethodState method,
+            object[] inputArguments)
+        {
+            try
+            {
+                CertificateDeliveredAuditEventState e = new CertificateDeliveredAuditEventState(null);
+
+                TranslationInfo message = new TranslationInfo(
+                       "CertificateUpdateRequestedAuditEvent",
+                       "en-US",
+                       "CertificateUpdateRequestedAuditEvent.");
+
+                e.Initialize(
+                   systemContext,
+                   null,
+                   EventSeverity.Min,
+                   new LocalizedText(message),
+                   true,
+                   DateTime.UtcNow);  // initializes Status, ActionTimeStamp, ServerId, ClientAuditEntryId, ClientUserId
+
+                e.SetChildValue(systemContext, Ua.BrowseNames.SourceNode, objectId, false);
+                e.SetChildValue(systemContext, Ua.BrowseNames.SourceName, "Method/UpdateCertificate", false);
+                e.SetChildValue(systemContext, Ua.BrowseNames.LocalTime, Utils.GetTimeZoneInfo(), false);
+
+                e.SetChildValue(systemContext, Ua.BrowseNames.MethodId, method?.NodeId, false);
+                e.SetChildValue(systemContext, Ua.BrowseNames.InputArguments, inputArguments, false);
+
+                server?.ReportAuditEvent(systemContext, e);
+            }
+            catch (Exception ex)
+            {
+                Utils.LogError(ex, "Error while reporting CertificateDeliveredAuditEventState event.");
+            }
+        }
+
+        /// <summary>
+        /// Raise CertificateDeliveredAudit event
+        /// </summary>
+        /// <param name="server">The server which reports audit events.</param>
+        /// <param name="systemContext">The current system context.</param>
+        /// <param name="objectId">The id of the object used for the method</param>
+        /// <param name="method">The method that triggered the audit event.</param>
+        /// <param name="inputArguments">The input arguments used to call the method that triggered the audit event.</param>
+        /// <param name="certificateGroupId">The id of the certificate group</param>
+        /// <param name="certificateTypeId">the certificate ype id</param>
+        /// <param name="exception">The exception resulted after executing the StartNewKeyPairRequest StartNewSigningRequest method. If null, the operation was successfull.</param>
+        public static void ReportCertificateRequestedAuditEvent(
+            this IAuditEventServer server,
+            ISystemContext systemContext,
+            NodeId objectId,
+            MethodState method,
+            object[] inputArguments,
+            NodeId certificateGroupId,
+            NodeId certificateTypeId,
+            Exception exception = null)
+        {
+            try
+            {
+                CertificateRequestedAuditEventState e = new CertificateRequestedAuditEventState(null);
+
+                TranslationInfo message = null;
+                if (exception == null)
+                {
+                    message = new TranslationInfo(
+                       "CertificateRequestedAuditEvent",
+                       "en-US",
+                       "CertificateRequestedAuditEvent.");
+                }
+                else
+                {
+                    message = new TranslationInfo(
+                      "CertificateRequestedAuditEvent",
+                      "en-US",
+                      $"CertificateRequestedAuditEvent - Exception: {exception.Message}.");
+                }
+
+                e.Initialize(
+                  systemContext,
+                  null,
+                  EventSeverity.Min,
+                  new LocalizedText(message),
+                  exception == null,
+                  DateTime.UtcNow);  // initializes Status, ActionTimeStamp, ServerId, ClientAuditEntryId, ClientUserId
+
+                e.SetChildValue(systemContext, Ua.BrowseNames.SourceNode, objectId, false);
+                e.SetChildValue(systemContext, Ua.BrowseNames.SourceName, "Method/UpdateCertificate", false);
+                e.SetChildValue(systemContext, Ua.BrowseNames.LocalTime, Utils.GetTimeZoneInfo(), false);
+
+                e.SetChildValue(systemContext, Ua.BrowseNames.MethodId, method?.NodeId, false);
+                e.SetChildValue(systemContext, Ua.BrowseNames.InputArguments, inputArguments, false);
+
+                e.SetChildValue(systemContext, BrowseNames.CertificateGroup, certificateGroupId, false);
+                e.SetChildValue(systemContext, BrowseNames.CertificateType, certificateTypeId, false);
+
+                server?.ReportAuditEvent(systemContext, e);
+            }
+            catch (Exception ex)
+            {
+                Utils.LogError(ex, "Error while reporting CertificateDeliveredAuditEventState event.");
+            }
+        }
+
+        /// <summary>
+        /// Raise ApplicationRegistrationChanged event
+        /// </summary>
+        /// <param name="server">The server which reports audit events.</param>
+        /// <param name="systemContext">The current system context.</param>
+        /// <param name="objectId">The id of the object used for register Application method</param>
+        /// <param name="method">The method that triggered the audit event.</param>
+        /// <param name="inputArguments">The input arguments used to call the method that triggered the audit event.</param>
+        public static void ReportApplicationRegistrationChangedAuditEvent(
+            this IAuditEventServer server,
+            ISystemContext systemContext,
+            NodeId objectId,
+            MethodState method,
+            object[] inputArguments)
+        {
+            try
+            {
+                ApplicationRegistrationChangedAuditEventState e = new ApplicationRegistrationChangedAuditEventState(null);
+
+                var message = new TranslationInfo(
+                       "ApplicationRegistrationChangedAuditEvent",
+                       "en-US",
+                       "ApplicationRegistrationChangedAuditEvent.");
+
+                e.Initialize(
+                   systemContext,
+                   null,
+                   EventSeverity.Min,
+                   new LocalizedText(message),
+                   true,
+                   DateTime.UtcNow);  // initializes Status, ActionTimeStamp, ServerId, ClientAuditEntryId, ClientUserId
+
+                e.SetChildValue(systemContext, Ua.BrowseNames.SourceNode, objectId, false);
+                e.SetChildValue(systemContext, Ua.BrowseNames.SourceName, "Method/UpdateCertificate", false);
+                e.SetChildValue(systemContext, Ua.BrowseNames.LocalTime, Utils.GetTimeZoneInfo(), false);
+
+                e.SetChildValue(systemContext, Ua.BrowseNames.MethodId, method?.NodeId, false);
+                e.SetChildValue(systemContext, Ua.BrowseNames.InputArguments, inputArguments, false);
+
+                server?.ReportAuditEvent(systemContext, e);
+            }
+            catch (Exception ex)
+            {
+                Utils.LogError(ex, "Error while reporting CertificateDeliveredAuditEventState event.");
+            }
+        }
+    }
+}

--- a/Libraries/Opc.Ua.Gds.Server.Common/Diagnostics/AuditEvents.cs
+++ b/Libraries/Opc.Ua.Gds.Server.Common/Diagnostics/AuditEvents.cs
@@ -1,8 +1,33 @@
+/* ========================================================================
+ * Copyright (c) 2005-2024 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ * 
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ * 
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Opc.Ua.Server;
 
 namespace Opc.Ua.Gds.Server.Diagnostics

--- a/Libraries/Opc.Ua.Server/Configuration/ConfigurationNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/Configuration/ConfigurationNodeManager.cs
@@ -350,6 +350,7 @@ namespace Opc.Ua.Server
             object[] inputArguments = new object[] { certificateGroupId, certificateTypeId, certificate, issuerCertificates, privateKeyFormat, privateKey };
             X509Certificate2 newCert = null;
 
+            Server.ReportCertificateUpdateRequestedAuditEvent(context, objectId, method, inputArguments);
             try
             {
                 if (certificate == null)

--- a/Libraries/Opc.Ua.Server/Configuration/TrustList.cs
+++ b/Libraries/Opc.Ua.Server/Configuration/TrustList.cs
@@ -302,6 +302,8 @@ namespace Opc.Ua.Server
             uint fileHandle,
             ref bool restartRequired)
         {
+            object[] inputParameters = new object[] { fileHandle };
+            m_node.ReportTrustListUpdateRequestedAuditEvent(context, objectId, "Method/CloseAndUpdate", method.NodeId, inputParameters);
             HasSecureWriteAccess(context);
 
             ServiceResult result = StatusCodes.Good;
@@ -416,7 +418,6 @@ namespace Opc.Ua.Server
             restartRequired = false;
 
             // report the TrustListUpdatedAuditEvent
-            object[] inputParameters = new object[] { fileHandle };
             m_node.ReportTrustListUpdatedAuditEvent(context, objectId, "Method/CloseAndUpdate", method.NodeId, inputParameters, result.StatusCode);
 
             return result;
@@ -429,6 +430,8 @@ namespace Opc.Ua.Server
             byte[] certificate,
             bool isTrustedCertificate)
         {
+            object[] inputParameters = new object[] { certificate, isTrustedCertificate };
+            m_node.ReportTrustListUpdateRequestedAuditEvent(context, objectId, "Method/AddCertificate", method.NodeId, inputParameters);
             HasSecureWriteAccess(context);
 
             ServiceResult result = StatusCodes.Good;
@@ -471,7 +474,6 @@ namespace Opc.Ua.Server
             }
 
             // report the TrustListUpdatedAuditEvent
-            object[] inputParameters = new object[] { certificate, isTrustedCertificate };
             m_node.ReportTrustListUpdatedAuditEvent(context, objectId, "Method/AddCertificate", method.NodeId, inputParameters, result.StatusCode);
 
             return result;
@@ -485,6 +487,9 @@ namespace Opc.Ua.Server
             string thumbprint,
             bool isTrustedCertificate)
         {
+            object[] inputParameters = new object[] { thumbprint };
+            m_node.ReportTrustListUpdateRequestedAuditEvent(context, objectId, "Method/RemoveCertificate", method.NodeId, inputParameters);
+
             HasSecureWriteAccess(context);
             ServiceResult result = StatusCodes.Good;
             lock (m_lock)
@@ -548,7 +553,6 @@ namespace Opc.Ua.Server
             }
 
             // report the TrustListUpdatedAuditEvent
-            object[] inputParameters = new object[] { thumbprint };
             m_node.ReportTrustListUpdatedAuditEvent(context, objectId, "Method/RemoveCertificate", method.NodeId, inputParameters, result.StatusCode);
 
             return result;

--- a/Libraries/Opc.Ua.Server/Diagnostics/AuditEvents.cs
+++ b/Libraries/Opc.Ua.Server/Diagnostics/AuditEvents.cs
@@ -1010,7 +1010,7 @@ namespace Opc.Ua.Server
         /// </summary>
         /// <param name="server">The server which reports audit events.</param>
         /// <param name="systemContext">The current system context.</param>
-        /// <param name="objectId">The id of the object ued for update certificate method</param>
+        /// <param name="objectId">The id of the object used for update certificate method</param>
         /// <param name="method">The method that triggered the audit event.</param>
         /// <param name="inputArguments">The input arguments used to call the method that triggered the audit event.</param>
         /// <param name="certificateGroupId">The id of the certificate group</param>
@@ -1077,54 +1077,43 @@ namespace Opc.Ua.Server
         /// </summary>
         /// <param name="server">The server which reports audit events.</param>
         /// <param name="systemContext">The current system context.</param>
-        /// <param name="objectId">The id of the object ued for update certificate method</param>
+        /// <param name="objectId">The id of the object used for update certificate method</param>
         /// <param name="method">The method that triggered the audit event.</param>
         /// <param name="inputArguments">The input arguments used to call the method that triggered the audit event.</param>
-        /// <param name="exception">The exception resulted after executing the UpdateCertificate method. If null, the operation was successfull.</param>
         public static void ReportCertificateUpdateRequestedAuditEvent(
             this IAuditEventServer server,
             ISystemContext systemContext,
             NodeId objectId,
             MethodState method,
-            object[] inputArguments,
-            Exception exception = null)
+            object[] inputArguments)
         {
             try
             {
                 CertificateUpdateRequestedAuditEventState e = new CertificateUpdateRequestedAuditEventState(null);
 
-                TranslationInfo message = null;
-                if (exception == null)
-                {
-                    message = new TranslationInfo(
+                TranslationInfo message = new TranslationInfo(
                        "CertificateUpdateRequestedAuditEvent",
                        "en-US",
                        "CertificateUpdateRequestedAuditEvent.");
-                }
-                else
-                {
-                    message = new TranslationInfo(
-                      "CertificateUpdateRequestedAuditEvent",
-                      "en-US",
-                      $"CertificateUpdateRequestedAuditEvent - Exception: {exception.Message}.");
-                }
+                
+                
 
                 e.Initialize(
                    systemContext,
                    null,
                    EventSeverity.Min,
                    new LocalizedText(message),
-                   exception == null,
+                   true,
                    DateTime.UtcNow);  // initializes Status, ActionTimeStamp, ServerId, ClientAuditEntryId, ClientUserId
 
                 e.SetChildValue(systemContext, BrowseNames.SourceNode, objectId, false);
                 e.SetChildValue(systemContext, BrowseNames.SourceName, "Method/UpdateCertificate", false);
                 e.SetChildValue(systemContext, BrowseNames.LocalTime, Utils.GetTimeZoneInfo(), false);
 
-                e.SetChildValue(systemContext, BrowseNames.MethodId, method.NodeId, false);
+                e.SetChildValue(systemContext, BrowseNames.MethodId, method?.NodeId, false);
                 e.SetChildValue(systemContext, BrowseNames.InputArguments, inputArguments, false);
 
-                server.ReportAuditEvent(systemContext, e);
+                server?.ReportAuditEvent(systemContext, e);
             }
             catch (Exception ex)
             {

--- a/Libraries/Opc.Ua.Server/Diagnostics/AuditEvents.cs
+++ b/Libraries/Opc.Ua.Server/Diagnostics/AuditEvents.cs
@@ -1073,6 +1073,66 @@ namespace Opc.Ua.Server
         }
 
         /// <summary>
+        /// Raise CertificateUpdateRequestedAudit event
+        /// </summary>
+        /// <param name="server">The server which reports audit events.</param>
+        /// <param name="systemContext">The current system context.</param>
+        /// <param name="objectId">The id of the object ued for update certificate method</param>
+        /// <param name="method">The method that triggered the audit event.</param>
+        /// <param name="inputArguments">The input arguments used to call the method that triggered the audit event.</param>
+        /// <param name="exception">The exception resulted after executing the UpdateCertificate method. If null, the operation was successfull.</param>
+        public static void ReportCertificateUpdateRequestedAuditEvent(
+            this IAuditEventServer server,
+            ISystemContext systemContext,
+            NodeId objectId,
+            MethodState method,
+            object[] inputArguments,
+            Exception exception = null)
+        {
+            try
+            {
+                CertificateUpdateRequestedAuditEventState e = new CertificateUpdateRequestedAuditEventState(null);
+
+                TranslationInfo message = null;
+                if (exception == null)
+                {
+                    message = new TranslationInfo(
+                       "CertificateUpdateRequestedAuditEvent",
+                       "en-US",
+                       "CertificateUpdateRequestedAuditEvent.");
+                }
+                else
+                {
+                    message = new TranslationInfo(
+                      "CertificateUpdateRequestedAuditEvent",
+                      "en-US",
+                      $"CertificateUpdateRequestedAuditEvent - Exception: {exception.Message}.");
+                }
+
+                e.Initialize(
+                   systemContext,
+                   null,
+                   EventSeverity.Min,
+                   new LocalizedText(message),
+                   exception == null,
+                   DateTime.UtcNow);  // initializes Status, ActionTimeStamp, ServerId, ClientAuditEntryId, ClientUserId
+
+                e.SetChildValue(systemContext, BrowseNames.SourceNode, objectId, false);
+                e.SetChildValue(systemContext, BrowseNames.SourceName, "Method/UpdateCertificate", false);
+                e.SetChildValue(systemContext, BrowseNames.LocalTime, Utils.GetTimeZoneInfo(), false);
+
+                e.SetChildValue(systemContext, BrowseNames.MethodId, method.NodeId, false);
+                e.SetChildValue(systemContext, BrowseNames.InputArguments, inputArguments, false);
+
+                server.ReportAuditEvent(systemContext, e);
+            }
+            catch (Exception ex)
+            {
+                Utils.LogError(ex, "Error while reporting CertificateUpdateRequestedAuditEvent event.");
+            }
+        }
+
+        /// <summary>
         /// Report the AuditAddNodesEvent
         /// </summary>
         /// <param name="server">The server which reports audit events.</param>
@@ -1468,6 +1528,55 @@ namespace Opc.Ua.Server
             catch (Exception ex)
             {
                 Utils.LogError(ex, "Error while reporting ReportTrustListUpdatedAuditEvent event.");
+            }
+        }
+
+        /// <summary>
+        /// Reports an TrustListUpdatedAudit event.
+        /// </summary>
+        /// <param name="node">The trustlist node.</param>
+        /// <param name="systemContext">The current system context</param>
+        /// <param name="objectId">The object id where the truest list update methods was called</param>
+        /// <param name="sourceName">The source name string</param>
+        /// <param name="methodId">The id of the method that was called</param>
+        /// <param name="inputParameters">The input parameters of the called method</param>
+        public static void ReportTrustListUpdateRequestedAuditEvent(
+            this TrustListState node,
+            ISystemContext systemContext,
+            NodeId objectId,
+            string sourceName,
+            NodeId methodId,
+            object[] inputParameters)
+        {
+            try
+            {
+                TrustListUpdateRequestedAuditEventState e = new TrustListUpdateRequestedAuditEventState(null);
+
+                TranslationInfo message = new TranslationInfo(
+                   "TrustListUpdateRequestedAuditEvent",
+                   "en-US",
+                   $"TrustListUpdateRequestedAuditEvent.");
+
+                e.Initialize(
+                   systemContext,
+                   null,
+                   EventSeverity.Min,
+                   new LocalizedText(message),
+                   true,
+                   DateTime.UtcNow);  // initializes Status, ActionTimeStamp, ServerId, ClientAuditEntryId, ClientUserId
+
+                e.SetChildValue(systemContext, BrowseNames.SourceNode, objectId, false);
+                e.SetChildValue(systemContext, BrowseNames.SourceName, sourceName, false);
+                e.SetChildValue(systemContext, BrowseNames.LocalTime, Utils.GetTimeZoneInfo(), false);
+
+                e.SetChildValue(systemContext, BrowseNames.MethodId, methodId, false);
+                e.SetChildValue(systemContext, BrowseNames.InputArguments, inputParameters, false);
+
+                node?.ReportEvent(systemContext, e);
+            }
+            catch (Exception ex)
+            {
+                Utils.LogError(ex, "Error while reporting TrustListUpdateRequestedAuditEvent event.");
             }
         }
         #endregion Report Audit Events


### PR DESCRIPTION
## Proposed changes

Make the GDS an Auditing Server by adding all needed Audit Events to the GDS:

ApplicationRegistrationChangedAuditEventType
https://reference.opcfoundation.org/GDS/v105/docs/6.6.12

CertificateDeliveredAuditEventType
https://reference.opcfoundation.org/GDS/v105/docs/7.9.13

CertificateRequestedAuditEventType
https://reference.opcfoundation.org/GDS/v105/docs/7.9.12

Add missing evetns to Server ConfigurationNode:

TrustListUpdateRequestedAuditEventType
https://reference.opcfoundation.org/GDS/v105/docs/7.8.2.10

CertificateUpdateRequestedAuditEventType
https://reference.opcfoundation.org/GDS/v105/docs/7.10.13
## Related Issues

- Fixes #2469 

## Types of changes


- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [x] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

