### PR TITLE
[Server] Fix Sampling Group creating a new long running task for every Client AddMonitoredItems Method Call

### DIFF
--- a/Libraries/Opc.Ua.Server/NodeManager/SamplingGroup.cs
+++ b/Libraries/Opc.Ua.Server/NodeManager/SamplingGroup.cs
@@ -121,6 +121,8 @@ namespace Opc.Ua.Server
             {
                 m_shutdownEvent.Set();
                 m_items.Clear();
+                Utils.SilentDispose(m_samplingTask);
+                m_samplingTask = null;
             }
         }
 

--- a/Libraries/Opc.Ua.Server/NodeManager/SamplingGroup.cs
+++ b/Libraries/Opc.Ua.Server/NodeManager/SamplingGroup.cs
@@ -123,6 +123,7 @@ namespace Opc.Ua.Server
                 m_items.Clear();
                 Utils.SilentDispose(m_samplingTask);
                 m_samplingTask = null;
+                Utils.SilentDispose(m_shutdownEvent);
             }
         }
 

--- a/Libraries/Opc.Ua.Server/NodeManager/SamplingGroup.cs
+++ b/Libraries/Opc.Ua.Server/NodeManager/SamplingGroup.cs
@@ -106,7 +106,7 @@ namespace Opc.Ua.Server
             {
                 m_shutdownEvent.Reset();
 
-                Task.Factory.StartNew(() => {
+                m_samplingTask = Task.Factory.StartNew(() => {
                     SampleMonitoredItems(m_samplingInterval);
                 }, TaskCreationOptions.LongRunning | TaskCreationOptions.DenyChildAttach);
             }
@@ -243,7 +243,7 @@ namespace Opc.Ua.Server
                 m_itemsToRemove.Clear();
 
                 // start the group if it is not running.
-                if (m_items.Count > 0)
+                if (m_samplingTask == null && m_items.Count > 0)
                 {
                     Startup();
                 }
@@ -487,6 +487,7 @@ namespace Opc.Ua.Server
         private Dictionary<uint, ISampledDataChangeMonitoredItem> m_items;
         private ManualResetEvent m_shutdownEvent;
         private List<SamplingRateGroup> m_samplingRates;
+        private Task m_samplingTask;
         #endregion
     }
 }


### PR DESCRIPTION
## Proposed changes

Fix the SamplingGroup of the Server to only initiate startup of the sampling task if it does not exist yet. As in the previous implementation a new sampling task was started on every Client AddMonitoredItems Service Call for a node being handled by the core Node Manager.

## Related Issues

- Fixes #2983 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

