### PR TITLE
[Console Reference Client] Durable Subscription Implementation

### DIFF
--- a/Applications/ConsoleReferenceClient/ClientSamples.cs
+++ b/Applications/ConsoleReferenceClient/ClientSamples.cs
@@ -358,11 +358,12 @@ namespace Quickstarts
                 int subscriptionPublishingInterval = 1000;
                 int itemSamplingInterval = 1000;
                 uint queueSize = 10;
+                uint lifetime = minLifeTime;
 
                 if (enableDurableSubscriptions)
                 {
-                    subscriptionPublishingInterval = 30000;
-                    queueSize = 600;
+                    queueSize = 100;
+                    lifetime = 20;
                 }
 
                 // Define Subscription parameters
@@ -371,7 +372,8 @@ namespace Quickstarts
                     PublishingEnabled = true,
                     PublishingInterval = subscriptionPublishingInterval,
                     LifetimeCount = 0,
-                    MinLifetimeInterval = minLifeTime,
+                    MinLifetimeInterval = lifetime,
+                    KeepAliveCount = 5,
                 };
 
                 session.AddSubscription(subscription);

--- a/Applications/ConsoleReferenceClient/ClientSamples.cs
+++ b/Applications/ConsoleReferenceClient/ClientSamples.cs
@@ -342,12 +342,14 @@ namespace Quickstarts
         /// <summary>
         /// Create Subscription and MonitoredItems for DataChanges
         /// </summary>
-        public void SubscribeToDataChanges(ISession session, uint minLifeTime, bool enableDurableSubscriptions)
+        public bool SubscribeToDataChanges(ISession session, uint minLifeTime, bool enableDurableSubscriptions)
         {
+            bool isDurable = false;
+
             if (session == null || session.Connected == false)
             {
                 m_output.WriteLine("Session not connected!");
-                return;
+                return isDurable;
             }
 
             try
@@ -385,6 +387,8 @@ namespace Quickstarts
 
                     if (subscription.SetSubscriptionDurable(1, out revisedLifetimeInHours))
                     {
+                        isDurable = true;
+
                         m_output.WriteLine("Subscription {0} is now durable, Revised Lifetime {1} in hours.",
                             subscription.Id, revisedLifetimeInHours);
                     }
@@ -480,6 +484,8 @@ namespace Quickstarts
             {
                 m_output.WriteLine("Subscribe error: {0}", ex.Message);
             }
+
+            return isDurable;
         }
         #endregion
 

--- a/Applications/ConsoleReferenceClient/ClientSamples.cs
+++ b/Applications/ConsoleReferenceClient/ClientSamples.cs
@@ -385,7 +385,8 @@ namespace Quickstarts
 
                     if (subscription.SetSubscriptionDurable(1, out revisedLifetimeInHours))
                     {
-                        m_output.WriteLine("Subscription {0} is now durable.", subscription.Id);
+                        m_output.WriteLine("Subscription {0} is now durable, Revised Lifetime {1} in hours.",
+                            subscription.Id, revisedLifetimeInHours);
                     }
                     else
                     {

--- a/Applications/ConsoleReferenceClient/ClientSamples.cs
+++ b/Applications/ConsoleReferenceClient/ClientSamples.cs
@@ -35,6 +35,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
@@ -69,6 +70,13 @@ namespace Quickstarts
             m_validateResponse = validateResponse ?? ClientBase.ValidateResponse;
             m_quitEvent = quitEvent;
             m_verbose = verbose;
+            m_desiredEventFields = new Dictionary<int, QualifiedNameCollection>();
+            int eventIndexCounter = 0;
+            m_desiredEventFields.Add(eventIndexCounter++, new QualifiedNameCollection(new QualifiedName[] { BrowseNames.Time }));
+            m_desiredEventFields.Add(eventIndexCounter++, new QualifiedNameCollection(new QualifiedName[] { BrowseNames.ActiveState }));
+            m_desiredEventFields.Add(eventIndexCounter++, new QualifiedNameCollection(new QualifiedName[] { BrowseNames.Message }));
+            m_desiredEventFields.Add(eventIndexCounter++, new QualifiedNameCollection(new QualifiedName[] { BrowseNames.LimitState, BrowseNames.CurrentState }));
+            m_desiredEventFields.Add(eventIndexCounter++, new QualifiedNameCollection(new QualifiedName[] { BrowseNames.LimitState, BrowseNames.LastTransition }));
         }
 
         #region Public Sample Methods
@@ -290,9 +298,51 @@ namespace Quickstarts
         }
 
         /// <summary>
+        /// Call the Start method for Alarming to enable events
+        /// </summary>
+        public void EnableEvents(ISession session, uint timeToRun)
+        {
+            if (session == null || session.Connected == false)
+            {
+                m_output.WriteLine("Session not connected!");
+                return;
+            }
+
+            try
+            {
+                // Define the UA Method to call
+                // Parent node - Objects\CTT\Alarms
+                // Method node - Objects\CTT\Alarms\Start
+                NodeId objectId = new NodeId("ns=7;s=Alarms");
+                NodeId methodId = new NodeId("ns=7;s=Alarms.Start");
+
+                // Define the method parameters
+                // Input argument requires a Float and an UInt32 value
+                object[] inputArguments = new object[] { timeToRun };
+                IList<object> outputArguments = null;
+
+                // Invoke Call service
+                m_output.WriteLine("Calling UAMethod for node {0} ...", methodId);
+                outputArguments = session.Call(objectId, methodId, inputArguments);
+
+                // Display results
+                m_output.WriteLine("Method call returned {0} output argument(s):", outputArguments.Count);
+
+                foreach (var outputArgument in outputArguments)
+                {
+                    m_output.WriteLine("     OutputValue = {0}", outputArgument.ToString());
+                }
+            }
+            catch (Exception ex)
+            {
+                m_output.WriteLine("Method call error: {0}", ex.Message);
+            }
+        }
+
+        /// <summary>
         /// Create Subscription and MonitoredItems for DataChanges
         /// </summary>
-        public void SubscribeToDataChanges(ISession session, uint minLifeTime)
+        public void SubscribeToDataChanges(ISession session, uint minLifeTime, bool enableDurableSubscriptions)
         {
             if (session == null || session.Connected == false)
             {
@@ -303,12 +353,21 @@ namespace Quickstarts
             try
             {
                 // Create a subscription for receiving data change notifications
+                int subscriptionPublishingInterval = 1000;
+                int itemSamplingInterval = 1000;
+                uint queueSize = 10;
+
+                if (enableDurableSubscriptions)
+                {
+                    subscriptionPublishingInterval = 30000;
+                    queueSize = 600;
+                }
 
                 // Define Subscription parameters
                 Subscription subscription = new Subscription(session.DefaultSubscription) {
                     DisplayName = "Console ReferenceClient Subscription",
                     PublishingEnabled = true,
-                    PublishingInterval = 1000,
+                    PublishingInterval = subscriptionPublishingInterval,
                     LifetimeCount = 0,
                     MinLifetimeInterval = minLifeTime,
                 };
@@ -317,7 +376,22 @@ namespace Quickstarts
 
                 // Create the subscription on Server side
                 subscription.Create();
-                m_output.WriteLine("New Subscription created with SubscriptionId = {0}.", subscription.Id);
+                m_output.WriteLine("New Subscription created with SubscriptionId = {0}, Sampling Interval {1}, Publishing Interval {2}.",
+                    subscription.Id, itemSamplingInterval, subscriptionPublishingInterval);
+
+                if (enableDurableSubscriptions)
+                {
+                    uint revisedLifetimeInHours = 0;
+
+                    if (subscription.SetSubscriptionDurable(1, out revisedLifetimeInHours))
+                    {
+                        m_output.WriteLine("Subscription {0} is now durable.", subscription.Id);
+                    }
+                    else
+                    {
+                        m_output.WriteLine("Subscription {0} failed durable call", subscription.Id);
+                    }
+                }
 
                 // Create MonitoredItems for data changes (Reference Server)
 
@@ -326,8 +400,8 @@ namespace Quickstarts
                 intMonitoredItem.StartNodeId = new NodeId("ns=2;s=Scalar_Simulation_Int32");
                 intMonitoredItem.AttributeId = Attributes.Value;
                 intMonitoredItem.DisplayName = "Int32 Variable";
-                intMonitoredItem.SamplingInterval = 1000;
-                intMonitoredItem.QueueSize = 10;
+                intMonitoredItem.SamplingInterval = itemSamplingInterval;
+                intMonitoredItem.QueueSize = queueSize;
                 intMonitoredItem.DiscardOldest = true;
                 intMonitoredItem.Notification += OnMonitoredItemNotification;
 
@@ -338,8 +412,8 @@ namespace Quickstarts
                 floatMonitoredItem.StartNodeId = new NodeId("ns=2;s=Scalar_Simulation_Float");
                 floatMonitoredItem.AttributeId = Attributes.Value;
                 floatMonitoredItem.DisplayName = "Float Variable";
-                floatMonitoredItem.SamplingInterval = 1000;
-                floatMonitoredItem.QueueSize = 10;
+                floatMonitoredItem.SamplingInterval = itemSamplingInterval;
+                floatMonitoredItem.QueueSize = queueSize;
                 floatMonitoredItem.Notification += OnMonitoredItemNotification;
 
                 subscription.AddItem(floatMonitoredItem);
@@ -349,11 +423,53 @@ namespace Quickstarts
                 stringMonitoredItem.StartNodeId = new NodeId("ns=2;s=Scalar_Simulation_String");
                 stringMonitoredItem.AttributeId = Attributes.Value;
                 stringMonitoredItem.DisplayName = "String Variable";
-                stringMonitoredItem.SamplingInterval = 1000;
-                stringMonitoredItem.QueueSize = 10;
+                stringMonitoredItem.SamplingInterval = itemSamplingInterval;
+                stringMonitoredItem.QueueSize = queueSize;
                 stringMonitoredItem.Notification += OnMonitoredItemNotification;
 
                 subscription.AddItem(stringMonitoredItem);
+
+                MonitoredItem eventMonitoredItem = new MonitoredItem(subscription.DefaultItem);
+                eventMonitoredItem.StartNodeId = new NodeId(Opc.Ua.ObjectIds.Server);
+                eventMonitoredItem.AttributeId = Attributes.EventNotifier;
+                eventMonitoredItem.DisplayName = "Event Variable";
+                eventMonitoredItem.SamplingInterval = itemSamplingInterval;
+                eventMonitoredItem.QueueSize = queueSize;
+                eventMonitoredItem.Notification += OnMonitoredItemEventNotification;
+
+                EventFilter filter = new EventFilter();
+
+                SimpleAttributeOperandCollection simpleAttributeOperands = new SimpleAttributeOperandCollection();
+
+                foreach (QualifiedNameCollection desiredEventField in m_desiredEventFields.Values)
+                {
+                    simpleAttributeOperands.Add(new SimpleAttributeOperand() {
+                        AttributeId = Attributes.Value,
+                        TypeDefinitionId = ObjectTypeIds.BaseEventType,
+                        BrowsePath = desiredEventField
+                    });
+                }
+                filter.SelectClauses = simpleAttributeOperands;
+
+                ContentFilter whereClause = new ContentFilter();
+                SimpleAttributeOperand existingEventType = new SimpleAttributeOperand() {
+                    AttributeId = Attributes.Value,
+                    TypeDefinitionId = ObjectTypeIds.ExclusiveLevelAlarmType,
+                    BrowsePath = new QualifiedNameCollection(new QualifiedName[] { "EventType" })
+                };
+                LiteralOperand desiredEventType = new LiteralOperand();
+                desiredEventType.Value = new Variant(new NodeId(Opc.Ua.ObjectTypeIds.ExclusiveLevelAlarmType));
+
+
+                whereClause.Push(FilterOperator.Equals, new FilterOperand[] { existingEventType, desiredEventType });
+
+                filter.WhereClause = whereClause;
+
+                eventMonitoredItem.Filter = filter;
+                eventMonitoredItem.NodeClass = NodeClass.Object;
+
+
+                subscription.AddItem(eventMonitoredItem);
 
                 // Create the monitored items on Server side
                 subscription.ApplyChanges();
@@ -1186,13 +1302,82 @@ namespace Quickstarts
             {
                 // Log MonitoredItem Notification event
                 MonitoredItemNotification notification = e.NotificationValue as MonitoredItemNotification;
-                m_output.WriteLine("Notification: {0} \"{1}\" and Value = {2}.", notification.Message.SequenceNumber, monitoredItem.ResolvedNodeId, notification.Value);
+                DateTime localTime = notification.Value.SourceTimestamp.ToLocalTime();
+                m_output.WriteLine("Notification: {0} \"{1}\" and Value = {2} at [{3}].",
+                    notification.Message.SequenceNumber,
+                    monitoredItem.ResolvedNodeId,
+                    notification.Value,
+                    localTime.ToLongTimeString());
             }
             catch (Exception ex)
             {
                 m_output.WriteLine("OnMonitoredItemNotification error: {0}", ex.Message);
             }
         }
+
+        /// <summary>
+        /// Handle Requested Event notifications from Server
+        /// </summary>
+        private void OnMonitoredItemEventNotification(MonitoredItem monitoredItem, MonitoredItemNotificationEventArgs e)
+        {
+            try
+            {
+                // Log MonitoredItem Notification event
+                EventFieldList notification = e.NotificationValue as EventFieldList;
+
+                foreach (KeyValuePair<int, QualifiedNameCollection> entry in m_desiredEventFields)
+                {
+                    Variant field = notification.EventFields[entry.Key];
+                    if (field.TypeInfo.BuiltInType != BuiltInType.Null)
+                    {
+                        StringBuilder fieldPath = new StringBuilder();
+
+                        int lastIndex = entry.Value.Count - 1;
+                        for (int index = 0; index < entry.Value.Count; index++)
+                        {
+                            fieldPath.Append(entry.Value[index].Name);
+                            if (index < lastIndex)
+                            {
+                                fieldPath.Append(".");
+                            }
+                        }
+
+                        string fieldName = fieldPath.ToString();
+                        if (fieldName.Equals("Time"))
+                        {
+                            try
+                            {
+                                DateTime currentTime = (DateTime)field.Value;
+                                TimeSpan timeSpan = currentTime - m_lastEventTime;
+                                m_lastEventTime = currentTime;
+                                m_processedEvents++;
+                                string timeBetweenEvents = "";
+                                if (m_processedEvents > 1)
+                                {
+                                    timeBetweenEvents = ", time since last event = " + timeSpan.Seconds.ToString() + " seconds";
+                                }
+
+                                m_output.WriteLine("Event Received - total count = {0}{1}",
+                                    m_processedEvents.ToString(),
+                                    timeBetweenEvents);
+                            }
+                            catch (Exception ex)
+                            {
+                                m_output.WriteLine("Unexpected error retrieving Event Time Field Value: {0}", ex.Message);
+                            }
+                        }
+
+                        m_output.WriteLine("\tField [{0}] \"{1}\" = [{2}]",
+                            entry.Key.ToString(), fieldName, field.Value);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                m_output.WriteLine("OnMonitoredItemEventNotification error: {0}", ex.Message);
+            }
+        }
+
 
         /// <summary>
         /// Event handler to defer publish response sequence number acknowledge.
@@ -1256,5 +1441,8 @@ namespace Quickstarts
         private readonly TextWriter m_output;
         private readonly ManualResetEvent m_quitEvent;
         private readonly bool m_verbose;
+        private Dictionary<int, QualifiedNameCollection> m_desiredEventFields = null;
+        private int m_processedEvents = 0;
+        private DateTime m_lastEventTime = DateTime.Now;
     }
 }

--- a/Applications/ConsoleReferenceClient/Program.cs
+++ b/Applications/ConsoleReferenceClient/Program.cs
@@ -419,7 +419,7 @@ namespace Quickstarts.ConsoleReferenceClient
                                         if (waitCounters == restartSessionTime)
                                         {
                                             output.WriteLine("Restarting Session at " + DateTime.Now.ToLongTimeString());
-                                            await uaClient.ReconnectAndTransfer(
+                                            await uaClient.DurableSubscriptionTransfer(
                                                 serverUrl.ToString(),
                                                 useSecurity: !noSecurity,
                                                 quitCTS.Token);

--- a/Applications/ConsoleReferenceClient/Program.cs
+++ b/Applications/ConsoleReferenceClient/Program.cs
@@ -89,6 +89,7 @@ namespace Quickstarts.ConsoleReferenceClient
             string reverseConnectUrlString = null;
             bool leakChannels = false;
             bool forever = false;
+            bool enableDurableSubscriptions = false;
 
             Mono.Options.OptionSet options = new Mono.Options.OptionSet {
                 usage,
@@ -115,6 +116,7 @@ namespace Quickstarts.ConsoleReferenceClient
                 { "rc|reverseconnect=", "Connect using the reverse connect endpoint. (e.g. rc=opc.tcp://localhost:65300)", (string url) => reverseConnectUrlString = url},
                 { "forever", "run inner connect/disconnect loop forever", f => { if (f != null) forever = true; } },
                 { "leakchannels", "Leave a channel leak open when disconnecting a session.", l => { if (l != null) leakChannels = true; } },
+                { "ds|durablesubscription", "SetDurableSubscription example", ds => { if (ds != null) enableDurableSubscriptions = true; } },
             };
 
             ReverseConnectManager reverseConnectManager = null;
@@ -379,17 +381,51 @@ namespace Quickstarts.ConsoleReferenceClient
                             }
                             else
                             {
+                                int quitTimeout = 30_000;
+                                if (enableDurableSubscriptions)
+                                {
+                                    quitTimeout = 300_000;
+                                }
+
                                 // Run tests for available methods on reference server.
                                 samples.ReadNodes(uaClient.Session);
                                 samples.WriteNodes(uaClient.Session);
                                 samples.Browse(uaClient.Session);
                                 samples.CallMethod(uaClient.Session);
-                                samples.SubscribeToDataChanges(uaClient.Session, 120_000);
+                                samples.EnableEvents(uaClient.Session, (uint)quitTimeout);
+                                samples.SubscribeToDataChanges(uaClient.Session, 120_000, enableDurableSubscriptions);
 
                                 output.WriteLine("Waiting...");
 
                                 // Wait for some DataChange notifications from MonitoredItems
-                                quit = quitEvent.WaitOne(timeout > 0 ? waitTime : 30_000);
+                                int waitCounters = 0;
+                                int closeSessionTime = uaClient.ReconnectPeriod * 35;
+                                int restartSessionTime = uaClient.ReconnectPeriod * 65;
+                                while (!quit && waitCounters < quitTimeout)
+                                {
+                                    quit = quitEvent.WaitOne(uaClient.ReconnectPeriod);
+                                    waitCounters += uaClient.ReconnectPeriod;
+                                    if (enableDurableSubscriptions)
+                                    {
+                                        if (waitCounters == closeSessionTime)
+                                        {
+                                            if (uaClient.Session.SubscriptionCount == 1)
+                                            {
+                                                output.WriteLine("Closing Session at " + DateTime.Now.ToLongTimeString());
+                                                uaClient.Session.Close(closeChannel: false);
+                                            }
+                                        }
+
+                                        if (waitCounters == restartSessionTime)
+                                        {
+                                            output.WriteLine("Restarting Session at " + DateTime.Now.ToLongTimeString());
+                                            await uaClient.ReconnectAndTransfer(
+                                                serverUrl.ToString(),
+                                                useSecurity: !noSecurity,
+                                                quitCTS.Token);
+                                        }
+                                    }
+                                }
                             }
 
                             output.WriteLine("Client disconnected.");

--- a/Applications/ConsoleReferenceClient/UAClient.cs
+++ b/Applications/ConsoleReferenceClient/UAClient.cs
@@ -130,13 +130,9 @@ namespace Quickstarts
 
         #region Public Methods
         /// <summary>
-        /// 
+        /// Do a Durable Subscription Transfer
         /// </summary>
-        /// <param name="serverUrl"></param>
-        /// <param name="useSecurity"></param>
-        /// <param name="ct"></param>
-        /// <returns></returns>
-        public async Task<bool> ReconnectAndTransfer(string serverUrl, bool useSecurity = true, CancellationToken ct = default)
+        public async Task<bool> DurableSubscriptionTransfer(string serverUrl, bool useSecurity = true, CancellationToken ct = default)
         {
             bool success = false;
             SubscriptionCollection subscriptions = new SubscriptionCollection(m_session.Subscriptions);

--- a/Applications/ConsoleReferenceClient/UAClient.cs
+++ b/Applications/ConsoleReferenceClient/UAClient.cs
@@ -304,7 +304,7 @@ namespace Quickstarts
             try
             {
                 // check for events from discarded sessions.
-                if (!m_session.Equals(session))
+                if (m_session == null || !m_session.Equals(session))
                 {
                     return;
                 }

--- a/Applications/ConsoleReferenceClient/UAClient.cs
+++ b/Applications/ConsoleReferenceClient/UAClient.cs
@@ -130,6 +130,35 @@ namespace Quickstarts
 
         #region Public Methods
         /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="serverUrl"></param>
+        /// <param name="useSecurity"></param>
+        /// <param name="ct"></param>
+        /// <returns></returns>
+        public async Task<bool> ReconnectAndTransfer(string serverUrl, bool useSecurity = true, CancellationToken ct = default)
+        {
+            bool success = false;
+            SubscriptionCollection subscriptions = new SubscriptionCollection(m_session.Subscriptions);
+            m_session = null;
+            if (await ConnectAsync(serverUrl, useSecurity, ct))
+            {
+                if (subscriptions != null && m_session != null)
+                {
+                    m_output.WriteLine("Transferring " + subscriptions.Count.ToString() +
+                        " subscriptions from old session to new session...");
+                    success = m_session.TransferSubscriptions(subscriptions, true);
+                    if (success)
+                    {
+                        m_output.WriteLine("Subscriptions transferred.");
+                    }
+                }
+            }
+
+            return success;
+        }
+
+        /// <summary>
         /// Creates a session with the UA server
         /// </summary>
         public async Task<bool> ConnectAsync(string serverUrl, bool useSecurity = true, CancellationToken ct = default)

--- a/Libraries/Opc.Ua.Client/Subscription/Subscription.cs
+++ b/Libraries/Opc.Ua.Client/Subscription/Subscription.cs
@@ -1681,6 +1681,57 @@ namespace Opc.Ua.Client
             }
             return false;
         }
+
+        /// <summary>
+        /// Call the GetMonitoredItems method on the server.
+        /// </summary>
+        public bool GetMonitoredItems(out UInt32Collection serverHandles, out UInt32Collection clientHandles)
+        {
+            serverHandles = new UInt32Collection();
+            clientHandles = new UInt32Collection();
+            try
+            {
+                var outputArguments = m_session.Call(ObjectIds.Server, MethodIds.Server_GetMonitoredItems, m_transferId);
+                if (outputArguments != null && outputArguments.Count == 2)
+                {
+                    serverHandles.AddRange((uint[])outputArguments[0]);
+                    clientHandles.AddRange((uint[])outputArguments[1]);
+                    return true;
+                }
+            }
+            catch (ServiceResultException sre)
+            {
+                Utils.LogError(sre, "SubscriptionId {0}: Failed to call GetMonitoredItems on server", m_id);
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Set the subscription to durable.
+        /// </summary>
+        public bool SetSubscriptionDurable(uint lifetimeInHours, out uint revisedLifetimeInHours)
+        {
+            revisedLifetimeInHours = lifetimeInHours;
+
+            try
+            {
+                var outputArguments = m_session.Call(ObjectIds.Server,
+                    MethodIds.Server_SetSubscriptionDurable,
+                    m_id, lifetimeInHours);
+
+                if (outputArguments != null && outputArguments.Count == 1)
+                {
+                    revisedLifetimeInHours = (uint)outputArguments[0];
+                    return true;
+                }
+            }
+            catch (ServiceResultException sre)
+            {
+                Utils.LogError(sre, "SubscriptionId {0}: Failed to call SetSubscriptionDurable on server", m_id);
+            }
+
+            return false;
+        }
         #endregion
 
         #region Private Methods
@@ -1764,35 +1815,11 @@ namespace Opc.Ua.Client
             }
         }
 
-        /// <summary>
-        /// Call the GetMonitoredItems method on the server.
-        /// </summary>
-        private bool GetMonitoredItems(out UInt32Collection serverHandles, out UInt32Collection clientHandles)
-        {
-            serverHandles = new UInt32Collection();
-            clientHandles = new UInt32Collection();
-            try
-            {
-                var outputArguments = m_session.Call(ObjectIds.Server, MethodIds.Server_GetMonitoredItems, m_transferId);
-                if (outputArguments != null && outputArguments.Count == 2)
-                {
-                    serverHandles.AddRange((uint[])outputArguments[0]);
-                    clientHandles.AddRange((uint[])outputArguments[1]);
-                    return true;
-                }
-            }
-            catch (ServiceResultException sre)
-            {
-                Utils.LogError(sre, "SubscriptionId {0}: Failed to call GetMonitoredItems on server", m_id);
-            }
-            return false;
-        }
-
 #if CLIENT_ASYNC
         /// <summary>
         /// Call the GetMonitoredItems method on the server.
         /// </summary>
-        private async Task<(bool, UInt32Collection, UInt32Collection)> GetMonitoredItemsAsync(CancellationToken ct = default)
+        public async Task<(bool, UInt32Collection, UInt32Collection)> GetMonitoredItemsAsync(CancellationToken ct = default)
         {
             var serverHandles = new UInt32Collection();
             var clientHandles = new UInt32Collection();
@@ -1812,6 +1839,37 @@ namespace Opc.Ua.Client
             }
             return (false, serverHandles, clientHandles);
         }
+
+        /// <summary>
+        /// Set the subscription to durable.
+        /// </summary>
+        public async Task<(bool, UInt32)> SetSubscriptionDurableAsync(uint lifetimeInHours, CancellationToken ct = default)
+        {
+            uint revisedLifetimeInHours = lifetimeInHours;
+
+            try
+            {
+                var outputArguments = await m_session.CallAsync(
+                    ObjectIds.Server,
+                    MethodIds.Server_SetSubscriptionDurable,
+                    ct, m_transferId,
+                    lifetimeInHours).ConfigureAwait(false);
+
+                if (outputArguments != null && outputArguments.Count == 1)
+                {
+                    revisedLifetimeInHours = (uint)outputArguments[0];
+                    return (true, revisedLifetimeInHours);
+
+                }
+            }
+            catch (ServiceResultException sre)
+            {
+                Utils.LogError(sre, "SubscriptionId {0}: Failed to call SetSubscriptionDurable on server", m_id);
+            }
+
+            return (false, revisedLifetimeInHours);
+        }
+
 #endif
 
         /// <summary>

--- a/Tests/Opc.Ua.Client.Tests/ClientTest.cs
+++ b/Tests/Opc.Ua.Client.Tests/ClientTest.cs
@@ -1550,6 +1550,266 @@ namespace Opc.Ua.Client.Tests
             Assert.AreEqual(buildInfo.BuildNumber, values[5].Value);
             Assert.AreEqual(buildInfo.BuildDate, values[6].Value);
         }
+
+        /// <summary>
+        /// Happy SetSubscriptionDurable
+        /// </summary>
+        [Test, Order(11000)]
+        public void SetSubscriptionDurable_Success()
+        {
+            uint expectedRevised = 5;
+
+            List<object> outputParameters = new List<object>();
+            outputParameters.Add(expectedRevised);
+
+            Moq.Mock<ISession> sessionMock = new Mock<ISession>();
+
+            sessionMock.Setup(mock => mock.Call(
+                It.IsAny<NodeId>(),
+                It.IsAny<NodeId>(),
+                It.IsAny<uint>(),
+                It.IsAny<uint>()
+                ))
+                .Returns(outputParameters);
+
+            Subscription subscription = MockOutSubscriptionSession(sessionMock);
+
+            if (subscription.SetSubscriptionDurable(1, out uint revised))
+            {
+                Assert.AreEqual(expectedRevised, revised);
+            }
+            else
+            {
+                Assert.Fail("Unexpected Error in SetSubscriptionDurable");
+            }
+        }
+
+        /// <summary>
+        /// SetSubscriptionDurable Typical Failure 
+        /// </summary>
+        [Test, Order(11010)]
+        public void SetSubscriptionDurable_Exception()
+        {
+            Moq.Mock<ISession> sessionMock = new Mock<ISession>();
+
+            sessionMock.Setup(mock => mock.Call(
+                It.IsAny<NodeId>(),
+                It.IsAny<NodeId>(),
+                It.IsAny<uint>(),
+                It.IsAny<uint>()
+                ))
+                .Throws(new ServiceResultException(StatusCodes.BadSubscriptionIdInvalid));
+
+            Subscription subscription = MockOutSubscriptionSession(sessionMock);
+
+            Assert.IsFalse(subscription.SetSubscriptionDurable(1, out uint revised));
+        }
+
+        /// <summary>
+        /// SetSubscriptionDurable No Output Parameters
+        /// Not an expected case
+        /// </summary>
+        [Test, Order(11020)]
+        public void SetSubscriptionDurable_NoOutputParameters()
+        {
+            List<object> outputParameters = new List<object>();
+
+            Moq.Mock<ISession> sessionMock = new Mock<ISession>();
+
+            sessionMock.Setup(mock => mock.Call(
+                It.IsAny<NodeId>(),
+                It.IsAny<NodeId>(),
+                It.IsAny<uint>(),
+                It.IsAny<uint>()
+                ))
+                .Returns(outputParameters);
+
+            Subscription subscription = MockOutSubscriptionSession(sessionMock);
+
+            Assert.IsFalse(subscription.SetSubscriptionDurable(1, out uint revised));
+        }
+
+        /// <summary>
+        /// SetSubscriptionDurable No Output Parameters
+        /// Not an expected case
+        /// </summary>
+        [Test, Order(11030)]
+        public void SetSubscriptionDurable_NullOutputParameters()
+        {
+            List<object> outputParameters = null;
+
+            Moq.Mock<ISession> sessionMock = new Mock<ISession>();
+
+            sessionMock.Setup(mock => mock.Call(
+                It.IsAny<NodeId>(),
+                It.IsAny<NodeId>(),
+                It.IsAny<uint>(),
+                It.IsAny<uint>()
+                ))
+                .Returns(outputParameters);
+
+            Subscription subscription = MockOutSubscriptionSession(sessionMock);
+
+            Assert.IsFalse(subscription.SetSubscriptionDurable(1, out uint revised));
+        }
+
+        /// <summary>
+        /// SetSubscriptionDurable with in invalid number of Output Parameters
+        /// Not an expected case
+        /// </summary>
+        [Test, Order(11040)]
+        public void SetSubscriptionDurable_TooManyOutputParameters()
+        {
+            uint expectedRevised = 5;
+
+            List<object> outputParameters = new List<object>();
+            outputParameters.Add(expectedRevised);
+            outputParameters.Add(expectedRevised);
+
+            Moq.Mock<ISession> sessionMock = new Mock<ISession>();
+
+            sessionMock.Setup(mock => mock.Call(
+                It.IsAny<NodeId>(),
+                It.IsAny<NodeId>(),
+                It.IsAny<uint>(),
+                It.IsAny<uint>()
+                ))
+                .Returns(outputParameters);
+
+            Subscription subscription = MockOutSubscriptionSession(sessionMock);
+
+            Assert.IsFalse(subscription.SetSubscriptionDurable(1, out uint revised));
+        }
+
+        /// <summary>
+        /// GetMonitoredItems Success Case
+        /// </summary>
+        [Test, Order(11100)]
+        public void GetMonitoredItems_Success()
+        {
+            List<object> outputParameters = new List<object>();
+            outputParameters.Add(new uint[] { 1, 2, 3, 4, 5 });
+            outputParameters.Add(new uint[] { 6, 7, 8, 9, 10 });
+
+            Moq.Mock<ISession> sessionMock = new Mock<ISession>();
+
+            sessionMock.Setup(mock => mock.Call(
+                It.IsAny<NodeId>(),
+                It.IsAny<NodeId>(),
+                It.IsAny<uint>()
+                ))
+                .Returns(outputParameters);
+
+            Subscription subscription = MockOutSubscriptionSession(sessionMock);
+
+            UInt32Collection serverHandles;
+            UInt32Collection clientHandles;
+            Assert.IsTrue(subscription.GetMonitoredItems(out serverHandles, out clientHandles));
+            Assert.AreEqual(5, serverHandles.Count);
+            Assert.AreEqual(5, clientHandles.Count);
+        }
+
+        /// <summary>
+        /// GetMonitoredItems Error Case
+        /// </summary>
+        [Test, Order(11110)]
+        public void GetMonitoredItems_Exception()
+        {
+            Moq.Mock<ISession> sessionMock = new Mock<ISession>();
+
+            sessionMock.Setup(mock => mock.Call(
+                It.IsAny<NodeId>(),
+                It.IsAny<NodeId>(),
+                It.IsAny<uint>()
+                ))
+                .Throws(new ServiceResultException(StatusCodes.BadSubscriptionIdInvalid));
+
+            Subscription subscription = MockOutSubscriptionSession(sessionMock);
+
+            Assert.IsFalse(subscription.GetMonitoredItems(
+                out UInt32Collection serverHandles,
+                out UInt32Collection clientHandles));
+        }
+
+        /// <summary>
+        /// GetMonitoredItems No Output Parameters
+        /// Not an expected case
+        /// </summary>
+        [Test, Order(11120)]
+        public void GetMonitoredItems_NoOutputParameters()
+        {
+            List<object> outputParameters = new List<object>();
+
+            Moq.Mock<ISession> sessionMock = new Mock<ISession>();
+
+            sessionMock.Setup(mock => mock.Call(
+                It.IsAny<NodeId>(),
+                It.IsAny<NodeId>(),
+                It.IsAny<uint>()
+                ))
+                .Returns(outputParameters);
+
+            Subscription subscription = MockOutSubscriptionSession(sessionMock);
+
+            Assert.IsFalse(subscription.GetMonitoredItems(
+                out UInt32Collection serverHandles,
+                out UInt32Collection clientHandles));
+        }
+
+        /// <summary>
+        /// GetMonitoredItems Null Output Parameters
+        /// Not an expected case
+        /// </summary>
+        [Test, Order(11130)]
+        public void GetMonitoredItems_NullOutputParameters()
+        {
+            List<object> outputParameters = null;
+
+            Moq.Mock<ISession> sessionMock = new Mock<ISession>();
+
+            sessionMock.Setup(mock => mock.Call(
+                It.IsAny<NodeId>(),
+                It.IsAny<NodeId>(),
+                It.IsAny<uint>()
+                ))
+                .Returns(outputParameters);
+
+            Subscription subscription = MockOutSubscriptionSession(sessionMock);
+
+            Assert.IsFalse(subscription.GetMonitoredItems(
+                out UInt32Collection serverHandles,
+                out UInt32Collection clientHandles));
+        }
+
+        /// <summary>
+        /// GetMonitoredItems invalid number of Output Parameters
+        /// Not an expected case
+        /// </summary>
+        [Test, Order(11140)]
+        public void GetMonitoredItems_TooManyOutputParameters()
+        {
+            List<object> outputParameters = new List<object>();
+            outputParameters.Add(new uint[] { 1, 2, 3, 4, 5 });
+            outputParameters.Add(new uint[] { 6, 7, 8, 9, 10 });
+            outputParameters.Add(new uint[] { 11, 12, 13, 14, 15 });
+
+            Moq.Mock<ISession> sessionMock = new Mock<ISession>();
+
+            sessionMock.Setup(mock => mock.Call(
+                It.IsAny<NodeId>(),
+                It.IsAny<NodeId>(),
+                It.IsAny<uint>()
+                ))
+                .Returns(outputParameters);
+
+            Subscription subscription = MockOutSubscriptionSession(sessionMock);
+
+            Assert.IsFalse(subscription.GetMonitoredItems(
+                out UInt32Collection serverHandles,
+                out UInt32Collection clientHandles));
+        }
+
+
         #endregion
 
         #region Benchmarks
@@ -1572,6 +1832,19 @@ namespace Opc.Ua.Client.Tests
                 Assert.NotZero(clientLimit);
             }
         }
+
+        private Subscription MockOutSubscriptionSession(Moq.Mock<ISession> sessionMock)
+        {
+            Subscription subscription = new Subscription();
+            Type subscriptionType = subscription.GetType();
+            System.Reflection.FieldInfo sessionFieldInfo = subscriptionType.GetField("m_session",
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+
+            Assert.IsNotNull(sessionFieldInfo);
+            sessionFieldInfo.SetValue(subscription, sessionMock.Object);
+            return subscription;
+        }
+
         #endregion
     }
 }


### PR DESCRIPTION
## Proposed changes

Implement a helper method in Opc.Ua.Client.Subscription that calls the Server SetSubscriptionDurable method.

In the ConsoleReferenceClient, Implement a sample implementation that shows the functionality of SetSubscriptionDurable from the client's perspective of pausing a subscription, then creating a new session and subscription and after transfer, retrieve all values with loosing any.

Also in ConsoleReferenceClient, allow for the retrieval of event data, with and without Durable Subscriptions.

## Related Issues

https://github.com/orgs/OPCFoundation/projects/1/views/18 Task 1 - Addfunctionto client SDK to support SetSubscriptionDurable

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [x] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [x] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments
