### PR TITLE
Fix: RegisterServer and RegisterServer2 do not initiate connection

### DIFF
--- a/Stack/Opc.Ua.Core/Stack/Tcp/UaSCBinaryClientChannel.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/UaSCBinaryClientChannel.cs
@@ -818,7 +818,10 @@ namespace Opc.Ua.Bindings
                 request.TypeId == DataTypeIds.CreateSessionRequest ||
                 request.TypeId == DataTypeIds.GetEndpointsRequest ||
                 request.TypeId == DataTypeIds.FindServersOnNetworkRequest ||
-                request.TypeId == DataTypeIds.FindServersRequest)
+                request.TypeId == DataTypeIds.FindServersRequest ||
+                request.TypeId == DataTypeIds.RegisterServerRequest ||
+                request.TypeId == DataTypeIds.RegisterServer2Request
+                )
             {
                 m_queuedOperations.Add(queuedOperation);
                 return true;


### PR DESCRIPTION
## Proposed changes

Add RegisterServerRequest and RegisterServer2 to the list of operations that must be sent first and which allow for a connect.

## Related Issues

LDS registration was broken after the recent changes. This commit should fix the registration.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

None
