### PR TITLE
Server SDK mistakenly uses SendBufferSize as ReceiveBufferSize and vice versa

### DIFF
--- a/Stack/Opc.Ua.Core/Stack/Tcp/TcpServerChannel.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/TcpServerChannel.cs
@@ -360,8 +360,9 @@ namespace Opc.Ua.Bindings
 
                     // read requested buffer sizes.
                     protocolVersion = decoder.ReadUInt32(null);
-                    receiveBufferSize = decoder.ReadUInt32(null);
+                    // note: swapped the send and receive buffer size read to reflect the server view
                     sendBufferSize = decoder.ReadUInt32(null);
+                    receiveBufferSize = decoder.ReadUInt32(null);
                     maxMessageSize = decoder.ReadUInt32(null);
                     maxChunkCount = decoder.ReadUInt32(null);
 
@@ -394,26 +395,12 @@ namespace Opc.Ua.Bindings
                 }
 
                 // update receive buffer size.
-                if (receiveBufferSize < ReceiveBufferSize)
-                {
-                    ReceiveBufferSize = (int)receiveBufferSize;
-                }
-
-                if (ReceiveBufferSize < TcpMessageLimits.MinBufferSize)
-                {
-                    ReceiveBufferSize = TcpMessageLimits.MinBufferSize;
-                }
+                ReceiveBufferSize = Math.Min(ReceiveBufferSize, (int)receiveBufferSize);
+                ReceiveBufferSize = Math.Min(Math.Max(ReceiveBufferSize, TcpMessageLimits.MinBufferSize), TcpMessageLimits.MaxBufferSize);
 
                 // update send buffer size.
-                if (sendBufferSize < SendBufferSize)
-                {
-                    SendBufferSize = (int)sendBufferSize;
-                }
-
-                if (SendBufferSize < TcpMessageLimits.MinBufferSize)
-                {
-                    SendBufferSize = TcpMessageLimits.MinBufferSize;
-                }
+                SendBufferSize = Math.Min(SendBufferSize, (int)sendBufferSize);
+                SendBufferSize = Math.Min(Math.Max(SendBufferSize, TcpMessageLimits.MinBufferSize), TcpMessageLimits.MaxBufferSize);
 
                 // update the max message size.
                 if (maxMessageSize > 0 && maxMessageSize < MaxResponseMessageSize)

--- a/Stack/Opc.Ua.Core/Stack/Tcp/UaSCBinaryClientChannel.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/UaSCBinaryClientChannel.cs
@@ -447,10 +447,41 @@ namespace Opc.Ua.Bindings
                 ReadAndVerifyMessageTypeAndSize(decoder, TcpMessageType.Acknowledge, messageChunk.Count);
 
                 uint protocolVersion = decoder.ReadUInt32(null);
-                SendBufferSize = (int)decoder.ReadUInt32(null);
-                ReceiveBufferSize = (int)decoder.ReadUInt32(null);
-                int maxMessageSize = (int)decoder.ReadUInt32(null);
-                int maxChunkCount = (int)decoder.ReadUInt32(null);
+                // note: decode of send and receive buffer size are swapped here to reflect the view of the client
+                uint sendBufferSize = decoder.ReadUInt32(null);
+                uint receiveBufferSize = decoder.ReadUInt32(null);
+                uint maxMessageSize = decoder.ReadUInt32(null);
+                uint maxChunkCount = decoder.ReadUInt32(null);
+
+                // returned buffer sizes shall not be larger than requested sizes
+                if (sendBufferSize > SendBufferSize)
+                {
+                    m_handshakeOperation.Fault(StatusCodes.BadTcpNotEnoughResources, "Returned client send buffer size is larger than requested size ({0}>{1} bytes).", sendBufferSize, SendBufferSize);
+                    return false;
+                }
+
+                if (receiveBufferSize > ReceiveBufferSize)
+                {
+                    m_handshakeOperation.Fault(StatusCodes.BadTcpNotEnoughResources, "Returned client receive buffer size is larger than requested size ({0}>{1} bytes).", receiveBufferSize, ReceiveBufferSize);
+                    return false;
+                }
+
+                // validate buffer sizes.
+                if (receiveBufferSize < TcpMessageLimits.MinBufferSize || receiveBufferSize > TcpMessageLimits.MaxBufferSize)
+                {
+                    m_handshakeOperation.Fault(StatusCodes.BadTcpNotEnoughResources, "Client receive buffer size is out of valid range ({0} bytes).", receiveBufferSize);
+                    return false;
+                }
+
+                if (sendBufferSize < TcpMessageLimits.MinBufferSize || sendBufferSize > TcpMessageLimits.MaxBufferSize)
+                {
+                    m_handshakeOperation.Fault(StatusCodes.BadTcpNotEnoughResources, "Client send buffer size is out of valid range ({0} bytes).", sendBufferSize);
+                    return false;
+                }
+
+                // assign new values once ensured that sizes are within bounds
+                SendBufferSize = (int)sendBufferSize;
+                ReceiveBufferSize = (int)receiveBufferSize;
 
                 // update the max message size.
                 if (maxMessageSize > 0 && maxMessageSize < MaxRequestMessageSize)
@@ -473,19 +504,7 @@ namespace Opc.Ua.Bindings
                 decoder.Close();
             }
 
-            // valdiate buffer sizes.
-            if (ReceiveBufferSize < TcpMessageLimits.MinBufferSize)
-            {
-                m_handshakeOperation.Fault(StatusCodes.BadTcpNotEnoughResources, "Server receive buffer size is too small ({0} bytes).", ReceiveBufferSize);
-                return false;
-            }
-
-            if (SendBufferSize < TcpMessageLimits.MinBufferSize)
-            {
-                m_handshakeOperation.Fault(StatusCodes.BadTcpNotEnoughResources, "Server send buffer size is too small ({0} bytes).", SendBufferSize);
-                return false;
-            }
-
+ 
             // ready to open the channel.
             State = TcpChannelState.Opening;
 


### PR DESCRIPTION
## Proposed changes

The error was undetected as long as send and receive buffer size were the same size.
Ensure the right values are used for client and server and add some more sanity checks on buffer sizes.

## Related Issues

- Fixes #2717 

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
