### PR TITLE
Make NodeStateCollectionConcurrencyTests more robust

### DIFF
--- a/Tests/Opc.Ua.Core.Tests/Stack/State/NodeStateCollectionConcurrencyTests.cs
+++ b/Tests/Opc.Ua.Core.Tests/Stack/State/NodeStateCollectionConcurrencyTests.cs
@@ -17,6 +17,7 @@ namespace Opc.Ua.Core.Tests.Stack.State
     public class NodeStateCollectionConcurrencyTests
     {
         [Test]
+        [CancelAfter(10000)]
         public void NodeStateReferencesCollectionConcurrencyTest()
         {
             var testNodeState = new AnalogUnitRangeState(null);
@@ -56,7 +57,7 @@ namespace Opc.Ua.Core.Tests.Stack.State
 
             });
 
-            while (referenceTargets.TryTake(out ExpandedNodeId target, TimeSpan.FromSeconds(1)))
+            foreach (var target in referenceTargets.GetConsumingEnumerable())
             {
                 var removeReferenceSuccess = testNodeState.RemoveReference(ReferenceTypeIds.HasComponent, false, target);
                 Assert.IsTrue(removeReferenceSuccess);
@@ -72,6 +73,7 @@ namespace Opc.Ua.Core.Tests.Stack.State
         }
 
         [Test]
+        [CancelAfter(10000)]
         public void NodeStateNotifiersCollectionConcurrencyTest()
         {
             var serviceMessageContext = new ServiceMessageContext();
@@ -120,7 +122,7 @@ namespace Opc.Ua.Core.Tests.Stack.State
 
             });
 
-            while (notifierTargets.TryTake(out NodeState target, TimeSpan.FromSeconds(1)))
+            foreach(var target in notifierTargets.GetConsumingEnumerable())
             {
                 testNodeState.RemoveNotifier(systemContext, target, false);
             }
@@ -135,6 +137,7 @@ namespace Opc.Ua.Core.Tests.Stack.State
         }
 
         [Test]
+        [CancelAfter(10000)]
         public void NodeStateChildrenCollectionConcurrencyTest()
         {
             var serviceMessageContext = new ServiceMessageContext();
@@ -183,7 +186,7 @@ namespace Opc.Ua.Core.Tests.Stack.State
 
             });
 
-            while (childrenCollection.TryTake(out BaseInstanceState child, TimeSpan.FromSeconds(1)))
+            foreach (var child in childrenCollection.GetConsumingEnumerable())
             {
                 testNodeState.RemoveChild(child);
             }

--- a/Tests/Opc.Ua.Core.Tests/Stack/State/NodeStateCollectionConcurrencyTests.cs
+++ b/Tests/Opc.Ua.Core.Tests/Stack/State/NodeStateCollectionConcurrencyTests.cs
@@ -18,7 +18,7 @@ namespace Opc.Ua.Core.Tests.Stack.State
     {
         [Test]
         [CancelAfter(10000)]
-        public void NodeStateReferencesCollectionConcurrencyTest()
+        public void NodeStateReferencesCollectionConcurrencyTest(CancellationToken cancellationToken)
         {
             var testNodeState = new AnalogUnitRangeState(null);
             var serviceMessageContext = new ServiceMessageContext();
@@ -57,13 +57,13 @@ namespace Opc.Ua.Core.Tests.Stack.State
 
             });
 
-            foreach (var target in referenceTargets.GetConsumingEnumerable())
+            foreach (var target in referenceTargets.GetConsumingEnumerable(cancellationToken))
             {
                 var removeReferenceSuccess = testNodeState.RemoveReference(ReferenceTypeIds.HasComponent, false, target);
                 Assert.IsTrue(removeReferenceSuccess);
             }
 
-            task.Wait();
+            task.Wait(cancellationToken);
 
             references.Clear();
             testNodeState.GetReferences(systemContext, references);
@@ -74,7 +74,7 @@ namespace Opc.Ua.Core.Tests.Stack.State
 
         [Test]
         [CancelAfter(10000)]
-        public void NodeStateNotifiersCollectionConcurrencyTest()
+        public void NodeStateNotifiersCollectionConcurrencyTest(CancellationToken cancellationToken)
         {
             var serviceMessageContext = new ServiceMessageContext();
             var systemContext = new SystemContext() { NamespaceUris = serviceMessageContext.NamespaceUris };
@@ -122,12 +122,12 @@ namespace Opc.Ua.Core.Tests.Stack.State
 
             });
 
-            foreach(var target in notifierTargets.GetConsumingEnumerable())
+            foreach(var target in notifierTargets.GetConsumingEnumerable(cancellationToken))
             {
                 testNodeState.RemoveNotifier(systemContext, target, false);
             }
 
-            task.Wait();
+            task.Wait(cancellationToken);
 
             notifiers.Clear();
             testNodeState.GetNotifiers(systemContext, notifiers);
@@ -138,7 +138,7 @@ namespace Opc.Ua.Core.Tests.Stack.State
 
         [Test]
         [CancelAfter(10000)]
-        public void NodeStateChildrenCollectionConcurrencyTest()
+        public void NodeStateChildrenCollectionConcurrencyTest(CancellationToken cancellationToken)
         {
             var serviceMessageContext = new ServiceMessageContext();
             var systemContext = new SystemContext() { NamespaceUris = serviceMessageContext.NamespaceUris };
@@ -186,12 +186,12 @@ namespace Opc.Ua.Core.Tests.Stack.State
 
             });
 
-            foreach (var child in childrenCollection.GetConsumingEnumerable())
+            foreach (var child in childrenCollection.GetConsumingEnumerable(cancellationToken))
             {
                 testNodeState.RemoveChild(child);
             }
 
-            task.Wait();
+            task.Wait(cancellationToken);
 
             children.Clear();
             testNodeState.GetChildren(systemContext, children);

--- a/Tests/Opc.Ua.Core.Tests/Stack/State/NodeStateCollectionConcurrencyTests.cs
+++ b/Tests/Opc.Ua.Core.Tests/Stack/State/NodeStateCollectionConcurrencyTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using Assert = NUnit.Framework.Legacy.ClassicAssert;


### PR DESCRIPTION
Made tests more robust by using GetConsumingEnumerable which blocks indefinitely.

## Proposed changes

These changes aim to make the NodeStateCollectionConcurrencyTests to not randomly fail in the CI build.

## Related Issues

- Fixes #2592

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [x] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [x] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

I'm not 100% sure that this fixes the flaky CI builds since I was not able to reproduce the issue without modifying the test code. My assumption is that the test fails because I was calling TryTake on the BlockingCollection with timeout of 1 second. Maybe in some cases in the CI system there is some slowness that causes the other Task which is adding items to the collection to take more than 1 second. In this case the TryTake returns false and while loop is exited and then the items from the BlockingCollection are never removed. 

I was able to reproduce the issue by adding a 1 second Thread.Sleep at the begin of the Task that adds items to the collection. I fixed this issue by using GetConsumingEnumerable instead of TryTake. The GetConsumingEnumerable block indefinitely so there is no danger of some slowness to fail the build. Since I'm using indefinite blocking I added timeout to each of the tests so that they don't take too long in case something goes wrong in the test.
