### PR TITLE
[Server] ValidateRolePermissions of MonitoredItems based of the saved user identity to allow  validation when no session is present

### DIFF
--- a/Applications/Quickstarts.Servers/SampleNodeManager/DataChangeMonitoredItem.cs
+++ b/Applications/Quickstarts.Servers/SampleNodeManager/DataChangeMonitoredItem.cs
@@ -341,6 +341,18 @@ namespace Opc.Ua.Sample
         }
 
         /// <summary>
+        /// The monitored items owner identity.
+        /// </summary>
+        public IUserIdentity EffectiveIdentity
+        {
+            get
+            {
+                ISubscription subscription = m_subscription;
+                return subscription?.EffectiveIdentity;
+            }
+        }
+
+        /// <summary>
         /// The identifier for the subscription that the monitored item belongs to.
         /// </summary>
         public uint SubscriptionId

--- a/Libraries/Opc.Ua.Server/Diagnostics/CustomNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/Diagnostics/CustomNodeManager.cs
@@ -3752,7 +3752,7 @@ namespace Opc.Ua.Server
         /// <returns></returns>
         public ServiceResult ValidateRolePermissions(OperationContext operationContext, NodeId nodeId, PermissionType requestedPermission)
         {
-            if (operationContext.Session == null || requestedPermission == PermissionType.None)
+            if (requestedPermission == PermissionType.None)
             {
                 // no permission is required hence the validation passes.
                 return StatusCodes.Good;

--- a/Libraries/Opc.Ua.Server/Diagnostics/MonitoredNode.cs
+++ b/Libraries/Opc.Ua.Server/Diagnostics/MonitoredNode.cs
@@ -299,7 +299,7 @@ namespace Opc.Ua.Server
 
                         if (ServiceResult.IsBad(validationResult))
                         {
-                            // skip reading the value MonitoredItem without permissions
+                            // skip if the monitored item does not have permission to read
                             continue;
                         }
 

--- a/Libraries/Opc.Ua.Server/Diagnostics/MonitoredNode.cs
+++ b/Libraries/Opc.Ua.Server/Diagnostics/MonitoredNode.cs
@@ -294,6 +294,15 @@ namespace Opc.Ua.Server
 
                     if (monitoredItem.AttributeId == Attributes.Value && (changes & NodeStateChangeMasks.Value) != 0)
                     {
+                        // validate if the monitored item has the required role permissions to read the value
+                        ServiceResult validationResult = NodeManager.ValidateRolePermissions(new OperationContext(monitoredItem), node.NodeId, PermissionType.Read);
+
+                        if (ServiceResult.IsBad(validationResult))
+                        {
+                            // skip reading the value MonitoredItem without permissions
+                            continue;
+                        }
+
                         QueueValue(context, node, monitoredItem);
                         continue;
                     }

--- a/Libraries/Opc.Ua.Server/NodeManager/MasterNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/NodeManager/MasterNodeManager.cs
@@ -3233,7 +3233,7 @@ namespace Opc.Ua.Server
         /// <returns></returns>
         protected internal static ServiceResult ValidateRolePermissions(OperationContext context, NodeMetadata nodeMetadata, PermissionType requestedPermission)
         {
-            if (context.Session == null || nodeMetadata == null || requestedPermission == PermissionType.None)
+            if (nodeMetadata == null || requestedPermission == PermissionType.None)
             {
                 // no permission is required hence the validation passes
                 return StatusCodes.Good;
@@ -3323,7 +3323,7 @@ namespace Opc.Ua.Server
                 }
             }
 
-            var currentRoleIds = context.Session.Identity.GrantedRoleIds;
+            var currentRoleIds = context.UserIdentity.GrantedRoleIds;
             if (currentRoleIds == null || currentRoleIds.Count == 0)
             {
                 return ServiceResult.Create(StatusCodes.BadUserAccessDenied, "Current user has no granted role.");

--- a/Libraries/Opc.Ua.Server/Server/OperationContext.cs
+++ b/Libraries/Opc.Ua.Server/Server/OperationContext.cs
@@ -127,6 +127,7 @@ namespace Opc.Ua.Server
             if (monitoredItem == null) throw new ArgumentNullException(nameof(monitoredItem));
             
             m_channelContext = null;
+            m_identity = monitoredItem.EffectiveIdentity;
             m_session = monitoredItem.Session;
 
             if (m_session != null)

--- a/Libraries/Opc.Ua.Server/Subscription/IMonitoredItem.cs
+++ b/Libraries/Opc.Ua.Server/Subscription/IMonitoredItem.cs
@@ -53,6 +53,11 @@ namespace Opc.Ua.Server
         Session Session { get; }
 
         /// <summary>
+        /// The monitored items owner identity.
+        /// </summary>
+        IUserIdentity EffectiveIdentity { get; }
+
+        /// <summary>
         /// The identifier for the item that is unique within the server.
         /// </summary>
         uint Id { get; }

--- a/Libraries/Opc.Ua.Server/Subscription/MonitoredItem.cs
+++ b/Libraries/Opc.Ua.Server/Subscription/MonitoredItem.cs
@@ -398,6 +398,19 @@ namespace Opc.Ua.Server
                 }
             }
         }
