### PR TITLE
[Client] select the most secure User Identity Token if a server offers multiple ones

### DIFF
--- a/Libraries/Opc.Ua.Client/CoreClientUtils.cs
+++ b/Libraries/Opc.Ua.Client/CoreClientUtils.cs
@@ -30,6 +30,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Opc.Ua.Security;
 
 namespace Opc.Ua.Client
 {
@@ -280,14 +281,10 @@ namespace Opc.Ua.Client
                         selectedEndpoint = endpoint;
                     }
 
-                    // The security level is a relative measure assigned by the server to the 
-                    // endpoints that it returns. Clients should always pick the highest level
-                    // unless they have a reason not too.
-                    // Some servers however, mess this up a bit. So prefer a higher SecurityMode
-                    // over the SecurityLevel.
-                    if (endpoint.SecurityMode > selectedEndpoint.SecurityMode
-                        || (endpoint.SecurityMode == selectedEndpoint.SecurityMode
-                            && endpoint.SecurityLevel > selectedEndpoint.SecurityLevel))
+
+                    //Select endpoint if it has a higher calculated security level, than the previously selected one
+                    if (SecuredApplication.CalculateSecurityLevel(endpoint.SecurityMode, endpoint.SecurityPolicyUri)
+                        > SecuredApplication.CalculateSecurityLevel(selectedEndpoint.SecurityMode, endpoint.SecurityPolicyUri))
                     {
                         selectedEndpoint = endpoint;
                     }

--- a/Libraries/Opc.Ua.Client/CoreClientUtils.cs
+++ b/Libraries/Opc.Ua.Client/CoreClientUtils.cs
@@ -284,7 +284,7 @@ namespace Opc.Ua.Client
 
                     //Select endpoint if it has a higher calculated security level, than the previously selected one
                     if (SecuredApplication.CalculateSecurityLevel(endpoint.SecurityMode, endpoint.SecurityPolicyUri)
-                        > SecuredApplication.CalculateSecurityLevel(selectedEndpoint.SecurityMode, endpoint.SecurityPolicyUri))
+                        > SecuredApplication.CalculateSecurityLevel(selectedEndpoint.SecurityMode, selectedEndpoint.SecurityPolicyUri))
                     {
                         selectedEndpoint = endpoint;
                     }

--- a/Stack/Opc.Ua.Core/Schema/ApplicationConfiguration.cs
+++ b/Stack/Opc.Ua.Core/Schema/ApplicationConfiguration.cs
@@ -15,6 +15,7 @@ using System.Collections.Generic;
 using System.Runtime.Serialization;
 using System.Security.Cryptography.X509Certificates;
 using Opc.Ua.Bindings;
+using Opc.Ua.Security;
 
 namespace Opc.Ua
 {
@@ -650,7 +651,7 @@ namespace Opc.Ua
 
     #region ServerSecurityPolicy Class
     /// <summary>
-    /// A class that defines a group of sampling rates supported by the server.
+    /// A class that defines a group of security policies supported by the server.
     /// </summary>
     [DataContract(Namespace = Namespaces.OpcUaConfig)]
     public class ServerSecurityPolicy
@@ -689,29 +690,7 @@ namespace Opc.Ua
         /// </summary>
         public static byte CalculateSecurityLevel(MessageSecurityMode mode, string policyUri)
         {
-            if ((mode == MessageSecurityMode.Invalid) || (mode == MessageSecurityMode.None))
-            {
-                return 0;
-            }
-
-            byte result = 0;
-            switch (policyUri)
-            {
-                case SecurityPolicies.Basic128Rsa15: result = 2; break;
-                case SecurityPolicies.Basic256: result = 4; break;
-                case SecurityPolicies.Basic256Sha256: result = 6; break;
-                case SecurityPolicies.Aes128_Sha256_RsaOaep: result = 8; break;
-                case SecurityPolicies.Aes256_Sha256_RsaPss: result = 10; break;
-                case SecurityPolicies.None:
-                default: return 0;
-            }
-
-            if (mode == MessageSecurityMode.SignAndEncrypt)
-            {
-                result += 100;
-            }
-
-            return result;
+            return SecuredApplication.CalculateSecurityLevel(mode, policyUri);
         }
 
         /// <summary>

--- a/Stack/Opc.Ua.Core/Schema/SecuredApplicationHelpers.cs
+++ b/Stack/Opc.Ua.Core/Schema/SecuredApplicationHelpers.cs
@@ -372,6 +372,38 @@ namespace Opc.Ua.Security
         }
 
         /// <summary>
