### PR TITLE
Added a new setting MessageTransportMode which enables the user to decide if DataEfficiency or TimeCriticality is important

### DIFF
--- a/Libraries/Opc.Ua.Client/Session/Session.cs
+++ b/Libraries/Opc.Ua.Client/Session/Session.cs
@@ -5800,7 +5800,6 @@ namespace Opc.Ua.Client
                         m_endpoint.Configuration,
                         m_instanceCertificate,
                         m_configuration.SecurityConfiguration.SendCertificateChain ? m_instanceCertificateChain : null,
-                        m_transportMode,
                         MessageContext);
 
                     // disposes the existing channel.

--- a/Libraries/Opc.Ua.Client/Session/Session.cs
+++ b/Libraries/Opc.Ua.Client/Session/Session.cs
@@ -178,7 +178,6 @@ namespace Opc.Ua.Client
             // save configuration information.
             m_configuration = configuration;
             m_endpoint = endpoint;
-            m_transportMode = configuration.ClientConfiguration.MessageTransportMode;
 
             // update the default subscription.
             m_defaultSubscription.MinLifetimeInterval = (uint)configuration.ClientConfiguration.MinSubscriptionLifetime;
@@ -230,7 +229,6 @@ namespace Opc.Ua.Client
             m_factory = EncodeableFactory.GlobalFactory;
             m_configuration = null;
             m_instanceCertificate = null;
-            m_transportMode = MessageTransportMode.DataEfficient;
             m_endpoint = null;
             m_subscriptions = new List<Subscription>();
             m_dictionaries = new Dictionary<NodeId, DataDictionary>();
@@ -1043,8 +1041,6 @@ namespace Opc.Ua.Client
                 clientCertificateChain = await LoadCertificateChainAsync(configuration, clientCertificate).ConfigureAwait(false);
             }
 
-            MessageTransportMode transportMode = configuration.ClientConfiguration.MessageTransportMode;
-
             // initialize the channel which will be created with the server.
             ITransportChannel channel;
             if (connection != null)
@@ -1056,7 +1052,6 @@ namespace Opc.Ua.Client
                     endpointConfiguration,
                     clientCertificate,
                     clientCertificateChain,
-                    transportMode,
                     messageContext);
             }
             else
@@ -1067,7 +1062,6 @@ namespace Opc.Ua.Client
                      endpointConfiguration,
                      clientCertificate,
                      clientCertificateChain,
-                     transportMode,
                      messageContext);
             }
 
@@ -1265,8 +1259,8 @@ namespace Opc.Ua.Client
                 template.ConfiguredEndpoint.Description,
                 template.ConfiguredEndpoint.Configuration,
                 template.m_instanceCertificate,
-                template.m_configuration.SecurityConfiguration.SendCertificateChain ? template.m_instanceCertificateChain : null,
-                template.m_transportMode,
+                template.m_configuration.SecurityConfiguration.SendCertificateChain ?
+                    template.m_instanceCertificateChain : null,
                 messageContext);
 
             // create the session object.
@@ -1313,7 +1307,6 @@ namespace Opc.Ua.Client
                 template.m_instanceCertificate,
                 template.m_configuration.SecurityConfiguration.SendCertificateChain ?
                     template.m_instanceCertificateChain : null,
-                template.m_transportMode,
                 messageContext);
 
             // create the session object.
@@ -5836,7 +5829,6 @@ namespace Opc.Ua.Client
                         m_endpoint.Configuration,
                         m_instanceCertificate,
                         m_configuration.SecurityConfiguration.SendCertificateChain ? m_instanceCertificateChain : null,
-                        m_transportMode,
                         MessageContext);
 
                     // disposes the existing channel.
@@ -6608,11 +6600,6 @@ namespace Opc.Ua.Client
         /// The Instance Certificate.
         /// </summary>
         protected X509Certificate2 m_instanceCertificate;
-
-        /// <summary>
-        /// The transport mode used for the message.
-        /// </summary>
-        protected MessageTransportMode m_transportMode;
 
         /// <summary>
         /// The Instance Certificate Chain.

--- a/Libraries/Opc.Ua.Client/Session/SessionAsync.cs
+++ b/Libraries/Opc.Ua.Client/Session/SessionAsync.cs
@@ -1548,8 +1548,8 @@ namespace Opc.Ua.Client
                 sessionTemplate.m_endpoint.Description,
                 sessionTemplate.m_endpoint.Configuration,
                 sessionTemplate.m_instanceCertificate,
-                sessionTemplate.m_configuration.SecurityConfiguration.SendCertificateChain ? sessionTemplate.m_instanceCertificateChain : null,
-                sessionTemplate.m_transportMode,
+                sessionTemplate.m_configuration.SecurityConfiguration.SendCertificateChain ?
+                    sessionTemplate.m_instanceCertificateChain : null,
                 messageContext);
 
             // create the session object.

--- a/Libraries/Opc.Ua.Client/Session/SessionAsync.cs
+++ b/Libraries/Opc.Ua.Client/Session/SessionAsync.cs
@@ -1502,6 +1502,7 @@ namespace Opc.Ua.Client
                 sessionTemplate.m_instanceCertificate,
                 sessionTemplate.m_configuration.SecurityConfiguration.SendCertificateChain ?
                     sessionTemplate.m_instanceCertificateChain : null,
+                sessionTemplate.m_transportMode,
                 messageContext);
 
             // create the session object.
@@ -1548,8 +1549,8 @@ namespace Opc.Ua.Client
                 sessionTemplate.m_endpoint.Description,
                 sessionTemplate.m_endpoint.Configuration,
                 sessionTemplate.m_instanceCertificate,
-                sessionTemplate.m_configuration.SecurityConfiguration.SendCertificateChain ?
-                    sessionTemplate.m_instanceCertificateChain : null,
+                sessionTemplate.m_configuration.SecurityConfiguration.SendCertificateChain ? sessionTemplate.m_instanceCertificateChain : null,
+                sessionTemplate.m_transportMode,
                 messageContext);
 
             // create the session object.

--- a/Libraries/Opc.Ua.Client/Session/SessionAsync.cs
+++ b/Libraries/Opc.Ua.Client/Session/SessionAsync.cs
@@ -1502,7 +1502,6 @@ namespace Opc.Ua.Client
                 sessionTemplate.m_instanceCertificate,
                 sessionTemplate.m_configuration.SecurityConfiguration.SendCertificateChain ?
                     sessionTemplate.m_instanceCertificateChain : null,
-                sessionTemplate.m_transportMode,
                 messageContext);
 
             // create the session object.

--- a/Libraries/Opc.Ua.Configuration/ApplicationConfigurationBuilder.cs
+++ b/Libraries/Opc.Ua.Configuration/ApplicationConfigurationBuilder.cs
@@ -2,7 +2,7 @@
  * Copyright (c) 2005-2021 The OPC Foundation, Inc. All rights reserved.
  *
  * OPC Foundation MIT License 1.00
- * 
+ *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
  * files (the "Software"), to deal in the Software without
@@ -11,7 +11,7 @@
  * copies of the Software, and to permit persons to whom the
  * Software is furnished to do so, subject to the following
  * conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be
  * included in all copies or substantial portions of the Software.
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
@@ -914,6 +914,13 @@ namespace Opc.Ua.Configuration
         public IApplicationConfigurationBuilderClientOptions SetClientOperationLimits(OperationLimits operationLimits)
         {
             ApplicationConfiguration.ClientConfiguration.OperationLimits = operationLimits;
+            return this;
+        }
+
+        /// <inheritdoc/>
+        public IApplicationConfigurationBuilderClientOptions SetClientMessageTransportMode(MessageTransportMode messageTransportMode)
+        {
+            ApplicationConfiguration.ClientConfiguration.MessageTransportMode = messageTransportMode;
             return this;
         }
 

--- a/Libraries/Opc.Ua.Configuration/IApplicationConfigurationBuilder.cs
+++ b/Libraries/Opc.Ua.Configuration/IApplicationConfigurationBuilder.cs
@@ -2,7 +2,7 @@
  * Copyright (c) 2005-2021 The OPC Foundation, Inc. All rights reserved.
  *
  * OPC Foundation MIT License 1.00
- * 
+ *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
  * files (the "Software"), to deal in the Software without
@@ -11,7 +11,7 @@
  * copies of the Software, and to permit persons to whom the
  * Software is furnished to do so, subject to the following
  * conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be
  * included in all copies or substantial portions of the Software.
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
@@ -313,6 +313,9 @@ namespace Opc.Ua.Configuration
 
         /// <inheritdoc cref="ClientConfiguration.OperationLimits"/>
         IApplicationConfigurationBuilderClientOptions SetClientOperationLimits(OperationLimits operationLimits);
+
+        /// <inheritdoc cref="ClientConfiguration.MessageTransportMode"/>
+        IApplicationConfigurationBuilderClientOptions SetClientMessageTransportMode(MessageTransportMode messageTransportMode);
     }
 
     /// <summary>
@@ -423,7 +426,7 @@ namespace Opc.Ua.Configuration
             string appRoot = null,
             string rejectedRoot = null
             );
-        
+
         /// <summary>
         /// Add the security configuration.
         /// </summary>

--- a/Stack/Opc.Ua.Core/Schema/ApplicationConfiguration.cs
+++ b/Stack/Opc.Ua.Core/Schema/ApplicationConfiguration.cs
@@ -2526,19 +2526,22 @@ namespace Opc.Ua
 
     #region MessageTransportMode Enumeration
     /// <summary>
-    /// The type of binary encoding support allowed by a channel.
+    /// The mode of message transportation.
     /// </summary>
+    /// <remarks>
+    /// When using TCP this <see cref="MessageTransportMode"/> affects the configuration of the <seealso cref="System.Net.Sockets.Socket"/>.
+    /// </remarks>
     [DataContract(Namespace = Namespaces.OpcUaConfig)]
     public enum MessageTransportMode
     {
         /// <summary>
-        /// The UA binary encoding may be used.
+        /// This mode signalizes, that delay in message transportation is accepted.
         /// </summary>
         [EnumMember()]
         DataEfficient,
 
         /// <summary>
-        /// The UA binary encoding must be used.
+        /// This mode signalizes, that delay in message transportation is not accepted.
         /// </summary>
         [EnumMember()]
         TimeCritical

--- a/Stack/Opc.Ua.Core/Schema/ApplicationConfiguration.cs
+++ b/Stack/Opc.Ua.Core/Schema/ApplicationConfiguration.cs
@@ -256,7 +256,7 @@ namespace Opc.Ua
         }
 
         /// <summary>
-        /// Disabling / enabling high resolution clock 
+        /// Disabling / enabling high resolution clock
         /// </summary>
         /// <value><c>true</c> if high resolution clock is disabled; otherwise, <c>false</c>.</value>
         [DataMember(IsRequired = false, EmitDefaultValue = false, Order = 12)]
@@ -416,7 +416,7 @@ namespace Opc.Ua
         }
 
         /// <summary>
-        /// The number of times the decoder can recover from a decoder error 
+        /// The number of times the decoder can recover from a decoder error
         /// of an IEncodeable before throwing a decoder error.
         /// </summary>
         [DataMember(IsRequired = false, Order = 7)]
@@ -521,7 +521,7 @@ namespace Opc.Ua
         }
 
         /// <summary>
-        /// The masks used to select what is written to the output  
+        /// The masks used to select what is written to the output
         /// Masks supported by the trace feature:
         /// - Do not output any messages -None = 0x0;
         /// - Output error messages - Error = 0x1;
@@ -599,9 +599,9 @@ namespace Opc.Ua
         /// </summary>
         /// <value>The name of the type.</value>
         /// <remarks>
-        /// This can be any instance of the System.ServiceModel.Channels.Binding class 
+        /// This can be any instance of the System.ServiceModel.Channels.Binding class
         /// that implements these constructors:
-        /// 
+        ///
         /// XxxBinding(EndpointDescription description, EndpointConfiguration configuration);
         /// XxxBinding(IList{EndpointDescription} descriptions, EndpointConfiguration configuration)
         /// XxxBinding(EndpointConfiguration configuration)
@@ -929,7 +929,7 @@ namespace Opc.Ua
         /// <summary>
         /// A store where invalid certificates can be placed for later review by the administrator.
         /// </summary>
-        /// <value> 
+        /// <value>
         /// A store where invalid certificates can be placed for later review by the administrator.
         /// </value>
         [DataMember(IsRequired = false, EmitDefaultValue = false, Order = 7)]
@@ -1178,7 +1178,7 @@ namespace Opc.Ua
 
         #endregion
 
-        #region Private Fields       
+        #region Private Fields
         private CertificateIdentifierCollection m_applicationCertificates;
         private CertificateTrustList m_trustedIssuerCertificates;
         private CertificateTrustList m_trustedPeerCertificates;
@@ -1944,7 +1944,7 @@ namespace Opc.Ua
 
         /// <summary>
         /// The server capabilities.
-        /// The latest set of server capabilities is listed 
+        /// The latest set of server capabilities is listed
         /// <see href="http://www.opcfoundation.org/UA/schemas/1.05/ServerCapabilities.csv">here.</see>
         /// </summary>
         /// <value>The array of server capabilites.</value>
@@ -2041,6 +2041,17 @@ namespace Opc.Ua
             get { return m_httpsMutualTls; }
             set { m_httpsMutualTls = value; }
         }
+
+        /// <summary>
+        /// The message transport mode.
+        /// </summary>
+        /// <value>The message transport mode.</value>
+        [DataMember(IsRequired = false, Order = 38)]
+        public MessageTransportMode MessageTransportMode
+        {
+            get { return m_messageTransportMode; }
+            set { m_messageTransportMode = value; }
+        }
         #endregion
 
         #region Private Members
@@ -2080,6 +2091,7 @@ namespace Opc.Ua
         private OperationLimits m_operationLimits;
         private bool m_auditingEnabled;
         private bool m_httpsMutualTls;
+        private MessageTransportMode m_messageTransportMode;
         #endregion
     }
     #endregion
@@ -2499,6 +2511,17 @@ namespace Opc.Ua
             get { return m_operationLimits; }
             set { m_operationLimits = value; }
         }
+
+        /// <summary>
+        /// The message transport mode.
+        /// </summary>
+        /// <value>The message transport mode.</value>
+        [DataMember(IsRequired = false, Order = 7)]
+        public MessageTransportMode MessageTransportMode
+        {
+            get { return m_messageTransportMode; }
+            set { m_messageTransportMode = value; }
+        }
         #endregion
 
         #region Private Members
@@ -2509,8 +2532,30 @@ namespace Opc.Ua
         private int m_minSubscriptionLifetime;
         private ReverseConnectClientConfiguration m_reverseConnect;
         private OperationLimits m_operationLimits;
+        private MessageTransportMode m_messageTransportMode;
         #endregion
     }
+
+    #region MessageTransportMode Enumeration
+    /// <summary>
+    /// The type of binary encoding support allowed by a channel.
+    /// </summary>
+    [DataContract(Namespace = Namespaces.OpcUaConfig)]
+    public enum MessageTransportMode
+    {
+        /// <summary>
+        /// The UA binary encoding may be used.
+        /// </summary>
+        [EnumMember()]
+        DataEfficient,
+
+        /// <summary>
+        /// The UA binary encoding must be used.
+        /// </summary>
+        [EnumMember()]
+        TimeCritical
+    }
+    #endregion
     #endregion
 
     #region ReverseConnectClientConfiguration Class
@@ -2786,9 +2831,9 @@ namespace Opc.Ua
         /// or similar network infrastructure. If these paths are specified in the configuration
         /// file then the server will use the domain of the URL used by the client to determine
         /// which, if any, or the alternate addresses to use instead of the primary addresses.
-        /// 
+        ///
         /// In the ideal world the server would provide these URLs during registration but this
-        /// table allows the administrator to provide the information to the discovery server 
+        /// table allows the administrator to provide the information to the discovery server
         /// directly without requiring a patch to the server.
         /// </remarks>
         [DataMember(IsRequired = false, EmitDefaultValue = false, Order = 2)]
@@ -2921,7 +2966,7 @@ namespace Opc.Ua
         }
 
         /// <summary>
-        /// The name of the certificate store that contains the trusted certificates. 
+        /// The name of the certificate store that contains the trusted certificates.
         /// </summary>
         [DataMember(IsRequired = false, EmitDefaultValue = false, Order = 2)]
         [Obsolete("Use StoreType/StorePath instead")]
@@ -2932,7 +2977,7 @@ namespace Opc.Ua
         }
 
         /// <summary>
-        /// The location of the certificate store that contains the trusted certificates. 
+        /// The location of the certificate store that contains the trusted certificates.
         /// </summary>
         [DataMember(IsRequired = false, EmitDefaultValue = false, Order = 3)]
         [Obsolete("Use StoreType/StorePath instead")]
@@ -3196,7 +3241,7 @@ namespace Opc.Ua
         /// <value>
         /// The distinguished name of an X509 certificate acording to the Abstract Syntax Notation One (ASN.1) syntax.
         /// </value>
-        /// <remarks> The subject field identifies the entity associated with the public key stored in the subject public 
+        /// <remarks> The subject field identifies the entity associated with the public key stored in the subject public
         /// key field.  The subject name MAY be carried in the subject field and/or the subjectAltName extension.
         /// Where it is non-empty, the subject field MUST contain an X.500 distinguished name (DN).
         /// Name is defined by the following ASN.1 structures:
@@ -3212,26 +3257,26 @@ namespace Opc.Ua
         ///   universalString         UniversalString (SIZE (1..MAX)),
         ///   utf8String              UTF8String (SIZE (1..MAX)),
         ///   bmpString               BMPString (SIZE (1..MAX)) }
-        ///  The Name describes a hierarchical name composed of attributes, such as country name, and 
-        ///  corresponding values, such as US.  The type of the component AttributeValue is determined by 
+        ///  The Name describes a hierarchical name composed of attributes, such as country name, and
+        ///  corresponding values, such as US.  The type of the component AttributeValue is determined by
         ///  the AttributeType; in general it will be a DirectoryString.
         /// String X.500 AttributeType:
         /// <list type="bullet">
-        /// <item>CN commonName</item> 
+        /// <item>CN commonName</item>
         /// <item>L localityName</item>
         /// <item>ST stateOrProvinceName</item>
-        /// <item>O organizationName</item> 
+        /// <item>O organizationName</item>
         /// <item>OU organizationalUnitName</item>
         /// <item>C countryName</item>
         /// <item>STREET streetAddress</item>
         /// <item>DC domainComponent</item>
         /// <item>UID userid</item>
         /// </list>
-        /// This notation is designed to be convenient for common forms of name. This section gives a few 
+        /// This notation is designed to be convenient for common forms of name. This section gives a few
         /// examples of distinguished names written using this notation. First is a name containing three relative
         /// distinguished names (RDNs):
         /// <code>CN=Steve Kille,O=Isode Limited,C=GB</code>
-        /// 
+        ///
         /// RFC 3280 Internet X.509 Public Key Infrastructure, April 2002
         /// RFC 2253 LADPv3 Distinguished Names, December 1997
         /// </remarks>

--- a/Stack/Opc.Ua.Core/Schema/ApplicationConfiguration.cs
+++ b/Stack/Opc.Ua.Core/Schema/ApplicationConfiguration.cs
@@ -2041,17 +2041,6 @@ namespace Opc.Ua
             get { return m_httpsMutualTls; }
             set { m_httpsMutualTls = value; }
         }
-
-        /// <summary>
-        /// The message transport mode.
-        /// </summary>
-        /// <value>The message transport mode.</value>
-        [DataMember(IsRequired = false, Order = 38)]
-        public MessageTransportMode MessageTransportMode
-        {
-            get { return m_messageTransportMode; }
-            set { m_messageTransportMode = value; }
-        }
         #endregion
 
         #region Private Members
@@ -2091,7 +2080,6 @@ namespace Opc.Ua
         private OperationLimits m_operationLimits;
         private bool m_auditingEnabled;
         private bool m_httpsMutualTls;
-        private MessageTransportMode m_messageTransportMode;
         #endregion
     }
     #endregion

--- a/Stack/Opc.Ua.Core/Schema/ApplicationConfiguration.xsd
+++ b/Stack/Opc.Ua.Core/Schema/ApplicationConfiguration.xsd
@@ -169,6 +169,7 @@
           <xs:element name="OperationLimits" type="OperationLimits" minOccurs="0" />
           <xs:element name="AuditingEnabled" type="xs:boolean" minOccurs="0" />
           <xs:element name="HttpsMutualTls" type="xs:boolean" minOccurs="0" />
+          <xs:element name="MessageTransportMode" type="MessageTransportMode" default="DataEfficient" minOccurs="0" />
         </xs:sequence>
       </xs:extension>
     </xs:complexContent>
@@ -214,6 +215,13 @@
       <xs:element name="MaxMonitoredItemsPerCall" type="xs:int" minOccurs="0" />
     </xs:sequence>
   </xs:complexType>
+    
+  <xs:simpleType name="MessageTransportMode">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="DataEfficient" />
+      <xs:enumeration value="TimeCritical" />
+    </xs:restriction>
+  </xs:simpleType>
 
   <xs:complexType name="DiscoveryServerConfiguration">
     <xs:complexContent mixed="false">
@@ -249,6 +257,7 @@
       <xs:element name="MinSubscriptionLifetime" type="xs:int" minOccurs="0" />
       <xs:element name="ReverseConnect" type="ReverseConnectClientConfiguration" minOccurs="0" />
       <xs:element name="OperationLimits" type="OperationLimits" minOccurs="0" />
+      <xs:element name="MessageTransportMode" type="MessageTransportMode" minOccurs="0" />
     </xs:sequence>
   </xs:complexType>
 

--- a/Stack/Opc.Ua.Core/Stack/Client/DiscoveryClient.cs
+++ b/Stack/Opc.Ua.Core/Stack/Client/DiscoveryClient.cs
@@ -292,21 +292,21 @@ namespace Opc.Ua
     public partial class DiscoveryChannel
     {
         #region Constructors
-
         /// <summary>
         /// Creates a new transport channel that supports the ISessionChannel service contract.
         /// </summary>
         /// <param name="discoveryUrl">The discovery url.</param>
         /// <param name="endpointConfiguration">The configuration to use with the endpoint.</param>
-        /// <param name="transportMode"></param>
         /// <param name="messageContext">The message context to use when serializing the messages.</param>
         /// <param name="clientCertificate">The client certificate to use.</param>
+        /// <param name="transportMode">The transport mode to use when sending messages.</param>
         /// <returns></returns>
-        public static ITransportChannel Create(Uri discoveryUrl,
+        public static ITransportChannel Create(
+            Uri discoveryUrl,
             EndpointConfiguration endpointConfiguration,
-            MessageTransportMode transportMode,
             IServiceMessageContext messageContext,
-            X509Certificate2 clientCertificate = null)
+            X509Certificate2 clientCertificate = null,
+            MessageTransportMode transportMode = MessageTransportMode.DataEfficient)
         {
             // create a default description.
             EndpointDescription endpoint = new EndpointDescription {
@@ -322,7 +322,6 @@ namespace Opc.Ua
                 endpoint,
                 endpointConfiguration,
                 clientCertificate,
-                transportMode,
                 messageContext);
 
             return channel;
@@ -346,7 +345,8 @@ namespace Opc.Ua
             };
             endpoint.Server.ApplicationUri = endpoint.EndpointUrl;
             endpoint.Server.ApplicationType = ApplicationType.DiscoveryServer;
-            MessageTransportMode transportMode = configuration.ClientConfiguration.MessageTransportMode;
+            MessageTransportMode transportMode = configuration?.ClientConfiguration?.MessageTransportMode ??
+                                                 MessageTransportMode.DataEfficient;
 
             ITransportChannel channel = CreateUaBinaryChannel(
                 configuration,
@@ -355,7 +355,6 @@ namespace Opc.Ua
                 endpointConfiguration,
                 clientCertificate,
                 (X509Certificate2Collection)null,
-                transportMode,
                 messageContext);
 
             return channel;
@@ -379,7 +378,8 @@ namespace Opc.Ua
             };
             endpoint.Server.ApplicationUri = endpoint.EndpointUrl;
             endpoint.Server.ApplicationType = ApplicationType.DiscoveryServer;
-            MessageTransportMode transportMode = configuration?.ClientConfiguration?.MessageTransportMode ?? default;
+            MessageTransportMode transportMode = configuration?.ClientConfiguration?.MessageTransportMode ??
+                                                 MessageTransportMode.DataEfficient;
 
             ITransportChannel channel = CreateUaBinaryChannel(
                 configuration,
@@ -387,7 +387,6 @@ namespace Opc.Ua
                 endpointConfiguration,
                 clientCertificate,
                 (X509Certificate2Collection)null,
-                transportMode,
                 messageContext);
 
             return channel;

