### PR TITLE
Fix regression in Node AccessRestrictions: change return type from uint32 to ushort

### DIFF
--- a/Stack/Opc.Ua.Core/Stack/State/NodeState.cs
+++ b/Stack/Opc.Ua.Core/Stack/State/NodeState.cs
@@ -3669,7 +3669,7 @@ namespace Opc.Ua
 
                     if (ServiceResult.IsGood(result))
                     {
-                        value = accessRestrictions;
+                        value = (ushort)accessRestrictions;
                     }
 
                     if (value != null || result != null)


### PR DESCRIPTION
## Proposed changes

Cast the AccessRestrictions explicitly to ushort to conform to spec (regression from 1.05.03. Nodeset update).

See also https://github.com/OPCFoundation/UA-.NETStandard/commit/1e927dd502979eebc574ca5ec22dac0937e1e9a4  

## Related Issues

- Fixes #2870

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

