### PR TITLE
[Server] Fix Shutdown Delay when registration is enabled no LDS is present.

### DIFF
--- a/Libraries/Opc.Ua.Server/Server/StandardServer.cs
+++ b/Libraries/Opc.Ua.Server/Server/StandardServer.cs
@@ -2325,7 +2325,7 @@ namespace Opc.Ua.Server
                                 {
                                     client.RegisterServer(requestHeader, m_registrationInfo);
                                 }
-
+                                m_registeredWithDiscoveryServer = true;
                                 return true;
                             }
                             catch (Exception e)
@@ -2362,7 +2362,7 @@ namespace Opc.Ua.Server
                     configuration.CertificateValidator.CertificateValidation -= registrationCertificateValidator;
                 }
             }
-
+            m_registeredWithDiscoveryServer = false;
             return false;
         }
 
@@ -3075,9 +3075,10 @@ namespace Opc.Ua.Server
             // attempt graceful shutdown the server.
             try
             {
-                if (m_maxRegistrationInterval > 0)
+                
+                if (m_maxRegistrationInterval > 0 && m_registeredWithDiscoveryServer)
                 {
-                    // unregister from Discovery Server
+                    // unregister from Discovery Server if registered before
                     m_registrationInfo.IsOnline = false;
                     RegisterWithDiscoveryServer();
                 }
@@ -3353,6 +3354,7 @@ namespace Opc.Ua.Server
         private int m_minRegistrationInterval;
         private int m_maxRegistrationInterval;
         private int m_lastRegistrationInterval;
+        private bool m_registeredWithDiscoveryServer = false;
         private int m_minNonceLength;
         private bool m_useRegisterServer2;
         private List<INodeManagerFactory> m_nodeManagerFactories;

--- a/Libraries/Opc.Ua.Server/Server/StandardServer.cs
+++ b/Libraries/Opc.Ua.Server/Server/StandardServer.cs
@@ -3007,6 +3007,7 @@ namespace Opc.Ua.Server
 
                         m_registrationEndpoints.Add(endpoint);
 
+                        m_registeredWithDiscoveryServer = false;
                         m_minRegistrationInterval = 1000;
                         m_lastRegistrationInterval = m_minRegistrationInterval;
 
@@ -3354,7 +3355,7 @@ namespace Opc.Ua.Server
         private int m_minRegistrationInterval;
         private int m_maxRegistrationInterval;
         private int m_lastRegistrationInterval;
-        private bool m_registeredWithDiscoveryServer = false;
+        private bool m_registeredWithDiscoveryServer;
         private int m_minNonceLength;
         private bool m_useRegisterServer2;
         private List<INodeManagerFactory> m_nodeManagerFactories;

--- a/Libraries/Opc.Ua.Server/Server/StandardServer.cs
+++ b/Libraries/Opc.Ua.Server/Server/StandardServer.cs
@@ -2325,7 +2325,8 @@ namespace Opc.Ua.Server
                                 {
                                     client.RegisterServer(requestHeader, m_registrationInfo);
                                 }
-                                m_registeredWithDiscoveryServer = true;
+                                
+                                m_registeredWithDiscoveryServer = m_registrationInfo.IsOnline;
                                 return true;
                             }
                             catch (Exception e)


### PR DESCRIPTION
## Proposed changes

The server no remembers if a registration with a LDS was done and only tries to unregister on shutdown if this is the case.
This mitigates the shutdown delay when no LDS is present on the network.

Benchmark:

Test Runtime for Server Shutdown Test decreased from >10s to <2s


## Related Issues

- Fixes #2422

## Types of changes


- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [x] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments


