### PR TITLE
check Application URI of the server Certificate on OpenSecureChannel

### DIFF
--- a/Libraries/Opc.Ua.Client/Session.cs
+++ b/Libraries/Opc.Ua.Client/Session.cs
@@ -5271,14 +5271,16 @@ namespace Opc.Ua.Client
         private void ValidateServerCertificateApplicationUri(
             X509Certificate2 serverCertificate)
         {
-            var applicationUri = m_endpoint.Description.Server.ApplicationUri;
+            var applicationUri = m_endpoint?.Description?.Server?.ApplicationUri;
             //check is only neccessary if the ApplicatioUri is specified for the Endpoint
             if (string.IsNullOrEmpty(applicationUri))
             {
-                return;
+                throw ServiceResultException.Create(
+                    StatusCodes.BadSecurityChecksFailed,
+                    "No ApplicationUri is specified for the server in the EndpointDescription.");
             }
             string certificateApplicationUri = X509Utils.GetApplicationUriFromCertificate(serverCertificate);
-            if (certificateApplicationUri != applicationUri)
+            if (!string.Equals(certificateApplicationUri, applicationUri, StringComparison.Ordinal))
             {
                 throw ServiceResultException.Create(
                     StatusCodes.BadSecurityChecksFailed,

--- a/Libraries/Opc.Ua.Client/Session.cs
+++ b/Libraries/Opc.Ua.Client/Session.cs
@@ -5266,25 +5266,23 @@ namespace Opc.Ua.Client
             }
         }
         /// <summary>
-        /// validates the server Certificates Application Uri to match the specified ApplicationUri of the Endpoint for an open call (Spec Part 4 5.4.1)
+        /// Validates the ServerCertificate ApplicationUri to match the ApplicationUri of the Endpoint for an open call (Spec Part 4 5.4.1)
         /// </summary>
         private void ValidateServerCertificateApplicationUri(
             X509Certificate2 serverCertificate)
         {
-            //check only neccessary if the Application Uri for the Endpoint is specified
             var applicationUri = m_endpoint.Description.Server.ApplicationUri;
+            //check is only neccessary if the ApplicatioUri is specified for the Endpoint
             if (string.IsNullOrEmpty(applicationUri))
             {
                 return;
             }
+            string certificateApplicationUri = X509Utils.GetApplicationUriFromCertificate(serverCertificate);
+            if (certificateApplicationUri != applicationUri)
             {
-                string certificateApplicationUri = X509Utils.GetApplicationUriFromCertificate(serverCertificate);
-                if (certificateApplicationUri != applicationUri)
-                {
-                    throw ServiceResultException.Create(
-                        StatusCodes.BadSecurityChecksFailed,
-                        "Server did not return a Certificate matching the ApplicationUri specified in the EndpointDescription.");
-                }
+                throw ServiceResultException.Create(
+                    StatusCodes.BadSecurityChecksFailed,
+                    "Server did not return a Certificate matching the ApplicationUri specified in the EndpointDescription.");
             }
         }
 

--- a/Libraries/Opc.Ua.Client/SessionAsync.cs
+++ b/Libraries/Opc.Ua.Client/SessionAsync.cs
@@ -93,6 +93,7 @@ namespace Opc.Ua.Client
 
                 if (requireEncryption)
                 {
+                    ValidateServerCertificateApplicationUri(serverCertificate);
                     if (checkDomain)
                     {
                         await m_configuration.CertificateValidator.ValidateAsync(serverCertificateChain, m_endpoint, ct).ConfigureAwait(false);


### PR DESCRIPTION
## Proposed changes

Implement OpenSecureChannel in compliance with 
[Spec Part 5.4.1](https://reference.opcfoundation.org/Core/Part4/v105/docs/5.4.1)

The ApplicationUri specified in the Server Certificate is the same as the ApplicationUri provided in the EndpointDescription.

## Related Issues

- Fixes #2032

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [x] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

