### PR TITLE
make tests put out readable StatusCodes

### DIFF
--- a/Tests/Opc.Ua.Client.Tests/ClientTest.cs
+++ b/Tests/Opc.Ua.Client.Tests/ClientTest.cs
@@ -287,7 +287,7 @@ namespace Opc.Ua.Client.Tests
                 {
                     Assert.Inconclusive($"Unexpected Status: {sre}" );
                 }
-                Assert.AreEqual(StatusCodes.BadSecurityPolicyRejected, sre.StatusCode, "Unexpected Status: {0}", sre);
+                Assert.AreEqual((StatusCode)StatusCodes.BadSecurityPolicyRejected, (StatusCode)sre.StatusCode, "Unexpected Status: {0}", sre);
             }
         }
 
@@ -316,7 +316,7 @@ namespace Opc.Ua.Client.Tests
                 {
                     Assert.Inconclusive($"Unexpected Status: {sre}" );
                 }
-                Assert.AreEqual(StatusCodes.BadSecurityPolicyRejected, sre.StatusCode, "Unexpected Status: {0}", sre);
+                Assert.AreEqual((StatusCode)StatusCodes.BadSecurityPolicyRejected, (StatusCode)sre.StatusCode, "Unexpected Status: {0}", sre);
             }
         }
 
@@ -377,7 +377,7 @@ namespace Opc.Ua.Client.Tests
                 await Task.Delay(5_000).ConfigureAwait(false);
 
                 var sre = Assert.ThrowsAsync<ServiceResultException>(async () => await session.ReadNodeAsync(nodeId, CancellationToken.None).ConfigureAwait(false));
-                Assert.AreEqual((StatusCode)StatusCodes.BadSessionIdInvalid, sre.StatusCode);
+                Assert.AreEqual((StatusCode)StatusCodes.BadSessionIdInvalid, (StatusCode)sre.StatusCode);
             }
         }
 
@@ -404,7 +404,7 @@ namespace Opc.Ua.Client.Tests
                 await Task.Delay(5_000).ConfigureAwait(false);
 
                 var sre = Assert.ThrowsAsync<ServiceResultException>(async () => await session.ReadNodeAsync(nodeId, CancellationToken.None).ConfigureAwait(false));
-                Assert.AreEqual((StatusCode)StatusCodes.BadSessionIdInvalid, sre.StatusCode);
+                Assert.AreEqual((StatusCode)StatusCodes.BadSessionIdInvalid, (StatusCode)sre.StatusCode);
 
                 // reconect/reactivate
                 await session.OpenAsync(sessionName, userIdentity, CancellationToken.None).ConfigureAwait(false);
@@ -641,7 +641,7 @@ namespace Opc.Ua.Client.Tests
 
                 // cannot read using a detached channel
                 var exception = Assert.Throws<ServiceResultException>(() => session1.ReadValue(VariableIds.Server_ServerStatus, typeof(ServerStatusDataType)));
-                Assert.AreEqual(StatusCodes.BadSecureChannelClosed, exception.StatusCode);
+                Assert.AreEqual((StatusCode)StatusCodes.BadSecureChannelClosed, (StatusCode)exception.StatusCode);
             }
 
             // the inactive channel
@@ -673,7 +673,7 @@ namespace Opc.Ua.Client.Tests
 
             // cannot read using a closed session, validate the status code
             sre = Assert.Throws<ServiceResultException>(() => session1.ReadValue(VariableIds.Server_ServerStatus, typeof(ServerStatusDataType)));
-            Assert.AreEqual(StatusCodes.BadSessionIdInvalid, sre.StatusCode, sre.Message);
+            Assert.AreEqual((StatusCode)StatusCodes.BadSessionIdInvalid, (StatusCode)sre.StatusCode, sre.Message);
 
             // close the channel
             channel2.Close();
@@ -687,11 +687,11 @@ namespace Opc.Ua.Client.Tests
             {
                 if (endpoint.EndpointUrl.ToString().StartsWith(Utils.UriSchemeOpcTcp, StringComparison.Ordinal))
                 {
-                    Assert.AreEqual(StatusCodes.BadSessionIdInvalid, sre.StatusCode, sre.Message);
+                    Assert.AreEqual((StatusCode)StatusCodes.BadSessionIdInvalid, (StatusCode)sre.StatusCode, sre.Message);
                 }
                 else
                 {
-                    Assert.AreEqual(StatusCodes.BadUnknownResponse, sre.StatusCode, sre.Message);
+                    Assert.AreEqual((StatusCode)StatusCodes.BadUnknownResponse, (StatusCode)sre.StatusCode, sre.Message);
                 }
             }
         }
@@ -771,7 +771,7 @@ namespace Opc.Ua.Client.Tests
             if (endpoint.EndpointUrl.ToString().StartsWith(Utils.UriSchemeOpcTcp, StringComparison.Ordinal))
             {
                 sre = Assert.Throws<ServiceResultException>(() => session1.ReadValue(VariableIds.Server_ServerStatus, typeof(ServerStatusDataType)));
-                Assert.AreEqual(StatusCodes.BadSecureChannelIdInvalid, sre.StatusCode, sre.Message);
+                Assert.AreEqual((StatusCode)StatusCodes.BadSecureChannelIdInvalid, (StatusCode)sre.StatusCode, sre.Message);
             }
             else
             {
@@ -860,7 +860,7 @@ namespace Opc.Ua.Client.Tests
             _ = Session.ReadValue(VariableIds.Server_ServerRedundancy_RedundancySupport, typeof(Int32));
             _ = Session.ReadValue(VariableIds.Server_ServerStatus, typeof(ServerStatusDataType));
             var sre = Assert.Throws<ServiceResultException>(() => Session.ReadValue(VariableIds.Server_ServerStatus, typeof(ServiceHost)));
-            Assert.AreEqual(StatusCodes.BadTypeMismatch, sre.StatusCode);
+            Assert.AreEqual((StatusCode)StatusCodes.BadTypeMismatch, (StatusCode)sre.StatusCode);
         }
 
         [Test]
