### PR TITLE
Fix ExpandedNodeId.Format output for not well formed uri and JSON Verbose WriteStatusCode

### DIFF
--- a/Stack/Opc.Ua.Core/Types/Encoders/JsonEncoder.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/JsonEncoder.cs
@@ -1346,25 +1346,17 @@ namespace Opc.Ua
             }
 
             // Verbose and NonReversible
+            PushStructure(fieldName);
             if (value != StatusCodes.Good)
             {
-                PushStructure(fieldName);
                 WriteSimpleField("Code", value.Code.ToString(CultureInfo.InvariantCulture), EscapeOptions.NoFieldNameEscape);
                 string symbolicId = StatusCode.LookupSymbolicId(value.CodeBits);
                 if (!string.IsNullOrEmpty(symbolicId))
                 {
                     WriteSimpleField("Symbol", symbolicId, EscapeOptions.Quotes | EscapeOptions.NoFieldNameEscape);
                 }
-                PopStructure();
-                return;
             }
-
-            // Verbose needs empty object
-            if (EncodingToUse == JsonEncodingType.Verbose)
-            {
-                PushStructure(fieldName);
-                PopStructure();
-            }
+            PopStructure();
         }
 
         /// <summary>

--- a/Stack/Opc.Ua.Core/Types/Encoders/JsonEncoder.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/JsonEncoder.cs
@@ -1345,6 +1345,7 @@ namespace Opc.Ua
                 return;
             }
 
+            // Verbose and NonReversible
             if (value != StatusCodes.Good)
             {
                 PushStructure(fieldName);
@@ -1354,6 +1355,14 @@ namespace Opc.Ua
                 {
                     WriteSimpleField("Symbol", symbolicId, EscapeOptions.Quotes | EscapeOptions.NoFieldNameEscape);
                 }
+                PopStructure();
+                return;
+            }
+
+            // Verbose needs empty object
+            if (EncodingToUse == JsonEncodingType.Verbose)
+            {
+                PushStructure(fieldName);
                 PopStructure();
             }
         }

--- a/Tests/Opc.Ua.Client.ComplexTypes.Tests/Types/JsonEncoderTests.cs
+++ b/Tests/Opc.Ua.Client.ComplexTypes.Tests/Types/JsonEncoderTests.cs
@@ -374,13 +374,19 @@ namespace Opc.Ua.Client.ComplexTypes.Tests.Types
                                 if (jsonEncoding == JsonEncodingType.Compact || jsonEncoding == JsonEncodingType.Reversible)
                                 {
                                     oText = "0";
+                                    // default statuscode is not encoded
+                                    continue;
+                                }
+                                else if (jsonEncoding == JsonEncodingType.Verbose)
+                                {
+                                    oText = "{}";
                                 }
                                 else
                                 {
                                     oText = "{\"Code\": 0,\"Symbol\":\"Good\"}";
                                     // default statuscode is not encoded
+                                    continue;
                                 }
-                                continue;
                             }
                             else if (property.Name == "Guid")
                             {

--- a/Tests/Opc.Ua.Core.Tests/Types/Encoders/JsonEncoderTests.cs
+++ b/Tests/Opc.Ua.Core.Tests/Types/Encoders/JsonEncoderTests.cs
@@ -438,6 +438,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
                 Assert.Throws<NotSupportedException>(() => encoder.ForceNamespaceUriForIndex1 = true);
                 Assert.Throws<NotSupportedException>(() => encoder.IncludeDefaultNumberValues = true);
                 Assert.Throws<NotSupportedException>(() => encoder.IncludeDefaultValues = true);
+                Assert.Throws<NotSupportedException>(() => encoder.EncodeNodeIdAsString = false);
             }
         }
 

--- a/Tests/Opc.Ua.Core.Tests/Types/Encoders/JsonEncoderTests.cs
+++ b/Tests/Opc.Ua.Core.Tests/Types/Encoders/JsonEncoderTests.cs
@@ -1164,6 +1164,23 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
         }
 
         /// <summary>
