### PR TITLE
[ECC] Implicitly set CertificateType of Certificate Identifier & allow Revocation with ECC Issuer Certificate & fix VerifyECDsaKeyPair 

### DIFF
--- a/Libraries/Opc.Ua.Security.Certificates/X509Certificate/X509PfxUtils.cs
+++ b/Libraries/Opc.Ua.Security.Certificates/X509Certificate/X509PfxUtils.cs
@@ -257,8 +257,8 @@ namespace Opc.Ua.Security.Certificates
             bool throwOnError = false)
         {
             bool result = false;
-            using (ECDsa ecdsaPublicKey = certWithPrivateKey.GetECDsaPublicKey())
-            using (ECDsa ecdsaPrivateKey = certWithPublicKey.GetECDsaPrivateKey())
+            using (ECDsa ecdsaPublicKey = certWithPublicKey.GetECDsaPublicKey())
+            using (ECDsa ecdsaPrivateKey = certWithPrivateKey.GetECDsaPrivateKey())
             {
                 try
                 {

--- a/Stack/Opc.Ua.Core/Schema/ApplicationConfiguration.cs
+++ b/Stack/Opc.Ua.Core/Schema/ApplicationConfiguration.cs
@@ -3067,7 +3067,7 @@ namespace Opc.Ua
         public CertificateIdentifier(X509Certificate2 certificate)
         {
             Initialize();
-            m_certificate = certificate;
+            Certificate = certificate;
         }
 
         /// <summary>
@@ -3076,7 +3076,7 @@ namespace Opc.Ua
         public CertificateIdentifier(X509Certificate2 certificate, CertificateValidationOptions validationOptions)
         {
             Initialize();
-            m_certificate = certificate;
+            Certificate = certificate;
             m_validationOptions = validationOptions;
         }
 
@@ -3087,7 +3087,7 @@ namespace Opc.Ua
         public CertificateIdentifier(byte[] rawData)
         {
             Initialize();
-            m_certificate = CertificateFactory.Create(rawData, true);
+            Certificate = CertificateFactory.Create(rawData, true);
         }
 
         /// <summary>

--- a/Stack/Opc.Ua.Core/Schema/ApplicationConfiguration.cs
+++ b/Stack/Opc.Ua.Core/Schema/ApplicationConfiguration.cs
@@ -3324,6 +3324,7 @@ namespace Opc.Ua
                 m_certificate = CertificateFactory.Create(value, true);
                 m_subjectName = m_certificate.Subject;
                 m_thumbprint = m_certificate.Thumbprint;
+                m_certificateType = GetCertificateType(m_certificate);
             }
         }
 

--- a/Stack/Opc.Ua.Core/Security/Certificates/CertificateFactory.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/CertificateFactory.cs
@@ -292,7 +292,19 @@ namespace Opc.Ua
                 .SetNextUpdate(nextUpdate)
                 .AddCRLExtension(X509Extensions.BuildAuthorityKeyIdentifier(issuerCertificate))
                 .AddCRLExtension(X509Extensions.BuildCRLNumber(crlSerialNumber + 1));
-            return new X509CRL(crlBuilder.CreateForRSA(issuerCertificate));
+
+            if (X509PfxUtils.IsECDsaSignature(issuerCertificate))
+            {
+#if ECC_SUPPORT
+                return new X509CRL(crlBuilder.CreateForECDsa(issuerCertificate));
+#else
+                throw new NotSupportedException("CRL can only be created for an RSA Certificate on this system");
+#endif
+            }
+            else
+            {
+                return new X509CRL(crlBuilder.CreateForRSA(issuerCertificate));
+            }
         }
 
 #if NETSTANDARD2_1 || NET472_OR_GREATER || NET5_0_OR_GREATER

--- a/Stack/Opc.Ua.Core/Security/Certificates/CertificateIdentifier.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/CertificateIdentifier.cs
@@ -145,7 +145,14 @@ namespace Opc.Ua
         public X509Certificate2 Certificate
         {
             get { return m_certificate; }
-            set { m_certificate = value; }
+            set
+            {
+                m_certificate = value;
+                if (m_certificate != null)
+                {
+                    m_certificateType = GetCertificateType(m_certificate);
+                }
+            }
         }
         #endregion
 

--- a/Tests/Opc.Ua.Security.Certificates.Tests/CRLTests.cs
+++ b/Tests/Opc.Ua.Security.Certificates.Tests/CRLTests.cs
@@ -30,6 +30,7 @@
 
 using System;
 using System.Globalization;
+using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
@@ -44,6 +45,7 @@ namespace Opc.Ua.Security.Certificates.Tests
     /// </summary>
     [TestFixture, Category("CRL")]
     [Parallelizable]
+    [TestFixtureSource(nameof(FixtureArgs))]
     [SetCulture("en-us")]
     public class CRLTests
     {
@@ -58,6 +60,24 @@ namespace Opc.Ua.Security.Certificates.Tests
             { 4096, HashAlgorithmName.SHA512 } }.ToArray();
         #endregion
 
