### PR TITLE
Improve ArraySegmentStream with ReadOnlyMemory/Span signatures, avoid extra alloc/copy

### DIFF
--- a/.azurepipelines/test.yml
+++ b/.azurepipelines/test.yml
@@ -26,6 +26,7 @@ jobs:
 - job: testall${{ parameters.jobnamesuffix }}
   displayName: Tests (${{ parameters.framework }})
   dependsOn: testprep${{ parameters.jobnamesuffix }}
+  timeoutInMinutes: 120
   strategy:
     matrix: $[dependencies.testprep${{ parameters.jobnamesuffix }}.outputs['testmatrix.jobMatrix'] ]
   variables:

--- a/.azurepipelines/test.yml
+++ b/.azurepipelines/test.yml
@@ -22,7 +22,7 @@ jobs:
     inputs:
       targetType: filePath
       filePath: ./.azurepipelines/get-matrix.ps1
-      arguments: -FileName azure-pipelines.yml -AgentTable ${{ parameters.agents }}
+      arguments: -FileName *.Tests.csproj -AgentTable ${{ parameters.agents }}
 - job: testall${{ parameters.jobnamesuffix }}
   displayName: Tests (${{ parameters.framework }})
   dependsOn: testprep${{ parameters.jobnamesuffix }}
@@ -63,12 +63,12 @@ jobs:
     displayName: Restore ${{ parameters.configuration }}
     inputs:
       command: restore
-      projects: '**/*.Tests.csproj'
+      projects: $(file)
       arguments: '${{ variables.DotCliCommandline }} --configuration ${{ parameters.configuration }}'
   - task: DotNetCoreCLI@2
     displayName: Test ${{ parameters.configuration }}
-    timeoutInMinutes: 60
+    timeoutInMinutes: 30
     inputs:
       command: test
-      projects: '**/*.Tests.csproj'
+      projects: $(file)
       arguments: '--no-restore ${{ variables.DotCliCommandline }} --configuration ${{ parameters.configuration }}'

--- a/.editorconfig
+++ b/.editorconfig
@@ -336,6 +336,12 @@ dotnet_diagnostic.IDE1005.severity                                            = 
 # CA1305: Specify IFormatProvider
 dotnet_diagnostic.CA1305.severity                                             = warning
 
+# CA1819: Properties should not return arrays
+dotnet_diagnostic.CA1819.severity                                             = silent
+
+# CA1721: The property name is confusing given the existence of another method with the same name.
+dotnet_diagnostic.CA1721.severity                                             = silent
+
 # exclude generated code
 [**/Generated/*.cs]
 generated_code = true

--- a/Stack/Opc.Ua.Core/Stack/Bindings/ArraySegmentStream.cs
+++ b/Stack/Opc.Ua.Core/Stack/Bindings/ArraySegmentStream.cs
@@ -321,15 +321,7 @@ namespace Opc.Ua.Bindings
 #else
                     m_currentBuffer.Array[m_currentBuffer.Offset + m_currentPosition] = value;
 #endif
-                    m_currentPosition++;
-
-                    if (m_bufferIndex == m_buffers.Count - 1)
-                    {
-                        if (m_endOfLastBuffer < m_currentPosition)
-                        {
-                            m_endOfLastBuffer = m_currentPosition;
-                        }
-                    }
+                    UpdateCurrentPosition(1);
 
                     return;
                 }
@@ -358,15 +350,7 @@ namespace Opc.Ua.Bindings
                 {
                     buffer.Slice(offset, count).CopyTo(m_currentBuffer.AsSpan(m_currentPosition));
 
-                    m_currentPosition += count;
-
-                    if (m_bufferIndex == m_buffers.Count - 1)
-                    {
-                        if (m_endOfLastBuffer < m_currentPosition)
-                        {
-                            m_endOfLastBuffer = m_currentPosition;
-                        }
-                    }
+                    UpdateCurrentPosition(count);
 
                     return;
                 }
@@ -398,15 +382,7 @@ namespace Opc.Ua.Bindings
                 {
                     Array.Copy(buffer, offset, m_currentBuffer.Array, m_currentPosition + m_currentBuffer.Offset, count);
 
-                    m_currentPosition += count;
-
-                    if (m_bufferIndex == m_buffers.Count - 1)
-                    {
-                        if (m_endOfLastBuffer < m_currentPosition)
-                        {
-                            m_endOfLastBuffer = m_currentPosition;
-                        }
-                    }
+                    UpdateCurrentPosition(count);
 
                     return;
                 }
@@ -450,6 +426,23 @@ namespace Opc.Ua.Bindings
         #endregion
 
         #region Private Methods
+        /// <summary>
+        /// Update the current buffer count.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void UpdateCurrentPosition(int count)
+        {
+            m_currentPosition += count;
+
+            if (m_bufferIndex == m_buffers.Count - 1)
+            {
+                if (m_endOfLastBuffer < m_currentPosition)
+                {
+                    m_endOfLastBuffer = m_currentPosition;
+                }
+            }
+        }
+
         /// <summary>
         /// Sets the current buffer.
         /// </summary>

--- a/Stack/Opc.Ua.Core/Stack/Bindings/ArraySegmentStream.cs
+++ b/Stack/Opc.Ua.Core/Stack/Bindings/ArraySegmentStream.cs
@@ -74,7 +74,7 @@ namespace Opc.Ua.Bindings
         /// </summary>
         /// <param name="bufferManager">The buffer manager.</param>
         public ArraySegmentStream(BufferManager bufferManager)
-            : this(bufferManager, bufferManager.MaxBufferSize, 0, bufferManager.MaxBufferSize)
+            : this(bufferManager, bufferManager.MaxSuggestedBufferSize, 0, bufferManager.MaxSuggestedBufferSize)
         {
         }
         #endregion

--- a/Stack/Opc.Ua.Core/Stack/Bindings/ArraySegmentStream.cs
+++ b/Stack/Opc.Ua.Core/Stack/Bindings/ArraySegmentStream.cs
@@ -85,16 +85,12 @@ namespace Opc.Ua.Bindings
         {
             if (disposing)
             {
-                if (m_buffers != null)
+                if (m_buffers != null && m_bufferManager != null)
                 {
-                    if (m_bufferManager != null)
+                    for (int ii = 0; ii < m_buffers.Count; ii++)
                     {
-                        for (int ii = 0; ii < m_buffers.Count; ii++)
-                        {
-                            m_bufferManager.ReturnBuffer(m_buffers[ii].Array, "ArraySegmentStream.Dispose");
-                        }
+                        m_bufferManager.ReturnBuffer(m_buffers[ii].Array, "ArraySegmentStream.Dispose");
                     }
-
                     m_buffers.Clear();
                     m_buffers = null;
                 }

--- a/Stack/Opc.Ua.Core/Stack/Bindings/ArraySegmentStream.cs
+++ b/Stack/Opc.Ua.Core/Stack/Bindings/ArraySegmentStream.cs
@@ -69,6 +69,26 @@ namespace Opc.Ua.Bindings
         }
         #endregion
 
+        #region IDisposable
+        /// <inheritdoc/>
+        protected override void Dispose(bool disposing)
+        {
+            if (m_bufferManager != null)
+            {
+                for (int ii = 0; ii < m_buffers.Count; ii++)
+                {
+                    m_bufferManager.ReturnBuffer(m_buffers[ii].Array, "ArraySegmentStream.Dispose");
+                }
+            }
+
+            m_buffers.Clear();
+            m_buffers = null;
+            m_bufferManager = null;
+
+            base.Dispose(disposing);
+        }
+        #endregion
+
         #region Public Methods
         /// <summary>
         /// Returns ownership of the buffers stored in the stream.
@@ -166,6 +186,11 @@ namespace Opc.Ua.Bindings
         }
 
 #if STREAM_WITH_SPAN_SUPPORT
+        /// <summary>
+        /// Helper to benchmark the performance of the stream.
+        /// </summary>
+        internal int ReadMemoryStream(Span<byte> buffer) => base.Read(buffer);
+
         /// <inheritdoc/>
         public override int Read(Span<byte> buffer)
         {
@@ -333,6 +358,11 @@ namespace Opc.Ua.Bindings
         }
 
 #if STREAM_WITH_SPAN_SUPPORT
+        /// <summary>
+        /// Helper to benchmark the performance of the stream.
+        /// </summary>
+        internal void WriteMemoryStream(ReadOnlySpan<byte> buffer) => base.Write(buffer);
+
         /// <inheritdoc/>
         public override void Write(ReadOnlySpan<byte> buffer)
         {

--- a/Stack/Opc.Ua.Core/Stack/Bindings/BufferManager.cs
+++ b/Stack/Opc.Ua.Core/Stack/Bindings/BufferManager.cs
@@ -340,7 +340,7 @@ namespace Opc.Ua.Bindings
         /// <summary>
         /// Returns the max size of data in the buffers.
         /// </summary>
-        public int MaxBufferSize => m_maxBufferSize;
+        public int MaxBufferSize => m_maxBufferSize - kCookieLength;
         #endregion
 
         #region Private Fields

--- a/Stack/Opc.Ua.Core/Stack/Bindings/BufferManager.cs
+++ b/Stack/Opc.Ua.Core/Stack/Bindings/BufferManager.cs
@@ -353,7 +353,7 @@ namespace Opc.Ua.Bindings
         private const byte kCookieLocked = 0xa5;
         private const byte kCookieUnlocked = 0x5a;
 #if TRACK_MEMORY
-        const byte kCookieLength = 5;
+        private const byte kCookieLength = 5;
         class Allocation
         {
             public int Id;

--- a/Stack/Opc.Ua.Core/Stack/Bindings/BufferManager.cs
+++ b/Stack/Opc.Ua.Core/Stack/Bindings/BufferManager.cs
@@ -336,6 +336,11 @@ namespace Opc.Ua.Bindings
 #endif
             m_arrayPool.Return(buffer);
         }
+
+        /// <summary>
+        /// Returns the max size of data in the buffers.
+        /// </summary>
+        public int MaxBufferSize => m_maxBufferSize;
         #endregion
 
         #region Private Fields

--- a/Stack/Opc.Ua.Core/Stack/Bindings/BufferSegment.cs
+++ b/Stack/Opc.Ua.Core/Stack/Bindings/BufferSegment.cs
@@ -35,7 +35,7 @@ namespace Opc.Ua.Bindings
     /// <summary>
     /// Helper to build a ReadOnlySequence from a set of buffers.
     /// </summary>
-    public class BufferSegment : ReadOnlySequenceSegment<byte>
+    public sealed class BufferSegment : ReadOnlySequenceSegment<byte>
     {
         /// <summary>
         /// Returns the base array of the buffer.

--- a/Stack/Opc.Ua.Core/Stack/Bindings/BufferSegment.cs
+++ b/Stack/Opc.Ua.Core/Stack/Bindings/BufferSegment.cs
@@ -1,0 +1,70 @@
+/* ========================================================================
+ * Copyright (c) 2005-2024 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using System.Buffers;
+
+namespace Opc.Ua.Bindings
+{
+    /// <summary>
+    /// Helper to build a ReadOnlySequence from a set of buffers.
+    /// </summary>
+    public class BufferSegment : ReadOnlySequenceSegment<byte>
+    {
+        /// <summary>
+        /// Returns the base array of the buffer.
+        /// </summary>
+        public byte[] Array() => m_array;
+
+        /// <summary>
+        /// Constructor for a buffer segment.
+        /// </summary>
+        public BufferSegment(byte[] array, int offset, int length)
+        {
+            Memory = new ReadOnlyMemory<byte>(array, offset, length);
+            m_array = array;
+        }
+
+        /// <summary>
+        /// Appends a buffer to the sequence.
+        /// </summary>
+        public BufferSegment Append(byte[] array, int offset, int length)
+        {
+            var segment = new BufferSegment(array, offset, length) {
+                RunningIndex = RunningIndex + Memory.Length
+            };
+            Next = segment;
+            return segment;
+        }
+
+        #region Private Fields
+        private byte[] m_array;
+        #endregion
+    }
+}

--- a/Stack/Opc.Ua.Core/Stack/Bindings/BufferSequence.cs
+++ b/Stack/Opc.Ua.Core/Stack/Bindings/BufferSequence.cs
@@ -35,7 +35,7 @@ namespace Opc.Ua.Bindings
     /// <summary>
     /// A class to hold a sequence of buffers until disposed.
     /// </summary>
-    public class BufferSequence : IDisposable
+    public sealed class BufferSequence : IDisposable
     {
         /// <summary>
         /// The constructor to create the sequence of buffers.

--- a/Stack/Opc.Ua.Core/Stack/Bindings/BufferSequence.cs
+++ b/Stack/Opc.Ua.Core/Stack/Bindings/BufferSequence.cs
@@ -1,0 +1,77 @@
+/* ========================================================================
+ * Copyright (c) 2005-2024 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using System.Buffers;
+
+namespace Opc.Ua.Bindings
+{
+    /// <summary>
+    /// A class to hold a sequence of buffers until disposed.
+    /// </summary>
+    public class BufferSequence : IDisposable
+    {
+        /// <summary>
+        /// The constructor to create the sequence of buffers.
+        /// </summary>
+        public BufferSequence(BufferManager bufferManager, string owner, BufferSegment firstSegment, ReadOnlySequence<byte> sequence)
+        {
+            m_bufferManager = bufferManager;
+            m_owner = owner;
+            m_firstSegment = firstSegment;
+            m_sequence = sequence;
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            BufferSegment segment = m_firstSegment;
+            while (segment != null)
+            {
+                m_bufferManager.ReturnBuffer(segment.Array(), m_owner);
+                segment = (BufferSegment)segment.Next;
+            }
+            m_sequence = ReadOnlySequence<byte>.Empty;
+            m_firstSegment = null;
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Returns a sequence which can be used to access the buffers.
+        /// </summary>
+        public ReadOnlySequence<byte> Sequence => m_sequence;
+
+        #region Private 
+        private BufferManager m_bufferManager;
+        private BufferSegment m_firstSegment;
+        private ReadOnlySequence<byte> m_sequence;
+        private string m_owner;
+        #endregion
+    }
+}

--- a/Stack/Opc.Ua.Core/Types/Encoders/JsonEncoder.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/JsonEncoder.cs
@@ -283,39 +283,31 @@ namespace Opc.Ua
         /// </summary>
         public string CloseAndReturnText()
         {
-            Close();
-            if (m_memoryStream == null)
+            try
             {
-                if (m_stream is MemoryStream memoryStream)
+                InternalClose(false);
+                if (m_memoryStream == null)
                 {
-                    return Encoding.UTF8.GetString(memoryStream.ToArray());
+                    if (m_stream is MemoryStream memoryStream)
+                    {
+                        return Encoding.UTF8.GetString(memoryStream.ToArray());
+                    }
+                    throw new NotSupportedException("Cannot get text from external stream. Use Close or MemoryStream instead.");
                 }
-                throw new NotSupportedException("Cannot get text from external stream. Use Close or MemoryStream instead.");
+                return Encoding.UTF8.GetString(m_memoryStream.ToArray());
             }
-            return Encoding.UTF8.GetString(m_memoryStream.ToArray());
+            finally
+            {
+                m_writer.Dispose();
+                m_writer = null;
+            }
         }
 
         /// <summary>
         /// Completes writing and returns the text length.
+        /// The StreamWriter is disposed.
         /// </summary>
-        public int Close()
-        {
-            if (!m_dontWriteClosing)
-            {
-                if (m_topLevelIsArray)
-                {
-                    m_writer.Write(s_rightSquareBracket);
-                }
-                else
-                {
-                    m_writer.Write(s_rightCurlyBrace);
-                }
-            }
-
-            m_writer.Flush();
-            int length = (int)m_writer.BaseStream.Position;
-            return length;
-        }
+        public int Close() => InternalClose(true);
         #endregion
 
         #region IDisposable Members
@@ -337,8 +329,7 @@ namespace Opc.Ua
             {
                 if (m_writer != null)
                 {
-                    Close();
-                    Utils.SilentDispose(m_writer);
+                    InternalClose(true);
                     m_writer = null;
                 }
 
@@ -2579,6 +2570,33 @@ namespace Opc.Ua
         #endregion
 
         #region Private Methods
+        /// <summary>
+        /// Completes writing and returns the text length.
+        /// </summary>
+        private int InternalClose(bool dispose)
+        {
+            if (!m_dontWriteClosing)
+            {
+                if (m_topLevelIsArray)
+                {
+                    m_writer.Write(s_rightSquareBracket);
+                }
+                else
+                {
+                    m_writer.Write(s_rightCurlyBrace);
+                }
+            }
+
+            m_writer.Flush();
+            int length = (int)m_writer.BaseStream.Position;
+            if (dispose)
+            {
+                m_writer.Dispose();
+                m_writer = null;
+            }
+            return length;
+        }
+
         /// <summary>
         /// Writes a DiagnosticInfo to the stream.
         /// Ignores InnerDiagnosticInfo field if the nesting level

--- a/Stack/Opc.Ua.Core/Types/Encoders/JsonEncoder.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/JsonEncoder.cs
@@ -298,7 +298,7 @@ namespace Opc.Ua
             }
             finally
             {
-                m_writer.Dispose();
+                m_writer?.Dispose();
                 m_writer = null;
             }
         }

--- a/Stack/Opc.Ua.Core/Types/Encoders/JsonEncoder.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/JsonEncoder.cs
@@ -314,8 +314,6 @@ namespace Opc.Ua
 
             m_writer.Flush();
             int length = (int)m_writer.BaseStream.Position;
-            m_writer.Dispose();
-            m_writer = null;
             return length;
         }
         #endregion
@@ -340,6 +338,7 @@ namespace Opc.Ua
                 if (m_writer != null)
                 {
                     Close();
+                    Utils.SilentDispose(m_writer);
                     m_writer = null;
                 }
 

--- a/Tests/Opc.Ua.Client.ComplexTypes.Tests/Types/ComplexTypesCommon.cs
+++ b/Tests/Opc.Ua.Client.ComplexTypes.Tests/Types/ComplexTypesCommon.cs
@@ -276,6 +276,7 @@ namespace Opc.Ua.Client.ComplexTypes.Tests.Types
         /// </summary>
         protected void EncodeDecodeComplexType(
             IServiceMessageContext encoderContext,
+            MemoryStreamType memoryStreamType,
             EncodingType encoderType,
             StructureType structureType,
             ExpandedNodeId nodeId,
@@ -291,7 +292,7 @@ namespace Opc.Ua.Client.ComplexTypes.Tests.Types
             TestContext.Out.WriteLine(expected);
 
             byte[] buffer;
-            using (var encoderStream = new MemoryStream())
+            using (var encoderStream = CreateEncoderMemoryStream(memoryStreamType))
             {
                 using (IEncoder encoder = CreateEncoder(encoderType, encoderContext, encoderStream, typeof(DataValue)))
                 {

--- a/Tests/Opc.Ua.Client.ComplexTypes.Tests/Types/EncoderTests.cs
+++ b/Tests/Opc.Ua.Client.ComplexTypes.Tests/Types/EncoderTests.cs
@@ -30,6 +30,7 @@
 using System;
 using System.Collections.Generic;
 using NUnit.Framework;
+using Opc.Ua.Core.Tests.Types.Encoders;
 
 namespace Opc.Ua.Client.ComplexTypes.Tests.Types
 {
@@ -86,6 +87,7 @@ namespace Opc.Ua.Client.ComplexTypes.Tests.Types
         [Theory]
         [Category("ComplexTypes")]
         public void ReEncodeComplexType(
+            MemoryStreamType memoryStreamType,
             EncodingType encoderType,
             StructureType structureType
             )
@@ -96,7 +98,7 @@ namespace Opc.Ua.Client.ComplexTypes.Tests.Types
             object emittedType = Activator.CreateInstance(complexType);
             var baseType = emittedType as BaseComplexType;
             FillStructWithValues(baseType, true);
-            EncodeDecodeComplexType(EncoderContext, encoderType, structureType, nodeId, emittedType);
+            EncodeDecodeComplexType(EncoderContext, memoryStreamType, encoderType, structureType, nodeId, emittedType);
         }
 
         /// <summary>
@@ -106,6 +108,7 @@ namespace Opc.Ua.Client.ComplexTypes.Tests.Types
         [Theory]
         [Category("ComplexTypes")]
         public void ReEncodeStructureWithOptionalFieldsComplexType(
+            MemoryStreamType memoryStreamType,
             EncodingType encoderType,
             StructureFieldParameter structureFieldParameter
             )
@@ -118,17 +121,17 @@ namespace Opc.Ua.Client.ComplexTypes.Tests.Types
             var builtInType = structureFieldParameter.BuiltInType;
             TestContext.Out.WriteLine($"Optional Field: {structureFieldParameter.BuiltInType} is the only value.");
             baseType[structureFieldParameter.Name] = DataGenerator.GetRandom(builtInType);
-            EncodeDecodeComplexType(EncoderContext, encoderType, StructureType.StructureWithOptionalFields, nodeId, emittedType);
+            EncodeDecodeComplexType(EncoderContext, memoryStreamType, encoderType, StructureType.StructureWithOptionalFields, nodeId, emittedType);
             TestContext.Out.WriteLine($"Optional Field: {structureFieldParameter.BuiltInType} is null.");
             baseType[structureFieldParameter.Name] = null;
-            EncodeDecodeComplexType(EncoderContext, encoderType, StructureType.StructureWithOptionalFields, nodeId, emittedType);
+            EncodeDecodeComplexType(EncoderContext, memoryStreamType, encoderType, StructureType.StructureWithOptionalFields, nodeId, emittedType);
             TestContext.Out.WriteLine($"Optional Field: {structureFieldParameter.BuiltInType} is null, all other fields have random values.");
             FillStructWithValues(baseType, true);
             baseType[structureFieldParameter.Name] = null;
-            EncodeDecodeComplexType(EncoderContext, encoderType, StructureType.StructureWithOptionalFields, nodeId, emittedType);
+            EncodeDecodeComplexType(EncoderContext, memoryStreamType, encoderType, StructureType.StructureWithOptionalFields, nodeId, emittedType);
             TestContext.Out.WriteLine($"Optional Field: {structureFieldParameter.BuiltInType} has random value.");
             baseType[structureFieldParameter.Name] = DataGenerator.GetRandom(builtInType);
-            EncodeDecodeComplexType(EncoderContext, encoderType, StructureType.StructureWithOptionalFields, nodeId, emittedType);
+            EncodeDecodeComplexType(EncoderContext, memoryStreamType, encoderType, StructureType.StructureWithOptionalFields, nodeId, emittedType);
         }
 
         /// <summary>
@@ -138,6 +141,7 @@ namespace Opc.Ua.Client.ComplexTypes.Tests.Types
         [Theory]
         [Category("ComplexTypes")]
         public void ReEncodeUnionComplexType(
+            MemoryStreamType memoryStreamType,
             EncodingType encoderType,
             StructureFieldParameter structureFieldParameter
             )
@@ -150,10 +154,10 @@ namespace Opc.Ua.Client.ComplexTypes.Tests.Types
             var builtInType = structureFieldParameter.BuiltInType;
             TestContext.Out.WriteLine($"Union Field: {structureFieldParameter.BuiltInType} is random.");
             baseType[structureFieldParameter.Name] = DataGenerator.GetRandom(builtInType);
-            EncodeDecodeComplexType(EncoderContext, encoderType, StructureType.Union, nodeId, emittedType);
+            EncodeDecodeComplexType(EncoderContext, memoryStreamType, encoderType, StructureType.Union, nodeId, emittedType);
             TestContext.Out.WriteLine($"Union Field: {structureFieldParameter.BuiltInType} is null.");
             baseType[structureFieldParameter.Name] = null;
-            EncodeDecodeComplexType(EncoderContext, encoderType, StructureType.Union, nodeId, emittedType);
+            EncodeDecodeComplexType(EncoderContext, memoryStreamType, encoderType, StructureType.Union, nodeId, emittedType);
         }
         #endregion Test Methods
     }

--- a/Tests/Opc.Ua.Client.ComplexTypes.Tests/Types/JsonEncoderTests.cs
+++ b/Tests/Opc.Ua.Client.ComplexTypes.Tests/Types/JsonEncoderTests.cs
@@ -120,7 +120,9 @@ namespace Opc.Ua.Client.ComplexTypes.Tests.Types
         /// </summary>
         [Theory]
         public void JsonEncodeStructureRev(
-            JsonValidationData jsonValidationData)
+            JsonValidationData jsonValidationData,
+            MemoryStreamType memoryStreamType
+            )
         {
             ExpandedNodeId nodeId;
             Type complexType;
@@ -131,6 +133,7 @@ namespace Opc.Ua.Client.ComplexTypes.Tests.Types
             ExtensionObject extensionObject = CreateExtensionObject(StructureType.Structure, nodeId, emittedType);
             EncodeJsonComplexTypeVerifyResult(
                 jsonValidationData.BuiltInType,
+                memoryStreamType,
                 extensionObject,
                 true,
                 jsonValidationData.ExpectedNonReversible ?? jsonValidationData.ExpectedReversible,
@@ -142,7 +145,9 @@ namespace Opc.Ua.Client.ComplexTypes.Tests.Types
         /// </summary>
         [Theory]
         public void JsonEncodeStructureNonRev(
-            JsonValidationData jsonValidationData)
+            JsonValidationData jsonValidationData,
+            MemoryStreamType memoryStreamType
+            )
         {
             ExpandedNodeId nodeId;
             Type complexType;
@@ -153,6 +158,7 @@ namespace Opc.Ua.Client.ComplexTypes.Tests.Types
             ExtensionObject extensionObject = CreateExtensionObject(StructureType.Structure, nodeId, emittedType);
             EncodeJsonComplexTypeVerifyResult(
                 jsonValidationData.BuiltInType,
+                memoryStreamType,
                 extensionObject,
                 false,
                 jsonValidationData.ExpectedNonReversible ?? jsonValidationData.ExpectedReversible,
@@ -165,7 +171,8 @@ namespace Opc.Ua.Client.ComplexTypes.Tests.Types
         /// </summary>
         [Theory]
         public void JsonEncodeOptionalFieldsRev(
-            JsonValidationData jsonValidationData)
+            JsonValidationData jsonValidationData,
+            MemoryStreamType memoryStreamType)
         {
             ExpandedNodeId nodeId;
             Type complexType;
@@ -176,6 +183,7 @@ namespace Opc.Ua.Client.ComplexTypes.Tests.Types
             ExtensionObject extensionObject = CreateExtensionObject(StructureType.StructureWithOptionalFields, nodeId, emittedType);
             EncodeJsonComplexTypeVerifyResult(
                 jsonValidationData.BuiltInType,
+                memoryStreamType,
                 extensionObject,
                 true,
                 jsonValidationData.ExpectedNonReversible ?? jsonValidationData.ExpectedReversible,
@@ -188,7 +196,8 @@ namespace Opc.Ua.Client.ComplexTypes.Tests.Types
         /// </summary>
         [Theory]
         public void JsonEncodeOptionalFieldsNonRev(
-            JsonValidationData jsonValidationData)
+            JsonValidationData jsonValidationData,
+            MemoryStreamType memoryStreamType)
         {
             ExpandedNodeId nodeId;
             Type complexType;
@@ -199,6 +208,7 @@ namespace Opc.Ua.Client.ComplexTypes.Tests.Types
             ExtensionObject extensionObject = CreateExtensionObject(StructureType.StructureWithOptionalFields, nodeId, emittedType);
             EncodeJsonComplexTypeVerifyResult(
                 jsonValidationData.BuiltInType,
+                memoryStreamType,
                 extensionObject,
                 false,
                 jsonValidationData.ExpectedNonReversible ?? jsonValidationData.ExpectedReversible,
@@ -210,7 +220,8 @@ namespace Opc.Ua.Client.ComplexTypes.Tests.Types
         /// </summary>
         [Theory]
         public void JsonEncodeUnionRev(
-            JsonValidationData jsonValidationData)
+            JsonValidationData jsonValidationData,
+            MemoryStreamType memoryStreamType)
         {
             ExpandedNodeId nodeId;
             Type complexType;
@@ -221,6 +232,7 @@ namespace Opc.Ua.Client.ComplexTypes.Tests.Types
             ExtensionObject extensionObject = CreateExtensionObject(StructureType.Union, nodeId, emittedType);
             EncodeJsonComplexTypeVerifyResult(
                 jsonValidationData.BuiltInType,
+                memoryStreamType,
                 extensionObject,
                 true,
                 jsonValidationData.ExpectedNonReversible ?? jsonValidationData.ExpectedReversible,
@@ -232,7 +244,8 @@ namespace Opc.Ua.Client.ComplexTypes.Tests.Types
         /// </summary>
         [Theory]
         public void JsonEncodeUnionNonRev(
-            JsonValidationData jsonValidationData)
+            JsonValidationData jsonValidationData,
+            MemoryStreamType memoryStreamType)
         {
             ExpandedNodeId nodeId;
             Type complexType;
@@ -243,6 +256,7 @@ namespace Opc.Ua.Client.ComplexTypes.Tests.Types
             ExtensionObject extensionObject = CreateExtensionObject(StructureType.Union, nodeId, emittedType);
             EncodeJsonComplexTypeVerifyResult(
                 jsonValidationData.BuiltInType,
+                memoryStreamType,
                 extensionObject,
                 false,
                 jsonValidationData.ExpectedNonReversible ?? jsonValidationData.ExpectedReversible,
@@ -253,6 +267,7 @@ namespace Opc.Ua.Client.ComplexTypes.Tests.Types
         #region Private Methods
         protected void EncodeJsonComplexTypeVerifyResult(
             BuiltInType builtInType,
+            MemoryStreamType memoryStreamType,
             ExtensionObject data,
             bool useReversibleEncoding,
             string expected,
@@ -269,7 +284,7 @@ namespace Opc.Ua.Client.ComplexTypes.Tests.Types
             _ = PrettifyAndValidateJson(expected);
 
             byte[] buffer;
-            using (var encoderStream = new MemoryStream())
+            using (var encoderStream = CreateEncoderMemoryStream(memoryStreamType))
             {
                 using (IEncoder encoder = CreateEncoder(
                     EncodingType.Json, EncoderContext, encoderStream,

--- a/Tests/Opc.Ua.Client.ComplexTypes.Tests/Types/JsonEncoderTests.cs
+++ b/Tests/Opc.Ua.Client.ComplexTypes.Tests/Types/JsonEncoderTests.cs
@@ -120,8 +120,7 @@ namespace Opc.Ua.Client.ComplexTypes.Tests.Types
         /// </summary>
         [Theory]
         public void JsonEncodeStructureRev(
-            JsonValidationData jsonValidationData,
-            MemoryStreamType memoryStreamType
+            JsonValidationData jsonValidationData
             )
         {
             ExpandedNodeId nodeId;
@@ -133,7 +132,7 @@ namespace Opc.Ua.Client.ComplexTypes.Tests.Types
             ExtensionObject extensionObject = CreateExtensionObject(StructureType.Structure, nodeId, emittedType);
             EncodeJsonComplexTypeVerifyResult(
                 jsonValidationData.BuiltInType,
-                memoryStreamType,
+                MemoryStreamType.MemoryStream,
                 extensionObject,
                 true,
                 jsonValidationData.ExpectedNonReversible ?? jsonValidationData.ExpectedReversible,
@@ -145,8 +144,7 @@ namespace Opc.Ua.Client.ComplexTypes.Tests.Types
         /// </summary>
         [Theory]
         public void JsonEncodeStructureNonRev(
-            JsonValidationData jsonValidationData,
-            MemoryStreamType memoryStreamType
+            JsonValidationData jsonValidationData
             )
         {
             ExpandedNodeId nodeId;
@@ -158,7 +156,7 @@ namespace Opc.Ua.Client.ComplexTypes.Tests.Types
             ExtensionObject extensionObject = CreateExtensionObject(StructureType.Structure, nodeId, emittedType);
             EncodeJsonComplexTypeVerifyResult(
                 jsonValidationData.BuiltInType,
-                memoryStreamType,
+                MemoryStreamType.ArraySegmentStream,
                 extensionObject,
                 false,
                 jsonValidationData.ExpectedNonReversible ?? jsonValidationData.ExpectedReversible,
@@ -171,8 +169,8 @@ namespace Opc.Ua.Client.ComplexTypes.Tests.Types
         /// </summary>
         [Theory]
         public void JsonEncodeOptionalFieldsRev(
-            JsonValidationData jsonValidationData,
-            MemoryStreamType memoryStreamType)
+            JsonValidationData jsonValidationData
+            )
         {
             ExpandedNodeId nodeId;
             Type complexType;
@@ -183,7 +181,7 @@ namespace Opc.Ua.Client.ComplexTypes.Tests.Types
             ExtensionObject extensionObject = CreateExtensionObject(StructureType.StructureWithOptionalFields, nodeId, emittedType);
             EncodeJsonComplexTypeVerifyResult(
                 jsonValidationData.BuiltInType,
-                memoryStreamType,
+                MemoryStreamType.ArraySegmentStream,
                 extensionObject,
                 true,
                 jsonValidationData.ExpectedNonReversible ?? jsonValidationData.ExpectedReversible,
@@ -196,8 +194,7 @@ namespace Opc.Ua.Client.ComplexTypes.Tests.Types
         /// </summary>
         [Theory]
         public void JsonEncodeOptionalFieldsNonRev(
-            JsonValidationData jsonValidationData,
-            MemoryStreamType memoryStreamType)
+            JsonValidationData jsonValidationData)
         {
             ExpandedNodeId nodeId;
             Type complexType;
@@ -208,7 +205,7 @@ namespace Opc.Ua.Client.ComplexTypes.Tests.Types
             ExtensionObject extensionObject = CreateExtensionObject(StructureType.StructureWithOptionalFields, nodeId, emittedType);
             EncodeJsonComplexTypeVerifyResult(
                 jsonValidationData.BuiltInType,
-                memoryStreamType,
+                MemoryStreamType.RecyclableMemoryStream,
                 extensionObject,
                 false,
                 jsonValidationData.ExpectedNonReversible ?? jsonValidationData.ExpectedReversible,
@@ -220,8 +217,8 @@ namespace Opc.Ua.Client.ComplexTypes.Tests.Types
         /// </summary>
         [Theory]
         public void JsonEncodeUnionRev(
-            JsonValidationData jsonValidationData,
-            MemoryStreamType memoryStreamType)
+            JsonValidationData jsonValidationData
+            )
         {
             ExpandedNodeId nodeId;
             Type complexType;
@@ -232,7 +229,7 @@ namespace Opc.Ua.Client.ComplexTypes.Tests.Types
             ExtensionObject extensionObject = CreateExtensionObject(StructureType.Union, nodeId, emittedType);
             EncodeJsonComplexTypeVerifyResult(
                 jsonValidationData.BuiltInType,
-                memoryStreamType,
+                MemoryStreamType.ArraySegmentStream,
                 extensionObject,
                 true,
                 jsonValidationData.ExpectedNonReversible ?? jsonValidationData.ExpectedReversible,
@@ -244,8 +241,8 @@ namespace Opc.Ua.Client.ComplexTypes.Tests.Types
         /// </summary>
         [Theory]
         public void JsonEncodeUnionNonRev(
-            JsonValidationData jsonValidationData,
-            MemoryStreamType memoryStreamType)
+            JsonValidationData jsonValidationData
+            )
         {
             ExpandedNodeId nodeId;
             Type complexType;
@@ -256,7 +253,7 @@ namespace Opc.Ua.Client.ComplexTypes.Tests.Types
             ExtensionObject extensionObject = CreateExtensionObject(StructureType.Union, nodeId, emittedType);
             EncodeJsonComplexTypeVerifyResult(
                 jsonValidationData.BuiltInType,
-                memoryStreamType,
+                MemoryStreamType.ArraySegmentStream,
                 extensionObject,
                 false,
                 jsonValidationData.ExpectedNonReversible ?? jsonValidationData.ExpectedReversible,

--- a/Tests/Opc.Ua.Client.ComplexTypes.Tests/Types/MockResolverTests.cs
+++ b/Tests/Opc.Ua.Client.ComplexTypes.Tests/Types/MockResolverTests.cs
@@ -36,6 +36,7 @@ using System.Runtime.Serialization;
 using System.Text;
 using System.Threading.Tasks;
 using NUnit.Framework;
+using Opc.Ua.Core.Tests.Types.Encoders;
 
 namespace Opc.Ua.Client.ComplexTypes.Tests.Types
 {
@@ -148,7 +149,7 @@ namespace Opc.Ua.Client.ComplexTypes.Tests.Types
         /// Test the functionality to create a custom complex type.
         /// </summary>
         [Theory]
-        public async Task CreateMockTypeAsync(EncodingType encodingType)
+        public async Task CreateMockTypeAsync(EncodingType encodingType, MemoryStreamType memoryStreamType)
         {
             var mockResolver = new MockResolver();
 
@@ -255,7 +256,7 @@ namespace Opc.Ua.Client.ComplexTypes.Tests.Types
             };
 
             byte[] buffer;
-            using (var encoderStream = new MemoryStream())
+            using (var encoderStream = CreateEncoderMemoryStream(memoryStreamType))
             {
                 using (IEncoder encoder = CreateEncoder(EncodingType.Json, encoderContext, encoderStream, carType))
                 {
@@ -267,7 +268,7 @@ namespace Opc.Ua.Client.ComplexTypes.Tests.Types
             _ = PrettifyAndValidateJson(Encoding.UTF8.GetString(buffer));
 
             // test encoder/decoder
-            EncodeDecodeComplexType(encoderContext, encodingType, StructureType.Structure, nodeId, car);
+            EncodeDecodeComplexType(encoderContext, memoryStreamType, encodingType, StructureType.Structure, nodeId, car);
 
             // Test extracting type definition
 
@@ -281,7 +282,7 @@ namespace Opc.Ua.Client.ComplexTypes.Tests.Types
         /// Test the functionality to create a custom complex type.
         /// </summary>
         [Theory]
-        public async Task CreateMockArrayTypeAsync(EncodingType encodingType)
+        public async Task CreateMockArrayTypeAsync(EncodingType encodingType, MemoryStreamType memoryStreamType)
         {
             var mockResolver = new MockResolver();
 
@@ -430,7 +431,7 @@ namespace Opc.Ua.Client.ComplexTypes.Tests.Types
             };
 
             byte[] buffer;
-            using (var encoderStream = new MemoryStream())
+            using (var encoderStream = CreateEncoderMemoryStream(memoryStreamType))
             {
                 using (IEncoder encoder = CreateEncoder(EncodingType.Json, encoderContext, encoderStream, arraysTypes, false))
                 {
@@ -442,7 +443,7 @@ namespace Opc.Ua.Client.ComplexTypes.Tests.Types
             _ = PrettifyAndValidateJson(Encoding.UTF8.GetString(buffer));
 
             // test encoder/decoder
-            EncodeDecodeComplexType(encoderContext, encodingType, StructureType.Structure, dataTypeNode.NodeId, arrays);
+            EncodeDecodeComplexType(encoderContext, memoryStreamType, encodingType, StructureType.Structure, dataTypeNode.NodeId, arrays);
 
             // Test extracting type definition
 
@@ -456,7 +457,7 @@ namespace Opc.Ua.Client.ComplexTypes.Tests.Types
         /// Create a complex type with a single scalar or array type, with default and random values .
         /// </summary>
         [Theory]
-        public async Task CreateMockSingleTypeAsync(EncodingType encodingType, TestType typeDescription, bool randomValues, TestRanks testRank)
+        public async Task CreateMockSingleTypeAsync(EncodingType encodingType, MemoryStreamType memoryStreamType, TestType typeDescription, bool randomValues, TestRanks testRank)
         {
             SetRepeatedRandomSeed();
 
@@ -611,7 +612,7 @@ namespace Opc.Ua.Client.ComplexTypes.Tests.Types
             };
 
             byte [] buffer;
-            using (var encoderStream = new MemoryStream())
+            using (var encoderStream = CreateEncoderMemoryStream(memoryStreamType))
             {
                 using (IEncoder encoder = CreateEncoder(EncodingType.Json, encoderContext, encoderStream, arraysTypes, false))
                 {
@@ -623,7 +624,7 @@ namespace Opc.Ua.Client.ComplexTypes.Tests.Types
             _ = PrettifyAndValidateJson(Encoding.UTF8.GetString(buffer));
 
             // test encoder/decoder
-            EncodeDecodeComplexType(encoderContext, encodingType, StructureType.Structure, dataTypeNode.NodeId, testType);
+            EncodeDecodeComplexType(encoderContext, memoryStreamType, encodingType, StructureType.Structure, dataTypeNode.NodeId, testType);
 
             // Test extracting type definition
 

--- a/Tests/Opc.Ua.Client.Tests/ClientTest.cs
+++ b/Tests/Opc.Ua.Client.Tests/ClientTest.cs
@@ -614,13 +614,16 @@ namespace Opc.Ua.Client.Tests
             sre = Assert.Throws<ServiceResultException>(() => session1.ReadValue(VariableIds.Server_ServerStatus, typeof(ServerStatusDataType)));
 
             // TODO: Both channel should return BadSecureChannelClosed
-            if (endpoint.EndpointUrl.ToString().StartsWith(Utils.UriSchemeOpcTcp, StringComparison.Ordinal))
+            if (!(StatusCodes.BadSecureChannelClosed == sre.StatusCode))
             {
-                Assert.AreEqual(StatusCodes.BadSessionIdInvalid, sre.StatusCode, sre.Message);
-            }
-            else
-            {
-                Assert.AreEqual(StatusCodes.BadUnknownResponse, sre.StatusCode, sre.Message);
+                if (endpoint.EndpointUrl.ToString().StartsWith(Utils.UriSchemeOpcTcp, StringComparison.Ordinal))
+                {
+                    Assert.AreEqual(StatusCodes.BadSessionIdInvalid, sre.StatusCode, sre.Message);
+                }
+                else
+                {
+                    Assert.AreEqual(StatusCodes.BadUnknownResponse, sre.StatusCode, sre.Message);
+                }
             }
         }
 

--- a/Tests/Opc.Ua.Core.Tests/Types/Bindings/BufferManagerBenchmarks.cs
+++ b/Tests/Opc.Ua.Core.Tests/Types/Bindings/BufferManagerBenchmarks.cs
@@ -43,7 +43,7 @@ namespace Opc.Ua.Core.Tests.Stack.Bindings
     public class BufferManagerBenchmarks
     {
         //[Params(8192, 65535, 1024 * 1024 - 1)]
-        public int BufferSize { get; set; } = 65535;
+        public int BufferSize { get; set; } = TcpMessageLimits.DefaultMaxBufferSize;
 
         //[Params( /*8,*/ 64, 256, 1024)]
         public int Allocations { get; set; } = 256;

--- a/Tests/Opc.Ua.Core.Tests/Types/Encoders/BinaryDecoderBenchmarks.cs
+++ b/Tests/Opc.Ua.Core.Tests/Types/Encoders/BinaryDecoderBenchmarks.cs
@@ -1,0 +1,239 @@
+/* ========================================================================
+ * Copyright (c) 2005-2024 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ * 
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ * 
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System.IO;
+using BenchmarkDotNet.Attributes;
+using NUnit.Framework;
+using Opc.Ua.Bindings;
+
+namespace Opc.Ua.Core.Tests.Types.Encoders
+{
+    [TestFixture, Category("BinaryEncoder")]
+    [SetCulture("en-us"), SetUICulture("en-us")]
+    [NonParallelizable]
+    [MemoryDiagnoser]
+    [DisassemblyDiagnoser]
+    public class BinaryDecoderBenchmarks : EncoderBenchmarks
+    {
+        /// <summary>
+        /// Test decoding with internal memory stream.
+        /// </summary>
+        [Test]
+        public void BinaryDecoderInternalMemoryStreamTest()
+        {
+            using (var binaryDecoder = new BinaryDecoder(m_encodedByteArray, m_context))
+            {
+                TestDecoding(binaryDecoder);
+            }
+        }
+
+        /// <summary>
+        /// Test decoding with ArrayPool memory stream.
+        /// </summary>
+        [Test]
+        public void BinaryDecoderArraySegmentStreamTest()
+        {
+            using (var memoryStream = new ArraySegmentStream(m_encodedBufferList))
+            using (var binaryDecoder = new BinaryDecoder(memoryStream, m_context))
+            {
+                TestDecoding(binaryDecoder);
+            }
+        }
+
+        /// <summary>
+        /// Test decoding with ArrayPool memory stream that has no span support.
+        /// </summary>
+        [Test]
+        public void BinaryDecoderArraySegmentStreamNoSpanTest()
+        {
+#if NET6_0_OR_GREATER
+            using (var arraySegmentStream = new ArraySegmentStreamNoSpan(m_encodedBufferList))
+#else
+            using (var arraySegmentStream = new ArraySegmentStream(m_encodedBufferList))
+#endif
+            using (var binaryDecoder = new BinaryDecoder(arraySegmentStream, m_context))
+            {
+                TestDecoding(binaryDecoder);
+            }
+        }
+
+        /// <summary>
+        /// Benchmark decoding with memory stream.
+        /// </summary>
+        [Benchmark(Baseline = true)]
+        [Test]
+        public void BinaryDecoderMemoryStream()
+        {
+            using (var memoryStream = new MemoryStream(m_encodedByteArray))
+            {
+                BinaryDecoder_Stream(memoryStream);
+            }
+        }
+
+        /// <summary>
+        /// Benchmark decoding with array segment memory stream.
+        /// </summary>
+        [Benchmark]
+        [Test]
+        public void BinaryDecoderArraySegmentStream()
+        {
+            using (var arraySegmentStream = new ArraySegmentStream(m_encodedBufferList))
+            {
+                BinaryDecoder_Stream(arraySegmentStream);
+            }
+        }
+
+        /// <summary>
+        /// Benchmark decoding with array segment memory stream without span support.
+        /// </summary>
+        [Benchmark]
+        [Test]
+        public void BinaryDecoderArraySegmentStreamNoSpan()
+        {
+#if NET6_0_OR_GREATER
+            using (var arraySegmentStream = new ArraySegmentStreamNoSpan(m_encodedBufferList))
+#else
+            using (var arraySegmentStream = new ArraySegmentStream(m_encodedBufferList))
+#endif
+            {
+                BinaryDecoder_Stream(arraySegmentStream);
+            }
+        }
+
+        #region Private Methods
+        private void TestStreamDecode(MemoryStream memoryStream)
+        {
+            using (var binaryDecoder = new BinaryDecoder(memoryStream, m_context))
+            {
+                TestDecoding(binaryDecoder);
+                TestDecoding(binaryDecoder);
+                binaryDecoder.Close();
+            }
+        }
+
+        private void BinaryDecoder_Stream(MemoryStream memoryStream)
+        {
+            using (var binaryDecoder = new BinaryDecoder(memoryStream, m_context))
+            {
+                TestDecoding(binaryDecoder);
+                TestDecoding(binaryDecoder);
+                binaryDecoder.Close();
+            }
+        }
+        #endregion
+
+        #region Test Setup
+        [OneTimeSetUp]
+        public new void OneTimeSetUp()
+        {
+            base.OneTimeSetUp();
+            InitializeEncodedTestData();
+        }
+
+        [OneTimeTearDown]
+        public new void OneTimeTearDown()
+        {
+            base.OneTimeTearDown();
+        }
+        #endregion
+
+        #region Benchmark Setup
+        /// <summary>
+        /// Set up some variables for benchmarks.
+        /// </summary>
+        [GlobalSetup]
+        public new void GlobalSetup()
+        {
+            base.GlobalSetup();
+            InitializeEncodedBenchmarkData();
+        }
+
+        /// <summary>
+        /// Tear down benchmark variables.
+        /// </summary>
+        [GlobalCleanup]
+        public new void GlobalCleanup()
+        {
+            base.GlobalCleanup();
+        }
+        #endregion
+
+        #region Private Methods
+        /// <summary>
+        /// Initialize encoded data.
+        /// </summary>
+        private void InitializeEncodedTestData()
+        {
+            using (var memoryStream = new MemoryStream(StreamBufferSize))
+            using (var binaryEncoder = new BinaryEncoder(memoryStream, m_context, true))
+            {
+                TestEncoding(binaryEncoder);
+                TestEncoding(binaryEncoder);
+                m_encodedByteArray = binaryEncoder.CloseAndReturnBuffer();
+            }
+
+            using (var memoryStream = new ArraySegmentStream(m_bufferManager))
+            using (var binaryEncoder = new BinaryEncoder(memoryStream, m_context, true))
+            {
+                TestEncoding(binaryEncoder);
+                TestEncoding(binaryEncoder);
+                binaryEncoder.Close();
+                m_encodedBufferList = memoryStream.GetBuffers("writer");
+            }
+        }
+
+        /// <summary>
+        /// Initialize encoded data.
+        /// </summary>
+        private void InitializeEncodedBenchmarkData()
+        {
+            using (var memoryStream = new MemoryStream(StreamBufferSize))
+            using (var binaryEncoder = new BinaryEncoder(memoryStream, m_context, true))
+            {
+                TestEncoding(binaryEncoder);
+                TestEncoding(binaryEncoder);
+                m_encodedByteArray = binaryEncoder.CloseAndReturnBuffer();
+            }
+
+            using (var memoryStream = new ArraySegmentStream(m_bufferManager))
+            using (var binaryEncoder = new BinaryEncoder(memoryStream, m_context, true))
+            {
+                TestEncoding(binaryEncoder);
+                TestEncoding(binaryEncoder);
+                binaryEncoder.Close();
+                m_encodedBufferList = memoryStream.GetBuffers("writer");
+            }
+        }
+        #endregion
+
+        private byte[] m_encodedByteArray;
+        private BufferCollection m_encodedBufferList;
+
+    }
+}

--- a/Tests/Opc.Ua.Core.Tests/Types/Encoders/BinaryEncoderBenchmarks.cs
+++ b/Tests/Opc.Ua.Core.Tests/Types/Encoders/BinaryEncoderBenchmarks.cs
@@ -80,7 +80,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
         [Theory]
         public void BinaryEncoderArraySegmentStreamTest(bool toArray)
         {
-            using (var memoryStream = new ArraySegmentStream(m_bufferManager, StreamBufferSize, 0, StreamBufferSize))
+            using (var memoryStream = new ArraySegmentStream(m_bufferManager))
             {
                 TestStreamEncode(memoryStream, toArray);
             }
@@ -147,7 +147,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
         [Test]
         public void BinaryEncoderArraySegmentStream()
         {
-            using (var arraySegmentStream = new ArraySegmentStream(m_bufferManager, StreamBufferSize, 0, StreamBufferSize))
+            using (var arraySegmentStream = new ArraySegmentStream(m_bufferManager))
             {
                 BinaryEncoder_StreamLeaveOpen(arraySegmentStream);
                 // get buffers and return them to buffer manager
@@ -168,9 +168,9 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
         public void BinaryEncoderArraySegmentStreamNoSpan()
         {
 #if NET6_0_OR_GREATER
-            using (var arraySegmentStream = new ArraySegmentStreamNoSpan(m_bufferManager, StreamBufferSize, 0, StreamBufferSize))
+            using (var arraySegmentStream = new ArraySegmentStreamNoSpan(m_bufferManager))
 #else
-            using (var arraySegmentStream = new ArraySegmentStream(m_bufferManager, StreamBufferSize, 0, StreamBufferSize))
+            using (var arraySegmentStream = new ArraySegmentStream(m_bufferManager))
 #endif
             {
                 BinaryEncoder_StreamLeaveOpen(arraySegmentStream);
@@ -210,7 +210,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
             }
         }
 
-        private void BinaryEncoder_StreamLeaveOpen(MemoryStream memoryStream, bool testResult = false)
+        private int BinaryEncoder_StreamLeaveOpen(MemoryStream memoryStream, bool testResult = false)
         {
             int length1;
             int length2;
@@ -231,6 +231,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
                 Assert.NotNull(result);
                 Assert.AreEqual(length2, memoryStream.Position);
             }
+            return length1 + length2;
         }
         #endregion
 

--- a/Tests/Opc.Ua.Core.Tests/Types/Encoders/BinaryEncoderBenchmarks.cs
+++ b/Tests/Opc.Ua.Core.Tests/Types/Encoders/BinaryEncoderBenchmarks.cs
@@ -1,5 +1,5 @@
 /* ========================================================================
- * Copyright (c) 2005-2023 The OPC Foundation, Inc. All rights reserved.
+ * Copyright (c) 2005-2024 The OPC Foundation, Inc. All rights reserved.
  *
  * OPC Foundation MIT License 1.00
  * 
@@ -27,11 +27,10 @@
  * http://opcfoundation.org/License/MIT/1.00/
  * ======================================================================*/
 
-using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using BenchmarkDotNet.Attributes;
+using Microsoft.IO;
 using NUnit.Framework;
 using Opc.Ua.Bindings;
 
@@ -42,67 +41,88 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
     [NonParallelizable]
     [MemoryDiagnoser]
     [DisassemblyDiagnoser]