+        /// Validate that a ExpandedNodeId returns the expected
+        /// result for a not well formed Uri.
+        /// </summary>
+        [Test]
+        public void NotWellFormedUriInExpandedNodeId2String()
+        {
+            string namespaceUri = "KEPServerEX";
+            string nodeName = "Data Type Examples.16 Bit Device.K Registers.Double3";
+            String expectedNodeIdString = $"nsu={namespaceUri};s={nodeName}";
+            ExpandedNodeId expandedNodeId = new ExpandedNodeId(expectedNodeIdString);
+
+            string stringifiedExpandedNodId = expandedNodeId.ToString();
+            TestContext.Out.WriteLine(stringifiedExpandedNodId);
+            Assert.AreEqual(expectedNodeIdString, stringifiedExpandedNodId);
+        }
+
+        /// <summary>
         /// Validate that the DateTime format strings return an equal result.
         /// </summary>
         public void DateTimeEncodeStringTest(DateTime testDateTime)

--- a/Tests/Opc.Ua.Core.Tests/Types/Encoders/JsonEncoderTests.cs
+++ b/Tests/Opc.Ua.Core.Tests/Types/Encoders/JsonEncoderTests.cs
@@ -287,7 +287,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
                     $"\"ns=88;b={s_byteString64}\"", null},
 
             {   BuiltInType.StatusCode, new StatusCode(StatusCodes.Good), null, null, null, "{}"},
-            {   BuiltInType.StatusCode, new StatusCode(StatusCodes.Good), $"{StatusCodes.Good}", "", null, "{}", true},
+            {   BuiltInType.StatusCode, new StatusCode(StatusCodes.Good), $"{StatusCodes.Good}", "{}", null, "{}", true},
             {   BuiltInType.StatusCode, new StatusCode(StatusCodes.BadBoundNotFound), $"{StatusCodes.BadBoundNotFound}",
                     $"{{\"Code\":{StatusCodes.BadBoundNotFound}, \"Symbol\":\"{nameof(StatusCodes.BadBoundNotFound)}\"}}"},
             {   BuiltInType.StatusCode, new StatusCode(StatusCodes.BadCertificateInvalid),
@@ -353,8 +353,8 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
             {   BuiltInType.DataValue, new DataValue(), "{}", null},
             {   BuiltInType.DataValue, new DataValue(StatusCodes.Good), "{}", null},
             {   BuiltInType.DataValue, new DataValue(StatusCodes.BadNotWritable),
-                    $"{StatusCodes.BadNotWritable}",
-                    $"{{\"Code\":{StatusCodes.BadNotWritable}, \"Symbol\":\"{nameof(StatusCodes.BadNotWritable)}\"}}"},
+                    $"{{\"StatusCode\":{StatusCodes.BadNotWritable}}}",
+                    $"{{\"StatusCode\":{{\"Code\":{StatusCodes.BadNotWritable}, \"Symbol\":\"{nameof(StatusCodes.BadNotWritable)}\"}}}}"},
 
             {   BuiltInType.Enumeration, (TestEnumType) 0, "0", "\"0\""},
             {   BuiltInType.Enumeration, TestEnumType.Three, TestEnumType.Three.ToString("d"), $"\"{TestEnumType.Three}_{TestEnumType.Three.ToString("d")}\""},
@@ -1192,10 +1192,11 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
         [Theory]
         public void DataValueWithStatusCodes(
             JsonEncodingType jsonEncodingType,
+            [ValueSource(nameof(GoodAndBadStatusCodes))] StatusCode statusCodeVariant,
             [ValueSource(nameof(GoodAndBadStatusCodes))] StatusCode statusCode)
         {
             var dataValue = new DataValue() {
-                Value = new Variant(12345),
+                Value = new Variant(statusCodeVariant),
                 ServerTimestamp = DateTime.UtcNow,
                 StatusCode = statusCode
             };


### PR DESCRIPTION
## Proposed changes

- JSON Encoder Verbose encoding WriteStatusCode may produce invalid JSON
- ExpandedNodeId.Format does not handle not well formed uri correctly, as in the previous implementation

## Related Issues

- Fixes #2793
- Fixes #2788

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