--- a/Stack/Opc.Ua.Core/Stack/Client/DiscoveryClient.cs
+++ b/Stack/Opc.Ua.Core/Stack/Client/DiscoveryClient.cs
@@ -249,8 +249,8 @@ namespace Opc.Ua
         private EndpointDescriptionCollection PatchEndpointUrls(EndpointDescriptionCollection endpoints)
         {
             // if a server is behind a firewall, can only be accessed with a FQDN or IP address
-            // it may return URLs that are not accessible to the client. This problem can be avoided 
-            // by assuming that the domain in the URL used to call GetEndpoints can be used to 
+            // it may return URLs that are not accessible to the client. This problem can be avoided
+            // by assuming that the domain in the URL used to call GetEndpoints can be used to
             // access any of the endpoints. This code patches the returned endpoints accordingly.
             Uri endpointUrl = Utils.ParseUri(this.Endpoint.EndpointUrl);
             if (endpointUrl != null)
@@ -292,17 +292,19 @@ namespace Opc.Ua
     public partial class DiscoveryChannel
     {
         #region Constructors
+
         /// <summary>
         /// Creates a new transport channel that supports the ISessionChannel service contract.
         /// </summary>
         /// <param name="discoveryUrl">The discovery url.</param>
         /// <param name="endpointConfiguration">The configuration to use with the endpoint.</param>
+        /// <param name="transportMode"></param>
         /// <param name="messageContext">The message context to use when serializing the messages.</param>
         /// <param name="clientCertificate">The client certificate to use.</param>
         /// <returns></returns>
-        public static ITransportChannel Create(
-            Uri discoveryUrl,
+        public static ITransportChannel Create(Uri discoveryUrl,
             EndpointConfiguration endpointConfiguration,
+            MessageTransportMode transportMode,
             IServiceMessageContext messageContext,
             X509Certificate2 clientCertificate = null)
         {
@@ -320,6 +322,7 @@ namespace Opc.Ua
                 endpoint,
                 endpointConfiguration,
                 clientCertificate,
+                transportMode,
                 messageContext);
 
             return channel;
@@ -343,6 +346,7 @@ namespace Opc.Ua
             };
             endpoint.Server.ApplicationUri = endpoint.EndpointUrl;
             endpoint.Server.ApplicationType = ApplicationType.DiscoveryServer;
+            MessageTransportMode transportMode = configuration.ClientConfiguration.MessageTransportMode;
 
             ITransportChannel channel = CreateUaBinaryChannel(
                 configuration,
@@ -351,6 +355,7 @@ namespace Opc.Ua
                 endpointConfiguration,
                 clientCertificate,
                 (X509Certificate2Collection)null,
+                transportMode,
                 messageContext);
 
             return channel;
@@ -374,6 +379,7 @@ namespace Opc.Ua
             };
             endpoint.Server.ApplicationUri = endpoint.EndpointUrl;
             endpoint.Server.ApplicationType = ApplicationType.DiscoveryServer;
+            MessageTransportMode transportMode = configuration?.ClientConfiguration?.MessageTransportMode ?? default;
 
             ITransportChannel channel = CreateUaBinaryChannel(
                 configuration,
@@ -381,6 +387,7 @@ namespace Opc.Ua
                 endpointConfiguration,
                 clientCertificate,
                 (X509Certificate2Collection)null,
+                transportMode,
                 messageContext);
 
             return channel;

--- a/Stack/Opc.Ua.Core/Stack/Client/DiscoveryClient.cs
+++ b/Stack/Opc.Ua.Core/Stack/Client/DiscoveryClient.cs
@@ -299,14 +299,12 @@ namespace Opc.Ua
         /// <param name="endpointConfiguration">The configuration to use with the endpoint.</param>
         /// <param name="messageContext">The message context to use when serializing the messages.</param>
         /// <param name="clientCertificate">The client certificate to use.</param>
-        /// <param name="transportMode">The transport mode to use when sending messages.</param>
         /// <returns></returns>
         public static ITransportChannel Create(
             Uri discoveryUrl,
             EndpointConfiguration endpointConfiguration,
             IServiceMessageContext messageContext,
-            X509Certificate2 clientCertificate = null,
-            MessageTransportMode transportMode = MessageTransportMode.DataEfficient)
+            X509Certificate2 clientCertificate = null)
         {
             // create a default description.
             EndpointDescription endpoint = new EndpointDescription {
@@ -345,8 +343,6 @@ namespace Opc.Ua
             };
             endpoint.Server.ApplicationUri = endpoint.EndpointUrl;
             endpoint.Server.ApplicationType = ApplicationType.DiscoveryServer;
-            MessageTransportMode transportMode = configuration?.ClientConfiguration?.MessageTransportMode ??
-                                                 MessageTransportMode.DataEfficient;
 
             ITransportChannel channel = CreateUaBinaryChannel(
                 configuration,
@@ -378,8 +374,6 @@ namespace Opc.Ua
             };
             endpoint.Server.ApplicationUri = endpoint.EndpointUrl;
             endpoint.Server.ApplicationType = ApplicationType.DiscoveryServer;
-            MessageTransportMode transportMode = configuration?.ClientConfiguration?.MessageTransportMode ??
-                                                 MessageTransportMode.DataEfficient;
 
             ITransportChannel channel = CreateUaBinaryChannel(
                 configuration,

--- a/Stack/Opc.Ua.Core/Stack/Client/RegistrationClient.cs
+++ b/Stack/Opc.Ua.Core/Stack/Client/RegistrationClient.cs
@@ -29,12 +29,13 @@ namespace Opc.Ua
         /// <param name="description">The description.</param>
         /// <param name="endpointConfiguration">The endpoint configuration.</param>
         /// <param name="instanceCertificate">The instance certificate.</param>
-        /// <returns></returns>
-        public static RegistrationClient Create(
-            ApplicationConfiguration configuration,
+        /// <param name="transportMode">The transport mode to use with thic client.</param>
+        /// <returns>the registration client</returns>
+        public static RegistrationClient Create(ApplicationConfiguration configuration,
             EndpointDescription description,
             EndpointConfiguration endpointConfiguration,
-            X509Certificate2 instanceCertificate)
+            X509Certificate2 instanceCertificate,
+            MessageTransportMode transportMode)
         {
             if (configuration == null) throw new ArgumentNullException(nameof(configuration));
             if (description == null) throw new ArgumentNullException(nameof(description));
@@ -44,6 +45,7 @@ namespace Opc.Ua
                 description,
                 endpointConfiguration,
                 instanceCertificate,
+                transportMode,
                 new ServiceMessageContext());
 
             return new RegistrationClient(channel);
@@ -58,6 +60,7 @@ namespace Opc.Ua
     public partial class RegistrationChannel
     {
         #region Constructors
+
         /// <summary>
         /// Creates a new transport channel that supports the IRegistrationChannel service contract.
         /// </summary>
@@ -65,13 +68,14 @@ namespace Opc.Ua
         /// <param name="description">The description for the endpoint.</param>
         /// <param name="endpointConfiguration">The configuration to use with the endpoint.</param>
         /// <param name="clientCertificate">The client certificate.</param>
+        /// <param name="transportMode"></param>
         /// <param name="messageContext">The message context to use when serializing the messages.</param>
         /// <returns></returns>
-        public static ITransportChannel Create(
-            ApplicationConfiguration configuration,
+        public static ITransportChannel Create(ApplicationConfiguration configuration,
             EndpointDescription description,
             EndpointConfiguration endpointConfiguration,
             X509Certificate2 clientCertificate,
+            MessageTransportMode transportMode,
             IServiceMessageContext messageContext)
         {
             // create a UA binary channel.
@@ -80,6 +84,7 @@ namespace Opc.Ua
                 description,
                 endpointConfiguration,
                 clientCertificate,
+                transportMode,
                 messageContext);
 
             // create a registration channel.
@@ -88,10 +93,12 @@ namespace Opc.Ua
                 Uri endpointUrl = new Uri(description.EndpointUrl);
                 channel = new RegistrationChannel();
 
-                TransportChannelSettings settings = new TransportChannelSettings();
-                settings.Configuration = endpointConfiguration;
-                settings.Description = description;
-                settings.ClientCertificate = clientCertificate;
+                var settings = new TransportChannelSettings {
+                    Configuration = endpointConfiguration,
+                    Description = description,
+                    ClientCertificate = clientCertificate,
+                    TransportMode = transportMode
+                };
                 channel.Initialize(endpointUrl, settings);
             }
 

--- a/Stack/Opc.Ua.Core/Stack/Client/RegistrationClient.cs
+++ b/Stack/Opc.Ua.Core/Stack/Client/RegistrationClient.cs
@@ -29,13 +29,12 @@ namespace Opc.Ua
         /// <param name="description">The description.</param>
         /// <param name="endpointConfiguration">The endpoint configuration.</param>
         /// <param name="instanceCertificate">The instance certificate.</param>
-        /// <param name="transportMode">The transport mode to use with thic client.</param>
-        /// <returns>the registration client</returns>
-        public static RegistrationClient Create(ApplicationConfiguration configuration,
+        /// <returns></returns>
+        public static RegistrationClient Create(
+            ApplicationConfiguration configuration,
             EndpointDescription description,
             EndpointConfiguration endpointConfiguration,
-            X509Certificate2 instanceCertificate,
-            MessageTransportMode transportMode)
+            X509Certificate2 instanceCertificate)
         {
             if (configuration == null) throw new ArgumentNullException(nameof(configuration));
             if (description == null) throw new ArgumentNullException(nameof(description));
@@ -45,7 +44,6 @@ namespace Opc.Ua
                 description,
                 endpointConfiguration,
                 instanceCertificate,
-                transportMode,
                 new ServiceMessageContext());
 
             return new RegistrationClient(channel);
@@ -60,7 +58,6 @@ namespace Opc.Ua
     public partial class RegistrationChannel
     {
         #region Constructors
-
         /// <summary>
         /// Creates a new transport channel that supports the IRegistrationChannel service contract.
         /// </summary>
@@ -68,14 +65,13 @@ namespace Opc.Ua
         /// <param name="description">The description for the endpoint.</param>
         /// <param name="endpointConfiguration">The configuration to use with the endpoint.</param>
         /// <param name="clientCertificate">The client certificate.</param>
-        /// <param name="transportMode"></param>
         /// <param name="messageContext">The message context to use when serializing the messages.</param>
         /// <returns></returns>
-        public static ITransportChannel Create(ApplicationConfiguration configuration,
+        public static ITransportChannel Create(
+            ApplicationConfiguration configuration,
             EndpointDescription description,
             EndpointConfiguration endpointConfiguration,
             X509Certificate2 clientCertificate,
-            MessageTransportMode transportMode,
             IServiceMessageContext messageContext)
         {
             // create a UA binary channel.
@@ -84,7 +80,6 @@ namespace Opc.Ua
                 description,
                 endpointConfiguration,
                 clientCertificate,
-                transportMode,
                 messageContext);
 
             // create a registration channel.
@@ -97,7 +92,7 @@ namespace Opc.Ua
                     Configuration = endpointConfiguration,
                     Description = description,
                     ClientCertificate = clientCertificate,
-                    TransportMode = transportMode
+                    TransportMode = configuration?.ClientConfiguration?.MessageTransportMode ?? MessageTransportMode.DataEfficient
                 };
                 channel.Initialize(endpointUrl, settings);
             }

--- a/Stack/Opc.Ua.Core/Stack/Client/SessionChannel.cs
+++ b/Stack/Opc.Ua.Core/Stack/Client/SessionChannel.cs
@@ -28,17 +28,15 @@ namespace Opc.Ua
         /// <param name="description">The description for the endpoint.</param>
         /// <param name="endpointConfiguration">The configuration to use with the endpoint.</param>
         /// <param name="clientCertificate">The client certificate.</param>
-        /// <param name="transportMode">The transport mode of messages.</param>
         /// <param name="messageContext">The message context to use when serializing the messages.</param>
         /// <returns></returns>
         public static ITransportChannel Create(ApplicationConfiguration configuration,
             EndpointDescription description,
             EndpointConfiguration endpointConfiguration,
             X509Certificate2 clientCertificate,
-            MessageTransportMode transportMode,
             IServiceMessageContext messageContext)
         {
-            return Create(configuration, description, endpointConfiguration, clientCertificate, null, transportMode, messageContext);
+            return Create(configuration, description, endpointConfiguration, clientCertificate, null, messageContext);
         }
 
         /// <summary>
@@ -49,7 +47,6 @@ namespace Opc.Ua
         /// <param name="endpointConfiguration">The configuration to use with the endpoint.</param>
         /// <param name="clientCertificate">The client certificate.</param>
         /// <param name="clientCertificateChain">The client certificate chain.</param>
-        /// <param name="transportMode">The transport mode of messages.</param>
         /// <param name="messageContext">The message context to use when serializing the messages.</param>
         /// <returns></returns>
         public static ITransportChannel Create(ApplicationConfiguration configuration,
@@ -57,7 +54,6 @@ namespace Opc.Ua
             EndpointConfiguration endpointConfiguration,
             X509Certificate2 clientCertificate,
             X509Certificate2Collection clientCertificateChain,
-            MessageTransportMode transportMode,
             IServiceMessageContext messageContext)
         {
             // create a UA binary channel.
@@ -67,7 +63,6 @@ namespace Opc.Ua
                 endpointConfiguration,
                 clientCertificate,
                 clientCertificateChain,
-                transportMode,
                 messageContext);
 
             return channel;
@@ -102,7 +97,6 @@ namespace Opc.Ua
                 endpointConfiguration,
                 clientCertificate,
                 clientCertificateChain,
-                transportMode,
                 messageContext);
 
             return channel;

--- a/Stack/Opc.Ua.Core/Stack/Client/SessionChannel.cs
+++ b/Stack/Opc.Ua.Core/Stack/Client/SessionChannel.cs
@@ -20,6 +20,7 @@ namespace Opc.Ua
     public partial class SessionChannel
     {
         #region Constructors
+
         /// <summary>
         /// Creates a new transport channel that supports the ISessionChannel service contract.
         /// </summary>
@@ -27,16 +28,17 @@ namespace Opc.Ua
         /// <param name="description">The description for the endpoint.</param>
         /// <param name="endpointConfiguration">The configuration to use with the endpoint.</param>
         /// <param name="clientCertificate">The client certificate.</param>
+        /// <param name="transportMode">The transport mode of messages.</param>
         /// <param name="messageContext">The message context to use when serializing the messages.</param>
         /// <returns></returns>
-        public static ITransportChannel Create(
-            ApplicationConfiguration configuration,
+        public static ITransportChannel Create(ApplicationConfiguration configuration,
             EndpointDescription description,
             EndpointConfiguration endpointConfiguration,
             X509Certificate2 clientCertificate,
+            MessageTransportMode transportMode,
             IServiceMessageContext messageContext)
         {
-            return Create(configuration, description, endpointConfiguration, clientCertificate, null, messageContext);
+            return Create(configuration, description, endpointConfiguration, clientCertificate, null, transportMode, messageContext);
         }
 
         /// <summary>
@@ -47,14 +49,15 @@ namespace Opc.Ua
         /// <param name="endpointConfiguration">The configuration to use with the endpoint.</param>
         /// <param name="clientCertificate">The client certificate.</param>
         /// <param name="clientCertificateChain">The client certificate chain.</param>
+        /// <param name="transportMode">The transport mode of messages.</param>
         /// <param name="messageContext">The message context to use when serializing the messages.</param>
         /// <returns></returns>
-        public static ITransportChannel Create(
-            ApplicationConfiguration configuration,
+        public static ITransportChannel Create(ApplicationConfiguration configuration,
             EndpointDescription description,
             EndpointConfiguration endpointConfiguration,
             X509Certificate2 clientCertificate,
             X509Certificate2Collection clientCertificateChain,
+            MessageTransportMode transportMode,
             IServiceMessageContext messageContext)
         {
             // create a UA binary channel.
@@ -64,6 +67,7 @@ namespace Opc.Ua
                 endpointConfiguration,
                 clientCertificate,
                 clientCertificateChain,
+                transportMode,
                 messageContext);
 
             return channel;
@@ -78,15 +82,16 @@ namespace Opc.Ua
         /// <param name="endpointConfiguration">The configuration to use with the endpoint.</param>
         /// <param name="clientCertificate">The client certificate.</param>
         /// <param name="clientCertificateChain">The client certificate chain.</param>
+        /// <param name="transportMode"></param>
         /// <param name="messageContext">The message context to use when serializing the messages.</param>
         /// <returns></returns>
-        public static ITransportChannel Create(
-            ApplicationConfiguration configuration,
+        public static ITransportChannel Create(ApplicationConfiguration configuration,
             ITransportWaitingConnection connection,
             EndpointDescription description,
             EndpointConfiguration endpointConfiguration,
             X509Certificate2 clientCertificate,
             X509Certificate2Collection clientCertificateChain,
+            MessageTransportMode transportMode,
             IServiceMessageContext messageContext)
         {
             // create a UA binary channel.
@@ -97,6 +102,7 @@ namespace Opc.Ua
                 endpointConfiguration,
                 clientCertificate,
                 clientCertificateChain,
+                transportMode,
                 messageContext);
 
             return channel;

--- a/Stack/Opc.Ua.Core/Stack/Client/SessionChannel.cs
+++ b/Stack/Opc.Ua.Core/Stack/Client/SessionChannel.cs
@@ -77,7 +77,6 @@ namespace Opc.Ua
         /// <param name="endpointConfiguration">The configuration to use with the endpoint.</param>
         /// <param name="clientCertificate">The client certificate.</param>
         /// <param name="clientCertificateChain">The client certificate chain.</param>
-        /// <param name="transportMode"></param>
         /// <param name="messageContext">The message context to use when serializing the messages.</param>
         /// <returns></returns>
         public static ITransportChannel Create(ApplicationConfiguration configuration,
@@ -86,7 +85,6 @@ namespace Opc.Ua
             EndpointConfiguration endpointConfiguration,
             X509Certificate2 clientCertificate,
             X509Certificate2Collection clientCertificateChain,
-            MessageTransportMode transportMode,
             IServiceMessageContext messageContext)
         {
             // create a UA binary channel.

--- a/Stack/Opc.Ua.Core/Stack/Client/UaChannelBase.cs
+++ b/Stack/Opc.Ua.Core/Stack/Client/UaChannelBase.cs
@@ -715,13 +715,13 @@ namespace Opc.Ua
         /// <summary>
         /// Creates a new UA-binary transport channel if requested. Null otherwise.
         /// </summary>
-        public static ITransportChannel CreateUaBinaryChannel(
-            ApplicationConfiguration configuration,
+        public static ITransportChannel CreateUaBinaryChannel(ApplicationConfiguration configuration,
             ITransportWaitingConnection connection,
             EndpointDescription description,
             EndpointConfiguration endpointConfiguration,
             X509Certificate2 clientCertificate,
             X509Certificate2Collection clientCertificateChain,
+            MessageTransportMode transportMode,
             IServiceMessageContext messageContext)
         {
             // initialize the channel which will be created with the server.
@@ -739,7 +739,8 @@ namespace Opc.Ua
                 Description = description,
                 Configuration = endpointConfiguration,
                 ClientCertificate = clientCertificate,
-                ClientCertificateChain = clientCertificateChain
+                ClientCertificateChain = clientCertificateChain,
+                TransportMode = transportMode,
             };
 
             if (description.ServerCertificate != null && description.ServerCertificate.Length > 0)
@@ -768,16 +769,17 @@ namespace Opc.Ua
         /// <param name="description">The description for the endpoint.</param>
         /// <param name="endpointConfiguration">The configuration to use with the endpoint.</param>
         /// <param name="clientCertificate">The client certificate.</param>
+        /// <param name="transportMode">The transport mode of messages.</param>
         /// <param name="messageContext">The message context to use when serializing the messages.</param>
         /// <returns></returns>
-        public static ITransportChannel CreateUaBinaryChannel(
-            ApplicationConfiguration configuration,
+        public static ITransportChannel CreateUaBinaryChannel(ApplicationConfiguration configuration,
             EndpointDescription description,
             EndpointConfiguration endpointConfiguration,
             X509Certificate2 clientCertificate,
+            MessageTransportMode transportMode,
             IServiceMessageContext messageContext)
         {
-            return CreateUaBinaryChannel(configuration, description, endpointConfiguration, clientCertificate, null, messageContext);
+            return CreateUaBinaryChannel(configuration, description, endpointConfiguration, clientCertificate, null, transportMode, messageContext);
         }
 
         /// <summary>
@@ -788,14 +790,15 @@ namespace Opc.Ua
         /// <param name="endpointConfiguration">The configuration to use with the endpoint.</param>
         /// <param name="clientCertificate">The client certificate.</param>
         /// <param name="clientCertificateChain">The client certificate chain.</param>
+        /// <param name="transportMode"></param>
         /// <param name="messageContext">The message context to use when serializing the messages.</param>
         /// <returns></returns>
-        public static ITransportChannel CreateUaBinaryChannel(
-            ApplicationConfiguration configuration,
+        public static ITransportChannel CreateUaBinaryChannel(ApplicationConfiguration configuration,
             EndpointDescription description,
             EndpointConfiguration endpointConfiguration,
             X509Certificate2 clientCertificate,
             X509Certificate2Collection clientCertificateChain,
+            MessageTransportMode transportMode,
             IServiceMessageContext messageContext)
         {
             string uriScheme = new Uri(description.EndpointUrl).Scheme;
@@ -835,7 +838,8 @@ namespace Opc.Ua
                 Description = description,
                 Configuration = endpointConfiguration,
                 ClientCertificate = clientCertificate,
-                ClientCertificateChain = clientCertificateChain
+                ClientCertificateChain = clientCertificateChain,
+                TransportMode = transportMode,
             };
 
             if (description.ServerCertificate != null && description.ServerCertificate.Length > 0)

--- a/Stack/Opc.Ua.Core/Stack/Client/UaChannelBase.cs
+++ b/Stack/Opc.Ua.Core/Stack/Client/UaChannelBase.cs
@@ -715,13 +715,13 @@ namespace Opc.Ua
         /// <summary>
         /// Creates a new UA-binary transport channel if requested. Null otherwise.
         /// </summary>
-        public static ITransportChannel CreateUaBinaryChannel(ApplicationConfiguration configuration,
+        public static ITransportChannel CreateUaBinaryChannel(
+            ApplicationConfiguration configuration,
             ITransportWaitingConnection connection,
             EndpointDescription description,
             EndpointConfiguration endpointConfiguration,
             X509Certificate2 clientCertificate,
             X509Certificate2Collection clientCertificateChain,
-            MessageTransportMode transportMode,
             IServiceMessageContext messageContext)
         {
             // initialize the channel which will be created with the server.
@@ -740,7 +740,7 @@ namespace Opc.Ua
                 Configuration = endpointConfiguration,
                 ClientCertificate = clientCertificate,
                 ClientCertificateChain = clientCertificateChain,
-                TransportMode = transportMode,
+                TransportMode = configuration?.ClientConfiguration?.MessageTransportMode ?? MessageTransportMode.DataEfficient,
             };
 
             if (description.ServerCertificate != null && description.ServerCertificate.Length > 0)
@@ -769,17 +769,16 @@ namespace Opc.Ua
         /// <param name="description">The description for the endpoint.</param>
         /// <param name="endpointConfiguration">The configuration to use with the endpoint.</param>
         /// <param name="clientCertificate">The client certificate.</param>
-        /// <param name="transportMode">The transport mode of messages.</param>
         /// <param name="messageContext">The message context to use when serializing the messages.</param>
         /// <returns></returns>
-        public static ITransportChannel CreateUaBinaryChannel(ApplicationConfiguration configuration,
+        public static ITransportChannel CreateUaBinaryChannel(
+            ApplicationConfiguration configuration,
             EndpointDescription description,
             EndpointConfiguration endpointConfiguration,
             X509Certificate2 clientCertificate,
-            MessageTransportMode transportMode,
             IServiceMessageContext messageContext)
         {
-            return CreateUaBinaryChannel(configuration, description, endpointConfiguration, clientCertificate, null, transportMode, messageContext);
+            return CreateUaBinaryChannel(configuration, description, endpointConfiguration, clientCertificate, null, messageContext);
         }
 
         /// <summary>
@@ -790,15 +789,14 @@ namespace Opc.Ua
         /// <param name="endpointConfiguration">The configuration to use with the endpoint.</param>
         /// <param name="clientCertificate">The client certificate.</param>
         /// <param name="clientCertificateChain">The client certificate chain.</param>
-        /// <param name="transportMode"></param>
         /// <param name="messageContext">The message context to use when serializing the messages.</param>
         /// <returns></returns>
-        public static ITransportChannel CreateUaBinaryChannel(ApplicationConfiguration configuration,
+        public static ITransportChannel CreateUaBinaryChannel(
+            ApplicationConfiguration configuration,
             EndpointDescription description,
             EndpointConfiguration endpointConfiguration,
             X509Certificate2 clientCertificate,
             X509Certificate2Collection clientCertificateChain,
-            MessageTransportMode transportMode,
             IServiceMessageContext messageContext)
         {
             string uriScheme = new Uri(description.EndpointUrl).Scheme;
@@ -839,7 +837,7 @@ namespace Opc.Ua
                 Configuration = endpointConfiguration,
                 ClientCertificate = clientCertificate,
                 ClientCertificateChain = clientCertificateChain,
-                TransportMode = transportMode,
+                TransportMode = configuration?.ClientConfiguration?.MessageTransportMode ?? MessageTransportMode.DataEfficient
             };
 
             if (description.ServerCertificate != null && description.ServerCertificate.Length > 0)

--- a/Stack/Opc.Ua.Core/Stack/Tcp/TcpMessageSocket.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/TcpMessageSocket.cs
@@ -267,8 +267,7 @@ namespace Opc.Ua.Bindings
             IMessageSink sink,
             Socket socket,
             BufferManager bufferManager,
-            int receiveBufferSize,
-            MessageTransportMode transportMode = MessageTransportMode.DataEfficient)
+            int receiveBufferSize)
         {
             if (socket == null) throw new ArgumentNullException(nameof(socket));
             if (bufferManager == null) throw new ArgumentNullException(nameof(bufferManager));
@@ -277,7 +276,7 @@ namespace Opc.Ua.Bindings
             m_socket = socket;
             m_bufferManager = bufferManager;
             m_receiveBufferSize = receiveBufferSize;
-            m_transportMode = transportMode;
+            m_transportMode = MessageTransportMode.DataEfficient;
             m_incomingMessageSize = -1;
             m_readComplete = OnReadComplete;
         }

--- a/Stack/Opc.Ua.Core/Stack/Tcp/TcpMessageSocket.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/TcpMessageSocket.cs
@@ -106,11 +106,7 @@ namespace Opc.Ua.Bindings
             }
         }
 
-        /// <summary>
-        /// The method should be called by a derived class to signalize the completion of the socket operation.
-        /// </summary>
-        /// <param name="sender">the sender of the operation</param>
-        /// <param name="e">the socket argument</param>
+        /// <inheritdoc/>
         protected void OnComplete(object sender, SocketAsyncEventArgs e)
         {
             if (e.UserToken == null)
@@ -118,7 +114,7 @@ namespace Opc.Ua.Bindings
                 return;
             }
 
-            m_InternalComplete?.Invoke(this, e.UserToken as IMessageSocketAsyncEventArgs);
+            m_InternalComplete(this, e.UserToken as IMessageSocketAsyncEventArgs);
         }
 
         /// <inheritdoc/>
@@ -220,14 +216,12 @@ namespace Opc.Ua.Bindings
     /// </summary>
     public class TcpMessageSocketFactory : IMessageSocketFactory
     {
-        /// <summary>
-        /// The method creates a new instance of a UA-TCP message socket
-        /// </summary>
-        /// <returns> the message socket</returns>
-        public IMessageSocket Create(IMessageSink sink,
+        /// <inheritdoc />
+        public IMessageSocket Create(
+            IMessageSink sink,
             BufferManager bufferManager,
             int receiveBufferSize,
-            MessageTransportMode transportMode)
+            MessageTransportMode transportMode = MessageTransportMode.DataEfficient)
         {
             return new TcpMessageSocket(sink, bufferManager, receiveBufferSize, transportMode);
         }
@@ -252,7 +246,7 @@ namespace Opc.Ua.Bindings
             IMessageSink sink,
             BufferManager bufferManager,
             int receiveBufferSize,
-            MessageTransportMode transportMode)
+            MessageTransportMode transportMode = MessageTransportMode.DataEfficient)
         {
             if (bufferManager == null) throw new ArgumentNullException(nameof(bufferManager));
 
@@ -273,7 +267,8 @@ namespace Opc.Ua.Bindings
             IMessageSink sink,
             Socket socket,
             BufferManager bufferManager,
-            int receiveBufferSize)
+            int receiveBufferSize,
+            MessageTransportMode transportMode = MessageTransportMode.DataEfficient)
         {
             if (socket == null) throw new ArgumentNullException(nameof(socket));
             if (bufferManager == null) throw new ArgumentNullException(nameof(bufferManager));
@@ -282,7 +277,7 @@ namespace Opc.Ua.Bindings
             m_socket = socket;
             m_bufferManager = bufferManager;
             m_receiveBufferSize = receiveBufferSize;
-            m_transportMode = MessageTransportMode.DataEfficient;
+            m_transportMode = transportMode;
             m_incomingMessageSize = -1;
             m_readComplete = OnReadComplete;
         }
@@ -463,10 +458,7 @@ namespace Opc.Ua.Bindings
                     // after processing the ReadComplete and let the outer call handle it
                     if (!innerCall && !ServiceResult.IsBad(error))
                     {
-                        while (ReadNext())
-                        {
-                            // Read the next block
-                        }
+                        while (ReadNext()) ;
                     }
                 }
                 catch (Exception ex)

--- a/Stack/Opc.Ua.Core/Stack/Tcp/TcpServerChannel.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/TcpServerChannel.cs
@@ -38,7 +38,7 @@ namespace Opc.Ua.Bindings
             ChannelQuotas quotas,
             CertificateTypesProvider serverCertificateTypesProvider,
             EndpointDescriptionCollection endpoints,
-            MessageTransportMode transportMode)
+            MessageTransportMode transportMode = MessageTransportMode.DataEfficient)
         :
             base(contextId, listener, bufferManager, quotas, serverCertificateTypesProvider, endpoints)
         {

--- a/Stack/Opc.Ua.Core/Stack/Tcp/TcpTransportListener.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/TcpTransportListener.cs
@@ -218,7 +218,7 @@ namespace Opc.Ua.Bindings
                         m_kBlockDurationMs);
                 }
 
-                // Remove clients that haven't had any potential problematic actions in the last m_kEntryExpirationMs interval 
+                // Remove clients that haven't had any potential problematic actions in the last m_kEntryExpirationMs interval
                 int elapsedSinceBadActionTicks = currentTicks - rClient.LastActionTicks;
                 if (elapsedSinceBadActionTicks > m_kEntryExpirationMs)
                 {
@@ -245,7 +245,7 @@ namespace Opc.Ua.Bindings
             {
                 return false;
             }
-            // C# signed arithmetic 
+            // C# signed arithmetic
             int diff = blockedUntilTicks - currentTicks;
             // If currentTicks < blockedUntilTicks then it is still blocked
             // Works even if TickCount has wrapped around due to C# signed integer arithmetic
@@ -393,6 +393,7 @@ namespace Opc.Ua.Bindings
             m_channels = new ConcurrentDictionary<uint, TcpListenerChannel>();
             m_reverseConnectListener = settings.ReverseConnectListener;
             m_maxChannelCount = settings.MaxChannelCount;
+            m_transportMode = settings.TransportMode;
 
             // save the callback to the server.
             m_callback = callback;
@@ -503,7 +504,8 @@ namespace Opc.Ua.Bindings
                 m_bufferManager,
                 m_quotas,
                 m_serverCertificateTypesProvider,
-                m_descriptions);
+                m_descriptions,
+                m_transportMode);
 
             uint channelId = GetNextChannelId();
             channel.StatusChanged += Channel_StatusChanged;
@@ -833,7 +835,8 @@ namespace Opc.Ua.Bindings
                                         m_bufferManager,
                                         m_quotas,
                                         m_serverCertificateTypesProvider,
-                                        m_descriptions);
+                                    m_descriptions,
+                                    m_transportMode);
                                 }
 
                                 if (m_callback != null)
