### PR TITLE
[Client] Fix UserIdentity for CertificateIdentifer & add parameter for console reference client to specify UserCertificate

### DIFF
--- a/Applications/ConsoleReferenceClient/README.md
+++ b/Applications/ConsoleReferenceClient/README.md
@@ -14,7 +14,7 @@ Specify as console parameters:
     `-up YourPassword`
 
 #### Certificate
-Place certificate in the TrustedUserCertificatesStore (the path can be found in the client configuration XML).
+Place your user certificate in the TrustedUserCertificatesStore (the path can be found in the client configuration XML). Make shure to include an accessible private key with the certificate.
 Specify console parameters:
     `-uc Thumbprint` (of the user certificate to select)
     `-ucp Password` (of the user certificates private key (optional))

--- a/Applications/ConsoleReferenceClient/README.md
+++ b/Applications/ConsoleReferenceClient/README.md
@@ -1,0 +1,20 @@
+# OPC Foundation UA .NET Standard Reference Client
+
+## Introduction
+
+The console reference client can be configured using several console parameters.
+Some of these parameters are explained in more detail below.
+
+To see all available parameters call console reference client the with the parameter `-h`.
+
+### How to specify User Identity
+#### Username & Password
+Specify as console parameters:
+    `-un YourUsername`
+    `-up YourPassword`
+
+#### Certificate
+Place certificate in the TrustedUserCertificatesStore (the path can be found in the client configuration XML).
+Specify console parameters:
+    `-uc Thumbprint` (of the user certificate to select)
+    `-ucp Password` (of the user certificates private key (optional))

--- a/Docs/README.md
+++ b/Docs/README.md
@@ -14,6 +14,7 @@ UA Core stack related:
 
 Reference application related:
 * [Reference Server](../Applications/ReferenceServer/README.md) documentation for running against CTT.
+* [Reference Client](../Applications/ConsoleReferenceClient/README.md) documentation for configuration of the console reference client using parameters.
 * Using the [Container support](ContainerReferenceServer.md) of the Reference Server in VS2022 and for local testing.
 
 For the PubSub support library:


### PR DESCRIPTION
## Proposed changes

- Fix the UserIdentity constructor to load the private key of a provided certificateIdenifier.
- make UserIdentity constructor throw a ServiceResultException when a Certificate with no private key is specified.
- extend console reference client with two new parameters:
   -uc Thumbprint of a user certifiate located in the TrustedUserCertificatesStore
   -ucp Password of the private key of the user certificate
- add documentation for console reference client

## Related Issues

- Fixes #2615

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [x] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

Tested with a Certificate created with XCA.
Public Key was exported as DER
Private key was exported as PEM without PW and also as PFX with a password.
Both work as a user identity token.