### PR TITLE
Some cleanup of the new APIs and Union implementation.

### DIFF
--- a/Libraries/Opc.Ua.Client.ComplexTypes/Types/OptionalFieldsComplexType.cs
+++ b/Libraries/Opc.Ua.Client.ComplexTypes/Types/OptionalFieldsComplexType.cs
@@ -93,10 +93,7 @@ namespace Opc.Ua.Client.ComplexTypes
         {
             encoder.PushNamespace(XmlNamespace);
 
-            if (encoder.UseReversibleEncoding)
-            {
-                encoder.WriteUInt32("EncodingMask", m_encodingMask);
-            }
+            encoder.WriteEncodingMask(m_encodingMask);
 
             foreach (var property in GetPropertyEnumerator())
             {
@@ -118,7 +115,7 @@ namespace Opc.Ua.Client.ComplexTypes
         {
             decoder.PushNamespace(XmlNamespace);
 
-            m_encodingMask = decoder.ReadUInt32("EncodingMask");
+            m_encodingMask = decoder.ReadEncodingMask(null);
 
             foreach (var property in GetPropertyEnumerator())
             {

--- a/Libraries/Opc.Ua.Client.ComplexTypes/Types/OptionalFieldsComplexType.cs
+++ b/Libraries/Opc.Ua.Client.ComplexTypes/Types/OptionalFieldsComplexType.cs
@@ -93,7 +93,7 @@ namespace Opc.Ua.Client.ComplexTypes
         {
             encoder.PushNamespace(XmlNamespace);
 
-            encoder.WriteEncodingMask(m_encodingMask);
+            encoder.WriteEncodingMask("EncodingMask", m_encodingMask);
 
             foreach (var property in GetPropertyEnumerator())
             {

--- a/Libraries/Opc.Ua.Client.ComplexTypes/Types/OptionalFieldsComplexType.cs
+++ b/Libraries/Opc.Ua.Client.ComplexTypes/Types/OptionalFieldsComplexType.cs
@@ -93,7 +93,7 @@ namespace Opc.Ua.Client.ComplexTypes
         {
             encoder.PushNamespace(XmlNamespace);
 
-            encoder.WriteEncodingMask("EncodingMask", m_encodingMask);
+            encoder.WriteEncodingMask(m_encodingMask);
 
             foreach (var property in GetPropertyEnumerator())
             {
@@ -117,6 +117,21 @@ namespace Opc.Ua.Client.ComplexTypes
 
             m_encodingMask = decoder.ReadEncodingMask(null);
 
+            // try again if the mask is implicitly defined by the JSON keys
+            if (m_encodingMask == 0 && decoder is IJsonDecoder)
+            {
+                var masks = new StringCollection();
+                foreach (var property in GetPropertyEnumerator())
+                {
+                    if (property.IsOptional)
+                    {
+                        masks.Add(property.Name);
+                    }
+                }
+
+                m_encodingMask = decoder.ReadEncodingMask(masks);
+            }
+
             foreach (var property in GetPropertyEnumerator())
             {
                 if (property.IsOptional)
@@ -129,6 +144,7 @@ namespace Opc.Ua.Client.ComplexTypes
 
                 DecodeProperty(decoder, property);
             }
+
             decoder.PopNamespace();
         }
 

--- a/Libraries/Opc.Ua.Client.ComplexTypes/Types/UnionComplexType.cs
+++ b/Libraries/Opc.Ua.Client.ComplexTypes/Types/UnionComplexType.cs
@@ -96,9 +96,10 @@ namespace Opc.Ua.Client.ComplexTypes
 
             string fieldName = null;
 
+            encoder.WriteSwitchField(m_switchField);
+
             if (encoder.UseReversibleEncoding)
             {
-                encoder.WriteUInt32("SwitchField", m_switchField);
                 fieldName = "Value";
             }
 
@@ -139,7 +140,7 @@ namespace Opc.Ua.Client.ComplexTypes
             string fieldName = "Value";
             UInt32 unionSelector = 0;
 
-            if (decoder is JsonDecoder jd)
+            if (decoder is IJsonDecoder jd)
             {
                 object token = null;
                 m_switchField = 0;

--- a/Libraries/Opc.Ua.Client.ComplexTypes/Types/UnionComplexType.cs
+++ b/Libraries/Opc.Ua.Client.ComplexTypes/Types/UnionComplexType.cs
@@ -96,7 +96,7 @@ namespace Opc.Ua.Client.ComplexTypes
 
             string fieldName = null;
 
-            encoder.WriteSwitchField(m_switchField);
+            encoder.WriteSwitchField("SwitchField", m_switchField);
 
             if (encoder.UseReversibleEncoding)
             {

--- a/Libraries/Opc.Ua.Client/Opc.Ua.Client.csproj
+++ b/Libraries/Opc.Ua.Client/Opc.Ua.Client.csproj
@@ -21,10 +21,6 @@
     <PackageId>$(PackageId).Debug</PackageId>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'net6.0' AND '$(TargetFramework)' != 'net7.0' AND '$(TargetFramework)' != 'net8.0'">
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.1" />
-  </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\Stack\Opc.Ua.Core\Opc.Ua.Core.csproj" />
     <ProjectReference Include="..\Opc.Ua.Configuration\Opc.Ua.Configuration.csproj" />

--- a/Libraries/Opc.Ua.Configuration/ApplicationConfigurationBuilder.cs
+++ b/Libraries/Opc.Ua.Configuration/ApplicationConfigurationBuilder.cs
@@ -66,6 +66,12 @@ namespace Opc.Ua.Configuration
 
         #region Public Methods
         /// <inheritdoc/>
+        public IApplicationConfigurationBuilderGlobalConfiguration SetHiResClockDisabled(bool disableHiResClock)
+        {
+            ApplicationConfiguration.DisableHiResClock = disableHiResClock;
+            return this;
+        }
+        /// <inheritdoc/>
         public IApplicationConfigurationBuilderClientSelected AsClient()
         {
             switch (ApplicationInstance.ApplicationType)
@@ -137,7 +143,7 @@ namespace Opc.Ua.Configuration
                     StorePath = DefaultCertificateStorePath(TrustlistType.IssuerUser, pkiRoot)
                 },
                 // rejected store
-                RejectedCertificateStore = new CertificateTrustList() {
+                RejectedCertificateStore = new CertificateStoreIdentifier() {
                     StoreType = rejectedRootType,
                     StorePath = DefaultCertificateStorePath(TrustlistType.Rejected, rejectedRoot)
                 },
@@ -178,7 +184,7 @@ namespace Opc.Ua.Configuration
                     StorePath = DefaultCertificateStorePath(TrustlistType.Issuer, issuerRoot)
                 },
                 // rejected store
-                RejectedCertificateStore = new CertificateTrustList() {
+                RejectedCertificateStore = new CertificateStoreIdentifier() {
                     StoreType = rejectedRootType,
                     StorePath = DefaultCertificateStorePath(TrustlistType.Rejected, rejectedRoot)
                 },

--- a/Libraries/Opc.Ua.Configuration/IApplicationConfigurationBuilder.cs
+++ b/Libraries/Opc.Ua.Configuration/IApplicationConfigurationBuilder.cs
@@ -450,6 +450,7 @@ namespace Opc.Ua.Configuration
     /// Add security options to the configuration.
     /// </summary>
     public interface IApplicationConfigurationBuilderSecurityOptions :
+        IApplicationConfigurationBuilderGlobalConfiguration,
         IApplicationConfigurationBuilderTraceConfiguration,
         IApplicationConfigurationBuilderExtension,
         IApplicationConfigurationBuilderCreate
@@ -540,6 +541,20 @@ namespace Opc.Ua.Configuration
         /// <param name="elementName">The name of the extension, null to use the name.</param>
         /// <param name="value">The object to add and encode.</param>
         IApplicationConfigurationBuilderExtension AddExtension<T>(XmlQualifiedName elementName, object value);
+    }
+
+    /// <summary>
+    /// Add some global configuration settings.
+    /// </summary>
+    public interface IApplicationConfigurationBuilderGlobalConfiguration :
+        IApplicationConfigurationBuilderCreate,
+        IApplicationConfigurationBuilderTraceConfiguration
+    {
+        /// <summary>
+        /// Set the high resolution clock to disabled or enabled.
+        /// </summary>
+        /// <param name="hiResClockDisabled"><value><c>true</c> if high resolution clock is disabled; otherwise, <c>false</c>.</value></param>
+        IApplicationConfigurationBuilderGlobalConfiguration SetHiResClockDisabled(bool hiResClockDisabled);
     }
 
     /// <summary>

--- a/Libraries/Opc.Ua.PubSub/Encoding/JsonNetworkMessage.cs
+++ b/Libraries/Opc.Ua.PubSub/Encoding/JsonNetworkMessage.cs
@@ -195,7 +195,9 @@ namespace Opc.Ua.PubSub.Encoding
         {
             bool topLevelIsArray = !HasNetworkMessageHeader && !HasSingleDataSetMessage && !IsMetaDataMessage;
 
-            using (IJsonEncoder encoder = new JsonEncoder(messageContext, true, topLevelIsArray, stream))
+            using (IJsonEncoder encoder = new JsonEncoder(messageContext, true, topLevelIsArray, stream) {
+                IncludeDefaultValues = true
+            })
             {
                 if (IsMetaDataMessage)
                 {

--- a/Libraries/Opc.Ua.PubSub/Encoding/JsonNetworkMessage.cs
+++ b/Libraries/Opc.Ua.PubSub/Encoding/JsonNetworkMessage.cs
@@ -195,9 +195,7 @@ namespace Opc.Ua.PubSub.Encoding
         {
             bool topLevelIsArray = !HasNetworkMessageHeader && !HasSingleDataSetMessage && !IsMetaDataMessage;
 
-            using (IJsonEncoder encoder = new JsonEncoder(messageContext, true, topLevelIsArray, stream) {
-                IncludeDefaultValues = true
-            })
+            using (IJsonEncoder encoder = new JsonEncoder(messageContext, true, topLevelIsArray, stream))
             {
                 if (IsMetaDataMessage)
                 {

--- a/Libraries/Opc.Ua.Server/Diagnostics/CustomNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/Diagnostics/CustomNodeManager.cs
@@ -2977,16 +2977,16 @@ namespace Opc.Ua.Server
             List<ServiceResult> argumentErrors = new List<ServiceResult>();
             VariantCollection outputArguments = new VariantCollection();
 
-            ServiceResult error = method.Call(
+            ServiceResult callResult = method.Call(
                 context,
                 methodToCall.ObjectId,
                 methodToCall.InputArguments,
                 argumentErrors,
                 outputArguments);
 
-            if (ServiceResult.IsBad(error))
+            if (ServiceResult.IsBad(callResult))
             {
-                return error;
+                return callResult;
             }
 
             // check for argument errors.
@@ -3041,7 +3041,8 @@ namespace Opc.Ua.Server
             // return output arguments.
             result.OutputArguments = outputArguments;
 
-            return ServiceResult.Good;
+            // return the actual result of the original call
+            return callResult;
         }
 
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ More samples based on the official [Nuget](https://www.nuget.org/packages/OPCFou
 - **Thread Safety and Locking**: Improved thread safety and reduced locking in secure channel operations.
 - **Audit and Redaction**: New interfaces for auditing and redacting sensitive information.
 
-#### **New in 1.05.374 December release**
+#### **New in 1.05.374 January release**
 * Nodeset for Version 1.05.04 
 * Final version of JsonEncoder Compact and Verbose profiles
 

--- a/Stack/Opc.Ua.Core/Opc.Ua.Core.csproj
+++ b/Stack/Opc.Ua.Core/Opc.Ua.Core.csproj
@@ -9,6 +9,7 @@
     <Description>OPC UA Core Class Library</Description>
     <IsPackable>true</IsPackable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
@@ -88,23 +89,31 @@
 
   <Target Name="GetPackagingOutputs" />
 
-  <!-- Produces a zipped version of the Nodeset 2 to reduce assembly size by 2.7MB ! -->
-  <ItemGroup>
-    <EmbeddedResource Include="Schema\Opc.Ua.NodeSet2.xml.zip" />
-  </ItemGroup>
-
+  <!-- Produces a zipped version of the Nodeset 2 to reduce assembly size! -->
   <PropertyGroup>
-    <ZipTmp>$(BaseIntermediateOutputPath)/zipnodeset2</ZipTmp>
-    <ZipNodeSet2XML>Schema/Opc.Ua.NodeSet2.xml</ZipNodeSet2XML>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <ZipTmp>$(BaseIntermediateOutputPath)$(Configuration)/$(TargetFramework)/zipnodeset2</ZipTmp>
+    <NodeSet2XML>Schema/Opc.Ua.NodeSet2.xml</NodeSet2XML>
+    <ZipNodeSet2XML>$(BaseIntermediateOutputPath)$(Configuration)/$(TargetFramework)/Opc.Ua.NodeSet2.xml.zip</ZipNodeSet2XML>
   </PropertyGroup>
 
-  <Target Name="ZipNodeSet2" BeforeTargets="PrepareForBuild" Inputs="$(ZipNodeSet2XML)" Outputs="$(ZipNodeSet2XML).zip">
-    <Message Text="Zip $(ZipNodeSet2XML) in $(ZipTmp)." Importance="high" />
-    <Copy SourceFiles="$(ZipNodeSet2XML)" DestinationFolder="$(ZipTmp)" />
-    <ZipDirectory SourceDirectory="$(ZipTmp)" DestinationFile="$(ZipNodeSet2XML).zip" Overwrite="true" />
+  <!-- Embed the zipped Nodeset2 file -->
+  <ItemGroup>
+    <EmbeddedResource Include="$(ZipNodeSet2XML)" Link="$(NodeSet2XML).zip" />
+  </ItemGroup>
+
+  <!-- Zip the NodeSet2 file -->
+  <Target Name="ZipNodeSet2" BeforeTargets="PrepareForBuild" Inputs="$(NodeSet2XML)" Outputs="$(ZipNodeSet2XML)">
+    <Message Text="Zip $(NodeSet2XML) in $(ZipNodeSet2XML)." Importance="high" />
+    <Copy SourceFiles="$(NodeSet2XML)" DestinationFolder="$(ZipTmp)" />
+    <ZipDirectory SourceDirectory="$(ZipTmp)" DestinationFile="$(ZipNodeSet2XML)" Overwrite="true" />
     <RemoveDir Directories="$(ZipTmp)" />
     <Message Text="Zip NodeSet2 completed, $(ZipTmp) removed." Importance="high" />
   </Target>
-
+  
+  <!-- Clean up the zip file -->
+  <Target Name="RemoveZipNodeset2" AfterTargets="Clean" Condition="Exists('$(ZipNodeSet2XML)')">
+    <Message Text="Delete Zip $(ZipNodeSet2XML)" Importance="high"></Message>
+    <Delete Files="$(ZipNodeSet2XML)"></Delete>
+  </Target>
+  
 </Project>

--- a/Stack/Opc.Ua.Core/Stack/Client/UserIdentity.cs
+++ b/Stack/Opc.Ua.Core/Stack/Client/UserIdentity.cs
@@ -134,7 +134,6 @@ namespace Opc.Ua
         public string DisplayName
         {
             get { return m_displayName; }
-            set { m_displayName = value; }
         }
 
         /// <summary cref="IUserIdentity.TokenType" />

--- a/Stack/Opc.Ua.Core/Stack/State/MethodState.cs
+++ b/Stack/Opc.Ua.Core/Stack/State/MethodState.cs
@@ -706,7 +706,7 @@ namespace Opc.Ua
             }
 
             // copy out arguments.
-            if (ServiceResult.IsGood(result))
+            if (ServiceResult.IsGoodOrUncertain(result))
             {
                 for (int ii = 0; ii < outputs.Count; ii++)
                 {

--- a/Stack/Opc.Ua.Core/Types/Encoders/BinaryDecoder.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/BinaryDecoder.cs
@@ -1516,10 +1516,10 @@ namespace Opc.Ua
         }
 
         /// <inheritdoc/>
-        public uint ReadSwitchField(Type switches) => ReadUInt32("SwitchField");
+        public uint ReadSwitchField(StringCollection switches) => ReadUInt32("SwitchField");
 
         /// <inheritdoc/>
-        public uint ReadEncodingMask(Type masks) => ReadUInt32("EncodingMask");
+        public uint ReadEncodingMask(StringCollection masks) => ReadUInt32("EncodingMask");
         #endregion
 
         #region Private Methods

--- a/Stack/Opc.Ua.Core/Types/Encoders/BinaryEncoder.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/BinaryEncoder.cs
@@ -2004,10 +2004,10 @@ namespace Opc.Ua
         }
 
         /// <inheritdoc/>
-        public void WriteSwitchField(uint switchField) => WriteUInt32("SwitchField", switchField);
+        public void WriteSwitchField(string fieldName, uint switchField) => WriteUInt32(fieldName, switchField);
 
         /// <inheritdoc/>
-        public void WriteEncodingMask(uint encodingMask) => WriteUInt32("EncodingMask", encodingMask);
+        public void WriteEncodingMask(string fieldName, uint encodingMask) => WriteUInt32(fieldName, encodingMask);
         #endregion
 
         #region Private Methods

--- a/Stack/Opc.Ua.Core/Types/Encoders/BinaryEncoder.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/BinaryEncoder.cs
@@ -2004,10 +2004,14 @@ namespace Opc.Ua
         }
 
         /// <inheritdoc/>
-        public void WriteSwitchField(string fieldName, uint switchField) => WriteUInt32(fieldName, switchField);
+        public void WriteSwitchField(uint switchField, out string fieldName)
+        {
+            fieldName = null;
+            WriteUInt32("SwitchField", switchField);
+        }
 
         /// <inheritdoc/>
-        public void WriteEncodingMask(string fieldName, uint encodingMask) => WriteUInt32(fieldName, encodingMask);
+        public void WriteEncodingMask(uint encodingMask) => WriteUInt32("EncodingMask", encodingMask);
         #endregion
 
         #region Private Methods

--- a/Stack/Opc.Ua.Core/Types/Encoders/BinaryEncoder.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/BinaryEncoder.cs
@@ -2004,10 +2004,10 @@ namespace Opc.Ua
         }
 
         /// <inheritdoc/>
-        public void WriteSwitchField(string fieldName, uint switchField) => WriteUInt32(fieldName, switchField);
+        public void WriteSwitchField(uint switchField) => WriteUInt32("SwitchField", switchField);
 
         /// <inheritdoc/>
-        public void WriteEncodingMask(string fieldName, uint encodingMask) => WriteUInt32(fieldName, encodingMask);
+        public void WriteEncodingMask(uint encodingMask) => WriteUInt32("EncodingMask", encodingMask);
         #endregion
 
         #region Private Methods

--- a/Stack/Opc.Ua.Core/Types/Encoders/IDecoder.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/IDecoder.cs
@@ -354,11 +354,13 @@ namespace Opc.Ua
         /// <summary>
         /// Decode the switch field for a union.
         /// </summary>
-        uint ReadSwitchField(Type switches);
+        /// <param name="switches">The list of field names in the order of the union selector.</param>
+        uint ReadSwitchField(StringCollection switches);
 
         /// <summary>
         /// Decode the encoding mask for a structure with optional fields.
         /// </summary>
-        uint ReadEncodingMask(Type masks);
+        /// <param name="masks">The list of field names in the order of the bits in the optional fields mask.</param>
+        uint ReadEncodingMask(StringCollection masks);
     }
 }

--- a/Stack/Opc.Ua.Core/Types/Encoders/IEncoder.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/IEncoder.cs
@@ -165,12 +165,12 @@ namespace Opc.Ua
         void WriteByteString(string fieldName, ReadOnlySpan<byte> value);
 #endif
         /// <summary>
-        /// Writes an XmlElement to the stream.
+        /// Writes a XmlElement to the stream.
         /// </summary>
         void WriteXmlElement(string fieldName, XmlElement value);
 
         /// <summary>
-        /// Writes an NodeId to the stream.
+        /// Writes a NodeId to the stream.
         /// </summary>
         void WriteNodeId(string fieldName, NodeId value);
 
@@ -180,32 +180,32 @@ namespace Opc.Ua
         void WriteExpandedNodeId(string fieldName, ExpandedNodeId value);
 
         /// <summary>
-        /// Writes an StatusCode to the stream.
+        /// Writes a StatusCode to the stream.
         /// </summary>
         void WriteStatusCode(string fieldName, StatusCode value);
 
         /// <summary>
-        /// Writes an DiagnosticInfo to the stream.
+        /// Writes a DiagnosticInfo to the stream.
         /// </summary>
         void WriteDiagnosticInfo(string fieldName, DiagnosticInfo value);
 
         /// <summary>
-        /// Writes an QualifiedName to the stream.
+        /// Writes a QualifiedName to the stream.
         /// </summary>
         void WriteQualifiedName(string fieldName, QualifiedName value);
 
         /// <summary>
-        /// Writes an LocalizedText to the stream.
+        /// Writes a LocalizedText to the stream.
         /// </summary>
         void WriteLocalizedText(string fieldName, LocalizedText value);
 
         /// <summary>
-        /// Writes an Variant array to the stream.
+        /// Writes a Variant array to the stream.
         /// </summary>
         void WriteVariant(string fieldName, Variant value);
 
         /// <summary>
-        /// Writes an DataValue array to the stream.
+        /// Writes a DataValue array to the stream.
         /// </summary>
         void WriteDataValue(string fieldName, DataValue value);
 
@@ -372,12 +372,12 @@ namespace Opc.Ua
         /// <summary>
         /// Encode the switch field for a union.
         /// </summary>
-        void WriteSwitchField(string fieldName, uint switchField);
+        void WriteSwitchField(uint switchField);
 
         /// <summary>
         /// Encode the encoding mask for a structure with optional fields.
         /// </summary>
-        void WriteEncodingMask(string fieldName, uint encodingMask);
+        void WriteEncodingMask(uint encodingMask);
     }
 
     /// <summary>

--- a/Stack/Opc.Ua.Core/Types/Encoders/IEncoder.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/IEncoder.cs
@@ -372,12 +372,14 @@ namespace Opc.Ua
         /// <summary>
         /// Encode the switch field for a union.
         /// </summary>
-        void WriteSwitchField(string fieldName, uint switchField);
+        /// <params name="switchField">The switch field </params>
+        /// <params name="alternateFieldName">Returns an alternate fieldName for the encoded union property if the encoder requires it, null otherwise.</params>
+        void WriteSwitchField(uint switchField, out string alternateFieldName);
 
         /// <summary>
         /// Encode the encoding mask for a structure with optional fields.
         /// </summary>
-        void WriteEncodingMask(string fieldName, uint encodingMask);
+        void WriteEncodingMask(uint encodingMask);
     }
 
     /// <summary>

--- a/Stack/Opc.Ua.Core/Types/Encoders/IEncoder.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/IEncoder.cs
@@ -372,12 +372,12 @@ namespace Opc.Ua
         /// <summary>
         /// Encode the switch field for a union.
         /// </summary>
-        void WriteSwitchField(uint switchField);
+        void WriteSwitchField(string fieldName, uint switchField);
 
         /// <summary>
         /// Encode the encoding mask for a structure with optional fields.
         /// </summary>
-        void WriteEncodingMask(uint encodingMask);
+        void WriteEncodingMask(string fieldName, uint encodingMask);
     }
 
     /// <summary>

--- a/Stack/Opc.Ua.Core/Types/Encoders/JsonDecoder.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/JsonDecoder.cs
@@ -2780,6 +2780,11 @@ namespace Opc.Ua
         /// <inheritdoc/>
         public uint ReadSwitchField(Type switches)
         {
+            if (switches == null)
+            {
+                return ReadUInt32("SwitchField");
+            }
+
             if (m_stack.Peek() is Dictionary<string, object> context)
             {
                 if (context.ContainsKey("SwitchField"))
@@ -2804,6 +2809,11 @@ namespace Opc.Ua
         /// <inheritdoc/>
         public uint ReadEncodingMask(Type masks)
         {
+            if (masks == null)
+            {
+                return ReadUInt32("EncodingMask");
+            }
+
             if (m_stack.Peek() is Dictionary<string, object> context)
             {
                 if (context.ContainsKey("EncodingMask"))

--- a/Stack/Opc.Ua.Core/Types/Encoders/JsonEncoder.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/JsonEncoder.cs
@@ -514,20 +514,36 @@ namespace Opc.Ua
         }
 
         /// <inheritdoc/>
-        public void WriteSwitchField(string fieldName, uint switchField)
+        public void WriteSwitchField(uint switchField, out string fieldName)
         {
-            if ((!SuppressArtifacts && EncodingToUse == JsonEncodingType.Compact) || EncodingToUse == JsonEncodingType.Reversible)
+            fieldName = null;
+
+            switch (EncodingToUse)
             {
-                WriteUInt32(fieldName, switchField);
+                case JsonEncodingType.Compact:
+                    if (SuppressArtifacts)
+                    {
+                        return;
+                    }
+                    break;
+                case JsonEncodingType.Reversible:
+                    fieldName = "Value";
+                    break;
+                case JsonEncodingType.Verbose:
+                case JsonEncodingType.NonReversible:
+                default:
+                    return;
             }
+
+            WriteUInt32("SwitchField", switchField);
         }
 
         /// <inheritdoc/>
-        public void WriteEncodingMask(string fieldName, uint encodingMask)
+        public void WriteEncodingMask(uint encodingMask)
         {
             if ((!SuppressArtifacts && EncodingToUse == JsonEncodingType.Compact) || EncodingToUse == JsonEncodingType.Reversible)
             {
-                WriteUInt32(fieldName, encodingMask);
+                WriteUInt32("EncodingMask", encodingMask);
             }
         }
         #endregion
@@ -537,7 +553,7 @@ namespace Opc.Ua
         public EncodingType EncodingType => EncodingType.Json;
 
         /// <inheritdoc/>
-        public bool UseReversibleEncoding => EncodingToUse != JsonEncodingType.NonReversible && EncodingToUse != JsonEncodingType.Verbose;
+        public bool UseReversibleEncoding => EncodingToUse != JsonEncodingType.NonReversible;
 
         /// <summary>
         /// The message context associated with the encoder.

--- a/Stack/Opc.Ua.Core/Types/Encoders/JsonEncoder.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/JsonEncoder.cs
@@ -514,20 +514,20 @@ namespace Opc.Ua
         }
 
         /// <inheritdoc/>
-        public void WriteSwitchField(uint switchField)
+        public void WriteSwitchField(string fieldName, uint switchField)
         {
             if ((!SuppressArtifacts && EncodingToUse == JsonEncodingType.Compact) || EncodingToUse == JsonEncodingType.Reversible)
             {
-                WriteUInt32("SwitchField", switchField);
+                WriteUInt32(fieldName, switchField);
             }
         }
 
         /// <inheritdoc/>
-        public void WriteEncodingMask(uint encodingMask)
+        public void WriteEncodingMask(string fieldName, uint encodingMask)
         {
             if ((!SuppressArtifacts && EncodingToUse == JsonEncodingType.Compact) || EncodingToUse == JsonEncodingType.Reversible)
             {
-                WriteUInt32("EncodingMask", encodingMask);
+                WriteUInt32(fieldName, encodingMask);
             }
         }
         #endregion

--- a/Stack/Opc.Ua.Core/Types/Encoders/XmlDecoder.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/XmlDecoder.cs
@@ -2644,10 +2644,10 @@ namespace Opc.Ua
         }
 
         /// <inheritdoc/>
-        public uint ReadSwitchField(Type switches) => ReadUInt32("SwitchField");
+        public uint ReadSwitchField(StringCollection switches) => ReadUInt32("SwitchField");
 
         /// <inheritdoc/>
-        public uint ReadEncodingMask(Type masks) => ReadUInt32("EncodingMask");
+        public uint ReadEncodingMask(StringCollection masks) => ReadUInt32("EncodingMask");
         #endregion
 
         #region Private Methods

--- a/Stack/Opc.Ua.Core/Types/Encoders/XmlEncoder.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/XmlEncoder.cs
@@ -534,6 +534,7 @@ namespace Opc.Ua
         /// <summary>
         /// Writes a byte string to the stream.
         /// </summary>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2265:Do not compare Span<T> to 'null' or 'default'", Justification = "Null compare works with ReadOnlySpan<byte>")]
         public void WriteByteString(string fieldName, ReadOnlySpan<byte> value)
         {
             if (BeginField(fieldName, value == null, true, false))
@@ -1779,10 +1780,14 @@ namespace Opc.Ua
         }
 
         /// <inheritdoc/>
-        public void WriteSwitchField(string fieldName, uint switchField) => WriteUInt32(fieldName, switchField);
+        public void WriteSwitchField(uint switchField, out string fieldName)
+        {
+            fieldName = null;
+            WriteUInt32("SwitchField", switchField);
+        }
 
         /// <inheritdoc/>
-        public void WriteEncodingMask(string fieldName, uint encodingMask) => WriteUInt32(fieldName, encodingMask);
+        public void WriteEncodingMask(uint encodingMask) => WriteUInt32("EncodingMask", encodingMask);
         #endregion
 
         #region Public Methods

--- a/Stack/Opc.Ua.Core/Types/Encoders/XmlEncoder.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/XmlEncoder.cs
@@ -1779,10 +1779,10 @@ namespace Opc.Ua
         }
 
         /// <inheritdoc/>
-        public void WriteSwitchField(uint switchField) => WriteUInt32("SwitchField", switchField);
+        public void WriteSwitchField(string fieldName, uint switchField) => WriteUInt32(fieldName, switchField);
 
         /// <inheritdoc/>
-        public void WriteEncodingMask(uint encodingMask) => WriteUInt32("EncodingMask", encodingMask);
+        public void WriteEncodingMask(string fieldName, uint encodingMask) => WriteUInt32(fieldName, encodingMask);
         #endregion
 
         #region Public Methods

--- a/Stack/Opc.Ua.Core/Types/Encoders/XmlEncoder.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/XmlEncoder.cs
@@ -1779,10 +1779,10 @@ namespace Opc.Ua
         }
 
         /// <inheritdoc/>
-        public void WriteSwitchField(string fieldName, uint switchField) => WriteUInt32(fieldName, switchField);
+        public void WriteSwitchField(uint switchField) => WriteUInt32("SwitchField", switchField);
 
         /// <inheritdoc/>
-        public void WriteEncodingMask(string fieldName, uint encodingMask) => WriteUInt32(fieldName, encodingMask);
+        public void WriteEncodingMask(uint encodingMask) => WriteUInt32("EncodingMask", encodingMask);
         #endregion
 
         #region Public Methods

--- a/Stack/Opc.Ua.Core/Types/Utils/ServiceResult.cs
+++ b/Stack/Opc.Ua.Core/Types/Utils/ServiceResult.cs
@@ -525,6 +525,19 @@ namespace Opc.Ua
         }
 
         /// <summary>
+        /// Returns true if the status code is good or uncertain.
+        /// </summary>
+        public static bool IsGoodOrUncertain(ServiceResult status)
+        {
+            if (status != null)
+            {
+                return StatusCode.IsGood(status.m_code) || StatusCode.IsUncertain(status.m_code);
+            }
+
+            return false;
+        }
+
+        /// <summary>
         /// Returns true if the status is good or uncertain.
         /// </summary>
         public static bool IsNotUncertain(ServiceResult status)

--- a/Tests/Opc.Ua.Client.ComplexTypes.Tests/Types/JsonEncoderTests.cs
+++ b/Tests/Opc.Ua.Client.ComplexTypes.Tests/Types/JsonEncoderTests.cs
@@ -215,8 +215,7 @@ namespace Opc.Ua.Client.ComplexTypes.Tests.Types
                     EncodingType.Json, EncoderContext, encoderStream,
                     typeof(ExtensionObject), jsonEncoding, topLevelIsArray))
                 {
-                    var builtInTypeString = (jsonEncoding != JsonEncodingType.NonReversible) ? builtInType.ToString() : null;
-                    Encode(encoder, BuiltInType.ExtensionObject, builtInTypeString, data);
+                    Encode(encoder, BuiltInType.ExtensionObject, builtInType.ToString(), data);
                 }
                 buffer = encoderStream.ToArray();
             }
@@ -226,11 +225,6 @@ namespace Opc.Ua.Client.ComplexTypes.Tests.Types
             try
             {
                 result = Encoding.UTF8.GetString(buffer);
-                if (data.Body is UnionComplexType && (jsonEncoding == JsonEncodingType.NonReversible))
-                {
-                    // helper to create testable JSON output for Unions
-                    result = result.Replace("{", "{\"Union\" :");
-                }
                 formattedResult = PrettifyAndValidateJson(result);
                 var jsonLoadSettings = new JsonLoadSettings() {
                     CommentHandling = CommentHandling.Ignore,
@@ -315,7 +309,7 @@ namespace Opc.Ua.Client.ComplexTypes.Tests.Types
                     }
                     else if (jsonEncoding == JsonEncodingType.NonReversible)
                     {
-                        expected = "{\"Union\" :" + expected + "}";
+                        expected = $"{{\"{builtInType}\" :" + expected + "}";
                     }
                     else
                     {
@@ -350,7 +344,8 @@ namespace Opc.Ua.Client.ComplexTypes.Tests.Types
                 {
                     if (jsonEncoding == JsonEncodingType.NonReversible)
                     {
-                        expected = $"{{\"{builtInType}\" :" + expected + "}";
+                        var json = $"{{\"{builtInType}\" :";
+                        expected = json + $"{{\"{builtInType}\" :" + expected + "}}";
                     }
                     else
                     {
@@ -499,7 +494,8 @@ namespace Opc.Ua.Client.ComplexTypes.Tests.Types
 
                     if (jsonEncoding == JsonEncodingType.NonReversible)
                     {
-                        expected = "{" + body + "}";
+                        var json = $"{{\"{builtInType}\" :{{";
+                        expected = json + body + "}";
                     }
                     else
                     {

--- a/Tests/Opc.Ua.Core.Tests/Types/Encoders/EncoderTests.cs
+++ b/Tests/Opc.Ua.Core.Tests/Types/Encoders/EncoderTests.cs
@@ -55,6 +55,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
         }
 
         public EncodingType EncoderType { get; }
+
         public JsonEncodingType JsonEncodingType { get; }
 
         public string ToString(string format, IFormatProvider formatProvider)
@@ -398,45 +399,76 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
             EncodeDecodeDataValue(encoderType, jsonEncodingType, BuiltInType.Variant, MemoryStreamType.ArraySegmentStream, variant);
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2265:Do not compare Span<T> to 'null' or 'default'", Justification = "Null compare works with ReadOnlySpan<byte>")]
+        private string WriteByteStringData(IEncoder encoder)
+        {
+            encoder.WriteByteString("ByteString1", new byte[] { 0, 1, 2, 3, 4, 5 }, 1, 3);
+            encoder.WriteByteString("ByteString2", null);
+            encoder.WriteByteString("ByteString3", null, 1, 2);
+#if SPAN_SUPPORT
+            var span = new ReadOnlySpan<byte>(new byte[] { 0, 1, 2, 3, 4, 5 }, 1, 3);
+            encoder.WriteByteString("ByteString4", span);
+
+            var nullspan = new ReadOnlySpan<byte>(null);
+            encoder.WriteByteString("ByteString5", nullspan);
+            Assert.IsTrue(nullspan.IsEmpty);
+            Assert.IsTrue(nullspan == null);
+
+            ReadOnlySpan<byte> defaultspan = default;
+            encoder.WriteByteString("ByteString6", defaultspan);
+            Assert.IsTrue(defaultspan.IsEmpty);
+            Assert.IsTrue(defaultspan == null);
+
+            ReadOnlySpan<byte> emptyspan = Array.Empty<byte>();
+            encoder.WriteByteString("ByteString7", emptyspan);
+            Assert.IsTrue(emptyspan.IsEmpty);
+            Assert.IsTrue(emptyspan != null);
+#endif
+            return encoder.CloseAndReturnText();
+        }
+
+        private void ReadByteStringData(IDecoder decoder)
+        {
+            var result = decoder.ReadByteString("ByteString1");
+            Assert.AreEqual(new byte[] { 1, 2, 3 }, result);
+            result = decoder.ReadByteString("ByteString2");
+            Assert.AreEqual(null, result);
+            result = decoder.ReadByteString("ByteString3");
+            Assert.AreEqual(null, result);
+#if SPAN_SUPPORT
+            result = decoder.ReadByteString("ByteString4");
+            Assert.AreEqual(new byte[] { 1, 2, 3 }, result);
+            result = decoder.ReadByteString("ByteString5");
+            Assert.AreEqual(null, result);
+            result = decoder.ReadByteString("ByteString6");
+            Assert.AreEqual(null, result);
+            result = decoder.ReadByteString("ByteString7");
+            Assert.AreEqual(Array.Empty<byte>(), result);
+#endif
+        }
+
         [Test]
         [Category("WriteByteString")]
         public void BinaryEncoder_WriteByteString()
         {
             using (var stream = new MemoryStream())
             {
+                string text;
                 using (IEncoder encoder = new BinaryEncoder(stream, new ServiceMessageContext(), true))
                 {
-                    encoder.WriteByteString("ByteString1", new byte[] { 0, 1, 2, 3, 4, 5 }, 1, 3);
-#if SPAN_SUPPORT
-                    var span = new ReadOnlySpan<byte>(new byte[] { 0, 1, 2, 3, 4, 5 }, 1, 3);
-                    var nullspan = new ReadOnlySpan<byte>(null);
-                    encoder.WriteByteString("ByteString2", span);
-                    encoder.WriteByteString("ByteString3", nullspan);
-#endif
-                    encoder.WriteByteString("ByteString4", null);
-                    encoder.WriteByteString("ByteString5", null, 1, 2);
+                    text = WriteByteStringData(encoder);
                 }
                 stream.Position = 0;
                 using (var decoder = new BinaryDecoder(stream, new ServiceMessageContext()))
                 {
-                    var result = decoder.ReadByteString("ByteString1");
-                    Assert.AreEqual(new byte[] { 1, 2, 3 }, result);
-#if SPAN_SUPPORT
-                    result = decoder.ReadByteString("ByteString2");
-                    Assert.AreEqual(new byte[] { 1, 2, 3 }, result);
-                    result = decoder.ReadByteString("ByteString3");
-                    Assert.AreEqual(null, result);
-#endif
-                    result = decoder.ReadByteString("ByteString4");
-                    Assert.AreEqual(null, result);
-                    result = decoder.ReadByteString("ByteString5");
-                    Assert.AreEqual(null, result);
+                    ReadByteStringData(decoder);
                 }
             }
         }
 
         [Test]
         [Category("WriteByteString")]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2265:Do not compare Span<T> to 'null' or 'default'", Justification = "Null compare works with ReadOnlySpan<byte>")]
         public void XmlEncoder_WriteByteString()
         {
             using (var stream = new MemoryStream())
@@ -445,32 +477,13 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
                 using (XmlWriter writer = XmlWriter.Create(stream, settings))
                 using (IEncoder encoder = new XmlEncoder(new XmlQualifiedName("ByteStrings", Namespaces.OpcUaXsd), writer, new ServiceMessageContext()))
                 {
-                    encoder.WriteByteString("ByteString1", new byte[] { 0, 1, 2, 3, 4, 5 }, 1, 3);
-#if SPAN_SUPPORT
-                    var span = new ReadOnlySpan<byte>(new byte[] { 0, 1, 2, 3, 4, 5 }, 1, 3);
-                    var nullspan = new ReadOnlySpan<byte>(null);
-                    encoder.WriteByteString("ByteString2", span);
-                    encoder.WriteByteString("ByteString3", nullspan);
-#endif
-                    encoder.WriteByteString("ByteString4", null);
-                    encoder.WriteByteString("ByteString5", null, 1, 2);
+                    string text = WriteByteStringData(encoder);
                 }
                 stream.Position = 0;
                 using (XmlReader reader = XmlReader.Create(stream, Utils.DefaultXmlReaderSettings()))
                 using (var decoder = new XmlDecoder(null, reader, new ServiceMessageContext()))
                 {
-                    var result = decoder.ReadByteString("ByteString1");
-                    Assert.AreEqual(new byte[] { 1, 2, 3 }, result);
-#if SPAN_SUPPORT
-                    result = decoder.ReadByteString("ByteString2");
-                    Assert.AreEqual(new byte[] { 1, 2, 3 }, result);
-                    result = decoder.ReadByteString("ByteString3");
-                    Assert.AreEqual(null, result);
-#endif
-                    result = decoder.ReadByteString("ByteString4");
-                    Assert.AreEqual(null, result);
-                    result = decoder.ReadByteString("ByteString5");
-                    Assert.AreEqual(null, result);
+                    ReadByteStringData(decoder);
                 }
             }
         }
@@ -481,34 +494,18 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
         {
             using (var stream = new MemoryStream())
             {
+                string text;
                 using (IEncoder encoder = new JsonEncoder(new ServiceMessageContext(), true, false, stream, true))
                 {
-                    encoder.WriteByteString("ByteString1", new byte[] { 0, 1, 2, 3, 4, 5 }, 1, 3);
-#if SPAN_SUPPORT
-                    var span = new ReadOnlySpan<byte>(new byte[] { 0, 1, 2, 3, 4, 5 }, 1, 3);
-                    var nullspan = new ReadOnlySpan<byte>(null);
-                    encoder.WriteByteString("ByteString2", span);
-                    encoder.WriteByteString("ByteString3", nullspan);
-#endif
-                    encoder.WriteByteString("ByteString4", null);
-                    encoder.WriteByteString("ByteString5", null, 1, 2);
+                    text = WriteByteStringData(encoder);
+
                 }
+
                 stream.Position = 0;
                 var jsonTextReader = new JsonTextReader(new StreamReader(stream));
                 using (var decoder = new JsonDecoder(null, jsonTextReader, new ServiceMessageContext()))
                 {
-                    var result = decoder.ReadByteString("ByteString1");
-                    Assert.AreEqual(new byte[] { 1, 2, 3 }, result);
-#if SPAN_SUPPORT
-                    result = decoder.ReadByteString("ByteString2");
-                    Assert.AreEqual(new byte[] { 1, 2, 3 }, result);
-                    result = decoder.ReadByteString("ByteString3");
-                    Assert.AreEqual(null, result);
-#endif
-                    result = decoder.ReadByteString("ByteString4");
-                    Assert.AreEqual(null, result);
-                    result = decoder.ReadByteString("ByteString5");
-                    Assert.AreEqual(null, result);
+                    ReadByteStringData(decoder);
                 }
             }
         }

--- a/Tests/Opc.Ua.Core.Tests/Types/Encoders/JsonEncoderEscapeStringBenchmarks.cs
+++ b/Tests/Opc.Ua.Core.Tests/Types/Encoders/JsonEncoderEscapeStringBenchmarks.cs
@@ -248,6 +248,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
             {
                 EscapeStringSystemTextJson(m_testString);
             }
+            m_streamWriter.Flush();
         }
 #endif
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -68,7 +68,7 @@ stages:
     parameters:
       configuration: Release
       framework: net6.0
-      agents: '@{ windows = "windows-2022"; linux="ubuntu-22.04"; mac = "macOS-12"}'
+      agents: '@{ windows = "windows-2022"; linux="ubuntu-22.04"; mac = "macOS-15"}'
       jobnamesuffix: net60
       customtestarget: net6.0
 - stage: testreleasepr

--- a/common.props
+++ b/common.props
@@ -4,7 +4,7 @@
     <RepositoryUrl>https://github.com/OPCFoundation/UA-.NETStandard</RepositoryUrl>
     <VersionPrefix>1.05.374</VersionPrefix>
     <VersionSuffix>preview-$([System.DateTime]::Now.ToString("yyyyMMdd"))</VersionSuffix>
-    <Copyright>Copyright © 2004-2024 OPC Foundation, Inc</Copyright>
+    <Copyright>Copyright © 2004-2025 OPC Foundation, Inc</Copyright>
     <PackagePrefix>OPCFoundation.NetStandard</PackagePrefix>
     <Company>OPC Foundation</Company>
     <Authors>OPC Foundation</Authors>


### PR DESCRIPTION
## Proposed changes

- Simplify some of the test cases for Unions
- Simplify some of the new IEncoder API
- Try use the new API for reading/writning encodingmask&switchfield
- make a few helpers in JsonEncoder private, that seem only to be used internally

### Enhancements to Encoding/Decoding Methods:

* [`OptionalFieldsComplexType.cs`](diffhunk://#diff-f8a63c419fe26215183c0d924479ca812350d73e1c5fd0ac1cf3eb02b0f2e757L96-R96): Replaced `WriteUInt32` with `WriteEncodingMask` and added logic to handle JSON decoders when the encoding mask is implicitly defined. [[1]](diffhunk://#diff-f8a63c419fe26215183c0d924479ca812350d73e1c5fd0ac1cf3eb02b0f2e757L96-R96) [[2]](diffhunk://#diff-f8a63c419fe26215183c0d924479ca812350d73e1c5fd0ac1cf3eb02b0f2e757L121-R133)
* [`UnionComplexType.cs`](diffhunk://#diff-b00bf00b30c5b2cdbab44405dd71a8756b1dd764928d120d145c7c1d6b0b2c18L97-R99): Introduced `WriteSwitchField` and updated logic to support reversible JSON encoding. [[1]](diffhunk://#diff-b00bf00b30c5b2cdbab44405dd71a8756b1dd764928d120d145c7c1d6b0b2c18L97-R99) [[2]](diffhunk://#diff-b00bf00b30c5b2cdbab44405dd71a8756b1dd764928d120d145c7c1d6b0b2c18L119-R124) [[3]](diffhunk://#diff-b00bf00b30c5b2cdbab44405dd71a8756b1dd764928d120d145c7c1d6b0b2c18L142-R174)

### Configuration Improvements:

* [`ApplicationConfigurationBuilder.cs`](diffhunk://#diff-bd8ddfef69f6e1bc6ae450cefc29c8a271675949c110a4ca62f2d23a0499b529R69-R74): Added `SetHiResClockDisabled` method to control high-resolution clock settings.
* [`IApplicationConfigurationBuilder.cs`](diffhunk://#diff-300ccaef80fc8cf5d32b29b749f6446e3a995c82573222c13d991ce7f38fbb16R546-R559): Introduced `IApplicationConfigurationBuilderGlobalConfiguration` interface for global configuration settings.

### Project Settings and Cleanup:

* [`Opc.Ua.Client.csproj`](diffhunk://#diff-3f942e6451a48b4ea8864181524d56188162f6c566bee915108000587fa08fe3L24-L27): Removed unnecessary `PackageReference` for `System.Diagnostics.DiagnosticSource`.
* [`Opc.Ua.Core.csproj`](diffhunk://#diff-8557fb7ab79d8c8a861c6e366b24d63e4792c807b4cd42d8f0659228140e3121R12): Updated the build process for zipping the NodeSet2 file and allowed unsafe blocks. [[1]](diffhunk://#diff-8557fb7ab79d8c8a861c6e366b24d63e4792c807b4cd42d8f0659228140e3121R12) [[2]](diffhunk://#diff-8557fb7ab79d8c8a861c6e366b24d63e4792c807b4cd42d8f0659228140e3121L91-R118)

### Miscellaneous Fixes:

* [`CustomNodeManager.cs`](diffhunk://#diff-cb5cdba3e59a0412870bbe03f95873dfcdded9fc902a1127c0a7855d59581d7aL2980-R2989): Renamed variable `error` to `callResult` and ensured the actual result of the original call is returned. [[1]](diffhunk://#diff-cb5cdba3e59a0412870bbe03f95873dfcdded9fc902a1127c0a7855d59581d7aL2980-R2989) [[2]](diffhunk://#diff-cb5cdba3e59a0412870bbe03f95873dfcdded9fc902a1127c0a7855d59581d7aL3044-R3045)
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L46-R46): Corrected the release month from December to January.
## Related Issues

- Fixes #

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [x] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
