### PR TITLE
Add DisableHiResClock to ApplicationConfigurationBuilder

### DIFF
--- a/Libraries/Opc.Ua.Configuration/ApplicationConfigurationBuilder.cs
+++ b/Libraries/Opc.Ua.Configuration/ApplicationConfigurationBuilder.cs
@@ -66,6 +66,12 @@ namespace Opc.Ua.Configuration
 
         #region Public Methods
         /// <inheritdoc/>
+        public IApplicationConfigurationBuilder SetHiResClockDisabled(bool disableHiResClock)
+        {
+            ApplicationConfiguration.DisableHiResClock = disableHiResClock;
+            return this;
+        }
+        /// <inheritdoc/>
         public IApplicationConfigurationBuilderClientSelected AsClient()
         {
             switch (ApplicationInstance.ApplicationType)

--- a/Libraries/Opc.Ua.Configuration/IApplicationConfigurationBuilder.cs
+++ b/Libraries/Opc.Ua.Configuration/IApplicationConfigurationBuilder.cs
@@ -49,6 +49,11 @@ namespace Opc.Ua.Configuration
         IApplicationConfigurationBuilderServerPolicies,
         IApplicationConfigurationBuilderCreate
     {
+        /// <summary>
+        /// Set the high resolution clock to disabled or enabled
+        /// </summary>
+        /// <param name="hiResClockDisabled"><value><c>true</c> if high resolution clock is disabled; otherwise, <c>false</c>.</value></param>
+        IApplicationConfigurationBuilder SetHiResClockDisabled(bool hiResClockDisabled);
     };
 
     /// <summary>


### PR DESCRIPTION
## Proposed changes

Add the method SetHiResClockDisabled to IApplicationConfigurationBuilder

## Related Issues

- Fixes #2892

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