@@ -1016,7 +1016,7 @@ namespace Opc.Ua.Client.Tests
                 {
                     Session.OperationLimits.MaxNodesPerRead = 0;
                     var sre = Assert.Throws<ServiceResultException>(() => Session.ReadDisplayName(nodeIds, out var displayNames, out var errors));
-                    Assert.AreEqual(StatusCodes.BadTooManyOperations, sre.StatusCode);
+                    Assert.AreEqual((StatusCode)StatusCodes.BadTooManyOperations, (StatusCode)sre.StatusCode);
                     while (nodeIds.Count > 0)
                     {
                         Session.ReadDisplayName(nodeIds.Take((int)OperationLimits.MaxNodesPerRead).ToArray(), out var displayNames, out var errors);
@@ -1251,7 +1251,7 @@ namespace Opc.Ua.Client.Tests
         public void ReadAvailableEncodings()
         {
             var sre = Assert.Throws<ServiceResultException>(() => Session.ReadAvailableEncodings(DataTypeIds.BaseDataType));
-            Assert.AreEqual(StatusCodes.BadNodeIdInvalid, sre.StatusCode);
+            Assert.AreEqual((StatusCode)StatusCodes.BadNodeIdInvalid, (StatusCode)sre.StatusCode);
             var encoding = Session.ReadAvailableEncodings(VariableIds.Server_ServerStatus_CurrentTime);
             Assert.NotNull(encoding);
             Assert.AreEqual(0, encoding.Count);
@@ -1263,7 +1263,7 @@ namespace Opc.Ua.Client.Tests
             var sre = Assert.ThrowsAsync<ServiceResultException>(async () => {
                 var t = await Session.LoadDataTypeSystem(ObjectIds.ObjectAttributes_Encoding_DefaultJson).ConfigureAwait(false);
             });
-            Assert.AreEqual(StatusCodes.BadNodeIdInvalid, sre.StatusCode);
+            Assert.AreEqual((StatusCode)StatusCodes.BadNodeIdInvalid, (StatusCode)sre.StatusCode);
             var typeSystem = await Session.LoadDataTypeSystem().ConfigureAwait(false);
             Assert.NotNull(typeSystem);
             typeSystem = await Session.LoadDataTypeSystem(ObjectIds.OPCBinarySchema_TypeSystem).ConfigureAwait(false);

--- a/Tests/Opc.Ua.Client.Tests/SessionClientBatchTest.cs
+++ b/Tests/Opc.Ua.Client.Tests/SessionClientBatchTest.cs
@@ -147,7 +147,7 @@ namespace Opc.Ua.Client.Tests
                 Assert.AreEqual(diagnosticInfos.Count, diagnosticInfos.Count);
             });
 
-            Assert.AreEqual(StatusCodes.BadServiceUnsupported, sre.StatusCode);
+            Assert.AreEqual((StatusCode)StatusCodes.BadServiceUnsupported, (StatusCode)sre.StatusCode);
         }
 
 #if (CLIENT_ASYNC)
@@ -174,7 +174,7 @@ namespace Opc.Ua.Client.Tests
                 Assert.AreEqual(diagnosticInfos.Count, diagnosticInfos.Count);
             });
 
-            Assert.AreEqual(StatusCodes.BadServiceUnsupported, sre.StatusCode, sre.ToString());
+            Assert.AreEqual((StatusCode)StatusCodes.BadServiceUnsupported, (StatusCode)sre.StatusCode, sre.ToString());
         }
 #endif
 
@@ -200,7 +200,7 @@ namespace Opc.Ua.Client.Tests
                 Assert.AreEqual(diagnosticInfos.Count, diagnosticInfos.Count);
             });
 
-            Assert.AreEqual(StatusCodes.BadServiceUnsupported, sre.StatusCode);
+            Assert.AreEqual((StatusCode)StatusCodes.BadServiceUnsupported, (StatusCode)sre.StatusCode);
         }
 
 #if (CLIENT_ASYNC)
@@ -227,7 +227,7 @@ namespace Opc.Ua.Client.Tests
                 Assert.AreEqual(diagnosticInfos.Count, diagnosticInfos.Count);
             });
 
-            Assert.AreEqual(StatusCodes.BadServiceUnsupported, sre.StatusCode);
+            Assert.AreEqual((StatusCode)StatusCodes.BadServiceUnsupported, (StatusCode)sre.StatusCode);
         }
 #endif
 
@@ -253,7 +253,7 @@ namespace Opc.Ua.Client.Tests
                 Assert.AreEqual(diagnosticInfos.Count, diagnosticInfos.Count);
             });
 
-            Assert.AreEqual(StatusCodes.BadServiceUnsupported, sre.StatusCode);
+            Assert.AreEqual((StatusCode)StatusCodes.BadServiceUnsupported, (StatusCode)sre.StatusCode);
         }
 
 #if (CLIENT_ASYNC)
@@ -280,7 +280,7 @@ namespace Opc.Ua.Client.Tests
                 Assert.AreEqual(diagnosticInfos.Count, diagnosticInfos.Count);
             });
 
-            Assert.AreEqual(StatusCodes.BadServiceUnsupported, sre.StatusCode);
+            Assert.AreEqual((StatusCode)StatusCodes.BadServiceUnsupported, (StatusCode)sre.StatusCode);
         }
 #endif
 
@@ -306,7 +306,7 @@ namespace Opc.Ua.Client.Tests
                 Assert.AreEqual(diagnosticInfos.Count, diagnosticInfos.Count);
             });
 
-            Assert.AreEqual(StatusCodes.BadServiceUnsupported, sre.StatusCode);
+            Assert.AreEqual((StatusCode)StatusCodes.BadServiceUnsupported, (StatusCode)sre.StatusCode);
         }
 
 #if (CLIENT_ASYNC)
@@ -333,7 +333,7 @@ namespace Opc.Ua.Client.Tests
                 Assert.AreEqual(diagnosticInfos.Count, diagnosticInfos.Count);
             });
 
-            Assert.AreEqual(StatusCodes.BadServiceUnsupported, sre.StatusCode);
+            Assert.AreEqual((StatusCode)StatusCodes.BadServiceUnsupported, (StatusCode)sre.StatusCode);
         }
 #endif
 

--- a/Tests/Opc.Ua.Client.Tests/SubscriptionTest.cs
+++ b/Tests/Opc.Ua.Client.Tests/SubscriptionTest.cs
@@ -169,7 +169,7 @@ namespace Opc.Ua.Client.Tests
 
             subscription.ConditionRefresh();
             var sre = Assert.Throws<ServiceResultException>(() => subscription.Republish(subscription.SequenceNumber + 100));
-            Assert.AreEqual(StatusCodes.BadMessageNotAvailable, sre.StatusCode);
+            Assert.AreEqual((StatusCode)StatusCodes.BadMessageNotAvailable, (StatusCode)sre.StatusCode);
 
             // verify that reconnect created subclassed version of subscription and monitored item
             foreach (var s in Session.Subscriptions)