-    public class BinaryEncoderBenchmarks
+    public class BinaryEncoderBenchmarks : EncoderBenchmarks
     {
-        const int kBufferSize = 4096;
-
-        [Params(1, 2, 8, 64)]
-        public int PayLoadSize { get; set; } = 64;
-
         /// <summary>
-        /// Benchmark encoding with internal memory stream.
+        /// Test encoding with internal memory stream.
         /// </summary>
-        [Benchmark]
         [Test]
-        public void BinaryEncoderConstructor2()
+        public void BinaryEncoderInternalMemoryStreamTest()
         {
             using (var binaryEncoder = new BinaryEncoder(m_context))
             {
                 TestEncoding(binaryEncoder);
-                _ = binaryEncoder.CloseAndReturnBuffer();
+                var result = binaryEncoder.CloseAndReturnBuffer();
+                Assert.NotNull(result);
+            }
+        }
+
+
+        /// <summary>
+        /// Test encoding with internal memory stream,
+        /// uses reflection to get array from memory stream.
+        /// </summary>
+        [Test]
+        public void BinaryEncoderConstructorStreamwriterReflection2()
+        {
+            using (var memoryStream = new MemoryStream(StreamBufferSize))
+            using (var binaryEncoder = new BinaryEncoder(memoryStream, m_context, true))
+            {
+                TestEncoding(binaryEncoder);
+                var result = binaryEncoder.CloseAndReturnBuffer();
+                Assert.NotNull(result);
             }
         }
 
         /// <summary>
-        /// Benchmark encoding with ArrayPool memory stream.
+        /// Test encoding with ArrayPool memory stream.
         /// </summary>
-        [Benchmark]
-        [Test]
-        public void BinaryEncoderConstructor3()
+        [Theory]
+        public void BinaryEncoderArraySegmentStreamTest(bool toArray)
         {
-            using (var stream = new ArraySegmentStream(m_bufferManager, kBufferSize, 0, kBufferSize))
+            using (var memoryStream = new ArraySegmentStream(m_bufferManager, StreamBufferSize, 0, StreamBufferSize))
             {
-                using (var binaryEncoder = new BinaryEncoder(stream, m_context, false))
-                {
-                    TestEncoding(binaryEncoder);
-                    _ = binaryEncoder.CloseAndReturnBuffer();
-                }
+                TestStreamEncode(memoryStream, toArray);
+            }
+        }
+
+        /// <summary>
+        /// Test encoding with memory stream kept open.
+        /// </summary>
+        [Theory]
+        public void BinaryEncoderMemoryStreamTest(bool toArray)
+        {
+            using (var memoryStream = new MemoryStream(StreamBufferSize))
+            {
+                TestStreamEncode(memoryStream, toArray);
+            }
+        }
+
+        /// <summary>
+        /// Test encoding with recyclable memory stream kept open.
+        /// </summary>
+        [Theory]
+        public void BinaryEncoderRecyclableMemoryStream(bool toArray)
+        {
+            using (var memoryStream = new RecyclableMemoryStream(m_memoryManager))
+            {
+                TestStreamEncode(memoryStream, toArray);
             }
         }
 
         /// <summary>
         /// Benchmark encoding with memory stream kept open.
         /// </summary>
-        [Benchmark]
+        [Benchmark(Baseline = true)]
         [Test]
-        public void BinaryEncoderConstructorStreamwriter2()
+        public void BinaryEncoderMemoryStream()
         {
-            using (IEncoder binaryEncoder = new BinaryEncoder(m_memoryStream, m_context, true))
+            using (var memoryStream = new MemoryStream(StreamBufferSize))
             {
-                TestEncoding(binaryEncoder);
-                int length = binaryEncoder.Close();
-                var result = Encoding.UTF8.GetString(m_memoryStream.ToArray());
+                BinaryEncoder_StreamLeaveOpen(memoryStream);
+                // get buffer for write
+                _ = memoryStream.ToArray();
             }
-        }
-
-        /// <summary>
-        /// Encoding test with memory stream kept open.
-        /// </summary>
-        [Benchmark]
-        [Test]
-        public void BinaryEncoderStreamLeaveOpenMemoryStream()
-        {
-            BinaryEncoder_StreamLeaveOpen(m_memoryStream);
         }
 
         /// <summary>
@@ -110,99 +130,116 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
         /// </summary>
         [Benchmark]
         [Test]
-        public void BinaryEncoderStreamLeaveOpenRecyclableMemoryStream()
+        public void BinaryEncoderRecyclableMemoryStream()
         {
-            BinaryEncoder_StreamLeaveOpen(m_recyclableMemoryStream);
-        }
-
-        /// <summary>
-        /// Encoding test with memory stream kept open.
-        /// </summary>
-        [Benchmark]
-        [Test]
-        public void BinaryEncoderStreamLeaveOpenArraySegmentStream()
-        {
-            BinaryEncoder_StreamLeaveOpen(m_arraySegmentStream);
-        }
-
-        /// <summary>
-        /// Benchmark encoding with memory stream kept open,
-        /// use internal reflection to get string from memory stream.
-        /// </summary>
-        [Benchmark]
-        [Test]
-        public void BinaryEncoderConstructorStreamwriterReflection2()
-        {
-            using (var binaryEncoder = new BinaryEncoder(m_memoryStream, m_context, true))
+            using (var recyclableMemoryStream = new RecyclableMemoryStream(m_memoryManager))
             {
-                TestEncoding(binaryEncoder);
-                var result = binaryEncoder.CloseAndReturnBuffer();
+                BinaryEncoder_StreamLeaveOpen(recyclableMemoryStream);
+                // get buffers for write
+                _ = recyclableMemoryStream.GetReadOnlySequence();
+            }
+        }
+
+        /// <summary>
+        /// Benchmark encoding with array segment memory stream kept open.
+        /// </summary>
+        [Benchmark]
+        [Test]
+        public void BinaryEncoderArraySegmentStream()
+        {
+            using (var arraySegmentStream = new ArraySegmentStream(m_bufferManager, StreamBufferSize, 0, StreamBufferSize))
+            {
+                BinaryEncoder_StreamLeaveOpen(arraySegmentStream);
+                // get buffers and return them to buffer manager
+                var buffers = arraySegmentStream.GetBuffers("writer");
+                foreach (var buffer in buffers)
+                {
+                    m_bufferManager.ReturnBuffer(buffer.Array, "testreturn");
+                }
+            }
+        }
+
+        /// <summary>
+        /// Benchmark encoding with array segment memory stream kept open,
+        /// to compare the version without span support.
+        /// </summary>
+        [Benchmark]
+        [Test]
+        public void BinaryEncoderArraySegmentStreamNoSpan()
+        {
+#if NET6_0_OR_GREATER
+            using (var arraySegmentStream = new ArraySegmentStreamNoSpan(m_bufferManager, StreamBufferSize, 0, StreamBufferSize))
+#else
+            using (var arraySegmentStream = new ArraySegmentStream(m_bufferManager, StreamBufferSize, 0, StreamBufferSize))
+#endif
+            {
+                BinaryEncoder_StreamLeaveOpen(arraySegmentStream);
+                // get buffers and return them to buffer manager
+                var buffers = arraySegmentStream.GetBuffers("writer");
+                foreach (var buffer in buffers)
+                {
+                    m_bufferManager.ReturnBuffer(buffer.Array, "testreturn");
+                }
             }
         }
 
         #region Private Methods
-        private void BinaryEncoder_StreamLeaveOpen(MemoryStream stream)
+        private void TestStreamEncode(MemoryStream memoryStream, bool toArray)
+        {
+            using (var binaryEncoder = new BinaryEncoder(memoryStream, m_context, true))
+            {
+                TestEncoding(binaryEncoder);
+                _ = binaryEncoder.Close();
+            }
+            using (var binaryEncoder = new BinaryEncoder(memoryStream, m_context, true))
+            {
+                TestEncoding(binaryEncoder);
+                if (toArray)
+                {
+                    int length = binaryEncoder.Close();
+                    Assert.AreEqual(length, memoryStream.Position);
+                    var result = memoryStream.ToArray();
+                    Assert.NotNull(result);
+                    Assert.AreEqual(length, result.Length);
+                }
+                else
+                {
+                    var result = binaryEncoder.CloseAndReturnBuffer();
+                    Assert.NotNull(result);
+                }
+            }
+        }
+
+        private void BinaryEncoder_StreamLeaveOpen(MemoryStream memoryStream, bool testResult = false)
         {
             int length1;
             int length2;
-            m_memoryStream.Position = 0;
-            using (IEncoder encoder = new BinaryEncoder(stream, m_context, true))
+            using (var encoder = new BinaryEncoder(memoryStream, m_context, true))
             {
                 TestEncoding(encoder);
                 length1 = encoder.Close();
             }
-            using (IEncoder encoder = new BinaryEncoder(stream, m_context, true))
+            using (var encoder = new BinaryEncoder(memoryStream, m_context, true))
             {
                 TestEncoding(encoder);
                 length2 = encoder.Close();
             }
-            Assert.AreEqual(length1 * 2, length2);
-            var result = Encoding.UTF8.GetString(stream.ToArray());
-            Assert.NotNull(result);
-            Assert.AreEqual(length2, stream.Position);
-        }
-
-        private void TestEncoding(IEncoder encoder)
-        {
-            int payLoadSize = PayLoadSize;
-            encoder.WriteByte("Byte", 0);
-            while (--payLoadSize > 0)
+            if (testResult)
             {
-                encoder.WriteBoolean("Boolean", true);
-                encoder.WriteUInt64("UInt64", 1234566890);
-                encoder.WriteString("String", "The quick brown fox...");
-                encoder.WriteNodeId("NodeId", s_nodeId);
-                encoder.WriteInt32Array("Array", s_list);
+                Assert.AreEqual(length1 * 2, length2);
+                var result = Encoding.UTF8.GetString(memoryStream.ToArray());
+                Assert.NotNull(result);
+                Assert.AreEqual(length2, memoryStream.Position);
             }
         }
         #endregion
 
         #region Test Setup
         [OneTimeSetUp]
-        public void OneTimeSetUp()
-        {
-            // for validating benchmark tests
-            m_context = new ServiceMessageContext();
-            m_memoryStream = new MemoryStream();
-            m_memoryManager = new Microsoft.IO.RecyclableMemoryStreamManager();
-            m_recyclableMemoryStream = new Microsoft.IO.RecyclableMemoryStream(m_memoryManager);
-            m_bufferManager = new BufferManager(nameof(BinaryEncoder), kBufferSize);
-            m_arraySegmentStream = new ArraySegmentStream(m_bufferManager, kBufferSize, 0, kBufferSize);
-        }
+        public new void OneTimeSetUp() => base.OneTimeSetUp();
 
         [OneTimeTearDown]
-        public void OneTimeTearDown()
-        {
-            m_context = null;
-            m_memoryStream.Dispose();
-            m_memoryStream = null;
-            m_recyclableMemoryStream.Dispose();
-            m_recyclableMemoryStream = null;
-            m_memoryManager = null;
-            m_bufferManager = null;
-            m_arraySegmentStream.Dispose();
-            m_arraySegmentStream = null;
-        }
+        public new void OneTimeTearDown() => base.OneTimeTearDown();
         #endregion
 
         #region Benchmark Setup
@@ -210,44 +247,13 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
         /// Set up some variables for benchmarks.
         /// </summary>
         [GlobalSetup]
-        public void GlobalSetup()
-        {
-            // for validating benchmark tests
-            m_context = new ServiceMessageContext();
-            m_memoryStream = new MemoryStream();
-            m_memoryManager = new Microsoft.IO.RecyclableMemoryStreamManager();
-            m_recyclableMemoryStream = new Microsoft.IO.RecyclableMemoryStream(m_memoryManager);
-            m_bufferManager = new BufferManager(nameof(BinaryEncoder), kBufferSize);
-            m_arraySegmentStream = new ArraySegmentStream(m_bufferManager, kBufferSize, 0, kBufferSize);
-        }
+        public new void GlobalSetup() => base.GlobalSetup();
 
         /// <summary>
         /// Tear down benchmark variables.
         /// </summary>
         [GlobalCleanup]
-        public void GlobalCleanup()
-        {
-            m_context = null;
-            m_memoryStream.Dispose();
-            m_memoryStream = null;
-            m_recyclableMemoryStream.Dispose();
-            m_recyclableMemoryStream = null;
-            m_memoryManager = null;
-            m_bufferManager = null;
-            m_arraySegmentStream.Dispose();
-            m_arraySegmentStream = null;
-        }
-        #endregion
-
-        #region Private Fields
-        private static NodeId s_nodeId = new NodeId(1234);
-        private static IList<Int32> s_list = new List<Int32>() { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
-        private IServiceMessageContext m_context;
-        private MemoryStream m_memoryStream;
-        private Microsoft.IO.RecyclableMemoryStreamManager m_memoryManager;
-        private Microsoft.IO.RecyclableMemoryStream m_recyclableMemoryStream;
-        private BufferManager m_bufferManager;
-        private ArraySegmentStream m_arraySegmentStream;
+        public new void GlobalCleanup() => base.GlobalCleanup();
         #endregion
     }
 }

