### PR TITLE
#2686: Fix accessing subscription diagnostics in the current session …

### DIFF
--- a/Libraries/Opc.Ua.Server/Diagnostics/DiagnosticsNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/Diagnostics/DiagnosticsNodeManager.cs
@@ -2,7 +2,7 @@
  * Copyright (c) 2005-2020 The OPC Foundation, Inc. All rights reserved.
  *
  * OPC Foundation MIT License 1.00
- * 
+ *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
  * files (the "Software"), to deal in the Software without
@@ -11,7 +11,7 @@
  * copies of the Software, and to permit persons to whom the
  * Software is furnished to do so, subject to the following
  * conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be
  * included in all copies or substantial portions of the Software.
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
@@ -112,7 +112,7 @@ namespace Opc.Ua.Server
         /// <remarks>
         /// The externalReferences is an out parameter that allows the node manager to link to nodes
         /// in other node managers. For example, the 'Objects' node is managed by the CoreNodeManager and
-        /// should have a reference to the root folder node(s) exposed by this node manager.  
+        /// should have a reference to the root folder node(s) exposed by this node manager.
         /// </remarks>
         public override void CreateAddressSpace(IDictionary<NodeId, IList<IReference>> externalReferences)
         {
@@ -804,7 +804,7 @@ namespace Opc.Ua.Server
                 {
                     array3.OnSimpleReadValue = OnReadDiagnosticsArray;
                     // Hook the OnReadUserRolePermissions callback to control which user roles can access the services on this node
-                    array3.OnReadUserRolePermissions = OnReadUserRolePermissions;
+                    // array3.OnReadUserRolePermissions = OnReadUserRolePermissions;
                 }
 
                 // send initial update.
@@ -1849,7 +1849,7 @@ namespace Opc.Ua.Server
         /// Returns an index for the NamespaceURI (Adds it to the server namespace table if it does not already exist).
         /// </summary>
         /// <remarks>
-        /// Returns the server's default index (1) if the namespaceUri is empty or null. 
+        /// Returns the server's default index (1) if the namespaceUri is empty or null.
         /// </remarks>
         public ushort GetNamespaceIndex(string namespaceUri)
         {
@@ -1872,7 +1872,7 @@ namespace Opc.Ua.Server
         {
             return null;
         }
-    
+
         public ILocalNode GetLocalNode(NodeId nodeId)
         {
             return null;
@@ -1908,7 +1908,7 @@ namespace Opc.Ua.Server
 
         public void DeleteNode(NodeId nodeId, bool deleteChildren, bool silent)
         {
-        }       
+        }
 
         public ILocalNode ReferenceSharedNode(
             ILocalNode source,
@@ -1927,7 +1927,7 @@ namespace Opc.Ua.Server
         {
             return null;
         }
-        
+
         public NodeId CreateUniqueNodeId()
         {
             return null;
@@ -1952,7 +1952,7 @@ namespace Opc.Ua.Server
         {
             return null;
         }
-                
+
         public NodeId CreateVariable(
             NodeId parentId,
             NodeId referenceTypeId,
@@ -2071,7 +2071,7 @@ namespace Opc.Ua.Server
         }
 
         /// <summary>
-        /// Polls each monitored item which requires sample. 
+        /// Polls each monitored item which requires sample.
         /// </summary>
         private void DoSample(object state)
         {


### PR DESCRIPTION
…context.

Commented out the `OnReadUserRolePermissions` callback assignment for `array3` to gain access to the filtered diagnostics array.  There is no apparent reason to deiy access to the session creator.

## Related Issues

- Fixes #2686 

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
