### PR TITLE
Set TCP defaults for max message size to align with min buffer size

### DIFF
--- a/Stack/Opc.Ua.Core/Stack/Tcp/TcpMessageType.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/TcpMessageType.cs
@@ -242,7 +242,7 @@ namespace Opc.Ua.Bindings
         /// <summary>
         /// The default maximum chunk count for Request and Response messages.
         /// </summary>
-        public const int DefaultMaxChunkCount = 32;
+        public const int DefaultMaxChunkCount = DefaultMaxMessageSize / MinBufferSize;
 
         /// <summary>
         /// The default maximum message size.
@@ -250,7 +250,7 @@ namespace Opc.Ua.Bindings
         /// <remarks>
         /// This default is for the Tcp transport. <see cref="DefaultEncodingLimits.MaxMessageSize"/> for the generic default.
         /// </remarks>
-        public const int DefaultMaxMessageSize = DefaultMaxChunkCount * DefaultMaxBufferSize;
+        public const int DefaultMaxMessageSize = 0x10000 * 16;
 
         /// <summary>
         /// The default maximum message size for the discovery channel.

--- a/Stack/Opc.Ua.Core/Stack/Tcp/TcpMessageType.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/TcpMessageType.cs
@@ -301,5 +301,14 @@ namespace Opc.Ua.Bindings
         /// The certificates that have the key size larger than KeySizeExtraPadding need an extra padding byte in the transport message
         /// </summary>
         public const int KeySizeExtraPadding = 2048;
+
+        /// <summary>
+        /// Aligns the max message size to the nearest min buffer size.
+        /// </summary>
+        public static int AlignRoundMaxMessageSize(int value)
+        {
+            int alignmentMask = MinBufferSize - 1;
+            return (value + alignmentMask) & ~alignmentMask;
+        }
     }
 }

--- a/Stack/Opc.Ua.Core/Stack/Tcp/TcpMessageType.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/TcpMessageType.cs
@@ -248,9 +248,10 @@ namespace Opc.Ua.Bindings
         /// The default maximum message size.
         /// </summary>
         /// <remarks>
+        /// The default is 2MB. Ensure to set this to a value aligned to <see cref="MinBufferSize"/>.
         /// This default is for the Tcp transport. <see cref="DefaultEncodingLimits.MaxMessageSize"/> for the generic default.
         /// </remarks>
-        public const int DefaultMaxMessageSize = 0x10000 * 16;
+        public const int DefaultMaxMessageSize = MinBufferSize * 256;
 
         /// <summary>
         /// The default maximum message size for the discovery channel.
@@ -305,6 +306,9 @@ namespace Opc.Ua.Bindings
         /// <summary>
         /// Aligns the max message size to the nearest min buffer size.
         /// </summary>
