### PR TITLE
CustomNodeManager2 initialize predefined nodes in constructor

### DIFF
--- a/Libraries/Opc.Ua.Server/Diagnostics/CustomNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/Diagnostics/CustomNodeManager.cs
@@ -107,6 +107,8 @@ namespace Opc.Ua.Server
             // create the table of monitored nodes.
             // these are created by the node manager whenever a client subscribe to an attribute of the node.
             m_monitoredNodes = new NodeIdDictionary<MonitoredNode2>();
+
+            m_predefinedNodes = new NodeIdDictionary<NodeState>();
         }
         #endregion
 
@@ -129,7 +131,7 @@ namespace Opc.Ua.Server
             {
                 lock (Lock)
                 {
-                    foreach (NodeState node in m_predefinedNodes?.Values)
+                    foreach (NodeState node in m_predefinedNodes.Values)
                     {
                         Utils.SilentDispose(node);
                     }
@@ -321,7 +323,7 @@ namespace Opc.Ua.Server
         public NodeState Find(NodeId nodeId)
         {
             NodeState node = null;
-            if (m_predefinedNodes?.TryGetValue(nodeId, out node) == true)
+            if (m_predefinedNodes.TryGetValue(nodeId, out node) == true)
             {
                 return node;
             }
@@ -349,11 +351,6 @@ namespace Opc.Ua.Server
 
             lock (Lock)
             {
-                if (m_predefinedNodes == null)
-                {
-                    m_predefinedNodes = new NodeIdDictionary<NodeState>();
-                }
-
                 instance.ReferenceTypeId = referenceTypeId;
 
                 NodeState parent = null;
@@ -390,7 +387,7 @@ namespace Opc.Ua.Server
             List<LocalReference> referencesToRemove = new List<LocalReference>();
 
             NodeState node = null;
-            if (m_predefinedNodes?.TryGetValue(nodeId, out node) != true)
+            if (m_predefinedNodes.TryGetValue(nodeId, out node) != true)
             {
                 return false;
             }
@@ -477,11 +474,6 @@ namespace Opc.Ua.Server
             string resourcePath,
             IDictionary<NodeId, IList<IReference>> externalReferences)
         {
-            if (m_predefinedNodes == null)
-            {
-                m_predefinedNodes = new NodeIdDictionary<NodeState>();
-            }
-
             // load the predefined nodes from an XML document.
             NodeStateCollection predefinedNodes = new NodeStateCollection();
             predefinedNodes.LoadFromResource(context, resourcePath, assembly, true);
@@ -544,11 +536,6 @@ namespace Opc.Ua.Server
         /// </summary>
         protected virtual void AddPredefinedNode(ISystemContext context, NodeState node)
         {
-            if (m_predefinedNodes == null)
-            {
-                m_predefinedNodes = new NodeIdDictionary<NodeState>();
-            }
-
             // assign a default value to any variable in namespace 0
             if (node is BaseVariableState nodeStateVar)
             {
@@ -614,7 +601,7 @@ namespace Opc.Ua.Server
             NodeState node,
             List<LocalReference> referencesToRemove)
         {
-            if (m_predefinedNodes?.TryRemove(node.NodeId, out _) != true)
+            if (m_predefinedNodes.TryRemove(node.NodeId, out _) != true)
             {
                 return;
             }
@@ -687,7 +674,7 @@ namespace Opc.Ua.Server
         /// <param name="externalReferences">A list of references to add to external targets.</param>
         protected virtual void AddReverseReferences(IDictionary<NodeId, IList<IReference>> externalReferences)
         {
-            foreach (NodeState source in m_predefinedNodes?.Values)
+            foreach (NodeState source in m_predefinedNodes.Values)
             {
                 IList<IReference> references = new List<IReference>();
                 source.GetReferences(SystemContext, references);
@@ -855,15 +842,12 @@ namespace Opc.Ua.Server
         /// </summary>
         public virtual void DeleteAddressSpace()
         {
-            if (m_predefinedNodes != null)
-            {
-                var nodes = m_predefinedNodes.Values.ToArray();
-                m_predefinedNodes.Clear();
+            var nodes = m_predefinedNodes.Values.ToArray();
+            m_predefinedNodes.Clear();
 
-                foreach (NodeState node in nodes)
-                {
-                    Utils.SilentDispose(node);
-                }
+            foreach (NodeState node in nodes)
+            {
+                Utils.SilentDispose(node);
             }
         }
 
@@ -894,7 +878,7 @@ namespace Opc.Ua.Server
             }
 
             NodeState node = null;
-            if (m_predefinedNodes?.TryGetValue(nodeId, out node) == true)
+            if (m_predefinedNodes.TryGetValue(nodeId, out node) == true)
             {
                 var handle = new NodeHandle {
                     NodeId = nodeId,


### PR DESCRIPTION
## Proposed changes
-  initialize m_predefinedNodes in constructor
- remove nullabilty checks

## Related Issues

- Fixes #2964 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments
