### PR TITLE
[Server] [Performance] Reduce locking in CustomNodeManager2

### DIFF
--- a/Applications/Quickstarts.Servers/Alarms/AlarmNodeManager.cs
+++ b/Applications/Quickstarts.Servers/Alarms/AlarmNodeManager.cs
@@ -29,6 +29,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Threading;
 using Opc.Ua;
 using Opc.Ua.Server;
@@ -143,7 +144,7 @@ namespace Alarms
 
                     Type alarmControllerType = Type.GetType("Alarms.AlarmController");
                     int interval = 1000;
-                    string intervalString = interval.ToString();
+                    string intervalString = interval.ToString(CultureInfo.InvariantCulture);
 
                     int conditionTypeIndex = 0;
                     #endregion
@@ -765,20 +766,20 @@ namespace Alarms
                 // check for valid handle.
                 NodeHandle initialHandle = GetManagerHandle(systemContext, methodToCall.ObjectId, operationCache);
 
-                lock (Lock)
+                if (initialHandle == null)
                 {
-                    if (initialHandle == null)
+                    if (ackConfirmMethod)
                     {
-                        if (ackConfirmMethod)
-                        {
-                            // Mantis 6944
-                            errors[ii] = StatusCodes.BadNodeIdUnknown;
-                            methodToCall.Processed = true;
-                        }
-
-                        continue;
+                        // Mantis 6944
+                        errors[ii] = StatusCodes.BadNodeIdUnknown;
+                        methodToCall.Processed = true;
                     }
 
+                    continue;
+                }
+
+                lock (Lock)
+                {
                     // owned by this node manager.
                     methodToCall.Processed = true;
 

--- a/Applications/Quickstarts.Servers/Alarms/AlarmNodeManager.cs
+++ b/Applications/Quickstarts.Servers/Alarms/AlarmNodeManager.cs
@@ -762,11 +762,11 @@ namespace Alarms
 
                 MethodState method = null;
 
+                // check for valid handle.
+                NodeHandle initialHandle = GetManagerHandle(systemContext, methodToCall.ObjectId, operationCache);
+
                 lock (Lock)
                 {
-                    // check for valid handle.
-                    NodeHandle initialHandle = GetManagerHandle(systemContext, methodToCall.ObjectId, operationCache);
-
                     if (initialHandle == null)
                     {
                         if (ackConfirmMethod)

--- a/Applications/Quickstarts.Servers/Alarms/AlarmNodeManager.cs
+++ b/Applications/Quickstarts.Servers/Alarms/AlarmNodeManager.cs
@@ -30,6 +30,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using System.Threading;
 using Opc.Ua;
 using Opc.Ua.Server;
@@ -854,7 +855,7 @@ namespace Alarms
                     {
                         if (RootNotifiers != null)
                         {
-                            nodesToRefresh.AddRange(RootNotifiers);
+                            nodesToRefresh.AddRange(RootNotifiers.Values.ToList());
                         }
                     }
                     else

--- a/Applications/Quickstarts.Servers/ReferenceServer/ReferenceNodeManager.cs
+++ b/Applications/Quickstarts.Servers/ReferenceServer/ReferenceNodeManager.cs
@@ -2726,29 +2726,27 @@ namespace Quickstarts.ReferenceServer
         /// </summary>
         protected override NodeHandle GetManagerHandle(ServerSystemContext context, NodeId nodeId, IDictionary<NodeId, NodeState> cache)
         {
-            lock (Lock)
+            // quickly exclude nodes that are not in the namespace. 
+            if (!IsNodeIdInNamespace(nodeId))
             {
-                // quickly exclude nodes that are not in the namespace. 
-                if (!IsNodeIdInNamespace(nodeId))
-                {
-                    return null;
-                }
-
-                NodeState node = null;
-
-                if (!PredefinedNodes.TryGetValue(nodeId, out node))
-                {
-                    return null;
-                }
-
-                NodeHandle handle = new NodeHandle();
-
-                handle.NodeId = nodeId;
-                handle.Node = node;
-                handle.Validated = true;
-
-                return handle;
+                return null;
             }
+
+            NodeState node = null;
+
+            if (!PredefinedNodes.TryGetValue(nodeId, out node))
+            {
+                return null;
+            }
+
+            NodeHandle handle = new NodeHandle {
+                NodeId = nodeId,
+                Node = node,
+                Validated = true
+            };
+
+            return handle;
+
         }
 
         /// <summary>

--- a/Applications/Quickstarts.Servers/TestData/TestDataNodeManager.cs
+++ b/Applications/Quickstarts.Servers/TestData/TestDataNodeManager.cs
@@ -185,9 +185,9 @@ namespace TestData
                     new NodeId(Objects.Data_Conditions, m_typeNamespaceIndex),
                     typeof(NodeState));
 
-                foreach (KeyValuePair<NodeId, NodeState> kvp in PredefinedNodes)
+                foreach (NodeState node in PredefinedNodes.Values)
                 {
-                    if (kvp.Value is ConditionState condition && !ReferenceEquals(condition.Parent, conditionsFolder))
+                    if (node is ConditionState condition && !ReferenceEquals(condition.Parent, conditionsFolder))
                     {
                         condition.AddNotifier(SystemContext, null, true, conditionsFolder);
                         conditionsFolder.AddNotifier(SystemContext, null, false, condition);

--- a/Applications/Quickstarts.Servers/TestData/TestDataNodeManager.cs
+++ b/Applications/Quickstarts.Servers/TestData/TestDataNodeManager.cs
@@ -185,10 +185,9 @@ namespace TestData
                     new NodeId(Objects.Data_Conditions, m_typeNamespaceIndex),
                     typeof(NodeState));
 
-                foreach (NodeState node in PredefinedNodes.Values.ToArray())
+                foreach (KeyValuePair<NodeId, NodeState> kvp in PredefinedNodes)
                 {
-                    ConditionState condition = node as ConditionState;
-                    if (condition != null && !Object.ReferenceEquals(condition.Parent, conditionsFolder))
+                    if (kvp.Value is ConditionState condition && !ReferenceEquals(condition.Parent, conditionsFolder))
                     {
                         condition.AddNotifier(SystemContext, null, true, conditionsFolder);
                         conditionsFolder.AddNotifier(SystemContext, null, false, condition);

--- a/Applications/Quickstarts.Servers/TestData/TestDataNodeManager.cs
+++ b/Applications/Quickstarts.Servers/TestData/TestDataNodeManager.cs
@@ -185,7 +185,7 @@ namespace TestData
                     new NodeId(Objects.Data_Conditions, m_typeNamespaceIndex),
                     typeof(NodeState));
 
-                foreach (NodeState node in PredefinedNodes.Values)
+                foreach (NodeState node in PredefinedNodes.Values.ToArray())
                 {
                     ConditionState condition = node as ConditionState;
                     if (condition != null && !Object.ReferenceEquals(condition.Parent, conditionsFolder))

--- a/Libraries/Opc.Ua.Client/Session/TraceableSession.cs
+++ b/Libraries/Opc.Ua.Client/Session/TraceableSession.cs
@@ -1300,7 +1300,7 @@ namespace Opc.Ua.Client
         {
             using (Activity activity = ActivitySource.StartActivity())
             {
-                return await m_session.ManagedBrowseAsync(requestHeader, view, nodesToBrowse, maxResultsToReturn, browseDirection, referenceTypeId, includeSubtypes, nodeClassMask, ct);
+                return await m_session.ManagedBrowseAsync(requestHeader, view, nodesToBrowse, maxResultsToReturn, browseDirection, referenceTypeId, includeSubtypes, nodeClassMask, ct).ConfigureAwait(false);
             }
         }
 

--- a/Libraries/Opc.Ua.Gds.Server.Common/ApplicationsNodeManager.cs
+++ b/Libraries/Opc.Ua.Gds.Server.Common/ApplicationsNodeManager.cs
@@ -1464,10 +1464,7 @@ namespace Opc.Ua.Gds.Server
                 {
                     NodeHandle handle = new NodeHandle(nodeId, node);
 
-                    if (cache != null)
-                    {
-                        cache.Add(nodeId, node);
-                    }
+                    cache?.Add(nodeId, node);
 
                     return handle;
                 }

--- a/Libraries/Opc.Ua.Server/Diagnostics/CustomNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/Diagnostics/CustomNodeManager.cs
@@ -388,15 +388,15 @@ namespace Opc.Ua.Server
                 return false;
             }
 
-            NodeState node = null;
 
-            if (m_predefinedNodes.TryGetValue(nodeId, out node))
+            if (m_predefinedNodes.TryGetValue(nodeId, out NodeState node))
             {
                 RemovePredefinedNode(contextToUse, node, referencesToRemove);
                 found = true;
+
+                RemoveRootNotifier(node);
             }
 
-            RemoveRootNotifier(node);
 
             if (referencesToRemove.Count > 0)
             {

--- a/Libraries/Opc.Ua.Server/Diagnostics/CustomNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/Diagnostics/CustomNodeManager.cs
@@ -4639,7 +4639,8 @@ namespace Opc.Ua.Server
             bool componentPathExists = !string.IsNullOrEmpty(handle.ComponentPath);
             NodeId nodeId = componentPathExists ? handle.RootId : handle.NodeId;
 
-            if (m_componentCache?.TryGetValue(nodeId, out CacheEntry entry) == true)
+            CacheEntry entry = null;
+            if (m_componentCache?.TryGetValue(nodeId, out entry) == true)
             {
                 if (componentPathExists)
                 {

--- a/Libraries/Opc.Ua.Server/Diagnostics/CustomNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/Diagnostics/CustomNodeManager.cs
@@ -1988,7 +1988,7 @@ namespace Opc.Ua.Server
 
                 if (propertyState != null && property != null && propertyState.NodeId == property.NodeId && !Utils.IsEqual(newPropertyValue, previousPropertyValue))
                 {
-                    foreach (var monitoredItem in monitoredNode.DataChangeMonitoredItems)
+                    foreach (var monitoredItem in monitoredNode.DataChangeMonitoredItems.Values)
                     {
                         if (monitoredItem.AttributeId == Attributes.Value)
                         {
@@ -3259,12 +3259,11 @@ namespace Opc.Ua.Server
                 MonitoredNodes[source.NodeId] = monitoredNode = new MonitoredNode2(this, source);
             }
 
-            if (monitoredNode.EventMonitoredItems != null)
-            {
-                // remove existing monitored items with the same Id prior to insertion in order to avoid duplicates
-                // this is necessary since the SubscribeToEvents method is called also from ModifyMonitoredItemsForEvents
-                monitoredNode.EventMonitoredItems.RemoveAll(e => e.Id == monitoredItem.Id);
-            }
+
+            // remove existing monitored items with the same Id prior to insertion in order to avoid duplicates
+            // this is necessary since the SubscribeToEvents method is called also from ModifyMonitoredItemsForEvents
+            monitoredNode.EventMonitoredItems?.TryRemove(monitoredItem.Id, out _);
+
 
             // this links the node to specified monitored item and ensures all events
             // reported by the node are added to the monitored item's queue.

--- a/Libraries/Opc.Ua.Server/Diagnostics/CustomNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/Diagnostics/CustomNodeManager.cs
@@ -4663,7 +4663,8 @@ namespace Opc.Ua.Server
             bool componentPathExists = !string.IsNullOrEmpty(handle.ComponentPath);
             NodeId nodeId = componentPathExists ? handle.RootId : handle.NodeId;
 
-            if (m_componentCache?.TryGetValue(nodeId, out CacheEntry entry) == true)
+            CacheEntry entry = null;
+            if (m_componentCache?.TryGetValue(nodeId, out entry) == true)
             {
                 int refCount = Interlocked.Decrement(ref entry.RefCount);
 

--- a/Libraries/Opc.Ua.Server/Diagnostics/CustomNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/Diagnostics/CustomNodeManager.cs
@@ -902,7 +902,8 @@ namespace Opc.Ua.Server
                 return null;
             }
 
-            if (m_predefinedNodes?.TryGetValue(nodeId, out NodeState node) == true)
+            NodeState node = null;
+            if (m_predefinedNodes?.TryGetValue(nodeId, out node) == true)
             {
                 var handle = new NodeHandle {
                     NodeId = nodeId,

--- a/Libraries/Opc.Ua.Server/Diagnostics/CustomNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/Diagnostics/CustomNodeManager.cs
@@ -4663,7 +4663,8 @@ namespace Opc.Ua.Server
 
                     if (refCount == 0)
                     {
-                        m_componentCache.Remove(nodeId);
+                        //this will only remove the value if it did not change after retrieving from the dictionary
+                        m_componentCache.TryRemove(nodeId, entry);
                     }
                 }
             }
@@ -4694,7 +4695,7 @@ namespace Opc.Ua.Server
                         Entry = node.GetHierarchyRoot()
                     },
                     (nodeId, entry) => {
-                        entry.RefCount++;
+                        Interlocked.Increment(ref entry.RefCount);
                         return entry;
                     }
                 );
@@ -4711,7 +4712,7 @@ namespace Opc.Ua.Server
                         Entry = node
                     },
                     (nodeId, entry) => {
-                        entry.RefCount++;
+                        Interlocked.Increment(ref entry.RefCount);
                         return entry;
                     }
                 );

--- a/Libraries/Opc.Ua.Server/Diagnostics/CustomNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/Diagnostics/CustomNodeManager.cs
@@ -4670,7 +4670,7 @@ namespace Opc.Ua.Server
 
                 if (refCount == 0)
                 {
-                    //this will only remove the value if it did not change after retrieving from the dictionary
+                    //this will only remove the value if it was not changed by another thread
                     m_componentCache.TryRemove(nodeId, entry);
                 }
             }
@@ -4722,7 +4722,6 @@ namespace Opc.Ua.Server
                         return entry;
                     }
                 );
-
             }
 
             return node;

--- a/Stack/Opc.Ua.Core/Stack/Tcp/TcpTransportListener.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/TcpTransportListener.cs
@@ -14,6 +14,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.Linq;
 using System.Net;
 using System.Net.Sockets;
@@ -416,7 +417,7 @@ namespace Opc.Ua.Bindings
             try
             {
                 var channelIdString = globalChannelId.Substring(ListenerId.Length + 1);
-                var channelId = Convert.ToUInt32(channelIdString);
+                var channelId = Convert.ToUInt32(channelIdString, CultureInfo.InvariantCulture);
 
                 TcpListenerChannel channel = null;
                 if (channelId > 0 &&

--- a/Stack/Opc.Ua.Core/Stack/Tcp/UaSCBinaryClientChannel.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/UaSCBinaryClientChannel.cs
@@ -13,6 +13,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
@@ -653,7 +654,7 @@ namespace Opc.Ua.Bindings
                     throw new ServiceResultException(StatusCodes.BadNonceInvalid);
                 }
 
-                string implementation = String.Format(g_ImplementationString, m_socketFactory.Implementation);
+                string implementation = string.Format(CultureInfo.InvariantCulture, g_ImplementationString, m_socketFactory.Implementation);
 
                 // log security information.
                 if (State == TcpChannelState.Opening)

--- a/Stack/Opc.Ua.Core/Types/BuiltIn/NodeIdDictionary.cs
+++ b/Stack/Opc.Ua.Core/Types/BuiltIn/NodeIdDictionary.cs
@@ -18,7 +18,7 @@
 // the original implementation using multiple SortedDictionary instances
 
 using System;
-using System.Collections;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 
 namespace Opc.Ua
@@ -42,6 +42,28 @@ namespace Opc.Ua
         /// Creates an empty dictionary with capacity.
         /// </summary>
         public NodeIdDictionary(int capacity) : base(capacity, s_comparer)
+        {
+        }
+    }
+    /// <summary>
+    /// A concurrent dictionary designed to provide efficient lookups for objects identified by a NodeId
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public class ConcurrentNodeIdDictionary<T> : ConcurrentDictionary<NodeId, T>
+    {
+        private static readonly NodeIdComparer s_comparer = new NodeIdComparer();
+
+        /// <summary>
+        /// Creates an empty dictionary.
+        /// </summary>
+        public ConcurrentNodeIdDictionary() : base(s_comparer)
+        {
+        }
+
+        /// <summary>
+        /// Creates an empty dictionary with capacity.
+        /// </summary>
+        public ConcurrentNodeIdDictionary(int capacity) : base(Environment.ProcessorCount, capacity, s_comparer)
         {
         }
     }

--- a/Stack/Opc.Ua.Core/Types/BuiltIn/NodeIdDictionary.cs
+++ b/Stack/Opc.Ua.Core/Types/BuiltIn/NodeIdDictionary.cs
@@ -20,6 +20,7 @@
 using System;
 using System.Collections;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 
 namespace Opc.Ua
 {
@@ -60,6 +61,19 @@ namespace Opc.Ua
         public void Remove(NodeId key)
         {
             TryRemove(key, out _);
+        }
+
+        /// <summary>
+        /// remove a entry from the dictionary only if it has the provided value
+        /// https://devblogs.microsoft.com/pfxteam/little-known-gems-atomic-conditional-removals-from-concurrentdictionary/
+        /// </summary>
+        /// <param name="key">the key of the entry to remove</param>
+        /// <param name="value">the value of the entry to remove</param>
+        /// <returns>true if removed, false if not removed</returns>
+        public bool TryRemove(NodeId key, T value)
+        {
+            return ((ICollection<KeyValuePair<NodeId, T>>)this).Remove(
+                new KeyValuePair<NodeId, T>(key, value));
         }
     }
 

--- a/Tests/Opc.Ua.Server.Tests/CustomNodeManagerTests.cs
+++ b/Tests/Opc.Ua.Server.Tests/CustomNodeManagerTests.cs
@@ -1,0 +1,202 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using NUnit.Framework;
+
+namespace Opc.Ua.Server.Tests
+{ /// <summary>
+  /// Test <see cref="CustomNodeManager2"/>
+  /// </summary>
+    [TestFixture, Category("CustomNodeManager")]
+    [SetCulture("en-us"), SetUICulture("en-us")]
+    [Parallelizable]
+    public class CustomNodeManagerTests
+    {
+        #region Test Methods
+        /// <summary>
+        /// Tests the componentCache methods with multiple threads
+        /// </summary>
+        [Test]
+        public async Task TestComponentCacheAsync()
+        {
+            var fixture = new ServerFixture<StandardServer>();
+
+            try
+            {
+                // Arrange
+                const string ns = "http://test.org/UA/Data/";
+                var server = await fixture.StartAsync(TestContext.Out).ConfigureAwait(false);
+
+                var nodeManager = new TestableCustomNodeManger2(server.CurrentInstance, ns);
+
+
+                var baseObject = new BaseObjectState(null);
+                var nodeHandle = new NodeHandle(new NodeId((string)CommonTestWorkers.NodeIdTestSetStatic.First().Identifier, 0), baseObject);
+
+                //Act
+                await RunTaskInParallel(() => UseComponentCacheAsync(nodeManager, baseObject, nodeHandle), 100);
+
+
+                //Assert, that entry was deleted from cache after parallel operations on the same node
+                NodeState handleFromCache = nodeManager.LookupNodeInComponentCache(nodeManager.SystemContext, nodeHandle);
+
+                Assert.That(handleFromCache, Is.Null);
+            }
+            finally
+            {
+                await fixture.StopAsync().ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
+        /// Tests the Predefined Nodes methods with multiple threads
+        /// </summary>
+        [Test]
+        public async Task TestPredefinedNodes()
+        {
+            var fixture = new ServerFixture<StandardServer>();
+
+            try
+            {
+                // Arrange
+                const string ns = "http://test.org/UA/Data/";
+                var server = await fixture.StartAsync(TestContext.Out).ConfigureAwait(false);
+
+                var nodeManager = new TestableCustomNodeManger2(server.CurrentInstance, ns);
+                var index = server.CurrentInstance.NamespaceUris.GetIndex(ns);
+
+                var baseObject = new DataItemState(null);
+                var nodeId = new NodeId((string)CommonTestWorkers.NodeIdTestSetStatic.First().Identifier, (ushort)index);
+
+                baseObject.NodeId = nodeId;
+
+                nodeManager.AddPredefinedNode(nodeManager.SystemContext, baseObject);
+
+                Assert.That(nodeManager.PredefinedNodes.ContainsKey(nodeId), Is.True);
+
+                nodeManager.DeleteNode(nodeManager.SystemContext, nodeId);
+
+                Assert.That(nodeManager.PredefinedNodes, Is.Empty);
+
+                //NodeState nodeState = nodeManager.Find(nodeId);
+
+                //NodeHandle handle = (NodeHandle)nodeManager.GetManagerHandle(nodeId);
+
+                //nodeManager.DeleteAddressSpace();
+
+                //Assert.That(handle, Is.Not.Null);
+
+                ////Act
+                ////await RunTaskInParallel(() => UseComponentCacheAsync(nodeManager, baseObject, nodeHandle), 100);
+
+
+                ////Assert, that entry was deleted from cache after parallel operations on the same node
+                //NodeState handleFromCache = nodeManager.LookupNodeInComponentCache(nodeManager.SystemContext, nodeHandle);
+
+                //Assert.That(handleFromCache, Is.Null);
+            }
+            finally
+            {
+                await fixture.StopAsync().ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
+        /// Test Methods  AddNodeToComponentCache,  RemoveNodeFromComponentCache & LookupNodeInComponentCache & verify the node is added to the cache
+        /// </summary>
+        /// <returns></returns>
+        private static async Task UseComponentCacheAsync(TestableCustomNodeManger2 nodeManager, BaseObjectState baseObject, NodeHandle nodeHandle)
+        {
+            //-- Act
+            nodeManager.AddNodeToComponentCache(nodeManager.SystemContext, nodeHandle, baseObject);
+            nodeManager.AddNodeToComponentCache(nodeManager.SystemContext, nodeHandle, baseObject);
+
+            NodeState handleFromCache = nodeManager.LookupNodeInComponentCache(nodeManager.SystemContext, nodeHandle);
+
+            //-- Assert
+
+            Assert.That(handleFromCache, Is.Not.Null);
+
+            nodeManager.RemoveNodeFromComponentCache(nodeManager.SystemContext, nodeHandle);
+
+            handleFromCache = nodeManager.LookupNodeInComponentCache(nodeManager.SystemContext, nodeHandle);
+
+            Assert.That(handleFromCache, Is.Not.Null);
+
+            nodeManager.RemoveNodeFromComponentCache(nodeManager.SystemContext, nodeHandle);
+
+            await Task.CompletedTask;
+        }
+        #endregion
+
+        public static async Task<(bool IsSuccess, Exception Error)> RunTaskInParallel(Func<Task> task, int iterations)
+        {
+            var cancellationTokenSource = new CancellationTokenSource();
+            Exception error = null;
+            int tasksCompletedCount = 0;
+            var result = Parallel.For(0, iterations, new ParallelOptions(),
+                          async index => {
+                              try
+                              {
+                                  await task();
+                              }
+                              catch (Exception ex)
+                              {
+                                  error = ex;
+                                  cancellationTokenSource.Cancel();
+                              }
+                              finally
+                              {
+                                  tasksCompletedCount++;
+                              }
+
+                          });
+
+            int spinWaitCount = 0;
+            int maxSpinWaitCount = 100;
+            while (iterations > tasksCompletedCount && error is null && spinWaitCount < maxSpinWaitCount)
+            {
+                await Task.Delay(TimeSpan.FromMilliseconds(100));
+                spinWaitCount++;
+            }
+
+            return (error == null, error);
+        }
+
+    }
+
+    public class TestableCustomNodeManger2 : CustomNodeManager2
+    {
+        public TestableCustomNodeManger2(IServerInternal server, params string[] namespaceUris) : base(server, namespaceUris)
+        { }
+
+        #region componentCache
+        public new NodeState AddNodeToComponentCache(ISystemContext context, NodeHandle handle, NodeState node)
+        {
+            return base.AddNodeToComponentCache(context, handle, node);
+        }
+        public new void RemoveNodeFromComponentCache(ISystemContext context, NodeHandle handle)
+        {
+            base.RemoveNodeFromComponentCache(context, handle);
+        }
+        public new NodeState LookupNodeInComponentCache(ISystemContext context, NodeHandle handle)
+        {
+            return base.LookupNodeInComponentCache(context, handle);
+        }
+        #endregion
+
+        #region PredefinedNodes
+
+        public new NodeIdDictionary<NodeState> PredefinedNodes => base.PredefinedNodes;
+        public new virtual void AddPredefinedNode(ISystemContext context, NodeState node)
+        {
+            base.AddPredefinedNode(context, node);
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
## Proposed changes

- Make NodeIdDictionary a ConcurrentDictionary and therefore allow to gradually remove locks from many parts of the server
- Update (m_)PredefinedNodes in CustomNodeManager2 to be used without locks
- make m_namespaceUris + (m_)NamespaceIndexes in CustomNodeManager2  ReadOnlyCollections and therefore threadsafe
- make m_componentCache a NodeIdDictionary
- make m_rootNotifiers a NodeIdDictionary
- make (m_)MonitoredNodes a NodeIdDictionary (faster compare + concurrentDictionary)
- make IsNodeInNamespace /IsHandleInNamespace /GetManagerHandle threadsafe 
- make underlying List of MIs in MonitoredNode a ConcurrentDictionary instead of lists, as the implementation before was not efficient


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

ToDo 
- Concurrent tests for RootNotifier & MonitoredNode

Optimized Methods:

- AlarmNodeManager Call
CustomNodeManger:
- SetNamespaces / SetNamespaceIndexes / IsNodeIdInNamespace (make thread safe by using IReadOnlyCollection for m_namespaceUris + (m_)NamespaceIndexes)
- Find(remove lock)
- DeleteNode (remove lock, only lock modifying m_rootNotifiers)
- AddPredefinedNode
- AddRootNotifier, RemoveRootNotifier (make Lock Free)
- DeleteAddressSpace (remove lock by copying predefined nodes to temp array)
- GetManagerHandle remove lock (IsNodeIdInNamespace & m_predefinedNodes are threadsafe)
- DeleteReference, GetNodeMetadata, GetPermissionMetadata, Browse, TranslateBrowsePath, Call (lock only after validating nodes are in the namespace of the NodeManager)
- CreateMonitoredItems, ModifyMonitoredItems, DeleteMonitoredItems, SetMonitoringMode (lock only after validating nodes are in the namespace of the NodeManager)
- LookupNodeInComponentCache, RemoveNodeFromComponentCache, AddNodeToComponentCache (Make these methods work Lock Free by making m_componentCache a NodeIDictionary)
- SubscribeToEvents (Add missing locks in callers)

Parallel Tests:
- ComponentCache
- PredefinedNodesDictionary

To Decide:
- iterate over Values of Dictionary (snapshot) or iterate KVPs (updated in Realtime, no snapshot)