+        /// <remarks>
+        /// Align user configured maximum message size to avoid rounding errors in other UA implementations.
+        /// </remarks>
         public static int AlignRoundMaxMessageSize(int value)
         {
             int alignmentMask = MinBufferSize - 1;

--- a/Stack/Opc.Ua.Core/Stack/Tcp/TcpTransportListener.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/TcpTransportListener.cs
@@ -138,12 +138,12 @@ namespace Opc.Ua.Bindings
             {
                 m_inactivityDetectPeriod = configuration.ChannelLifetime / 2;
                 m_quotas.MaxBufferSize = configuration.MaxBufferSize;
-                m_quotas.MaxMessageSize = configuration.MaxMessageSize;
+                m_quotas.MaxMessageSize = TcpMessageLimits.AlignRoundMaxMessageSize(configuration.MaxMessageSize);
                 m_quotas.ChannelLifetime = configuration.ChannelLifetime;
                 m_quotas.SecurityTokenLifetime = configuration.SecurityTokenLifetime;
                 messageContext.MaxArrayLength = configuration.MaxArrayLength;
                 messageContext.MaxByteStringLength = configuration.MaxByteStringLength;
-                messageContext.MaxMessageSize = configuration.MaxMessageSize;
+                messageContext.MaxMessageSize = TcpMessageLimits.AlignRoundMaxMessageSize(configuration.MaxMessageSize);
                 messageContext.MaxStringLength = configuration.MaxStringLength;
                 messageContext.MaxEncodingNestingLevels = configuration.MaxEncodingNestingLevels;
                 messageContext.MaxDecoderRecoveries = configuration.MaxDecoderRecoveries;

--- a/Stack/Opc.Ua.Core/Stack/Tcp/UaSCBinaryTransportChannel.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/UaSCBinaryTransportChannel.cs
@@ -423,13 +423,13 @@ namespace Opc.Ua.Bindings
             EndpointConfiguration configuration = m_settings.Configuration;
             m_quotas = new ChannelQuotas {
                 MaxBufferSize = configuration.MaxBufferSize,
-                MaxMessageSize = configuration.MaxMessageSize,
+                MaxMessageSize = TcpMessageLimits.AlignRoundMaxMessageSize(configuration.MaxMessageSize),
                 ChannelLifetime = configuration.ChannelLifetime,
                 SecurityTokenLifetime = configuration.SecurityTokenLifetime,
                 MessageContext = new ServiceMessageContext() {
                     MaxArrayLength = configuration.MaxArrayLength,
                     MaxByteStringLength = configuration.MaxByteStringLength,
-                    MaxMessageSize = configuration.MaxMessageSize,
+                    MaxMessageSize = TcpMessageLimits.AlignRoundMaxMessageSize(configuration.MaxMessageSize),
                     MaxStringLength = configuration.MaxStringLength,
                     MaxEncodingNestingLevels = configuration.MaxEncodingNestingLevels,
                     MaxDecoderRecoveries = configuration.MaxDecoderRecoveries,

--- a/Stack/Opc.Ua.Core/Types/Utils/DefaultEncodingLimits.cs
+++ b/Stack/Opc.Ua.Core/Types/Utils/DefaultEncodingLimits.cs
@@ -38,7 +38,7 @@ namespace Opc.Ua
         /// <summary>
         /// The maximum length for any Message.
         /// </summary>
-        public static readonly int MaxMessageSize = UInt16.MaxValue * 32;
+        public static readonly int MaxMessageSize = 0x10000 * 16;
 
         /// <summary>
         /// The maximum nesting level accepted while encoding or decoding objects.

--- a/Stack/Opc.Ua.Core/Types/Utils/DefaultEncodingLimits.cs
+++ b/Stack/Opc.Ua.Core/Types/Utils/DefaultEncodingLimits.cs
@@ -11,6 +11,7 @@
 */
 
 using System;
+using Opc.Ua.Bindings;
 
 namespace Opc.Ua
 {
@@ -21,32 +22,35 @@ namespace Opc.Ua
     public static class DefaultEncodingLimits
     {
         /// <summary>
-        /// The maximum length for any string, byte string or xml element.
+        /// The default maximum length for any string, byte string or xml element.
         /// </summary>
         public static readonly int MaxStringLength = UInt16.MaxValue;
 
         /// <summary>
-        /// The maximum length for any array.
+        /// The default maximum length for any array.
         /// </summary>
         public static readonly int MaxArrayLength = UInt16.MaxValue;
 
         /// <summary>
-        /// The maximum length for any ByteString.
+        /// The default maximum length for any ByteString.
         /// </summary>
         public static readonly int MaxByteStringLength = UInt16.MaxValue * 16;
 
         /// <summary>
-        /// The maximum length for any Message.
+        /// The default maximum length for any Message.
         /// </summary>
-        public static readonly int MaxMessageSize = 0x10000 * 16;
+        /// <remarks>
+        /// Default is 2MB. Set to multiple of MinBufferSize to avoid rounding errors in other UA implementations.
+        /// </remarks>
+        public static readonly int MaxMessageSize = TcpMessageLimits.MinBufferSize * 256;
 
         /// <summary>
-        /// The maximum nesting level accepted while encoding or decoding objects.
+        /// The default maximum nesting level accepted while encoding or decoding objects.
         /// </summary>
         public static readonly int MaxEncodingNestingLevels = 200;
 
         /// <summary>
-        /// The number of times the decoder can recover from an error 
+        /// The default number of times the decoder can recover from an error 
         /// caused by an encoded ExtensionObject before throwing a decoder error.
         /// </summary>
         public static readonly int MaxDecoderRecoveries = 0;


### PR DESCRIPTION
## Proposed changes

Avoid user configuration errors by setting unaligned max message size values, fix defaults.

## Related Issues

- Fixes #

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
