### PR TITLE
Fix template based constructor in Subscription.cs

### DIFF
--- a/Libraries/Opc.Ua.Client/Subscription/Subscription.cs
+++ b/Libraries/Opc.Ua.Client/Subscription/Subscription.cs
@@ -83,22 +83,6 @@ namespace Opc.Ua.Client
                     displayName = m_displayName;
                 }
 
-                // remove any existing numeric suffix.
-                int index = displayName.LastIndexOf(' ');
-
-                if (index != -1)
-                {
-                    try
-                    {
-                        displayName = displayName.Substring(0, index);
-                    }
-                    catch
-                    {
-                        // not a numeric suffix.
-                    }
-                }
-
-                m_displayName = Utils.Format("{0} {1}", displayName, Utils.IncrementIdentifier(ref s_globalSubscriptionCounter));
                 m_publishingInterval = template.m_publishingInterval;
                 m_keepAliveCount = template.m_keepAliveCount;
                 m_lifetimeCount = template.m_lifetimeCount;
@@ -2850,8 +2834,6 @@ namespace Opc.Ua.Client
         }
 
         private LinkedList<IncomingMessage> m_incomingMessages;
-
-        private static long s_globalSubscriptionCounter;
         #endregion
     }
 

--- a/Libraries/Opc.Ua.Client/Subscription/Subscription.cs
+++ b/Libraries/Opc.Ua.Client/Subscription/Subscription.cs
@@ -76,13 +76,7 @@ namespace Opc.Ua.Client
 
             if (template != null)
             {
-                string displayName = template.DisplayName;
-
-                if (String.IsNullOrEmpty(displayName))
-                {
-                    displayName = m_displayName;
-                }
-
+                m_displayName = template.m_displayName;
                 m_publishingInterval = template.m_publishingInterval;
                 m_keepAliveCount = template.m_keepAliveCount;
                 m_lifetimeCount = template.m_lifetimeCount;


### PR DESCRIPTION
## Proposed changes

The display name in the constructor of the client subscription made changes to the display name. After the correction the display name is copied to the target like any other attribute.

## Related Issues

- Fixes #2676 

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [x] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
