### PR TITLE
In the managed browse, pass the request header into browse next.

### DIFF
--- a/Libraries/Opc.Ua.Client/Session/SessionAsync.cs
+++ b/Libraries/Opc.Ua.Client/Session/SessionAsync.cs
@@ -1291,19 +1291,21 @@ namespace Opc.Ua.Client
                         nextResults.Add(previousResults[ii]);
                         nextErrors.Add(previousErrors[ii]);
                     }
-                    // ToDo: status code is bad and continuation point is not null
                 }
             }
             while (nextContinuationPoints.Count > 0)
             {
-
+                if (requestHeader != null)
+                {
+                    requestHeader.RequestHandle = 0;
+                }
                 (
                     _,
                     ByteStringCollection revisedContinuationPoints,
                     IList<ReferenceDescriptionCollection> browseNextResults,
                     IList<ServiceResult> browseNextErrors
                 ) = await BrowseNextAsync(
-                    null,
+                    requestHeader,
                     nextContinuationPoints,
                     false,
                     ct


### PR DESCRIPTION
## Proposed changes

This is a bugfix. The ManagedBrowseAsync method receives a request header, which was passed on into the call to BrowseAsync, but not into the BrowseNext method call.

## Related Issues

- Fixes #

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [x] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
