### PR TITLE
IOP: Fix FetchOperationLimits for some use cases

### DIFF
--- a/Libraries/Opc.Ua.Client/Session/Session.cs
+++ b/Libraries/Opc.Ua.Client/Session/Session.cs
@@ -1686,19 +1686,19 @@ namespace Opc.Ua.Client
                     }
                     property.SetValue(operationLimits, value);
                 }
-
                 OperationLimits = operationLimits;
-                if (values[maxBrowseContinuationPointIndex] != null
-                    && ServiceResult.IsNotBad(errors[maxBrowseContinuationPointIndex]))
+
+                if (values[maxBrowseContinuationPointIndex].Value is UInt16 serverMaxContinuationPointsPerBrowse &&
+                    ServiceResult.IsNotBad(errors[maxBrowseContinuationPointIndex]))
                 {
-                    ServerMaxContinuationPointsPerBrowse = (UInt16)values[maxBrowseContinuationPointIndex];
-                }
-                if (values[maxByteStringLengthIndex] != null
-                    && ServiceResult.IsNotBad(errors[maxByteStringLengthIndex]))
-                {
-                    ServerMaxByteStringLength = (UInt32)values[maxByteStringLengthIndex];
+                    ServerMaxContinuationPointsPerBrowse = serverMaxContinuationPointsPerBrowse;
                 }
 
+                if (values[maxByteStringLengthIndex].Value is UInt32 serverMaxByteStringLength &&
+                    ServiceResult.IsNotBad(errors[maxByteStringLengthIndex]))
+                {
+                    ServerMaxByteStringLength = serverMaxByteStringLength;
+                }
             }
             catch (Exception ex)
             {

--- a/Libraries/Opc.Ua.Client/Session/Session.cs
+++ b/Libraries/Opc.Ua.Client/Session/Session.cs
@@ -1688,13 +1688,13 @@ namespace Opc.Ua.Client
                 }
                 OperationLimits = operationLimits;
 
-                if (values[maxBrowseContinuationPointIndex].Value is UInt16 serverMaxContinuationPointsPerBrowse &&
+                if (values[maxBrowseContinuationPointIndex] is UInt16 serverMaxContinuationPointsPerBrowse &&
                     ServiceResult.IsNotBad(errors[maxBrowseContinuationPointIndex]))
                 {
                     ServerMaxContinuationPointsPerBrowse = serverMaxContinuationPointsPerBrowse;
                 }
 
-                if (values[maxByteStringLengthIndex].Value is UInt32 serverMaxByteStringLength &&
+                if (values[maxByteStringLengthIndex] is UInt32 serverMaxByteStringLength &&
                     ServiceResult.IsNotBad(errors[maxByteStringLengthIndex]))
                 {
                     ServerMaxByteStringLength = serverMaxByteStringLength;

--- a/Libraries/Opc.Ua.Client/Session/SessionAsync.cs
+++ b/Libraries/Opc.Ua.Client/Session/SessionAsync.cs
@@ -639,8 +639,7 @@ namespace Opc.Ua.Client
                     .GetValue(null))
                     );
 
-                // add the server capability MaxContinuationPointPerBrowse. Add further capabilities
-                // later (when support form them will be implemented and in a more generic fashion)
+                // add the server capability MaxContinuationPointPerBrowse and MaxByteStringLength
                 nodeIds.Add(VariableIds.Server_ServerCapabilities_MaxBrowseContinuationPoints);
                 int maxBrowseContinuationPointIndex = nodeIds.Count - 1;
 
@@ -670,17 +669,18 @@ namespace Opc.Ua.Client
                     }
                     property.SetValue(operationLimits, value);
                 }
-
                 OperationLimits = operationLimits;
-                if (values[maxBrowseContinuationPointIndex].Value != null
-                    && ServiceResult.IsNotBad(errors[maxBrowseContinuationPointIndex]))
+
+                if (values[maxBrowseContinuationPointIndex].Value is UInt16 serverMaxContinuationPointsPerBrowse &&
+                    ServiceResult.IsNotBad(errors[maxBrowseContinuationPointIndex]))
                 {
-                    ServerMaxContinuationPointsPerBrowse = (UInt16)values[maxBrowseContinuationPointIndex].Value;
+                    ServerMaxContinuationPointsPerBrowse = serverMaxContinuationPointsPerBrowse;
                 }
-                if (values[maxByteStringLengthIndex] != null
-                    && ServiceResult.IsNotBad(errors[maxByteStringLengthIndex]))
+
+                if (values[maxByteStringLengthIndex].Value is UInt32 serverMaxByteStringLength &&
+                    ServiceResult.IsNotBad(errors[maxByteStringLengthIndex]))
                 {
-                    ServerMaxByteStringLength = (UInt32)values[maxByteStringLengthIndex].Value;
+                    ServerMaxByteStringLength = serverMaxByteStringLength;
                 }
             }
             catch (Exception ex)


### PR DESCRIPTION
## Proposed changes

- FetchOperationLimits may throw null pointer exception if server MaxByteStringLength is empty or null.

In this case operation limits were ignored and other `BadTooManyOperations` errors may be returned because default operation limits were used.

## Related Issues

- Fixes #

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
