### PR TITLE
Register callback to notify about new channel token activation (#2872)

### DIFF
--- a/Stack/Opc.Ua.Core/Stack/Client/UaChannelBase.cs
+++ b/Stack/Opc.Ua.Core/Stack/Client/UaChannelBase.cs
@@ -198,6 +198,13 @@ namespace Opc.Ua
         /// </summary>
         public ChannelToken CurrentToken => null;
 
+        /// <inheritdoc/>
+        public event ChannelTokenActivatedEventHandler OnTokenActivated
+        {
+            add { }
+            remove { }
+        }
+
         /// <summary>
         /// Gets or sets the default timeout for requests send via the channel.
         /// </summary>
@@ -685,7 +692,7 @@ namespace Opc.Ua
         #endregion
         }
         #endregion
-        
+
         /// <summary>
         /// Processes the request.
         /// </summary>

--- a/Stack/Opc.Ua.Core/Stack/Https/HttpsTransportChannel.cs
+++ b/Stack/Opc.Ua.Core/Stack/Https/HttpsTransportChannel.cs
@@ -109,6 +109,13 @@ namespace Opc.Ua.Bindings
         public ChannelToken CurrentToken => null;
 
         /// <inheritdoc/>
+        public event ChannelTokenActivatedEventHandler OnTokenActivated
+        {
+            add { }
+            remove { }
+        }
+
+        /// <inheritdoc/>
         public int OperationTimeout
         {
             get => m_operationTimeout;

--- a/Stack/Opc.Ua.Core/Stack/Tcp/UaSCBinaryChannel.Symmetric.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/UaSCBinaryChannel.Symmetric.cs
@@ -38,6 +38,11 @@ namespace Opc.Ua.Bindings
         protected ChannelToken RenewedToken => m_renewedToken;
 
         /// <summary>
+        /// Called when the token changes
+        /// </summary>
+        protected internal Action<ChannelToken, ChannelToken> OnTokenActivated { get; set; }
+
+        /// <summary>
         /// Creates a new token.
         /// </summary>
         protected ChannelToken CreateToken()
@@ -70,6 +75,8 @@ namespace Opc.Ua.Bindings
             Utils.SilentDispose(m_renewedToken);
             m_renewedToken = null;
 
+            OnTokenActivated?.Invoke(token, m_previousToken);
+
             Utils.LogInfo("ChannelId {0}: Token #{1} activated. CreatedAt={2:HH:mm:ss.fff}-{3}. Lifetime={4}.",
                 Id, token.TokenId, token.CreatedAt, token.CreatedAtTickCount, token.Lifetime);
         }
@@ -96,6 +103,8 @@ namespace Opc.Ua.Bindings
             m_currentToken = null;
             Utils.SilentDispose(m_renewedToken);
             m_renewedToken = null;
+
+            OnTokenActivated?.Invoke(null, null);
         }
         #endregion
 

--- a/Stack/Opc.Ua.Core/Stack/Tcp/UaSCBinaryClientChannel.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/UaSCBinaryClientChannel.cs
@@ -105,6 +105,8 @@ namespace Opc.Ua.Bindings
 
             if (disposing)
             {
+                OnTokenActivated = null;
+
                 Utils.SilentDispose(m_handshakeTimer);
                 m_handshakeTimer = null;
                 Utils.SilentDispose(m_requestedToken);
@@ -589,7 +591,7 @@ namespace Opc.Ua.Bindings
         {
             Utils.LogTrace("ChannelId {0}: ProcessOpenSecureChannelResponse()", ChannelId);
 
-            // validate the channel state.            
+            // validate the channel state.
             if (State != TcpChannelState.Opening && State != TcpChannelState.Open)
             {
                 ForceReconnect(ServiceResult.Create(StatusCodes.BadTcpMessageTypeInvalid, "Server sent an unexpected OpenSecureChannel response."));
@@ -653,7 +655,7 @@ namespace Opc.Ua.Bindings
                     throw ServiceResultException.Create(StatusCodes.BadTypeMismatch, "Server did not return a valid OpenSecureChannelResponse.");
                 }
 
-                // the client needs to use the creation time assigned when it sent 
+                // the client needs to use the creation time assigned when it sent
                 // the request and ignores the creation time in the response because
                 // the server and client clocks may not be synchronized.
 
@@ -691,7 +693,7 @@ namespace Opc.Ua.Bindings
                 State = TcpChannelState.Open;
                 m_reconnecting = false;
 
-                // enable reconnects. DO NOT USE! 
+                // enable reconnects. DO NOT USE!
                 // m_waitBetweenReconnects = TcpMessageLimits.MinTimeBetweenReconnects;
                 m_waitBetweenReconnects = Timeout.Infinite;
 
@@ -1178,7 +1180,7 @@ namespace Opc.Ua.Bindings
                     socket.Close();
                 }
 
-                // set the state.       
+                // set the state.
                 ChannelStateChanged(TcpChannelState.Closed, reason);
             }
         }