+        /// Calculates the security level, given the security mode and policy
+        /// Invalid and none is discouraged
+        /// Just signing is always weaker than any use of encryption
+        /// </summary>
+        public static byte CalculateSecurityLevel(MessageSecurityMode mode, string policyUri)
+        {
+            if ((mode == MessageSecurityMode.Invalid) || (mode == MessageSecurityMode.None))
+            {
+                return 0;
+            }
+
+            byte result = 0;
+            switch (policyUri)
+            {
+                case SecurityPolicies.Basic128Rsa15: result = 2; break;
+                case SecurityPolicies.Basic256: result = 4; break;
+                case SecurityPolicies.Basic256Sha256: result = 6; break;
+                case SecurityPolicies.Aes128_Sha256_RsaOaep: result = 8; break;
+                case SecurityPolicies.Aes256_Sha256_RsaPss: result = 10; break;
+                case SecurityPolicies.None:
+                default: return 0;
+            }
+
+            if (mode == MessageSecurityMode.SignAndEncrypt)
+            {
+                result += 100;
+            }
+
+            return result;
+        }
+
+        /// <summary>
         /// Creates a new policy object.
         /// Always uses sign and encrypt for all security policies except none
         /// </summary>

--- a/Stack/Opc.Ua.Core/Schema/SecuredApplicationHelpers.cs
+++ b/Stack/Opc.Ua.Core/Schema/SecuredApplicationHelpers.cs
@@ -378,7 +378,7 @@ namespace Opc.Ua.Security
         /// </summary>
         public static byte CalculateSecurityLevel(MessageSecurityMode mode, string policyUri)
         {
-            if ((mode == MessageSecurityMode.Invalid) || (mode == MessageSecurityMode.None))
+            if ((mode != MessageSecurityMode.Sign) && (mode == MessageSecurityMode.SignAndEncrypt))
             {
                 return 0;
             }
@@ -392,7 +392,9 @@ namespace Opc.Ua.Security
                 case SecurityPolicies.Aes128_Sha256_RsaOaep: result = 8; break;
                 case SecurityPolicies.Aes256_Sha256_RsaPss: result = 10; break;
                 case SecurityPolicies.None:
-                default: return 0;
+                default:
+                    Utils.LogWarning("Security level requested for unknown Security Policy {policy}. Returning security level 0", policyUri);
+                    return 0;
             }
 
             if (mode == MessageSecurityMode.SignAndEncrypt)