@@ -281,7 +281,7 @@ namespace Opc.Ua.Client.Tests
 
             await subscription.ConditionRefreshAsync().ConfigureAwait(false);
             var sre = Assert.ThrowsAsync<ServiceResultException>(async () => await subscription.RepublishAsync(subscription.SequenceNumber + 100).ConfigureAwait(false));
-            Assert.AreEqual(StatusCodes.BadMessageNotAvailable, sre.StatusCode, $"Expected BadMessageNotAvailable, but received {sre.Message}");
+            Assert.AreEqual((StatusCode)StatusCodes.BadMessageNotAvailable, (StatusCode)sre.StatusCode, $"Expected BadMessageNotAvailable, but received {sre.Message}");
 
             // verify that reconnect created subclassed version of subscription and monitored item
             foreach (var s in Session.Subscriptions)
@@ -668,7 +668,7 @@ namespace Opc.Ua.Client.Tests
             if (endpoint.EndpointUrl.ToString().StartsWith(Utils.UriSchemeOpcTcp, StringComparison.Ordinal))
             {
                 sre = Assert.Throws<ServiceResultException>(() => session1.ReadValue(VariableIds.Server_ServerStatus, typeof(ServerStatusDataType)));
-                Assert.AreEqual(StatusCodes.BadSecureChannelIdInvalid, sre.StatusCode, sre.Message);
+                Assert.AreEqual((StatusCode)StatusCodes.BadSecureChannelIdInvalid, (StatusCode)sre.StatusCode, sre.Message);
             }
             else
             {
@@ -1186,7 +1186,7 @@ namespace Opc.Ua.Client.Tests
             Assert.True(conditionRefresh);
 
             var sre = Assert.Throws<ServiceResultException>(() => subscription.Republish(subscription.SequenceNumber + 100));
-            Assert.AreEqual(StatusCodes.BadMessageNotAvailable, sre.StatusCode);
+            Assert.AreEqual((StatusCode)StatusCodes.BadMessageNotAvailable, (StatusCode)sre.StatusCode);
 
             subscription.RemoveItems(list);
             subscription.ApplyChanges();

--- a/Tests/Opc.Ua.Configuration.Tests/ApplicationInstanceTests.cs
+++ b/Tests/Opc.Ua.Configuration.Tests/ApplicationInstanceTests.cs
@@ -444,7 +444,7 @@ namespace Opc.Ua.Configuration.Tests
                 {
                     var sre = Assert.ThrowsAsync<ServiceResultException>(async () =>
                         await applicationInstance.CheckApplicationInstanceCertificate(true, 0).ConfigureAwait(false));
-                    Assert.AreEqual(StatusCodes.BadConfigurationError, sre.StatusCode);
+                    Assert.AreEqual((StatusCode)StatusCodes.BadConfigurationError, (StatusCode)sre.StatusCode);
                 }
             }
         }
@@ -531,7 +531,7 @@ namespace Opc.Ua.Configuration.Tests
                 {
                     var sre = Assert.ThrowsAsync<ServiceResultException>(async () =>
                         await applicationInstance.CheckApplicationInstanceCertificate(true, 0).ConfigureAwait(false));
-                    Assert.AreEqual(StatusCodes.BadConfigurationError, sre.StatusCode);
+                    Assert.AreEqual((StatusCode)StatusCodes.BadConfigurationError, (StatusCode)sre.StatusCode);
                 }
             }
         }
@@ -612,7 +612,7 @@ namespace Opc.Ua.Configuration.Tests
             {
                 var sre = Assert.ThrowsAsync<ServiceResultException>(async () =>
                     await applicationInstance.CheckApplicationInstanceCertificate(true, 0).ConfigureAwait(false));
-                Assert.AreEqual(StatusCodes.BadConfigurationError, sre.StatusCode);
+                Assert.AreEqual((StatusCode)StatusCodes.BadConfigurationError, (StatusCode)sre.StatusCode);
             }
             else
             {

--- a/Tests/Opc.Ua.Core.Tests/Security/Certificates/CertificateValidatorTest.cs
+++ b/Tests/Opc.Ua.Core.Tests/Security/Certificates/CertificateValidatorTest.cs
@@ -225,7 +225,7 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
                 foreach (var cert in m_appSelfSignedCerts)
                 {
                     var serviceResultException = Assert.Throws<ServiceResultException>(() => certValidator.Validate(new X509Certificate2(cert)));
-                    Assert.AreEqual(StatusCodes.BadCertificateUntrusted, serviceResultException.StatusCode, serviceResultException.Message);
+                    Assert.AreEqual((StatusCode)StatusCodes.BadCertificateUntrusted, (StatusCode)serviceResultException.StatusCode, serviceResultException.Message);
                 }
                 Assert.AreEqual(m_appSelfSignedCerts.Count, validator.RejectedStore.Enumerate().GetAwaiter().GetResult().Count);
 
@@ -271,7 +271,7 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
                 foreach (var cert in m_appSelfSignedCerts)
                 {
                     var serviceResultException = Assert.Throws<ServiceResultException>(() => certValidator.Validate(new X509Certificate2(cert)));
-                    Assert.AreEqual(StatusCodes.BadCertificateUntrusted, serviceResultException.StatusCode, serviceResultException.Message);
+                    Assert.AreEqual((StatusCode)StatusCodes.BadCertificateUntrusted, (StatusCode)serviceResultException.StatusCode, serviceResultException.Message);
                 }
             }
         }
@@ -296,7 +296,7 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
                     foreach (var cert in m_appSelfSignedCerts)
                     {
                         var serviceResultException = Assert.Throws<ServiceResultException>(() => certValidator.Validate(new X509Certificate2(cert)));
-                        Assert.AreEqual(StatusCodes.BadCertificateUntrusted, serviceResultException.StatusCode, serviceResultException.Message);
+                        Assert.AreEqual((StatusCode)StatusCodes.BadCertificateUntrusted, (StatusCode)serviceResultException.StatusCode, serviceResultException.Message);
                     }
                     Assert.AreEqual(m_appSelfSignedCerts.Count, validator.RejectedStore.Enumerate().Result.Count);
                 }
@@ -431,7 +431,7 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
                     foreach (var app in m_goodApplicationTestSet)
                     {
                         var serviceResultException = Assert.Throws<ServiceResultException>(() => certValidator.Validate(new X509Certificate2(app.Certificate)));
-                        Assert.AreEqual(StatusCodes.BadCertificateChainIncomplete, serviceResultException.StatusCode, serviceResultException.Message);
+                        Assert.AreEqual((StatusCode)StatusCodes.BadCertificateChainIncomplete, (StatusCode)serviceResultException.StatusCode, serviceResultException.Message);
                     }
                 }
             }
