### PR TITLE
Fix NullReference in XmlDecoder.ReadExpandedNodeId

### DIFF
--- a/Stack/Opc.Ua.Core/Types/Encoders/XmlDecoder.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/XmlDecoder.cs
@@ -1074,7 +1074,7 @@ namespace Opc.Ua
                 EndField(fieldName);
             }
 
-            if (m_namespaceMappings != null && m_namespaceMappings.Length > value.NamespaceIndex)
+            if (m_namespaceMappings != null && m_namespaceMappings.Length > value.NamespaceIndex && !value.IsNull)
             {
                 value.SetNamespaceIndex(m_namespaceMappings[value.NamespaceIndex]);
             }

--- a/Stack/Opc.Ua.Core/Types/Encoders/XmlDecoder.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/XmlDecoder.cs
@@ -1050,7 +1050,7 @@ namespace Opc.Ua
                 EndField(fieldName);
             }
 
-            if (m_namespaceMappings != null && m_namespaceMappings.Length > value.NamespaceIndex)
+            if (m_namespaceMappings != null && m_namespaceMappings.Length > value.NamespaceIndex && !value.IsNull)
             {
                 value.SetNamespaceIndex(m_namespaceMappings[value.NamespaceIndex]);
             }
@@ -1079,7 +1079,7 @@ namespace Opc.Ua
                 value.SetNamespaceIndex(m_namespaceMappings[value.NamespaceIndex]);
             }
 
-            if (m_serverMappings != null && m_serverMappings.Length > value.ServerIndex)
+            if (m_serverMappings != null && m_serverMappings.Length > value.ServerIndex && !value.IsNull)
             {
                 value.SetServerIndex(m_serverMappings[value.ServerIndex]);
             }

--- a/Stack/Opc.Ua.Core/Types/Encoders/XmlDecoder.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/XmlDecoder.cs
@@ -1050,7 +1050,7 @@ namespace Opc.Ua
                 EndField(fieldName);
             }
 
-            if (m_namespaceMappings != null && m_namespaceMappings.Length > value.NamespaceIndex && !value.IsNull)
+            if (m_namespaceMappings != null && m_namespaceMappings.Length > value.NamespaceIndex)
             {
                 value.SetNamespaceIndex(m_namespaceMappings[value.NamespaceIndex]);
             }


### PR DESCRIPTION
## Proposed changes

A check for a null nodeid is performed before attempting to set the NamespaceIndex via SetNamespaceIndex.

## Related Issues

- Fixes #2635 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.
