### PR TITLE
Remove unnecessary casts to RoleBasedIdentity when checking for WellKnownRoles

### DIFF
--- a/Libraries/Opc.Ua.Gds.Server.Common/RoleBasedUserManagement/AuthorizationHelper.cs
+++ b/Libraries/Opc.Ua.Gds.Server.Common/RoleBasedUserManagement/AuthorizationHelper.cs
@@ -110,13 +110,11 @@ namespace Opc.Ua.Gds.Server
         }
         private static bool HasRole(IUserIdentity userIdentity, IEnumerable<Role> roles)
         {
-            RoleBasedIdentity identity = userIdentity as RoleBasedIdentity;
-
-            if (identity != null)
+            if (userIdentity != null && userIdentity.TokenType != UserTokenType.Anonymous)
             {
                 foreach (Role role in roles)
                 {
-                    if ((identity.Roles.Contains(role)))
+                    if (!NodeId.IsNull(role.RoleId) && userIdentity.GrantedRoleIds.Contains(role.RoleId))
                     {
                         return true;
                     }

--- a/Libraries/Opc.Ua.Server/Configuration/ConfigurationNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/Configuration/ConfigurationNodeManager.cs
@@ -317,14 +317,14 @@ namespace Opc.Ua.Server
             {
                 if (operationContext.ChannelContext?.EndpointDescription?.SecurityMode != MessageSecurityMode.SignAndEncrypt)
                 {
-                    throw new ServiceResultException(StatusCodes.BadUserAccessDenied, "Secure Application Administrator access required.");
+                    throw new ServiceResultException(StatusCodes.BadUserAccessDenied, "Access to this item is only allowed with MessageSecurityMode SignAndEncrypt.");
                 }
-
+                IUserIdentity identity = operationContext.UserIdentity;
                 // allow access to system configuration only with Role SecurityAdmin
-                if (context.UserIdentity == null || context.UserIdentity.TokenType == UserTokenType.Anonymous ||
-                    !context.UserIdentity.GrantedRoleIds.Contains(ObjectIds.WellKnownRole_SecurityAdmin))
+                if (identity == null || identity.TokenType == UserTokenType.Anonymous ||
+                    identity.GrantedRoleIds.Contains(ObjectIds.WellKnownRole_SecurityAdmin))
                 {
-                    throw new ServiceResultException(StatusCodes.BadUserAccessDenied, "Security Admin Role required.");
+                    throw new ServiceResultException(StatusCodes.BadUserAccessDenied, "Security Admin Role required to access this item.");
                 }
 
             }

--- a/Libraries/Opc.Ua.Server/Configuration/ConfigurationNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/Configuration/ConfigurationNodeManager.cs
@@ -322,7 +322,7 @@ namespace Opc.Ua.Server
                 IUserIdentity identity = operationContext.UserIdentity;
                 // allow access to system configuration only with Role SecurityAdmin
                 if (identity == null || identity.TokenType == UserTokenType.Anonymous ||
-                    identity.GrantedRoleIds.Contains(ObjectIds.WellKnownRole_SecurityAdmin))
+                    !identity.GrantedRoleIds.Contains(ObjectIds.WellKnownRole_SecurityAdmin))
                 {
                     throw new ServiceResultException(StatusCodes.BadUserAccessDenied, "Security Admin Role required to access this item.");
                 }

--- a/Libraries/Opc.Ua.Server/Configuration/ConfigurationNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/Configuration/ConfigurationNodeManager.cs
@@ -320,10 +320,9 @@ namespace Opc.Ua.Server
                     throw new ServiceResultException(StatusCodes.BadUserAccessDenied, "Secure Application Administrator access required.");
                 }
 
-                // allow access to system configuration only through special identity
-                IUserIdentity user = context.UserIdentity as RoleBasedIdentity;               
-                if (user == null || user.TokenType == UserTokenType.Anonymous ||
-                    !user.GrantedRoleIds.Contains(ObjectIds.WellKnownRole_SecurityAdmin))
+                // allow access to system configuration only with Role SecurityAdmin
+                if (context.UserIdentity == null || context.UserIdentity.TokenType == UserTokenType.Anonymous ||
+                    !context.UserIdentity.GrantedRoleIds.Contains(ObjectIds.WellKnownRole_SecurityAdmin))
                 {
                     throw new ServiceResultException(StatusCodes.BadUserAccessDenied, "Security Admin Role required.");
                 }

--- a/Libraries/Opc.Ua.Server/RoleBasedUserManagement/RoleBasedIdentity.cs
+++ b/Libraries/Opc.Ua.Server/RoleBasedUserManagement/RoleBasedIdentity.cs
@@ -184,7 +184,6 @@ namespace Opc.Ua.Server
         public NodeIdCollection GrantedRoleIds
         {
             get { return m_identity.GrantedRoleIds; }
-            set { m_identity.GrantedRoleIds = value; }
         }
 
         /// <summary>

--- a/Stack/Opc.Ua.Core/Stack/Client/IUserIdentity.cs
+++ b/Stack/Opc.Ua.Core/Stack/Client/IUserIdentity.cs
@@ -52,7 +52,7 @@ namespace Opc.Ua
         /// <summary>
         /// Get or sets the list of granted role ids associated to the UserIdentity.
         /// </summary>
-        NodeIdCollection GrantedRoleIds { get; set; }
+        NodeIdCollection GrantedRoleIds { get; }
 
         /// <summary>
         /// Returns a UA user identity token containing the user information.

--- a/Stack/Opc.Ua.Core/Stack/Client/UserIdentity.cs
+++ b/Stack/Opc.Ua.Core/Stack/Client/UserIdentity.cs
@@ -155,7 +155,6 @@ namespace Opc.Ua
         public NodeIdCollection GrantedRoleIds
         {
             get { return m_grantedRoleIds; }
-            set { m_grantedRoleIds = value; }
         }
 
         /// <summary cref="IUserIdentity.GetIdentityToken" />


### PR DESCRIPTION

## Proposed changes

Do not cast to RoleBasedIdentity when only IUserIdentity is needed because only WellKnownRoles are cheked.
This allows users to use own implementations of IUserIdentity

## Related Issues

- Fixes #1948

## Types of changes

What types of changes does your code introduce?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [x] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments
