### PR TITLE
Fix bugs in JSON decoder

### DIFF
--- a/Fuzzing/Encoders/Fuzz.Tests/EncoderTests.cs
+++ b/Fuzzing/Encoders/Fuzz.Tests/EncoderTests.cs
@@ -66,6 +66,12 @@ namespace Opc.Ua.Fuzzing
         }
 
         [Theory]
+        public void FuzzEmptyByteArray(FuzzTargetFunction fuzzableCode)
+        {
+            FuzzTarget(fuzzableCode, Array.Empty<byte>());
+        }
+
+        [Theory]
         public void FuzzCrashAssets(FuzzTargetFunction fuzzableCode)
         {
             // note: too many crash files can take forever to create

--- a/Stack/Opc.Ua.Core/Types/Encoders/JsonDecoder.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/JsonDecoder.cs
@@ -82,7 +82,7 @@ namespace Opc.Ua
         /// <summary>
         /// Create a JSON decoder to decode a <see cref="Type"/>from a <see cref="JsonTextReader"/>.
         /// </summary>
-        /// <param name="systemType">The system type of the encoded JSON stram.</param>
+        /// <param name="systemType">The system type of the encoded JSON stream.</param>
         /// <param name="reader">The text reader.</param>
         /// <param name="context">The service message context to use.</param>
         public JsonDecoder(Type systemType, JsonTextReader reader, IServiceMessageContext context)
@@ -2847,7 +2847,7 @@ namespace Opc.Ua
                     if (handler?.Invoke(text, NumberStyles.Integer, CultureInfo.InvariantCulture, out number) == false)
                     {
                         int lastIndex = text.LastIndexOf('_');
-                        if (lastIndex == -1)
+                        if (lastIndex != -1)
                         {
                             text = text.Substring(lastIndex + 1);
                             retry = true;
@@ -3280,7 +3280,7 @@ namespace Opc.Ua
                         EncodeAsJson(writer, element);
                     }
 
-                    writer.WriteStartArray();
+                    writer.WriteEndArray();
                     return;
                 }
 


### PR DESCRIPTION
## Proposed changes

- JSON ReadEnumeratedString does not decode the number in e.g. "Red_0".
- JSON reencode of JSON content in an extension object runs into a encoder error.

## Related Issues

- Fixes #

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
