### PR TITLE
Client ReadNodes, throw BadInvalidType if a value type returned by an attribute is null

### DIFF
--- a/Libraries/Opc.Ua.Client/Session/Session.cs
+++ b/Libraries/Opc.Ua.Client/Session/Session.cs
@@ -4409,7 +4409,7 @@ namespace Opc.Ua.Client
                         throw ServiceResultException.Create(StatusCodes.BadUnexpectedError, "Object does not support the EventNotifier attribute.");
                     }
 
-                    objectNode.EventNotifier = (byte)value.GetValue(typeof(byte));
+                    objectNode.EventNotifier = value.GetValueOrDefault<byte>();
                     node = objectNode;
                     break;
                 }
@@ -4425,7 +4425,7 @@ namespace Opc.Ua.Client
                         throw ServiceResultException.Create(StatusCodes.BadUnexpectedError, "ObjectType does not support the IsAbstract attribute.");
                     }
 
-                    objectTypeNode.IsAbstract = (bool)value.GetValue(typeof(bool));
+                    objectTypeNode.IsAbstract = value.GetValueOrDefault<bool>();
                     node = objectTypeNode;
                     break;
                 }
@@ -4452,7 +4452,7 @@ namespace Opc.Ua.Client
                         throw ServiceResultException.Create(StatusCodes.BadUnexpectedError, "Variable does not support the ValueRank attribute.");
                     }
 
-                    variableNode.ValueRank = (int)value.GetValue(typeof(int));
+                    variableNode.ValueRank = value.GetValueOrDefault<int>();
 
                     // ArrayDimensions Attribute
                     value = attributes[Attributes.ArrayDimensions];
@@ -4477,7 +4477,7 @@ namespace Opc.Ua.Client
                         throw ServiceResultException.Create(StatusCodes.BadUnexpectedError, "Variable does not support the AccessLevel attribute.");
                     }
 
-                    variableNode.AccessLevel = (byte)value.GetValue(typeof(byte));
+                    variableNode.AccessLevel = value.GetValueOrDefault<byte>();
 
                     // UserAccessLevel Attribute
                     value = attributes[Attributes.UserAccessLevel];
@@ -4487,7 +4487,7 @@ namespace Opc.Ua.Client
                         throw ServiceResultException.Create(StatusCodes.BadUnexpectedError, "Variable does not support the UserAccessLevel attribute.");
                     }
 
-                    variableNode.UserAccessLevel = (byte)value.GetValue(typeof(byte));
+                    variableNode.UserAccessLevel = value.GetValueOrDefault<byte>();
 
                     // Historizing Attribute
                     value = attributes[Attributes.Historizing];
@@ -4497,7 +4497,7 @@ namespace Opc.Ua.Client
                         throw ServiceResultException.Create(StatusCodes.BadUnexpectedError, "Variable does not support the Historizing attribute.");
                     }
 
-                    variableNode.Historizing = (bool)value.GetValue(typeof(bool));
+                    variableNode.Historizing = value.GetValueOrDefault<bool>();
 
                     // MinimumSamplingInterval Attribute
                     value = attributes[Attributes.MinimumSamplingInterval];
@@ -4512,7 +4512,7 @@ namespace Opc.Ua.Client
 
                     if (value != null)
                     {
-                        variableNode.AccessLevelEx = (uint)value.GetValue(typeof(uint));
+                        variableNode.AccessLevelEx = value.GetValueOrDefault<uint>();
                     }
 
                     node = variableNode;
@@ -4531,7 +4531,7 @@ namespace Opc.Ua.Client
                         throw ServiceResultException.Create(StatusCodes.BadUnexpectedError, "VariableType does not support the IsAbstract attribute.");
                     }
 
-                    variableTypeNode.IsAbstract = (bool)value.GetValue(typeof(bool));
+                    variableTypeNode.IsAbstract = value.GetValueOrDefault<bool>();
 
                     // DataType Attribute
                     value = attributes[Attributes.DataType];
@@ -4551,7 +4551,7 @@ namespace Opc.Ua.Client
                         throw ServiceResultException.Create(StatusCodes.BadUnexpectedError, "VariableType does not support the ValueRank attribute.");
                     }
 
-                    variableTypeNode.ValueRank = (int)value.GetValue(typeof(int));
+                    variableTypeNode.ValueRank = value.GetValueOrDefault<int>();
 
                     // ArrayDimensions Attribute
                     value = attributes[Attributes.ArrayDimensions];
@@ -4577,7 +4577,7 @@ namespace Opc.Ua.Client
                         throw ServiceResultException.Create(StatusCodes.BadUnexpectedError, "Method does not support the Executable attribute.");
                     }
 
-                    methodNode.Executable = (bool)value.GetValue(typeof(bool));
+                    methodNode.Executable = value.GetValueOrDefault<bool>();
 
                     // UserExecutable Attribute
                     value = attributes[Attributes.UserExecutable];
@@ -4587,7 +4587,7 @@ namespace Opc.Ua.Client
                         throw ServiceResultException.Create(StatusCodes.BadUnexpectedError, "Method does not support the UserExecutable attribute.");
                     }
 
-                    methodNode.UserExecutable = (bool)value.GetValue(typeof(bool));
+                    methodNode.UserExecutable = value.GetValueOrDefault<bool>();
 
                     node = methodNode;
                     break;
@@ -4605,7 +4605,7 @@ namespace Opc.Ua.Client
                         throw ServiceResultException.Create(StatusCodes.BadUnexpectedError, "DataType does not support the IsAbstract attribute.");
                     }
 
-                    dataTypeNode.IsAbstract = (bool)value.GetValue(typeof(bool));
+                    dataTypeNode.IsAbstract = value.GetValueOrDefault<bool>();
 
                     // DataTypeDefinition Attribute
                     value = attributes[Attributes.DataTypeDefinition];
@@ -4631,7 +4631,7 @@ namespace Opc.Ua.Client
                         throw ServiceResultException.Create(StatusCodes.BadUnexpectedError, "ReferenceType does not support the IsAbstract attribute.");
                     }
 
-                    referenceTypeNode.IsAbstract = (bool)value.GetValue(typeof(bool));
+                    referenceTypeNode.IsAbstract = value.GetValueOrDefault<bool>();
 
                     // Symmetric Attribute
                     value = attributes[Attributes.Symmetric];
@@ -4641,7 +4641,7 @@ namespace Opc.Ua.Client
                         throw ServiceResultException.Create(StatusCodes.BadUnexpectedError, "ReferenceType does not support the Symmetric attribute.");
                     }
 
-                    referenceTypeNode.Symmetric = (bool)value.GetValue(typeof(bool));
+                    referenceTypeNode.Symmetric = value.GetValueOrDefault<bool>();
 
                     // InverseName Attribute
                     value = attributes[Attributes.InverseName];
@@ -4667,7 +4667,7 @@ namespace Opc.Ua.Client
                         throw ServiceResultException.Create(StatusCodes.BadUnexpectedError, "View does not support the EventNotifier attribute.");
                     }
 
-                    viewNode.EventNotifier = (byte)value.GetValue(typeof(byte));
+                    viewNode.EventNotifier = value.GetValueOrDefault<byte>();
 
                     // ContainsNoLoops Attribute
                     value = attributes[Attributes.ContainsNoLoops];
@@ -4677,7 +4677,7 @@ namespace Opc.Ua.Client
                         throw ServiceResultException.Create(StatusCodes.BadUnexpectedError, "View does not support the ContainsNoLoops attribute.");
                     }
 
-                    viewNode.ContainsNoLoops = (bool)value.GetValue(typeof(bool));
+                    viewNode.ContainsNoLoops = value.GetValueOrDefault<bool>();
 
                     node = viewNode;
                     break;
@@ -4728,14 +4728,14 @@ namespace Opc.Ua.Client
             if (attributes.TryGetValue(Attributes.WriteMask, out value) &&
                 value != null)
             {
-                node.WriteMask = (uint)value.GetValue(typeof(uint));
+                node.WriteMask = value.GetValueOrDefault<uint>();
             }
 
             // UserWriteMask Attribute
             if (attributes.TryGetValue(Attributes.UserWriteMask, out value) &&
                 value != null)
             {
-                node.UserWriteMask = (uint)value.GetValue(typeof(uint));
+                node.UserWriteMask = value.GetValueOrDefault<uint>();
             }
 
             // RolePermissions Attribute
