### PR TITLE
fix disposal of ConsoleReferenceClient

### DIFF
--- a/Applications/ConsoleReferenceClient/UAClient.cs
+++ b/Applications/ConsoleReferenceClient/UAClient.cs
@@ -74,6 +74,7 @@ namespace Quickstarts
         /// </summary>
         public void Dispose()
         {
+            m_disposed = true;
             Utils.SilentDispose(m_session);
             m_configuration.CertificateValidator.CertificateValidation -= CertificateValidation;
             GC.SuppressFinalize(this);
@@ -133,6 +134,7 @@ namespace Quickstarts
         /// </summary>
         public async Task<bool> ConnectAsync(string serverUrl, bool useSecurity = true, CancellationToken ct = default)
         {
+            if (m_disposed) throw new ObjectDisposedException(nameof(UAClient));
             if (serverUrl == null) throw new ArgumentNullException(nameof(serverUrl));
 
             try
@@ -393,6 +395,7 @@ namespace Quickstarts
         private ISession m_session;
         private readonly TextWriter m_output;
         private readonly Action<IList, IList> m_validateResponse;
+        private bool m_disposed = false;
         #endregion
     }
 }


### PR DESCRIPTION
## Proposed changes

Make ConsoleReferenceClient throw an object disposed exception when trying to use after dispose

## Related Issues

- Closes #2374

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments
