### PR TITLE
[Server] Fix: Return full CertificateChain after Certificate Update

### DIFF
--- a/Libraries/Opc.Ua.Server/Configuration/ConfigurationNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/Configuration/ConfigurationNodeManager.cs
@@ -80,7 +80,7 @@ namespace Opc.Ua.Server
             ServerCertificateGroup defaultApplicationGroup = new ServerCertificateGroup {
                 NodeId = Opc.Ua.ObjectIds.ServerConfiguration_CertificateGroups_DefaultApplicationGroup,
                 BrowseName = Opc.Ua.BrowseNames.DefaultApplicationGroup,
-                CertificateTypes = new NodeId[]{},
+                CertificateTypes = new NodeId[] { },
                 ApplicationCertificates = new CertificateIdentifierCollection(),
                 IssuerStore = new CertificateStoreIdentifier(configuration.SecurityConfiguration.TrustedIssuerCertificates.StorePath),
                 TrustedStore = new CertificateStoreIdentifier(configuration.SecurityConfiguration.TrustedPeerCertificates.StorePath)
@@ -397,7 +397,7 @@ namespace Opc.Ua.Server
 
                 // identify the existing certificate to be updated
                 // it should be of the same type and same subject name as the new certificate
-                CertificateIdentifier existingCertIdentifier = certificateGroup.ApplicationCertificates.FirstOrDefault(cert => 
+                CertificateIdentifier existingCertIdentifier = certificateGroup.ApplicationCertificates.FirstOrDefault(cert =>
                     X509Utils.CompareDistinguishedName(cert.Certificate.Subject, newCert.Subject) &&
                     cert.CertificateType == certificateTypeId);
 
@@ -451,8 +451,8 @@ namespace Opc.Ua.Server
                     {
                         // verify cert with issuer chain
                         CertificateValidator certValidator = new CertificateValidator();
-// TODO: why?
-//                        certValidator.MinimumCertificateKeySize = 1024;
+                        // TODO: why?
+                        //                        certValidator.MinimumCertificateKeySize = 1024;
                         CertificateTrustList issuerStore = new CertificateTrustList();
                         CertificateIdentifierCollection issuerCollection = new CertificateIdentifierCollection();
                         foreach (var issuerCert in newIssuerCollection)
@@ -677,7 +677,15 @@ namespace Opc.Ua.Server
                     // give the client some time to receive the response
                     // before the certificate update may disconnect all sessions
                     await Task.Delay(1000).ConfigureAwait(false);
-                    await m_configuration.CertificateValidator.UpdateCertificateAsync(m_configuration.SecurityConfiguration).ConfigureAwait(false);
+                    try
+                    {
+                        await m_configuration.CertificateValidator.UpdateCertificateAsync(m_configuration.SecurityConfiguration).ConfigureAwait(false);
+                    }
+                    catch (Exception ex)
+                    {
+                        Utils.LogError(ex, "Failed to sucessfully Apply Changes: Error updating application instance certificate");
+                        throw ex;
+                    }
                 }
                 );
             }

--- a/Libraries/Opc.Ua.Server/Configuration/ConfigurationNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/Configuration/ConfigurationNodeManager.cs
@@ -452,7 +452,7 @@ namespace Opc.Ua.Server
                         // verify cert with issuer chain
                         CertificateValidator certValidator = new CertificateValidator();
                         // TODO: why?
-                        //                        certValidator.MinimumCertificateKeySize = 1024;
+                        // certValidator.MinimumCertificateKeySize = 1024;
                         CertificateTrustList issuerStore = new CertificateTrustList();
                         CertificateIdentifierCollection issuerCollection = new CertificateIdentifierCollection();
                         foreach (var issuerCert in newIssuerCollection)
@@ -683,7 +683,7 @@ namespace Opc.Ua.Server
                     }
                     catch (Exception ex)
                     {
-                        Utils.LogError(ex, "Failed to sucessfully Apply Changes: Error updating application instance certificate");
+                        Utils.LogCritical(ex, "Failed to sucessfully Apply Changes: Error updating application instance certificates. Server could be in faulted state.");
                         throw ex;
                     }
                 }