@@ -465,7 +465,7 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
                     foreach (var app in m_goodApplicationTestSet)
                     {
                         var serviceResultException = Assert.Throws<ServiceResultException>(() => certValidator.Validate(new X509Certificate2(app.Certificate)));
-                        Assert.AreEqual(StatusCodes.BadCertificateChainIncomplete, serviceResultException.StatusCode, serviceResultException.Message);
+                        Assert.AreEqual((StatusCode)StatusCodes.BadCertificateChainIncomplete, (StatusCode)serviceResultException.StatusCode, serviceResultException.Message);
                     }
                 }
             }
@@ -736,7 +736,7 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
                     foreach (var app in m_goodApplicationTestSet)
                     {
                         var serviceResultException = Assert.Throws<ServiceResultException>(() => certValidator.Validate(new X509Certificate2(app.Certificate)));
-                        Assert.AreEqual(StatusCodes.BadCertificateChainIncomplete, serviceResultException.StatusCode, serviceResultException.Message);
+                        Assert.AreEqual((StatusCode)StatusCodes.BadCertificateChainIncomplete, (StatusCode)serviceResultException.StatusCode, serviceResultException.Message);
                     }
                 }
             }
@@ -849,17 +849,17 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
             var serviceResultException = Assert.Throws<ServiceResultException>(() => certValidator.Validate(cert));
             if (!trusted)
             {
-                Assert.AreEqual(StatusCodes.BadCertificateUntrusted, serviceResultException.StatusCode, serviceResultException.Message);
+                Assert.AreEqual((StatusCode)StatusCodes.BadCertificateUntrusted, (StatusCode)serviceResultException.StatusCode, serviceResultException.Message);
                 // check the chained service result
                 ServiceResult innerResult = serviceResultException.InnerResult.InnerResult;
                 Assert.NotNull(innerResult);
-                Assert.AreEqual(StatusCodes.BadCertificateTimeInvalid,
-                    innerResult.StatusCode.Code,
+                Assert.AreEqual((StatusCode)StatusCodes.BadCertificateTimeInvalid,
+                    innerResult.StatusCode,
                     innerResult.LocalizedText.Text);
             }
             else
             {
-                Assert.AreEqual(StatusCodes.BadCertificateTimeInvalid, serviceResultException.StatusCode, serviceResultException.Message);
+                Assert.AreEqual((StatusCode)StatusCodes.BadCertificateTimeInvalid, (StatusCode)serviceResultException.StatusCode, serviceResultException.Message);
             }
         }
 
@@ -893,11 +893,11 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
             var serviceResultException = Assert.Throws<ServiceResultException>(() => certValidator.Validate(cert));
             if (!trusted)
             {
-                Assert.AreEqual(StatusCodes.BadCertificateUntrusted, serviceResultException.StatusCode, serviceResultException.Message);
+                Assert.AreEqual((StatusCode)StatusCodes.BadCertificateUntrusted, (StatusCode)serviceResultException.StatusCode, serviceResultException.Message);
             }
             else
             {
-                Assert.AreEqual(StatusCodes.BadCertificateTimeInvalid, serviceResultException.StatusCode, serviceResultException.Message);
+                Assert.AreEqual((StatusCode)StatusCodes.BadCertificateTimeInvalid, (StatusCode)serviceResultException.StatusCode, serviceResultException.Message);
             }
         }
 
@@ -930,14 +930,14 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
             }
             var certValidator = validator.Update();
             var serviceResultException = Assert.Throws<ServiceResultException>(() => certValidator.Validate(cert));
-            Assert.AreEqual(StatusCodes.BadCertificateChainIncomplete, serviceResultException.StatusCode, serviceResultException.Message);
+            Assert.AreEqual((StatusCode)StatusCodes.BadCertificateChainIncomplete, (StatusCode)serviceResultException.StatusCode, serviceResultException.Message);
             // approver tries to suppress error which is not suppressable
             var approver = new CertValidationApprover(new StatusCode[] {
                 StatusCodes.BadCertificateTimeInvalid,
                 StatusCodes.BadCertificateChainIncomplete
             });
             certValidator.CertificateValidation += approver.OnCertificateValidation;
-            Assert.AreEqual(StatusCodes.BadCertificateChainIncomplete, serviceResultException.StatusCode, serviceResultException.Message);
+            Assert.AreEqual((StatusCode)StatusCodes.BadCertificateChainIncomplete, (StatusCode)serviceResultException.StatusCode, serviceResultException.Message);
             certValidator.CertificateValidation -= approver.OnCertificateValidation;
         }
 
@@ -989,14 +989,14 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
             if (rejectSHA1)
             {
                 var serviceResultException = Assert.Throws<ServiceResultException>(() => certValidator.Validate(cert));
-                Assert.AreEqual(StatusCodes.BadCertificatePolicyCheckFailed, serviceResultException.StatusCode, serviceResultException.Message);
+                Assert.AreEqual((StatusCode)StatusCodes.BadCertificatePolicyCheckFailed, (StatusCode)serviceResultException.StatusCode, serviceResultException.Message);
                 Assert.NotNull(serviceResultException.InnerResult);
                 ServiceResult innerResult = serviceResultException.InnerResult.InnerResult;
                 if (!trusted)
                 {
                     Assert.NotNull(innerResult);
-                    Assert.AreEqual(StatusCodes.BadCertificateUntrusted,
-                        innerResult.StatusCode.Code,
+                    Assert.AreEqual((StatusCode)StatusCodes.BadCertificateUntrusted,
+                        innerResult.StatusCode,
                         innerResult.LocalizedText.Text);
                 }
                 else
@@ -1013,7 +1013,7 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
                 else
                 {
                     var serviceResultException = Assert.Throws<ServiceResultException>(() => certValidator.Validate(cert));
-                    Assert.AreEqual(StatusCodes.BadCertificateUntrusted, serviceResultException.StatusCode, serviceResultException.Message);
+                    Assert.AreEqual((StatusCode)StatusCodes.BadCertificateUntrusted, (StatusCode)serviceResultException.StatusCode, serviceResultException.Message);
                     Assert.NotNull(serviceResultException.InnerResult);
                 }
             }
@@ -1039,7 +1039,7 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
             }
             var certValidator = validator.Update();
             var serviceResultException = Assert.Throws<ServiceResultException>(() => certValidator.Validate(cert));
-            Assert.AreEqual(StatusCodes.BadCertificateUseNotAllowed, serviceResultException.StatusCode, serviceResultException.Message);
+            Assert.AreEqual((StatusCode)StatusCodes.BadCertificateUseNotAllowed, (StatusCode)serviceResultException.StatusCode, serviceResultException.Message);
             Assert.NotNull(serviceResultException.InnerResult);
             var innerResult = serviceResultException.InnerResult.InnerResult;
             if (trusted)
