### PR TITLE
[Server] [Performance] Improve handling of MonitoredNodes & NodeCache & RootNotifier

### DIFF
--- a/Applications/Quickstarts.Servers/ReferenceServer/ReferenceNodeManager.cs
+++ b/Applications/Quickstarts.Servers/ReferenceServer/ReferenceNodeManager.cs
@@ -2726,29 +2726,27 @@ namespace Quickstarts.ReferenceServer
         /// </summary>
         protected override NodeHandle GetManagerHandle(ServerSystemContext context, NodeId nodeId, IDictionary<NodeId, NodeState> cache)
         {
-            lock (Lock)
+            // quickly exclude nodes that are not in the namespace. 
+            if (!IsNodeIdInNamespace(nodeId))
             {
-                // quickly exclude nodes that are not in the namespace. 
-                if (!IsNodeIdInNamespace(nodeId))
-                {
-                    return null;
-                }
-
-                NodeState node = null;
-
-                if (!PredefinedNodes.TryGetValue(nodeId, out node))
-                {
-                    return null;
-                }
-
-                NodeHandle handle = new NodeHandle();
-
-                handle.NodeId = nodeId;
-                handle.Node = node;
-                handle.Validated = true;
-
-                return handle;
+                return null;
             }
+
+            NodeState node = null;
+
+            if (!PredefinedNodes.TryGetValue(nodeId, out node))
+            {
+                return null;
+            }
+
+            NodeHandle handle = new NodeHandle {
+                NodeId = nodeId,
+                Node = node,
+                Validated = true
+            };
+
+            return handle;
+
         }
 
         /// <summary>

--- a/Applications/Quickstarts.Servers/TestData/TestDataNodeManager.cs
+++ b/Applications/Quickstarts.Servers/TestData/TestDataNodeManager.cs
@@ -187,8 +187,7 @@ namespace TestData
 
                 foreach (NodeState node in PredefinedNodes.Values)
                 {
-                    ConditionState condition = node as ConditionState;
-                    if (condition != null && !Object.ReferenceEquals(condition.Parent, conditionsFolder))
+                    if (node is ConditionState condition && !ReferenceEquals(condition.Parent, conditionsFolder))
                     {
                         condition.AddNotifier(SystemContext, null, true, conditionsFolder);
                         conditionsFolder.AddNotifier(SystemContext, null, false, condition);

--- a/Libraries/Opc.Ua.Gds.Server.Common/ApplicationsNodeManager.cs
+++ b/Libraries/Opc.Ua.Gds.Server.Common/ApplicationsNodeManager.cs
@@ -1464,10 +1464,7 @@ namespace Opc.Ua.Gds.Server
                 {
                     NodeHandle handle = new NodeHandle(nodeId, node);
 
-                    if (cache != null)
-                    {
-                        cache.Add(nodeId, node);
-                    }
+                    cache?.Add(nodeId, node);
 
                     return handle;
                 }

--- a/Libraries/Opc.Ua.Server/Diagnostics/CustomNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/Diagnostics/CustomNodeManager.cs
@@ -3139,31 +3139,31 @@ namespace Opc.Ua.Server
             {
                 notifier.OnReportEvent = OnReportEvent;
 
-                    if (!notifier.ReferenceExists(ReferenceTypeIds.HasNotifier, true, ObjectIds.Server))
-                    {
-                        notifier.AddReference(ReferenceTypeIds.HasNotifier, true, ObjectIds.Server);
-                    }
-                }
-
-                // subscribe to existing events.
-                if (m_server.EventManager != null)
+                if (!notifier.ReferenceExists(ReferenceTypeIds.HasNotifier, true, ObjectIds.Server))
                 {
-                    IList<IEventMonitoredItem> monitoredItems = m_server.EventManager.GetMonitoredItems();
+                    notifier.AddReference(ReferenceTypeIds.HasNotifier, true, ObjectIds.Server);
+                }
+            }
 
-                    for (int ii = 0; ii < monitoredItems.Count; ii++)
+            // subscribe to existing events.
+            if (m_server.EventManager != null)
+            {
+                IList<IEventMonitoredItem> monitoredItems = m_server.EventManager.GetMonitoredItems();
+
+                for (int ii = 0; ii < monitoredItems.Count; ii++)
+                {
+                    if (monitoredItems[ii].MonitoringAllEvents)
                     {
-                        if (monitoredItems[ii].MonitoringAllEvents)
-                        {
-                            SubscribeToEvents(
-                            SystemContext,
-                            notifier,
-                            monitoredItems[ii],
-                            true);
-                        }
+                        SubscribeToEvents(
+                        SystemContext,
+                        notifier,
+                        monitoredItems[ii],
+                        true);
                     }
                 }
             }
         }
+
 
         /// <summary>
         /// Removes a root notifier previously added with AddRootNotifier.

--- a/Stack/Opc.Ua.Core/Stack/Tcp/UaSCBinaryClientChannel.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/UaSCBinaryClientChannel.cs
@@ -13,6 +13,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;

--- a/Stack/Opc.Ua.Core/Stack/Tcp/UaSCBinaryClientChannel.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/UaSCBinaryClientChannel.cs
@@ -13,7 +13,6 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Globalization;
 using System.IO;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;

--- a/Tests/Opc.Ua.Server.Tests/CustomNodeManagerTests.cs
+++ b/Tests/Opc.Ua.Server.Tests/CustomNodeManagerTests.cs
@@ -1,14 +1,17 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Moq;
 using NUnit.Framework;
 
 namespace Opc.Ua.Server.Tests
 {
     /// <summary>
-    /// Test <see cref="CustomNodeManager2"/>
-    /// </summary>
+  /// Test <see cref="CustomNodeManager2"/>
+  /// </summary>
     [TestFixture, Category("CustomNodeManager")]
     [SetCulture("en-us"), SetUICulture("en-us")]
     [Parallelizable]

--- a/Tests/Opc.Ua.Server.Tests/CustomNodeManagerTests.cs
+++ b/Tests/Opc.Ua.Server.Tests/CustomNodeManagerTests.cs
@@ -1,17 +1,14 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Moq;
 using NUnit.Framework;
 
 namespace Opc.Ua.Server.Tests
 {
     /// <summary>
-  /// Test <see cref="CustomNodeManager2"/>
-  /// </summary>
+    /// Test <see cref="CustomNodeManager2"/>
+    /// </summary>
     [TestFixture, Category("CustomNodeManager")]
     [SetCulture("en-us"), SetUICulture("en-us")]
     [Parallelizable]
@@ -172,7 +169,8 @@ namespace Opc.Ua.Server.Tests
             Exception error = null;
             int tasksCompletedCount = 0;
             var result = Parallel.For(0, iterations, new ParallelOptions(),
-                          async index => {
+                          async index =>
+                          {
                               try
                               {
                                   await task();


### PR DESCRIPTION
## Proposed changes

- make m_componentCache a NodeIdDictionary
- make m_rootNotifiers a NodeIdDictionary
- make (m_)MonitoredNodes a NodeIdDictionary (faster compare + ConcurrentDictionary)
- make underlying List of MIs in MonitoredNode a ConcurrentDictionary instead of Lists, as the implementation before was not efficient


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments
ToDo
Concurrent tests for RootNotifier & MonitoredNode

Optimized Methods:
AlarmNodeManager Call
CustomNodeManger:
DeleteNode (remove lock, only lock modifying m_rootNotifiers)
AddPredefinedNode
AddRootNotifier, RemoveRootNotifier (make Lock Free)
LookupNodeInComponentCache, RemoveNodeFromComponentCache, AddNodeToComponentCache (Make these methods work Lock Free by making m_componentCache a NodeIDictionary)
SubscribeToEvents (Add missing locks in callers)