+        /// <summary>
+        /// store types to run the tests with
+        /// </summary>
+        public static readonly object[] FixtureArgs = {
+            new object [] { nameof(Opc.Ua.ObjectTypeIds.RsaSha256ApplicationCertificateType)},
+            new object [] { nameof(Opc.Ua.ObjectTypeIds.EccNistP256ApplicationCertificateType)}
+        };
+
+        public CRLTests(string certificateType)
+        {
+            if (certificateType == CertificateStoreType.X509Store && !RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                Assert.Ignore("X509 Store with crls is only supported on Windows, skipping test run");
+            }
+            m_certifiateType = certificateType;
+        }
+
+
         #region Test Setup
         /// <summary>
         /// Set up a Global Discovery Server and Client instance and connect the session
@@ -65,9 +85,23 @@ namespace Opc.Ua.Security.Certificates.Tests
         [OneTimeSetUp]
         protected void OneTimeSetUp()
         {
-            m_issuerCert = CertificateBuilder.Create("CN=Root CA, O=OPC Foundation")
-                .SetCAConstraint()
-                .CreateForRSA();
+            if (m_certifiateType == nameof(Opc.Ua.ObjectTypeIds.RsaSha256ApplicationCertificateType))
+            {
+                m_issuerCert = CertificateBuilder.Create("CN=Root CA, O=OPC Foundation")
+                    .SetCAConstraint()
+                    .CreateForRSA();
+            }
+            else if (m_certifiateType == nameof(Opc.Ua.ObjectTypeIds.EccNistP256ApplicationCertificateType))
+            {
+                m_issuerCert = CertificateBuilder.Create("CN=Root CA, O=OPC Foundation")
+                    .SetCAConstraint()
+                    .SetECCurve(ECCurve.NamedCurves.nistP256)
+                    .CreateForECDsa();
+            }
+            else
+            {
+                throw new NotImplementedException();
+            }
         }
 
         /// <summary>
@@ -144,8 +178,16 @@ namespace Opc.Ua.Security.Certificates.Tests
                 crlBuilder.CrlExtensions.Add(X509Extensions.BuildCRLNumber(1111));
                 crlBuilder.CrlExtensions.Add(X509Extensions.BuildAuthorityKeyIdentifier(m_issuerCert));
             }
+            IX509CRL i509Crl;
+            if (X509PfxUtils.IsECDsaSignature(m_issuerCert))
+            {
 
-            var i509Crl = crlBuilder.CreateForRSA(m_issuerCert);
+                i509Crl = crlBuilder.CreateForECDsa(m_issuerCert);
+            }
+            else
+            {
+                i509Crl = crlBuilder.CreateForRSA(m_issuerCert);
+            }
             X509CRL x509Crl = new X509CRL(i509Crl.RawData);
             Assert.NotNull(x509Crl);
             Assert.NotNull(x509Crl.CrlExtensions);
@@ -203,10 +245,21 @@ namespace Opc.Ua.Security.Certificates.Tests
             crlBuilder.CrlExtensions.Add(X509Extensions.BuildAuthorityKeyIdentifier(m_issuerCert));
 
             IX509CRL ix509Crl;
-            using (RSA rsa = m_issuerCert.GetRSAPrivateKey())
+            if (X509PfxUtils.IsECDsaSignature(m_issuerCert))
             {
-                X509SignatureGenerator generator = X509SignatureGenerator.CreateForRSA(rsa, RSASignaturePadding.Pkcs1);
-                ix509Crl = crlBuilder.CreateSignature(generator);
+                using (ECDsa ecdsa = m_issuerCert.GetECDsaPrivateKey())
+                {
+                    X509SignatureGenerator generator = X509SignatureGenerator.CreateForECDsa(ecdsa);
+                    ix509Crl = crlBuilder.CreateSignature(generator);
+                }
+            }
+            else
+            {
+                using (RSA rsa = m_issuerCert.GetRSAPrivateKey())
+                {
+                    X509SignatureGenerator generator = X509SignatureGenerator.CreateForRSA(rsa, RSASignaturePadding.Pkcs1);
+                    ix509Crl = crlBuilder.CreateSignature(generator);
+                }
             }
             X509CRL x509Crl = new X509CRL(ix509Crl);
             Assert.NotNull(x509Crl);
@@ -322,6 +375,7 @@ namespace Opc.Ua.Security.Certificates.Tests
 
         #region Private Fields
         X509Certificate2 m_issuerCert;
+        private string m_certifiateType;
         #endregion
     }
 


### PR DESCRIPTION
## Proposed changes

- implicitly set certificate type of certificate identifier to allow existing implementations to work with ECC Certs. Before this patch the private key could not be received as the certificate type was null if not explicitly set.
- extend CertificateFactory RevokeCertificate function to allow Revocation with ECC Issuer Certificate.
- fix X509 PFXUtils VerifyECDsaKeyPair for cases comparing certificate with only public key

## Related Issues

- Fixes #

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments
