### PR TITLE
fix build for legacy platforms by disabling ECC on  .NET 4.6.2 & NET-Standard2.0

### DIFF
--- a/Libraries/Opc.Ua.Client/Session/Session.cs
+++ b/Libraries/Opc.Ua.Client/Session/Session.cs
@@ -6539,6 +6539,7 @@ namespace Opc.Ua.Client
             {
                 foreach (var ii in parameters.Parameters)
                 {
+#if ECC_SUPPORT
                     if (ii.Key == "ECDHKey")
                     {
                         if (ii.Value.TypeInfo == TypeInfo.Scalars.StatusCode)
@@ -6566,10 +6567,11 @@ namespace Opc.Ua.Client
 
                         m_eccServerEphemeralKey = Nonce.CreateNonce(m_userTokenSecurityPolicyUri, key.PublicKey);
                     }
+#endif
                 }
             }
         }
-        #endregion
+#endregion
 
         #region Protected Fields
         /// <summary>

--- a/Libraries/Opc.Ua.Configuration/ApplicationConfigurationBuilder.cs
+++ b/Libraries/Opc.Ua.Configuration/ApplicationConfigurationBuilder.cs
@@ -954,8 +954,13 @@ namespace Opc.Ua.Configuration
                     StorePath = storePath,
                     SubjectName = subjectName,
                     CertificateType = ObjectTypeIds.RsaSha256ApplicationCertificateType
-                },
-                new CertificateIdentifier {
+                }
+            };
+#if ECC_SUPPORT
+            certificateIdentifiers.AddRange(
+                    new CertificateIdentifierCollection
+                    {
+            new CertificateIdentifier {
                     StoreType = storeType,
                     StorePath = storePath,
                     SubjectName = subjectName,
@@ -967,7 +972,7 @@ namespace Opc.Ua.Configuration
                     SubjectName = subjectName,
                     CertificateType = ObjectTypeIds.EccNistP384ApplicationCertificateType
                 }
-            };
+            });
 
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
@@ -990,11 +995,11 @@ namespace Opc.Ua.Configuration
                         }
                     });
             }
-
+#endif
             return certificateIdentifiers;
 
         }
-        #endregion
+#endregion
 
         #region Private Methods
         /// <summary>

--- a/Stack/Opc.Ua.Core/Security/Certificates/CertificateValidator.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/CertificateValidator.cs
@@ -1776,6 +1776,7 @@ namespace Opc.Ua
         /// </summary>
         private static readonly Dictionary<string, int> NamedCurveBitSizes = new Dictionary<string, int>
         {
+#if ECC_SUPPORT
             // NIST Curves
             { ECCurve.NamedCurves.nistP256.Oid.Value ?? "1.2.840.10045.3.1.7", 256 },    // NIST P-256
             { ECCurve.NamedCurves.nistP384.Oid.Value ?? "1.3.132.0.34"       , 384 },    // NIST P-384
@@ -1784,6 +1785,7 @@ namespace Opc.Ua
             // Brainpool Curves
             { ECCurve.NamedCurves.brainpoolP256r1.Oid.Value ?? "1.3.36.3.3.2.8.1.1.7", 256 },  // BrainpoolP256r1
             { ECCurve.NamedCurves.brainpoolP384r1.Oid.Value ?? "1.3.36.3.3.2.8.1.1.11", 384 },  // BrainpoolP384r1
+#endif
         };
 
         /// <summary>
@@ -1844,7 +1846,7 @@ namespace Opc.Ua
             }
             return domainFound;
         }
-
+#if ECC_SUPPORT
         /// <summary>
         /// Returns if the certificate is secure enough for the profile.
         /// </summary>
@@ -1883,7 +1885,8 @@ namespace Opc.Ua
                 }
             }
         }
-        #endregion
+#endif
+#endregion
 
         #region Private Enum
         /// <summary>

--- a/Stack/Opc.Ua.Core/Security/Certificates/EccUtils.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/EccUtils.cs
@@ -1168,7 +1168,7 @@ namespace Opc.Ua
 
             return secret;
         }
-
+#else
         /// <summary>
         /// Verifies a ECDsa signature.
         /// </summary>
@@ -1338,7 +1338,7 @@ namespace Opc.Ua
             string[] securityPolicyUris;
             return GetPublicKey(certificate, out securityPolicyUris);
         }
-#endif
+
         /// <summary>
         /// Returns the hash algorithm for the specified security policy.
         /// </summary>
@@ -1374,5 +1374,7 @@ namespace Opc.Ua
                 }
             }
         }
+
+#endif
     }
 }

--- a/Stack/Opc.Ua.Core/Security/Certificates/EccUtils.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/EccUtils.cs
@@ -1168,7 +1168,7 @@ namespace Opc.Ua
 
             return secret;
         }
-#else
+
         /// <summary>
         /// Verifies a ECDsa signature.
         /// </summary>
@@ -1338,8 +1338,8 @@ namespace Opc.Ua
             string[] securityPolicyUris;
             return GetPublicKey(certificate, out securityPolicyUris);
         }
-
-            /// <summary>
+#endif
+        /// <summary>
         /// Returns the hash algorithm for the specified security policy.
         /// </summary>
         /// <param name="securityPolicyUri"></param>
@@ -1374,7 +1374,5 @@ namespace Opc.Ua
                 }
             }
         }
-    
-#endif
     }
 }

--- a/Stack/Opc.Ua.Core/Security/Certificates/Nonce.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/Nonce.cs
@@ -574,9 +574,10 @@ namespace Opc.Ua
         /// <param name="context"></param>
         protected Nonce(SerializationInfo info, StreamingContext context)
         {
+#if ECC_SUPPORT
             var curveName = info.GetString("CurveName");
 
-#if ECC_SUPPORT
+
             if (curveName != null)
             {
                 var ecParams = new ECParameters {

--- a/Stack/Opc.Ua.Core/Security/Certificates/Nonce.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/Nonce.cs
@@ -194,10 +194,12 @@ namespace Opc.Ua
 
             switch (securityPolicyUri)
             {
+#if ECC_SUPPORT
                 case SecurityPolicies.ECC_nistP256: { return CreateNonce(ECCurve.NamedCurves.nistP256); }
                 case SecurityPolicies.ECC_nistP384: { return CreateNonce(ECCurve.NamedCurves.nistP384); }
                 case SecurityPolicies.ECC_brainpoolP256r1: { return CreateNonce(ECCurve.NamedCurves.brainpoolP256r1); }
                 case SecurityPolicies.ECC_brainpoolP384r1: { return CreateNonce(ECCurve.NamedCurves.brainpoolP384r1); }
+#endif
 #if CURVE25519
                 case SecurityPolicies.ECC_curve25519:
                 {
@@ -245,11 +247,12 @@ namespace Opc.Ua
 
             switch (securityPolicyUri)
             {
+#if ECC_SUPPORT
                 case SecurityPolicies.ECC_nistP256: { return CreateNonce(ECCurve.NamedCurves.nistP256, nonceData); }
                 case SecurityPolicies.ECC_nistP384: { return CreateNonce(ECCurve.NamedCurves.nistP384, nonceData); }
                 case SecurityPolicies.ECC_brainpoolP256r1: { return CreateNonce(ECCurve.NamedCurves.brainpoolP256r1, nonceData); }
                 case SecurityPolicies.ECC_brainpoolP384r1: { return CreateNonce(ECCurve.NamedCurves.brainpoolP384r1, nonceData); }
-
+#endif
                 case SecurityPolicies.ECC_curve25519:
                 {
                     return CreateNonceForCurve25519(nonceData);
@@ -268,7 +271,7 @@ namespace Opc.Ua
 
             return nonce;
         }
-        #endregion
+#endregion
 
         #region Utility Methods
 
@@ -422,7 +425,7 @@ namespace Opc.Ua
 
             return nonce;
         }
-
+#if ECC_SUPPORT
         /// <summary>
         /// Creates a new Nonce instance with the specified ECC curve and nonce data.
         /// </summary>
@@ -431,7 +434,7 @@ namespace Opc.Ua
         /// <returns>A new Nonce instance with the specified curve and nonce data.</returns>
         private static Nonce CreateNonce(ECCurve curve, byte[] nonceData)
         {
-#if ECC_SUPPORT
+
             Nonce nonce = new Nonce() {
                 Data = nonceData
             };
@@ -464,9 +467,6 @@ namespace Opc.Ua
             }
 
             return nonce;
-#else
-            throw new NotSupportedException("Platform does not support ECC curves");
-#endif
         }
 
         /// <summary>
@@ -476,7 +476,7 @@ namespace Opc.Ua
         /// <returns>A new Nonce instance.</returns>
         private static Nonce CreateNonce(ECCurve curve)
         {
-#if ECC_SUPPORT
+
             var ecdh = (ECDiffieHellman)ECDiffieHellman.Create(curve);
             var ecdhParameters = ecdh.ExportParameters(false);
             int xLen = ecdhParameters.Q.X.Length;
@@ -492,12 +492,8 @@ namespace Opc.Ua
             };
 
             return nonce;
-
-#else
-            throw new NotSupportedException("Platform does not support ECC curves");
-#endif
         }
-
+#endif
 
 
         /// <summary>

--- a/Stack/Opc.Ua.Core/Types/Utils/Utils.cs
+++ b/Stack/Opc.Ua.Core/Types/Utils/Utils.cs
@@ -3148,7 +3148,7 @@ namespace Opc.Ua
             }
             return false;
         }
-
+#if ECC_SUPPORT
         /// <summary>
         /// Check if known curve is supported by platform
         /// </summary>
@@ -3182,6 +3182,7 @@ namespace Opc.Ua
             { ECCurve.NamedCurves.brainpoolP256r1.Oid.FriendlyName, new Lazy<bool>(() => IsCurveSupported(ECCurve.NamedCurves.brainpoolP256r1)) },
             { ECCurve.NamedCurves.brainpoolP384r1.Oid.FriendlyName, new Lazy<bool>(() => IsCurveSupported(ECCurve.NamedCurves.brainpoolP384r1)) },
         };
+#endif
 
         /// <summary>
         /// Lazy helper to allow runtime check for Mono.
@@ -3198,6 +3199,6 @@ namespace Opc.Ua
         {
             return s_isRunningOnMonoValue.Value;
         }
-        #endregion
+#endregion
     }
 }

--- a/Tests/Opc.Ua.Client.Tests/ClientTest.cs
+++ b/Tests/Opc.Ua.Client.Tests/ClientTest.cs
@@ -1673,7 +1673,7 @@ namespace Opc.Ua.Client.Tests
                 Assert.NotNull(value1);
             }
         }
-
+#if ECC_SUPPORT
         /// <summary>
         /// Open a session on a channel using ECC encrypted UserCertificateIdentityToken
         /// </summary>
@@ -1732,7 +1732,8 @@ namespace Opc.Ua.Client.Tests
                 }
             }
         }
-        #endregion
+#endif
+#endregion
 
         #region Benchmarks
         /// <summary>


### PR DESCRIPTION
## Proposed changes

After merging ECC build for legacy platforms (.NET 4.6.2 & NetStandard2.0) was broken. This PR fixes the build for legacy platforms

## Related Issues

- Fixes #

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist


- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments