### PR TITLE
Do not create the default folders for DirectoryStore on Open

### DIFF
--- a/Stack/Opc.Ua.Core/Security/Certificates/DirectoryCertificateStore.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/DirectoryCertificateStore.cs
@@ -109,7 +109,7 @@ namespace Opc.Ua
                     NoPrivateKeys = noPrivateKeys;
                     StorePath = location;
                     m_directory = directory;
-                    if (m_noSubDirs)
+                    if (m_noSubDirs || m_directory == null)
                     {
                         m_certificateSubdir = m_directory;
                         m_crlSubdir = m_directory;
@@ -125,39 +125,6 @@ namespace Opc.Ua
                     // force load
                     ClearCertificates();
                     m_lastDirectoryCheck = DateTime.MinValue;
-
-                    // create folders if they do not exist
-                    try
-                    {
-                        if (!m_directory.Exists)
-                        {
-                            m_directory.Create();
-                        }
-
-                        if (!m_certificateSubdir.Exists)
-                        {
-                            m_certificateSubdir.Create();
-                        }
-
-                        if (noPrivateKeys)
-                        {
-                            if (!m_crlSubdir.Exists)
-                            {
-                                m_crlSubdir.Create();
-                            }
-                        }
-                        else
-                        {
-                            if (!m_privateKeySubdir.Exists)
-                            {
-                                m_privateKeySubdir.Create();
-                            }
-                        }
-                    }
-                    catch (IOException ex)
-                    {
-                        Utils.LogError("Failed to create certificate store: {0}", ex.Message);
-                    }
                 }
             }
         }
@@ -527,7 +494,7 @@ namespace Opc.Ua
 #if NETSTANDARD2_1_OR_GREATER || NET472_OR_GREATER || NET5_0_OR_GREATER
                         if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
                         {
-                            defaultStorageSet |= X509KeyStorageFlags.EphemeralKeySet;
+                            // defaultStorageSet |= X509KeyStorageFlags.EphemeralKeySet;
                         }
 #endif
 

--- a/Stack/Opc.Ua.Core/Security/Certificates/DirectoryCertificateStore.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/DirectoryCertificateStore.cs
@@ -792,7 +792,7 @@ namespace Opc.Ua
                 DateTime now = DateTime.UtcNow;
 
                 // refresh the directories.
-                m_certificateSubdir.Refresh();
+                m_certificateSubdir?.Refresh();
 
                 if (!NoPrivateKeys)
                 {
@@ -800,9 +800,8 @@ namespace Opc.Ua
                 }
 
                 // check if store exists.
-                if (!m_certificateSubdir.Exists)
+                if (m_certificateSubdir?.Exists != true)
                 {
-                    m_certificateSubdir.Create();
                     ClearCertificates();
                     return m_certificates;
                 }


### PR DESCRIPTION
## Proposed changes

For convenience, the DirectoryStore class creates the default folders when the DirectoryStore is opened. (since #2720)
However this may lead into issues mapping folders to the store when started in docker.

Fix: remove the code which creates default folders and ensure a null directory does not throw a NullReferenceException.

## Related Issues

- Fixes #2720

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