@@ -1294,7 +1296,7 @@ namespace Opc.Ua.Bindings
         }
 
         /// <summary>
-        /// Creates an object to manage the state of an asynchronous operation. 
+        /// Creates an object to manage the state of an asynchronous operation.
         /// </summary>
         private WriteOperation BeginOperation(int timeout, AsyncCallback callback, object state)
         {
@@ -1442,7 +1444,7 @@ namespace Opc.Ua.Bindings
         {
             ServiceResult error;
 
-            // read request buffer sizes.            
+            // read request buffer sizes.
             using (var decoder = new BinaryDecoder(messageChunk, Quotas.MessageContext))
             {
                 ReadAndVerifyMessageTypeAndSize(decoder, TcpMessageType.Error, messageChunk.Count);

--- a/Stack/Opc.Ua.Core/Stack/Tcp/UaSCBinaryTransportChannel.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/UaSCBinaryTransportChannel.cs
@@ -70,6 +70,16 @@ namespace Opc.Ua.Bindings
         #endregion
 
         #region ITransportChannel Members
+
+        /// <summary>
+        /// Called when the token changes
+        /// </summary>
+        public event ChannelTokenActivatedEventHandler OnTokenActivated
+        {
+            add => m_OnTokenActivated += value;
+            remove => m_OnTokenActivated -= value;
+        }
+
         /// <summary>
         /// A masking indicating which features are implemented.
         /// </summary>
@@ -482,6 +492,9 @@ namespace Opc.Ua.Bindings
                 channel.ReverseSocket = true;
             }
 
+            // Register the token changed event handler with the internal channel
+            channel.OnTokenActivated =
+                (current, previous) => m_OnTokenActivated?.Invoke(this, current, previous);
             return channel;
         }
         #endregion
@@ -494,6 +507,7 @@ namespace Opc.Ua.Bindings
         private ChannelQuotas m_quotas;
         private BufferManager m_bufferManager;
         private UaSCUaBinaryClientChannel m_channel;
+        private event ChannelTokenActivatedEventHandler m_OnTokenActivated;
         private IMessageSocketFactory m_messageSocketFactory;
         #endregion
     }

--- a/Stack/Opc.Ua.Core/Stack/Transport/ITransportChannel.cs
+++ b/Stack/Opc.Ua.Core/Stack/Transport/ITransportChannel.cs
@@ -18,7 +18,18 @@ using Opc.Ua.Bindings;
 namespace Opc.Ua
 {
     /// <summary>
-    /// This is an interface to a channel which supports 
+    /// Callback when the token is activated
+    /// </summary>
+    /// <param name="channel"></param>
+    /// <param name="currentToken"></param>
+    /// <param name="previousToken"></param>
+    public delegate void ChannelTokenActivatedEventHandler(
+        ITransportChannel channel,
+        ChannelToken currentToken,
+        ChannelToken previousToken);
+
+    /// <summary>
+    /// This is an interface to a channel which supports
     /// </summary>
     public interface ITransportChannel : IDisposable
     {
@@ -46,6 +57,11 @@ namespace Opc.Ua
         /// Gets the the channel's current security token.
         /// </summary>
         ChannelToken CurrentToken { get; }
+
+        /// <summary>
+        /// Register for token change events
+        /// </summary>
+        event ChannelTokenActivatedEventHandler OnTokenActivated;
 
         /// <summary>
         /// Gets or sets the default timeout for requests send via the channel.
@@ -200,7 +216,7 @@ namespace Opc.Ua
 
         /// <summary>
         /// Completes an asynchronous operation to send a request over the secure channel.
-        /// Awaitable version  
+        /// Awaitable version
         /// </summary>
         /// <param name="result">The result returned from the BeginSendRequest call.</param>
         /// <param name="ct">The cancellation token.</param>


### PR DESCRIPTION
For better client diagnostic it is important to have access to the channel token. Today tooling must monitor the channel token change to be aware of the current token, it is more efficient for the tooling to be called back when the token changes. This can be now accomplished in that the owner of a client (Discovery, Session) can retrieve the Transport channel after connect, read the current token and register a change callback.

* Add OnTokenActivated event for token change notifications

Added a new event `OnTokenActivated` to the `UaChannelBase` class in the `Opc.Ua` namespace to notify when a channel token is activated. Implemented this event in the `HttpsTransportChannel` class within the `Opc.Ua.Bindings` namespace. Introduced a protected internal `OnTokenActivated` event handler in the `UaSCBinaryChannel.Symmetric` class, invoked during token changes in the `ActivateToken` and `DiscardTokens` methods. Cleaned up the event handler in the `Dispose` method of the `UaSCBinaryClientChannel` class. Registered the event handler with the internal channel in the `UaSCBinaryTransportChannel` class. Added a new delegate `ChannelTokenActivatedEventHandler` in the `ITransportChannel` interface and updated the interface to include the `OnTokenActivated` event. Made minor formatting and comment adjustments for improved readability and consistency.

* Include channel in callback

## Proposed changes

Describe the changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Related Issues

- Fixes #

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
