### PR TITLE
Null pointer exception when reading a complex type with empty arrays.…

### DIFF
--- a/Stack/Opc.Ua.Core/Types/Encoders/BinaryDecoder.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/BinaryDecoder.cs
@@ -1386,15 +1386,15 @@ namespace Opc.Ua
                 switch (builtInType)
                 {
                     case BuiltInType.Boolean:
-                        return ReadBooleanArray(fieldName).ToArray();
+                        return ReadBooleanArray(fieldName)?.ToArray();
                     case BuiltInType.SByte:
-                        return ReadSByteArray(fieldName).ToArray();
+                        return ReadSByteArray(fieldName)?.ToArray();
                     case BuiltInType.Byte:
-                        return ReadByteArray(fieldName).ToArray();
+                        return ReadByteArray(fieldName)?.ToArray();
                     case BuiltInType.Int16:
-                        return ReadInt16Array(fieldName).ToArray();
+                        return ReadInt16Array(fieldName)?.ToArray();
                     case BuiltInType.UInt16:
-                        return ReadUInt16Array(fieldName).ToArray();
+                        return ReadUInt16Array(fieldName)?.ToArray();
                     case BuiltInType.Enumeration:
                     {
                         DetermineIEncodeableSystemType(ref systemType, encodeableTypeId);
@@ -1406,51 +1406,51 @@ namespace Opc.Ua
                         goto case BuiltInType.Int32;
                     }
                     case BuiltInType.Int32:
-                        return ReadInt32Array(fieldName).ToArray();
+                        return ReadInt32Array(fieldName)?.ToArray();
                     case BuiltInType.UInt32:
-                        return ReadUInt32Array(fieldName).ToArray();
+                        return ReadUInt32Array(fieldName)?.ToArray();
                     case BuiltInType.Int64:
-                        return ReadInt64Array(fieldName).ToArray();
+                        return ReadInt64Array(fieldName)?.ToArray();
                     case BuiltInType.UInt64:
-                        return ReadUInt64Array(fieldName).ToArray();
+                        return ReadUInt64Array(fieldName)?.ToArray();
                     case BuiltInType.Float:
-                        return ReadFloatArray(fieldName).ToArray();
+                        return ReadFloatArray(fieldName)?.ToArray();
                     case BuiltInType.Double:
-                        return ReadDoubleArray(fieldName).ToArray();
+                        return ReadDoubleArray(fieldName)?.ToArray();
                     case BuiltInType.String:
-                        return ReadStringArray(fieldName).ToArray();
+                        return ReadStringArray(fieldName)?.ToArray();
                     case BuiltInType.DateTime:
-                        return ReadDateTimeArray(fieldName).ToArray();
+                        return ReadDateTimeArray(fieldName)?.ToArray();
                     case BuiltInType.Guid:
-                        return ReadGuidArray(fieldName).ToArray();
+                        return ReadGuidArray(fieldName)?.ToArray();
                     case BuiltInType.ByteString:
-                        return ReadByteStringArray(fieldName).ToArray();
+                        return ReadByteStringArray(fieldName)?.ToArray();
                     case BuiltInType.XmlElement:
-                        return ReadXmlElementArray(fieldName).ToArray();
+                        return ReadXmlElementArray(fieldName)?.ToArray();
                     case BuiltInType.NodeId:
-                        return ReadNodeIdArray(fieldName).ToArray();
+                        return ReadNodeIdArray(fieldName)?.ToArray();
                     case BuiltInType.ExpandedNodeId:
-                        return ReadExpandedNodeIdArray(fieldName).ToArray();
+                        return ReadExpandedNodeIdArray(fieldName)?.ToArray();
                     case BuiltInType.StatusCode:
-                        return ReadStatusCodeArray(fieldName).ToArray();
+                        return ReadStatusCodeArray(fieldName)?.ToArray();
                     case BuiltInType.QualifiedName:
-                        return ReadQualifiedNameArray(fieldName).ToArray();
+                        return ReadQualifiedNameArray(fieldName)?.ToArray();
                     case BuiltInType.LocalizedText:
-                        return ReadLocalizedTextArray(fieldName).ToArray();
+                        return ReadLocalizedTextArray(fieldName)?.ToArray();
                     case BuiltInType.DataValue:
-                        return ReadDataValueArray(fieldName).ToArray();
+                        return ReadDataValueArray(fieldName)?.ToArray();
                     case BuiltInType.Variant:
                     {
                         if (DetermineIEncodeableSystemType(ref systemType, encodeableTypeId))
                         {
                             return ReadEncodeableArray(fieldName, systemType, encodeableTypeId);
                         }
-                        return ReadVariantArray(fieldName).ToArray();
+                        return ReadVariantArray(fieldName)?.ToArray();
                     }
                     case BuiltInType.ExtensionObject:
-                        return ReadExtensionObjectArray(fieldName).ToArray();
+                        return ReadExtensionObjectArray(fieldName)?.ToArray();
                     case BuiltInType.DiagnosticInfo:
-                        return ReadDiagnosticInfoArray(fieldName).ToArray();
+                        return ReadDiagnosticInfoArray(fieldName)?.ToArray();
                     default:
                     {
                         if (DetermineIEncodeableSystemType(ref systemType, encodeableTypeId))
@@ -1604,7 +1604,7 @@ namespace Opc.Ua
         }
 
         /// <summary>
-        /// Reads and returns an array of elements of the specified length and builtInType 
+        /// Reads and returns an array of elements of the specified length and builtInType
         /// </summary>
         private Array ReadArrayElements(int length, BuiltInType builtInType)
         {


### PR DESCRIPTION
… (#2798)

The server under test has a extension object with a complex type.  Type id = {nsu=http://opcfoundation.org/UA/Machinery/Result/;i=5008}.  This contains something with a variant array that is null though (-1).  SetProperty should support setting a Array that is null.  Therefore, test for null collection (case when length was encoded as -1) before dereferencing ahead of the ToArrray() conversion to Array.

## Proposed changes

Describe the changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Related Issues

- Fixes #

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