@@ -1089,13 +1092,13 @@ namespace Opc.Ua.Bindings
         private int m_inactivityDetectPeriod;
         private Timer m_inactivityDetectionTimer;
         private int m_maxChannelCount;
-
         private ActiveClientTracker m_activeClientTracker;
+        private MessageTransportMode m_transportMode;
         #endregion
     }
 
     /// <summary>
-    /// The Tcp specific arguments passed to the ConnectionWaiting event. 
+    /// The Tcp specific arguments passed to the ConnectionWaiting event.
     /// </summary>
     public class TcpConnectionWaitingEventArgs : ConnectionWaitingEventArgs
     {

--- a/Stack/Opc.Ua.Core/Stack/Tcp/UaSCBinaryClientChannel.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/UaSCBinaryClientChannel.cs
@@ -30,7 +30,8 @@ namespace Opc.Ua.Bindings
         /// <summary>
         /// Creates a channel for for a client.
         /// </summary>
-        public UaSCUaBinaryClientChannel(string contextId,
+        public UaSCUaBinaryClientChannel(
+            string contextId,
             BufferManager bufferManager,
             IMessageSocketFactory socketFactory,
             ChannelQuotas quotas,
@@ -38,7 +39,7 @@ namespace Opc.Ua.Bindings
             X509Certificate2Collection clientCertificateChain,
             X509Certificate2 serverCertificate,
             EndpointDescription endpoint,
-            MessageTransportMode transportMode)
+            MessageTransportMode transportMode = MessageTransportMode.DataEfficient)
         :
             base(
                 contextId,

--- a/Stack/Opc.Ua.Core/Stack/Tcp/UaSCBinaryClientChannel.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/UaSCBinaryClientChannel.cs
@@ -30,15 +30,15 @@ namespace Opc.Ua.Bindings
         /// <summary>
         /// Creates a channel for for a client.
         /// </summary>
-        public UaSCUaBinaryClientChannel(
-            string contextId,
+        public UaSCUaBinaryClientChannel(string contextId,
             BufferManager bufferManager,
             IMessageSocketFactory socketFactory,
             ChannelQuotas quotas,
             X509Certificate2 clientCertificate,
             X509Certificate2Collection clientCertificateChain,
             X509Certificate2 serverCertificate,
-            EndpointDescription endpoint)
+            EndpointDescription endpoint,
+            MessageTransportMode transportMode)
         :
             base(
                 contextId,
@@ -71,6 +71,7 @@ namespace Opc.Ua.Bindings
             m_startHandshake = new TimerCallback(OnScheduledHandshake);
             m_handshakeComplete = new AsyncCallback(OnHandshakeComplete);
             m_socketFactory = socketFactory;
+            m_transportMode = transportMode;
 
             // save the endpoint.
             EndpointDescription = endpoint;
@@ -149,7 +150,7 @@ namespace Opc.Ua.Bindings
                 }
                 else
                 {
-                    Socket = m_socketFactory.Create(this, BufferManager, Quotas.MaxBufferSize);
+                    Socket = m_socketFactory.Create(this, BufferManager, Quotas.MaxBufferSize, m_transportMode);
                     Socket.BeginConnect(m_via, m_ConnectCallback, operation);
                 }
 
@@ -977,7 +978,7 @@ namespace Opc.Ua.Bindings
                         m_handshakeOperation = BeginOperation(Int32.MaxValue, m_handshakeComplete, null);
 
                         State = TcpChannelState.Connecting;
-                        Socket = m_socketFactory.Create(this, BufferManager, Quotas.MaxBufferSize);
+                        Socket = m_socketFactory.Create(this, BufferManager, Quotas.MaxBufferSize, m_transportMode);
 
                         // set the state.
                         ChannelStateChanged(TcpChannelState.Connecting, ServiceResult.Good);
@@ -1619,6 +1620,8 @@ namespace Opc.Ua.Bindings
         private List<QueuedOperation> m_queuedOperations;
         private Random m_random;
         private readonly string g_ImplementationString = "UA.NETStandard ClientChannel {0} " + Utils.GetAssemblyBuildNumber();
+        private readonly MessageTransportMode m_transportMode;
+
         #endregion
     }
 }

--- a/Stack/Opc.Ua.Core/Stack/Tcp/UaSCBinaryTransportChannel.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/UaSCBinaryTransportChannel.cs
@@ -482,7 +482,8 @@ namespace Opc.Ua.Bindings
                 m_settings.ClientCertificate,
                 m_settings.ClientCertificateChain,
                 m_settings.ServerCertificate,
-                m_settings.Description);
+                m_settings.Description,
+                m_settings.TransportMode);
 
             // use socket for reverse connections, ignore otherwise
             if (socket != null)

--- a/Stack/Opc.Ua.Core/Stack/Transport/IMessageSocket.cs
+++ b/Stack/Opc.Ua.Core/Stack/Transport/IMessageSocket.cs
@@ -81,7 +81,7 @@ namespace Opc.Ua.Bindings
         /// <param name="buffer">The data buffer to use with an asynchronous socket method.</param>
         /// <param name="offset">The offset, in bytes, in the data buffer where the operation starts.</param>
         /// <param name="count">The maximum amount of data, in bytes, to send or receive in the buffer.</param>
-        /// 
+        ///
         void SetBuffer(byte[] buffer, int offset, int count);
     }
 
@@ -109,7 +109,7 @@ namespace Opc.Ua.Bindings
 
 
     /// <summary>
-    /// This is an interface to a message socket which supports a factory 
+    /// This is an interface to a message socket which supports a factory
     /// </summary>
     public interface IMessageSocketFactory
     {
@@ -117,10 +117,10 @@ namespace Opc.Ua.Bindings
         /// Creates an unconnected socket.
         /// </summary>
         /// <returns>the message socket</returns>
-        IMessageSocket Create(
-            IMessageSink sink,
+        IMessageSocket Create(IMessageSink sink,
             BufferManager bufferManager,
-            int receiveBufferSize);
+            int receiveBufferSize,
+            MessageTransportMode transportMode = MessageTransportMode.DataEfficient);
 
         /// <summary>
         /// Gets the implementation description.

--- a/Stack/Opc.Ua.Core/Stack/Transport/TransportChannelSettings.cs
+++ b/Stack/Opc.Ua.Core/Stack/Transport/TransportChannelSettings.cs
@@ -92,7 +92,7 @@ namespace Opc.Ua
         /// This is a thread safe object that may be updated by the application at any time.
         /// This table is used to lookup the NamespaceURI for the DataTypeEncodingId when decoding ExtensionObjects.
         /// If the NamespaceURI can be found the decoder will use the Factory to create an instance of a .NET object.
-        /// The raw data is passed to application if the NamespaceURI cannot be found or there is no .NET class 
+        /// The raw data is passed to application if the NamespaceURI cannot be found or there is no .NET class
         /// associated with the DataTypeEncodingId then.
         /// </remarks>
         /// <seealso cref="Factory" />
@@ -121,6 +121,19 @@ namespace Opc.Ua
             get { return m_channelFactory; }
             set { m_channelFactory = value; }
         }
+
+        /// <summary>
+        /// Defines the way the transport layer should process the payload data.
+        /// </summary>
+        /// <remarks>
+        /// Data Efficiency vs. Urgency
+        /// </remarks>
+        public MessageTransportMode TransportMode
+        {
+            get => m_transportMode;
+            set => m_transportMode = value;
+        }
+
         #endregion
 
         #region Private Fields
@@ -132,6 +145,7 @@ namespace Opc.Ua
         private ICertificateValidator m_certificateValidator;
         private NamespaceTable m_namespaceUris;
         private IEncodeableFactory m_channelFactory;
+        private MessageTransportMode m_transportMode;
         #endregion
     }
 }

--- a/Stack/Opc.Ua.Core/Stack/Transport/TransportListenerSettings.cs
+++ b/Stack/Opc.Ua.Core/Stack/Transport/TransportListenerSettings.cs
@@ -69,7 +69,7 @@ namespace Opc.Ua
         /// This is a thread safe object that may be updated by the application at any time.
         /// This table is used to lookup the NamespaceURI for the DataTypeEncodingId when decoding ExtensionObjects.
         /// If the NamespaceURI can be found the decoder will use the Factory to create an instance of a .NET object.
-        /// The raw data is passed to application if the NamespaceURI cannot be found or there is no .NET class 
+        /// The raw data is passed to application if the NamespaceURI cannot be found or there is no .NET class
         /// associated with the DataTypeEncodingId then.
         /// </remarks>
         /// <seealso cref="Factory" />
@@ -97,6 +97,18 @@ namespace Opc.Ua
         {
             get { return m_channelFactory; }
             set { m_channelFactory = value; }
+        }
+
+        /// <summary>
+        /// Defines the way the transport layer should process the payload data.
+        /// </summary>
+        /// <remarks>
+        /// Data Efficiency vs. Urgency
+        /// </remarks>
+        public MessageTransportMode TransportMode
+        {
+            get => m_transportMode;
+            set => m_transportMode = value;
         }
 
         /// <summary>
@@ -140,6 +152,8 @@ namespace Opc.Ua
         private bool m_reverseConnectListener;
         private int m_maxChannelCount;
         private bool m_httpMutualTls;
+        private MessageTransportMode m_transportMode;
+
         #endregion
     }
 }


### PR DESCRIPTION
## Proposed changes

I and my colleagues encountered a perfomance issue lately using the default OPC UA Stack.
We were issuing a method call and waited in parallel for a node value to change. Which signalled the end of the running method.
Calling the method alone took us 17ms in median, but when waiting for the node value changes to occurr we suddenly were waiting for up to 200ms. However, we were rather expecting about 45ms.

Debugging into the OPC UA stack I realized, when I set the `NoDelay` property of the Socket to `true` that these 200ms shrunk down to 47ms in median, totally meeting our expectations.

In this PR I propose a new setting in the application configuration. I call it `MessageTransportMode` and the user can select between two modes `DataEfficient` (`NoDelay = false`) and `TimeCritical` (`NoDelay = true`). These settings are added into the `ClientConfiguration` and `ServerConfiguration` sections of the `ApplicationConfiguration` and passed throgh the whole stack.

## Related Issues

- Fixes #

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [x] I ran tests locally with my changes, all passed.
- [x] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [x] Any dependent changes have been merged and published in downstream modules.

## Further comments

None
