### PR TITLE
Improve crl handling in certificate stores

### DIFF
--- a/Libraries/Opc.Ua.Gds.Server.Common/GlobalDiscoverySampleServer.cs
+++ b/Libraries/Opc.Ua.Gds.Server.Common/GlobalDiscoverySampleServer.cs
@@ -35,7 +35,6 @@ using Opc.Ua.Gds.Server.Database;
 using Opc.Ua.Server.UserDatabase;
 using System.Linq;
 using Opc.Ua.Security.Certificates;
-using System.Security.Cryptography;
 
 namespace Opc.Ua.Gds.Server
 {

--- a/Libraries/Opc.Ua.Gds.Server.Common/GlobalDiscoverySampleServer.cs
+++ b/Libraries/Opc.Ua.Gds.Server.Common/GlobalDiscoverySampleServer.cs
@@ -269,19 +269,10 @@ namespace Opc.Ua.Gds.Server
                 var crls = AuthoritiesStore.EnumerateCRLs().Result;
                 foreach (X509CRL crl in crls)
                 {
-                    try
+                    if (crl.IsRevoked(applicationInstanceCertificate))
                     {
-                        if (crl.IsRevoked(applicationInstanceCertificate))
-                        {
-                            applicationRegistered = false;
-                        }
+                        applicationRegistered = false;
                     }
-                    catch (CryptographicException e)
-                    {
-                        Utils.LogError(e, "Failed to decode crl in store {store}", configuration.AuthoritiesStorePath);
-                        continue;
-                    }
-
                 }
             }
             return applicationRegistered;

--- a/Libraries/Opc.Ua.Security.Certificates/X509Crl/X509Crl.cs
+++ b/Libraries/Opc.Ua.Security.Certificates/X509Crl/X509Crl.cs
@@ -50,6 +50,7 @@ namespace Opc.Ua.Security.Certificates
         public X509CRL(string filePath) : this()
         {
             RawData = File.ReadAllBytes(filePath);
+            EnsureDecoded();
         }
 
         /// <summary>
@@ -58,6 +59,7 @@ namespace Opc.Ua.Security.Certificates
         public X509CRL(byte[] crl) : this()
         {
             RawData = crl;
+            EnsureDecoded();
         }
 
         /// <summary>
@@ -78,6 +80,7 @@ namespace Opc.Ua.Security.Certificates
                 m_crlExtensions.Add(extension);
             }
             RawData = crl.RawData;
+            EnsureDecoded();
         }
 
         /// <summary>
@@ -99,7 +102,6 @@ namespace Opc.Ua.Security.Certificates
         {
             get
             {
-                EnsureDecoded();
                 return m_issuerName;
             }
         }
@@ -250,14 +252,8 @@ namespace Opc.Ua.Security.Certificates
                     // Signature Algorithm Identifier
                     AsnReader sigReader = seqReader.ReadSequence();
                     string oid = sigReader.ReadObjectIdentifier();
-                    try
-                    {
-                        m_hashAlgorithmName = Oids.GetHashAlgorithmName(oid);
-                    }
-                    catch (CryptographicException)
-                    {
-                        //decode crl sucesfully even if hash algorithm name of the crl is not a known opc ua hash algorithm
-                    }
+                    m_hashAlgorithmName = Oids.GetHashAlgorithmName(oid);
+
                     if (sigReader.HasData)
                     {
                         sigReader.ReadNull();

--- a/Libraries/Opc.Ua.Security.Certificates/X509Crl/X509Crl.cs
+++ b/Libraries/Opc.Ua.Security.Certificates/X509Crl/X509Crl.cs
@@ -114,7 +114,6 @@ namespace Opc.Ua.Security.Certificates
         {
             get
             {
-                EnsureDecoded();
                 return m_thisUpdate;
             }
         }
@@ -124,7 +123,6 @@ namespace Opc.Ua.Security.Certificates
         {
             get
             {
-                EnsureDecoded();
                 return m_nextUpdate;
             }
         }
@@ -134,7 +132,6 @@ namespace Opc.Ua.Security.Certificates
         {
             get
             {
-                EnsureDecoded();
                 return m_hashAlgorithmName;
             }
         }
@@ -144,7 +141,6 @@ namespace Opc.Ua.Security.Certificates
         {
             get
             {
-                EnsureDecoded();
                 return m_revokedCertificates.AsReadOnly();
             }
         }
@@ -154,7 +150,6 @@ namespace Opc.Ua.Security.Certificates
         {
             get
             {
-                EnsureDecoded();
                 return m_crlExtensions;
             }
         }
@@ -253,7 +248,6 @@ namespace Opc.Ua.Security.Certificates
                     AsnReader sigReader = seqReader.ReadSequence();
                     string oid = sigReader.ReadObjectIdentifier();
                     m_hashAlgorithmName = Oids.GetHashAlgorithmName(oid);
-
                     if (sigReader.HasData)
                     {
                         sigReader.ReadNull();

--- a/Libraries/Opc.Ua.Security.Certificates/X509Crl/X509Crl.cs
+++ b/Libraries/Opc.Ua.Security.Certificates/X509Crl/X509Crl.cs
@@ -250,7 +250,14 @@ namespace Opc.Ua.Security.Certificates
                     // Signature Algorithm Identifier
                     AsnReader sigReader = seqReader.ReadSequence();
                     string oid = sigReader.ReadObjectIdentifier();
-                    m_hashAlgorithmName = Oids.GetHashAlgorithmName(oid);
+                    try
+                    {
+                        m_hashAlgorithmName = Oids.GetHashAlgorithmName(oid);
+                    }
+                    catch (CryptographicException)
+                    {
+                        //decode crl sucesfully even if hash algorithm name of the crl is not a known opc ua hash algorithm
+                    }
                     if (sigReader.HasData)
                     {
                         sigReader.ReadNull();

--- a/Libraries/Opc.Ua.Server/Configuration/TrustList.cs
+++ b/Libraries/Opc.Ua.Server/Configuration/TrustList.cs
@@ -29,6 +29,7 @@
 
 using System;
 using System.IO;
+using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 using Opc.Ua.Security.Certificates;
@@ -538,12 +539,21 @@ namespace Opc.Ua.Server
                             {
                                 foreach (var cert in certCollection)
                                 {
-                                    if (X509Utils.CompareDistinguishedName(cert.SubjectName, crl.IssuerName) &&
-                                        crl.VerifySignature(cert, false))
+                                    try
                                     {
-                                        crlsToDelete.Add(crl);
+                                        if (X509Utils.CompareDistinguishedName(cert.SubjectName, crl.IssuerName) &&
+                                       crl.VerifySignature(cert, false))
+                                        {
+                                            crlsToDelete.Add(crl);
+                                            break;
+                                        }
+                                    }
+                                    catch (CryptographicException e)
+                                    {
+                                        Utils.LogError(e, "Failed to decode crl in store {store}", storeIdentifier.StorePath);
                                         break;
                                     }
+                                   
                                 }
                             }
 

--- a/Libraries/Opc.Ua.Server/Configuration/TrustList.cs
+++ b/Libraries/Opc.Ua.Server/Configuration/TrustList.cs
@@ -29,7 +29,6 @@
 
 using System;
 using System.IO;
-using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 using Opc.Ua.Security.Certificates;

--- a/Libraries/Opc.Ua.Server/Configuration/TrustList.cs
+++ b/Libraries/Opc.Ua.Server/Configuration/TrustList.cs
@@ -472,7 +472,7 @@ namespace Opc.Ua.Server
                         result = StatusCodes.BadCertificateInvalid;
                     }
 
-                    var storeIdentifier = isTrustedCertificate? m_trustedStore : m_issuerStore;
+                    var storeIdentifier = isTrustedCertificate ? m_trustedStore : m_issuerStore;
                     ICertificateStore store = storeIdentifier.OpenStore();
                     try
                     {
@@ -539,21 +539,12 @@ namespace Opc.Ua.Server
                             {
                                 foreach (var cert in certCollection)
                                 {
-                                    try
+                                    if (X509Utils.CompareDistinguishedName(cert.SubjectName, crl.IssuerName) &&
+                                   crl.VerifySignature(cert, false))
                                     {
-                                        if (X509Utils.CompareDistinguishedName(cert.SubjectName, crl.IssuerName) &&
-                                       crl.VerifySignature(cert, false))
-                                        {
-                                            crlsToDelete.Add(crl);
-                                            break;
-                                        }
-                                    }
-                                    catch (CryptographicException e)
-                                    {
-                                        Utils.LogError(e, "Failed to decode crl in store {store}", storeIdentifier.StorePath);
+                                        crlsToDelete.Add(crl);
                                         break;
                                     }
-                                   
                                 }
                             }
 

--- a/Stack/Opc.Ua.Core/Security/Certificates/DirectoryCertificateStore.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/DirectoryCertificateStore.cs
@@ -14,6 +14,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Threading.Tasks;

--- a/Stack/Opc.Ua.Core/Security/Certificates/DirectoryCertificateStore.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/DirectoryCertificateStore.cs
@@ -620,7 +620,7 @@ namespace Opc.Ua
                     }
                     catch (Exception e)
                     {
-                        Utils.LogError(e, "Could not parse CRL file {file}.", file.FullName);
+                        Utils.LogError(e, "Failed to parse CRL {0} in store {1}.", file.FullName, StorePath);
                         continue;
                     }
 
@@ -677,7 +677,7 @@ namespace Opc.Ua
                     }
                     catch (Exception e)
                     {
-                        Utils.LogError(e, "Failed to parse CRL in store {store}.", StorePath);
+                        Utils.LogError(e, "Failed to parse CRL {0} in store {1}.", file.FullName, StorePath);
                     }
 
                 }

--- a/Stack/Opc.Ua.Core/Security/Certificates/DirectoryCertificateStore.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/DirectoryCertificateStore.cs
@@ -14,13 +14,11 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Threading.Tasks;
 using Opc.Ua.Security.Certificates;
 using Opc.Ua.Redaction;
-using System.Security.Cryptography;
 
 namespace Opc.Ua
 {

--- a/Stack/Opc.Ua.Core/Security/Certificates/DirectoryCertificateStore.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/DirectoryCertificateStore.cs
@@ -624,32 +624,24 @@ namespace Opc.Ua
                         continue;
                     }
 
-                    try
+                    if (!X509Utils.CompareDistinguishedName(crl.IssuerName, issuer.SubjectName))
                     {
-                        if (!X509Utils.CompareDistinguishedName(crl.IssuerName, issuer.SubjectName))
-                        {
-                            continue;
-                        }
-
-                        if (!crl.VerifySignature(issuer, false))
-                        {
-                            continue;
-                        }
-
-                        if (crl.IsRevoked(certificate))
-                        {
-                            return Task.FromResult((StatusCode)StatusCodes.BadCertificateRevoked);
-                        }
-
-                        if (crl.ThisUpdate <= DateTime.UtcNow && (crl.NextUpdate == DateTime.MinValue || crl.NextUpdate >= DateTime.UtcNow))
-                        {
-                            crlExpired = false;
-                        }
-                    }
-                    catch (CryptographicException e)
-                    {
-                        Utils.LogError(e, "Failed to parse CRL {file}.", file.FullName);
                         continue;
+                    }
+
+                    if (!crl.VerifySignature(issuer, false))
+                    {
+                        continue;
+                    }
+
+                    if (crl.IsRevoked(certificate))
+                    {
+                        return Task.FromResult((StatusCode)StatusCodes.BadCertificateRevoked);
+                    }
+
+                    if (crl.ThisUpdate <= DateTime.UtcNow && (crl.NextUpdate == DateTime.MinValue || crl.NextUpdate >= DateTime.UtcNow))
+                    {
+                        crlExpired = false;
                     }
                 }
 

--- a/Stack/Opc.Ua.Core/Security/Certificates/X509CertificateStore/X509CertificateStore.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/X509CertificateStore/X509CertificateStore.cs
@@ -19,6 +19,7 @@ using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Threading.Tasks;
+using System.Xml.Linq;
 using Opc.Ua.Security.Certificates;
 using Opc.Ua.X509StoreExtensions;
 
@@ -305,7 +306,7 @@ namespace Opc.Ua
                     }
                     catch (Exception e)
                     {
-                        Utils.LogError(e, "Failed to parse CRL in store {store}.", m_storeName);
+                        Utils.LogError(e, "Failed to parse CRL in store {0}.", store.Name);
                     }
                 }
             }

--- a/Stack/Opc.Ua.Core/Security/Certificates/X509CertificateStore/X509CertificateStore.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/X509CertificateStore/X509CertificateStore.cs
@@ -15,11 +15,9 @@
 */
 
 using System;
-using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Threading.Tasks;
-using System.Xml.Linq;
 using Opc.Ua.Security.Certificates;
 using Opc.Ua.X509StoreExtensions;
 


### PR DESCRIPTION
## Proposed changes

Improve crl handling in X509CertificateStore & DirectoryCertificateStore:
- allow crls with unknown hash algorithm names to sucessfully be decoded
- skip crls that fail to decode in functions enumerating over all crls of a store

## Related Issues

- Fixes #2823

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments
