### PR TITLE
Check server application Uri with the create session response

### DIFF
--- a/Libraries/Opc.Ua.Client/ReverseConnectManager.cs
+++ b/Libraries/Opc.Ua.Client/ReverseConnectManager.cs
@@ -152,11 +152,14 @@ namespace Opc.Ua.Client
             }
 
             /// <summary>
-            /// Register with the server certificate.
+            /// Register with the server certificate to extract the application Uri.
             /// </summary>
-            /// <param name="serverCertificate"></param>
-            /// <param name="endpointUrl"></param>
-            /// <param name="onConnectionWaiting"></param>
+            /// <remarks>
+            /// The first Uri in the subject alternate name field is considered the application Uri.
+            /// </remarks>
+            /// <param name="serverCertificate">The server certificate with the application Uri.</param>
+            /// <param name="endpointUrl">The endpoint Url of the server.</param>
+            /// <param name="onConnectionWaiting">The connection to use.</param>
             public Registration(
                 X509Certificate2 serverCertificate,
                 Uri endpointUrl,

--- a/Libraries/Opc.Ua.Client/ReverseConnectManager.cs
+++ b/Libraries/Opc.Ua.Client/ReverseConnectManager.cs
@@ -163,7 +163,7 @@ namespace Opc.Ua.Client
                 EventHandler<ConnectionWaitingEventArgs> onConnectionWaiting) :
                 this(endpointUrl, onConnectionWaiting)
             {
-                ServerUri = X509Utils.GetApplicationUriFromCertificate(serverCertificate);
+                ServerUri = X509Utils.GetApplicationUrisFromCertificate(serverCertificate).FirstOrDefault();
             }
 
             private Registration(

--- a/Libraries/Opc.Ua.Client/Session/Session.cs
+++ b/Libraries/Opc.Ua.Client/Session/Session.cs
@@ -5370,12 +5370,20 @@ namespace Opc.Ua.Client
                 if (string.IsNullOrEmpty(applicationUri))
                 {
                     throw ServiceResultException.Create(
-                        StatusCodes.BadSecurityChecksFailed,
+                        StatusCodes.BadCertificateUriInvalid,
                         "Server did not return an ApplicationUri in the EndpointDescription.");
                 }
 
-                bool noMatch = true;
                 var certificateApplicationUris = X509Utils.GetApplicationUrisFromCertificate(serverCertificate);
+                if (certificateApplicationUris.Count == 0)
+                {
+                    throw ServiceResultException.Create(
+                            StatusCodes.BadCertificateUriInvalid,
+                            "The Server Certificate ({1}) does not contain an applicationUri.",
+                            serverCertificate.Subject);
+                }
+
+                bool noMatch = true;
                 foreach (var certificateApplicationUri in certificateApplicationUris)
                 {
                     if (string.Equals(certificateApplicationUri, applicationUri, StringComparison.Ordinal))
@@ -5388,8 +5396,9 @@ namespace Opc.Ua.Client
                 if (noMatch)
                 {
                     throw ServiceResultException.Create(
-                        StatusCodes.BadSecurityChecksFailed,
-                        "Server did not return the ApplicationUri in the EndpointDescription that is used in the server certificate.");
+                        StatusCodes.BadCertificateUriInvalid,
+                        "The Application in the EndpointDescription ({0}) is not in the Server Certificate ({1}).",
+                        applicationUri, serverCertificate.Subject);
                 }
             }
         }

--- a/Libraries/Opc.Ua.Client/Session/Session.cs
+++ b/Libraries/Opc.Ua.Client/Session/Session.cs
@@ -2416,24 +2416,24 @@ namespace Opc.Ua.Client
             if (!successCreateSession)
             {
                 base.CreateSession(
-                        null,
-                        clientDescription,
-                        m_endpoint.Description.Server.ApplicationUri,
-                        m_endpoint.EndpointUrl.ToString(),
-                        sessionName,
-                        clientNonce,
-                        clientCertificateChainData != null ? clientCertificateChainData : clientCertificateData,
-                        sessionTimeout,
-                        (uint)MessageContext.MaxMessageSize,
-                        out sessionId,
-                        out sessionCookie,
-                        out m_sessionTimeout,
-                        out serverNonce,
-                        out serverCertificateData,
-                        out serverEndpoints,
-                        out serverSoftwareCertificates,
-                        out serverSignature,
-                        out m_maxRequestMessageSize);
+                    null,
+                    clientDescription,
+                    m_endpoint.Description.Server.ApplicationUri,
+                    m_endpoint.EndpointUrl.ToString(),
+                    sessionName,
+                    clientNonce,
+                    clientCertificateChainData != null ? clientCertificateChainData : clientCertificateData,
+                    sessionTimeout,
+                    (uint)MessageContext.MaxMessageSize,
+                    out sessionId,
+                    out sessionCookie,
+                    out m_sessionTimeout,
+                    out serverNonce,
+                    out serverCertificateData,
+                    out serverEndpoints,
+                    out serverSoftwareCertificates,
+                    out serverSignature,
+                    out m_maxRequestMessageSize);
             }
 
             // save session id.
