### PR TITLE
Allow bad status code for optional Attributes in ReadNodes

### DIFF
--- a/Libraries/Opc.Ua.Client/Session/Session.cs
+++ b/Libraries/Opc.Ua.Client/Session/Session.cs
@@ -4358,15 +4358,6 @@ namespace Opc.Ua.Client
                             continue;
                         }
 
-                        // ignore errors with attributes, which were not in 1.03 
-                        if (values[ii].StatusCode == StatusCodes.BadNodeIdUnknown)
-                        {
-                            if (attributeId == Attributes.AccessLevelEx)
-                            {
-                                continue;
-                            }
-                        }
-
                         // ignore errors on optional attributes
                         if (StatusCode.IsBad(values[ii].StatusCode))
                         {
@@ -4375,7 +4366,12 @@ namespace Opc.Ua.Client
                                 attributeId == Attributes.RolePermissions ||
                                 attributeId == Attributes.UserRolePermissions ||
                                 attributeId == Attributes.UserWriteMask ||
-                                attributeId == Attributes.WriteMask)
+                                attributeId == Attributes.WriteMask ||
+                                attributeId == Attributes.AccessLevelEx ||
+                                attributeId == Attributes.ArrayDimensions ||
+                                attributeId == Attributes.DataTypeDefinition ||
+                                attributeId == Attributes.InverseName ||
+                                attributeId == Attributes.MinimumSamplingInterval)
                             {
                                 continue;
                             }

--- a/Libraries/Opc.Ua.Client/Session/Session.cs
+++ b/Libraries/Opc.Ua.Client/Session/Session.cs
@@ -4358,6 +4358,15 @@ namespace Opc.Ua.Client
                             continue;
                         }
 
+                        // ignore errors with attributes, which were not in 1.03 
+                        if (values[ii].StatusCode == StatusCodes.BadNodeIdUnknown)
+                        {
+                            if (attributeId == Attributes.AccessLevelEx)
+                            {
+                                continue;
+                            }
+                        }
+
                         // ignore errors on optional attributes
                         if (StatusCode.IsBad(values[ii].StatusCode))
                         {
@@ -4366,8 +4375,7 @@ namespace Opc.Ua.Client
                                 attributeId == Attributes.RolePermissions ||
                                 attributeId == Attributes.UserRolePermissions ||
                                 attributeId == Attributes.UserWriteMask ||
-                                attributeId == Attributes.WriteMask ||
-                                attributeId == Attributes.AccessLevelEx)
+                                attributeId == Attributes.WriteMask)
                             {
                                 continue;
                             }
@@ -4502,9 +4510,10 @@ namespace Opc.Ua.Client
                         variableNode.MinimumSamplingInterval = Convert.ToDouble(attributes[Attributes.MinimumSamplingInterval].Value, CultureInfo.InvariantCulture);
                     }
 
-                    // AccessLevelEx Attribute (optional, since it is missing in 1.03)
-                    if (attributes.TryGetValue(Attributes.AccessLevelEx, out value) &&
-                        value != null)
+                    // AccessLevelEx Attribute
+                    value = attributes[Attributes.AccessLevelEx];
+
+                    if (value != null)
                     {
                         variableNode.AccessLevelEx = (uint)value.GetValue(typeof(uint));
                     }

--- a/Libraries/Opc.Ua.Client/Session/Session.cs
+++ b/Libraries/Opc.Ua.Client/Session/Session.cs
@@ -4366,7 +4366,8 @@ namespace Opc.Ua.Client
                                 attributeId == Attributes.RolePermissions ||
                                 attributeId == Attributes.UserRolePermissions ||
                                 attributeId == Attributes.UserWriteMask ||
-                                attributeId == Attributes.WriteMask)
+                                attributeId == Attributes.WriteMask ||
+                                attributeId == Attributes.AccessLevelEx)
                             {
                                 continue;
                             }
@@ -4501,10 +4502,9 @@ namespace Opc.Ua.Client
                         variableNode.MinimumSamplingInterval = Convert.ToDouble(attributes[Attributes.MinimumSamplingInterval].Value, CultureInfo.InvariantCulture);
                     }
 
-                    // AccessLevelEx Attribute
-                    value = attributes[Attributes.AccessLevelEx];
-
-                    if (value != null)
+                    // AccessLevelEx Attribute (optional, since it is missing in 1.03)
+                    if (attributes.TryGetValue(Attributes.AccessLevelEx, out value) &&
+                        value != null)
                     {
                         variableNode.AccessLevelEx = (uint)value.GetValue(typeof(uint));
                     }

--- a/Tests/Opc.Ua.Client.Tests/ClientTest.cs
+++ b/Tests/Opc.Ua.Client.Tests/ClientTest.cs
@@ -1235,13 +1235,6 @@ namespace Opc.Ua.Client.Tests
             Assert.AreEqual(nodes.Count, nodeCollection.Count);
             Assert.AreEqual(nodes.Count, errors.Count);
 
-            (nodeCollection, errors) = await Session.ReadNodesAsync(nodes, NodeClass.Variable, true).ConfigureAwait(false);
-            Assert.NotNull(nodeCollection);
-            Assert.NotNull(errors);
-            Assert.AreEqual(nodes.Count, nodeCollection.Count);
-            Assert.AreEqual(nodes.Count, errors.Count);
-            Assert.IsTrue(nodeCollection.All(n => n is VariableNode vn));
-
             int ii = 0;
             var variableNodes = new NodeIdCollection();
             foreach (Node node in nodeCollection)

--- a/Tests/Opc.Ua.Client.Tests/ClientTest.cs
+++ b/Tests/Opc.Ua.Client.Tests/ClientTest.cs
@@ -1235,6 +1235,13 @@ namespace Opc.Ua.Client.Tests
             Assert.AreEqual(nodes.Count, nodeCollection.Count);
             Assert.AreEqual(nodes.Count, errors.Count);
 
+            (nodeCollection, errors) = await Session.ReadNodesAsync(nodes, NodeClass.Variable, true).ConfigureAwait(false);
+            Assert.NotNull(nodeCollection);
+            Assert.NotNull(errors);
+            Assert.AreEqual(nodes.Count, nodeCollection.Count);
+            Assert.AreEqual(nodes.Count, errors.Count);
+            Assert.IsTrue(nodeCollection.All(n => n is VariableNode vn));
+
             int ii = 0;
             var variableNodes = new NodeIdCollection();
             foreach (Node node in nodeCollection)


### PR DESCRIPTION
## Proposed changes

ReadNodes() (and some other methods) allow bad status codes for optional values. However, this list is not complete, which means that some optional attributes with a `Bad` StatusCode cause the read to fail. This Pull Request does not fix something, which is wrong (according to the specification), but rather increases the resilience against servers with problems.

List of optional attributes: https://reference.opcfoundation.org/Core/Part3/v105/docs/5.9

## Related Issues

- Fixes #2732 

## Types of changes

What types of changes does your code introduce?

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [X] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [X] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [x] I ran tests locally with my changes, all passed.
- [x] I fixed all failing tests in the CI pipelines. 
- [x] I fixed all introduced issues with CodeQL and LGTM.
- [x] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [X] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.
