### PR TITLE
[Client] Fix: KeepAliveInterval was not updated on ModifySubscription

### DIFF
--- a/Libraries/Opc.Ua.Client/Subscription/Subscription.cs
+++ b/Libraries/Opc.Ua.Client/Subscription/Subscription.cs
@@ -1824,15 +1824,9 @@ namespace Opc.Ua.Client
             {
                 Utils.SilentDispose(m_publishTimer);
                 m_publishTimer = null;
-
+                m_keepAliveInterval = CalculateKeepAliveInterval();
                 Interlocked.Exchange(ref m_lastNotificationTime, DateTime.UtcNow.Ticks);
                 m_lastNotificationTickCount = HiResClock.TickCount;
-                m_keepAliveInterval = (int)(Math.Min(m_currentPublishingInterval * (m_currentKeepAliveCount + 1), Int32.MaxValue));
-                if (m_keepAliveInterval < kMinKeepAliveTimerInterval)
-                {
-                    m_keepAliveInterval = (int)(Math.Min(m_publishingInterval * (m_keepAliveCount + 1), Int32.MaxValue));
-                    m_keepAliveInterval = Math.Max(kMinKeepAliveTimerInterval, m_keepAliveInterval);
-                }
 #if NET6_0_OR_GREATER
                 var publishTimer = new PeriodicTimer(TimeSpan.FromMilliseconds(m_keepAliveInterval));
                 _ = Task.Run(() => OnKeepAliveAsync(publishTimer));
@@ -2020,9 +2014,10 @@ namespace Opc.Ua.Client
             {
                 m_currentPublishingEnabled = m_publishingEnabled;
                 m_transferId = m_id = subscriptionId;
-                StartKeepAliveTimer();
                 m_changeMask |= SubscriptionChangeMask.Created;
             }
+
+            StartKeepAliveTimer();
 
             if (m_keepAliveCount != revisedKeepAliveCount)
             {
@@ -2051,6 +2046,21 @@ namespace Opc.Ua.Client
             {
                 Utils.LogInfo("For subscription {0}, the priority was set to 0.", Id);
             }
+        }
+
+        /// <summary>
+        /// Calculate the KeepAliveInterval based on <see cref="m_currentPublishingInterval"/> and <see cref="m_currentKeepAliveCount"/>
+        /// </summary>
+        /// <returns></returns>
+        private int CalculateKeepAliveInterval()
+        {
+            int keepAliveInterval = (int)(Math.Min(m_currentPublishingInterval * (m_currentKeepAliveCount + 1), Int32.MaxValue));
+            if (m_keepAliveInterval < kMinKeepAliveTimerInterval)
+            {
+                keepAliveInterval = (int)(Math.Min(m_publishingInterval * (m_keepAliveCount + 1), Int32.MaxValue));
+                keepAliveInterval = Math.Max(kMinKeepAliveTimerInterval, keepAliveInterval);
+            }
+            return keepAliveInterval;
         }
 
         /// <summary>


### PR DESCRIPTION
## Proposed changes

Restart KeepAlive Timer with Correct KeepAliveInterval on ModifySubsription

## Related Issues

- Fixes #2863

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [x] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.
