### PR TITLE
[Client] Read large dictionaries

### DIFF
--- a/Libraries/Opc.Ua.Client/DataDictionary.cs
+++ b/Libraries/Opc.Ua.Client/DataDictionary.cs
@@ -31,6 +31,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.ExceptionServices;
 using System.Runtime.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
@@ -313,27 +314,53 @@ namespace Opc.Ua.Client
             // read value.
             DataValueCollection values;
             DiagnosticInfoCollection diagnosticInfos;
-
-            ResponseHeader responseHeader = m_session.Read(
-                null,
-                0,
-                TimestampsToReturn.Neither,
-                itemsToRead,
-                out values,
-                out diagnosticInfos);
-
-            ClientBase.ValidateResponse(values, itemsToRead);
-            ClientBase.ValidateDiagnosticInfos(diagnosticInfos, itemsToRead);
-
-            // check for error.
-            if (StatusCode.IsBad(values[0].StatusCode))
+            try
             {
-                ServiceResult result = ClientBase.GetResult(values[0].StatusCode, 0, diagnosticInfos, responseHeader);
-                throw new ServiceResultException(result);
+                ResponseHeader responseHeader = m_session.Read(
+                    null,
+                    0,
+                    TimestampsToReturn.Neither,
+                    itemsToRead,
+                    out values,
+                    out diagnosticInfos);
+
+                ClientBase.ValidateResponse(values, itemsToRead);
+                ClientBase.ValidateDiagnosticInfos(diagnosticInfos, itemsToRead);
+
+                // check for error.
+                if (StatusCode.IsBad(values[0].StatusCode))
+                {
+                    ServiceResult result = ClientBase.GetResult(values[0].StatusCode, 0, diagnosticInfos, responseHeader);
+                    throw new ServiceResultException(result);
+                }
+
+                // return as a byte array.
+                return values[0].Value as byte[];
+                
+            }
+            catch (ServiceResultException ex)
+            {
+                if (ex.StatusCode != StatusCodes.BadEncodingLimitsExceeded)
+                {
+                    throw;
+                }
+                else
+                {
+                    try
+                    {
+                        byte[] dictionary = m_session.ReadByteStringInChunks(dictionaryId);
+                        return dictionary;
+                    }
+                    catch
+                    {
+                        ExceptionDispatchInfo.Capture(ex).Throw();
+                        throw;
+                    }
+
+                }
             }
 
-            // return as a byte array.
-            return values[0].Value as byte[];
+            
         }
 
         /// <summary>

--- a/Libraries/Opc.Ua.Client/Session/ISession.cs
+++ b/Libraries/Opc.Ua.Client/Session/ISession.cs
@@ -544,6 +544,13 @@ namespace Opc.Ua.Client
         void ReadValues(IList<NodeId> nodeIds, out DataValueCollection values, out IList<ServiceResult> errors);
 
         /// <summary>
+        /// Reads a byte string which is too large for the (server side) encoder to handle.
+        /// </summary>
+        /// <param name="nodeId">The node id of a byte string variable</param>
+        /// <returns></returns>
+        byte[] ReadByteStringInChunks(NodeId nodeId);
+
+        /// <summary>
         /// Fetches all references for the specified node.
         /// </summary>
         /// <param name="nodeId">The node id.</param>

--- a/Libraries/Opc.Ua.Client/Session/SessionAsync.cs
+++ b/Libraries/Opc.Ua.Client/Session/SessionAsync.cs
@@ -644,6 +644,9 @@ namespace Opc.Ua.Client
                 nodeIds.Add(VariableIds.Server_ServerCapabilities_MaxBrowseContinuationPoints);
                 int maxBrowseContinuationPointIndex = nodeIds.Count - 1;
 
+                nodeIds.Add(VariableIds.Server_ServerCapabilities_MaxByteStringLength);
+                int maxByteStringLengthIndex = nodeIds.Count - 1;
+
                 (DataValueCollection values, IList<ServiceResult> errors) = await ReadValuesAsync(nodeIds, ct).ConfigureAwait(false);
 
                 OperationLimits configOperationLimits = m_configuration?.ClientConfiguration?.OperationLimits ?? new OperationLimits();
@@ -673,6 +676,11 @@ namespace Opc.Ua.Client
                     && ServiceResult.IsNotBad(errors[maxBrowseContinuationPointIndex]))
                 {
                     ServerMaxContinuationPointsPerBrowse = (UInt16)values[maxBrowseContinuationPointIndex].Value;
+                }
+                if (values[maxByteStringLengthIndex] != null
+                    && ServiceResult.IsNotBad(errors[maxByteStringLengthIndex]))
+                {
+                    ServerMaxByteStringLength = (UInt32)values[maxByteStringLengthIndex].Value;
                 }
             }
             catch (Exception ex)

--- a/Libraries/Opc.Ua.Client/Session/TraceableSession.cs
+++ b/Libraries/Opc.Ua.Client/Session/TraceableSession.cs
@@ -661,9 +661,18 @@ namespace Opc.Ua.Client
                 m_session.ReadValues(variableIds, expectedTypes, out values, out errors);
             }
         }
-
+        
         /// <inheritdoc/>
-        public void ReadDisplayName(IList<NodeId> nodeIds, out IList<string> displayNames, out IList<ServiceResult> errors)
+        public byte[] ReadByteStringInChunks(NodeId nodeId)
+        {
+            using (Activity activity = ActivitySource.StartActivity())
+            {
+                return m_session.ReadByteStringInChunks(nodeId);
+            }
+        }
+
+            /// <inheritdoc/>
+            public void ReadDisplayName(IList<NodeId> nodeIds, out IList<string> displayNames, out IList<ServiceResult> errors)
         {
             using (Activity activity = ActivitySource.StartActivity())
             {

--- a/Tests/Opc.Ua.Client.Tests/ClientTestServerQuotas.cs
+++ b/Tests/Opc.Ua.Client.Tests/ClientTestServerQuotas.cs
@@ -1,0 +1,246 @@
+/* ========================================================================
+ * Copyright (c) 2005-2020 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using Moq;
+using NUnit.Framework;
+using Opc.Ua.Bindings;
+using Opc.Ua.Configuration;
+using Opc.Ua.Server.Tests;
+using Quickstarts.ReferenceServer;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
+
+namespace Opc.Ua.Client.Tests
+{
+    public class ClientTestServerQuotas : ClientTestFramework
+    {
+        const int MaxByteStringLengthForTest = 4096;
+        public ClientTestServerQuotas() : base(Utils.UriSchemeOpcTcp)
+        {
+        }
+
+        public ClientTestServerQuotas(string uriScheme = Utils.UriSchemeOpcTcp) :
+            base(uriScheme)
+        {
+        }
+
+        #region DataPointSources
+        public static readonly NodeId[] DataDictionaries = {
+            new NodeId("i=7617"),
+            new NodeId("ns=3;i=3518")
+        };
+        #endregion
+
+        #region Test Setup
+        /// <summary>
+        /// Set up a Server and a Client instance.
+        /// </summary>
+        [OneTimeSetUp]
+        public new Task OneTimeSetUp()
+        {
+            SupportsExternalServerUrl = true;
+            return base.OneTimeSetUpAsync(null, true, false, false, false);
+        }
+
+        /// <summary>
+        /// Tear down the Server and the Client.
+        /// </summary>
+        [OneTimeTearDown]
+        public new Task OneTimeTearDownAsync()
+        {
+            return base.OneTimeTearDownAsync();
+        }
+
+        /// <summary>
+        /// Test setup.
+        /// </summary>
+        [SetUp]
+        public new Task SetUp()
+        {
+            return base.SetUp();
+        }
+
+        public override async Task CreateReferenceServerFixture(bool enableTracing, bool disableActivityLogging, bool securityNone, TextWriter writer)
+        {
+            {
+                // start Ref server
+                ServerFixture = new ServerFixture<ReferenceServer>(enableTracing, disableActivityLogging) {
+                    UriScheme = UriScheme,
+                    SecurityNone = securityNone,
+                    AutoAccept = true,
+                    AllNodeManagers = true,
+                    OperationLimits = true
+                };
+            }
+
+            if (writer != null)
+            {
+                ServerFixture.TraceMasks = Utils.TraceMasks.Error | Utils.TraceMasks.Security;
+            }
+
+            await ServerFixture.LoadConfiguration(PkiRoot).ConfigureAwait(false);
+            ServerFixture.Config.TransportQuotas.MaxMessageSize = TransportQuotaMaxMessageSize;
+            ServerFixture.Config.TransportQuotas.MaxByteStringLength = MaxByteStringLengthForTest;
+            ServerFixture.Config.TransportQuotas.MaxStringLength = TransportQuotaMaxStringLength;
+            ServerFixture.Config.ServerConfiguration.UserTokenPolicies.Add(new UserTokenPolicy(UserTokenType.UserName));
+            ServerFixture.Config.ServerConfiguration.UserTokenPolicies.Add(new UserTokenPolicy(UserTokenType.Certificate));
+            ServerFixture.Config.ServerConfiguration.UserTokenPolicies.Add(
+                new UserTokenPolicy(UserTokenType.IssuedToken) { IssuedTokenType = Opc.Ua.Profiles.JwtUserToken });
+
+            ReferenceServer = await ServerFixture.StartAsync(writer ?? TestContext.Out).ConfigureAwait(false);
+            ReferenceServer.TokenValidator = this.TokenValidator;
+            ServerFixturePort = ServerFixture.Port;
+        }
+
+        /// <summary>
+        /// Test teardown.
+        /// </summary>
+        [TearDown]
+        public new Task TearDown()
+        {
+            return base.TearDown();
+        }
+        #endregion
+
+        #region Benchmark Setup
+        /// <summary>
+        /// Global Setup for benchmarks.
+        /// </summary>
+        [GlobalSetup]
+        public new void GlobalSetup()
+        {
+            base.GlobalSetup();
+        }
+
+        /// <summary>
+        /// Global cleanup for benchmarks.
+        /// </summary>
+        [GlobalCleanup]
+        public new void GlobalCleanup()
+        {
+            base.GlobalCleanup();
+        }
+        #endregion
+
+        #region Test Methods
+
+        [Test, Order(100)]
+        [TestCaseSource(nameof(DataDictionaries))]
+        public void ReadDictionaryByteString(NodeId dataDictionaryId)
+        {
+            Session theSession = ((Session)(((TraceableSession)Session).Session));
+            ReferenceDescription referenceDescription = new ReferenceDescription();
+
+            referenceDescription.NodeId = NodeId.ToExpandedNodeId(dataDictionaryId, theSession.NodeCache.NamespaceUris);
+
+            // make sure the dictionary is too large to fit in a single message
+            ReadValueId readValueId = new ReadValueId {
+                NodeId = dataDictionaryId,
+                AttributeId = Attributes.Value,
+                IndexRange = null,
+                DataEncoding = null
+            };
+
+            ReadValueIdCollection nodesToRead = new ReadValueIdCollection {
+                readValueId
+            };
+
+            var x = Assert.Throws<ServiceResultException>(() => {
+                theSession.Read(null, 0, TimestampsToReturn.Neither, nodesToRead, out DataValueCollection results, out DiagnosticInfoCollection diagnosticInfos);
+            });
+
+            Assert.AreEqual(StatusCodes.BadEncodingLimitsExceeded, x.StatusCode);
+
+            // now ensure we get the dictionary in chunks
+            DataDictionary dictionary = theSession.LoadDataDictionary(referenceDescription);
+            Assert.IsNotNull(dictionary);
+
+            // Sanity checks: verify that some well-known information is present
+            Assert.AreEqual(dictionary.TypeSystemName, "OPC Binary");
+
+            if (dataDictionaryId == DataDictionaries[0])
+            {
+                Assert.IsTrue(dictionary.DataTypes.Count > 160);
+                Assert.IsTrue(dictionary.DataTypes.ContainsKey(VariableIds.OpcUa_BinarySchema_Union));
+                Assert.IsTrue(dictionary.DataTypes.ContainsKey(VariableIds.OpcUa_BinarySchema_OptionSet));
+                Assert.AreEqual("http://opcfoundation.org/UA/", dictionary.TypeDictionary.TargetNamespace);
+            }
+            else if (dataDictionaryId == DataDictionaries[1])
+            {
+                Assert.IsTrue(dictionary.DataTypes.Count >= 10);
+                Assert.AreEqual("http://test.org/UA/Data/", dictionary.TypeDictionary.TargetNamespace);
+            }
+        }
+
+
+        [Test, Order(200)]
+        public void TestBoundaryCaseForReadingChunks()
+        {
+            NodeId NodeId = new NodeId("ns=2;s=Scalar_Static_ByteString");
+
+            Session theSession = ((Session)(((TraceableSession)Session).Session));
+
+            Random random = new Random();
+
+            byte[] chunk = new byte[MaxByteStringLengthForTest];
+            random.NextBytes(chunk);
+
+            WriteValue WriteValue = new WriteValue {
+                NodeId = NodeId,
+                AttributeId = Attributes.Value,
+                Value = new DataValue() { WrappedValue = new Variant(chunk) },
+                IndexRange = null
+            };
+            WriteValueCollection writeValues = new WriteValueCollection {
+                    WriteValue
+                };
+            theSession.Write(null, writeValues, out StatusCodeCollection results, out DiagnosticInfoCollection diagnosticInfos);
+
+            if (results[0] != StatusCodes.Good)
+            {
+                Assert.Fail($"Write failed with status code {results[0]}");
+            }
+
+            byte[] readData = theSession.ReadByteStringInChunks(NodeId);
+
+            Assert.IsTrue(Utils.IsEqual(chunk, readData));
+        }
+        #endregion // Test Methods 
+
+    }
+}


### PR DESCRIPTION
## Proposed changes

A new method is implemented which reads byte strings in chunks and therefore allows to read byte strings which exceed the encoding limits of the server. This is used in the method which reads v103 data dictionaries.

## Related Issues

- Fixes #2781 

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- [x] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [x] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [x] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments
I have extended the ISession interface by a method `ReadByteStringInChunks`. Extending the interface may be considered a breaking change.

The new method takes a node id as input (which must point to a valid byte string typed variable) and is supposed to return the byte string value from that node id, even if it is too large for the server to encode it. It is implemented in `Session` and `TraceableSession` and used in the `DataDictionary` class, when the Read call to read the byte string which contains the dictionary fails with a BadEncodingLimitsExceeded` Service Result Exception.

(The method is currently intended to only fix the scenario in the bug mentioned. But as it is also exposed in the interface it could be used to read any byte string. The logic in that method is, in principal, also valid when reading other byte strings than data dictionaries or strings which are too large, or arrays which are too large).