### PR TITLE
Use HiresClock ticks instead of DateTime for IntervalRunner publish time calculation

### DIFF
--- a/Libraries/Opc.Ua.PubSub/IntervalRunner.cs
+++ b/Libraries/Opc.Ua.PubSub/IntervalRunner.cs
@@ -192,7 +192,7 @@ namespace Opc.Ua.PubSub
                 }
                 else if (sleepCycle >= 0 && sleepCycle <= 16)
                 {
-                    while (HiResClock.Ticks < m_nextPublishTick)
+                    while (HiResClock.Ticks < nextPublishTick)
                     {
                         // Busy-wait and avoid overhead of Task.Delay for verry small wait times
                     }

--- a/Libraries/Opc.Ua.PubSub/IntervalRunner.cs
+++ b/Libraries/Opc.Ua.PubSub/IntervalRunner.cs
@@ -184,18 +184,12 @@ namespace Opc.Ua.PubSub
                     nowTick = HiResClock.Ticks;
                     if (nowTick < nextPublishTick)
                     {
-                        while (HiResClock.Ticks < nextPublishTick)
-                        {
-                            // Busy-wait and avoid overhead of Task.Delay for verry small wait times
-                        }
+                        SpinWait.SpinUntil(() => HiResClock.Ticks >= nextPublishTick);
                     }
                 }
                 else if (sleepCycle >= 0 && sleepCycle <= 16)
                 {
-                    while (HiResClock.Ticks < nextPublishTick)
-                    {
-                        // Busy-wait and avoid overhead of Task.Delay for verry small wait times
-                    }
+                    SpinWait.SpinUntil(() => HiResClock.Ticks >= nextPublishTick);
                 }
                     
                 lock (m_lock)

--- a/Tests/Opc.Ua.PubSub.Tests/Configuration/UaPublisherTests.cs
+++ b/Tests/Opc.Ua.PubSub.Tests/Configuration/UaPublisherTests.cs
@@ -45,9 +45,9 @@ namespace Opc.Ua.PubSub.Tests.Configuration
 
         [Test(Description = "Test that PublishMessage method is called after a UAPublisher is started.")]
         [Combinatorial]
-        //#if !CUSTOM_TESTS
-        //[Ignore("This test should be executed locally")]
-        //#endif
+#if !CUSTOM_TESTS
+        [Ignore("This test should be executed locally")]
+#endif
         public void ValidateUaPublisherPublishIntervalDeviation(
             [Values(100, 1000, 2000)] double publishingInterval,
             [Values(30, 40)] double maxDeviation,

--- a/Tests/Opc.Ua.PubSub.Tests/Configuration/UaPublisherTests.cs
+++ b/Tests/Opc.Ua.PubSub.Tests/Configuration/UaPublisherTests.cs
@@ -37,28 +37,34 @@ using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace Opc.Ua.PubSub.Tests.Configuration
 {
-    [TestFixture(Description = "Tests for UAPublisher class")]
+    [TestFixture(Description = "Tests for UAPublisher class"), SingleThreaded]
     public class UaPublisherTests
     {
-        static IList<DateTime> s_publishTimes = new List<DateTime>();
+        static List<long> s_publishTicks = new List<long>();
+        static object s_lock = new Object();
 
         [Test(Description = "Test that PublishMessage method is called after a UAPublisher is started.")]
         [Combinatorial]
-#if !CUSTOM_TESTS
-        [Ignore("This test should be executed locally")]
-#endif
+        //#if !CUSTOM_TESTS
+        //[Ignore("This test should be executed locally")]
+        //#endif
         public void ValidateUaPublisherPublishIntervalDeviation(
             [Values(100, 1000, 2000)] double publishingInterval,
             [Values(30, 40)] double maxDeviation,
             [Values(10)] int publishTimeInSeconds)
         {
             //Arrange
-            s_publishTimes.Clear();
+            s_publishTicks.Clear();
             var mockConnection = new Mock<IUaPubSubConnection>();
             mockConnection.Setup(x => x.CanPublish(It.IsAny<WriterGroupDataType>())).Returns(true);
 
             mockConnection.Setup(x => x.CreateNetworkMessages(It.IsAny<WriterGroupDataType>(), It.IsAny<WriterGroupPublishState>()))
-                .Callback(() => s_publishTimes.Add(DateTime.Now));
+                .Callback(() => {
+                    lock (s_lock)
+                    {
+                        s_publishTicks.Add(HiResClock.Ticks);
+                    }
+                });
 
             WriterGroupDataType writerGroupDataType = new WriterGroupDataType();
             writerGroupDataType.PublishingInterval = publishingInterval;
@@ -70,25 +76,38 @@ namespace Opc.Ua.PubSub.Tests.Configuration
             //wait so many seconds
             Thread.Sleep(publishTimeInSeconds * 1000);
             publisher.Stop();
+
             int faultIndex = -1;
             double faultDeviation = 0;
 
-            s_publishTimes = (from t in s_publishTimes
+            s_publishTicks = (from t in s_publishTicks
                               orderby t
                               select t).ToList();
 
             //Assert
-            for (int i = 1; i < s_publishTimes.Count; i++)
+            for (int i = 1; i < s_publishTicks.Count; i++)
             {
-                double interval = s_publishTimes[i].Subtract(s_publishTimes[i - 1]).TotalMilliseconds;
-                double deviation = Math.Abs(publishingInterval - interval);
-                if (deviation >= maxDeviation && deviation > faultDeviation)
+                double interval = (s_publishTicks[i] - s_publishTicks[i - 1])/HiResClock.TicksPerMillisecond;
+                if (interval != 0)
                 {
-                    faultIndex = i;
-                    faultDeviation = deviation;
+                    double deviation = -1;
+                    if (interval != publishingInterval)
+                    {
+                        deviation = Math.Abs(publishingInterval - interval);
+                    }
+                    if (deviation >= maxDeviation && deviation > faultDeviation)
+                    {
+                        faultIndex = i;
+                        faultDeviation = deviation;
+                    }
                 }
             }
-            Assert.IsTrue(faultIndex < 0, "publishingInterval={0}, maxDeviation={1}, publishTimeInSecods={2}, deviation[{3}] = {4} has maximum deviation", publishingInterval, maxDeviation, publishTimeInSeconds, faultIndex, faultDeviation);
+            Assert.IsTrue(faultIndex < 0, "publishingInterval={0}, maxDeviation={1}, publishTimeInSecods={2}, deviation[{3}] = {4} as max deviation",
+                publishingInterval,
+                maxDeviation,
+                publishTimeInSeconds,
+                faultIndex,
+                faultDeviation);
         }
     }
 }


### PR DESCRIPTION
Use HiresClock instead of DateTime for IntervalRunner publish time calculation

## Proposed changes

PubSub IntervalRunner used System clock dependent DateTime values for calculating the publish time, which may produce wrong time values and all consequences that derive from this.
This PR replaces DateTime values in the time calculation with HiresClock (Stopwatch) monotonic values.

## Related Issues

- Fixes #2740 

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [x] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
