### PR TITLE
[Client] add null check to avoid warning message when checking Security Level for anonymous user token

### DIFF
--- a/Stack/Opc.Ua.Core/Schema/SecuredApplicationHelpers.cs
+++ b/Stack/Opc.Ua.Core/Schema/SecuredApplicationHelpers.cs
@@ -378,7 +378,9 @@ namespace Opc.Ua.Security
         /// </summary>
         public static byte CalculateSecurityLevel(MessageSecurityMode mode, string policyUri)
         {
-            if ((mode != MessageSecurityMode.Sign) && (mode != MessageSecurityMode.SignAndEncrypt))
+            if ((mode != MessageSecurityMode.Sign &&
+                mode != MessageSecurityMode.SignAndEncrypt) ||
+                policyUri == null)
             {
                 return 0;
             }


### PR DESCRIPTION
## Proposed changes

This PR fixes a warning being printed when the client checks the security Level of the anonymous user token while using a secure channel.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