@@ -1049,7 +1049,7 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
             else
             {
                 Assert.NotNull(innerResult);
-                Assert.AreEqual(StatusCodes.BadCertificateUntrusted, innerResult.StatusCode.Code, innerResult.LocalizedText.Text);
+                Assert.AreEqual((StatusCode)StatusCodes.BadCertificateUntrusted, (StatusCode)innerResult.StatusCode.Code, innerResult.LocalizedText.Text);
             }
         }
 
@@ -1089,7 +1089,7 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
             if (ca)
             {
                 // The CA version fails for the key usage flags
-                Assert.AreEqual(StatusCodes.BadCertificateUseNotAllowed, serviceResultException.StatusCode, serviceResultException.Message);
+                Assert.AreEqual((StatusCode)StatusCodes.BadCertificateUseNotAllowed, (StatusCode)serviceResultException.StatusCode, serviceResultException.Message);
                 Assert.NotNull(serviceResultException.InnerResult);
                 innerResult = serviceResultException.InnerResult.InnerResult;
             }
@@ -1101,15 +1101,15 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
             {
                 // for the untrusted case, the untrusted error is also reported.
                 Assert.NotNull(innerResult);
-                Assert.AreEqual(StatusCodes.BadCertificateUntrusted,
-                    innerResult.StatusCode.Code,
+                Assert.AreEqual((StatusCode)StatusCodes.BadCertificateUntrusted,
+                    innerResult.StatusCode,
                     innerResult.LocalizedText.Text);
                 innerResult = innerResult.InnerResult;
             }
             // However, all cert versions got an invalid signature, must fail...
             Assert.NotNull(innerResult);
-            Assert.AreEqual(StatusCodes.BadCertificateInvalid,
-                innerResult.StatusCode.Code,
+            Assert.AreEqual((StatusCode)StatusCodes.BadCertificateInvalid,
+                innerResult.StatusCode,
                 innerResult.LocalizedText.Text);
             Assert.AreEqual(0, approver.Count);
         }
@@ -1131,14 +1131,14 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
             }
             var certValidator = validator.Update();
             var serviceResultException = Assert.Throws<ServiceResultException>(() => certValidator.Validate(cert));
-            Assert.AreEqual(StatusCodes.BadCertificatePolicyCheckFailed, serviceResultException.StatusCode, serviceResultException.Message);
+            Assert.AreEqual((StatusCode)StatusCodes.BadCertificatePolicyCheckFailed, (StatusCode)serviceResultException.StatusCode, serviceResultException.Message);
             Assert.NotNull(serviceResultException.InnerResult);
             ServiceResult innerResult = serviceResultException.InnerResult.InnerResult;
             if (!trusted)
             {
                 Assert.NotNull(innerResult);
-                Assert.AreEqual(StatusCodes.BadCertificateUntrusted,
-                    innerResult.StatusCode.Code,
+                Assert.AreEqual((StatusCode)StatusCodes.BadCertificateUntrusted,
+                    innerResult.StatusCode,
                     innerResult.LocalizedText.Text);
             }
             else
@@ -1158,7 +1158,7 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
             else
             {
                 serviceResultException = Assert.Throws<ServiceResultException>(() => certValidator.Validate(cert));
-                Assert.AreEqual(StatusCodes.BadCertificateUntrusted, serviceResultException.StatusCode, serviceResultException.Message);
+                Assert.AreEqual((StatusCode)StatusCodes.BadCertificateUntrusted, (StatusCode)serviceResultException.StatusCode, serviceResultException.Message);
             }
             certValidator.CertificateValidation -= approver.OnCertificateValidation;
         }
@@ -1186,7 +1186,7 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
             else
             {
                 var serviceResultException = Assert.Throws<ServiceResultException>(() => certValidator.Validate(cert));
-                Assert.AreEqual(StatusCodes.BadCertificateUntrusted, serviceResultException.StatusCode, serviceResultException.Message);
+                Assert.AreEqual((StatusCode)StatusCodes.BadCertificateUntrusted, (StatusCode)serviceResultException.StatusCode, serviceResultException.Message);
                 Assert.NotNull(serviceResultException.InnerResult);
                 ServiceResult innerResult = serviceResultException.InnerResult.InnerResult;
                 Assert.Null(innerResult);
@@ -1215,7 +1215,7 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
             else
             {
                 ServiceResultException serviceResultException = Assert.Throws<ServiceResultException>(() => certValidator.Validate(cert));
-                Assert.AreEqual(StatusCodes.BadCertificateUntrusted, serviceResultException.StatusCode, serviceResultException.Message);
+                Assert.AreEqual((StatusCode)StatusCodes.BadCertificateUntrusted, (StatusCode)serviceResultException.StatusCode, serviceResultException.Message);
             }
             certValidator.CertificateValidation -= approver.OnCertificateValidation;
         }
@@ -1419,7 +1419,7 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
                     foreach (var app in m_goodApplicationTestSet)
                     {
                         var serviceResultException = Assert.Throws<ServiceResultException>(() => certValidator.Validate(new X509Certificate2(app.Certificate)));
-                        Assert.AreEqual(StatusCodes.BadCertificateChainIncomplete, serviceResultException.StatusCode, serviceResultException.Message);
+                        Assert.AreEqual((StatusCode)StatusCodes.BadCertificateChainIncomplete, (StatusCode)serviceResultException.StatusCode, serviceResultException.Message);
                         // no need to check for inner exceptions, since an incomplete chain error cannot be suppressed.
                     }
                 }
@@ -1459,7 +1459,7 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
                     foreach (var app in m_notYetValidCertsApplicationTestSet)
                     {
                         var serviceResultException = Assert.Throws<ServiceResultException>(() => certValidator.Validate(new X509Certificate2(app.Certificate)));
-                        Assert.AreEqual(StatusCodes.BadCertificateTimeInvalid, serviceResultException.StatusCode, serviceResultException.Message);
+                        Assert.AreEqual((StatusCode)StatusCodes.BadCertificateTimeInvalid, (StatusCode)serviceResultException.StatusCode, serviceResultException.Message);
                     }
                 }
             }
