### PR TITLE
Added a minimal rogue client detection mechanism at the transport level

### DIFF
--- a/Stack/Opc.Ua.Core/Stack/Tcp/TcpListenerChannel.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/TcpListenerChannel.cs
@@ -268,14 +268,14 @@ namespace Opc.Ua.Bindings
 
                 if (close)
                 {
-                    // mark the RemoteAddress as potential rogue if Basic128Rsa15
+                    // mark the RemoteAddress as potential problematic if Basic128Rsa15
                     if ((SecurityPolicyUri == SecurityPolicies.Basic128Rsa15) &&
                         (reason.StatusCode == StatusCodes.BadSecurityChecksFailed || reason.StatusCode == StatusCodes.BadTcpMessageTypeInvalid))
                     {
                         var tcpTransportListener = m_listener as TcpTransportListener;
                         if (tcpTransportListener != null)
                         {
-                            tcpTransportListener.MarkAsPotentialRogue
+                            tcpTransportListener.MarkAsPotentialProblematic
                                 (((IPEndPoint)Socket.RemoteEndpoint).Address);
                         }
                     }

--- a/Stack/Opc.Ua.Core/Stack/Tcp/TcpListenerChannel.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/TcpListenerChannel.cs
@@ -268,8 +268,9 @@ namespace Opc.Ua.Bindings
 
                 if (close)
                 {
-                    // mark the RemoteAddress as potential rogue
-                    if (reason.StatusCode == StatusCodes.BadSecurityChecksFailed || reason.StatusCode == StatusCodes.BadTcpMessageTypeInvalid)
+                    // mark the RemoteAddress as potential rogue if Basic128Rsa15
+                    if ((SecurityPolicyUri == SecurityPolicies.Basic128Rsa15) &&
+                        (reason.StatusCode == StatusCodes.BadSecurityChecksFailed || reason.StatusCode == StatusCodes.BadTcpMessageTypeInvalid))
                     {
                         var tcpTransportListener = m_listener as TcpTransportListener;
                         if (tcpTransportListener != null)

--- a/Stack/Opc.Ua.Core/Stack/Tcp/TcpListenerChannel.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/TcpListenerChannel.cs
@@ -11,6 +11,7 @@
 */
 
 using System;
+using System.Net;
 using System.Net.Sockets;
 using System.Security.Cryptography.X509Certificates;
 using Microsoft.Extensions.Logging;
@@ -267,6 +268,17 @@ namespace Opc.Ua.Bindings
 
                 if (close)
                 {
+                    // mark the RemoteAddress as potential rogue
+                    if (reason.StatusCode == StatusCodes.BadSecurityChecksFailed || reason.StatusCode == StatusCodes.BadTcpMessageTypeInvalid)
+                    {
+                        var tcpTransportListener = m_listener as TcpTransportListener;
+                        if (tcpTransportListener != null)
+                        {
+                            tcpTransportListener.MarkAsPotentialRogue
+                                (((IPEndPoint)Socket.RemoteEndpoint).Address);
+                        }
+                    }
+
                     // close channel immediately.
                     ChannelFaulted();
                 }

--- a/Stack/Opc.Ua.Core/Stack/Tcp/TcpTransportListener.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/TcpTransportListener.cs
@@ -752,8 +752,9 @@ namespace Opc.Ua.Bindings
             {
                 bool isRogue = false;
 
-                // Filter out the RemoveAddresses which are detected with rogue behavior
-                if ((bool)m_rogueClientTracker?.IsBlocked(((IPEndPoint)e?.AcceptSocket?.RemoteEndPoint)?.Address))
+                // Filter out the Remote IP addresses which are detected with rogue behavior
+                IPAddress ipAddress = ((IPEndPoint)e?.AcceptSocket?.RemoteEndPoint)?.Address;
+                if (ipAddress != null && m_rogueClientTracker.IsBlocked(ipAddress))
                 {
                     Utils.LogError("OnAccept: RemoteEndpoint address: {0} refused access for behaving as potential rogue ",
                         ((IPEndPoint)e.AcceptSocket.RemoteEndPoint).Address.ToString());

--- a/Stack/Opc.Ua.Core/Stack/Tcp/TcpTransportListener.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/TcpTransportListener.cs
@@ -753,7 +753,7 @@ namespace Opc.Ua.Bindings
                 bool isRogue = false;
 
                 // Filter out the RemoveAddresses which are detected with rogue behavior
-                if (m_rogueClientTracker.IsBlocked(((IPEndPoint)e.AcceptSocket.RemoteEndPoint).Address))
+                if ((bool)m_rogueClientTracker?.IsBlocked(((IPEndPoint)e?.AcceptSocket?.RemoteEndPoint)?.Address))
                 {
                     Utils.LogError("OnAccept: RemoteEndpoint address: {0} refused access for behaving as potential rogue ",
                         ((IPEndPoint)e.AcceptSocket.RemoteEndPoint).Address.ToString());

--- a/Stack/Opc.Ua.Core/Stack/Tcp/TcpTransportListener.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/TcpTransportListener.cs
@@ -551,6 +551,8 @@ namespace Opc.Ua.Bindings
         {
             lock (m_lock)
             {
+                m_rogueClientTracker = new RogueClientTracker();
+
                 // ensure a valid port.
                 int port = m_uri.Port;
 
@@ -638,8 +640,6 @@ namespace Opc.Ua.Bindings
                         StatusCodes.BadNoCommunication,
                         "Failed to establish tcp listener sockets for Ipv4 and IPv6.");
                 }
-
-                m_rogueClientTracker = new RogueClientTracker();
             }
         }
 


### PR DESCRIPTION
## Proposed changes

Clients that behave rogue by repeatedly sending invalid messages in a certain interval of time are now tracked and blocked from connecting for a predefined amount of time.
Time calculations are independent of system time.

## Related Issues

- Fixes #

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
