### PR TITLE
Fix server time and move all readerwriter locks outside of try/finally

### DIFF
--- a/Libraries/Opc.Ua.Client/NodeCache/NodeCache.cs
+++ b/Libraries/Opc.Ua.Client/NodeCache/NodeCache.cs
@@ -104,10 +104,10 @@ namespace Opc.Ua.Client
             }
 
             INode node;
+
+            m_cacheLock.EnterReadLock();
             try
             {
-                m_cacheLock.EnterReadLock();
-
                 // check if node already exists.
                 node = m_nodes.Find(nodeId);
             }
@@ -155,10 +155,10 @@ namespace Opc.Ua.Client
             for (ii = 0; ii < count; ii++)
             {
                 INode node;
+
+                m_cacheLock.EnterReadLock();
                 try
                 {
-                    m_cacheLock.EnterReadLock();
-
                     // check if node already exists.
                     node = m_nodes.Find(nodeIds[ii]);
                 }
@@ -235,10 +235,10 @@ namespace Opc.Ua.Client
             }
 
             IList<IReference> references;
+
+            m_cacheLock.EnterReadLock();
             try
             {
-                m_cacheLock.EnterReadLock();
-
                 // find all references.
                 references = source.ReferenceTable.Find(referenceTypeId, isInverse, includeSubtypes, m_typeTree);
             }
@@ -285,10 +285,9 @@ namespace Opc.Ua.Client
             }
 
             IList<IReference> references;
+            m_cacheLock.EnterReadLock();
             try
             {
-                m_cacheLock.EnterReadLock();
-
                 // find all references.
                 references = source.ReferenceTable.Find(referenceTypeId, isInverse, includeSubtypes, m_typeTree);
             }
@@ -325,10 +324,9 @@ namespace Opc.Ua.Client
                 return false;
             }
 
+            m_cacheLock.EnterReadLock();
             try
             {
-                m_cacheLock.EnterReadLock();
-
                 return m_typeTree.IsKnown(typeId);
             }
             finally
@@ -347,10 +345,9 @@ namespace Opc.Ua.Client
                 return false;
             }
 
+            m_cacheLock.EnterReadLock();
             try
             {
-                m_cacheLock.EnterReadLock();
-
                 return m_typeTree.IsKnown(typeId);
             }
             finally
@@ -369,10 +366,9 @@ namespace Opc.Ua.Client
                 return null;
             }
 
+            m_cacheLock.EnterReadLock();
             try
             {
-                m_cacheLock.EnterReadLock();
-
                 return m_typeTree.FindSuperType(typeId);
             }
             finally
@@ -392,10 +388,9 @@ namespace Opc.Ua.Client
                 return null;
             }
 
+            m_cacheLock.EnterReadLock();
             try
             {
-                m_cacheLock.EnterReadLock();
-
                 return m_typeTree.FindSuperType(typeId);
             }
             finally
@@ -409,18 +404,18 @@ namespace Opc.Ua.Client
         public IList<NodeId> FindSubTypes(ExpandedNodeId typeId)
         {
             ILocalNode type = Find(typeId) as ILocalNode;
+            List<NodeId> subtypes = new List<NodeId>();
 
             if (type == null)
             {
-                return new List<NodeId>();
+                return subtypes;
             }
 
-            List<NodeId> subtypes = new List<NodeId>();
             IList<IReference> references;
+
+            m_cacheLock.EnterReadLock();
             try
             {
-                m_cacheLock.EnterReadLock();
-
                 references = type.References.Find(ReferenceTypeIds.HasSubtype, false, true, m_typeTree);
             }
             finally
@@ -459,10 +454,10 @@ namespace Opc.Ua.Client
             while (supertype != null)
             {
                 ExpandedNodeId currentId;
+
+                m_cacheLock.EnterReadLock();
                 try
                 {
-                    m_cacheLock.EnterReadLock();
-
                     currentId = supertype.References.FindTarget(ReferenceTypeIds.HasSubtype, true, true, m_typeTree, 0);
                 }
                 finally
@@ -501,10 +496,10 @@ namespace Opc.Ua.Client
             while (supertype != null)
             {
                 ExpandedNodeId currentId;
+
+                m_cacheLock.EnterReadLock();
                 try
                 {
-                    m_cacheLock.EnterReadLock();
-
                     currentId = supertype.References.FindTarget(ReferenceTypeIds.HasSubtype, true, true, m_typeTree, 0);
                 }
                 finally
@@ -526,10 +521,9 @@ namespace Opc.Ua.Client
         /// <inheritdoc/>
         public QualifiedName FindReferenceTypeName(NodeId referenceTypeId)
         {
+            m_cacheLock.EnterReadLock();
             try
             {
-                m_cacheLock.EnterReadLock();
-
                 return m_typeTree.FindReferenceTypeName(referenceTypeId);
             }
             finally
@@ -541,10 +535,9 @@ namespace Opc.Ua.Client
         /// <inheritdoc/>
         public NodeId FindReferenceType(QualifiedName browseName)
         {
+            m_cacheLock.EnterReadLock();
             try
             {
-                m_cacheLock.EnterReadLock();
-
                 return m_typeTree.FindReferenceType(browseName);
             }
             finally
@@ -564,10 +557,10 @@ namespace Opc.Ua.Client
             }
 
             IList<IReference> references;
+
+            m_cacheLock.EnterReadLock();
             try
             {
-                m_cacheLock.EnterReadLock();
-
                 references = encoding.References.Find(ReferenceTypeIds.HasEncoding, true, true, m_typeTree);
             }
             finally
@@ -611,10 +604,10 @@ namespace Opc.Ua.Client
             }
 
             IList<IReference> references;
+
+            m_cacheLock.EnterReadLock();
             try
             {
-                m_cacheLock.EnterReadLock();
-
                 references = encoding.References.Find(ReferenceTypeIds.HasEncoding, true, true, m_typeTree);
             }
             finally
@@ -706,10 +699,10 @@ namespace Opc.Ua.Client
             }
 
             IList<IReference> references;
+
+            m_cacheLock.EnterReadLock();
             try
             {
-                m_cacheLock.EnterReadLock();
-
                 references = encoding.References.Find(ReferenceTypeIds.HasEncoding, true, true, m_typeTree);
             }
             finally
@@ -736,10 +729,10 @@ namespace Opc.Ua.Client
             }
 
             IList<IReference> references;
+
+            m_cacheLock.EnterReadLock();
             try
             {
-                m_cacheLock.EnterReadLock();
-
                 references = encoding.References.Find(ReferenceTypeIds.HasEncoding, true, true, m_typeTree);
             }
             finally
@@ -769,10 +762,9 @@ namespace Opc.Ua.Client
             var assembly = typeof(ArgumentCollection).GetTypeInfo().Assembly;
             predefinedNodes.LoadFromBinaryResource(context, "Opc.Ua.Stack.Generated.Opc.Ua.PredefinedNodes.uanodes", assembly, true);
 
+            m_cacheLock.EnterWriteLock();
             try
             {
-                m_cacheLock.EnterWriteLock();
-
                 for (int ii = 0; ii < predefinedNodes.Count; ii++)
                 {
                     BaseTypeState type = predefinedNodes[ii] as BaseTypeState;
@@ -795,11 +787,10 @@ namespace Opc.Ua.Client
         /// <inheritdoc/>
         public void Clear()
         {
-            m_uaTypesLoaded = false;
+            m_cacheLock.EnterWriteLock();
             try
             {
-                m_cacheLock.EnterWriteLock();
-
+                m_uaTypesLoaded = false;
                 m_nodes.Clear();
             }
             finally
@@ -826,10 +817,9 @@ namespace Opc.Ua.Client
                 // fetch references from server.
                 ReferenceDescriptionCollection references = m_session.FetchReferences(localId);
 
+                m_cacheLock.EnterUpgradeableReadLock();
                 try
                 {
-                    m_cacheLock.EnterUpgradeableReadLock();
-
                     foreach (ReferenceDescription reference in references)
                     {
                         // create a placeholder for the node if it does not already exist.
@@ -896,10 +886,9 @@ namespace Opc.Ua.Client
 
                     foreach (ReferenceDescription reference in references)
                     {
+                        m_cacheLock.EnterUpgradeableReadLock();
                         try
                         {
-                            m_cacheLock.EnterUpgradeableReadLock();
-
                             // create a placeholder for the node if it does not already exist.
                             if (!m_nodes.Exists(reference.NodeId))
                             {
@@ -976,10 +965,10 @@ namespace Opc.Ua.Client
             }
 
             IList<IReference> references;
+
+            m_cacheLock.EnterReadLock();
             try
             {
-                m_cacheLock.EnterReadLock();
-
                 references = source.ReferenceTable.Find(referenceTypeId, isInverse, includeSubtypes, m_typeTree);
             }
             finally
@@ -1026,10 +1015,10 @@ namespace Opc.Ua.Client
                 foreach (var referenceTypeId in referenceTypeIds)
                 {
                     IList<IReference> references;
+
+                    m_cacheLock.EnterReadLock();
                     try
                     {
-                        m_cacheLock.EnterReadLock();
-
                         references = node.ReferenceTable.Find(referenceTypeId, isInverse, includeSubtypes, m_typeTree);
                     }
                     finally
@@ -1077,10 +1066,10 @@ namespace Opc.Ua.Client
             NodeId modellingRule = target.ModellingRule;
 
             IList<IReference> references;
+
+            m_cacheLock.EnterReadLock();
             try
             {
-                m_cacheLock.EnterReadLock();
-
                 references = target.ReferenceTable.Find(ReferenceTypeIds.Aggregates, true, true, m_typeTree);
             }
             finally
@@ -1167,10 +1156,9 @@ namespace Opc.Ua.Client
         #region Private Methods
         private void InternalWriteLockedAttach(ILocalNode node)
         {
+            m_cacheLock.EnterWriteLock();
             try
             {
-                m_cacheLock.EnterWriteLock();
-
                 // add to cache.
                 m_nodes.Attach(node);
             }

--- a/Libraries/Opc.Ua.Client/NodeCache/NodeCacheAsync.cs
+++ b/Libraries/Opc.Ua.Client/NodeCache/NodeCacheAsync.cs
@@ -52,11 +52,10 @@ namespace Opc.Ua.Client
                 return null;
             }
 
+            m_cacheLock.EnterReadLock();
             INode node;
             try
             {
-                m_cacheLock.EnterReadLock();
-
                 // check if node already exists.
                 node = m_nodes.Find(nodeId);
             }
@@ -104,10 +103,10 @@ namespace Opc.Ua.Client
             for (ii = 0; ii < count; ii++)
             {
                 INode node;
+
+                m_cacheLock.EnterReadLock();
                 try
                 {
-                    m_cacheLock.EnterReadLock();
-
                     // check if node already exists.
                     node = m_nodes.Find(nodeIds[ii]);
                 }
@@ -179,10 +178,9 @@ namespace Opc.Ua.Client
                 return null;
             }
 
+            m_cacheLock.EnterReadLock();
             try
             {
-                m_cacheLock.EnterReadLock();
-
                 return m_typeTree.FindSuperType(typeId);
             }
             finally
@@ -201,10 +199,9 @@ namespace Opc.Ua.Client
                 return null;
             }
 
+            m_cacheLock.EnterReadLock();
             try
             {
-                m_cacheLock.EnterReadLock();
-
                 return m_typeTree.FindSuperType(typeId);
             }
             finally
@@ -233,10 +230,9 @@ namespace Opc.Ua.Client
                 // fetch references from server.
                 ReferenceDescriptionCollection references = await m_session.FetchReferencesAsync(localId, ct).ConfigureAwait(false);
 
+                m_cacheLock.EnterUpgradeableReadLock();
                 try
                 {
-                    m_cacheLock.EnterUpgradeableReadLock();
-
                     foreach (ReferenceDescription reference in references)
                     {
                         // create a placeholder for the node if it does not already exist.
@@ -304,10 +300,9 @@ namespace Opc.Ua.Client
 
                     foreach (ReferenceDescription reference in references)
                     {
+                        m_cacheLock.EnterUpgradeableReadLock();
                         try
                         {
-                            m_cacheLock.EnterUpgradeableReadLock();
-
                             // create a placeholder for the node if it does not already exist.
                             if (!m_nodes.Exists(reference.NodeId))
                             {
@@ -356,10 +351,10 @@ namespace Opc.Ua.Client
             }
 
             IList<IReference> references;
+
+            m_cacheLock.EnterReadLock();
             try
             {
-                m_cacheLock.EnterReadLock();
-
                 references = source.ReferenceTable.Find(referenceTypeId, isInverse, includeSubtypes, m_typeTree);
             }
             finally
@@ -407,10 +402,10 @@ namespace Opc.Ua.Client
                 foreach (var referenceTypeId in referenceTypeIds)
                 {
                     IList<IReference> references;
+
+                    m_cacheLock.EnterReadLock();
                     try
                     {
-                        m_cacheLock.EnterReadLock();
-
                         references = node.ReferenceTable.Find(referenceTypeId, isInverse, includeSubtypes, m_typeTree);
                     }
                     finally

--- a/Libraries/Opc.Ua.Server/NodeManager/MasterNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/NodeManager/MasterNodeManager.cs
@@ -421,10 +421,9 @@ namespace Opc.Ua.Server
             // allocate a new table (using arrays instead of collections because lookup efficiency is critical).
             INodeManager[][] namespaceManagers = new INodeManager[m_server.NamespaceUris.Count][];
 
+            m_readWriterLockSlim.EnterWriteLock();
             try
             {
-                m_readWriterLockSlim.EnterWriteLock();
-
                 // copy existing values.
                 for (int ii = 0; ii < m_namespaceManagers.Length; ii++)
                 {
@@ -490,10 +489,9 @@ namespace Opc.Ua.Server
             // allocate a new table (using arrays instead of collections because lookup efficiency is critical).
             INodeManager[][] namespaceManagers = new INodeManager[m_server.NamespaceUris.Count][];
 
+            m_readWriterLockSlim.EnterWriteLock();
             try
             {
-                m_readWriterLockSlim.EnterWriteLock();
-
                 // copy existing values.
                 for (int ii = 0; ii < m_namespaceManagers.Length; ii++)
                 {
@@ -559,10 +557,9 @@ namespace Opc.Ua.Server
             // use the namespace index to select the node manager.
             int index = nodeId.NamespaceIndex;
 
+            m_readWriterLockSlim.EnterReadLock();
             try
             {
-                m_readWriterLockSlim.EnterReadLock();
-           
                 // check if node managers are registered - use the core node manager if unknown.
                 if (index >= m_namespaceManagers.Length || m_namespaceManagers[index] == null)
                 {

--- a/Libraries/Opc.Ua.Server/Server/ServerInternalData.cs
+++ b/Libraries/Opc.Ua.Server/Server/ServerInternalData.cs
@@ -743,6 +743,13 @@ namespace Opc.Ua.Server
                 DateTime now = DateTime.UtcNow;
                 m_serverStatus.Timestamp = now;
                 m_serverStatus.Value.CurrentTime = now;
+                // update other timestamps in NodeState objects which are used to derive the source timestamp
+                if (variable is ServerStatusValue serverStatusValue &&
+                    serverStatusValue.Variable is ServerStatusState serverStatusState)
+                {
+                    serverStatusState.Timestamp = now;
+                    serverStatusState.CurrentTime.Timestamp = now;
+                }
             }
         }
 

--- a/Stack/Opc.Ua.Core/Types/Encoders/EncodeableFactory.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/EncodeableFactory.cs
@@ -339,9 +339,9 @@ namespace Opc.Ua
         /// <param name="systemType">The underlying system type to add to the factory</param>
         public void AddEncodeableType(Type systemType)
         {
+            m_readerWriterLockSlim.EnterWriteLock();
             try
             {
-                m_readerWriterLockSlim.EnterWriteLock();
                 AddEncodeableType(systemType, null);
             }
             finally
@@ -365,9 +365,9 @@ namespace Opc.Ua
                     Utils.LogWarning("WARNING: Adding type '{0}' to shared Factory #{1}.", systemType.Name, m_instanceId);
                 }
 #endif
+                m_readerWriterLockSlim.EnterWriteLock();
                 try
                 {
-                    m_readerWriterLockSlim.EnterWriteLock();
                     m_encodeableTypes[encodingId] = systemType;
                 }
                 finally
@@ -402,10 +402,9 @@ namespace Opc.Ua
                 }
 #endif
 
+                m_readerWriterLockSlim.EnterWriteLock();
                 try
                 {
-                    m_readerWriterLockSlim.EnterWriteLock();
-
                     Type[] systemTypes = assembly.GetExportedTypes();
                     var unboundTypeIds = new Dictionary<string, ExpandedNodeId>();
 
@@ -470,9 +469,9 @@ namespace Opc.Ua
         /// <param name="systemTypes">The underlying system types to add to the factory</param>
         public void AddEncodeableTypes(IEnumerable<Type> systemTypes)
         {
+            m_readerWriterLockSlim.EnterWriteLock();
             try
             {
-                m_readerWriterLockSlim.EnterWriteLock();
                 foreach (var type in systemTypes)
                 {
                     if (type.GetTypeInfo().IsAbstract)
@@ -498,10 +497,9 @@ namespace Opc.Ua
         /// <param name="typeId">The type id to return the system-type of</param>
         public Type GetSystemType(ExpandedNodeId typeId)
         {
+            m_readerWriterLockSlim.EnterReadLock();
             try
             {
-                m_readerWriterLockSlim.EnterReadLock();
-
                 Type systemType = null;
 
                 if (NodeId.IsNull(typeId) || !m_encodeableTypes.TryGetValue(typeId, out systemType))
@@ -535,9 +533,9 @@ namespace Opc.Ua
         {
             EncodeableFactory clone = new EncodeableFactory(null);
 
+            m_readerWriterLockSlim.EnterReadLock();
             try
             {
-                m_readerWriterLockSlim.EnterReadLock();
                 foreach (KeyValuePair<ExpandedNodeId, Type> current in m_encodeableTypes)
                 {
                     clone.m_encodeableTypes.Add(current.Key, current.Value);


### PR DESCRIPTION
## Proposed changes

- Fix server time source timestamp is not updated. 
There are duplicate objects in generated code, on of which which holds the last timestamp was not updated. 

- Move all readerwriter locks outside of try/finally to avoid a SynchronizationLockException when a reader writer lock is disposed or is cancelled.

Currently there is no obvious fundamental bug in how the readerwriter locks are used, but outside the try/finally clause e.g. a disposed lock may not trigger a false exception.

## Related Issues

- Fixes #2888 
- Fixes #2886 

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