--- a/Libraries/Opc.Ua.Server/Server/StandardServer.cs
+++ b/Libraries/Opc.Ua.Server/Server/StandardServer.cs
@@ -488,7 +488,7 @@ namespace Opc.Ua.Server
                         // check if complete chain should be sent.
                         if (InstanceCertificateTypesProvider.SendCertificateChain)
                         {
-                            serverCertificate = InstanceCertificateTypesProvider.LoadCertificateChainRaw(instanceCertificate);
+                            serverCertificate = InstanceCertificateTypesProvider.LoadCertificateChainRawAsync(instanceCertificate).GetAwaiter().GetResult();
                         }
                         else
                         {

--- a/Stack/Opc.Ua.Bindings.Https/Stack/Https/HttpsServiceHost.cs
+++ b/Stack/Opc.Ua.Bindings.Https/Stack/Https/HttpsServiceHost.cs
@@ -125,7 +125,7 @@ namespace Opc.Ua.Bindings
                     // check if complete chain should be sent.
                     if (certificateTypesProvider.SendCertificateChain)
                     {
-                        description.ServerCertificate = certificateTypesProvider.LoadCertificateChainRaw(instanceCertificate);
+                        description.ServerCertificate = certificateTypesProvider.LoadCertificateChainRawAsync(instanceCertificate).GetAwaiter().GetResult();
                     }
                 }
 

--- a/Stack/Opc.Ua.Bindings.Https/Stack/Https/HttpsTransportListener.cs
+++ b/Stack/Opc.Ua.Bindings.Https/Stack/Https/HttpsTransportListener.cs
@@ -477,10 +477,9 @@ namespace Opc.Ua.Bindings
 
             foreach (EndpointDescription description in m_descriptions)
             {
-                ServerBase.SetServerCertificateInEndpointDescription(description,
-                    m_serverCertProvider.SendCertificateChain,
+                ServerBase.SetServerCertificateInEndpointDescriptionAsync(description,
                     certificateTypeProvider,
-                    false);
+                    false).GetAwaiter().GetResult();
             }
 
             Start();

--- a/Stack/Opc.Ua.Core/Security/Certificates/CertificateTypesProvider.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/CertificateTypesProvider.cs
@@ -135,7 +135,7 @@ namespace Opc.Ua.Security.Certificates
             }
 
             // load certificate chain.
-            Tuple<X509Certificate2Collection, byte[]> dictionaryValue = await LoadCertificateChainFromStoreAsync(certificate);
+            Tuple<X509Certificate2Collection, byte[]> dictionaryValue = await LoadCertificateChainFromStoreAsync(certificate).ConfigureAwait(false);
 
             // update cached values
             m_certificateChain[certificate.Thumbprint] = dictionaryValue;
@@ -160,7 +160,7 @@ namespace Opc.Ua.Security.Certificates
             }
 
             // load certificate chain.
-            Tuple<X509Certificate2Collection, byte[]> dictionaryValue = await LoadCertificateChainFromStoreAsync(certificate);
+            Tuple<X509Certificate2Collection, byte[]> dictionaryValue = await LoadCertificateChainFromStoreAsync(certificate).ConfigureAwait(false);
 
             // update cached values
             m_certificateChain[certificate.Thumbprint] = dictionaryValue;
@@ -175,10 +175,8 @@ namespace Opc.Ua.Security.Certificates
         public async Task UpdateAsync(SecurityConfiguration securityConfiguration)
         {
             m_securityConfiguration = securityConfiguration;
-            await Task.CompletedTask;
-            //ToDo intialize internal CertificateValidator after Certificate Update
-            //await InitializeAsync();
-
+            //ToDo intialize internal CertificateValidator after Certificate Update to clear cache of old application certificates
+            await Task.CompletedTask.ConfigureAwait(false);
         }
 
         /// <summary>

--- a/Stack/Opc.Ua.Core/Security/Certificates/CertificateTypesProvider.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/CertificateTypesProvider.cs
@@ -175,7 +175,10 @@ namespace Opc.Ua.Security.Certificates
         public async Task UpdateAsync(SecurityConfiguration securityConfiguration)
         {
             m_securityConfiguration = securityConfiguration;
-            await InitializeAsync();
+            await Task.CompletedTask;
+            //ToDo intialize internal CertificateValidator after Certificate Update
+            //await InitializeAsync();
+
         }
 
         /// <summary>

--- a/Stack/Opc.Ua.Core/Stack/Server/ServerBase.cs
+++ b/Stack/Opc.Ua.Core/Stack/Server/ServerBase.cs
@@ -795,6 +795,15 @@ namespace Opc.Ua
         protected virtual void OnCertificateUpdate(object sender, CertificateUpdateEventArgs e)
         {
             InstanceCertificateTypesProvider.UpdateAsync(e.SecurityConfiguration).GetAwaiter().GetResult();
+
+            //update certificate in the endpoint descriptions
+            foreach (EndpointDescription endpointDescription in m_endpoints)
+            {
+                SetServerCertificateInEndpointDescriptionAsync(
+                    endpointDescription,
+                    InstanceCertificateTypesProvider).GetAwaiter().GetResult();
+            }
+
             foreach (var listener in TransportListeners)
             {
                 listener.CertificateUpdate(e.CertificateValidator, InstanceCertificateTypesProvider);

--- a/Stack/Opc.Ua.Core/Stack/Server/ServerBase.cs
+++ b/Stack/Opc.Ua.Core/Stack/Server/ServerBase.cs
@@ -617,7 +617,7 @@ namespace Opc.Ua
                 // check if complete chain should be sent.
                 if (certificateTypesProvider.SendCertificateChain)
                 {
-                    description.ServerCertificate = await certificateTypesProvider.LoadCertificateChainRawAsync(serverCertificate);
+                    description.ServerCertificate = await certificateTypesProvider.LoadCertificateChainRawAsync(serverCertificate).ConfigureAwait(false);
                 }
                 else
                 {

--- a/Stack/Opc.Ua.Core/Stack/Tcp/TcpServiceHost.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/TcpServiceHost.cs
@@ -76,7 +76,6 @@ namespace Opc.Ua.Bindings
                     uri.Host = computerName;
                 }
 
-                bool sendCertificateChain = instanceCertificateTypesProvider.SendCertificateChain;
                 ITransportListener listener = this.Create();
                 if (listener != null)
                 {
@@ -96,10 +95,9 @@ namespace Opc.Ua.Bindings
                         };
                         description.UserIdentityTokens = serverBase.GetUserTokenPolicies(configuration, description);
 
-                        ServerBase.SetServerCertificateInEndpointDescription(
+                        ServerBase.SetServerCertificateInEndpointDescriptionAsync(
                             description,
-                            sendCertificateChain,
-                            instanceCertificateTypesProvider);
+                            instanceCertificateTypesProvider).GetAwaiter().GetResult();
 
                         listenerEndpoints.Add(description);
                     }

--- a/Stack/Opc.Ua.Core/Stack/Tcp/TcpTransportListener.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/TcpTransportListener.cs
@@ -490,7 +490,7 @@ namespace Opc.Ua.Bindings
                     X509Certificate2 serverCertificate = certificateTypesProvider.GetInstanceCertificate(description.SecurityPolicyUri);
                     if (certificateTypesProvider.SendCertificateChain)
                     {
-                        byte[] serverCertificateChainRaw = certificateTypesProvider.LoadCertificateChainRaw(serverCertificate);
+                        byte[] serverCertificateChainRaw = certificateTypesProvider.LoadCertificateChainRawAsync(serverCertificate).GetAwaiter().GetResult();
                         description.ServerCertificate = serverCertificateChainRaw;
                     }
                     else

--- a/Stack/Opc.Ua.Core/Stack/Tcp/UaSCBinaryChannel.Asymmetric.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/UaSCBinaryChannel.Asymmetric.cs
@@ -898,7 +898,7 @@ namespace Opc.Ua.Bindings
 
                 if (loadChain)
                 {
-                    m_serverCertificateChain = m_serverCertificateTypesProvider?.LoadCertificateChain(receiverCertificate);
+                    m_serverCertificateChain = m_serverCertificateTypesProvider?.LoadCertificateChainAsync(receiverCertificate).GetAwaiter().GetResult();
                 }
             }
             else
@@ -930,7 +930,7 @@ namespace Opc.Ua.Bindings
                             m_securityMode = endpoint.SecurityMode;
                             m_selectedEndpoint = endpoint;
                             m_serverCertificate = m_serverCertificateTypesProvider.GetInstanceCertificate(m_securityPolicyUri);
-                            m_serverCertificateChain = m_serverCertificateTypesProvider.LoadCertificateChain(m_serverCertificate);
+                            m_serverCertificateChain = m_serverCertificateTypesProvider.LoadCertificateChainAsync(m_serverCertificate).GetAwaiter().GetResult();
                             supported = true;
                             break;
                         }


### PR DESCRIPTION
## Proposed changes

Fix the CertificateTypesProvider to also return the correct chain after a CertificateUpdate occured.

## Related Issues

- Fixes #

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

