### PR TITLE
[Client] Fix reconnect when ReverseConnection is used

### DIFF
--- a/Libraries/Opc.Ua.Client/Session/SessionReconnectHandler.cs
+++ b/Libraries/Opc.Ua.Client/Session/SessionReconnectHandler.cs
@@ -459,12 +459,12 @@ namespace Opc.Ua.Client
                     ITransportWaitingConnection connection;
                     do
                     {
-                        var endpointDes = m_session.Endpoint;
-                        if(endpointDes == null)
-                             endpointDes = transportChannel.EndpointDescription;
+                        var endpointDescription = m_session.Endpoint;
+                        if(endpointDescription == null)
+                             endpointDescription = transportChannel.EndpointDescription;
                         connection = await m_reverseConnectManager.WaitForConnection(
-                                new Uri(endpointDes.EndpointUrl),
-                                endpointDes.Server.ApplicationUri
+                                new Uri(endpointDescription.EndpointUrl),
+                                endpointDescription.Server.ApplicationUri
                             ).ConfigureAwait(false);
 
                         if (m_updateFromServer)

--- a/Libraries/Opc.Ua.Client/Session/SessionReconnectHandler.cs
+++ b/Libraries/Opc.Ua.Client/Session/SessionReconnectHandler.cs
@@ -459,9 +459,12 @@ namespace Opc.Ua.Client
                     ITransportWaitingConnection connection;
                     do
                     {
+                        var endpointDes = m_session.Endpoint;
+                        if(endpointDes == null)
+                             endpointDes = transportChannel.EndpointDescription;
                         connection = await m_reverseConnectManager.WaitForConnection(
-                                new Uri(m_session.Endpoint.EndpointUrl),
-                                m_session.Endpoint.Server.ApplicationUri
+                                new Uri(endpointDes.EndpointUrl),
+                                endpointDes.Server.ApplicationUri
                             ).ConfigureAwait(false);
 
                         if (m_updateFromServer)


### PR DESCRIPTION
There is chance that m_session.DetachChannel can clear the member "Endpoint" info of the session, once that happened, there will be crash when use member "Endpoint" of the session as parameter of m_reverseConnectManager.WaitForConnection.

## Proposed changes

Always keep the member "Endpoint" of the session valid, avoid crash at null reference later.


## Related Issues
https://github.com/OPCFoundation/UA-.NETStandard/issues/2951

- Fixes #

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [x] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
