### PR TITLE
Fix handling of Subject Names with specials Characters /  and = using " as escaping character

### DIFF
--- a/Stack/Opc.Ua.Core/Security/Certificates/X509Utils.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/X509Utils.cs
@@ -437,7 +437,8 @@ namespace Opc.Ua
                     {
                         buffer.Append(value);
                     }
-                    var filtered = buffer.Replace("\"/\"", "/").Replace("\"=\"", "=").ToString();
+                    //remove subject name escaping character " (used for escaping = and / ) from result as per spec Part 12 7.9.4
+                    string filtered = buffer.Replace("\"/\"", "/").Replace("\"=\"", "=").ToString();
                     fields.Add(filtered);
                     buffer.Length = 0;
                 }

--- a/Stack/Opc.Ua.Core/Security/Certificates/X509Utils.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/X509Utils.cs
@@ -437,8 +437,8 @@ namespace Opc.Ua
                     {
                         buffer.Append(value);
                     }
-
-                    fields.Add(buffer.ToString());
+                    var filtered = buffer.Replace("\"/\"", "/").Replace("\"=\"", "=").ToString();
+                    fields.Add(filtered);
                     buffer.Length = 0;
                 }
 

--- a/Tests/Opc.Ua.Core.Tests/Security/Certificates/X509UtilsTest.cs
+++ b/Tests/Opc.Ua.Core.Tests/Security/Certificates/X509UtilsTest.cs
@@ -16,26 +16,27 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
     [SetCulture("en-us")]
     public class X509UtilsTest
     {
-        [Test]
-        public void ParseDistinguishedNameHandlesEscapingOfSlashChar()
+        [TestCase("CN=UA Yellow Green Server,DC=dogblueberry,O=OPC\"=\"Foundation")]
+        [TestCase("CN=UA Yellow Green Server,DC=dogblueberry,O=\"OPC=Foundation\"")]
+        public void ParseDistinguishedNameHandlesEscapingOfEqualsChar(string input)
         {
-            string input = "CN=UA Yellow Green Server,DC=dogblueberry,O=OPC\"=\"Foundation";
-
             List<string> result = X509Utils.ParseDistinguishedName(input);
 
+            Assert.True(result.Count == 3);
             Assert.Contains("CN=UA Yellow Green Server", result);
             Assert.Contains("DC=dogblueberry", result);
             Assert.Contains("O=\"OPC=Foundation\"", result);
         }
 
 
-        [Test]
-        public void ParseDistinguishedNameHandlesEscapingOfEqualsChar()
-        {
-            string input = "CN=UA Yellow Blue Server,DC=dogredberry,O=OPC\"/\"Foundation";
 
+        [TestCase("CN = UA Yellow Blue Server, DC = dogredberry, O =\"OPC/Foundation\"")]
+        [TestCase("CN = UA Yellow Blue Server, DC = dogredberry, O =OPC\"/\"Foundation")]
+        public void ParseDistinguishedNameHandlesEscapingOfSlashChar(string input)
+        {
             List<string> result = X509Utils.ParseDistinguishedName(input);
 
+            Assert.True(result.Count == 3);
             Assert.Contains("CN=UA Yellow Blue Server", result);
             Assert.Contains("DC=dogredberry", result);
             Assert.Contains("O=\"OPC/Foundation\"", result);

--- a/Tests/Opc.Ua.Core.Tests/Security/Certificates/X509UtilsTest.cs
+++ b/Tests/Opc.Ua.Core.Tests/Security/Certificates/X509UtilsTest.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Contracts;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace Opc.Ua.Core.Tests.Security.Certificates
+{
+    /// <summary>
+    /// Tests for the <see cref="X509Utils"/> class
+    /// </summary>
+    [TestFixture, Category("X509Utils")]
+    [Parallelizable]
+    [SetCulture("en-us")]
+    public class X509UtilsTest
+    {
+        [Test]
+        public void ParseDistinguishedNameHandlesEscapingOfSlashChar()
+        {
+            string input = "CN=UA Yellow Green Server,DC=dogblueberry,O=OPC\"=\"Foundation";
+
+            List<string> result = X509Utils.ParseDistinguishedName(input);
+
+            Assert.Contains("CN=UA Yellow Green Server", result);
+            Assert.Contains("DC=dogblueberry", result);
+            Assert.Contains("O=\"OPC=Foundation\"", result);
+        }
+
+
+        [Test]
+        public void ParseDistinguishedNameHandlesEscapingOfEqualsChar()
+        {
+            string input = "CN=UA Yellow Blue Server,DC=dogredberry,O=OPC\"/\"Foundation";
+
+            List<string> result = X509Utils.ParseDistinguishedName(input);
+
+            Assert.Contains("CN=UA Yellow Blue Server", result);
+            Assert.Contains("DC=dogredberry", result);
+            Assert.Contains("O=\"OPC/Foundation\"", result);
+        }
+    }
+}


### PR DESCRIPTION
## Proposed changes

As per OPC UA Spec a Subject Name can be provided to methods with a special escaping sequence:
 If the value contains a ‘/’ or a ‘=’ then it shall be enclosed in double quotes (‘”’).

https://reference.opcfoundation.org/GDS/v105/docs/7.8.3

This fix removes this special escaping sequence when parsing a subject Name.

## Related Issues

- #2586

## Types of changes

What types of changes does your code introduce?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [x] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

