### PR TITLE
Update brokerHostName  before MqttClientOptionsBuilder uses it's value

### DIFF
--- a/Libraries/Opc.Ua.PubSub/Transport/MqttPubSubConnection.cs
+++ b/Libraries/Opc.Ua.PubSub/Transport/MqttPubSubConnection.cs
@@ -717,6 +717,17 @@ namespace Opc.Ua.PubSub.Transport
                 return null;
             }
 
+            // Setup data needed also in mqttClientOptionsBuilder
+            if ((connectionUri.Scheme == Utils.UriSchemeMqtt) || (connectionUri.Scheme == Utils.UriSchemeMqtts))
+            {
+                if (!String.IsNullOrEmpty(connectionUri.Host))
+                {
+                    m_brokerHostName = connectionUri.Host;
+                    m_brokerPort = (connectionUri.Port > 0) ? connectionUri.Port : ((connectionUri.Scheme == Utils.UriSchemeMqtt) ? 1883 : 8883);
+                    m_urlScheme = connectionUri.Scheme;
+                }
+            }
+
             ITransportProtocolConfiguration transportProtocolConfiguration =
                 new MqttClientProtocolConfiguration(PubSubConnectionConfiguration.ConnectionProperties);
 
@@ -728,6 +739,7 @@ namespace Opc.Ua.PubSub.Transport
                     .ProtocolVersion;
                 // create uniques client id
                 string clientId = $"ClientId_{new Random().Next():D10}";
+
                 // MQTTS mqttConnection.
                 if (connectionUri.Scheme == Utils.UriSchemeMqtts)
                 {
@@ -794,6 +806,8 @@ namespace Opc.Ua.PubSub.Transport
                     // Set user credentials.
                     if (mqttProtocolConfiguration.UseCredentials)
                     {
+                        // Following Password usage in both cases is correct since it is the Password position
+                        // to be taken into account for the UserName to be read properly
                         mqttClientOptionsBuilder.WithCredentials(
                             new System.Net.NetworkCredential(string.Empty, mqttProtocolConfiguration.UserName)
                                 .Password,


### PR DESCRIPTION
## Proposed changes

MqttClientOptionsBuilder now uses the configured value and overrides the "localhost" default value of the brokerHostName.

## Related Issues

- Fixes #2827 

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