@@ -1498,7 +1498,7 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
                     foreach (var app in m_notYetValidCertsApplicationTestSet)
                     {
                         var serviceResultException = Assert.Throws<ServiceResultException>(() => certValidator.Validate(new X509Certificate2(app.Certificate)));
-                        Assert.AreEqual(StatusCodes.BadCertificateTimeInvalid, serviceResultException.StatusCode, serviceResultException.Message);
+                        Assert.AreEqual((StatusCode)StatusCodes.BadCertificateTimeInvalid, (StatusCode)serviceResultException.StatusCode, serviceResultException.Message);
 
                         // BadCertificateTimeInvalid can be suppressed. Ensure the other issues are caught, as well:
                         int isPresentCertificateIssuerRevocationUnknown = 0;
@@ -1559,7 +1559,7 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
                     foreach (var app in m_goodApplicationTestSet)
                     {
                         var serviceResultException = Assert.Throws<ServiceResultException>(() => certValidator.Validate(new X509Certificate2(app.Certificate)));
-                        Assert.AreEqual(StatusCodes.BadCertificateUntrusted, serviceResultException.StatusCode, serviceResultException.Message);
+                        Assert.AreEqual((StatusCode)StatusCodes.BadCertificateUntrusted, (StatusCode)serviceResultException.StatusCode, serviceResultException.Message);
                     }
                 }
             }

--- a/Tests/Opc.Ua.Core.Tests/Types/BuiltIn/BuiltInTests.cs
+++ b/Tests/Opc.Ua.Core.Tests/Types/BuiltIn/BuiltInTests.cs
@@ -373,7 +373,7 @@ namespace Opc.Ua.Core.Tests.Types.BuiltIn
             Assert.Throws<ArgumentException>(() => _ = new NodeId((object)(long)7777777, 123));
 
             var sre = Assert.Throws<ServiceResultException>(() => _ = NodeId.Create(123, "urn:xyz", new NamespaceTable()));
-            Assert.AreEqual(StatusCodes.BadNodeIdInvalid, sre.StatusCode);
+            Assert.AreEqual((StatusCode)StatusCodes.BadNodeIdInvalid, (StatusCode)sre.StatusCode);
 
             NodeId opaqueId = new byte[] { 33, 44, 55, 66 };
             NodeId stringId1 = "ns=1;s=Test";

--- a/Tests/Opc.Ua.Gds.Tests/ClientTest.cs
+++ b/Tests/Opc.Ua.Gds.Tests/ClientTest.cs
@@ -966,7 +966,7 @@ namespace Opc.Ua.Gds.Tests
                 {
                     var sre = Assert.Throws<ServiceResultException>(() => m_gdsClient.GDSClient.GetCertificateGroups(application.ApplicationRecord.ApplicationId));
                     Assert.NotNull(sre);
-                    Assert.AreEqual(StatusCodes.BadUserAccessDenied, sre.StatusCode, sre.Result.ToString());
+                    Assert.AreEqual((StatusCode)StatusCodes.BadUserAccessDenied, (StatusCode)sre.StatusCode, sre.Result.ToString());
 
                 }
             }
@@ -1004,7 +1004,7 @@ namespace Opc.Ua.Gds.Tests
                         m_gdsClient.GDSClient.GetCertificateGroups(testApplication.ApplicationRecord.ApplicationId)
                         );
                     Assert.NotNull(sre);
-                    Assert.AreEqual(StatusCodes.BadUserAccessDenied, sre.StatusCode, sre.Result.ToString());
+                    Assert.AreEqual((StatusCode)StatusCodes.BadUserAccessDenied, (StatusCode)sre.StatusCode, sre.Result.ToString());
                 }
             }
 
@@ -1063,7 +1063,7 @@ namespace Opc.Ua.Gds.Tests
                             certificateRequest)
                         );
                     Assert.NotNull(sre);
-                    Assert.AreEqual(StatusCodes.BadUserAccessDenied, sre.StatusCode, sre.Result.ToString());
+                    Assert.AreEqual((StatusCode)StatusCodes.BadUserAccessDenied, (StatusCode)sre.StatusCode, sre.Result.ToString());
                 }
             }
 
@@ -1166,7 +1166,7 @@ namespace Opc.Ua.Gds.Tests
                             testApplication.PrivateKeyPassword)
                         );
                     Assert.NotNull(sre);
-                    Assert.AreEqual(StatusCodes.BadUserAccessDenied, sre.StatusCode, sre.Result.ToString());
+                    Assert.AreEqual((StatusCode)StatusCodes.BadUserAccessDenied, (StatusCode)sre.StatusCode, sre.Result.ToString());
                 }
             }
 
@@ -1272,7 +1272,7 @@ namespace Opc.Ua.Gds.Tests
                 m_gdsClient.GDSClient.GetCertificateGroups(application.ApplicationRecord.ApplicationId)
                 );
             Assert.NotNull(sre);
-            Assert.AreEqual(StatusCodes.BadUserAccessDenied, sre.StatusCode, sre.Result.ToString());
+            Assert.AreEqual((StatusCode)StatusCodes.BadUserAccessDenied, (StatusCode)sre.StatusCode, sre.Result.ToString());
         }
 
         [Test, Order(690)]
@@ -1308,7 +1308,7 @@ namespace Opc.Ua.Gds.Tests
             foreach (var application in m_goodApplicationTestSet)
             {
                 m_gdsClient.GDSClient.CheckRevocationStatus(application.Certificate, out StatusCode certificateStatus, out DateTime validityTime);
-                Assert.AreEqual(StatusCodes.Good, certificateStatus.Code);
+                Assert.AreEqual((StatusCode)StatusCodes.Good, (StatusCode)certificateStatus.Code);
                 Assert.NotNull(validityTime);
             }
         }
@@ -1350,7 +1350,7 @@ namespace Opc.Ua.Gds.Tests
             foreach (var application in m_goodApplicationTestSet)
             {
                 m_gdsClient.GDSClient.CheckRevocationStatus(application.Certificate, out StatusCode certificateStatus, out DateTime validityTime);
-                Assert.AreEqual(StatusCodes.BadCertificateRevoked, certificateStatus.Code);
+                Assert.AreEqual((StatusCode)StatusCodes.BadCertificateRevoked, (StatusCode)certificateStatus.Code);
                 Assert.NotNull(validityTime);
             }
         }

