### PR TITLE
Enhance publish request count management to allow limiting the publish requests to a max count

### DIFF
--- a/Libraries/Opc.Ua.Client/Session/ISession.cs
+++ b/Libraries/Opc.Ua.Client/Session/ISession.cs
@@ -278,6 +278,11 @@ namespace Opc.Ua.Client
         int MinPublishRequestCount { get; set; }
 
         /// <summary>
+        /// Gets and sets the maximum number of publish requests to be used in the session.
+        /// </summary>
+        int MaxPublishRequestCount { get; set; }
+
+        /// <summary>
         /// Stores the operation limits of a OPC UA Server.
         /// </summary>
         OperationLimits OperationLimits { get; }

--- a/Libraries/Opc.Ua.Client/Session/Session.cs
+++ b/Libraries/Opc.Ua.Client/Session/Session.cs
@@ -880,7 +880,7 @@ namespace Opc.Ua.Client
         }
 
         /// <summary>
-        /// Gets and sets the minimum number of publish requests to be used in the session.
+        /// Gets and sets the maximum number of publish requests to be used in the session.
         /// </summary>
         public int MaxPublishRequestCount
         {

--- a/Libraries/Opc.Ua.Client/Session/Session.cs
+++ b/Libraries/Opc.Ua.Client/Session/Session.cs
@@ -5278,7 +5278,7 @@ namespace Opc.Ua.Client
             }
             else
             {
-                Utils.LogInfo("PUBLISH - Did not send another publish request. GoodPublishRequestCount={0}, MinPublishRequestCount={1}", requestCount, minPublishRequestCount);
+                Utils.LogDebug("PUBLISH - Did not send another publish request. GoodPublishRequestCount={0}, MinPublishRequestCount={1}", requestCount, minPublishRequestCount);
             }
         }
 

--- a/Libraries/Opc.Ua.Client/Session/TraceableSession.cs
+++ b/Libraries/Opc.Ua.Client/Session/TraceableSession.cs
@@ -231,6 +231,13 @@ namespace Opc.Ua.Client
         }
 
         /// <inheritdoc/>
+        public int MaxPublishRequestCount
+        {
+            get => m_session.MaxPublishRequestCount;
+            set => m_session.MaxPublishRequestCount = value;
+        }
+
+        /// <inheritdoc/>
         public OperationLimits OperationLimits => m_session.OperationLimits;
 
         /// <inheritdoc/>


### PR DESCRIPTION
- Added `MaxPublishRequestCount` property to `ISession` and `Session` in `Opc.Ua.Client`, allowing control over the maximum number of publish requests per session, with validation against predefined constants `kDefaultPublishRequestCount` and `kMaxPublishRequestCountMax` (set to `ushort.MaxValue`).
- Introduced `kMaxPublishRequestCountMax` constant in `Session` class for the maximum publish request count limit.
- Modified `Session` constructor to initialize `m_maxPublishRequestCount` with `kMaxPublishRequestCountMax`.
- Updated `StartPublishing` and `QueueBeginPublish` methods in `Session` to use `GetDesiredPublishRequestCount` for dynamic adjustment of publish requests, considering the session's current state and the new min/max limits.
- Added `GetDesiredPublishRequestCount` method in `Session` to calculate the optimal number of active publish requests, ensuring adherence to the newly established limits.
- Made minor adjustments and refactoring in `Session` for clarity, consistency, and to support the new publish request count management logic.

## Proposed changes

It is not often desired to have as many requests as subscriptions, it overwhelms some servers. We want to allow users of the session to limit the number of active publish requests.

## Related Issues

- Fixes #

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