--- a/Tests/Opc.Ua.Core.Tests/Types/Encoders/EncodeableTests.cs
+++ b/Tests/Opc.Ua.Core.Tests/Types/Encoders/EncodeableTests.cs
@@ -57,6 +57,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
         [Category("EncodeableTypes")]
         public void ActivateEncodeableType(
             EncodingType encoderType,
+            MemoryStreamType memoryStreamType,
             Type systemType
             )
         {
@@ -68,13 +69,14 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
             Assert.AreNotEqual(testObject.TypeId, testObject.BinaryEncodingId);
             Assert.AreNotEqual(testObject.TypeId, testObject.XmlEncodingId);
             Assert.AreNotEqual(testObject.BinaryEncodingId, testObject.XmlEncodingId);
-            EncodeDecode(encoderType, BuiltInType.ExtensionObject, new ExtensionObject(testObject.TypeId, testObject));
+            EncodeDecode(encoderType, BuiltInType.ExtensionObject, memoryStreamType, new ExtensionObject(testObject.TypeId, testObject));
         }
 
         [Theory]
         [Category("EncodeableTypes")]
         public void ActivateEncodeableTypeArray(
             EncodingType encoderType,
+            MemoryStreamType memoryStreamType,
             Type systemType
             )
         {
@@ -95,7 +97,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
             BuiltInType builtInType = BuiltInType.Variant;
 
             byte[] buffer;
-            using (var encoderStream = new MemoryStream())
+            using (var encoderStream = CreateEncoderMemoryStream(memoryStreamType))
             {
                 using (IEncoder encoder = CreateEncoder(encoderType, Context, encoderStream, systemType))
                 {
@@ -140,6 +142,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
         [Category("EncodeableTypes")]
         public void ActivateEncodeableTypeMatrix(
             EncodingType encoderType,
+            MemoryStreamType memoryStreamType,
             bool encodeAsMatrix,
             Type systemType
             )
@@ -167,7 +170,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
             Matrix matrix = new Matrix(array, builtInType, dimensions);
 
             byte[] buffer;
-            using (var encoderStream = new MemoryStream())
+            using (var encoderStream = CreateEncoderMemoryStream(memoryStreamType))
             {
                 using (IEncoder encoder = CreateEncoder(encoderType, Context, encoderStream, systemType))
                 {

--- a/Tests/Opc.Ua.Core.Tests/Types/Encoders/EncoderBenchmarks.cs
+++ b/Tests/Opc.Ua.Core.Tests/Types/Encoders/EncoderBenchmarks.cs
@@ -178,8 +178,8 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
     /// </summary>
     public class ArraySegmentStreamNoSpan : ArraySegmentStream
     {
-        public ArraySegmentStreamNoSpan(BufferManager bufferManager, int bufferSize, int offset, int count)
-            : base(bufferManager, bufferSize, offset, count)
+        public ArraySegmentStreamNoSpan(BufferManager bufferManager)
+            : base(bufferManager)
         {
         }
 

--- a/Tests/Opc.Ua.Core.Tests/Types/Encoders/EncoderBenchmarks.cs
+++ b/Tests/Opc.Ua.Core.Tests/Types/Encoders/EncoderBenchmarks.cs
@@ -1,0 +1,197 @@
+/* ========================================================================
+ * Copyright (c) 2005-2024 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ * 
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ * 
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+#pragma warning disable CA5394 // Do not use insecure randomness
+
+using System;
+using System.Collections.Generic;
+using BenchmarkDotNet.Attributes;
+using Microsoft.IO;
+using Opc.Ua.Bindings;
+
+namespace Opc.Ua.Core.Tests.Types.Encoders
+{
+    /// <summary>
+    /// Common code for encoder benchmarks.
+    /// </summary>
+    public class EncoderBenchmarks
+    {
+        public const int StreamBufferSize = 4096;
+        public const int DataValueCount = 10;
+
+        public EncoderBenchmarks()
+        {
+            m_random = new Random(0x62541);
+            m_nodeId = new NodeId((uint)m_random.Next(50000));
+            m_list = new List<int>();
+            for (int i = 0; i < DataValueCount; i++)
+            {
+                m_list.Add(m_random.Next());
+            }
+            m_values = new List<DataValue>();
+            DateTime now = new DateTime(2024, 03, 01, 06, 05, 59, DateTimeKind.Utc);
+            now += TimeSpan.FromTicks(456789);
+            for (int i = 0; i < DataValueCount; i++)
+            {
+                m_values.Add(new DataValue(new Variant((m_random.NextDouble() - 0.5) * 1000.0), m_random.NextDouble() > 0.1 ? StatusCodes.Good : StatusCodes.BadDataLost, now, now));
+            }
+        }
+
+        [Params(/*1, 2, 8, */64, 1024)]
+        public int PayLoadSize { get; set; } = 64;
+
+        #region Private Methods
+        protected void TestEncoding(IEncoder encoder)
+        {
+            var now = DateTime.UtcNow;
+            int payLoadSize = PayLoadSize;
+            encoder.WriteInt32("PayloadSize", payLoadSize);
+            while (--payLoadSize > 0)
+            {
+                encoder.WriteBoolean("Boolean", true);
+                encoder.WriteByte("Byte", 123);
+                encoder.WriteUInt16("UInt16", 1234);
+                encoder.WriteUInt32("UInt32", 123456);
+                encoder.WriteUInt64("UInt64", 1234566890);
+                encoder.WriteSByte("Int8", -123);
+                encoder.WriteInt16("Int16", -1234);
+                encoder.WriteInt32("Int32", -123456);
+                encoder.WriteInt64("Int64", -1234566890);
+                encoder.WriteFloat("Float", 123.456f);
+                encoder.WriteDouble("Double", 123456.789);
+                encoder.WriteDateTime("DateTime", now);
+                encoder.WriteString("String", "The quick brown fox jumps over the lazy dog.");
+                encoder.WriteNodeId("NodeId", m_nodeId);
+                encoder.WriteNodeId("ExpandedNodeId", m_nodeId);
+                encoder.WriteInt32Array("Array", m_list);
+                encoder.WriteDataValueArray("DataValues", m_values);
+            }
+        }
+
+        protected void TestDecoding(IDecoder decoder)
+        {
+            var now = DateTime.UtcNow;
+            var payLoadSize = decoder.ReadInt32("PayloadSize");
+            while (--payLoadSize > 0)
+            {
+                _ = decoder.ReadBoolean("Boolean");
+                _ = decoder.ReadByte("Byte");
+                _ = decoder.ReadUInt16("UInt16");
+                _ = decoder.ReadUInt32("UInt32");
+                _ = decoder.ReadUInt64("UInt64");
+                _ = decoder.ReadSByte("Int8");
+                _ = decoder.ReadInt16("Int16");
+                _ = decoder.ReadInt32("Int32");
+                _ = decoder.ReadInt64("Int64");
+                _ = decoder.ReadFloat("Float");
+                _ = decoder.ReadDouble("Double");
+                _ = decoder.ReadDateTime("DateTime");
+                _ = decoder.ReadString("String");
+                _ = decoder.ReadNodeId("NodeId");
+                _ = decoder.ReadNodeId("ExpandedNodeId");
+                _ = decoder.ReadInt32Array("Array");
+                _ = decoder.ReadDataValueArray("DataValues");
+            }
+        }
+        #endregion
+
+        #region Test Setup
+        public void OneTimeSetUp()
+        {
+            // for validating benchmark tests
+            m_context = new ServiceMessageContext();
+            m_memoryManager = new RecyclableMemoryStreamManager(new RecyclableMemoryStreamManager.Options { BlockSize = StreamBufferSize });
+            m_bufferManager = new BufferManager(nameof(BinaryEncoder), StreamBufferSize);
+        }
+
+        public void OneTimeTearDown()
+        {
+            m_context = null;
+            m_memoryManager = null;
+            m_bufferManager = null;
+        }
+        #endregion
+
+        #region Benchmark Setup
+        /// <summary>
+        /// Set up some variables for benchmarks.
+        /// </summary>
+        public void GlobalSetup()
+        {
+            // for validating benchmark tests
+            m_context = new ServiceMessageContext();
+            m_memoryManager = new RecyclableMemoryStreamManager(new RecyclableMemoryStreamManager.Options { BlockSize = StreamBufferSize });
+            m_bufferManager = new BufferManager(nameof(BinaryEncoder), StreamBufferSize);
+        }
+
+        /// <summary>
+        /// Tear down benchmark variables.
+        /// </summary>
+        public void GlobalCleanup()
+        {
+            m_context = null;
+            m_memoryManager = null;
+            m_bufferManager = null;
+        }
+        #endregion
+
+        #region Protected Fields
+        protected Random m_random;
+        protected NodeId m_nodeId = new NodeId(1234);
+        protected List<Int32> m_list;
+        protected List<DataValue> m_values;
+        protected IServiceMessageContext m_context;
+        protected RecyclableMemoryStreamManager m_memoryManager;
+        protected BufferManager m_bufferManager;
+        #endregion
+    }
+
+#if NET6_0_OR_GREATER
+    /// <summary>
+    /// Helper class to test ArraySegmentStream without Span support.
+    /// </summary>
+    public class ArraySegmentStreamNoSpan : ArraySegmentStream
+    {
+        public ArraySegmentStreamNoSpan(BufferManager bufferManager, int bufferSize, int offset, int count)
+            : base(bufferManager, bufferSize, offset, count)
+        {
+        }
+
+        public override int Read(Span<byte> buffer)
+        {
+            return base.ReadMemoryStream(buffer);
+        }
+
+        public override void Write(ReadOnlySpan<byte> buffer)
+        {
+            base.WriteMemoryStream(buffer);
+        }
+    }
+#endif
+}

--- a/Tests/Opc.Ua.Core.Tests/Types/Encoders/EncoderBenchmarks.cs
+++ b/Tests/Opc.Ua.Core.Tests/Types/Encoders/EncoderBenchmarks.cs
@@ -38,7 +38,7 @@ using Opc.Ua.Bindings;
 namespace Opc.Ua.Core.Tests.Types.Encoders
 {
     /// <summary>
-    /// Common code for encoder benchmarks.
+    /// Common code for encoder/decoder benchmarks.
     /// </summary>
     public class EncoderBenchmarks
     {
@@ -63,7 +63,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
             }
         }
 
-        [Params(/*1, 2, 8, */64, 1024)]
+        [Params(64, 1024)]
         public int PayLoadSize { get; set; } = 64;
 
         #region Private Methods
@@ -72,7 +72,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
             var now = DateTime.UtcNow;
             int payLoadSize = PayLoadSize;
             encoder.WriteInt32("PayloadSize", payLoadSize);
-            while (--payLoadSize > 0)
+            while (payLoadSize-- > 0)
             {
                 encoder.WriteBoolean("Boolean", true);
                 encoder.WriteByte("Byte", 123);
@@ -96,9 +96,8 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
 
         protected void TestDecoding(IDecoder decoder)
         {
-            var now = DateTime.UtcNow;
             var payLoadSize = decoder.ReadInt32("PayloadSize");
-            while (--payLoadSize > 0)
+            while (payLoadSize-- > 0)
             {
                 _ = decoder.ReadBoolean("Boolean");
                 _ = decoder.ReadByte("Byte");
@@ -180,6 +179,11 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
     {
         public ArraySegmentStreamNoSpan(BufferManager bufferManager)
             : base(bufferManager)
+        {
+        }
+
+        public ArraySegmentStreamNoSpan(BufferCollection buffers)
+            : base(buffers)
         {
         }
 

--- a/Tests/Opc.Ua.Core.Tests/Types/Encoders/EncoderCommon.cs
+++ b/Tests/Opc.Ua.Core.Tests/Types/Encoders/EncoderCommon.cs
@@ -67,7 +67,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
         protected const int kRandomStart = 4840;
         protected const int kRandomRepeats = 100;
         protected const int kMaxArrayLength = 1024 * 64;
-        protected const int kTestBufferSize = 0x1000 - 1;
+        protected const int kTestBlockSize = 0x1000 - 1;
         protected const string kApplicationUri = "uri:localhost:opcfoundation.org:EncoderCommon";
         protected RandomSource RandomSource { get; private set; }
         protected DataGenerator DataGenerator { get; private set; }
@@ -90,8 +90,8 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
             NameSpaceUris.GetIndexOrAppend(kApplicationUri);
             NameSpaceUris.GetIndexOrAppend(Namespaces.OpcUaGds);
             ServerUris = new StringTable();
-            BufferManager = new BufferManager(nameof(EncoderCommon), kTestBufferSize);
-            RecyclableMemoryManager = new RecyclableMemoryStreamManager(new RecyclableMemoryStreamManager.Options { BlockSize = kTestBufferSize });
+            BufferManager = new BufferManager(nameof(EncoderCommon), kTestBlockSize);
+            RecyclableMemoryManager = new RecyclableMemoryStreamManager(new RecyclableMemoryStreamManager.Options { BlockSize = kTestBlockSize });
         }
 
         [OneTimeTearDown]
@@ -402,8 +402,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
                 using (var stringReader = new StringReader(json))
                 {
                     using (var jsonReader = new JsonTextReader(stringReader))
-                    using (var jsonWriter = new JsonTextWriter(stringWriter)
-                    {
+                    using (var jsonWriter = new JsonTextWriter(stringWriter) {
                         FloatFormatHandling = FloatFormatHandling.String,
                         Formatting = Newtonsoft.Json.Formatting.Indented,
                         Culture = System.Globalization.CultureInfo.InvariantCulture
@@ -435,7 +434,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
             switch (memoryStreamType)
             {
                 case MemoryStreamType.MemoryStream:
-                    return new MemoryStream(kTestBufferSize);
+                    return new MemoryStream(kTestBlockSize);
                 case MemoryStreamType.ArraySegmentStream:
                     return new ArraySegmentStream(BufferManager);
                 case MemoryStreamType.RecyclableMemoryStream:

--- a/Tests/Opc.Ua.Core.Tests/Types/Encoders/EncoderCommon.cs
+++ b/Tests/Opc.Ua.Core.Tests/Types/Encoders/EncoderCommon.cs
@@ -67,7 +67,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
         protected const int kRandomStart = 4840;
         protected const int kRandomRepeats = 100;
         protected const int kMaxArrayLength = 1024 * 64;
-        protected const int kTestBlockSize = 0x1000 - 1;
+        protected const int kTestBlockSize = 0x1000;
         protected const string kApplicationUri = "uri:localhost:opcfoundation.org:EncoderCommon";
         protected RandomSource RandomSource { get; private set; }
         protected DataGenerator DataGenerator { get; private set; }

--- a/Tests/Opc.Ua.Core.Tests/Types/Encoders/EncoderCommon.cs
+++ b/Tests/Opc.Ua.Core.Tests/Types/Encoders/EncoderCommon.cs
@@ -37,13 +37,25 @@ using System.Runtime.Serialization;
 using System.Text;
 using System.Threading;
 using System.Xml;
+using Microsoft.IO;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
+using Opc.Ua.Bindings;
 using Opc.Ua.Test;
 
 namespace Opc.Ua.Core.Tests.Types.Encoders
 {
+    /// <summary>
+    /// Supported memory stream types.
+    /// </summary>
+    public enum MemoryStreamType
+    {
+        MemoryStream,
+        ArraySegmentStream,
+        RecyclableMemoryStream
+    }
+
     /// <summary>
     /// Base class for the encoder tests.
     /// </summary>
@@ -55,12 +67,16 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
         protected const int kRandomStart = 4840;
         protected const int kRandomRepeats = 100;
         protected const int kMaxArrayLength = 1024 * 64;
+        protected const int kTestBufferSize = 0x1000 - 1;
         protected const string kApplicationUri = "uri:localhost:opcfoundation.org:EncoderCommon";
         protected RandomSource RandomSource { get; private set; }
         protected DataGenerator DataGenerator { get; private set; }
         protected IServiceMessageContext Context { get; private set; }
         protected NamespaceTable NameSpaceUris { get; private set; }
         protected StringTable ServerUris { get; private set; }
+        protected BufferManager BufferManager { get; private set; }
+        protected RecyclableMemoryStreamManager RecyclableMemoryManager { get; private set; }
+
 
         #region Test Setup
         [OneTimeSetUp]
@@ -74,6 +90,8 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
             NameSpaceUris.GetIndexOrAppend(kApplicationUri);
             NameSpaceUris.GetIndexOrAppend(Namespaces.OpcUaGds);
             ServerUris = new StringTable();
+            BufferManager = new BufferManager(nameof(EncoderCommon), kTestBufferSize);
+            RecyclableMemoryManager = new RecyclableMemoryStreamManager(new RecyclableMemoryStreamManager.Options { BlockSize = kTestBufferSize });
         }
 
         [OneTimeTearDown]
@@ -135,6 +153,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
         protected string EncodeDataValue(
             EncodingType encoderType,
             BuiltInType builtInType,
+            MemoryStreamType memoryStreamType,
             object data,
             bool useReversibleEncoding = true
             )
@@ -146,7 +165,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
             TestContext.Out.WriteLine("Expected:");
             TestContext.Out.WriteLine(expected);
             Assert.IsNotNull(expected, "Expected DataValue is Null, " + encodeInfo);
-            using (var encoderStream = new MemoryStream())
+            using (var encoderStream = CreateEncoderMemoryStream(memoryStreamType))
             {
                 using (IEncoder encoder = CreateEncoder(encoderType, Context, encoderStream, typeof(DataValue), useReversibleEncoding))
                 {
@@ -164,6 +183,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
         protected void EncodeDecodeDataValue(
             EncodingType encoderType,
             BuiltInType builtInType,
+            MemoryStreamType memoryStreamType,
             object data
             )
         {
@@ -176,7 +196,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
             TestContext.Out.WriteLine(expected);
 
             byte[] buffer;
-            using (var encoderStream = new MemoryStream())
+            using (var encoderStream = CreateEncoderMemoryStream(memoryStreamType))
             {
                 using (IEncoder encoder = CreateEncoder(encoderType, Context, encoderStream, typeof(DataValue)))
                 {
@@ -217,6 +237,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
         protected void EncodeDecode(
             EncodingType encoderType,
             BuiltInType builtInType,
+            MemoryStreamType memoryStreamType,
             object expected
             )
         {
@@ -227,7 +248,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
             TestContext.Out.WriteLine(expected);
 
             byte[] buffer;
-            using (var encoderStream = new MemoryStream())
+            using (var encoderStream = CreateEncoderMemoryStream(memoryStreamType))
             {
                 using (IEncoder encoder = CreateEncoder(encoderType, Context, encoderStream, type))
                 {
@@ -272,6 +293,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
         /// </summary>
         protected void EncodeJsonVerifyResult(
             BuiltInType builtInType,
+            MemoryStreamType memoryStreamType,
             object data,
             bool useReversibleEncoding,
             string expected,
@@ -300,7 +322,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
             bool includeDefaultNumbers = isNumber ? includeDefaults : true;
 
             byte[] buffer;
-            using (var encoderStream = new MemoryStream())
+            using (var encoderStream = CreateEncoderMemoryStream(memoryStreamType))
             {
                 using (IEncoder encoder = CreateEncoder(EncodingType.Json, Context, encoderStream, typeof(DataValue),
                     useReversibleEncoding, topLevelIsArray, includeDefaultValues, includeDefaultNumbers))
@@ -379,16 +401,19 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
                 using (var stringWriter = new StringWriter())
                 using (var stringReader = new StringReader(json))
                 {
-                    var jsonReader = new JsonTextReader(stringReader);
-                    var jsonWriter = new JsonTextWriter(stringWriter) {
+                    using (var jsonReader = new JsonTextReader(stringReader))
+                    using (var jsonWriter = new JsonTextWriter(stringWriter)
+                    {
                         FloatFormatHandling = FloatFormatHandling.String,
                         Formatting = Newtonsoft.Json.Formatting.Indented,
                         Culture = System.Globalization.CultureInfo.InvariantCulture
-                    };
-                    jsonWriter.WriteToken(jsonReader);
-                    string formattedJson = stringWriter.ToString();
-                    TestContext.Out.WriteLine(formattedJson);
-                    return formattedJson;
+                    })
+                    {
+                        jsonWriter.WriteToken(jsonReader);
+                        string formattedJson = stringWriter.ToString();
+                        TestContext.Out.WriteLine(formattedJson);
+                        return formattedJson;
+                    }
                 }
             }
             catch (Exception ex)
@@ -397,6 +422,27 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
                 Assert.Fail("Invalid json data: " + ex.Message);
             }
             return json;
+        }
+
+        /// <summary>
+        /// Returns various implementations of a memory stream.
+        /// </summary>
+        /// <param name="memoryStreamType"></param>
+        /// <returns>A MemoryStream</returns>
+        /// <exception cref="ArgumentOutOfRangeException"></exception>
+        protected MemoryStream CreateEncoderMemoryStream(MemoryStreamType memoryStreamType)
+        {
+            switch (memoryStreamType)
+            {
+                case MemoryStreamType.MemoryStream:
+                    return new MemoryStream(kTestBufferSize);
+                case MemoryStreamType.ArraySegmentStream:
+                    return new ArraySegmentStream(BufferManager);
+                case MemoryStreamType.RecyclableMemoryStream:
+                    return new RecyclableMemoryStream(RecyclableMemoryManager);
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(memoryStreamType), memoryStreamType, "Invalid MemoryStreamType specified.");
+            }
         }
 
         /// <summary>
@@ -418,13 +464,13 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
             {
                 case EncodingType.Binary:
                     Assume.That(useReversibleEncoding, "Binary encoding only supports reversible option.");
-                    return new BinaryEncoder(stream, context, false);
+                    return new BinaryEncoder(stream, context, true);
                 case EncodingType.Xml:
                     Assume.That(useReversibleEncoding, "Xml encoding only supports reversible option.");
                     var xmlWriter = XmlWriter.Create(stream);
                     return new XmlEncoder(systemType, xmlWriter, context);
                 case EncodingType.Json:
-                    return new JsonEncoder(context, useReversibleEncoding, topLevelIsArray, stream) {
+                    return new JsonEncoder(context, useReversibleEncoding, topLevelIsArray, stream, true) {
                         IncludeDefaultValues = includeDefaultValues,
                         IncludeDefaultNumberValues = includeDefaultNumbers
                     };

--- a/Tests/Opc.Ua.Core.Tests/Types/Encoders/EncoderTests.cs
+++ b/Tests/Opc.Ua.Core.Tests/Types/Encoders/EncoderTests.cs
@@ -56,12 +56,11 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
         [Category("BuiltInType")]
         public void ReEncodeBuiltInTypeDefaultVariantInDataValue(
             EncodingType encoderType,
-            BuiltInType builtInType,
-            MemoryStreamType memoryStreamType
+            BuiltInType builtInType
             )
         {
             object defaultValue = TypeInfo.GetDefaultValue(builtInType);
-            EncodeDecodeDataValue(encoderType, builtInType, memoryStreamType, defaultValue);
+            EncodeDecodeDataValue(encoderType, builtInType, MemoryStreamType.MemoryStream, defaultValue);
         }
 
         /// <summary>
@@ -72,13 +71,12 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
         [Category("BuiltInType")]
         public void ReEncodeBuiltInTypeAsVariantInDataValue(
             EncodingType encoderType,
-            BuiltInType builtInType,
-            MemoryStreamType memoryStreamType
+            BuiltInType builtInType
             )
         {
             Assume.That(builtInType != BuiltInType.DiagnosticInfo);
             object randomData = DataGenerator.GetRandom(builtInType);
-            EncodeDecodeDataValue(encoderType, builtInType, memoryStreamType, randomData);
+            EncodeDecodeDataValue(encoderType, builtInType, MemoryStreamType.ArraySegmentStream, randomData);
         }
 
         /// <summary>
@@ -88,8 +86,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
         [Category("BuiltInType"), Repeat(kRandomRepeats)]
         public void ReEncodeBuiltInType(
             EncodingType encoderType,
-            BuiltInType builtInType,
-            MemoryStreamType memoryStreamType
+            BuiltInType builtInType
             )
         {
             SetRepeatedRandomSeed();
@@ -123,7 +120,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
                         break;
                 }
             };
-            EncodeDecode(encoderType, builtInType, memoryStreamType, randomData);
+            EncodeDecode(encoderType, builtInType, MemoryStreamType.ArraySegmentStream, randomData);
         }
 
         /// <summary>
@@ -133,8 +130,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
         [Category("BuiltInType")]
         public void ReEncodeBuiltInTypeDefaultValue(
             EncodingType encoderType,
-            BuiltInType builtInType,
-            MemoryStreamType memoryStreamType
+            BuiltInType builtInType
             )
         {
             object randomData = TypeInfo.GetDefaultValue(builtInType);
@@ -144,7 +140,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
                 // or encoding of extension objects fails.
                 randomData = ExtensionObject.Null;
             }
-            EncodeDecode(encoderType, builtInType, memoryStreamType, randomData);
+            EncodeDecode(encoderType, builtInType, MemoryStreamType.RecyclableMemoryStream, randomData);
         }
 
         /// <summary>
@@ -154,14 +150,13 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
         [Category("BuiltInType")]
         public void ReEncodeBuiltInTypeBoundaryValue(
             EncodingType encoderType,
-            BuiltInType builtInType,
-            MemoryStreamType memoryStreamType
+            BuiltInType builtInType
             )
         {
             Array boundaryValues = DataGenerator.GetRandomArray(builtInType, true, 10, true);
             foreach (var boundaryValue in boundaryValues)
             {
-                EncodeDecode(encoderType, builtInType, memoryStreamType, boundaryValue);
+                EncodeDecode(encoderType, builtInType, MemoryStreamType.MemoryStream, boundaryValue);
             }
         }
 
@@ -174,7 +169,6 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
         public void ReEncodeBuiltInTypeArrayAsRandomVariantInDataValue(
             EncodingType encoderType,
             BuiltInType builtInType,
-            MemoryStreamType memoryStreamType,
             bool useBoundaryValues,
             int arrayLength
             )
@@ -182,7 +176,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
             // ensure different sized arrays contain different data set
             SetRandomSeed(arrayLength);
             object randomData = DataGenerator.GetRandomArray(builtInType, useBoundaryValues, arrayLength, true);
-            EncodeDecodeDataValue(encoderType, builtInType, memoryStreamType, randomData);
+            EncodeDecodeDataValue(encoderType, builtInType, MemoryStreamType.ArraySegmentStream, randomData);
         }
 
         /// <summary>
@@ -193,12 +187,11 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
         [Category("BuiltInType")]
         public void ReEncodeBuiltInTypeZeroLengthArrayAsVariantInDataValue(
             EncodingType encoderType,
-            BuiltInType builtInType,
-            MemoryStreamType memoryStreamType
+            BuiltInType builtInType
             )
         {
             object randomData = DataGenerator.GetRandomArray(builtInType, false, 0, true);
-            EncodeDecodeDataValue(encoderType, builtInType, memoryStreamType, randomData);
+            EncodeDecodeDataValue(encoderType, builtInType, MemoryStreamType.RecyclableMemoryStream, randomData);
         }
 
         /// <summary>
@@ -208,13 +201,12 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
         [Theory]
         [Category("BuiltInType"), Repeat(kRandomRepeats)]
         public void ReEncodeBuiltInTypeRandomVariantInDataValue(
-            EncodingType encoderType,
-            MemoryStreamType memoryStreamType
+            EncodingType encoderType
             )
         {
             SetRepeatedRandomSeed();
             object randomData = DataGenerator.GetRandom(BuiltInType.Variant);
-            EncodeDecodeDataValue(encoderType, BuiltInType.Variant, memoryStreamType, randomData);
+            EncodeDecodeDataValue(encoderType, BuiltInType.Variant, MemoryStreamType.MemoryStream, randomData);
         }
 
         /// <summary>
@@ -224,8 +216,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
         [Theory]
         [Category("BuiltInType")]
         public void EncodeBuiltInTypeAsVariantInDataValueToNonReversibleJson(
-            BuiltInType builtInType,
-            MemoryStreamType memoryStreamType
+            BuiltInType builtInType
             )
         {
             object randomData = DataGenerator.GetRandom(builtInType);
@@ -233,11 +224,11 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
             {
                 Assert.Throws(
                     typeof(ServiceResultException),
-                    () => EncodeDataValue(EncodingType.Json, builtInType, memoryStreamType, randomData, false)
+                    () => EncodeDataValue(EncodingType.Json, builtInType, MemoryStreamType.ArraySegmentStream, randomData, false)
                 );
                 return;
             }
-            string json = EncodeDataValue(EncodingType.Json, builtInType, memoryStreamType, randomData, false);
+            string json = EncodeDataValue(EncodingType.Json, builtInType, MemoryStreamType.MemoryStream, randomData, false);
             PrettifyAndValidateJson(json);
         }
 
@@ -249,14 +240,13 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
         [Category("BuiltInType")]
         public void EncodeBuiltInTypeArrayAsVariantInDataValueToNonReversibleJson(
             BuiltInType builtInType,
-            MemoryStreamType memoryStreamType,
             bool useBoundaryValues,
             int arrayLength
             )
         {
             SetRandomSeed(arrayLength);
             object randomData = DataGenerator.GetRandomArray(builtInType, useBoundaryValues, arrayLength, true);
-            string json = EncodeDataValue(EncodingType.Json, builtInType, memoryStreamType, randomData, false);
+            string json = EncodeDataValue(EncodingType.Json, builtInType, MemoryStreamType.RecyclableMemoryStream, randomData, false);
             PrettifyAndValidateJson(json);
         }
 
@@ -267,12 +257,11 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
         [Theory]
         [Category("BuiltInType")]
         public void EncodeBuiltInTypeZeroLengthArrayAsVariantInDataValueToNonReversibleJson(
-            BuiltInType builtInType,
-            MemoryStreamType memoryStreamType
+            BuiltInType builtInType
             )
         {
             object randomData = DataGenerator.GetRandomArray(builtInType, false, 0, true);
-            string json = EncodeDataValue(EncodingType.Json, builtInType, memoryStreamType, randomData, false);
+            string json = EncodeDataValue(EncodingType.Json, builtInType, MemoryStreamType.MemoryStream, randomData, false);
             PrettifyAndValidateJson(json);
         }
 
@@ -282,8 +271,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
         [Theory]
         [Category("BuiltInType")]
         public void ReEncodeVariantCollectionInDataValue(
-            EncodingType encoderType,
-            MemoryStreamType memoryStreamType
+            EncodingType encoderType
             )
         {
             var variant = new VariantCollection {
@@ -296,7 +284,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
                 //new Variant(new TestEnumType[] { TestEnumType.One, TestEnumType.Two, TestEnumType.Hundred }),
                 new Variant(new Int32[] { 2, 3, 10 }, new TypeInfo(BuiltInType.Enumeration, 1))
             };
-            EncodeDecodeDataValue(encoderType, BuiltInType.Variant, memoryStreamType, variant);
+            EncodeDecodeDataValue(encoderType, BuiltInType.Variant, MemoryStreamType.ArraySegmentStream, variant);
         }
 
         /// <summary>
@@ -306,8 +294,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
         [Category("Array"), Repeat(kArrayRepeats)]
         public void ReEncodeVariantArrayInDataValue(
             EncodingType encoderType,
-            BuiltInType builtInType,
-            MemoryStreamType memoryStreamType
+            BuiltInType builtInType
             )
         {
             SetRepeatedRandomSeed();
@@ -315,7 +302,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
             int arrayDimension = RandomSource.NextInt32(99) + 1;
             Array randomData = DataGenerator.GetRandomArray(builtInType, false, arrayDimension, true);
             var variant = new Variant(randomData, new TypeInfo(builtInType, 1));
-            EncodeDecodeDataValue(encoderType, BuiltInType.Variant, memoryStreamType, variant);
+            EncodeDecodeDataValue(encoderType, BuiltInType.Variant, MemoryStreamType.RecyclableMemoryStream, variant);
         }
 
         /// <summary>
@@ -325,8 +312,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
         [Category("Array"), Repeat(kArrayRepeats)]
         public void EncodeArray(
             EncodingType encoderType,
-            BuiltInType builtInType,
-            MemoryStreamType memoryStreamType
+            BuiltInType builtInType
             )
         {
             SetRepeatedRandomSeed();
@@ -341,7 +327,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
             TestContext.Out.WriteLine(randomData);
 
             byte[] buffer;
-            using (var encoderStream = CreateEncoderMemoryStream(memoryStreamType))
+            using (var encoderStream = CreateEncoderMemoryStream(MemoryStreamType.MemoryStream))
             {
                 using (IEncoder encoder = CreateEncoder(encoderType, Context, encoderStream, type, true, false))
                 {
@@ -379,8 +365,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
         [Category("Matrix"), Repeat(kArrayRepeats)]
         public void ReEncodeVariantMatrixInDataValue(
             EncodingType encoderType,
-            BuiltInType builtInType,
-            MemoryStreamType memoryStreamType
+            BuiltInType builtInType
             )
         {
             SetRepeatedRandomSeed();
@@ -398,7 +383,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
             int elements = ElementsFromDimension(dimensions);
             Array randomData = DataGenerator.GetRandomArray(builtInType, false, elements, true);
             var variant = new Variant(new Matrix(randomData, builtInType, dimensions));
-            EncodeDecodeDataValue(encoderType, BuiltInType.Variant, memoryStreamType, variant);
+            EncodeDecodeDataValue(encoderType, BuiltInType.Variant, MemoryStreamType.RecyclableMemoryStream, variant);
         }
 
         /// <summary>
@@ -407,8 +392,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
         [Theory]
         [Category("Matrix"), Repeat(kArrayRepeats)]
         public void EncodeBuiltInTypeMatrixAsVariantInDataValueToNonReversibleJson(
-            BuiltInType builtInType,
-            MemoryStreamType memoryStreamType
+            BuiltInType builtInType
             )
         {
             SetRepeatedRandomSeed();
@@ -419,7 +403,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
             int elements = ElementsFromDimension(dimensions);
             Array randomData = DataGenerator.GetRandomArray(builtInType, false, elements, true);
             var variant = new Variant(new Matrix(randomData, builtInType, dimensions));
-            string json = EncodeDataValue(EncodingType.Json, BuiltInType.Variant, memoryStreamType, variant, false);
+            string json = EncodeDataValue(EncodingType.Json, BuiltInType.Variant, MemoryStreamType.ArraySegmentStream, variant, false);
             _ = PrettifyAndValidateJson(json);
         }
 
@@ -430,8 +414,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
         [Category("Matrix"), Repeat(kArrayRepeats)]
         public void EncodeMatrixInArray(
             EncodingType encoderType,
-            BuiltInType builtInType,
-            MemoryStreamType memoryStreamType)
+            BuiltInType builtInType)
         {
             SetRepeatedRandomSeed();
             Assume.That(builtInType != BuiltInType.Null);
@@ -449,7 +432,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
             TestContext.Out.WriteLine(matrix);
 
             byte[] buffer;
-            using (var encoderStream = CreateEncoderMemoryStream(memoryStreamType))
+            using (var encoderStream = CreateEncoderMemoryStream(MemoryStreamType.MemoryStream))
             {
                 using (IEncoder encoder = CreateEncoder(encoderType, Context, encoderStream, type))
                 {
@@ -487,8 +470,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
         [Category("Matrix")]
         public void MatrixOverflow(
             EncodingType encoderType,
-            BuiltInType builtInType,
-            MemoryStreamType memoryStreamType
+            BuiltInType builtInType
             )
         {
             Assume.That(builtInType != BuiltInType.Null);
@@ -522,7 +504,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
             TestContext.Out.WriteLine(expected);
 
             byte[] buffer;
-            using (var encoderStream = CreateEncoderMemoryStream(memoryStreamType))
+            using (var encoderStream = CreateEncoderMemoryStream(MemoryStreamType.MemoryStream))
             {
                 using (IEncoder encoder = CreateEncoder(encoderType, Context, encoderStream, typeof(DataValue)))
                 {
@@ -584,8 +566,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
         [Category("Matrix")]
         public void MatrixOverflowStaticDimensions(
             EncodingType encoderType,
-            BuiltInType builtInType,
-            MemoryStreamType memoryStreamType
+            BuiltInType builtInType
             )
         {
             Assume.That(builtInType != BuiltInType.Null);
@@ -614,7 +595,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
             TestContext.Out.WriteLine(expected);
 
             byte[] buffer;
-            using (var encoderStream = CreateEncoderMemoryStream(memoryStreamType))
+            using (var encoderStream = CreateEncoderMemoryStream(MemoryStreamType.ArraySegmentStream))
             {
                 using (IEncoder encoder = CreateEncoder(encoderType, Context, encoderStream, typeof(DataValue)))
                 {
@@ -676,8 +657,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
         [Category("Matrix")]
         public void EncodeMatrixInArrayOverflow(
             EncodingType encoderType,
-            BuiltInType builtInType,
-            MemoryStreamType memoryStreamType
+            BuiltInType builtInType
             )
         {
             Assume.That(builtInType != BuiltInType.Null);
@@ -707,7 +687,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
             TestContext.Out.WriteLine(matrix);
 
             byte[] buffer;
-            using (var encoderStream = CreateEncoderMemoryStream(memoryStreamType))
+            using (var encoderStream = CreateEncoderMemoryStream(MemoryStreamType.RecyclableMemoryStream))
             {
                 using (IEncoder encoder = CreateEncoder(encoderType, Context, encoderStream, type))
                 {

--- a/Tests/Opc.Ua.Core.Tests/Types/Encoders/EncoderTests.cs
+++ b/Tests/Opc.Ua.Core.Tests/Types/Encoders/EncoderTests.cs
@@ -56,11 +56,12 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
         [Category("BuiltInType")]
         public void ReEncodeBuiltInTypeDefaultVariantInDataValue(
             EncodingType encoderType,
-            BuiltInType builtInType
+            BuiltInType builtInType,
+            MemoryStreamType memoryStreamType
             )
         {
             object defaultValue = TypeInfo.GetDefaultValue(builtInType);
-            EncodeDecodeDataValue(encoderType, builtInType, defaultValue);
+            EncodeDecodeDataValue(encoderType, builtInType, memoryStreamType, defaultValue);
         }
 
         /// <summary>
@@ -71,12 +72,13 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
         [Category("BuiltInType")]
         public void ReEncodeBuiltInTypeAsVariantInDataValue(
             EncodingType encoderType,
-            BuiltInType builtInType
+            BuiltInType builtInType,
+            MemoryStreamType memoryStreamType
             )
         {
             Assume.That(builtInType != BuiltInType.DiagnosticInfo);
             object randomData = DataGenerator.GetRandom(builtInType);
-            EncodeDecodeDataValue(encoderType, builtInType, randomData);
+            EncodeDecodeDataValue(encoderType, builtInType, memoryStreamType, randomData);
         }
 
         /// <summary>
@@ -86,7 +88,8 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
         [Category("BuiltInType"), Repeat(kRandomRepeats)]
         public void ReEncodeBuiltInType(
             EncodingType encoderType,
-            BuiltInType builtInType
+            BuiltInType builtInType,
+            MemoryStreamType memoryStreamType
             )
         {
             SetRepeatedRandomSeed();
@@ -120,7 +123,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
                         break;
                 }
             };
-            EncodeDecode(encoderType, builtInType, randomData);
+            EncodeDecode(encoderType, builtInType, memoryStreamType, randomData);
         }
 
         /// <summary>
@@ -130,7 +133,8 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
         [Category("BuiltInType")]
         public void ReEncodeBuiltInTypeDefaultValue(
             EncodingType encoderType,
-            BuiltInType builtInType
+            BuiltInType builtInType,
+            MemoryStreamType memoryStreamType
             )
         {
             object randomData = TypeInfo.GetDefaultValue(builtInType);
@@ -140,7 +144,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
                 // or encoding of extension objects fails.
                 randomData = ExtensionObject.Null;
             }
-            EncodeDecode(encoderType, builtInType, randomData);
+            EncodeDecode(encoderType, builtInType, memoryStreamType, randomData);
         }
 
         /// <summary>
@@ -150,13 +154,14 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
         [Category("BuiltInType")]
         public void ReEncodeBuiltInTypeBoundaryValue(
             EncodingType encoderType,
-            BuiltInType builtInType
+            BuiltInType builtInType,
+            MemoryStreamType memoryStreamType
             )
         {
             Array boundaryValues = DataGenerator.GetRandomArray(builtInType, true, 10, true);
             foreach (var boundaryValue in boundaryValues)
             {
-                EncodeDecode(encoderType, builtInType, boundaryValue);
+                EncodeDecode(encoderType, builtInType, memoryStreamType, boundaryValue);
             }
         }
 
@@ -169,6 +174,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
         public void ReEncodeBuiltInTypeArrayAsRandomVariantInDataValue(
             EncodingType encoderType,
             BuiltInType builtInType,
+            MemoryStreamType memoryStreamType,
             bool useBoundaryValues,
             int arrayLength
             )
@@ -176,7 +182,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
             // ensure different sized arrays contain different data set
             SetRandomSeed(arrayLength);
             object randomData = DataGenerator.GetRandomArray(builtInType, useBoundaryValues, arrayLength, true);
-            EncodeDecodeDataValue(encoderType, builtInType, randomData);
+            EncodeDecodeDataValue(encoderType, builtInType, memoryStreamType, randomData);
         }
 
         /// <summary>
@@ -187,11 +193,12 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
         [Category("BuiltInType")]
         public void ReEncodeBuiltInTypeZeroLengthArrayAsVariantInDataValue(
             EncodingType encoderType,
-            BuiltInType builtInType
+            BuiltInType builtInType,
+            MemoryStreamType memoryStreamType
             )
         {
             object randomData = DataGenerator.GetRandomArray(builtInType, false, 0, true);
-            EncodeDecodeDataValue(encoderType, builtInType, randomData);
+            EncodeDecodeDataValue(encoderType, builtInType, memoryStreamType, randomData);
         }
 
         /// <summary>
@@ -201,12 +208,13 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
         [Theory]
         [Category("BuiltInType"), Repeat(kRandomRepeats)]
         public void ReEncodeBuiltInTypeRandomVariantInDataValue(
-            EncodingType encoderType
+            EncodingType encoderType,
+            MemoryStreamType memoryStreamType
             )
         {
             SetRepeatedRandomSeed();
             object randomData = DataGenerator.GetRandom(BuiltInType.Variant);
-            EncodeDecodeDataValue(encoderType, BuiltInType.Variant, randomData);
+            EncodeDecodeDataValue(encoderType, BuiltInType.Variant, memoryStreamType, randomData);
         }
 
         /// <summary>
@@ -216,7 +224,8 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
         [Theory]
         [Category("BuiltInType")]
         public void EncodeBuiltInTypeAsVariantInDataValueToNonReversibleJson(
-            BuiltInType builtInType
+            BuiltInType builtInType,
+            MemoryStreamType memoryStreamType
             )
         {
             object randomData = DataGenerator.GetRandom(builtInType);
@@ -224,11 +233,11 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
             {
                 Assert.Throws(
                     typeof(ServiceResultException),
-                    () => EncodeDataValue(EncodingType.Json, builtInType, randomData, false)
+                    () => EncodeDataValue(EncodingType.Json, builtInType, memoryStreamType, randomData, false)
                 );
                 return;
             }
-            string json = EncodeDataValue(EncodingType.Json, builtInType, randomData, false);
+            string json = EncodeDataValue(EncodingType.Json, builtInType, memoryStreamType, randomData, false);
             PrettifyAndValidateJson(json);
         }
 
@@ -240,13 +249,14 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
         [Category("BuiltInType")]
         public void EncodeBuiltInTypeArrayAsVariantInDataValueToNonReversibleJson(
             BuiltInType builtInType,
+            MemoryStreamType memoryStreamType,
             bool useBoundaryValues,
             int arrayLength
             )
         {
             SetRandomSeed(arrayLength);
             object randomData = DataGenerator.GetRandomArray(builtInType, useBoundaryValues, arrayLength, true);
-            string json = EncodeDataValue(EncodingType.Json, builtInType, randomData, false);
+            string json = EncodeDataValue(EncodingType.Json, builtInType, memoryStreamType, randomData, false);
             PrettifyAndValidateJson(json);
         }
 
@@ -257,11 +267,12 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
         [Theory]
         [Category("BuiltInType")]
         public void EncodeBuiltInTypeZeroLengthArrayAsVariantInDataValueToNonReversibleJson(
-            BuiltInType builtInType
+            BuiltInType builtInType,
+            MemoryStreamType memoryStreamType
             )
         {
             object randomData = DataGenerator.GetRandomArray(builtInType, false, 0, true);
-            string json = EncodeDataValue(EncodingType.Json, builtInType, randomData, false);
+            string json = EncodeDataValue(EncodingType.Json, builtInType, memoryStreamType, randomData, false);
             PrettifyAndValidateJson(json);
         }
 
@@ -271,7 +282,8 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
         [Theory]
         [Category("BuiltInType")]
         public void ReEncodeVariantCollectionInDataValue(
-            EncodingType encoderType
+            EncodingType encoderType,
+            MemoryStreamType memoryStreamType
             )
         {
             var variant = new VariantCollection {
@@ -284,7 +296,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
                 //new Variant(new TestEnumType[] { TestEnumType.One, TestEnumType.Two, TestEnumType.Hundred }),
                 new Variant(new Int32[] { 2, 3, 10 }, new TypeInfo(BuiltInType.Enumeration, 1))
             };
-            EncodeDecodeDataValue(encoderType, BuiltInType.Variant, variant);
+            EncodeDecodeDataValue(encoderType, BuiltInType.Variant, memoryStreamType, variant);
         }
 
         /// <summary>
@@ -294,7 +306,8 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
         [Category("Array"), Repeat(kArrayRepeats)]
         public void ReEncodeVariantArrayInDataValue(
             EncodingType encoderType,
-            BuiltInType builtInType
+            BuiltInType builtInType,
+            MemoryStreamType memoryStreamType
             )
         {
             SetRepeatedRandomSeed();
@@ -302,7 +315,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
             int arrayDimension = RandomSource.NextInt32(99) + 1;
             Array randomData = DataGenerator.GetRandomArray(builtInType, false, arrayDimension, true);
             var variant = new Variant(randomData, new TypeInfo(builtInType, 1));
-            EncodeDecodeDataValue(encoderType, BuiltInType.Variant, variant);
+            EncodeDecodeDataValue(encoderType, BuiltInType.Variant, memoryStreamType, variant);
         }
 
         /// <summary>
@@ -312,7 +325,8 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
         [Category("Array"), Repeat(kArrayRepeats)]
         public void EncodeArray(
             EncodingType encoderType,
-            BuiltInType builtInType
+            BuiltInType builtInType,
+            MemoryStreamType memoryStreamType
             )
         {
             SetRepeatedRandomSeed();
@@ -327,7 +341,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
             TestContext.Out.WriteLine(randomData);
 
             byte[] buffer;
-            using (var encoderStream = new MemoryStream())
+            using (var encoderStream = CreateEncoderMemoryStream(memoryStreamType))
             {
                 using (IEncoder encoder = CreateEncoder(encoderType, Context, encoderStream, type, true, false))
                 {
@@ -365,7 +379,8 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
         [Category("Matrix"), Repeat(kArrayRepeats)]
         public void ReEncodeVariantMatrixInDataValue(
             EncodingType encoderType,
-            BuiltInType builtInType
+            BuiltInType builtInType,
+            MemoryStreamType memoryStreamType
             )
         {
             SetRepeatedRandomSeed();
@@ -383,7 +398,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
             int elements = ElementsFromDimension(dimensions);
             Array randomData = DataGenerator.GetRandomArray(builtInType, false, elements, true);
             var variant = new Variant(new Matrix(randomData, builtInType, dimensions));
-            EncodeDecodeDataValue(encoderType, BuiltInType.Variant, variant);
+            EncodeDecodeDataValue(encoderType, BuiltInType.Variant, memoryStreamType, variant);
         }
 
         /// <summary>
@@ -392,7 +407,8 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
         [Theory]
         [Category("Matrix"), Repeat(kArrayRepeats)]
         public void EncodeBuiltInTypeMatrixAsVariantInDataValueToNonReversibleJson(
-            BuiltInType builtInType
+            BuiltInType builtInType,
+            MemoryStreamType memoryStreamType
             )
         {
             SetRepeatedRandomSeed();
@@ -403,7 +419,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
             int elements = ElementsFromDimension(dimensions);
             Array randomData = DataGenerator.GetRandomArray(builtInType, false, elements, true);
             var variant = new Variant(new Matrix(randomData, builtInType, dimensions));
-            string json = EncodeDataValue(EncodingType.Json, BuiltInType.Variant, variant, false);
+            string json = EncodeDataValue(EncodingType.Json, BuiltInType.Variant, memoryStreamType, variant, false);
             _ = PrettifyAndValidateJson(json);
         }
 
@@ -414,7 +430,8 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
         [Category("Matrix"), Repeat(kArrayRepeats)]
         public void EncodeMatrixInArray(
             EncodingType encoderType,
-            BuiltInType builtInType)
+            BuiltInType builtInType,
+            MemoryStreamType memoryStreamType)
         {
             SetRepeatedRandomSeed();
             Assume.That(builtInType != BuiltInType.Null);
@@ -432,7 +449,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
             TestContext.Out.WriteLine(matrix);
 
             byte[] buffer;
-            using (var encoderStream = new MemoryStream())
+            using (var encoderStream = CreateEncoderMemoryStream(memoryStreamType))
             {
                 using (IEncoder encoder = CreateEncoder(encoderType, Context, encoderStream, type))
                 {
@@ -470,7 +487,8 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
         [Category("Matrix")]
         public void MatrixOverflow(
             EncodingType encoderType,
-            BuiltInType builtInType
+            BuiltInType builtInType,
+            MemoryStreamType memoryStreamType
             )
         {
             Assume.That(builtInType != BuiltInType.Null);
@@ -504,7 +522,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
             TestContext.Out.WriteLine(expected);
 
             byte[] buffer;
-            using (var encoderStream = new MemoryStream())
+            using (var encoderStream = CreateEncoderMemoryStream(memoryStreamType))
             {
                 using (IEncoder encoder = CreateEncoder(encoderType, Context, encoderStream, typeof(DataValue)))
                 {
@@ -566,7 +584,8 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
         [Category("Matrix")]
         public void MatrixOverflowStaticDimensions(
             EncodingType encoderType,
-            BuiltInType builtInType
+            BuiltInType builtInType,
+            MemoryStreamType memoryStreamType
             )
         {
             Assume.That(builtInType != BuiltInType.Null);
@@ -595,7 +614,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
             TestContext.Out.WriteLine(expected);
 
             byte[] buffer;
-            using (var encoderStream = new MemoryStream())
+            using (var encoderStream = CreateEncoderMemoryStream(memoryStreamType))
             {
                 using (IEncoder encoder = CreateEncoder(encoderType, Context, encoderStream, typeof(DataValue)))
                 {
@@ -656,8 +675,9 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
         [Theory]
         [Category("Matrix")]
         public void EncodeMatrixInArrayOverflow(
-        EncodingType encoderType,
-        BuiltInType builtInType
+            EncodingType encoderType,
+            BuiltInType builtInType,
+            MemoryStreamType memoryStreamType
             )
         {
             Assume.That(builtInType != BuiltInType.Null);
@@ -687,7 +707,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
             TestContext.Out.WriteLine(matrix);
 
             byte[] buffer;
-            using (var encoderStream = new MemoryStream())
+            using (var encoderStream = CreateEncoderMemoryStream(memoryStreamType))
             {
                 using (IEncoder encoder = CreateEncoder(encoderType, Context, encoderStream, type))
                 {

--- a/Tests/Opc.Ua.Core.Tests/Types/Encoders/JsonEncoderBenchmarks.cs
+++ b/Tests/Opc.Ua.Core.Tests/Types/Encoders/JsonEncoderBenchmarks.cs
@@ -172,7 +172,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
         [Test]
         public void JsonEncoderArraySegmentStream()
         {
-            using (var arraySegmentStream = new ArraySegmentStream(m_bufferManager, StreamBufferSize, 0, StreamBufferSize))
+            using (var arraySegmentStream = new ArraySegmentStream(m_bufferManager))
             {
                 JsonEncoder_StreamLeaveOpen(arraySegmentStream);
                 // get buffers and return them to buffer manager
@@ -192,9 +192,9 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
         public void JsonEncoderArraySegmentStreamNoSpan()
         {
 #if NET6_0_OR_GREATER
-            using (var arraySegmentStream = new ArraySegmentStreamNoSpan(m_bufferManager, StreamBufferSize, 0, StreamBufferSize))
+            using (var arraySegmentStream = new ArraySegmentStreamNoSpan(m_bufferManager))
 #else
-            using (var arraySegmentStream = new ArraySegmentStream(m_bufferManager, StreamBufferSize, 0, StreamBufferSize))
+            using (var arraySegmentStream = new ArraySegmentStream(m_bufferManager))
 #endif
             {
                 JsonEncoder_StreamLeaveOpen(arraySegmentStream);

--- a/Tests/Opc.Ua.Core.Tests/Types/Encoders/JsonEncoderBenchmarks.cs
+++ b/Tests/Opc.Ua.Core.Tests/Types/Encoders/JsonEncoderBenchmarks.cs
@@ -27,13 +27,8 @@
  * http://opcfoundation.org/License/MIT/1.00/
  * ======================================================================*/
 
-using System;
-using System.Collections.Generic;
-using System.Globalization;
 using System.IO;
-using System.Runtime.CompilerServices;
 using System.Text;
-using System.Threading;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Diagnosers;
 using Microsoft.IO;
@@ -47,57 +42,55 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
     [NonParallelizable]
     [MemoryDiagnoser]
     [DisassemblyDiagnoser]
-    public class JsonEncoderBenchmarks
+    public class JsonEncoderBenchmarks : EncoderBenchmarks
     {
-        const int kBufferSize = 4096;
-
-        [Params(1, 2, 8, 64)]
-        public int PayLoadSize { get; set; } = 64;
-
         [Params(128, 512, 1024, 4096, 8192, 65536)]
         public int StreamSize { get; set; } = 1024;
 
         /// <summary>
         /// Benchmark overhead to create StreamWriter, MemoryStream is kept open.
         /// </summary>
-        [Benchmark]
         [Test]
         public void StreamWriter()
         {
-            using (var test = new StreamWriter(m_memoryStream, Encoding.UTF8, StreamSize, true))
+            using (var memoryStream = new MemoryStream())
+            using (var test = new StreamWriter(memoryStream, Encoding.UTF8, StreamSize, true))
+            {
                 test.Flush();
+            }
         }
 
         /// <summary>
         /// Benchmark overhead to create StreamWriter and MemoryStream.
         /// </summary>
-        [Benchmark]
         [Test]
         public void StreamWriterRecyclableMemoryStream()
         {
             using (var memoryStream = new RecyclableMemoryStream(m_memoryManager))
             using (var test = new StreamWriter(memoryStream, Encoding.UTF8, StreamSize))
+            {
                 test.Flush();
+            }
         }
 
         /// <summary>
         /// Benchmark overhead to create StreamWriter and MemoryStream.
         /// </summary>
-        [Benchmark]
         [Test]
         public void StreamWriterMemoryStream()
         {
             using (var memoryStream = new MemoryStream())
             using (var test = new StreamWriter(memoryStream, Encoding.UTF8, StreamSize))
+            {
                 test.Flush();
+            }
         }
 
         /// <summary>
         /// Benchmark encoding with internal memory stream.
         /// </summary>
-        [Benchmark]
         [Test]
-        public void JsonEncoderConstructor2()
+        public void JsonEncoderConstructor()
         {
             using (var jsonEncoder = new JsonEncoder(m_context, false))
             {
@@ -107,66 +100,141 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
         }
 
         /// <summary>
+        /// Test encoding with ArrayPool memory stream.
+        /// </summary>
+        [Theory]
+        public void JsonEncoderArraySegmentStreamTest(bool toText)
+        {
+            using (var memoryStream = new ArraySegmentStream(m_bufferManager, StreamBufferSize, 0, StreamBufferSize))
+            {
+                TestStreamEncode(memoryStream, toText);
+            }
+        }
+
+        /// <summary>
+        /// Test encoding with memory stream kept open.
+        /// </summary>
+        [Theory]
+        public void JsonEncoderMemoryStreamTest(bool toText)
+        {
+            using (var memoryStream = new MemoryStream(StreamBufferSize))
+            {
+                TestStreamEncode(memoryStream, toText);
+            }
+        }
+
+        /// <summary>
+        /// Test encoding with recyclable memory stream kept open.
+        /// </summary>
+        [Theory]
+        public void JsonEncoderRecyclableMemoryStream(bool toText)
+        {
+            using (var memoryStream = new RecyclableMemoryStream(m_memoryManager))
+            {
+                TestStreamEncode(memoryStream, toText);
+            }
+        }
+
+        /// <summary>
         /// Benchmark encoding with memory stream kept open.
         /// </summary>
         [Benchmark]
         [Test]
-        public void JsonEncoderStreamLeaveOpenMemoryStream()
+        public void JsonEncoderMemoryStream()
         {
-            JsonEncoder_StreamLeaveOpen(m_memoryStream);
-        }
-
-        /// <summary>
-        /// Benchmark encoding with recyclable memory stream kept open.
-        /// </summary>
-        [Benchmark]
-        [Test]
-        public void JsonEncoderStreamLeaveOpenRecyclableMemoryStream()
-        {
-            JsonEncoder_StreamLeaveOpen(m_recyclableMemoryStream);
-        }
-
-        /// <summary>
-        /// Benchmark encoding with recyclable memory stream kept open.
-        /// </summary>
-        [Benchmark]
-        [Test]
-        public void JsonEncoderStreamLeaveOpenArraySegmentStream()
-        {
-            JsonEncoder_StreamLeaveOpen(m_arraySegmentStream);
-        }
-
-        /// <summary>
-        /// Benchmark encoding with memory stream kept open,
-        /// use internal reflection to get string from memory stream.
-        /// </summary>
-        [Benchmark]
-        [Test]
-        public void JsonEncoderConstructorStreamwriterReflection2()
-        {
-            using (var jsonEncoder = new JsonEncoder(m_context, false, false, m_memoryStream, true, StreamSize))
+            using (var memoryStream = new MemoryStream(StreamBufferSize))
             {
-                TestEncoding(jsonEncoder);
-                var result = jsonEncoder.CloseAndReturnText();
+                JsonEncoder_StreamLeaveOpen(memoryStream);
+                // get buffer for write
+                _ = memoryStream.ToArray();
+            }
+        }
+
+        /// <summary>
+        /// Benchmark encoding with recyclable memory stream kept open.
+        /// </summary>
+        [Benchmark]
+        [Test]
+        public void JsonEncoderRecyclableMemoryStream()
+        {
+            using (var recyclableMemoryStream = new RecyclableMemoryStream(m_memoryManager))
+            {
+                JsonEncoder_StreamLeaveOpen(recyclableMemoryStream);
+                // get buffers for write
+                _ = recyclableMemoryStream.GetReadOnlySequence();
+            }
+        }
+
+        /// <summary>
+        /// Benchmark encoding with recyclable memory stream kept open.
+        /// </summary>
+        [Benchmark]
+        [Test]
+        public void JsonEncoderArraySegmentStream()
+        {
+            using (var arraySegmentStream = new ArraySegmentStream(m_bufferManager, StreamBufferSize, 0, StreamBufferSize))
+            {
+                JsonEncoder_StreamLeaveOpen(arraySegmentStream);
+                // get buffers and return them to buffer manager
+                var buffers = arraySegmentStream.GetBuffers("writer");
+                foreach (var buffer in buffers)
+                {
+                    m_bufferManager.ReturnBuffer(buffer.Array, "testreturn");
+                }
+            }
+        }
+
+        /// <summary>
+        /// Benchmark encoding with recyclable memory stream kept open.
+        /// </summary>
+        [Benchmark]
+        [Test]
+        public void JsonEncoderArraySegmentStreamNoSpan()
+        {
+#if NET6_0_OR_GREATER
+            using (var arraySegmentStream = new ArraySegmentStreamNoSpan(m_bufferManager, StreamBufferSize, 0, StreamBufferSize))
+#else
+            using (var arraySegmentStream = new ArraySegmentStream(m_bufferManager, StreamBufferSize, 0, StreamBufferSize))
+#endif
+            {
+                JsonEncoder_StreamLeaveOpen(arraySegmentStream);
+                // get buffers and return them to buffer manager
+                var buffers = arraySegmentStream.GetBuffers("writer");
+                foreach (var buffer in buffers)
+                {
+                    m_bufferManager.ReturnBuffer(buffer.Array, "testreturn");
+                }
             }
         }
 
         #region Private Methods
-        private void TestEncoding(IEncoder encoder)
+        private void TestStreamEncode(MemoryStream memoryStream, bool toArray)
         {
-            int payLoadSize = PayLoadSize;
-            encoder.WriteByte("Byte", 0);
-            while (--payLoadSize > 0)
+            using (var jsonEncoder = new JsonEncoder(m_context, false, false, memoryStream, true, StreamSize))
             {
-                encoder.WriteBoolean("Boolean", true);
-                encoder.WriteUInt64("UInt64", 1234566890);
-                encoder.WriteString("String", "The quick brown fox...");
-                encoder.WriteNodeId("NodeId", s_nodeId);
-                encoder.WriteInt32Array("Array", s_list);
+                TestEncoding(jsonEncoder);
+                _ = jsonEncoder.Close();
+            }
+            using (var jsonEncoder = new JsonEncoder(m_context, false, false, memoryStream, true, StreamSize))
+            {
+                TestEncoding(jsonEncoder);
+                if (toArray)
+                {
+                    int length = jsonEncoder.Close();
+                    Assert.AreEqual(length, memoryStream.Position);
+                    var result = memoryStream.ToArray();
+                    Assert.NotNull(result);
+                    Assert.AreEqual(length, result.Length);
+                }
+                else
+                {
+                    var result = jsonEncoder.CloseAndReturnText();
+                    Assert.NotNull(result);
+                }
             }
         }
 
-        private void JsonEncoder_StreamLeaveOpen(MemoryStream stream)
+        private void JsonEncoder_StreamLeaveOpen(MemoryStream stream, bool testResult = false)
         {
             int length1;
             int length2;
@@ -181,39 +249,22 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
                 TestEncoding(jsonEncoder);
                 length2 = jsonEncoder.Close();
             }
-            var result = Encoding.UTF8.GetString(stream.ToArray());
-            Assert.NotNull(result);
-            Assert.AreEqual(length1 * 2, length2);
-            Assert.AreEqual(length2, result.Length);
+            if (testResult)
+            {
+                var result = Encoding.UTF8.GetString(stream.ToArray());
+                Assert.NotNull(result);
+                Assert.AreEqual(length1 * 2, length2);
+                Assert.AreEqual(length2, result.Length);
+            }
         }
         #endregion
 
         #region Test Setup
         [OneTimeSetUp]
-        public void OneTimeSetUp()
-        {
-            // for validating benchmark tests
-            m_context = new ServiceMessageContext();
-            m_memoryStream = new MemoryStream();
-            m_memoryManager = new RecyclableMemoryStreamManager();
-            m_recyclableMemoryStream = new RecyclableMemoryStream(m_memoryManager);
-            m_bufferManager = new BufferManager(nameof(BinaryEncoder), kBufferSize);
-            m_arraySegmentStream = new ArraySegmentStream(m_bufferManager, kBufferSize, 0, kBufferSize);
-        }
+        public new void OneTimeSetUp() => base.OneTimeSetUp();
 
         [OneTimeTearDown]
-        public void OneTimeTearDown()
-        {
-            m_context = null;
-            m_memoryStream.Dispose();
-            m_memoryStream = null;
-            m_recyclableMemoryStream.Dispose();
-            m_recyclableMemoryStream = null;
-            m_memoryManager = null;
-            m_bufferManager = null;
-            m_arraySegmentStream.Dispose();
-            m_arraySegmentStream = null;
-        }
+        public new void OneTimeTearDown() => base.OneTimeTearDown();
         #endregion
 
         #region Benchmark Setup
@@ -221,983 +272,13 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
         /// Set up some variables for benchmarks.
         /// </summary>
         [GlobalSetup]
-        public void GlobalSetup()
-        {
-            // for validating benchmark tests
-            m_context = new ServiceMessageContext();
-            m_memoryStream = new MemoryStream();
-            m_memoryManager = new RecyclableMemoryStreamManager();
-            m_recyclableMemoryStream = new RecyclableMemoryStream(m_memoryManager);
-            m_bufferManager = new BufferManager(nameof(BinaryEncoder), kBufferSize);
-            m_arraySegmentStream = new ArraySegmentStream(m_bufferManager, kBufferSize, 0, kBufferSize);
-        }
+        public new void GlobalSetup() => base.GlobalSetup();
 
         /// <summary>
         /// Tear down benchmark variables.
         /// </summary>
         [GlobalCleanup]
-        public void GlobalCleanup()
-        {
-            m_context = null;
-            m_memoryStream.Dispose();
-            m_memoryStream = null;
-            m_recyclableMemoryStream.Dispose();
-            m_recyclableMemoryStream = null;
-            m_memoryManager = null;
-            m_bufferManager = null;
-            m_arraySegmentStream.Dispose();
-            m_arraySegmentStream = null;
-        }
-        #endregion
-
-        #region Private Fields
-        private static NodeId s_nodeId = new NodeId(1234);
-        private static IList<Int32> s_list = new List<Int32>() { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
-        private IServiceMessageContext m_context;
-        private MemoryStream m_memoryStream;
-        private RecyclableMemoryStreamManager m_memoryManager;
-        private RecyclableMemoryStream m_recyclableMemoryStream;
-        private BufferManager m_bufferManager;
-        private ArraySegmentStream m_arraySegmentStream;
-        #endregion
-    }
-
-    [TestFixture, Category("JsonEncoder")]
-    [SetCulture("en-us"), SetUICulture("en-us")]
-    [NonParallelizable]
-    [MemoryDiagnoser]
-    [DisassemblyDiagnoser]
-    public class JsonEncoderDateTimeBenchmark
-    {
-        [Params(0, 4, 7)]
-        public int DateTimeOmittedZeros { get; set; } = 0;
-
-        [Benchmark]
-        [Test]
-        public void DateTimeEncodeToString()
-        {
-            _ = m_dateTime.ToUniversalTime().ToString("yyyy-MM-dd'T'HH:mm:ss.FFFFFFFK", CultureInfo.InvariantCulture);
-        }
-
-        [Benchmark]
-        [Test]
-        public void ConvertToUniversalTime()
-        {
-            _ = JsonEncoder.ConvertUniversalTimeToString(m_dateTime);
-        }
-
-        #region Test Setup
-        [OneTimeSetUp]
-        public void OneTimeSetUp()
-        {
-            // for validating benchmark tests
-            m_dateTime = DateTime.UtcNow;
-        }
-
-        [OneTimeTearDown]
-        public void OneTimeTearDown()
-        {
-        }
-        #endregion
-
-        #region Benchmark Setup
-        /// <summary>
-        /// Set up some variables for benchmarks.
-        /// </summary>
-        [GlobalSetup]
-        public void GlobalSetup()
-        {
-            // for validating benchmark tests
-            switch (DateTimeOmittedZeros)
-            {
-                case 4: m_dateTime = new DateTime(2011, 11, 11, 11, 11, 11, 999, DateTimeKind.Utc); break;
-                case 7: m_dateTime = new DateTime(2011, 11, 11, 11, 11, 11, DateTimeKind.Utc); break;
-                default:
-                    do
-                    {
-                        m_dateTime = DateTime.UtcNow;
-                    } while (m_dateTime.Ticks % 10 == 0);
-                    break;
-            }
-        }
-
-        /// <summary>
-        /// Tear down benchmark variables.
-        /// </summary>
-        [GlobalCleanup]
-        public void GlobalCleanup()
-        {
-        }
-        #endregion
-
-        #region Private Fields
-        private DateTime m_dateTime;
-        #endregion
-    }
-
-    [TestFixture, Category("JsonEncoder")]
-    [SetCulture("en-us"), SetUICulture("en-us")]
-    [NonParallelizable]
-    [MemoryDiagnoser]
-    [DisassemblyDiagnoser(printSource: true)]
-    public class JsonEncoderEscapeStringBenchmarks
-    {
-        public const int InnerLoops = 100;
-        [DatapointSource]
-        [Params(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)]
-        public int StringVariantIndex { get; set; } = 1;
-
-        [DatapointSource]
-        // for benchmarking with different escaped strings
-        public static readonly string[] EscapeTestStrings =
-        {
-            // The use case without escape characters, plain text
-                "The quick brown fox jumps over the lazy dog.",
-            // The use case with many control characters escaped, 1 char spaces
-                "\" \n \r \t \b \f \\ ",
-            // The use case with many control characters escaped, 2 char spaces
-                "  \"  \n  \r  \t  \b  \f  \\  ",
-            // The use case with many control characters escaped, 3 char spaces
-                "   \"   \n   \r   \t   \b   \f   \\   ",
-            // The use case with many control characters escaped, 5 char spaces
-                "     \"     \n     \r     \t     \b     \f     \\     ",
-            // The use case with many binary characters escaped, 1 char spaces
-                "\0 \x01 \x02 \x03 \x04 ",
-            // The use case with many binary characters escaped, 2 char spaces
-                "  \0  \x01  \x02  \x03  \x04  ",
-            // The use case with many binary characters escaped, 3 char spaces
-                "   \0   \x01   \x02   \x03   \x04   ",
-            // The use case with many binary characters escaped, 5 char spaces
-                "     \0     \x01     \x02     \x03     \x04     ",
-            // The use case with all escape characters and a long string
-                "Ascii characters, special characters \n \b & control characters \0 \x04 ␀ ␁ ␂ ␃ ␄. This is a test.",
-        };
-
-        /// <summary>
-        /// Benchmark encoding of the previous implementation.
-        /// </summary>
-        [Benchmark(Baseline = true)]
-        public void EscapeStringLegacy()
-        {
-            m_memoryStream.Position = 0;
-            int repeats = InnerLoops;
-            while (repeats-- > 0)
-            {
-                EscapedStringLegacy(m_testString);
-            }
-            m_streamWriter.Flush();
-        }
-
-        /// <summary>
-        /// Benchmark encoding of the previous implementation with snall improvement for binary encoding.
-        /// </summary>
-        [Benchmark]
-        public void EscapeStringLegacyPlus()
-        {
-            m_memoryStream.Position = 0;
-            int repeats = InnerLoops;
-            while (repeats-- > 0)
-            {
-                EscapedStringLegacyPlus(m_testString);
-            }
-            m_streamWriter.Flush();
-        }
-
-        /// <summary>
-        /// A new implementation using StringBuilder.
-        /// </summary>
-        [Benchmark]
-        public void EscapeStringStringBuilder()
-        {
-            m_memoryStream.Position = 0;
-            int repeats = InnerLoops;
-            while (repeats-- > 0)
-            {
-                EscapeString(m_testString);
-            }
-            m_streamWriter.Flush();
-        }
-
-        /// <summary>
-        /// A new implementation using ThreadLocal StringBuilder.
-        /// </summary>
-        [Benchmark]
-        public void EscapeStringThreadLocal()
-        {
-            m_memoryStream.Position = 0;
-            int repeats = InnerLoops;
-            while (repeats-- > 0)
-            {
-                EscapeStringThreadLocal(m_testString);
-            }
-            m_streamWriter.Flush();
-        }
-
-        /// <summary>
-        /// A new implementation using ReadOnlySpan.
-        /// </summary>
-        [Benchmark]
-        public void EscapeStringSpan()
-        {
-            m_memoryStream.Position = 0;
-            int repeats = InnerLoops;
-            while (repeats-- > 0)
-            {
-                EscapeStringSpan(m_testString);
-            }
-            m_streamWriter.Flush();
-        }
-
-        /// <summary>
-        /// A new implementation using ReadOnlySpan and char write.
-        /// </summary>
-        [Benchmark]
-        public void EscapeStringSpanChars()
-        {
-            m_memoryStream.Position = 0;
-            int repeats = InnerLoops;
-            while (repeats-- > 0)
-            {
-                EscapeStringSpanChars(m_testString);
-            }
-            m_streamWriter.Flush();
-        }
-
-        /// <summary>
-        /// A new implementation using ReadOnlySpan and char write.
-        /// </summary>
-        [Benchmark]
-        public void EscapeStringSpanCharsInline()
-        {
-            m_memoryStream.Position = 0;
-            int repeats = InnerLoops;
-            while (repeats-- > 0)
-            {
-                EscapeStringSpanCharsInline(m_testString);
-            }
-            m_streamWriter.Flush();
-        }
-
-        /// <summary>
-        /// A new implementation using ReadOnlySpan and char write with const arrays.
-        /// </summary>
-        [Benchmark]
-        public void EscapeStringSpanCharsInlineConst()
-        {
-            m_memoryStream.Position = 0;
-            int repeats = InnerLoops;
-            while (repeats-- > 0)
-            {
-                EscapeStringSpanCharsInlineConst(m_testString);
-            }
-            m_streamWriter.Flush();
-        }
-
-        /// <summary>
-        /// A new implementation using ReadOnlySpan and IndexOf.
-        /// </summary>
-        [Benchmark]
-        public void EscapeStringSpanIndex()
-        {
-            m_memoryStream.Position = 0;
-            int repeats = InnerLoops;
-            while (repeats-- > 0)
-            {
-                EscapeStringSpanIndex(m_testString);
-            }
-            m_streamWriter.Flush();
-        }
-
-        /// <summary>
-        /// A new implementation using ReadOnlySpan and Dictionary.
-        /// </summary>
-        [Benchmark]
-        public void EscapeStringSpanDict()
-        {
-            m_memoryStream.Position = 0;
-            int repeats = InnerLoops;
-            while (repeats-- > 0)
-            {
-                EscapeStringSpanDict(m_testString);
-            }
-            m_streamWriter.Flush();
-        }
-
-        [Theory]
-        [TestCase("No Escape chars", 0)]
-        [TestCase("control chars escaped, 1 char space", 1)]
-        [TestCase("control chars escaped, 2 char spaces", 2)]
-        [TestCase("control chars escaped, 3 char spaces", 3)]
-        [TestCase("control chars escaped, 5 char spaces", 4)]
-        [TestCase("binary chars escaped, 1 char space", 5)]
-        [TestCase("binary chars escaped, 2 char spaces", 6)]
-        [TestCase("binary chars escaped, 3 char spaces", 7)]
-        [TestCase("binary chars escaped, 5 char spaces", 8)]
-        [TestCase("all escape chars and long string", 9)]
-        public void EscapeStringValidation(string name, int index)
-        {
-            m_testString = EscapeTestStrings[index];
-            TestContext.Out.WriteLine(m_testString);
-            var testArray = m_testString.ToCharArray();
-
-            m_memoryStream.Position = 0;
-            EscapeStringLegacy();
-            m_streamWriter.Flush();
-            byte[] resultLegacy = m_memoryStream.ToArray();
-            TestContext.Out.WriteLine(Encoding.UTF8.GetString(resultLegacy));
-
-            m_memoryStream.Position = 0;
-            EscapeStringLegacyPlus();
-            m_streamWriter.Flush();
-            byte[] resultLegacyPlus = m_memoryStream.ToArray();
-            TestContext.Out.WriteLine(Encoding.UTF8.GetString(resultLegacyPlus));
-
-            m_memoryStream.Position = 0;
-            EscapeStringStringBuilder();
-            m_streamWriter.Flush();
-            byte[] result = m_memoryStream.ToArray();
-            TestContext.Out.WriteLine(Encoding.UTF8.GetString(result));
-
-            m_memoryStream.Position = 0;
-            EscapeStringThreadLocal();
-            m_streamWriter.Flush();
-            byte[] resultThreadLocal = m_memoryStream.ToArray();
-            TestContext.Out.WriteLine(Encoding.UTF8.GetString(resultThreadLocal));
-
-            m_memoryStream.Position = 0;
-            EscapeStringSpan(m_testString);
-            m_streamWriter.Flush();
-            byte[] resultSpan = m_memoryStream.ToArray();
-            TestContext.Out.WriteLine(Encoding.UTF8.GetString(resultSpan));
-
-            m_memoryStream.Position = 0;
-            EscapeStringSpanChars(m_testString);
-            m_streamWriter.Flush();
-            byte[] resultSpanChars = m_memoryStream.ToArray();
-            TestContext.Out.WriteLine(Encoding.UTF8.GetString(resultSpanChars));
-
-            m_memoryStream.Position = 0;
-            EscapeStringSpanCharsInline(m_testString);
-            m_streamWriter.Flush();
-            byte[] resultSpanCharsInline = m_memoryStream.ToArray();
-            TestContext.Out.WriteLine(Encoding.UTF8.GetString(resultSpanCharsInline));
-
-            m_memoryStream.Position = 0;
-            EscapeStringSpanCharsInlineConst(m_testString);
-            m_streamWriter.Flush();
-            byte[] resultSpanCharsInlineConst = m_memoryStream.ToArray();
-            TestContext.Out.WriteLine(Encoding.UTF8.GetString(resultSpanCharsInlineConst));
-
-            m_memoryStream.Position = 0;
-            EscapeStringSpanIndex(m_testString);
-            m_streamWriter.Flush();
-            byte[] resultSpanIndex = m_memoryStream.ToArray();
-            TestContext.Out.WriteLine(Encoding.UTF8.GetString(resultSpanIndex));
-
-            m_memoryStream.Position = 0;
-            EscapeStringSpanDict(m_testString);
-            m_streamWriter.Flush();
-            byte[] resultSpanDict = m_memoryStream.ToArray();
-            TestContext.Out.WriteLine(Encoding.UTF8.GetString(resultSpanDict));
-
-            Assert.IsTrue(Utils.IsEqual(resultLegacy, result));
-            Assert.IsTrue(Utils.IsEqual(resultLegacy, resultLegacyPlus));
-            Assert.IsTrue(Utils.IsEqual(resultLegacy, resultThreadLocal));
-            Assert.IsTrue(Utils.IsEqual(resultLegacy, resultSpan));
-            Assert.IsTrue(Utils.IsEqual(resultLegacy, resultSpanChars));
-            Assert.IsTrue(Utils.IsEqual(resultLegacy, resultSpanCharsInline));
-            Assert.IsTrue(Utils.IsEqual(resultLegacy, resultSpanCharsInlineConst));
-            Assert.IsTrue(Utils.IsEqual(resultLegacy, resultSpanIndex));
-            Assert.IsTrue(Utils.IsEqual(resultLegacy, resultSpanDict));
-        }
-
-        #region Test Setup
-        [OneTimeSetUp]
-        public void OneTimeSetUp()
-        {
-            m_memoryManager = new RecyclableMemoryStreamManager();
-            m_memoryStream = new RecyclableMemoryStream(m_memoryManager);
-            m_streamWriter = new StreamWriter(m_memoryStream, new UTF8Encoding(false), m_streamSize, false);
-        }
-
-        [OneTimeTearDown]
-        public void OneTimeTearDown()
-        {
-            m_streamWriter?.Dispose();
-            m_streamWriter = null;
-            m_memoryStream?.Dispose();
-            m_memoryStream = null;
-            m_memoryManager = null;
-        }
-        #endregion
-
-        #region Benchmark Setup
-        /// <summary>4
-        /// Set up some variables for benchmarks.
-        /// </summary>
-        [GlobalSetup]
-        public void GlobalSetup()
-        {
-            m_memoryManager = new RecyclableMemoryStreamManager();
-            m_memoryStream = new RecyclableMemoryStream(m_memoryManager);
-            m_streamWriter = new StreamWriter(m_memoryStream, new UTF8Encoding(false), m_streamSize, false);
-            m_testString = EscapeTestStrings[StringVariantIndex - 1];
-        }
-
-        [GlobalCleanup]
-        public void GlobalCleanup()
-        {
-            m_streamWriter?.Dispose();
-            m_streamWriter = null;
-            m_memoryStream?.Dispose();
-            m_memoryStream = null;
-            m_memoryManager = null;
-        }
-        #endregion
-
-        #region Private Methods
-        /// <summary>
-        /// Version used previously in JsonEncoder.
-        /// </summary>
-        private void EscapedStringLegacy(string value)
-        {
-            foreach (char ch in value)
-            {
-                bool found = false;
-
-                for (int ii = 0; ii < m_specialChars.Length; ii++)
-                {
-                    if (m_specialChars[ii] == ch)
-                    {
-                        m_streamWriter.Write('\\');
-                        m_streamWriter.Write(m_substitution[ii]);
-                        found = true;
-                        break;
-                    }
-                }
-
-                if (!found)
-                {
-                    if (ch < 32)
-                    {
-                        m_streamWriter.Write("\\u");
-                        m_streamWriter.Write("{0:X4}", (int)ch);
-                        continue;
-                    }
-
-                    m_streamWriter.Write(ch);
-                }
-            }
-        }
-
-        /// <summary>
-        /// Version used previously in JsonEncoder plus improvement of binary encoding.
-        /// </summary>
-        /// <remarks>
-        /// For the underlying stream writer it is faster to write two chars than a 2 char string.
-        /// </remarks>
-        private void EscapedStringLegacyPlus(string value)
-        {
-            foreach (char ch in value)
-            {
-                bool found = false;
-
-                for (int ii = 0; ii < m_specialChars.Length; ii++)
-                {
-                    if (m_specialChars[ii] == ch)
-                    {
-                        m_streamWriter.Write('\\');
-                        m_streamWriter.Write(m_substitution[ii]);
-                        found = true;
-                        break;
-                    }
-                }
-
-                if (!found)
-                {
-                    if (ch < 32)
-                    {
-                        m_streamWriter.Write('\\');
-                        m_streamWriter.Write('u');
-                        m_streamWriter.Write(((int)ch).ToString("X4", CultureInfo.InvariantCulture));
-                        continue;
-                    }
-
-                    m_streamWriter.Write(ch);
-                }
-            }
-        }
-
-        /// <summary>
-        /// Using a span to escape the string, write strings to stream writer if possible.
-        /// </summary>
-        private void EscapeStringSpan(string value)
-        {
-            ReadOnlySpan<char> charSpan = value.AsSpan();
-            int lastOffset = 0;
-
-            for (int i = 0; i < charSpan.Length; i++)
-            {
-                bool found = false;
-                char ch = charSpan[i];
-
-                for (int ii = 0; ii < m_specialChars.Length; ii++)
-                {
-                    if (m_specialChars[ii] == ch)
-                    {
-                        if (lastOffset < i)
-                        {
-#if NETCOREAPP2_1_OR_GREATER
-                            m_streamWriter.Write(charSpan.Slice(lastOffset, i - lastOffset));
-#else
-                            m_streamWriter.Write(charSpan.Slice(lastOffset, i - lastOffset).ToString());
-#endif
-                        }
-                        lastOffset = i + 1;
-                        m_streamWriter.Write(m_substitutionStrings[ii]);
-                        found = true;
-                        break;
-                    }
-                }
-
-                if (!found && ch < 32)
-                {
-                    if (lastOffset < i)
-                    {
-#if NETCOREAPP2_1_OR_GREATER
-                        m_streamWriter.Write(charSpan.Slice(lastOffset, i - lastOffset));
-#else
-                        m_streamWriter.Write(charSpan.Slice(lastOffset, i - lastOffset).ToString());
-#endif
-                    }
-                    lastOffset = i + 1;
-                    m_streamWriter.Write("\\u");
-                    m_streamWriter.Write(((int)ch).ToString("X4", CultureInfo.InvariantCulture));
-                }
-            }
-            if (lastOffset == 0)
-            {
-                m_streamWriter.Write(value);
-            }
-            else if (lastOffset < charSpan.Length)
-            {
-#if NETCOREAPP2_1_OR_GREATER
-                m_streamWriter.Write(charSpan.Slice(lastOffset, charSpan.Length - lastOffset));
-#else
-                m_streamWriter.Write(charSpan.Slice(lastOffset, charSpan.Length - lastOffset).ToString());
-#endif
-            }
-        }
-
-        /// <summary>
-        /// Use span to escape the string, write only chars to stream writer.
-        /// </summary>
-        /// <param name="value"></param>
-        private void EscapeStringSpanChars(string value)
-        {
-            ReadOnlySpan<char> charSpan = value.AsSpan();
-
-            int lastOffset = 0;
-            for (int i = 0; i < charSpan.Length; i++)
-            {
-                bool found = false;
-                char ch = charSpan[i];
-
-                for (int ii = 0; ii < m_specialChars.Length; ii++)
-                {
-                    if (m_specialChars[ii] == ch)
-                    {
-                        if (lastOffset < i)
-                        {
-#if NETCOREAPP2_1_OR_GREATER
-                            m_streamWriter.Write(charSpan.Slice(lastOffset, i - lastOffset));
-#else
-                            m_streamWriter.Write(charSpan.Slice(lastOffset, i - lastOffset).ToString());
-#endif
-                        }
-                        lastOffset = i + 1;
-                        m_streamWriter.Write('\\');
-                        m_streamWriter.Write(m_substitution[ii]);
-                        found = true;
-                        break;
-                    }
-                }
-
-                if (!found && ch < 32)
-                {
-                    if (lastOffset < i - 1)
-                    {
-#if NETCOREAPP2_1_OR_GREATER
-                        m_streamWriter.Write(charSpan.Slice(lastOffset, i - lastOffset));
-#else
-                        m_streamWriter.Write(charSpan.Slice(lastOffset, i - lastOffset).ToString());
-#endif
-                    }
-                    else
-                    {
-                        while (lastOffset < i)
-                        {
-                            m_streamWriter.Write(charSpan[lastOffset++]);
-                        }
-                    }
-                    lastOffset = i + 1;
-                    m_streamWriter.Write('\\');
-                    m_streamWriter.Write('u');
-                    m_streamWriter.Write(((int)ch).ToString("X4", CultureInfo.InvariantCulture));
-                }
-            }
-
-            if (lastOffset == 0)
-            {
-#if NETCOREAPP2_1_OR_GREATER
-                m_streamWriter.Write(charSpan);
-#else
-                m_streamWriter.Write(value);
-#endif
-            }
-            else if (lastOffset < charSpan.Length)
-            {
-#if NETCOREAPP2_1_OR_GREATER
-                m_streamWriter.Write(charSpan.Slice(lastOffset, charSpan.Length - lastOffset));
-#else
-                m_streamWriter.Write(charSpan.Slice(lastOffset, charSpan.Length - lastOffset).ToString());
-#endif
-            }
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void WriteSpan(ref int lastOffset, ReadOnlySpan<char> valueSpan, int index)
-        {
-            if (lastOffset < index - 2)
-            {
-#if NETCOREAPP2_1_OR_GREATER
-                m_streamWriter.Write(valueSpan.Slice(lastOffset, index - lastOffset));
-#else
-                m_streamWriter.Write(valueSpan.Slice(lastOffset, index - lastOffset).ToString());
-#endif
-            }
-            else
-            {
-                while (lastOffset < index)
-                {
-                    m_streamWriter.Write(valueSpan[lastOffset++]);
-                }
-            }
-            lastOffset = index + 1;
-        }
-
-        /// <summary>
-        /// Write only chars to stream writer, inline the write sequence for readability.
-        /// </summary>
-        /// <param name="value"></param>
-        private void EscapeStringSpanCharsInline(string value)
-        {
-            ReadOnlySpan<char> charSpan = value.AsSpan();
-            int lastOffset = 0;
-
-            for (int i = 0; i < charSpan.Length; i++)
-            {
-                bool found = false;
-                char ch = charSpan[i];
-
-                for (int ii = 0; ii < m_specialChars.Length; ii++)
-                {
-                    if (m_specialChars[ii] == ch)
-                    {
-                        WriteSpan(ref lastOffset, charSpan, i);
-                        m_streamWriter.Write('\\');
-                        m_streamWriter.Write(m_substitution[ii]);
-                        found = true;
-                        break;
-                    }
-                }
-
-                if (!found && ch < 32)
-                {
-                    WriteSpan(ref lastOffset, charSpan, i);
-                    m_streamWriter.Write('\\');
-                    m_streamWriter.Write('u');
-                    m_streamWriter.Write(((int)ch).ToString("X4", CultureInfo.InvariantCulture));
-                }
-            }
-
-            if (lastOffset == 0)
-            {
-#if NETCOREAPP2_1_OR_GREATER
-                m_streamWriter.Write(charSpan);
-#else
-                m_streamWriter.Write(value);
-#endif
-            }
-            else
-            {
-                WriteSpan(ref lastOffset, charSpan, charSpan.Length);
-            }
-        }
-
-        // create version of EscapeStringSpanCharsInline that references cosnt arrays
-        private void EscapeStringSpanCharsInlineConst(string value)
-        {
-            ReadOnlySpan<char> charSpan = value.AsSpan();
-            int lastOffset = 0;
-
-            for (int i = 0; i < charSpan.Length; i++)
-            {
-                bool found = false;
-                char ch = charSpan[i];
-
-                for (int ii = 0; ii < m_specialCharsConst.Length; ii++)
-                {
-                    if (m_specialCharsConst[ii] == ch)
-                    {
-                        WriteSpan(ref lastOffset, charSpan, i);
-                        m_streamWriter.Write('\\');
-                        m_streamWriter.Write(m_substitutionConst[ii]);
-                        found = true;
-                        break;
-                    }
-                }
-
-                if (!found && ch < 32)
-                {
-                    WriteSpan(ref lastOffset, charSpan, i);
-                    m_streamWriter.Write('\\');
-                    m_streamWriter.Write('u');
-                    m_streamWriter.Write(((int)ch).ToString("X4", CultureInfo.InvariantCulture));
-                }
-            }
-
-            if (lastOffset == 0)
-            {
-                m_streamWriter.Write(value);
-            }
-            else
-            {
-                WriteSpan(ref lastOffset, charSpan, charSpan.Length);
-            }
-        }
-
-
-        private void EscapeStringSpanIndex(string value)
-        {
-            ReadOnlySpan<char> charSpan = value.AsSpan();
-
-            int lastOffset = 0;
-            for (int i = 0; i < charSpan.Length; i++)
-            {
-                char ch = charSpan[i];
-
-                int index = m_specialString.IndexOf(ch);
-                if (index >= 0)
-                {
-                    if (lastOffset < i)
-                    {
-#if NETCOREAPP2_1_OR_GREATER
-                        m_streamWriter.Write(charSpan.Slice(lastOffset, i - lastOffset));
-#else
-                        m_streamWriter.Write(charSpan.Slice(lastOffset, i - lastOffset).ToString());
-#endif
-                    }
-                    lastOffset = i + 1;
-                    m_streamWriter.Write(m_substitutionStrings[index]);
-                    continue;
-                }
-
-                if (ch < 32)
-                {
-                    if (lastOffset < i)
-                    {
-#if NETCOREAPP2_1_OR_GREATER
-                        m_streamWriter.Write(charSpan.Slice(lastOffset, i - lastOffset));
-#else
-                        m_streamWriter.Write(charSpan.Slice(lastOffset, i - lastOffset).ToString());
-#endif
-                    }
-                    lastOffset = i + 1;
-                    m_streamWriter.Write('\\');
-                    m_streamWriter.Write('u');
-                    m_streamWriter.Write(((int)ch).ToString("X4", CultureInfo.InvariantCulture));
-                }
-            }
-            if (lastOffset == 0)
-            {
-                m_streamWriter.Write(value);
-            }
-            else if (lastOffset < charSpan.Length)
-            {
-#if NETCOREAPP2_1_OR_GREATER
-                m_streamWriter.Write(charSpan.Slice(lastOffset, charSpan.Length - lastOffset));
-#else
-                m_streamWriter.Write(charSpan.Slice(lastOffset, charSpan.Length - lastOffset).ToString());
-#endif
-            }
-        }
-
-        private void EscapeStringSpanDict(string value)
-        {
-            ReadOnlySpan<char> charSpan = value.AsSpan();
-
-            int lastOffset = 0;
-            for (int i = 0; i < charSpan.Length; i++)
-            {
-                char ch = charSpan[i];
-
-                if (m_replace.TryGetValue(ch, out string escapeSequence))
-                {
-                    if (lastOffset < i)
-                    {
-#if NETCOREAPP2_1_OR_GREATER
-                        m_streamWriter.Write(charSpan.Slice(lastOffset, i - lastOffset));
-#else
-                        m_streamWriter.Write(charSpan.Slice(lastOffset, i - lastOffset).ToString());
-#endif
-                    }
-                    lastOffset = i + 1;
-                    m_streamWriter.Write(escapeSequence);
-                    continue;
-                }
-
-                if (ch < 32)
-                {
-                    if (lastOffset < i)
-                    {
-#if NETCOREAPP2_1_OR_GREATER
-                        m_streamWriter.Write(charSpan.Slice(lastOffset, i - lastOffset));
-#else
-                        m_streamWriter.Write(charSpan.Slice(lastOffset, i - lastOffset).ToString());
-#endif
-                    }
-                    lastOffset = i + 1;
-                    m_streamWriter.Write('\\');
-                    m_streamWriter.Write('u');
-                    m_streamWriter.Write(((int)ch).ToString("X4", CultureInfo.InvariantCulture));
-                }
-            }
-            if (lastOffset == 0)
-            {
-                m_streamWriter.Write(value);
-            }
-            else if (lastOffset < charSpan.Length)
-            {
-#if NETCOREAPP2_1_OR_GREATER
-                m_streamWriter.Write(charSpan.Slice(lastOffset, charSpan.Length - lastOffset));
-#else
-                m_streamWriter.Write(charSpan.Slice(lastOffset, charSpan.Length - lastOffset).ToString());
-#endif
-            }
-        }
-
-        private void EscapeString(string value)
-        {
-            StringBuilder stringBuilder = new StringBuilder(value.Length * 2);
-
-            foreach (char ch in value)
-            {
-                if (m_replace.TryGetValue(ch, out string escapeSequence))
-                {
-                    stringBuilder.Append(escapeSequence);
-                }
-                else if (ch < 32)
-                {
-                    stringBuilder.Append("\\u");
-                    stringBuilder.Append(((int)ch).ToString("X4", CultureInfo.InvariantCulture));
-                }
-                else
-                {
-                    stringBuilder.Append(ch);
-                }
-            }
-            m_streamWriter.Write(stringBuilder);
-        }
-
-        private void EscapeStringThreadLocal(string value)
-        {
-            StringBuilder stringBuilder = m_stringBuilderPool.Value;
-            stringBuilder.Clear();
-            stringBuilder.EnsureCapacity(value.Length * 2);
-
-            foreach (char ch in value)
-            {
-                if (m_replace.TryGetValue(ch, out string escapeSequence))
-                {
-                    stringBuilder.Append(escapeSequence);
-                }
-                else if (ch < 32)
-                {
-                    stringBuilder.Append("\\u");
-                    stringBuilder.Append(((int)ch).ToString("X4", CultureInfo.InvariantCulture));
-                }
-                else
-                {
-                    stringBuilder.Append(ch);
-                }
-            }
-            m_streamWriter.Write(stringBuilder);
-        }
-        #endregion
-
-        #region Private Fields
-        private ThreadLocal<StringBuilder> m_stringBuilderPool = new ThreadLocal<StringBuilder>(() => new StringBuilder());
-        private static string m_testString;
-        private RecyclableMemoryStreamManager m_memoryManager;
-        private RecyclableMemoryStream m_memoryStream;
-        private StreamWriter m_streamWriter;
-        private int m_streamSize = 1024;
-        private static readonly string m_specialString = "\"\\\n\r\t\b\f";
-
-        // Declare static readonly characters for the special characters
-        private static readonly char sro_quotation = '\"';
-        private static readonly char sro_backslash = '\\';
-        private static readonly char sro_newline = '\n';
-        private static readonly char sro_return = '\r';
-        private static readonly char sro_tab = '\t';
-        private static readonly char sro_backspace = '\b';
-        private static readonly char sro_formfeed = '\f';
-        private static readonly char[] m_specialChars = new char[] { sro_quotation, sro_backslash, sro_newline, sro_return, sro_tab, sro_backspace, sro_formfeed };
-
-        // Declare static readonly characters for the substitution characters
-        private static readonly char sro_quotationSub = '\"';
-        private static readonly char sro_backslashSub = '\\';
-        private static readonly char sro_newlineSub = 'n';
-        private static readonly char sro_returnSub = 'r';
-        private static readonly char sro_tabSub = 't';
-        private static readonly char sro_backspaceSub = 'b';
-        private static readonly char sro_formfeedSub = 'f';
-        private static readonly char[] m_substitution = new char[] { sro_quotationSub, sro_backslashSub, sro_newlineSub, sro_returnSub, sro_tabSub, sro_backspaceSub, sro_formfeedSub };
-
-        // Special characters as const
-        private const char s_quotation = '\"';
-        private const char s_backslash = '\\';
-        private const char s_newline = '\n';
-        private const char s_return = '\r';
-        private const char s_tab = '\t';
-        private const char s_backspace = '\b';
-        private const char s_formfeed = '\f';
-
-        private static readonly char[] m_specialCharsConst = new char[] { s_quotation, s_backslash, s_newline, s_return, s_tab, s_backspace, s_formfeed };
-
-        // Substitution as const
-        private const char s_quotationSub = '\"';
-        private const char s_backslashSub = '\\';
-        private const char s_newlineSub = 'n';
-        private const char s_returnSub = 'r';
-        private const char s_tabSub = 't';
-        private const char s_backspaceSub = 'b';
-        private const char s_formfeedSub = 'f';
-
-        private static readonly char[] m_substitutionConst = new char[] { s_quotationSub, s_backslashSub, s_newlineSub, s_returnSub, s_tabSub, s_backspaceSub, s_formfeedSub };
-
-        private static readonly string[] m_substitutionStrings = new string[] { "\\\"", "\\\\", "\\n", "\\r", "\\t", "\\b", "\\f" };
-        private static readonly Dictionary<char, string> m_replace = new Dictionary<char, string>
-        {
-            {  '\"', "\\\"" },
-            {  '\\', "\\\\" },
-            { '\n', "\\n" },
-            { '\r', "\\r" },
-            { '\t', "\\t" },
-            { '\b', "\\b" },
-            { '\f', "\\f" }
-        };
+        public new void GlobalCleanup() => base.GlobalCleanup();
         #endregion
     }
 }

--- a/Tests/Opc.Ua.Core.Tests/Types/Encoders/JsonEncoderDateTimeBenchmark.cs
+++ b/Tests/Opc.Ua.Core.Tests/Types/Encoders/JsonEncoderDateTimeBenchmark.cs
@@ -1,0 +1,110 @@
+/* ========================================================================
+ * Copyright (c) 2005-2024 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ * 
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ * 
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using System.Globalization;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Diagnosers;
+using NUnit.Framework;
+
+namespace Opc.Ua.Core.Tests.Types.Encoders
+{
+    [TestFixture, Category("JsonEncoder")]
+    [SetCulture("en-us"), SetUICulture("en-us")]
+    [NonParallelizable]
+    [MemoryDiagnoser]
+    [DisassemblyDiagnoser]
+    public class JsonEncoderDateTimeBenchmark
+    {
+        [Params(0, 4, 7)]
+        public int DateTimeOmittedZeros { get; set; } = 0;
+
+        [Benchmark]
+        [Test]
+        public void DateTimeEncodeToString()
+        {
+            _ = m_dateTime.ToUniversalTime().ToString("yyyy-MM-dd'T'HH:mm:ss.FFFFFFFK", CultureInfo.InvariantCulture);
+        }
+
+        [Benchmark]
+        [Test]
+        public void ConvertToUniversalTime()
+        {
+            _ = JsonEncoder.ConvertUniversalTimeToString(m_dateTime);
+        }
+
+        #region Test Setup
+        [OneTimeSetUp]
+        public void OneTimeSetUp()
+        {
+            // for validating benchmark tests
+            m_dateTime = DateTime.UtcNow;
+        }
+
+        [OneTimeTearDown]
+        public void OneTimeTearDown()
+        {
+        }
+        #endregion
+
+        #region Benchmark Setup
+        /// <summary>
+        /// Set up some variables for benchmarks.
+        /// </summary>
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            // for validating benchmark tests
+            switch (DateTimeOmittedZeros)
+            {
+                case 4: m_dateTime = new DateTime(2011, 11, 11, 11, 11, 11, 999, DateTimeKind.Utc); break;
+                case 7: m_dateTime = new DateTime(2011, 11, 11, 11, 11, 11, DateTimeKind.Utc); break;
+                default:
+                    do
+                    {
+                        m_dateTime = DateTime.UtcNow;
+                    } while (m_dateTime.Ticks % 10 == 0);
+                    break;
+            }
+        }
+
+        /// <summary>
+        /// Tear down benchmark variables.
+        /// </summary>
+        [GlobalCleanup]
+        public void GlobalCleanup()
+        {
+        }
+        #endregion
+
+        #region Private Fields
+        private DateTime m_dateTime;
+        #endregion
+    }
+}

--- a/Tests/Opc.Ua.Core.Tests/Types/Encoders/JsonEncoderEscapeStringBenchmarks.cs
+++ b/Tests/Opc.Ua.Core.Tests/Types/Encoders/JsonEncoderEscapeStringBenchmarks.cs
@@ -1,0 +1,860 @@
+/* ========================================================================
+ * Copyright (c) 2005-2024 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ * 
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ * 
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Text;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Diagnosers;
+using Microsoft.IO;
+using NUnit.Framework;
+
+namespace Opc.Ua.Core.Tests.Types.Encoders
+{
+    [TestFixture, Category("JsonEncoder")]
+    [SetCulture("en-us"), SetUICulture("en-us")]
+    [NonParallelizable]
+    [MemoryDiagnoser]
+    [DisassemblyDiagnoser(printSource: true)]
+    public class JsonEncoderEscapeStringBenchmarks
+    {
+        public const int InnerLoops = 100;
+        [DatapointSource]
+        [Params(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)]
+        public int StringVariantIndex { get; set; } = 1;
+
+        [DatapointSource]
+        // for benchmarking with different escaped strings
+        public static readonly string[] EscapeTestStrings =
+        {
+            // The use case without escape characters, plain text
+                "The quick brown fox jumps over the lazy dog.",
+            // The use case with many control characters escaped, 1 char spaces
+                "\" \n \r \t \b \f \\ ",
+            // The use case with many control characters escaped, 2 char spaces
+                "  \"  \n  \r  \t  \b  \f  \\  ",
+            // The use case with many control characters escaped, 3 char spaces
+                "   \"   \n   \r   \t   \b   \f   \\   ",
+            // The use case with many control characters escaped, 5 char spaces
+                "     \"     \n     \r     \t     \b     \f     \\     ",
+            // The use case with many binary characters escaped, 1 char spaces
+                "\0 \x01 \x02 \x03 \x04 ",
+            // The use case with many binary characters escaped, 2 char spaces
+                "  \0  \x01  \x02  \x03  \x04  ",
+            // The use case with many binary characters escaped, 3 char spaces
+                "   \0   \x01   \x02   \x03   \x04   ",
+            // The use case with many binary characters escaped, 5 char spaces
+                "     \0     \x01     \x02     \x03     \x04     ",
+            // The use case with all escape characters and a long string
+                "Ascii characters, special characters \n \b & control characters \0 \x04 ␀ ␁ ␂ ␃ ␄. This is a test.",
+        };
+
+        /// <summary>
+        /// Benchmark encoding of the previous implementation.
+        /// </summary>
+        [Benchmark(Baseline = true)]
+        public void EscapeStringLegacy()
+        {
+            m_memoryStream.Position = 0;
+            int repeats = InnerLoops;
+            while (repeats-- > 0)
+            {
+                EscapedStringLegacy(m_testString);
+            }
+            m_streamWriter.Flush();
+        }
+
+        /// <summary>
+        /// Benchmark encoding of the previous implementation with snall improvement for binary encoding.
+        /// </summary>
+        [Benchmark]
+        public void EscapeStringLegacyPlus()
+        {
+            m_memoryStream.Position = 0;
+            int repeats = InnerLoops;
+            while (repeats-- > 0)
+            {
+                EscapedStringLegacyPlus(m_testString);
+            }
+            m_streamWriter.Flush();
+        }
+
+        /// <summary>
+        /// A new implementation using StringBuilder.
+        /// </summary>
+        [Benchmark]
+        public void EscapeStringStringBuilder()
+        {
+            m_memoryStream.Position = 0;
+            int repeats = InnerLoops;
+            while (repeats-- > 0)
+            {
+                EscapeString(m_testString);
+            }
+            m_streamWriter.Flush();
+        }
+
+        /// <summary>
+        /// A new implementation using ReadOnlySpan.
+        /// </summary>
+        [Benchmark]
+        public void EscapeStringSpan()
+        {
+            m_memoryStream.Position = 0;
+            int repeats = InnerLoops;
+            while (repeats-- > 0)
+            {
+                EscapeStringSpan(m_testString);
+            }
+            m_streamWriter.Flush();
+        }
+
+        /// <summary>
+        /// A new implementation using ReadOnlySpan and char write.
+        /// </summary>
+        [Benchmark]
+        public void EscapeStringSpanChars()
+        {
+            m_memoryStream.Position = 0;
+            int repeats = InnerLoops;
+            while (repeats-- > 0)
+            {
+                EscapeStringSpanChars(m_testString);
+            }
+            m_streamWriter.Flush();
+        }
+
+        /// <summary>
+        /// A new implementation using ReadOnlySpan and char write.
+        /// </summary>
+        [Benchmark]
+        public void EscapeStringSpanCharsInline()
+        {
+            m_memoryStream.Position = 0;
+            int repeats = InnerLoops;
+            while (repeats-- > 0)
+            {
+                EscapeStringSpanCharsInline(m_testString);
+            }
+            m_streamWriter.Flush();
+        }
+
+        /// <summary>
+        /// A new implementation using ReadOnlySpan and char write with const arrays.
+        /// </summary>
+        [Benchmark]
+        public void EscapeStringSpanCharsInlineConst()
+        {
+            m_memoryStream.Position = 0;
+            int repeats = InnerLoops;
+            while (repeats-- > 0)
+            {
+                EscapeStringSpanCharsInlineConst(m_testString);
+            }
+            m_streamWriter.Flush();
+        }
+
+        /// <summary>
+        /// A new implementation using ReadOnlySpan and IndexOf.
+        /// </summary>
+        [Benchmark]
+        public void EscapeStringSpanIndex()
+        {
+            m_memoryStream.Position = 0;
+            int repeats = InnerLoops;
+            while (repeats-- > 0)
+            {
+                EscapeStringSpanIndex(m_testString);
+            }
+            m_streamWriter.Flush();
+        }
+
+        /// <summary>
+        /// A new implementation using ReadOnlySpan and Dictionary.
+        /// </summary>
+        [Benchmark]
+        public void EscapeStringSpanDict()
+        {
+            m_memoryStream.Position = 0;
+            int repeats = InnerLoops;
+            while (repeats-- > 0)
+            {
+                EscapeStringSpanDict(m_testString);
+            }
+            m_streamWriter.Flush();
+        }
+
+        [Theory]
+        [TestCase("No Escape chars", 0)]
+        [TestCase("control chars escaped, 1 char space", 1)]
+        [TestCase("control chars escaped, 2 char spaces", 2)]
+        [TestCase("control chars escaped, 3 char spaces", 3)]
+        [TestCase("control chars escaped, 5 char spaces", 4)]
+        [TestCase("binary chars escaped, 1 char space", 5)]
+        [TestCase("binary chars escaped, 2 char spaces", 6)]
+        [TestCase("binary chars escaped, 3 char spaces", 7)]
+        [TestCase("binary chars escaped, 5 char spaces", 8)]
+        [TestCase("all escape chars and long string", 9)]
+        public void EscapeStringValidation(string name, int index)
+        {
+            m_testString = EscapeTestStrings[index];
+            TestContext.Out.WriteLine(m_testString);
+            var testArray = m_testString.ToCharArray();
+
+            m_memoryStream.Position = 0;
+            EscapeStringLegacy();
+            m_streamWriter.Flush();
+            byte[] resultLegacy = m_memoryStream.ToArray();
+            TestContext.Out.WriteLine(Encoding.UTF8.GetString(resultLegacy));
+
+            m_memoryStream.Position = 0;
+            EscapeStringLegacyPlus();
+            m_streamWriter.Flush();
+            byte[] resultLegacyPlus = m_memoryStream.ToArray();
+            TestContext.Out.WriteLine(Encoding.UTF8.GetString(resultLegacyPlus));
+
+            m_memoryStream.Position = 0;
+            EscapeStringStringBuilder();
+            m_streamWriter.Flush();
+            byte[] result = m_memoryStream.ToArray();
+            TestContext.Out.WriteLine(Encoding.UTF8.GetString(result));
+
+            m_memoryStream.Position = 0;
+            EscapeStringSpan(m_testString);
+            m_streamWriter.Flush();
+            byte[] resultSpan = m_memoryStream.ToArray();
+            TestContext.Out.WriteLine(Encoding.UTF8.GetString(resultSpan));
+
+            m_memoryStream.Position = 0;
+            EscapeStringSpanChars(m_testString);
+            m_streamWriter.Flush();
+            byte[] resultSpanChars = m_memoryStream.ToArray();
+            TestContext.Out.WriteLine(Encoding.UTF8.GetString(resultSpanChars));
+
+            m_memoryStream.Position = 0;
+            EscapeStringSpanCharsInline(m_testString);
+            m_streamWriter.Flush();
+            byte[] resultSpanCharsInline = m_memoryStream.ToArray();
+            TestContext.Out.WriteLine(Encoding.UTF8.GetString(resultSpanCharsInline));
+
+            m_memoryStream.Position = 0;
+            EscapeStringSpanCharsInlineConst(m_testString);
+            m_streamWriter.Flush();
+            byte[] resultSpanCharsInlineConst = m_memoryStream.ToArray();
+            TestContext.Out.WriteLine(Encoding.UTF8.GetString(resultSpanCharsInlineConst));
+
+            m_memoryStream.Position = 0;
+            EscapeStringSpanIndex(m_testString);
+            m_streamWriter.Flush();
+            byte[] resultSpanIndex = m_memoryStream.ToArray();
+            TestContext.Out.WriteLine(Encoding.UTF8.GetString(resultSpanIndex));
+
+            m_memoryStream.Position = 0;
+            EscapeStringSpanDict(m_testString);
+            m_streamWriter.Flush();
+            byte[] resultSpanDict = m_memoryStream.ToArray();
+            TestContext.Out.WriteLine(Encoding.UTF8.GetString(resultSpanDict));
+
+            Assert.IsTrue(Utils.IsEqual(resultLegacy, result));
+            Assert.IsTrue(Utils.IsEqual(resultLegacy, resultLegacyPlus));
+            Assert.IsTrue(Utils.IsEqual(resultLegacy, resultSpan));
+            Assert.IsTrue(Utils.IsEqual(resultLegacy, resultSpanChars));
+            Assert.IsTrue(Utils.IsEqual(resultLegacy, resultSpanCharsInline));
+            Assert.IsTrue(Utils.IsEqual(resultLegacy, resultSpanCharsInlineConst));
+            Assert.IsTrue(Utils.IsEqual(resultLegacy, resultSpanIndex));
+            Assert.IsTrue(Utils.IsEqual(resultLegacy, resultSpanDict));
+        }
+
+        #region Test Setup
+        [OneTimeSetUp]
+        public void OneTimeSetUp()
+        {
+            m_memoryManager = new RecyclableMemoryStreamManager();
+            m_memoryStream = new RecyclableMemoryStream(m_memoryManager);
+            m_streamWriter = new StreamWriter(m_memoryStream, new UTF8Encoding(false), m_streamSize, false);
+        }
+
+        [OneTimeTearDown]
+        public void OneTimeTearDown()
+        {
+            m_streamWriter?.Dispose();
+            m_streamWriter = null;
+            m_memoryStream?.Dispose();
+            m_memoryStream = null;
+            m_memoryManager = null;
+        }
+        #endregion
+
+        #region Benchmark Setup
+        /// <summary>4
+        /// Set up some variables for benchmarks.
+        /// </summary>
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            m_memoryManager = new RecyclableMemoryStreamManager();
+            m_memoryStream = new RecyclableMemoryStream(m_memoryManager);
+            m_streamWriter = new StreamWriter(m_memoryStream, Encoding.UTF8, m_streamSize, false);
+            m_testString = EscapeTestStrings[StringVariantIndex - 1];
+        }
+
+        [GlobalCleanup]
+        public void GlobalCleanup()
+        {
+            m_streamWriter?.Dispose();
+            m_streamWriter = null;
+            m_memoryStream?.Dispose();
+            m_memoryStream = null;
+            m_memoryManager = null;
+        }
+        #endregion
+
+        #region Private Methods
+        /// <summary>
+        /// Version used previously in JsonEncoder.
+        /// </summary>
+        private void EscapedStringLegacy(string value)
+        {
+            foreach (char ch in value)
+            {
+                bool found = false;
+
+                for (int ii = 0; ii < m_specialChars.Length; ii++)
+                {
+                    if (m_specialChars[ii] == ch)
+                    {
+                        m_streamWriter.Write('\\');
+                        m_streamWriter.Write(m_substitution[ii]);
+                        found = true;
+                        break;
+                    }
+                }
+
+                if (!found)
+                {
+                    if (ch < 32)
+                    {
+                        m_streamWriter.Write("\\u");
+                        m_streamWriter.Write("{0:X4}", (int)ch);
+                        continue;
+                    }
+
+                    m_streamWriter.Write(ch);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Version used previously in JsonEncoder plus improvement of binary encoding.
+        /// </summary>
+        /// <remarks>
+        /// For the underlying stream writer it is faster to write two chars than a 2 char string.
+        /// </remarks>
+        private void EscapedStringLegacyPlus(string value)
+        {
+            foreach (char ch in value)
+            {
+                bool found = false;
+
+                for (int ii = 0; ii < m_specialChars.Length; ii++)
+                {
+                    if (m_specialChars[ii] == ch)
+                    {
+                        m_streamWriter.Write('\\');
+                        m_streamWriter.Write(m_substitution[ii]);
+                        found = true;
+                        break;
+                    }
+                }
+
+                if (!found)
+                {
+                    if (ch < 32)
+                    {
+                        m_streamWriter.Write('\\');
+                        m_streamWriter.Write('u');
+                        m_streamWriter.Write(((int)ch).ToString("X4", CultureInfo.InvariantCulture));
+                        continue;
+                    }
+
+                    m_streamWriter.Write(ch);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Using a span to escape the string, write strings to stream writer if possible.
+        /// </summary>
+        private void EscapeStringSpan(string value)
+        {
+            ReadOnlySpan<char> charSpan = value.AsSpan();
+            int lastOffset = 0;
+
+            for (int i = 0; i < charSpan.Length; i++)
+            {
+                bool found = false;
+                char ch = charSpan[i];
+
+                for (int ii = 0; ii < m_specialChars.Length; ii++)
+                {
+                    if (m_specialChars[ii] == ch)
+                    {
+                        if (lastOffset < i)
+                        {
+#if NETCOREAPP2_1_OR_GREATER
+                            m_streamWriter.Write(charSpan.Slice(lastOffset, i - lastOffset));
+#else
+                            m_streamWriter.Write(charSpan.Slice(lastOffset, i - lastOffset).ToString());
+#endif
+                        }
+                        lastOffset = i + 1;
+                        m_streamWriter.Write(m_substitutionStrings[ii]);
+                        found = true;
+                        break;
+                    }
+                }
+
+                if (!found && ch < 32)
+                {
+                    if (lastOffset < i)
+                    {
+#if NETCOREAPP2_1_OR_GREATER
+                        m_streamWriter.Write(charSpan.Slice(lastOffset, i - lastOffset));
+#else
+                        m_streamWriter.Write(charSpan.Slice(lastOffset, i - lastOffset).ToString());
+#endif
+                    }
+                    lastOffset = i + 1;
+                    m_streamWriter.Write("\\u");
+                    m_streamWriter.Write(((int)ch).ToString("X4", CultureInfo.InvariantCulture));
+                }
+            }
+            if (lastOffset == 0)
+            {
+                m_streamWriter.Write(value);
+            }
+            else if (lastOffset < charSpan.Length)
+            {
+#if NETCOREAPP2_1_OR_GREATER
+                m_streamWriter.Write(charSpan.Slice(lastOffset, charSpan.Length - lastOffset));
+#else
+                m_streamWriter.Write(charSpan.Slice(lastOffset, charSpan.Length - lastOffset).ToString());
+#endif
+            }
+        }
+
+        /// <summary>
+        /// Use span to escape the string, write only chars to stream writer.
+        /// </summary>
+        /// <param name="value"></param>
+        private void EscapeStringSpanChars(string value)
+        {
+            ReadOnlySpan<char> charSpan = value.AsSpan();
+
+            int lastOffset = 0;
+            for (int i = 0; i < charSpan.Length; i++)
+            {
+                bool found = false;
+                char ch = charSpan[i];
+
+                for (int ii = 0; ii < m_specialChars.Length; ii++)
+                {
+                    if (m_specialChars[ii] == ch)
+                    {
+                        if (lastOffset < i)
+                        {
+#if NETCOREAPP2_1_OR_GREATER
+                            m_streamWriter.Write(charSpan.Slice(lastOffset, i - lastOffset));
+#else
+                            m_streamWriter.Write(charSpan.Slice(lastOffset, i - lastOffset).ToString());
+#endif
+                        }
+                        lastOffset = i + 1;
+                        m_streamWriter.Write('\\');
+                        m_streamWriter.Write(m_substitution[ii]);
+                        found = true;
+                        break;
+                    }
+                }
+
+                if (!found && ch < 32)
+                {
+                    if (lastOffset < i - 1)
+                    {
+#if NETCOREAPP2_1_OR_GREATER
+                        m_streamWriter.Write(charSpan.Slice(lastOffset, i - lastOffset));
+#else
+                        m_streamWriter.Write(charSpan.Slice(lastOffset, i - lastOffset).ToString());
+#endif
+                    }
+                    else
+                    {
+                        while (lastOffset < i)
+                        {
+                            m_streamWriter.Write(charSpan[lastOffset++]);
+                        }
+                    }
+                    lastOffset = i + 1;
+                    m_streamWriter.Write('\\');
+                    m_streamWriter.Write('u');
+                    m_streamWriter.Write(((int)ch).ToString("X4", CultureInfo.InvariantCulture));
+                }
+            }
+
+            if (lastOffset == 0)
+            {
+#if NETCOREAPP2_1_OR_GREATER
+                m_streamWriter.Write(charSpan);
+#else
+                m_streamWriter.Write(value);
+#endif
+            }
+            else if (lastOffset < charSpan.Length)
+            {
+#if NETCOREAPP2_1_OR_GREATER
+                m_streamWriter.Write(charSpan.Slice(lastOffset, charSpan.Length - lastOffset));
+#else
+                m_streamWriter.Write(charSpan.Slice(lastOffset, charSpan.Length - lastOffset).ToString());
+#endif
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void WriteSpan(ref int lastOffset, ReadOnlySpan<char> valueSpan, int index)
+        {
+            if (lastOffset < index - 2)
+            {
+#if NETCOREAPP2_1_OR_GREATER
+                m_streamWriter.Write(valueSpan.Slice(lastOffset, index - lastOffset));
+#else
+                m_streamWriter.Write(valueSpan.Slice(lastOffset, index - lastOffset).ToString());
+#endif
+            }
+            else
+            {
+                while (lastOffset < index)
+                {
+                    m_streamWriter.Write(valueSpan[lastOffset++]);
+                }
+            }
+            lastOffset = index + 1;
+        }
+
+        /// <summary>
+        /// Write only chars to stream writer, inline the write sequence for readability.
+        /// </summary>
+        /// <param name="value"></param>
+        private void EscapeStringSpanCharsInline(string value)
+        {
+            ReadOnlySpan<char> charSpan = value.AsSpan();
+            int lastOffset = 0;
+
+            for (int i = 0; i < charSpan.Length; i++)
+            {
+                bool found = false;
+                char ch = charSpan[i];
+
+                for (int ii = 0; ii < m_specialChars.Length; ii++)
+                {
+                    if (m_specialChars[ii] == ch)
+                    {
+                        WriteSpan(ref lastOffset, charSpan, i);
+                        m_streamWriter.Write('\\');
+                        m_streamWriter.Write(m_substitution[ii]);
+                        found = true;
+                        break;
+                    }
+                }
+
+                if (!found && ch < 32)
+                {
+                    WriteSpan(ref lastOffset, charSpan, i);
+                    m_streamWriter.Write('\\');
+                    m_streamWriter.Write('u');
+                    m_streamWriter.Write(((int)ch).ToString("X4", CultureInfo.InvariantCulture));
+                }
+            }
+
+            if (lastOffset == 0)
+            {
+#if NETCOREAPP2_1_OR_GREATER
+                m_streamWriter.Write(charSpan);
+#else
+                m_streamWriter.Write(value);
+#endif
+            }
+            else
+            {
+                WriteSpan(ref lastOffset, charSpan, charSpan.Length);
+            }
+        }
+
+        // create version of EscapeStringSpanCharsInline that references cosnt arrays
+        private void EscapeStringSpanCharsInlineConst(string value)
+        {
+            ReadOnlySpan<char> charSpan = value.AsSpan();
+            int lastOffset = 0;
+
+            for (int i = 0; i < charSpan.Length; i++)
+            {
+                bool found = false;
+                char ch = charSpan[i];
+
+                for (int ii = 0; ii < m_specialCharsConst.Length; ii++)
+                {
+                    if (m_specialCharsConst[ii] == ch)
+                    {
+                        WriteSpan(ref lastOffset, charSpan, i);
+                        m_streamWriter.Write('\\');
+                        m_streamWriter.Write(m_substitutionConst[ii]);
+                        found = true;
+                        break;
+                    }
+                }
+
+                if (!found && ch < 32)
+                {
+                    WriteSpan(ref lastOffset, charSpan, i);
+                    m_streamWriter.Write('\\');
+                    m_streamWriter.Write('u');
+                    m_streamWriter.Write(((int)ch).ToString("X4", CultureInfo.InvariantCulture));
+                }
+            }
+
+            if (lastOffset == 0)
+            {
+                m_streamWriter.Write(value);
+            }
+            else
+            {
+                WriteSpan(ref lastOffset, charSpan, charSpan.Length);
+            }
+        }
+
+
+        private void EscapeStringSpanIndex(string value)
+        {
+            ReadOnlySpan<char> charSpan = value.AsSpan();
+
+            int lastOffset = 0;
+            for (int i = 0; i < charSpan.Length; i++)
+            {
+                char ch = charSpan[i];
+
+                int index = m_specialString.IndexOf(ch);
+                if (index >= 0)
+                {
+                    if (lastOffset < i)
+                    {
+#if NETCOREAPP2_1_OR_GREATER
+                        m_streamWriter.Write(charSpan.Slice(lastOffset, i - lastOffset));
+#else
+                        m_streamWriter.Write(charSpan.Slice(lastOffset, i - lastOffset).ToString());
+#endif
+                    }
+                    lastOffset = i + 1;
+                    m_streamWriter.Write(m_substitutionStrings[index]);
+                    continue;
+                }
+
+                if (ch < 32)
+                {
+                    if (lastOffset < i)
+                    {
+#if NETCOREAPP2_1_OR_GREATER
+                        m_streamWriter.Write(charSpan.Slice(lastOffset, i - lastOffset));
+#else
+                        m_streamWriter.Write(charSpan.Slice(lastOffset, i - lastOffset).ToString());
+#endif
+                    }
+                    lastOffset = i + 1;
+                    m_streamWriter.Write('\\');
+                    m_streamWriter.Write('u');
+                    m_streamWriter.Write(((int)ch).ToString("X4", CultureInfo.InvariantCulture));
+                }
+            }
+            if (lastOffset == 0)
+            {
+                m_streamWriter.Write(value);
+            }
+            else if (lastOffset < charSpan.Length)
+            {
+#if NETCOREAPP2_1_OR_GREATER
+                m_streamWriter.Write(charSpan.Slice(lastOffset, charSpan.Length - lastOffset));
+#else
+                m_streamWriter.Write(charSpan.Slice(lastOffset, charSpan.Length - lastOffset).ToString());
+#endif
+            }
+        }
+
+        private void EscapeStringSpanDict(string value)
+        {
+            ReadOnlySpan<char> charSpan = value.AsSpan();
+
+            int lastOffset = 0;
+            for (int i = 0; i < charSpan.Length; i++)
+            {
+                char ch = charSpan[i];
+
+                if (m_replace.TryGetValue(ch, out string escapeSequence))
+                {
+                    if (lastOffset < i)
+                    {
+#if NETCOREAPP2_1_OR_GREATER
+                        m_streamWriter.Write(charSpan.Slice(lastOffset, i - lastOffset));
+#else
+                        m_streamWriter.Write(charSpan.Slice(lastOffset, i - lastOffset).ToString());
+#endif
+                    }
+                    lastOffset = i + 1;
+                    m_streamWriter.Write(escapeSequence);
+                    continue;
+                }
+
+                if (ch < 32)
+                {
+                    if (lastOffset < i)
+                    {
+#if NETCOREAPP2_1_OR_GREATER
+                        m_streamWriter.Write(charSpan.Slice(lastOffset, i - lastOffset));
+#else
+                        m_streamWriter.Write(charSpan.Slice(lastOffset, i - lastOffset).ToString());
+#endif
+                    }
+                    lastOffset = i + 1;
+                    m_streamWriter.Write('\\');
+                    m_streamWriter.Write('u');
+                    m_streamWriter.Write(((int)ch).ToString("X4", CultureInfo.InvariantCulture));
+                }
+            }
+            if (lastOffset == 0)
+            {
+                m_streamWriter.Write(value);
+            }
+            else if (lastOffset < charSpan.Length)
+            {
+#if NETCOREAPP2_1_OR_GREATER
+                m_streamWriter.Write(charSpan.Slice(lastOffset, charSpan.Length - lastOffset));
+#else
+                m_streamWriter.Write(charSpan.Slice(lastOffset, charSpan.Length - lastOffset).ToString());
+#endif
+            }
+        }
+
+        private void EscapeString(string value)
+        {
+            StringBuilder stringBuilder = new StringBuilder(value.Length * 2);
+
+            foreach (char ch in value)
+            {
+                if (m_replace.TryGetValue(ch, out string escapeSequence))
+                {
+                    stringBuilder.Append(escapeSequence);
+                }
+                else if (ch < 32)
+                {
+                    stringBuilder.Append("\\u");
+                    stringBuilder.Append(((int)ch).ToString("X4", CultureInfo.InvariantCulture));
+                }
+                else
+                {
+                    stringBuilder.Append(ch);
+                }
+            }
+            m_streamWriter.Write(stringBuilder);
+        }
+        #endregion
+
+        #region Private Fields
+        private static string m_testString;
+        private RecyclableMemoryStreamManager m_memoryManager;
+        private RecyclableMemoryStream m_memoryStream;
+        private StreamWriter m_streamWriter;
+        private int m_streamSize = 1024;
+        private static readonly string m_specialString = "\"\\\n\r\t\b\f";
+
+        // Declare static readonly characters for the special characters
+        private static readonly char sro_quotation = '\"';
+        private static readonly char sro_backslash = '\\';
+        private static readonly char sro_newline = '\n';
+        private static readonly char sro_return = '\r';
+        private static readonly char sro_tab = '\t';
+        private static readonly char sro_backspace = '\b';
+        private static readonly char sro_formfeed = '\f';
+        private static readonly char[] m_specialChars = new char[] { sro_quotation, sro_backslash, sro_newline, sro_return, sro_tab, sro_backspace, sro_formfeed };
+
+        // Declare static readonly characters for the substitution characters
+        private static readonly char sro_quotationSub = '\"';
+        private static readonly char sro_backslashSub = '\\';
+        private static readonly char sro_newlineSub = 'n';
+        private static readonly char sro_returnSub = 'r';
+        private static readonly char sro_tabSub = 't';
+        private static readonly char sro_backspaceSub = 'b';
+        private static readonly char sro_formfeedSub = 'f';
+        private static readonly char[] m_substitution = new char[] { sro_quotationSub, sro_backslashSub, sro_newlineSub, sro_returnSub, sro_tabSub, sro_backspaceSub, sro_formfeedSub };
+
+        // Special characters as const
+        private const char s_quotation = '\"';
+        private const char s_backslash = '\\';
+        private const char s_newline = '\n';
+        private const char s_return = '\r';
+        private const char s_tab = '\t';
+        private const char s_backspace = '\b';
+        private const char s_formfeed = '\f';
+
+        private static readonly char[] m_specialCharsConst = new char[] { s_quotation, s_backslash, s_newline, s_return, s_tab, s_backspace, s_formfeed };
+
+        // Substitution as const
+        private const char s_quotationSub = '\"';
+        private const char s_backslashSub = '\\';
+        private const char s_newlineSub = 'n';
+        private const char s_returnSub = 'r';
+        private const char s_tabSub = 't';
+        private const char s_backspaceSub = 'b';
+        private const char s_formfeedSub = 'f';
+
+        private static readonly char[] m_substitutionConst = new char[] { s_quotationSub, s_backslashSub, s_newlineSub, s_returnSub, s_tabSub, s_backspaceSub, s_formfeedSub };
+
+        private static readonly string[] m_substitutionStrings = new string[] { "\\\"", "\\\\", "\\n", "\\r", "\\t", "\\b", "\\f" };
+        private static readonly Dictionary<char, string> m_replace = new Dictionary<char, string>
+        {
+            {  '\"', "\\\"" },
+            {  '\\', "\\\\" },
+            { '\n', "\\n" },
+            { '\r', "\\r" },
+            { '\t', "\\t" },
+            { '\b', "\\b" },
+            { '\f', "\\f" }
+        };
+        #endregion
+    }
+}

--- a/Tests/Opc.Ua.Core.Tests/Types/Encoders/JsonEncoderTests.cs
+++ b/Tests/Opc.Ua.Core.Tests/Types/Encoders/JsonEncoderTests.cs
@@ -400,7 +400,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
         public void ConstructorRecyclableMemoryStream()
         {
             var recyclableMemoryStreamManager = new RecyclableMemoryStreamManager(new RecyclableMemoryStreamManager.Options {
-                BlockSize = BufferManager.MaxBufferSize,
+                BlockSize = BufferManager.MaxSuggestedBufferSize,
             });
             using (var memoryStream = new RecyclableMemoryStream(recyclableMemoryStreamManager))
             {

--- a/Tests/Opc.Ua.Core.Tests/Types/Encoders/JsonEncoderTests.cs
+++ b/Tests/Opc.Ua.Core.Tests/Types/Encoders/JsonEncoderTests.cs
@@ -38,7 +38,6 @@ using BenchmarkDotNet.Attributes;
 using Microsoft.IO;
 using NUnit.Framework;
 using Opc.Ua.Bindings;
-using Swan;
 
 namespace Opc.Ua.Core.Tests.Types.Encoders
 {

--- a/common.props
+++ b/common.props
@@ -22,8 +22,11 @@
 
   <PropertyGroup>
     <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>    
-    <EnableNETAnalyzers>false</EnableNETAnalyzers>
     <CodeAnalysisTreatWarningsAsErrors>false</CodeAnalysisTreatWarningsAsErrors>
+  </PropertyGroup>
+  
+  <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/common.props
+++ b/common.props
@@ -22,10 +22,14 @@
 
   <PropertyGroup>
     <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
-    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <EnableNETAnalyzers>false</EnableNETAnalyzers>
     <CodeAnalysisTreatWarningsAsErrors>false</CodeAnalysisTreatWarningsAsErrors>
   </PropertyGroup>
   
+  <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+  </PropertyGroup>
+
   <PropertyGroup>
     <PackageIcon>images/logo.jpg</PackageIcon>
     <PackageProjectUrl>$(RepositoryUrl)</PackageProjectUrl>

--- a/common.props
+++ b/common.props
@@ -21,7 +21,8 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>    
+    <EnableNETAnalyzers>false</EnableNETAnalyzers>
     <CodeAnalysisTreatWarningsAsErrors>false</CodeAnalysisTreatWarningsAsErrors>
   </PropertyGroup>
 

--- a/common.props
+++ b/common.props
@@ -22,14 +22,10 @@
 
   <PropertyGroup>
     <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
-    <EnableNETAnalyzers>false</EnableNETAnalyzers>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <CodeAnalysisTreatWarningsAsErrors>false</CodeAnalysisTreatWarningsAsErrors>
   </PropertyGroup>
   
-  <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
-    <EnableNETAnalyzers>true</EnableNETAnalyzers>
-  </PropertyGroup>
-
   <PropertyGroup>
     <PackageIcon>images/logo.jpg</PackageIcon>
     <PackageProjectUrl>$(RepositoryUrl)</PackageProjectUrl>

--- a/common.props
+++ b/common.props
@@ -21,7 +21,8 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>    
+    <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
+    <EnableNETAnalyzers>false</EnableNETAnalyzers>
     <CodeAnalysisTreatWarningsAsErrors>false</CodeAnalysisTreatWarningsAsErrors>
   </PropertyGroup>
   


### PR DESCRIPTION
## Proposed changes

Many `MemoryStream` writer functions via `BinaryWriter` call the byte[] methods with an additional copy and allocation that can be avoided by providing the new methods with `int Read(Span<byte> buffer)` and `void Write(ReadOnlySpan<byte> buffer)`.
`ArraySegmentStream` outperforms or is on parity with `RecyclableMemoryStream` for both speed and memory allocations due to the special buffer handling.

Current benchmark results:
- binary encoding with `ArraySegmentStream` gets a speed up by a factor of two with the used test set and lesser memory allocations because the callers  in the underlying memory stream do not have to do an extra Rent/copy for small items (in `BinaryWriter`) like an int when calling the new Write signature (compare BinaryEncoderArraySegmentStream vs BinaryEncoderArraySegmentStreamNoSpan)
- binary decoding doesn't show a difference in memory use due to the nature of preallocated buffers. For .NET Framework 4.8  and .NET6 there is almost no penalty in not supporting the Read(Span). However, in .NET 8 there is all of a sudden a big difference when the Read(Span) is not supported. Still MemoryStream is the fastest, but without the Read(Span) signature the ArraySegmentStream were running slower than in .NET6, while the streams with span get a nice perf boost. RecycleMemoryStream has no implementation for decoding a ReadOnlySequence.
- JSON encoding seems unaffected due to the underlying `StreamWriter` class. There is no obvious perf difference. But for the JSON case `RecyclableMemoryStream` outperforms all other MemoryStream implementations by some 10 or 20%.
- It is worth to mention that `RecyclableMemoryStream` is for the binary encoder as slow as the NoSpan version of the `ArraySegmentStream`. So maybe the span support is missing? (Checked that it is implemented, needs investigation). For JSON encoding there is no difference between ArraySegmentStream and RecyclableMemoryStream. 

```
| Method                                | Runtime            | PayLoadSize | Mean        | Error     | StdDev    | Median      | Ratio | RatioSD | Code Size | Gen0     | Gen1     | Gen2     | Allocated  | Alloc Ratio |
|-------------------------------------- |------------------- |------------ |------------:|----------:|----------:|------------:|------:|--------:|----------:|---------:|---------:|---------:|-----------:|------------:|
| BinaryEncoderMemoryStream             | .NET 6.0           | 64          |    313.8 us |  11.49 us |  33.70 us |    306.8 us |  0.68 |    0.11 |   1,266 B |  24.9023 |        - |        - |  205.02 KB |        1.00 |
| BinaryEncoderRecyclableMemoryStream   | .NET 6.0           | 64          |    623.6 us |  20.15 us |  58.47 us |    615.3 us |  1.36 |    0.21 |   3,170 B |   3.9063 |        - |        - |   31.93 KB |        0.16 |
| *BinaryEncoderArraySegmentStream      | .NET 6.0           | 64          |    313.1 us |   9.20 us |  26.40 us |    307.7 us |  0.68 |    0.09 |   2,337 B |   3.4180 |        - |        - |   30.65 KB |        0.15 |
| BinaryEncoderArraySegmentStreamNoSpan | .NET 6.0           | 64          |    719.8 us |  21.85 us |  63.72 us |    703.2 us |  1.57 |    0.21 |   2,337 B |   2.9297 |        - |        - |   30.65 KB |        0.15 |
| BinaryEncoderMemoryStream             | .NET 8.0           | 64          |    226.3 us |   8.67 us |  25.44 us |    223.5 us |  0.49 |    0.08 |   2,360 B |  24.9023 |        - |        - |  205.02 KB |        1.00 |
| BinaryEncoderRecyclableMemoryStream   | .NET 8.0           | 64          |    522.0 us |  14.70 us |  42.88 us |    507.1 us |  1.14 |    0.16 |   5,305 B |   3.9063 |        - |        - |   31.94 KB |        0.16 |
| *BinaryEncoderArraySegmentStream      | .NET 8.0           | 64          |    233.4 us |   9.16 us |  27.00 us |    222.8 us |  0.51 |    0.09 |   5,849 B |   3.6621 |        - |        - |   30.65 KB |        0.15 |
| BinaryEncoderArraySegmentStreamNoSpan | .NET 8.0           | 64          |    596.9 us |  17.92 us |  52.27 us |    584.6 us |  1.30 |    0.16 |   5,839 B |   2.9297 |        - |        - |   30.65 KB |        0.15 |
| BinaryEncoderMemoryStream             | .NET Framework 4.8 | 64          |    466.0 us |  20.71 us |  61.07 us |    446.2 us |  1.00 |    0.00 |     819 B |  33.2031 |   4.8828 |        - |  205.54 KB |        1.00 |
| BinaryEncoderRecyclableMemoryStream   | .NET Framework 4.8 | 64          |  1,065.6 us |  44.37 us | 130.13 us |  1,050.4 us |  2.33 |    0.41 |   1,511 B |   3.9063 |        - |        - |   32.31 KB |        0.16 |
| *BinaryEncoderArraySegmentStream      | .NET Framework 4.8 | 64          |    628.1 us |  21.74 us |  64.11 us |    631.7 us |  1.37 |    0.20 |   1,921 B |   4.8828 |        - |        - |   31.05 KB |        0.15 |
| BinaryEncoderArraySegmentStreamNoSpan | .NET Framework 4.8 | 64          |    670.5 us |  28.36 us |  82.74 us |    678.1 us |  1.48 |    0.31 |   1,921 B |   4.8828 |        - |        - |   31.05 KB |        0.15 |
|                                       |                    |             |             |           |           |             |       |         |           |          |          |          |            |             |
| BinaryEncoderMemoryStream             | .NET 6.0           | 1024        |  5,922.9 us | 206.52 us | 605.69 us |  5,873.8 us |  0.70 |    0.11 |   1,266 B | 710.9375 | 679.6875 | 671.8750 | 3354.38 KB |        1.00 |
| BinaryEncoderRecyclableMemoryStream   | .NET 6.0           | 1024        | 10,432.2 us | 250.46 us | 722.64 us | 10,313.6 us |  1.24 |    0.17 |   3,170 B |  78.1250 |        - |        - |  670.88 KB |        0.20 |
| *BinaryEncoderArraySegmentStream      | .NET 6.0           | 1024        |  5,354.3 us | 120.44 us | 345.56 us |  5,294.9 us |  0.64 |    0.08 |   2,337 B | 132.8125 |  31.2500 |        - | 1125.15 KB |        0.34 |
| BinaryEncoderArraySegmentStreamNoSpan | .NET 6.0           | 1024        | 12,628.9 us | 326.79 us | 932.35 us | 12,402.7 us |  1.50 |    0.23 |   2,337 B | 125.0000 |  31.2500 |        - | 1125.15 KB |        0.34 |
| BinaryEncoderMemoryStream             | .NET 8.0           | 1024        |  4,315.1 us |  88.94 us | 258.02 us |  4,268.5 us |  0.51 |    0.07 |   2,362 B | 718.7500 | 671.8750 | 671.8750 | 3354.44 KB |        1.00 |
| BinaryEncoderRecyclableMemoryStream   | .NET 8.0           | 1024        |  8,205.3 us | 163.70 us | 422.56 us |  8,198.4 us |  0.96 |    0.10 |   5,305 B |  78.1250 |        - |        - |  670.85 KB |        0.20 |
| *BinaryEncoderArraySegmentStream      | .NET 8.0           | 1024        |  3,836.7 us |  93.93 us | 273.99 us |  3,784.1 us |  0.46 |    0.06 |   5,894 B |  58.5938 |        - |        - |  491.29 KB |        0.15 |
| BinaryEncoderArraySegmentStreamNoSpan | .NET 8.0           | 1024        |  9,933.1 us | 313.87 us | 920.52 us |  9,717.3 us |  1.18 |    0.15 |   5,847 B |  46.8750 |        - |        - |   491.3 KB |        0.15 |
| BinaryEncoderMemoryStream             | .NET Framework 4.8 | 1024        |  8,525.3 us | 286.61 us | 840.58 us |  8,698.8 us |  1.00 |    0.00 |     819 B | 750.0000 | 671.8750 | 671.8750 | 3358.61 KB |        1.00 |
| BinaryEncoderRecyclableMemoryStream   | .NET Framework 4.8 | 1024        | 12,748.4 us | 251.76 us | 680.65 us | 12,593.7 us |  1.50 |    0.17 |   1,511 B | 109.3750 |        - |        - |  673.15 KB |        0.20 |
| *BinaryEncoderArraySegmentStream      | .NET Framework 4.8 | 1024        |  7,540.7 us | 150.69 us | 425.04 us |  7,529.2 us |  0.90 |    0.12 |   1,921 B | 218.7500 | 109.3750 |        - |  1362.6 KB |        0.41 |
| BinaryEncoderArraySegmentStreamNoSpan | .NET Framework 4.8 | 1024        |  7,709.3 us | 152.26 us | 324.47 us |  7,586.7 us |  0.93 |    0.11 |   1,921 B | 218.7500 | 109.3750 |        - | 1362.55 KB |        0.41 |

| BinaryDecoderMemoryStream             | .NET 6.0           | 64          |   202.7 us |   6.00 us |  17.40 us |   196.8 us |  0.63 |    0.10 |  21.4844 |     920 B |  176.28 KB |        0.98 |
| BinaryDecoderArraySegmentStream       | .NET 6.0           | 64          |   278.7 us |   7.51 us |  21.92 us |   271.7 us |  0.86 |    0.10 |  21.4844 |   1,230 B |  176.34 KB |        0.98 |
| BinaryDecoderArraySegmentStreamNoSpan | .NET 6.0           | 64          |   280.6 us |   7.51 us |  21.05 us |   275.6 us |  0.87 |    0.11 |  21.4844 |   1,230 B |  176.34 KB |        0.98 |
| BinaryDecoderMemoryStream             | .NET 8.0           | 64          |   113.7 us |   5.52 us |  15.93 us |   107.0 us |  0.35 |    0.06 |  21.4844 |     832 B |  176.28 KB |        0.98 |
| BinaryDecoderArraySegmentStream       | .NET 8.0           | 64          |   194.6 us |   3.89 us |  11.22 us |   193.3 us |  0.60 |    0.08 |  21.4844 |   1,829 B |  176.34 KB |        0.98 |
| BinaryDecoderArraySegmentStreamNoSpan | .NET 8.0           | 64          |   446.3 us |   8.85 us |  24.67 us |   442.1 us |  1.39 |    0.18 |  21.4844 |   1,848 B |  176.34 KB |        0.98 |
| BinaryDecoderMemoryStream             | .NET Framework 4.8 | 64          |   327.1 us |  13.11 us |  38.04 us |   320.3 us |  1.00 |    0.00 |  28.8086 |     346 B |  179.94 KB |        1.00 |
| BinaryDecoderArraySegmentStream       | .NET Framework 4.8 | 64          |   366.3 us |  16.57 us |  48.59 us |   346.8 us |  1.14 |    0.22 |  29.2969 |     550 B |  180.02 KB |        1.00 |
| BinaryDecoderArraySegmentStreamNoSpan | .NET Framework 4.8 | 64          |   329.7 us |  10.12 us |  28.55 us |   322.2 us |  1.02 |    0.12 |  29.2969 |     550 B |  180.02 KB |        1.00 |
|                                       |                    |             |            |           |           |            |       |         |          |           |            |             |
| BinaryDecoderMemoryStream             | .NET 6.0           | 1024        | 2,811.5 us |  91.72 us | 267.55 us | 2,739.1 us |  0.59 |    0.07 | 343.7500 |     920 B | 2816.29 KB |        0.98 |
| BinaryDecoderArraySegmentStream       | .NET 6.0           | 1024        | 4,173.1 us |  82.09 us | 167.69 us | 4,134.7 us |  0.87 |    0.07 | 343.7500 |   1,230 B | 2816.34 KB |        0.98 |
| BinaryDecoderArraySegmentStreamNoSpan | .NET 6.0           | 1024        | 4,289.2 us | 162.97 us | 454.30 us | 4,195.9 us |  0.90 |    0.11 | 343.7500 |   1,230 B | 2816.34 KB |        0.98 |
| BinaryDecoderMemoryStream             | .NET 8.0           | 1024        | 1,742.0 us |  41.25 us | 116.34 us | 1,715.3 us |  0.37 |    0.03 | 343.7500 |     832 B | 2816.28 KB |        0.98 |
| BinaryDecoderArraySegmentStream       | .NET 8.0           | 1024        | 3,128.8 us |  93.15 us | 268.76 us | 3,083.5 us |  0.66 |    0.07 | 343.7500 |   1,851 B | 2816.34 KB |        0.98 |
| BinaryDecoderArraySegmentStreamNoSpan | .NET 8.0           | 1024        | 6,996.5 us | 191.56 us | 552.69 us | 6,849.0 us |  1.46 |    0.14 | 343.7500 |   1,848 B | 2816.35 KB |        0.98 |
| BinaryDecoderMemoryStream             | .NET Framework 4.8 | 1024        | 4,781.3 us | 105.90 us | 298.69 us | 4,694.5 us |  1.00 |    0.00 | 460.9375 |     346 B | 2872.91 KB |        1.00 |
| BinaryDecoderArraySegmentStream       | .NET Framework 4.8 | 1024        | 5,476.0 us | 123.49 us | 350.32 us | 5,403.4 us |  1.15 |    0.11 | 460.9375 |     550 B | 2872.98 KB |        1.00 |
| BinaryDecoderArraySegmentStreamNoSpan | .NET Framework 4.8 | 1024        | 5,377.5 us | 104.08 us | 263.03 us | 5,341.9 us |  1.14 |    0.08 | 460.9375 |     550 B | 2872.98 KB |        1.00 |
```

Additional changes:
- Implement dispose to return buffers that were not transferred. 
- Implement a GetSequence in ArraySegmentStream to allow use e.g. with an upcoming change in the MQTT encoder (see https://github.com/dotnet/MQTTnet/pull/1918)

## Related Issues

- Fixes #

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

For references the JSON Encoder results for 1024 buffer size of the stream writer:

```
| JsonEncoderMemoryStream             | .NET 6.0           | 1024       | 1024        |  35.864 ms | 1.2359 ms |  3.6246 ms |  35.535 ms |  0.37 |    0.08 | 1500.0000 |   1,583 B |  937.5000 |  875.0000 | 18067.35 KB |        0.97 |
| JsonEncoderMemoryStream             | .NET 8.0           | 1024       | 1024        |  33.237 ms | 0.7876 ms |  2.2472 ms |  32.918 ms |  0.33 |    0.06 | 1687.5000 |   4,891 B |  968.7500 |  968.7500 | 18020.14 KB |        0.96 |
| JsonEncoderMemoryStream             | .NET Framework 4.8 | 1024       | 1024        | 101.484 ms | 6.8832 ms | 20.2951 ms |  96.902 ms |  1.00 |    0.00 | 1800.0000 |     877 B |  800.0000 |  800.0000 | 18683.35 KB |        1.00 |
|                                     |                    |            |             |            |           |            |            |       |         |           |           |           |           |             |             |
| JsonEncoderRecyclableMemoryStream   | .NET 6.0           | 1024       | 1024        |  29.173 ms | 1.1374 ms |  3.3359 ms |  28.254 ms |  0.34 |    0.05 | 1125.0000 |   3,487 B |   93.7500 |         - |  9430.07 KB |        0.94 |
| JsonEncoderRecyclableMemoryStream   | .NET 8.0           | 1024       | 1024        |  25.674 ms | 0.8479 ms |  2.4599 ms |  24.984 ms |  0.30 |    0.04 | 1125.0000 |   7,991 B |   93.7500 |         - |  9361.57 KB |        0.93 |
| JsonEncoderRecyclableMemoryStream   | .NET Framework 4.8 | 1024       | 1024        |  86.740 ms | 3.1096 ms |  9.1200 ms |  85.490 ms |  1.00 |    0.00 | 1500.0000 |   1,569 B |         - |         - | 10063.86 KB |        1.00 |
|                                     |                    |            |             |            |           |            |            |       |         |           |           |           |           |             |             |
| JsonEncoderArraySegmentStream       | .NET 6.0           | 1024       | 1024        |  30.560 ms | 1.1539 ms |  3.3107 ms |  29.916 ms |  0.34 |    0.06 | 1125.0000 |   2,671 B |  500.0000 |         - |  9440.85 KB |        0.92 |
| JsonEncoderArraySegmentStream       | .NET 8.0           | 1024       | 1024        |  28.017 ms | 1.4165 ms |  4.1766 ms |  26.816 ms |  0.32 |    0.06 |  937.5000 |   9,061 B |  125.0000 |         - |  7839.43 KB |        0.77 |
| JsonEncoderArraySegmentStream       | .NET Framework 4.8 | 1024       | 1024        |  89.666 ms | 3.7346 ms | 11.0116 ms |  88.298 ms |  1.00 |    0.00 | 1500.0000 |   1,742 B |  666.6667 |         - | 10208.53 KB |        1.00 |

| JsonEncoderArraySegmentStreamNoSpan | .NET 6.0           | 1024       | 1024        |  30.402 ms | 0.9505 ms |  2.7424 ms |  30.310 ms |  0.36 |    0.05 | 1125.0000 |   2,671 B |  500.0000 |         - |  9428.39 KB |        0.93 |
| JsonEncoderArraySegmentStreamNoSpan | .NET 8.0           | 1024       | 1024        |  33.638 ms | 2.5311 ms |  7.4631 ms |  33.054 ms |  0.40 |    0.10 |  500.0000 |   9,040 B |         - |         - |  7852.71 KB |        0.77 |
| JsonEncoderArraySegmentStreamNoSpan | .NET Framework 4.8 | 1024       | 1024        |  84.359 ms | 3.3380 ms |  9.6310 ms |  81.471 ms |  1.00 |    0.00 | 1571.4286 |   1,742 B |  714.2857 |         - | 10181.83 KB |        1.00 |
```