--- a/Stack/Opc.Ua.Core/Schema/SecuredApplicationHelpers.cs
+++ b/Stack/Opc.Ua.Core/Schema/SecuredApplicationHelpers.cs
@@ -378,7 +378,7 @@ namespace Opc.Ua.Security
         /// </summary>
         public static byte CalculateSecurityLevel(MessageSecurityMode mode, string policyUri)
         {
-            if ((mode != MessageSecurityMode.Sign) && (mode == MessageSecurityMode.SignAndEncrypt))
+            if ((mode != MessageSecurityMode.Sign) && (mode != MessageSecurityMode.SignAndEncrypt))
             {
                 return 0;
             }

--- a/Stack/Opc.Ua.Core/Stack/Configuration/EndpointDescription.cs
+++ b/Stack/Opc.Ua.Core/Stack/Configuration/EndpointDescription.cs
@@ -11,8 +11,9 @@
 */
 
 using System;
-using System.Collections.Generic;
+using System.Linq;
 using System.Xml;
+using Opc.Ua.Security;
 
 namespace Opc.Ua
 {
@@ -124,8 +125,8 @@ namespace Opc.Ua
             // construct issuer type.
             string issuedTokenTypeText = issuedTokenType;
 
-            // find matching policy.
-            foreach (UserTokenPolicy policy in m_userIdentityTokens)
+            // find matching policy, return most secure matching policy first.
+            foreach (UserTokenPolicy policy in m_userIdentityTokens.OrderByDescending(token => SecuredApplication.CalculateSecurityLevel(MessageSecurityMode.Sign, token.SecurityPolicyUri)))
             {
                 // check token type.
                 if (tokenType != policy.TokenType)

--- a/Tests/Opc.Ua.Core.Tests/Schema/SecuredApplicationHelpersTests.cs
+++ b/Tests/Opc.Ua.Core.Tests/Schema/SecuredApplicationHelpersTests.cs
@@ -1,0 +1,71 @@
+using Opc.Ua.Security;
+using NUnit.Framework;
+
+namespace Opc.Ua.Core.Tests.Schema
+{
+    /// <summary>
+    /// Tests for the CertificateValidator class.
+    /// </summary>
+    [TestFixture, Category("SecuredApplicationHelpers")]
+    [Parallelizable]
+    [SetCulture("en-us")]
+    public class SecuredApplicationHelpersTests
+    {
+        /// <summary>
+        /// Verify CalculateSecurityLevel encryption is a higher security Level than signing
+        /// </summary>
+        [Test]
+        public void CalculateSecurityLevelEncryptionStrongerSigning()
+        {
+            Assert.That(
+                SecuredApplication.CalculateSecurityLevel(MessageSecurityMode.Sign, SecurityPolicies.Basic128Rsa15)
+                <
+                SecuredApplication.CalculateSecurityLevel(MessageSecurityMode.SignAndEncrypt, SecurityPolicies.Basic128Rsa15));
+            Assert.That(
+                SecuredApplication.CalculateSecurityLevel(MessageSecurityMode.Sign, SecurityPolicies.Basic128Rsa15)
+                <
+                SecuredApplication.CalculateSecurityLevel(MessageSecurityMode.SignAndEncrypt, SecurityPolicies.Aes256_Sha256_RsaPss));
+        }
+        /// <summary>
+        /// Verify CalculateSecurityLevel none or Invalid MessageSecurityMode return 0
+        /// </summary>
+        [Test]
+        public void CalculateSecurityLevelNoneOrInvalidZero()
+        {
+            Assert.That(
+                SecuredApplication.CalculateSecurityLevel(MessageSecurityMode.None, SecurityPolicies.Basic128Rsa15)
+                == 0);
+            Assert.That(
+                SecuredApplication.CalculateSecurityLevel(MessageSecurityMode.Invalid, SecurityPolicies.Basic128Rsa15)
+                == 0);
+        }
+
+        /// <summary>
+        /// Verify CalculateSecurityLevel none or Invalid MessageSecurityMode return 0
+        /// </summary>
+        [Test]
+        public void CalculateSecurityLevelOrderValid()
+        {
+            Assert.That(
+                SecuredApplication.CalculateSecurityLevel(MessageSecurityMode.Sign, SecurityPolicies.Basic128Rsa15)
+                <
+                SecuredApplication.CalculateSecurityLevel(MessageSecurityMode.Sign, SecurityPolicies.Basic256));
+
+            Assert.That(
+                SecuredApplication.CalculateSecurityLevel(MessageSecurityMode.Sign, SecurityPolicies.Basic256)
+                <
+                SecuredApplication.CalculateSecurityLevel(MessageSecurityMode.Sign, SecurityPolicies.Basic256Sha256));
+
+            Assert.That(
+                SecuredApplication.CalculateSecurityLevel(MessageSecurityMode.Sign, SecurityPolicies.Basic256Sha256)
+                <
+                SecuredApplication.CalculateSecurityLevel(MessageSecurityMode.Sign, SecurityPolicies.Aes128_Sha256_RsaOaep));
+
+            Assert.That(
+               SecuredApplication.CalculateSecurityLevel(MessageSecurityMode.Sign, SecurityPolicies.Aes128_Sha256_RsaOaep)
+               <
+               SecuredApplication.CalculateSecurityLevel(MessageSecurityMode.Sign, SecurityPolicies.Aes256_Sha256_RsaPss));
+
+        }
+    }
+}


### PR DESCRIPTION
## Proposed changes

This fix makes the client select the most secure UserIdentity Token if a server offers more than one.
Before the client just selected the first UserIdentity Token offered by the server.

## Related Issues

- Fixes #2191

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [x] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments