### PR TITLE
[Server] GDS Push: Enable regeneratePrivatekey for CreateSigningRequest method of Server

### DIFF
--- a/Libraries/Opc.Ua.Server/Configuration/ConfigurationNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/Configuration/ConfigurationNodeManager.cs
@@ -446,14 +446,10 @@ namespace Opc.Ua.Server
                         case "":
                         {
                             X509Certificate2 exportableKey;
-                            //use new generated private key if one exists and matches new certificate
+                            //use the new generated private key if one exists and matches the provided public key
                             if (certificateGroup.TemporaryApplicationCertificate != null && X509Utils.VerifyRSAKeyPair(newCert, certificateGroup.TemporaryApplicationCertificate))
                             {
                                 exportableKey = X509Utils.CreateCopyWithPrivateKey(certificateGroup.TemporaryApplicationCertificate, false);
-
-                                certificateGroup.TemporaryApplicationCertificate.Dispose();
-                                certificateGroup.TemporaryApplicationCertificate = null;
-
                             }
                             else
                             {
@@ -476,6 +472,10 @@ namespace Opc.Ua.Server
                             break;
                         }
                     }
+                    //dispose temporary new private key as it is no longer needed
+                    certificateGroup.TemporaryApplicationCertificate?.Dispose();
+                    certificateGroup.TemporaryApplicationCertificate = null;
+
                     updateCertificate.IssuerCollection = newIssuerCollection;
                     updateCertificate.SessionId = context.SessionId;
                 }

--- a/Libraries/Opc.Ua.Server/Configuration/ConfigurationNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/Configuration/ConfigurationNodeManager.cs
@@ -575,17 +575,17 @@ namespace Opc.Ua.Server
 
             if (regeneratePrivateKey)
             {
-                TimeSpan lifetime = certWithPrivateKey.NotAfter - certWithPrivateKey.NotBefore;
-                ushort keySize = (ushort)(certWithPrivateKey.GetRSAPrivateKey()?.KeySize ?? 0);
+                ushort keySize = (ushort)(certWithPrivateKey.GetRSAPublicKey()?.KeySize ?? 0);
 
                 certWithPrivateKey = CertificateFactory.CreateCertificate(
-                m_configuration.ApplicationUri,
-                m_configuration.ApplicationName,
-                certificateGroup.ApplicationCertificate.SubjectName,
-                X509Utils.GetDomainsFromCertificate(certificateGroup.ApplicationCertificate.Certificate))
-                .SetLifeTime(lifetime)
-                .SetRSAKeySize(keySize)
-                .CreateForRSA();
+                    m_configuration.ApplicationUri,
+                    null,
+                    certificateGroup.ApplicationCertificate.SubjectName,
+                    null)
+                    .SetNotBefore(DateTime.Today.AddDays(-1))
+                    .SetNotAfter(DateTime.Today.AddDays(14))
+                    .SetRSAKeySize(keySize)
+                    .CreateForRSA();
 
                 certificateGroup.TemporaryApplicationCertificate = certWithPrivateKey;
             }

--- a/Tests/Opc.Ua.Gds.Tests/PushTest.cs
+++ b/Tests/Opc.Ua.Gds.Tests/PushTest.cs
@@ -379,8 +379,19 @@ namespace Opc.Ua.Gds.Tests
             }
         }
 
+        [Test, Order(509)]
+        public void UpdateCertificateCASignedRegeneratePrivateKey()
+        {
+            UpdateCertificateCASigned(true);
+        }
+
         [Test, Order(510)]
         public void UpdateCertificateCASigned()
+        {
+            UpdateCertificateCASigned(false);
+        }
+
+        public void UpdateCertificateCASigned(bool regeneratePrivateKey = false)
         {
 #if NETCOREAPP3_1_OR_GREATER
             // this test fails on macOS, ignore
@@ -396,7 +407,7 @@ namespace Opc.Ua.Gds.Tests
                 null,
                 m_pushClient.PushClient.ApplicationCertificateType,
                 null,
-                false,
+                regeneratePrivateKey,
                 null);
             Assert.IsNotNull(csr);
             TestContext.Out.WriteLine("Start Signing Request");
@@ -613,7 +624,7 @@ namespace Opc.Ua.Gds.Tests
             }, Throws.Exception);
 
             m_pushClient.PushClient.GetCertificates(m_pushClient.PushClient.DefaultApplicationGroup, out NodeId[] certificateTypeIds, out byte[][] certificates);
-            
+
             Assert.That(certificateTypeIds.Length == 1);
             Assert.NotNull(certificates[0]);
             using (var x509 = new X509Certificate2(certificates[0]))


### PR DESCRIPTION
## Proposed changes

Enable the server to generate a new application Certificate Private key when the client requests so in the CreateSigningRequest method.

## Related Issues

- Fixes #2774 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [x] I ran tests locally with my changes, all passed.
- [] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments


