### PR TITLE
[Server] Fix: Return full CertificateChain after Certificate Update

### DIFF
--- a/Libraries/Opc.Ua.Server/Configuration/ConfigurationNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/Configuration/ConfigurationNodeManager.cs
@@ -677,7 +677,15 @@ namespace Opc.Ua.Server
                     // give the client some time to receive the response
                     // before the certificate update may disconnect all sessions
                     await Task.Delay(1000).ConfigureAwait(false);
-                    await m_configuration.CertificateValidator.UpdateCertificateAsync(m_configuration.SecurityConfiguration).ConfigureAwait(false);
+                    try
+                    {
+                        await m_configuration.CertificateValidator.UpdateCertificateAsync(m_configuration.SecurityConfiguration).ConfigureAwait(false);
+                    }
+                    catch (Exception ex)
+                    {
+                        Utils.LogCritical(ex, "Failed to sucessfully Apply Changes: Error updating application instance certificates. Server could be in faulted state.");
+                        throw ex;
+                    }
                 }
                 );
             }

--- a/Stack/Opc.Ua.Bindings.Https/Stack/Https/HttpsTransportListener.cs
+++ b/Stack/Opc.Ua.Bindings.Https/Stack/Https/HttpsTransportListener.cs
@@ -478,7 +478,6 @@ namespace Opc.Ua.Bindings
             foreach (EndpointDescription description in m_descriptions)
             {
                 ServerBase.SetServerCertificateInEndpointDescription(description,
-                    m_serverCertProvider.SendCertificateChain,
                     certificateTypeProvider,
                     false);
             }

--- a/Stack/Opc.Ua.Core/Security/Certificates/CertificateTypesProvider.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/CertificateTypesProvider.cs
@@ -119,7 +119,7 @@ namespace Opc.Ua.Security.Certificates
         }
 
         /// <summary>
-        /// Loads the cached certificate chain blob of a certificate for use in a secure channel as raw byte array.
+        /// Loads the cached certificate chain blob of a certificate for use in a secure channel as raw byte array from cache.
         /// </summary>
         /// <param name="certificate">The application certificate.</param>
         public byte[] LoadCertificateChainRaw(X509Certificate2 certificate)
@@ -199,6 +199,7 @@ namespace Opc.Ua.Security.Certificates
         public void Update(SecurityConfiguration securityConfiguration)
         {
             m_securityConfiguration = securityConfiguration;
+            //ToDo intialize internal CertificateValidator after Certificate Update to clear cache of old application certificates
         }
 
         CertificateValidator m_certificateValidator;

--- a/Stack/Opc.Ua.Core/Stack/Server/ServerBase.cs
+++ b/Stack/Opc.Ua.Core/Stack/Server/ServerBase.cs
@@ -604,12 +604,10 @@ namespace Opc.Ua
         /// Sets the Server Certificate in an Endpoint description if the description requires encryption.
         /// </summary>
         /// <param name="description">the endpoint Description to set the server certificate</param>
-        /// <param name="sendCertificateChain">true if the certificate chain shall be sent</param>
         /// <param name="certificateTypesProvider">The provider to get the server certificate per certificate type.</param>
         /// <param name="checkRequireEncryption">only set certificate if the endpoint does require Encryption</param>
         public static void SetServerCertificateInEndpointDescription(
             EndpointDescription description,
-            bool sendCertificateChain,
             CertificateTypesProvider certificateTypesProvider,
             bool checkRequireEncryption = true)
         {
@@ -617,7 +615,7 @@ namespace Opc.Ua
             {
                 X509Certificate2 serverCertificate = certificateTypesProvider.GetInstanceCertificate(description.SecurityPolicyUri);
                 // check if complete chain should be sent.
-                if (sendCertificateChain)
+                if (certificateTypesProvider.SendCertificateChain)
                 {
                     description.ServerCertificate = certificateTypesProvider.LoadCertificateChainRaw(serverCertificate);
                 }
@@ -803,6 +801,15 @@ namespace Opc.Ua
                 // preload chain 
                 InstanceCertificateTypesProvider.LoadCertificateChainAsync(certificateIdentifier.Find(false).GetAwaiter().GetResult()).GetAwaiter().GetResult();
             }
+
+            //update certificate in the endpoint descriptions
+            foreach (EndpointDescription endpointDescription in m_endpoints)
+            {
+                SetServerCertificateInEndpointDescription(
+                    endpointDescription,
+                    InstanceCertificateTypesProvider);
+            }
+
             foreach (var listener in TransportListeners)
             {
                 listener.CertificateUpdate(e.CertificateValidator, InstanceCertificateTypesProvider);

--- a/Stack/Opc.Ua.Core/Stack/Server/ServerBase.cs
+++ b/Stack/Opc.Ua.Core/Stack/Server/ServerBase.cs
@@ -797,6 +797,12 @@ namespace Opc.Ua
         protected virtual void OnCertificateUpdate(object sender, CertificateUpdateEventArgs e)
         {
             InstanceCertificateTypesProvider.Update(e.SecurityConfiguration);
+
+            foreach (var certificateIdentifier in Configuration.SecurityConfiguration.ApplicationCertificates)
+            {
+                // preload chain 
+                InstanceCertificateTypesProvider.LoadCertificateChainAsync(certificateIdentifier.Find(false).GetAwaiter().GetResult()).GetAwaiter().GetResult();
+            }
             foreach (var listener in TransportListeners)
             {
                 listener.CertificateUpdate(e.CertificateValidator, InstanceCertificateTypesProvider);
@@ -1472,7 +1478,7 @@ namespace Opc.Ua
         {
             request.CallSynchronously();
         }
-#endregion
+        #endregion
 
         #region RequestQueue Class
         /// <summary>
@@ -1702,7 +1708,7 @@ namespace Opc.Ua
                 }
             }
 #endif
-#endregion
+            #endregion
 
             #region Private Fields
             private ServerBase m_server;
@@ -1716,7 +1722,7 @@ namespace Opc.Ua
             private Queue<IEndpointIncomingRequest> m_queue;
             private int m_totalThreadCount;
 #endif
-#endregion
+            #endregion
 
         }
         #endregion

--- a/Stack/Opc.Ua.Core/Stack/Tcp/TcpServiceHost.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/TcpServiceHost.cs
@@ -98,7 +98,6 @@ namespace Opc.Ua.Bindings
 
                         ServerBase.SetServerCertificateInEndpointDescription(
                             description,
-                            sendCertificateChain,
                             instanceCertificateTypesProvider);
 
                         listenerEndpoints.Add(description);


### PR DESCRIPTION
## Proposed changes


Fix the CertificateTypesProvider to also return the correct chain after a CertificateUpdate occured.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.