@@ -4776,7 +4776,7 @@ namespace Opc.Ua.Client
             if (attributes.TryGetValue(Attributes.AccessRestrictions, out value) &&
                 value != null)
             {
-                node.AccessRestrictions = (ushort)value.GetValue(typeof(ushort));
+                node.AccessRestrictions = value.GetValueOrDefault<ushort>();
             }
 
             return node;

--- a/Libraries/Opc.Ua.Client/Session/Session.cs
+++ b/Libraries/Opc.Ua.Client/Session/Session.cs
@@ -1692,9 +1692,6 @@ namespace Opc.Ua.Client
             }
         }
 
-
-
-
         /// <inheritdoc/>
         public void FetchTypeTree(ExpandedNodeId typeId)
         {
@@ -4404,7 +4401,7 @@ namespace Opc.Ua.Client
 
                     value = attributes[Attributes.EventNotifier];
 
-                    if (value == null || value.Value is null)
+                    if (value == null)
                     {
                         throw ServiceResultException.Create(StatusCodes.BadUnexpectedError, "Object does not support the EventNotifier attribute.");
                     }

--- a/Stack/Opc.Ua.Core/Types/BuiltIn/DataValue.cs
+++ b/Stack/Opc.Ua.Core/Types/BuiltIn/DataValue.cs
@@ -591,6 +591,50 @@ namespace Opc.Ua
 
         /// <summary>
         /// Gets the value from the data value.
+        /// Returns default value for bad status.
+        /// </summary>
+        /// <typeparam name="T">The type of object.</typeparam>
+        /// <returns>The value.</returns>
+        /// <remarks>
+        /// Checks the StatusCode and returns default value for bad status.
+        /// Extracts the body from an ExtensionObject value if it has the correct type.
+        /// Throws exception only if there is a type mismatch; 
+        /// </remarks>
+        public T GetValueOrDefault<T>()
+        {
+            // return default for a DataValue with bad status code.
+            if (StatusCode.IsBad(this.StatusCode))
+            {
+                return default;
+            }
+
+            object value = this.Value;
+            if (value != null)
+            {
+                if (value is ExtensionObject extension)
+                {
+                    value = extension.Body;
+                }
+
+                if (!typeof(T).IsInstanceOfType(value))
+                {
+                    throw ServiceResultException.Create(StatusCodes.BadTypeMismatch, "DataValue is not of type {0}.", typeof(T).Name);
+                }
+
+                return (T)value;
+            }
+
+            // a null value for a value type should throw
+            if (typeof(T).IsValueType)
+            {
+                throw ServiceResultException.Create(StatusCodes.BadTypeMismatch, "DataValue is null and not of value type {0}.", typeof(T).Name);
+            }
+
+            return default;
+        }
+
+        /// <summary>
+        /// Gets the value from the data value.
         /// </summary>
         /// <typeparam name="T">The type of object.</typeparam>
         /// <param name="defaultValue">The default value to return if any error occurs.</param>

--- a/Tests/Opc.Ua.Core.Tests/Security/Certificates/CertificateValidatorTest.cs
+++ b/Tests/Opc.Ua.Core.Tests/Security/Certificates/CertificateValidatorTest.cs
@@ -301,7 +301,7 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
                         Assert.AreEqual((StatusCode)StatusCodes.BadCertificateUntrusted, (StatusCode)serviceResultException.StatusCode, serviceResultException.Message);
                     }
 
-                    Thread.Sleep(1000);
+                    await Task.Delay(1000).ConfigureAwait(false);
                     Assert.AreEqual(m_appSelfSignedCerts.Count, validator.RejectedStore.Enumerate().Result.Count);
                 }
             }
@@ -383,7 +383,7 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
                     certValidator.MaxRejectedCertificates = 3;
                     await Task.Delay(1000).ConfigureAwait(false);
                     certificates = await validator.RejectedStore.Enumerate().ConfigureAwait(false);
-                    Assert.LessOrEqual(3, certificates.Count);
+                    Assert.GreaterOrEqual(3, certificates.Count);
 
                     // test setter if allcerts are deleted
                     certValidator.MaxRejectedCertificates = -1;


### PR DESCRIPTION
## Proposed changes

Handle a case where a misconfigured server returns a null value for an attribute when a value type is expected. To avoid the NullReferenceException that stops the whole ReadNodes operation, flag the Node with the service result and or return a default value if required.

## Related Issues

More comprehensive fix for
- Fixes #2729, 
- Fixes #2638 

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