+        /// <summary>
+        /// The monitored items owner identity.
+        /// </summary>
+        public IUserIdentity EffectiveIdentity
+        {
+            get
+            {
+                lock (m_lock)
+                {
+                    return m_subscription?.EffectiveIdentity;
+                }
+            }
+        }
 
         /// <summary>
         /// The identifier for the item that is unique within the server.

--- a/Libraries/Opc.Ua.Server/Subscription/Subscription.cs
+++ b/Libraries/Opc.Ua.Server/Subscription/Subscription.cs
@@ -50,6 +50,11 @@ namespace Opc.Ua.Server
         Session Session { get; }
 
         /// <summary>
+        /// The subscriptions owner identity.
+        /// </summary>
+        IUserIdentity EffectiveIdentity { get; }
+
+        /// <summary>
         /// The identifier for the item that is unique within the server.
         /// </summary>
         uint Id { get; }
@@ -209,6 +214,14 @@ namespace Opc.Ua.Server
         }
 
         /// <summary>
+        /// The subscriptions owner identity.
+        /// </summary>
+        public IUserIdentity EffectiveIdentity
+        {
+            get { return (m_session != null) ? m_session.EffectiveIdentity : m_savedOwnerIdentity; }
+        }
+
+        /// <summary>
         /// Queues an item that is ready to publish.
         /// </summary>
         public void ItemReadyToPublish(IMonitoredItem monitoredItem)
@@ -253,14 +266,6 @@ namespace Opc.Ua.Server
                     return m_session.Id;
                 }
             }
-        }
-
-        /// <summary>
-        /// The owner identity.
-        /// </summary>
-        public UserIdentityToken OwnerIdentity
-        {
-            get { return (m_session != null) ? m_session.IdentityToken : m_savedOwnerIdentity; }
         }
 
         /// <summary>
@@ -594,7 +599,7 @@ namespace Opc.Ua.Server
             {
                 if (m_session != null)
                 {
-                    m_savedOwnerIdentity = m_session.IdentityToken;
+                    m_savedOwnerIdentity = m_session.EffectiveIdentity;
                     m_session = null;
                 }
             }
@@ -2414,7 +2419,7 @@ namespace Opc.Ua.Server
         private IServerInternal m_server;
         private Session m_session;
         private uint m_id;
-        private UserIdentityToken m_savedOwnerIdentity;
+        private IUserIdentity m_savedOwnerIdentity;
         private double m_publishingInterval;
         private uint m_maxLifetimeCount;
         private uint m_maxKeepAliveCount;

--- a/Libraries/Opc.Ua.Server/Subscription/SubscriptionManager.cs
+++ b/Libraries/Opc.Ua.Server/Subscription/SubscriptionManager.cs
@@ -1223,11 +1223,11 @@ namespace Opc.Ua.Server
                     }
 
                     // get the identity of the current or last owner
-                    UserIdentityToken ownerIdentity = subscription.OwnerIdentity;
+                    UserIdentityToken ownerIdentity = subscription.EffectiveIdentity.GetIdentityToken();
 
                     // Validate the identity of the user who owns/owned the subscription
                     // is the same as the new owner.
-                    bool validIdentity = Utils.IsEqualUserIdentity(ownerIdentity, context.Session.IdentityToken);
+                    bool validIdentity = Utils.IsEqualUserIdentity(ownerIdentity, context.Session.EffectiveIdentity.GetIdentityToken());
 
                     // Test if anonymous user is using a
                     // secure session using Sign or SignAndEncrypt


### PR DESCRIPTION
## Proposed changes

Extend IMonitoredItem Interface to allow the access to the savedUserIdentity of the owning Subscription.

This allows the MonitoredNode to validate the RolePermissions of the owning user of the MI to decide if reading the value /event is allowed.

## Related Issues

- Fixes #2656

## Types of changes

- [] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- x ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments