### PR TITLE
fix Role Permissions of Method UnregisterApplication & Add Parameter to CertificateStoreIdentifier OpenStore Method

### DIFF
--- a/Libraries/Opc.Ua.Gds.Server.Common/ApplicationsNodeManager.cs
+++ b/Libraries/Opc.Ua.Gds.Server.Common/ApplicationsNodeManager.cs
@@ -539,7 +539,7 @@ namespace Opc.Ua.Gds.Server
             NodeId objectId,
             NodeId applicationId)
         {
-            AuthorizationHelper.HasAuthorization(context, AuthorizationHelper.DiscoveryAdmin);
+            AuthorizationHelper.HasAuthorization(context, AuthorizationHelper.DiscoveryAdminOrSelfAdmin);
 
             Utils.LogInfo("OnUnregisterApplication: {0}", applicationId.ToString());
 

--- a/Libraries/Opc.Ua.Gds.Server.Common/RoleBasedUserManagement/AuthorizationHelper.cs
+++ b/Libraries/Opc.Ua.Gds.Server.Common/RoleBasedUserManagement/AuthorizationHelper.cs
@@ -41,6 +41,7 @@ namespace Opc.Ua.Gds.Server
     {
         internal static List<Role> AuthenticatedUser { get; } = new List<Role> { Role.AuthenticatedUser };
         internal static List<Role> DiscoveryAdmin { get; } = new List<Role> { GdsRole.DiscoveryAdmin };
+        internal static List<Role> DiscoveryAdminOrSelfAdmin { get; } = new List<Role> { GdsRole.DiscoveryAdmin, GdsRole.ApplicationSelfAdmin };
         internal static List<Role> AuthenticatedUserOrSelfAdmin { get; } = new List<Role> { Role.AuthenticatedUser, GdsRole.ApplicationSelfAdmin };
         internal static List<Role> CertificateAuthorityAdminOrSelfAdmin { get; } = new List<Role> { GdsRole.CertificateAuthorityAdmin, GdsRole.ApplicationSelfAdmin };
         internal static List<Role> CertificateAuthorityAdmin { get; } = new List<Role> { GdsRole.CertificateAuthorityAdmin };

--- a/Stack/Opc.Ua.Core/Security/Certificates/CertificateStoreIdentifier.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/CertificateStoreIdentifier.cs
@@ -182,6 +182,21 @@ namespace Opc.Ua
         /// <remarks>
         /// Opens an instance of the store which contains public keys.
         /// </remarks>
+        /// <param name="noPrivateKeys">Indicates whether NO private keys are found in the store. Default <c>true</c>.</param>
+        /// <returns>A disposable instance of the <see cref="ICertificateStore"/>.</returns>
+        public virtual ICertificateStore OpenStore(bool noPrivateKeys = true)
+        {
+            ICertificateStore store = CreateStore(this.StoreType);
+            store.Open(this.StorePath, noPrivateKeys);
+            return store;
+        }
+
+        /// <summary>
+        /// Returns an object to access the store containing the certificates.
+        /// </summary>
+        /// <remarks>
+        /// Opens an instance of the store which contains public keys.
+        /// </remarks>
         /// <returns>A disposable instance of the <see cref="ICertificateStore"/>.</returns>
         public virtual ICertificateStore OpenStore()
         {

--- a/Stack/Opc.Ua.Core/Security/Certificates/CertificateStoreIdentifier.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/CertificateStoreIdentifier.cs
@@ -182,21 +182,6 @@ namespace Opc.Ua
         /// <remarks>
         /// Opens an instance of the store which contains public keys.
         /// </remarks>
-        /// <param name="noPrivateKeys">Indicates whether NO private keys are found in the store. Default <c>true</c>.</param>
-        /// <returns>A disposable instance of the <see cref="ICertificateStore"/>.</returns>
-        public virtual ICertificateStore OpenStore(bool noPrivateKeys = true)
-        {
-            ICertificateStore store = CreateStore(this.StoreType);
-            store.Open(this.StorePath, noPrivateKeys);
-            return store;
-        }
-
-        /// <summary>
-        /// Returns an object to access the store containing the certificates.
-        /// </summary>
-        /// <remarks>
-        /// Opens an instance of the store which contains public keys.
-        /// </remarks>
         /// <returns>A disposable instance of the <see cref="ICertificateStore"/>.</returns>
         public virtual ICertificateStore OpenStore()
         {
@@ -204,18 +189,19 @@ namespace Opc.Ua
             store.Open(this.StorePath);
             return store;
         }
-
         /// <summary>
         /// Returns an object to access the store containing the certificates.
         /// </summary>
         /// <remarks>
         /// Opens an instance of the store which contains public keys.
         /// </remarks>
+        /// <param name="path">location of the store</param>
+        /// <param name="noPrivateKeys">Indicates whether NO private keys are found in the store. Default <c>true</c>.</param>
         /// <returns>A disposable instance of the <see cref="ICertificateStore"/>.</returns>
-        public static ICertificateStore OpenStore(string path)
+        public static ICertificateStore OpenStore(string path, bool noPrivateKeys = true)
         {
             ICertificateStore store = CertificateStoreIdentifier.CreateStore(CertificateStoreIdentifier.DetermineStoreType(path));
-            store.Open(path);
+            store.Open(path, noPrivateKeys);
             return store;
         }
         #endregion


### PR DESCRIPTION
## Proposed changes

Fix allowed Roles of Method Unregister Application  allow Application Self Admin Privilge:
https://reference.opcfoundation.org/GDS/v105/docs/6.6.8

Add Parameter NoPrivateKeys to OpenStoreMethod of CertificateStoreIdentifier 

## Related Issues

- Fixes #

## Types of changes


- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [x] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.