@@ -5361,24 +5361,23 @@ namespace Opc.Ua.Client
         /// with the applicationUri of the server description before the validation.
         /// </summary>
         private static void ValidateServerCertificateApplicationUri(ConfiguredEndpoint endpoint, X509Certificate2 serverCertificate)
-            X509Certificate2 serverCertificate)
         {
             if (serverCertificate != null)
             {
                 var applicationUri = endpoint?.Description?.Server?.ApplicationUri;
 
                 // check that an ApplicatioUri is specified for the Endpoint
-            if (string.IsNullOrEmpty(applicationUri))
-            {
-                throw ServiceResultException.Create(
-                    StatusCodes.BadSecurityChecksFailed,
+                if (string.IsNullOrEmpty(applicationUri))
+                {
+                    throw ServiceResultException.Create(
+                        StatusCodes.BadSecurityChecksFailed,
                         "Server did not return an ApplicationUri in the EndpointDescription.");
-            }
+                }
 
                 bool noMatch = true;
                 var certificateApplicationUris = X509Utils.GetApplicationUrisFromCertificate(serverCertificate);
                 foreach (var certificateApplicationUri in certificateApplicationUris)
-            {
+                {
                     if (string.Equals(certificateApplicationUri, applicationUri, StringComparison.Ordinal))
                     {
                         noMatch = false;
@@ -5388,11 +5387,11 @@ namespace Opc.Ua.Client
 
                 if (noMatch)
                 {
-                throw ServiceResultException.Create(
-                    StatusCodes.BadSecurityChecksFailed,
+                    throw ServiceResultException.Create(
+                        StatusCodes.BadSecurityChecksFailed,
                         "Server did not return the ApplicationUri in the EndpointDescription that is used in the server certificate.");
+                }
             }
-        }
         }
 
         private void BuildCertificateData(out byte[] clientCertificateData, out byte[] clientCertificateChainData)

--- a/Libraries/Opc.Ua.Client/Session/SessionAsync.cs
+++ b/Libraries/Opc.Ua.Client/Session/SessionAsync.cs
@@ -93,7 +93,6 @@ namespace Opc.Ua.Client
 
                 if (requireEncryption)
                 {
-                    ValidateServerCertificateApplicationUri(serverCertificate);
                     if (checkDomain)
                     {
                         await m_configuration.CertificateValidator.ValidateAsync(serverCertificateChain, m_endpoint, ct).ConfigureAwait(false);
@@ -200,6 +199,8 @@ namespace Opc.Ua.Client
                 ValidateServerCertificateData(serverCertificateData);
 
                 ValidateServerEndpoints(serverEndpoints);
+
+                ValidateServerCertificateApplicationUri(m_endpoint, serverCertificate);
 
                 ValidateServerSignature(serverCertificate, serverSignature, clientCertificateData, clientCertificateChainData, clientNonce);
 

--- a/Libraries/Opc.Ua.Configuration/ApplicationInstance.cs
+++ b/Libraries/Opc.Ua.Configuration/ApplicationInstance.cs
@@ -672,7 +672,7 @@ namespace Opc.Ua.Configuration
             }
 
             // check uri.
-            string applicationUri = X509Utils.GetApplicationUriFromCertificate(certificate);
+            string applicationUri = X509Utils.GetApplicationUrisFromCertificate(certificate).FirstOrDefault();
 
             if (String.IsNullOrEmpty(applicationUri))
             {

--- a/Libraries/Opc.Ua.Gds.Client.Common/CertificateWrapper.cs
+++ b/Libraries/Opc.Ua.Gds.Client.Common/CertificateWrapper.cs
@@ -29,6 +29,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.Serialization;
 using System.Security.Cryptography.X509Certificates;
 using Opc.Ua.Security.Certificates;
@@ -213,7 +214,7 @@ namespace Opc.Ua.Gds.Client
                 {
                     try
                     {
-                        return X509Utils.GetApplicationUriFromCertificate(Certificate);
+                        return X509Utils.GetApplicationUrisFromCertificate(Certificate).FirstOrDefault();
                     }
                     catch (Exception e)
                     {

--- a/Libraries/Opc.Ua.Security.Certificates/Extensions/X509SubjectAltNameExtension.cs
+++ b/Libraries/Opc.Ua.Security.Certificates/Extensions/X509SubjectAltNameExtension.cs
@@ -118,7 +118,23 @@ namespace Opc.Ua.Security.Certificates
         {
             Oid = new Oid(SubjectAltName2Oid, kFriendlyName);
             Critical = false;
-            Initialize(applicationUri, domainNames);
+            Initialize(new string[] { applicationUri }, domainNames);
+            RawData = Encode();
+            m_decoded = true;
+        }
+
+        /// <summary>
+        /// Build the Subject Alternative name extension (for OPC UA application certs).
+        /// </summary>
+        /// <param name="applicationUris">The application Uri</param>
+        /// <param name="domainNames">The domain names. DNS Hostnames, IPv4 or IPv6 addresses</param>
+        public X509SubjectAltNameExtension(
+            IEnumerable<string> applicationUris,
+            IEnumerable<string> domainNames)
+        {
+            Oid = new Oid(SubjectAltName2Oid, kFriendlyName);
+            Critical = false;
+            Initialize(applicationUris, domainNames);
             RawData = Encode();
             m_decoded = true;
         }
@@ -402,14 +418,17 @@ namespace Opc.Ua.Security.Certificates
         /// <summary>
         /// Initialize the Subject Alternative name extension.
         /// </summary>
-        /// <param name="applicationUri">The application Uri</param>
+        /// <param name="applicationUris">The application Uris</param>
         /// <param name="generalNames">The general names. DNS Hostnames, IPv4 or IPv6 addresses</param>
-        private void Initialize(string applicationUri, IEnumerable<string> generalNames)
+        private void Initialize(IEnumerable<string> applicationUris, IEnumerable<string> generalNames)
         {
             var uris = new List<string>();
             var domainNames = new List<string>();
             var ipAddresses = new List<string>();
-            uris.Add(applicationUri);
+            foreach (string applicationUri in applicationUris)
+            {
+                uris.Add(applicationUri);
+            }
             foreach (string generalName in generalNames)
             {
                 switch (Uri.CheckHostName(generalName))

--- a/Libraries/Opc.Ua.Server/Server/StandardServer.cs
+++ b/Libraries/Opc.Ua.Server/Server/StandardServer.cs
@@ -387,7 +387,8 @@ namespace Opc.Ua.Server
                                 var certificateApplicationUris = X509Utils.GetApplicationUrisFromCertificate(parsedClientCertificate);
                                 foreach (var certificateApplicationUri in certificateApplicationUris)
                                 {
-                                    if (!String.IsNullOrEmpty(certificateApplicationUri) && certificateApplicationUri == clientDescription.ApplicationUri)
+                                    if (!String.IsNullOrEmpty(certificateApplicationUri) &&
+                                        certificateApplicationUri == clientDescription.ApplicationUri)
                                     {
                                         noMatch = false;
                                         break;

--- a/Stack/Opc.Ua.Core/Security/Certificates/CertificateFactory.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/CertificateFactory.cs
@@ -319,10 +319,10 @@ namespace Opc.Ua
                 }
             }
 
-            string applicationUri = X509Utils.GetApplicationUriFromCertificate(certificate);
+            var applicationUris = X509Utils.GetApplicationUrisFromCertificate(certificate);
 
             // Subject Alternative Name
-            var subjectAltName = new X509SubjectAltNameExtension(applicationUri, domainNames);
+            var subjectAltName = new X509SubjectAltNameExtension(applicationUris, domainNames);
             request.CertificateExtensions.Add(new X509Extension(subjectAltName, false));
 
             using (RSA rsa = certificate.GetRSAPrivateKey())

--- a/Stack/Opc.Ua.Core/Security/Certificates/X509Utils.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/X509Utils.cs
@@ -126,6 +126,7 @@ namespace Opc.Ua
         /// </summary>
         /// <param name="certificate">The certificate.</param>
         /// <returns>The application URI.</returns>
+        [Obsolete("Use GetApplicationUrisFromCertificate instead. The certificate may contain more than one Uri.")]
         public static string GetApplicationUriFromCertificate(X509Certificate2 certificate)
         {
             // extract the alternate domains from the subject alternate name extension.
@@ -138,6 +139,25 @@ namespace Opc.Ua
             }
 
             return string.Empty;
+        }
+
+        /// <summary>
+        /// Extracts the application URIs specified in the certificate.
+        /// </summary>
+        /// <param name="certificate">The certificate.</param>
+        /// <returns>The application URIs.</returns>
+        public static IReadOnlyList<string> GetApplicationUrisFromCertificate(X509Certificate2 certificate)
+        {
+            // extract the alternate domains from the subject alternate name extension.
+            X509SubjectAltNameExtension alternateName = X509Extensions.FindExtension<X509SubjectAltNameExtension>(certificate);
+
+            // get the application uris.
+            if (alternateName != null && alternateName.Uris != null)
+            {
+                return alternateName.Uris;
+            }
+
+            return new List<string>();
         }
 
         /// <summary>

--- a/Stack/Opc.Ua.Core/Stack/Server/ServerBase.cs
+++ b/Stack/Opc.Ua.Core/Stack/Server/ServerBase.cs
@@ -1405,7 +1405,7 @@ namespace Opc.Ua
             // assign a unique identifier if none specified.
             if (String.IsNullOrEmpty(configuration.ApplicationUri))
             {
-                configuration.ApplicationUri = X509Utils.GetApplicationUriFromCertificate(InstanceCertificate);
+                configuration.ApplicationUri = X509Utils.GetApplicationUrisFromCertificate(InstanceCertificate).FirstOrDefault();
 
                 if (String.IsNullOrEmpty(configuration.ApplicationUri))
                 {

--- a/Stack/Opc.Ua.Core/Types/Utils/Utils.cs
+++ b/Stack/Opc.Ua.Core/Types/Utils/Utils.cs
@@ -2529,7 +2529,7 @@ namespace Opc.Ua
                 extensions.Add(document.DocumentElement);
             }
         }
-#endregion
+        #endregion
 
         #region Reflection Helper Functions
         /// <summary>

--- a/Tests/Opc.Ua.Core.Tests/Security/Certificates/CertificateFactoryTest.cs
+++ b/Tests/Opc.Ua.Core.Tests/Security/Certificates/CertificateFactoryTest.cs
@@ -435,8 +435,8 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
                 Assert.True(domainNames.Contains(domainName, StringComparer.OrdinalIgnoreCase));
             }
             Assert.True(subjectAlternateName.Uris.Count == 1);
-            var applicationUri = X509Utils.GetApplicationUriFromCertificate(cert);
-            TestContext.Out.WriteLine("ApplicationUri: ");
+            var applicationUri = X509Utils.GetApplicationUrisFromCertificate(cert).FirstOrDefault();
+            TestContext.Out.WriteLine("ApplicationUris: ");
             TestContext.Out.WriteLine(applicationUri);
             Assert.AreEqual(testApp.ApplicationUri, applicationUri);
         }

--- a/Tests/Opc.Ua.Gds.Tests/X509TestUtils.cs
+++ b/Tests/Opc.Ua.Gds.Tests/X509TestUtils.cs
@@ -156,7 +156,7 @@ namespace Opc.Ua.Gds.Tests
                 Assert.True(domainNames.Contains(domainName, StringComparer.OrdinalIgnoreCase));
             }
             Assert.True(subjectAlternateName.Uris.Count == 1);
-            var applicationUri = X509Utils.GetApplicationUriFromCertificate(signedCert);
+            var applicationUri = X509Utils.GetApplicationUrisFromCertificate(signedCert).FirstOrDefault();
             Assert.True(testApp.ApplicationRecord.ApplicationUri == applicationUri);
         }
     }


### PR DESCRIPTION
## Proposed changes

Address two issues:
- Instead of checking the application Uri wiith the discovered endpoint move the check to the result of the create session response, which then contains the application Uri returned from the server.
- Support that the server certificate may contain multiple application Uri and check all for a match.

## Related Issues

- Fixes #2709 
- #2721 
- #2583 
- #2032

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