--- a/Tests/Opc.Ua.Gds.Tests/GlobalDiscoveryTestClient.cs
+++ b/Tests/Opc.Ua.Gds.Tests/GlobalDiscoveryTestClient.cs
@@ -193,9 +193,7 @@ namespace Opc.Ua.Gds.Tests
             using (var x509 = new X509Certificate2(certificate))
             {
                 var certWithPrivateKey = CertificateFactory.CreateCertificateWithPEMPrivateKey(x509, privateKey);
-                m_client.Configuration.SecurityConfiguration.ApplicationCertificate.RawData = certWithPrivateKey.RawData;
-                m_client.Configuration.SecurityConfiguration.ApplicationCertificate.Thumbprint = certWithPrivateKey.Thumbprint;
-                m_client.Configuration.SecurityConfiguration.ApplicationCertificate.Certificate = certWithPrivateKey;
+                m_client.Configuration.SecurityConfiguration.ApplicationCertificate = new CertificateIdentifier(certWithPrivateKey);
                 var store = m_client.Configuration.SecurityConfiguration.ApplicationCertificate.OpenStore();
                 await store.Add(certWithPrivateKey).ConfigureAwait(false);
             }

--- a/Tests/Opc.Ua.Gds.Tests/PushTest.cs
+++ b/Tests/Opc.Ua.Gds.Tests/PushTest.cs
@@ -229,7 +229,7 @@ namespace Opc.Ua.Gds.Tests
             Assert.AreEqual(afterAddTrustList.TrustedCrls.Count, beforeTrustList.TrustedCrls.Count);
             Assert.IsFalse(Utils.IsEqual(beforeTrustList, afterAddTrustList));
             var serviceResultException = Assert.Throws<ServiceResultException>(() => { m_pushClient.PushClient.RemoveCertificate(m_caCert.Thumbprint, false); });
-            Assert.AreEqual(StatusCodes.BadInvalidArgument, serviceResultException.StatusCode, serviceResultException.Message);
+            Assert.AreEqual((StatusCode)StatusCodes.BadInvalidArgument, (StatusCode)serviceResultException.StatusCode, serviceResultException.Message);
             TrustListDataType afterRemoveTrustList = m_pushClient.PushClient.ReadTrustList();
             Assert.IsFalse(Utils.IsEqual(beforeTrustList, afterRemoveTrustList));
             m_pushClient.PushClient.RemoveCertificate(m_caCert.Thumbprint, true);

--- a/Tests/Opc.Ua.Server.Tests/CommonTestWorkers.cs
+++ b/Tests/Opc.Ua.Server.Tests/CommonTestWorkers.cs
@@ -152,7 +152,7 @@ namespace Opc.Ua.Server.Tests
                     _ = services.Browse(requestHeader, null,
                         0, browseDescriptionCollection.Take(0).ToArray(),
                         out var results, out var infos));
-                Assert.AreEqual(StatusCodes.BadNothingToDo, sre.StatusCode);
+                Assert.AreEqual((StatusCode)StatusCodes.BadNothingToDo, (StatusCode)sre.StatusCode);
             }
 
             while (browseDescriptionCollection.Any())
@@ -167,7 +167,7 @@ namespace Opc.Ua.Server.Tests
                         _ = services.Browse(requestHeader, null,
                             0, browseDescriptionCollection,
                             out var results, out var infos));
-                    Assert.AreEqual(StatusCodes.BadTooManyOperations, sre.StatusCode);
+                    Assert.AreEqual((StatusCode)StatusCodes.BadTooManyOperations, (StatusCode)sre.StatusCode);
 
                     // Test if server responds with BadTooManyOperations
                     var tempBrowsePath = browseDescriptionCollection.Take((int)operationLimits.MaxNodesPerBrowse + 1).ToArray();
@@ -175,7 +175,7 @@ namespace Opc.Ua.Server.Tests
                         _ = services.Browse(requestHeader, null,
                             0, tempBrowsePath,
                             out var results, out var infos));
-                    Assert.AreEqual(StatusCodes.BadTooManyOperations, sre.StatusCode);
+                    Assert.AreEqual((StatusCode)StatusCodes.BadTooManyOperations, (StatusCode)sre.StatusCode);
                 }
 
                 bool repeatBrowse;
@@ -289,7 +289,7 @@ namespace Opc.Ua.Server.Tests
                     // Test if server responds with BadTooManyOperations
                     var sre = Assert.Throws<ServiceResultException>(() =>
                         _ = services.TranslateBrowsePathsToNodeIds(requestHeader, browsePaths, out var results, out var infos));
-                    Assert.AreEqual(StatusCodes.BadTooManyOperations, sre.StatusCode);
+                    Assert.AreEqual((StatusCode)StatusCodes.BadTooManyOperations, (StatusCode)sre.StatusCode);
                 }
                 var browsePathSnippet = (operationLimits.MaxNodesPerTranslateBrowsePathsToNodeIds > 0) ?
                     browsePaths.Take((int)operationLimits.MaxNodesPerTranslateBrowsePathsToNodeIds).ToArray() :
@@ -353,7 +353,7 @@ namespace Opc.Ua.Server.Tests
             var sre = Assert.Throws<ServiceResultException>(() =>
                 services.CreateMonitoredItems(requestHeader, id, TimestampsToReturn.Neither, itemsToCreate,
                     out MonitoredItemCreateResultCollection mockResults, out DiagnosticInfoCollection mockInfos));
-            Assert.AreEqual(StatusCodes.BadNothingToDo, sre.StatusCode);
+            Assert.AreEqual((StatusCode)StatusCodes.BadNothingToDo, (StatusCode)sre.StatusCode);
 
             // add item
             uint handleCounter = 1;
@@ -532,7 +532,7 @@ namespace Opc.Ua.Server.Tests
             requestHeader.Timestamp = DateTime.UtcNow;
             var response = services.TransferSubscriptions(requestHeader, subscriptionIds, sendInitialData,
                 out TransferResultCollection transferResults, out DiagnosticInfoCollection diagnosticInfos);
-            Assert.AreEqual(StatusCodes.Good, response.ServiceResult.Code);
+            Assert.AreEqual((StatusCode)StatusCodes.Good, response.ServiceResult);
             Assert.AreEqual(subscriptionIds.Count, transferResults.Count);
             ServerFixtureUtils.ValidateResponse(response, transferResults, subscriptionIds);
             ServerFixtureUtils.ValidateDiagnosticInfos(diagnosticInfos, subscriptionIds, response.StringTable);
@@ -542,7 +542,7 @@ namespace Opc.Ua.Server.Tests
                 TestContext.Out.WriteLine("TransferResult: {0}", transferResult.StatusCode);
                 if (expectAccessDenied)
                 {
-                    Assert.AreEqual(StatusCodes.BadUserAccessDenied, transferResult.StatusCode.Code);
+                    Assert.AreEqual((StatusCode)StatusCodes.BadUserAccessDenied, transferResult.StatusCode);
                 }
                 else
                 {
@@ -562,7 +562,7 @@ namespace Opc.Ua.Server.Tests
                 out uint publishedId, out UInt32Collection availableSequenceNumbers,
                 out bool moreNotifications, out NotificationMessage notificationMessage,
                 out StatusCodeCollection _, out diagnosticInfos);
-            Assert.AreEqual(StatusCodes.Good, response.ServiceResult.Code);
+            Assert.AreEqual((StatusCode)StatusCodes.Good, response.ServiceResult);
             ServerFixtureUtils.ValidateResponse(response);
             ServerFixtureUtils.ValidateDiagnosticInfos(diagnosticInfos, acknowledgements, response.StringTable);
             Assert.AreEqual(subscriptionIds[0], publishedId);
@@ -578,7 +578,7 @@ namespace Opc.Ua.Server.Tests
 
             requestHeader.Timestamp = DateTime.UtcNow;
             response = services.DeleteSubscriptions(requestHeader, subscriptionIds, out StatusCodeCollection statusResults, out diagnosticInfos);
-            Assert.AreEqual(StatusCodes.Good, response.ServiceResult.Code);
+            Assert.AreEqual((StatusCode)StatusCodes.Good, response.ServiceResult);
         }
 
         /// <summary>

--- a/Tests/Opc.Ua.Server.Tests/ReferenceServerTest.cs
+++ b/Tests/Opc.Ua.Server.Tests/ReferenceServerTest.cs
@@ -386,7 +386,7 @@ namespace Opc.Ua.Server.Tests
                         m_requestHeader.Timestamp = DateTime.UtcNow;
                         CommonTestWorkers.VerifySubscriptionTransferred(serverTestServices, m_requestHeader, subscriptionIds, true);
                     });
-                    Assert.AreEqual(StatusCodes.BadNoSubscription, sre.StatusCode);
+                    Assert.AreEqual((StatusCode)StatusCodes.BadNoSubscription, (StatusCode)sre.StatusCode);
                 }
             }
             finally
@@ -482,7 +482,7 @@ namespace Opc.Ua.Server.Tests
                     out bool moreNotifications, out NotificationMessage notificationMessage,
                     out StatusCodeCollection _, out DiagnosticInfoCollection diagnosticInfos);
 
-                Assert.AreEqual(StatusCodes.Good, response.ServiceResult.Code);
+                Assert.AreEqual((StatusCode)StatusCodes.Good, response.ServiceResult);
                 ServerFixtureUtils.ValidateResponse(response);
                 ServerFixtureUtils.ValidateDiagnosticInfos(diagnosticInfos, acknowledgements, response.StringTable);
                 Assert.AreEqual(subscriptionIds[0], publishedId);
@@ -498,7 +498,7 @@ namespace Opc.Ua.Server.Tests
                         out moreNotifications, out notificationMessage,
                         out StatusCodeCollection _, out diagnosticInfos);
 
-                    Assert.AreEqual(StatusCodes.Good, response.ServiceResult.Code);
+                    Assert.AreEqual((StatusCode)StatusCodes.Good, response.ServiceResult);
                     ServerFixtureUtils.ValidateResponse(response);
                     ServerFixtureUtils.ValidateDiagnosticInfos(diagnosticInfos, acknowledgements, response.StringTable);
                     Assert.AreEqual(subscriptionIds[0], publishedId);
@@ -517,7 +517,7 @@ namespace Opc.Ua.Server.Tests
 
                 SecureChannelContext.Current = securityContext;
 
-                Assert.AreEqual(StatusCodes.BadUserAccessDenied, results[0].StatusCode.Code);
+                Assert.AreEqual((StatusCode)StatusCodes.BadUserAccessDenied, results[0].StatusCode);
                 ServerFixtureUtils.ValidateResponse(response, results, nodesToCall);
                 ServerFixtureUtils.ValidateDiagnosticInfos(diagnosticInfos, nodesToCall, response.StringTable);
 
@@ -528,7 +528,7 @@ namespace Opc.Ua.Server.Tests
                     out moreNotifications, out notificationMessage,
                     out StatusCodeCollection _, out diagnosticInfos);
 
-                Assert.AreEqual(StatusCodes.Good, response.ServiceResult.Code);
+                Assert.AreEqual((StatusCode)StatusCodes.Good, response.ServiceResult);
                 ServerFixtureUtils.ValidateResponse(response);
                 ServerFixtureUtils.ValidateDiagnosticInfos(diagnosticInfos, acknowledgements, response.StringTable);
                 Assert.AreEqual(subscriptionIds[0], publishedId);
@@ -555,7 +555,7 @@ namespace Opc.Ua.Server.Tests
                     out moreNotifications, out notificationMessage,
                     out StatusCodeCollection _, out diagnosticInfos);
 
-                Assert.AreEqual(StatusCodes.Good, response.ServiceResult.Code);
+                Assert.AreEqual((StatusCode)StatusCodes.Good, response.ServiceResult);
                 ServerFixtureUtils.ValidateResponse(response);
                 ServerFixtureUtils.ValidateDiagnosticInfos(diagnosticInfos, acknowledgements, response.StringTable);
                 Assert.AreEqual(subscriptionIds[0], publishedId);
@@ -576,7 +576,7 @@ namespace Opc.Ua.Server.Tests
                         out moreNotifications, out notificationMessage,
                         out StatusCodeCollection _, out diagnosticInfos);
 
-                    Assert.AreEqual(StatusCodes.Good, response.ServiceResult.Code);
+                    Assert.AreEqual((StatusCode)StatusCodes.Good, response.ServiceResult);
                     ServerFixtureUtils.ValidateResponse(response);
                     ServerFixtureUtils.ValidateDiagnosticInfos(diagnosticInfos, acknowledgements, response.StringTable);
                     Assert.AreEqual(subscriptionIds[0], publishedId);
@@ -597,7 +597,7 @@ namespace Opc.Ua.Server.Tests
                     out moreNotifications, out notificationMessage,
                     out StatusCodeCollection _, out diagnosticInfos);
 
-                Assert.AreEqual(StatusCodes.Good, response.ServiceResult.Code);
+                Assert.AreEqual((StatusCode)StatusCodes.Good, response.ServiceResult);
                 ServerFixtureUtils.ValidateResponse(response);
                 ServerFixtureUtils.ValidateDiagnosticInfos(diagnosticInfos, acknowledgements, response.StringTable);
                 Assert.AreEqual(subscriptionIds[0], publishedId);


### PR DESCRIPTION
## Proposed changes

Add explicit Casts to all Asserts checking for status codes, to make debugging failed tests more straightforward

simplify gds test client cert update

## Related Issues


## Types of changes


- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [x] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [x] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

