### PR TITLE
Enable Nullability for important Certificate Handling classes

### DIFF
--- a/Stack/Opc.Ua.Core/Schema/ApplicationConfiguration.cs
+++ b/Stack/Opc.Ua.Core/Schema/ApplicationConfiguration.cs
@@ -2848,6 +2848,7 @@ namespace Opc.Ua
     #endregion
 
     #region CertificateStoreIdentifier Class
+#nullable enable
     /// <summary>
     /// Describes a certificate store.
     /// </summary>
@@ -2862,7 +2863,7 @@ namespace Opc.Ua
         /// If the StoreName is not empty, the CertificateStoreType.X509Store is returned, otherwise the StoreType is returned.
         /// </value>
         [DataMember(IsRequired = false, EmitDefaultValue = false, Order = 0)]
-        public string StoreType
+        public string? StoreType
         {
             get
             {
@@ -2889,13 +2890,13 @@ namespace Opc.Ua
         /// If the StoreName is empty, the m_storePath is returned.
         /// </value>
         [DataMember(IsRequired = false, EmitDefaultValue = false, Order = 1)]
-        public string StorePath
+        public string? StorePath
         {
             get
             {
-                if (!String.IsNullOrEmpty(m_storeName))
+                if (!string.IsNullOrEmpty(m_storeName))
                 {
-                    if (String.IsNullOrEmpty(m_storeLocation))
+                    if (string.IsNullOrEmpty(m_storeLocation))
                     {
                         return CurrentUser + m_storeName;
                     }
@@ -2925,7 +2926,7 @@ namespace Opc.Ua
         /// </summary>
         [DataMember(IsRequired = false, EmitDefaultValue = false, Order = 2)]
         [Obsolete("Use StoreType/StorePath instead")]
-        public string StoreName
+        public string? StoreName
         {
             get { return m_storeName; }
             set { m_storeName = value; }
@@ -2936,7 +2937,7 @@ namespace Opc.Ua
         /// </summary>
         [DataMember(IsRequired = false, EmitDefaultValue = false, Order = 3)]
         [Obsolete("Use StoreType/StorePath instead")]
-        public string StoreLocation
+        public string? StoreLocation
         {
             get { return m_storeLocation; }
             set { m_storeLocation = value; }
@@ -2954,16 +2955,18 @@ namespace Opc.Ua
         #endregion
 
         #region Private Fields
-        private string m_storeType;
-        private string m_storePath;
-        private string m_storeLocation;
-        private string m_storeName;
+        private string? m_storeType;
+        private string? m_storePath;
+        private string? m_storeLocation;
+        private string? m_storeName;
         private CertificateValidationOptions m_validationOptions;
         #endregion
     }
+#nullable disable
     #endregion
 
     #region CertificateTrustList Class
+#nullable enable
     [DataContract(Namespace = Namespaces.OpcUaConfig)]
     [KnownType(typeof(CertificateTrustList))]
     public partial class CertificateTrustList : CertificateStoreIdentifier
@@ -2974,6 +2977,8 @@ namespace Opc.Ua
         /// </summary>
         public CertificateTrustList()
         {
+            //set in initialize
+            m_trustedCertificates = null!;
             Initialize();
         }
 
@@ -3024,6 +3029,7 @@ namespace Opc.Ua
         private CertificateIdentifierCollection m_trustedCertificates;
         #endregion
     }
+#nullable disable
     #endregion
 
     #region CertificateIdentifierCollection Class
@@ -3049,6 +3055,7 @@ namespace Opc.Ua
     #endregion
 
     #region CertificateIdentifier Class
+#nullable enable
     [DataContract(Namespace = Namespaces.OpcUaConfig)]
     public partial class CertificateIdentifier
     {
@@ -3110,11 +3117,11 @@ namespace Opc.Ua
         /// </summary>
         /// <value>The type of the store - defined in the <see cref="CertificateStoreType"/>.</value>
         [DataMember(IsRequired = false, EmitDefaultValue = false, Order = 10)]
-        public string StoreType
+        public string? StoreType
         {
             get
             {
-                if (!String.IsNullOrEmpty(m_storeName))
+                if (!string.IsNullOrEmpty(m_storeName))
                 {
                     return CertificateStoreType.X509Store;
                 }
@@ -3133,13 +3140,13 @@ namespace Opc.Ua
         /// </summary>
         /// <value>The store path in the form <c>StoreName\\Store Location</c> .</value>
         [DataMember(IsRequired = false, EmitDefaultValue = false, Order = 15)]
-        public string StorePath
+        public string? StorePath
         {
             get
             {
-                if (!String.IsNullOrEmpty(m_storeName))
+                if (!string.IsNullOrEmpty(m_storeName))
                 {
-                    if (String.IsNullOrEmpty(m_storeLocation))
+                    if (string.IsNullOrEmpty(m_storeLocation))
                     {
                         return Utils.Format("LocalMachine\\{0}", m_storeName);
                     }
@@ -3154,9 +3161,9 @@ namespace Opc.Ua
             {
                 m_storePath = value;
 
-                if (!String.IsNullOrEmpty(m_storePath))
+                if (!string.IsNullOrEmpty(m_storePath))
                 {
-                    if (String.IsNullOrEmpty(m_storeType))
+                    if (string.IsNullOrEmpty(m_storeType))
                     {
                         m_storeType = CertificateStoreIdentifier.DetermineStoreType(m_storePath);
                     }
@@ -3171,7 +3178,7 @@ namespace Opc.Ua
         /// <seealso cref="System.Security.Cryptography.X509Certificates.StoreName"/>
         [DataMember(IsRequired = false, EmitDefaultValue = false, Order = 20)]
         [Obsolete("Use StoreType/StorePath instead")]
-        public string StoreName
+        public string? StoreName
         {
             get { return m_storeName; }
             set { m_storeName = value; }
@@ -3184,7 +3191,7 @@ namespace Opc.Ua
         /// <seealso cref="System.Security.Cryptography.X509Certificates.StoreLocation"/>
         [DataMember(IsRequired = false, EmitDefaultValue = false, Order = 30)]
         [Obsolete("Use StoreType/StorePath instead")]
-        public string StoreLocation
+        public string? StoreLocation
         {
             get { return m_storeLocation; }
             set { m_storeLocation = value; }
@@ -3238,7 +3245,7 @@ namespace Opc.Ua
         /// <seealso cref="System.Security.Cryptography.X509Certificates.X500DistinguishedName"/>
         /// <seealso cref="System.Security.Cryptography.AsnEncodedData"/>
         [DataMember(IsRequired = false, EmitDefaultValue = false, Order = 40)]
-        public string SubjectName
+        public string? SubjectName
         {
             get
             {
@@ -3270,7 +3277,7 @@ namespace Opc.Ua
         /// <value>The thumbprint of a certificate..</value>
         /// <seealso cref="X509Certificate2"/>
         [DataMember(IsRequired = false, EmitDefaultValue = false, Order = 50)]
-        public string Thumbprint
+        public string? Thumbprint
         {
             get
             {
@@ -3301,7 +3308,7 @@ namespace Opc.Ua
         /// </summary>
         /// <value>A byte array containing the X.509 certificate data.</value>
         [DataMember(IsRequired = false, EmitDefaultValue = false, Order = 60)]
-        public byte[] RawData
+        public byte[]? RawData
         {
             get
             {
@@ -3344,7 +3351,7 @@ namespace Opc.Ua
         /// </summary>
         /// <value>The NodeId of the certificate type, e.g. EccNistP256ApplicationCertificateType.</value>
         [DataMember(IsRequired = false, EmitDefaultValue = false, Order = 80)]
-        public NodeId CertificateType
+        public NodeId? CertificateType
         {
             get => m_certificateType;
             set => m_certificateType = value;
@@ -3355,7 +3362,7 @@ namespace Opc.Ua
         /// </summary>
         /// <value>Rsa, RsaMin, RsaSha256, NistP256, NistP384, BrainpoolP256r1, BrainpoolP384r1, Curve25519, Curve448</value>
         [DataMember(IsRequired = false, EmitDefaultValue = false, Order = 90)]
-        public string CertificateTypeString
+        public string? CertificateTypeString
         {
             get => EncodeCertificateType(m_certificateType);
             set => m_certificateType = DecodeCertificateType(value);
@@ -3363,19 +3370,19 @@ namespace Opc.Ua
         #endregion
 
         #region Private Fields
-        private string m_storeType;
-        private string m_storePath;
-        private string m_storeLocation;
-        private string m_storeName;
-        private string m_subjectName;
-        private string m_thumbprint;
-        private X509Certificate2 m_certificate;
-        private NodeId m_certificateType;
+        private string? m_storeType;
+        private string? m_storePath;
+        private string? m_storeLocation;
+        private string? m_storeName;
+        private string? m_subjectName;
+        private string? m_thumbprint;
+        private X509Certificate2? m_certificate;
+        private NodeId? m_certificateType;
         private CertificateValidationOptions m_validationOptions;
         #endregion
     }
+#nullable disable
     #endregion
-
     #region ConfiguredEndpointCollection Class
     /// <summary>
     /// Stores a list of cached endpoints.

--- a/Stack/Opc.Ua.Core/Security/Certificates/CertificateIdentifier.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/CertificateIdentifier.cs
@@ -580,7 +580,7 @@ namespace Opc.Ua
         /// </summary>
         /// <param name="certificate">The certificate with a signature.</param>
         /// <param name="certificateType">The NodeId of the certificate type.</param>
-        public static bool ValidateCertificateType(X509Certificate2 certificate, NodeId certificateType)
+        public static bool ValidateCertificateType(X509Certificate2 certificate, NodeId? certificateType)
         {
             if (certificateType == null)
             {

--- a/Stack/Opc.Ua.Core/Security/Certificates/CertificateIdentifier.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/CertificateIdentifier.cs
@@ -18,6 +18,8 @@ using System.Text;
 using System.Threading.Tasks;
 using Opc.Ua.Security.Certificates;
 
+#nullable enable
+
 namespace Opc.Ua
 {
     /// <summary>
@@ -38,7 +40,7 @@ namespace Opc.Ua
         /// <returns>
         /// A <see cref="String"/> containing the value of the current instance in the specified format.
         /// </returns>
-        public string ToString(string format, IFormatProvider formatProvider)
+        public string ToString(string? format, IFormatProvider? formatProvider)
         {
             if (format != null) throw new FormatException(Utils.Format("Invalid format string: '{0}'.", format));
             return ToString();
@@ -64,13 +66,13 @@ namespace Opc.Ua
                 return m_subjectName;
             }
 
-            return m_thumbprint;
+            return m_thumbprint ?? "";
         }
 
         /// <summary>
         /// Returns true if the objects are equal.
         /// </summary>
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (Object.ReferenceEquals(this, obj))
             {
@@ -142,7 +144,7 @@ namespace Opc.Ua
         /// Gets or sets the actual certificate.
         /// </summary>
         /// <value>The X509 certificate used by this instance.</value>
-        public X509Certificate2 Certificate
+        public X509Certificate2? Certificate
         {
             get { return m_certificate; }
             set
@@ -160,7 +162,7 @@ namespace Opc.Ua
         /// <summary>
         /// Finds a certificate in a store.
         /// </summary>
-        public Task<X509Certificate2> Find(string applicationUri = null)
+        public Task<X509Certificate2?> Find(string? applicationUri = null)
         {
             return Find(false, applicationUri);
         }
@@ -168,22 +170,22 @@ namespace Opc.Ua
         /// <summary>
         /// Loads the private key for the certificate with an optional password.
         /// </summary>
-        public Task<X509Certificate2> LoadPrivateKey(string password, string applicationUri = null)
+        public Task<X509Certificate2?> LoadPrivateKey(string? password, string? applicationUri = null)
             => LoadPrivateKeyEx(password != null ? new CertificatePasswordProvider(password) : null, applicationUri);
 
         /// <summary>
         /// Loads the private key for the certificate with an optional password provider.
         /// </summary>
-        public async Task<X509Certificate2> LoadPrivateKeyEx(ICertificatePasswordProvider passwordProvider, string applicationUri = null)
+        public async Task<X509Certificate2?> LoadPrivateKeyEx(ICertificatePasswordProvider? passwordProvider, string? applicationUri = null)
         {
             if (this.StoreType != CertificateStoreType.X509Store)
             {
                 var certificateStoreIdentifier = new CertificateStoreIdentifier(this.StorePath, this.StoreType, false);
-                using (ICertificateStore store = certificateStoreIdentifier.OpenStore())
+                using (ICertificateStore? store = certificateStoreIdentifier.OpenStore())
                 {
                     if (store?.SupportsLoadPrivateKey == true)
                     {
-                        string password = passwordProvider?.GetPassword(this);
+                        string? password = passwordProvider?.GetPassword(this);
                         m_certificate = await store.LoadPrivateKey(this.Thumbprint, this.SubjectName, null, this.CertificateType, password).ConfigureAwait(false);
 
                         //find certificate by applicationUri instead of subjectName, as the subjectName could have changed after a certificate update
@@ -208,9 +210,9 @@ namespace Opc.Ua
         /// <param name="applicationUri">the application uri in the extensions of the certificate.</param>
         /// <returns>An instance of the <see cref="X509Certificate2"/> that is embedded by this instance or find it in 
         /// the selected store pointed out by the <see cref="StorePath"/> using selected <see cref="SubjectName"/> or if specified applicationUri.</returns>
-        public async Task<X509Certificate2> Find(bool needPrivateKey, string applicationUri = null)
+        public async Task<X509Certificate2?> Find(bool needPrivateKey, string? applicationUri = null)
         {
-            X509Certificate2 certificate = null;
+            X509Certificate2? certificate = null;
 
             // check if the entire certificate has been specified.
             if (m_certificate != null && (!needPrivateKey || m_certificate.HasPrivateKey))
@@ -221,7 +223,7 @@ namespace Opc.Ua
             {
                 // open store.
                 var certificateStoreIdentifier = new CertificateStoreIdentifier(StorePath, false);
-                using (ICertificateStore store = certificateStoreIdentifier.OpenStore())
+                using (ICertificateStore? store = certificateStoreIdentifier.OpenStore())
                 {
                     if (store == null)
                     {
@@ -327,16 +329,16 @@ namespace Opc.Ua
         /// <param name="certificateType">The certificate type.</param>
         /// <param name="needPrivateKey">if set to <c>true</c> [need private key].</param>
         /// <returns></returns>
-        public static X509Certificate2 Find(
+        public static X509Certificate2? Find(
             X509Certificate2Collection collection,
-            string thumbprint,
-            string subjectName,
-            string applicationUri,
-            NodeId certificateType,
+            string? thumbprint,
+            string? subjectName,
+            string? applicationUri,
+            NodeId? certificateType,
             bool needPrivateKey)
         {
             // find by thumbprint.
-            if (!String.IsNullOrEmpty(thumbprint))
+            if (!string.IsNullOrEmpty(thumbprint))
             {
                 collection = collection.Find(X509FindType.FindByThumbprint, thumbprint, false);
 
@@ -361,7 +363,7 @@ namespace Opc.Ua
                 return null;
             }
             // find by subject name.
-            if (!String.IsNullOrEmpty(subjectName))
+            if (!string.IsNullOrEmpty(subjectName))
             {
                 List<string> subjectName2 = X509Utils.ParseDistinguishedName(subjectName);
 
@@ -575,8 +577,12 @@ namespace Opc.Ua
         /// </summary>
         /// <param name="certificate">The certificate with a signature.</param>
         /// <param name="certificateType">The NodeId of the certificate type.</param>
-        public static bool ValidateCertificateType(X509Certificate2 certificate, NodeId certificateType)
+        public static bool ValidateCertificateType(X509Certificate2 certificate, NodeId? certificateType)
         {
+            if (certificateType == null)
+            {
+                return false;
+            }
             switch (certificate.SignatureAlgorithm.Value)
             {
                 case Oids.ECDsaWithSha1:
@@ -772,7 +778,7 @@ namespace Opc.Ua
         /// The tags of the supported certificate types used to encode the NodeId coressponding to existing value.
         /// </summary>
         // TODO: remove if not used
-        private static string EncodeCertificateType(NodeId certificateType)
+        private static string? EncodeCertificateType(NodeId? certificateType)
         {
             if (certificateType == null)
             {
@@ -794,7 +800,7 @@ namespace Opc.Ua
         /// The tags of the supported certificate types used to decode the NodeId coressponding to existing value.
         /// </summary>
         // TODO: remove if not used
-        private static NodeId DecodeCertificateType(string certificateType)
+        private static NodeId? DecodeCertificateType(string? certificateType)
         {
             if (certificateType == null)
             {
@@ -901,7 +907,7 @@ namespace Opc.Ua
 
             for (int ii = 0; ii < this.Count; ii++)
             {
-                X509Certificate2 certificate = await this[ii].Find(false).ConfigureAwait(false);
+                X509Certificate2? certificate = await this[ii].Find(false).ConfigureAwait(false);
 
                 if (certificate != null)
                 {
@@ -913,13 +919,13 @@ namespace Opc.Ua
         }
 
         /// <inheritdoc/>
-        public async Task Add(X509Certificate2 certificate, string password = null)
+        public async Task Add(X509Certificate2 certificate, string? password = null)
         {
             if (certificate == null) throw new ArgumentNullException(nameof(certificate));
 
             for (int ii = 0; ii < this.Count; ii++)
             {
-                X509Certificate2 current = await this[ii].Find(false).ConfigureAwait(false);
+                X509Certificate2? current = await this[ii].Find(false).ConfigureAwait(false);
 
                 if (current != null && current.Thumbprint == certificate.Thumbprint)
                 {
@@ -944,7 +950,7 @@ namespace Opc.Ua
 
             for (int ii = 0; ii < this.Count; ii++)
             {
-                X509Certificate2 certificate = await this[ii].Find(false).ConfigureAwait(false);
+                X509Certificate2? certificate = await this[ii].Find(false).ConfigureAwait(false);
 
                 if (certificate != null && certificate.Thumbprint == thumbprint)
                 {
@@ -957,16 +963,16 @@ namespace Opc.Ua
         }
 
         /// <inheritdoc/>
-        public async Task<X509Certificate2Collection> FindByThumbprint(string thumbprint)
+        public async Task<X509Certificate2Collection?> FindByThumbprint(string thumbprint)
         {
-            if (String.IsNullOrEmpty(thumbprint))
+            if (string.IsNullOrEmpty(thumbprint))
             {
                 return null;
             }
 
             for (int ii = 0; ii < this.Count; ii++)
             {
-                X509Certificate2 certificate = await this[ii].Find(false).ConfigureAwait(false);
+                X509Certificate2? certificate = await this[ii].Find(false).ConfigureAwait(false);
 
                 if (certificate != null && certificate.Thumbprint == thumbprint)
                 {
@@ -981,15 +987,15 @@ namespace Opc.Ua
         public bool SupportsLoadPrivateKey => false;
 
         /// <inheritdoc/>
-        public Task<X509Certificate2> LoadPrivateKey(string thumbprint, string subjectName, string password)
+        public Task<X509Certificate2?> LoadPrivateKey(string thumbprint, string subjectName, string password)
         {
-            return Task.FromResult<X509Certificate2>(null);
+            return Task.FromResult<X509Certificate2?>(null);
         }
 
         /// <inheritdoc/>
-        public Task<X509Certificate2> LoadPrivateKey(string thumbprint, string subjectName, string applicationUri, NodeId certificateType, string password)
+        public Task<X509Certificate2?> LoadPrivateKey(string thumbprint, string subjectName, string applicationUri, NodeId certificateType, string password)
         {
-            return Task.FromResult<X509Certificate2>(null);
+            return Task.FromResult<X509Certificate2?>(null);
         }
 
         /// <inheritdoc/>

--- a/Stack/Opc.Ua.Core/Security/Certificates/CertificateIdentifier.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/CertificateIdentifier.cs
@@ -523,7 +523,10 @@ namespace Opc.Ua
         public ICertificateStore OpenStore()
         {
             ICertificateStore store = CertificateStoreIdentifier.CreateStore(this.StoreType);
-            store.Open(this.StorePath, false);
+            if (this.StorePath != null)
+            {
+                store.Open(this.StorePath, false);
+            }
             return store;
         }
 
@@ -941,7 +944,7 @@ namespace Opc.Ua
         }
 
         /// <inheritdoc/>
-        public async Task<bool> Delete(string thumbprint)
+        public async Task<bool> Delete(string? thumbprint)
         {
             if (String.IsNullOrEmpty(thumbprint))
             {
@@ -963,11 +966,11 @@ namespace Opc.Ua
         }
 
         /// <inheritdoc/>
-        public async Task<X509Certificate2Collection?> FindByThumbprint(string thumbprint)
+        public async Task<X509Certificate2Collection> FindByThumbprint(string thumbprint)
         {
             if (string.IsNullOrEmpty(thumbprint))
             {
-                return null;
+                return new X509Certificate2Collection();
             }
 
             for (int ii = 0; ii < this.Count; ii++)
@@ -987,13 +990,13 @@ namespace Opc.Ua
         public bool SupportsLoadPrivateKey => false;
 
         /// <inheritdoc/>
-        public Task<X509Certificate2?> LoadPrivateKey(string thumbprint, string subjectName, string password)
+        public Task<X509Certificate2?> LoadPrivateKey(string? thumbprint, string? subjectName, string? password)
         {
             return Task.FromResult<X509Certificate2?>(null);
         }
 
         /// <inheritdoc/>
-        public Task<X509Certificate2?> LoadPrivateKey(string thumbprint, string subjectName, string applicationUri, NodeId certificateType, string password)
+        public Task<X509Certificate2?> LoadPrivateKey(string? thumbprint, string? subjectName, string? applicationUri, NodeId? certificateType, string? password)
         {
             return Task.FromResult<X509Certificate2?>(null);
         }

--- a/Stack/Opc.Ua.Core/Security/Certificates/CertificatePasswordProvider.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/CertificatePasswordProvider.cs
@@ -10,6 +10,8 @@
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 */
 
+#nullable enable
+
 namespace Opc.Ua
 {
     #region ICertificatePasswordProvider Interface

--- a/Stack/Opc.Ua.Core/Security/Certificates/CertificateStoreIdentifier.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/CertificateStoreIdentifier.cs
@@ -10,11 +10,12 @@
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 */
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading;
-#nullable enable
 
 namespace Opc.Ua
 {
@@ -249,8 +250,10 @@ namespace Opc.Ua
                     store = currentStore;
                 }
             }
-
-            store?.Open(this.StorePath, m_noPrivateKeys);
+            if (this.StorePath != null)
+            {
+                store?.Open(this.StorePath, m_noPrivateKeys);
+            }
 
             return store;
         }

--- a/Stack/Opc.Ua.Core/Security/Certificates/CertificateStoreIdentifier.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/CertificateStoreIdentifier.cs
@@ -14,6 +14,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading;
+#nullable enable
 
 namespace Opc.Ua
 {
@@ -36,7 +37,7 @@ namespace Opc.Ua
         /// </summary>
         /// <param name="storePath">The store path of the store.</param>
         /// <param name="noPrivateKeys">If the store supports no private keys.</param>
-        public CertificateStoreIdentifier(string storePath, bool noPrivateKeys = true)
+        public CertificateStoreIdentifier(string? storePath, bool noPrivateKeys = true)
         {
             StorePath = storePath;
             StoreType = DetermineStoreType(storePath);
@@ -49,7 +50,7 @@ namespace Opc.Ua
         /// <param name="storePath">The store path of the store.</param>
         /// <param name="storeType">The type of the store.</param>
         /// <param name="noPrivateKeys">If the store supports no private keys.</param>
-        public CertificateStoreIdentifier(string storePath, string storeType, bool noPrivateKeys = true)
+        public CertificateStoreIdentifier(string? storePath, string? storeType, bool noPrivateKeys = true)
         {
             StorePath = storePath;
             StoreType = storeType;
@@ -86,7 +87,7 @@ namespace Opc.Ua
         /// <returns>
         /// A <see cref="System.String"/> containing the value of the current instance in the specified format.
         /// </returns>
-        public string ToString(string format, IFormatProvider formatProvider)
+        public string ToString(string? format, IFormatProvider? formatProvider)
         {
             if (format != null) throw new FormatException(Utils.Format("Invalid format string: '{0}'.", format));
             return ToString();
@@ -145,14 +146,14 @@ namespace Opc.Ua
         /// <summary>
         /// Detects the type of store represented by the path.
         /// </summary>
-        public static string DetermineStoreType(string storePath)
+        public static string DetermineStoreType(string? storePath)
         {
-            if (String.IsNullOrEmpty(storePath))
+            if (string.IsNullOrEmpty(storePath))
             {
                 return CertificateStoreType.Directory;
             }
 
-            if (storePath.StartsWith(LocalMachine, StringComparison.OrdinalIgnoreCase))
+            if (storePath!.StartsWith(LocalMachine, StringComparison.OrdinalIgnoreCase))
             {
                 return CertificateStoreType.X509Store;
             }
@@ -164,8 +165,8 @@ namespace Opc.Ua
 
             foreach (string storeTypeName in CertificateStoreType.RegisteredStoreTypeNames)
             {
-                ICertificateStoreType storeType = CertificateStoreType.GetCertificateStoreTypeByName(storeTypeName);
-                if (storeType.SupportsStorePath(storePath))
+                ICertificateStoreType? storeType = CertificateStoreType.GetCertificateStoreTypeByName(storeTypeName);
+                if (storeType?.SupportsStorePath(storePath) == true)
                 {
                     return storeTypeName;
                 }
@@ -177,11 +178,11 @@ namespace Opc.Ua
         /// <summary>
         /// Returns an object that can be used to access the store.
         /// </summary>
-        public static ICertificateStore CreateStore(string storeTypeName)
+        public static ICertificateStore CreateStore(string? storeTypeName)
         {
-            ICertificateStore store = null;
+            ICertificateStore store;
 
-            if (String.IsNullOrEmpty(storeTypeName))
+            if (string.IsNullOrEmpty(storeTypeName))
             {
                 return new CertificateIdentifierCollection();
             }
@@ -200,7 +201,7 @@ namespace Opc.Ua
                 }
                 default:
                 {
-                    ICertificateStoreType storeType = CertificateStoreType.GetCertificateStoreTypeByName(storeTypeName);
+                    ICertificateStoreType? storeType = CertificateStoreType.GetCertificateStoreTypeByName(storeTypeName);
                     if (storeType != null)
                     {
                         store = storeType.CreateStore();
@@ -222,9 +223,9 @@ namespace Opc.Ua
         /// enforce unnecessary refresh of the cached certificate store.
         /// </remarks>
         /// <returns>A disposable instance of the <see cref="ICertificateStore"/>.</returns>
-        public virtual ICertificateStore OpenStore()
+        public virtual ICertificateStore? OpenStore()
         {
-            ICertificateStore store = m_store;
+            ICertificateStore? store = m_store;
 
             // determine if the store configuration changed
             if (store != null &&
@@ -273,7 +274,7 @@ namespace Opc.Ua
         #endregion
 
         #region Private Variables
-        private ICertificateStore m_store;
+        private ICertificateStore? m_store;
         private bool m_noPrivateKeys;
         #endregion
     }
@@ -307,10 +308,15 @@ namespace Opc.Ua
         /// </summary>
         /// <param name="storeTypeName"></param>
         /// <returns></returns>
-        public static ICertificateStoreType GetCertificateStoreTypeByName(string storeTypeName)
+        public static ICertificateStoreType? GetCertificateStoreTypeByName(string? storeTypeName)
         {
-            ICertificateStoreType result;
-            s_registeredStoreTypes.TryGetValue(storeTypeName, out result);
+            if (string.IsNullOrEmpty(storeTypeName))
+            {
+                return null;
+            }
+
+            ICertificateStoreType? result;
+            s_registeredStoreTypes.TryGetValue(storeTypeName!, out result);
             return result;
         }
 

--- a/Stack/Opc.Ua.Core/Security/Certificates/CertificateTrustList.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/CertificateTrustList.cs
@@ -13,6 +13,7 @@
 using System;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
+#nullable enable
 
 namespace Opc.Ua
 {
@@ -47,13 +48,16 @@ namespace Opc.Ua
         {
             X509Certificate2Collection collection = new X509Certificate2Collection();
 
-            if (!String.IsNullOrEmpty(this.StorePath))
+            if (!string.IsNullOrEmpty(this.StorePath))
             {
-                ICertificateStore store = null;
+                ICertificateStore? store = null;
                 try
                 {
                     store = OpenStore();
-                    collection = await store.Enumerate().ConfigureAwait(false);
+                    if (store != null)
+                    {
+                        collection = await store.Enumerate().ConfigureAwait(false);
+                    }
                 }
                 catch (Exception)
                 {
@@ -68,7 +72,7 @@ namespace Opc.Ua
 
             foreach (CertificateIdentifier trustedCertificate in TrustedCertificates)
             {
-                X509Certificate2 certificate = await trustedCertificate.Find().ConfigureAwait(false);
+                X509Certificate2? certificate = await trustedCertificate.Find().ConfigureAwait(false);
 
                 if (certificate != null)
                 {

--- a/Stack/Opc.Ua.Core/Security/Certificates/CertificateTrustList.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/CertificateTrustList.cs
@@ -10,10 +10,11 @@
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 */
 
+#nullable enable
+
 using System;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
-#nullable enable
 
 namespace Opc.Ua
 {

--- a/Stack/Opc.Ua.Core/Security/Certificates/CertificateTypesProvider.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/CertificateTypesProvider.cs
@@ -27,6 +27,8 @@
  * http://opcfoundation.org/License/MIT/1.00/
  * ======================================================================*/
 
+#nullable enable
+
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -45,7 +47,12 @@ namespace Opc.Ua.Security.Certificates
         /// <summary>
         /// Disallow to create types provider without configuration.
         /// </summary>
-        private CertificateTypesProvider() { }
+        private CertificateTypesProvider()
+        {
+            m_securityConfiguration = null!;
+            m_certificateValidator = null!;
+            m_certificateChain = null!;
+        }
 
         /// <summary>
         /// Create an instance of the certificate provider.
@@ -84,12 +91,12 @@ namespace Opc.Ua.Security.Certificates
         /// Return the instance certificate for a security policy.
         /// </summary>
         /// <param name="securityPolicyUri">The security policy Uri</param>
-        public X509Certificate2 GetInstanceCertificate(string securityPolicyUri)
+        public X509Certificate2? GetInstanceCertificate(string securityPolicyUri)
         {
             if (securityPolicyUri == SecurityPolicies.None)
             {
                 // return the default certificate for None
-                return m_securityConfiguration.ApplicationCertificates.FirstOrDefault().Certificate;
+                return m_securityConfiguration.ApplicationCertificates.FirstOrDefault()?.Certificate;
             }
             var certificateTypes = Opc.Ua.CertificateIdentifier.MapSecurityPolicyToCertificateTypes(securityPolicyUri);
             foreach (var certType in certificateTypes)
@@ -122,7 +129,7 @@ namespace Opc.Ua.Security.Certificates
         /// Loads the cached certificate chain blob of a certificate for use in a secure channel as raw byte array from cache.
         /// </summary>
         /// <param name="certificate">The application certificate.</param>
-        public byte[] LoadCertificateChainRaw(X509Certificate2 certificate)
+        public byte[]? LoadCertificateChainRaw(X509Certificate2 certificate)
         {
             if (certificate == null)
             {
@@ -141,7 +148,7 @@ namespace Opc.Ua.Security.Certificates
         /// Loads the certificate chain for an application certificate.
         /// </summary>
         /// <param name="certificate">The application certificate.</param>
-        public async Task<X509Certificate2Collection> LoadCertificateChainAsync(X509Certificate2 certificate)
+        public async Task<X509Certificate2Collection?> LoadCertificateChainAsync(X509Certificate2 certificate)
         {
             if (certificate == null)
             {
@@ -160,7 +167,10 @@ namespace Opc.Ua.Security.Certificates
             {
                 for (int i = 0; i < issuers.Count; i++)
                 {
-                    certificateChain.Add(issuers[i].Certificate);
+                    if (issuers[i]?.Certificate != null)
+                    {
+                        certificateChain.Add(issuers[i].Certificate!);
+                    }
                 }
             }
 
@@ -177,7 +187,7 @@ namespace Opc.Ua.Security.Certificates
         /// Loads the certificate chain for an application certificate from cache.
         /// </summary>
         /// <param name="certificate">The application certificate.</param>
-        public X509Certificate2Collection LoadCertificateChain(X509Certificate2 certificate)
+        public X509Certificate2Collection? LoadCertificateChain(X509Certificate2 certificate)
         {
             if (certificate == null)
             {

--- a/Stack/Opc.Ua.Core/Security/Certificates/CertificateValidator.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/CertificateValidator.cs
@@ -10,6 +10,8 @@
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 */
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -180,7 +182,7 @@ namespace Opc.Ua
         /// <summary>
         /// Updates the validator with the current state of the configuration.
         /// </summary>
-        public virtual async Task UpdateAsync(SecurityConfiguration configuration, string applicationUri = null)
+        public virtual async Task UpdateAsync(SecurityConfiguration configuration, string? applicationUri = null)
         {
             if (configuration == null)
             {
@@ -226,7 +228,7 @@ namespace Opc.Ua
                 {
                     foreach (var applicationCertificate in configuration.ApplicationCertificates)
                     {
-                        X509Certificate2 certificate = await applicationCertificate.Find(true, applicationUri).ConfigureAwait(false);
+                        X509Certificate2? certificate = await applicationCertificate.Find(true, applicationUri).ConfigureAwait(false);
                         if (certificate == null)
                         {
                             Utils.Trace(Utils.TraceMasks.Security, "Could not find application certificate: {0}", applicationCertificate);
@@ -251,7 +253,7 @@ namespace Opc.Ua
         /// <summary>
         /// Updates the validator with a new application certificate.
         /// </summary>
-        public virtual async Task UpdateCertificateAsync(SecurityConfiguration securityConfiguration, string applicationUri = null)
+        public virtual async Task UpdateCertificateAsync(SecurityConfiguration securityConfiguration, string? applicationUri = null)
         {
             await m_semaphore.WaitAsync().ConfigureAwait(false);
 
@@ -508,7 +510,7 @@ namespace Opc.Ua
         /// Validates a certificate with domain validation check.
         /// <see cref="ValidateAsync(X509Certificate2Collection, CancellationToken)"/>
         /// </summary>
-        public virtual async Task ValidateAsync(X509Certificate2Collection chain, ConfiguredEndpoint endpoint, CancellationToken ct)
+        public virtual async Task ValidateAsync(X509Certificate2Collection chain, ConfiguredEndpoint? endpoint, CancellationToken ct)
         {
             X509Certificate2 certificate = chain[0];
 
@@ -552,7 +554,7 @@ namespace Opc.Ua
         /// Validates a certificate with domain validation check.
         /// <see cref="Validate(X509Certificate2Collection)"/>
         /// </summary>
-        public virtual void Validate(X509Certificate2Collection chain, ConfiguredEndpoint endpoint)
+        public virtual void Validate(X509Certificate2Collection chain, ConfiguredEndpoint? endpoint)
         {
             X509Certificate2 certificate = chain[0];
 
@@ -597,12 +599,12 @@ namespace Opc.Ua
         /// Returns the issuers for the certificates.
         /// </summary>
         public async Task<bool> GetIssuersNoExceptionsOnGetIssuer(X509Certificate2Collection certificates,
-            List<CertificateIdentifier> issuers, Dictionary<X509Certificate2, ServiceResultException> validationErrors)
+            List<CertificateIdentifier> issuers, Dictionary<X509Certificate2, ServiceResultException?>? validationErrors)
         {
             bool isTrusted = false;
-            CertificateIdentifier issuer = null;
-            ServiceResultException revocationStatus = null;
-            X509Certificate2 certificate = certificates[0];
+            CertificateIdentifier? issuer = null;
+            ServiceResultException? revocationStatus = null;
+            X509Certificate2? certificate = certificates[0];
 
             CertificateIdentifierCollection untrustedCollection = new CertificateIdentifierCollection();
             for (int ii = 1; ii < certificates.Count; ii++)
@@ -612,6 +614,11 @@ namespace Opc.Ua
 
             do
             {
+                if (certificate == null)
+                {
+                    break;
+                }
+
                 // check for root.
                 if (X509Utils.IsSelfSigned(certificate))
                 {
@@ -734,9 +741,9 @@ namespace Opc.Ua
 
             // invoke callback.
             bool accept = false;
-            string applicationErrorMsg = string.Empty;
+            string? applicationErrorMsg = string.Empty;
 
-            ServiceResult serviceResult = se.Result;
+            ServiceResult? serviceResult = se.Result;
             lock (m_callbackLock)
             {
                 do
@@ -865,15 +872,18 @@ namespace Opc.Ua
                 {
                     Utils.LogTrace("Writing rejected certificate chain to: {0}", rejectedCertificateStore);
 
-                    ICertificateStore store = rejectedCertificateStore.OpenStore();
+                    ICertificateStore? store = rejectedCertificateStore.OpenStore();
                     try
                     {
-                        // number of certs for history + current chain
-                        await store.AddRejected(certificateChain, m_maxRejectedCertificates).ConfigureAwait(false);
+                        if (store != null)
+                        {
+                            // number of certs for history + current chain
+                            await store.AddRejected(certificateChain, m_maxRejectedCertificates).ConfigureAwait(false);
+                        }
                     }
                     finally
                     {
-                        store.Close();
+                        store?.Close();
                     }
                 }
                 finally
@@ -890,14 +900,14 @@ namespace Opc.Ua
         /// <summary>
         /// Returns the certificate information for a trusted peer certificate.
         /// </summary>
-        private async Task<CertificateIdentifier> GetTrustedCertificateAsync(X509Certificate2 certificate)
+        private async Task<CertificateIdentifier?> GetTrustedCertificateAsync(X509Certificate2 certificate)
         {
             // check if explicitly trusted.
             if (m_trustedCertificateList != null)
             {
                 for (int ii = 0; ii < m_trustedCertificateList.Count; ii++)
                 {
-                    X509Certificate2 trusted = await m_trustedCertificateList[ii].Find(false).ConfigureAwait(false);
+                    X509Certificate2? trusted = await m_trustedCertificateList[ii].Find(false).ConfigureAwait(false);
 
                     if (trusted != null && trusted.Thumbprint == certificate.Thumbprint)
                     {
@@ -912,7 +922,7 @@ namespace Opc.Ua
             // check if in peer trust store.
             if (m_trustedCertificateStore != null)
             {
-                ICertificateStore store = m_trustedCertificateStore.OpenStore();
+                ICertificateStore? store = m_trustedCertificateStore.OpenStore();
                 if (store != null)
                 {
                     try
@@ -944,8 +954,8 @@ namespace Opc.Ua
         private bool Match(
             X509Certificate2 certificate,
             X500DistinguishedName subjectName,
-            string serialNumber,
-            string authorityKeyId)
+            string? serialNumber,
+            string? authorityKeyId)
         {
             bool check = false;
 
@@ -993,21 +1003,21 @@ namespace Opc.Ua
         /// <summary>
         /// Returns the certificate information for a trusted issuer certificate.
         /// </summary>
-        private async Task<(CertificateIdentifier, ServiceResultException)> GetIssuerNoExceptionAsync(
+        private async Task<(CertificateIdentifier?, ServiceResultException?)> GetIssuerNoExceptionAsync(
             X509Certificate2 certificate,
-            CertificateIdentifierCollection explicitList,
-            CertificateStoreIdentifier certificateStore,
+            CertificateIdentifierCollection? explicitList,
+            CertificateStoreIdentifier? certificateStore,
             bool checkRecovationStatus)
         {
-            ServiceResultException serviceResult = null;
+            ServiceResultException? serviceResult = null;
 
 #if DEBUG // check if not self-signed, tested in outer loop
             Debug.Assert(!X509Utils.IsSelfSigned(certificate));
 #endif
 
             X500DistinguishedName subjectName = certificate.IssuerName;
-            string keyId = null;
-            string serialNumber = null;
+            string? keyId = null;
+            string? serialNumber = null;
 
             // find the authority key identifier.
             var authority = X509Extensions.FindExtension<Security.Certificates.X509AuthorityKeyIdentifierExtension>(certificate);
@@ -1022,7 +1032,7 @@ namespace Opc.Ua
             {
                 for (int ii = 0; ii < explicitList.Count; ii++)
                 {
-                    X509Certificate2 issuer = await explicitList[ii].Find(false).ConfigureAwait(false);
+                    X509Certificate2? issuer = await explicitList[ii].Find(false).ConfigureAwait(false);
 
                     if (issuer != null)
                     {
@@ -1043,68 +1053,72 @@ namespace Opc.Ua
             // check in certificate store.
             if (certificateStore != null)
             {
-                ICertificateStore store = certificateStore.OpenStore();
+                ICertificateStore? store = certificateStore.OpenStore();
 
-                try
+                if (store != null)
                 {
-                    X509Certificate2Collection certificates = await store.Enumerate().ConfigureAwait(false);
 
-                    for (int ii = 0; ii < certificates.Count; ii++)
+                    try
                     {
-                        X509Certificate2 issuer = certificates[ii];
+                        X509Certificate2Collection certificates = await store.Enumerate().ConfigureAwait(false);
 
-                        if (issuer != null)
+                        for (int ii = 0; ii < certificates.Count; ii++)
                         {
-                            if (!X509Utils.IsIssuerAllowed(issuer))
-                            {
-                                continue;
-                            }
+                            X509Certificate2 issuer = certificates[ii];
 
-                            if (Match(issuer, subjectName, serialNumber, keyId))
+                            if (issuer != null)
                             {
-                                CertificateValidationOptions options = certificateStore.ValidationOptions;
-
-                                if (checkRecovationStatus)
+                                if (!X509Utils.IsIssuerAllowed(issuer))
                                 {
-                                    StatusCode status = await store.IsRevoked(issuer, certificate).ConfigureAwait(false);
+                                    continue;
+                                }
 
-                                    if (StatusCode.IsBad(status) && status != StatusCodes.BadNotSupported)
+                                if (Match(issuer, subjectName, serialNumber, keyId))
+                                {
+                                    CertificateValidationOptions options = certificateStore.ValidationOptions;
+
+                                    if (checkRecovationStatus)
                                     {
-                                        if (status == StatusCodes.BadCertificateRevocationUnknown)
-                                        {
-                                            if (X509Utils.IsCertificateAuthority(certificate))
-                                            {
-                                                status.Code = StatusCodes.BadCertificateIssuerRevocationUnknown;
-                                            }
+                                        StatusCode status = await store.IsRevoked(issuer, certificate).ConfigureAwait(false);
 
-                                            if (m_rejectUnknownRevocationStatus &&
-                                                (options & CertificateValidationOptions.SuppressRevocationStatusUnknown) == 0)
+                                        if (StatusCode.IsBad(status) && status != StatusCodes.BadNotSupported)
+                                        {
+                                            if (status == StatusCodes.BadCertificateRevocationUnknown)
                                             {
+                                                if (X509Utils.IsCertificateAuthority(certificate))
+                                                {
+                                                    status.Code = StatusCodes.BadCertificateIssuerRevocationUnknown;
+                                                }
+
+                                                if (m_rejectUnknownRevocationStatus &&
+                                                    (options & CertificateValidationOptions.SuppressRevocationStatusUnknown) == 0)
+                                                {
+                                                    serviceResult = new ServiceResultException(status);
+                                                }
+                                            }
+                                            else
+                                            {
+                                                if (status == StatusCodes.BadCertificateRevoked && X509Utils.IsCertificateAuthority(certificate))
+                                                {
+                                                    status.Code = StatusCodes.BadCertificateIssuerRevoked;
+                                                }
                                                 serviceResult = new ServiceResultException(status);
                                             }
                                         }
-                                        else
-                                        {
-                                            if (status == StatusCodes.BadCertificateRevoked && X509Utils.IsCertificateAuthority(certificate))
-                                            {
-                                                status.Code = StatusCodes.BadCertificateIssuerRevoked;
-                                            }
-                                            serviceResult = new ServiceResultException(status);
-                                        }
                                     }
+
+                                    // already checked revocation for file based stores. windows based stores always suppress.
+                                    options |= CertificateValidationOptions.SuppressRevocationStatusUnknown;
+
+                                    return (new CertificateIdentifier(issuer, options), serviceResult);
                                 }
-
-                                // already checked revocation for file based stores. windows based stores always suppress.
-                                options |= CertificateValidationOptions.SuppressRevocationStatusUnknown;
-
-                                return (new CertificateIdentifier(issuer, options), serviceResult);
                             }
                         }
                     }
-                }
-                finally
-                {
-                    store.Close();
+                    finally
+                    {
+                        store?.Close();
+                    }
                 }
             }
 
@@ -1115,10 +1129,10 @@ namespace Opc.Ua
         /// <summary>
         /// Returns the certificate information for a trusted issuer certificate.
         /// </summary>
-        private async Task<CertificateIdentifier> GetIssuer(
+        private async Task<CertificateIdentifier?> GetIssuer(
             X509Certificate2 certificate,
-            CertificateIdentifierCollection explicitList,
-            CertificateStoreIdentifier certificateStore,
+            CertificateIdentifierCollection? explicitList,
+            CertificateStoreIdentifier? certificateStore,
             bool checkRecovationStatus)
         {
             // check for root.
@@ -1127,7 +1141,7 @@ namespace Opc.Ua
                 return null;
             }
 
-            (CertificateIdentifier result, ServiceResultException srex) =
+            (CertificateIdentifier? result, ServiceResultException? srex) =
                 await GetIssuerNoExceptionAsync(certificate, explicitList, certificateStore, checkRecovationStatus
                 ).ConfigureAwait(false);
             if (srex != null)
@@ -1145,12 +1159,12 @@ namespace Opc.Ua
         /// <param name="ct">The cancellation token.</param>
         /// <exception cref="ServiceResultException">If certificate[0] cannot be accepted</exception>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Roslynanalyzer", "IA5352:Do not set X509RevocationMode.NoCheck", Justification = "Revocation is already checked.")]
-        protected virtual async Task InternalValidateAsync(X509Certificate2Collection certificates, ConfiguredEndpoint endpoint, CancellationToken ct = default)
+        protected virtual async Task InternalValidateAsync(X509Certificate2Collection certificates, ConfiguredEndpoint? endpoint, CancellationToken ct = default)
         {
             X509Certificate2 certificate = certificates[0];
 
             // check for previously validated certificate.
-            X509Certificate2 certificate2 = null;
+            X509Certificate2? certificate2 = null;
 
             if (m_useValidatedCertificates &&
                 m_validatedCertificates.TryGetValue(certificate.Thumbprint, out certificate2))
@@ -1161,15 +1175,15 @@ namespace Opc.Ua
                 }
             }
 
-            CertificateIdentifier trustedCertificate = await GetTrustedCertificateAsync(certificate).ConfigureAwait(false);
+            CertificateIdentifier? trustedCertificate = await GetTrustedCertificateAsync(certificate).ConfigureAwait(false);
 
             // get the issuers (checks the revocation lists if using directory stores).
             List<CertificateIdentifier> issuers = new List<CertificateIdentifier>();
-            Dictionary<X509Certificate2, ServiceResultException> validationErrors = new Dictionary<X509Certificate2, ServiceResultException>();
+            Dictionary<X509Certificate2, ServiceResultException?> validationErrors = new Dictionary<X509Certificate2, ServiceResultException?>();
 
             bool isIssuerTrusted = await GetIssuersNoExceptionsOnGetIssuer(certificates, issuers, validationErrors).ConfigureAwait(false);
 
-            ServiceResult sresult = PopulateSresultWithValidationErrors(validationErrors);
+            ServiceResult? sresult = PopulateSresultWithValidationErrors(validationErrors);
 
             // setup policy chain
             X509ChainPolicy policy = new X509ChainPolicy() {
@@ -1194,7 +1208,10 @@ namespace Opc.Ua
 
                 // we did the revocation check in the GetIssuers call. No need here.
                 policy.RevocationMode = X509RevocationMode.NoCheck;
-                policy.ExtraStore.Add(issuer.Certificate);
+                if (issuer.Certificate != null)
+                {
+                    policy.ExtraStore.Add(issuer.Certificate);
+                }
             }
 
             // build chain.
@@ -1205,7 +1222,7 @@ namespace Opc.Ua
                 chain.Build(certificate);
 
                 // check the chain results.
-                CertificateIdentifier target = trustedCertificate;
+                CertificateIdentifier? target = trustedCertificate;
 
                 if (target == null)
                 {
@@ -1281,7 +1298,7 @@ namespace Opc.Ua
                 {
                     X509ChainElement element = chain.ChainElements[ii];
 
-                    CertificateIdentifier issuer = null;
+                    CertificateIdentifier? issuer = null;
 
                     if (ii < issuers.Count)
                     {
@@ -1308,7 +1325,7 @@ namespace Opc.Ua
                     {
                         foreach (X509ChainStatus status in element.ChainElementStatus)
                         {
-                            ServiceResult result = CheckChainStatus(status, target, issuer, (ii != 0));
+                            ServiceResult? result = CheckChainStatus(status, target, issuer, (ii != 0));
                             if (ServiceResult.IsBad(result))
                             {
                                 sresult = new ServiceResult(result, sresult);
@@ -1376,7 +1393,7 @@ namespace Opc.Ua
                 }
             }
 
-            Uri endpointUrl = endpoint?.EndpointUrl;
+            Uri? endpointUrl = endpoint?.EndpointUrl;
             if (endpointUrl != null && !FindDomain(certificate, endpointUrl))
             {
                 string message = Utils.Format(
@@ -1454,15 +1471,15 @@ namespace Opc.Ua
             }
         }
 
-        private ServiceResult PopulateSresultWithValidationErrors(Dictionary<X509Certificate2, ServiceResultException> validationErrors)
+        private ServiceResult? PopulateSresultWithValidationErrors(Dictionary<X509Certificate2, ServiceResultException?> validationErrors)
         {
             Dictionary<X509Certificate2, ServiceResultException> p1List = new Dictionary<X509Certificate2, ServiceResultException>();
             Dictionary<X509Certificate2, ServiceResultException> p2List = new Dictionary<X509Certificate2, ServiceResultException>();
             Dictionary<X509Certificate2, ServiceResultException> p3List = new Dictionary<X509Certificate2, ServiceResultException>();
 
-            ServiceResult sresult = null;
+            ServiceResult? sresult = null;
 
-            foreach (KeyValuePair<X509Certificate2, ServiceResultException> kvp in validationErrors)
+            foreach (KeyValuePair<X509Certificate2, ServiceResultException?> kvp in validationErrors)
             {
                 if (kvp.Value != null)
                 {
@@ -1558,7 +1575,7 @@ namespace Opc.Ua
             if (!serverValidation)
             {
                 if (m_useValidatedCertificates &&
-                    m_validatedCertificates.TryGetValue(serverCertificate.Thumbprint, out X509Certificate2 certificate2))
+                    m_validatedCertificates.TryGetValue(serverCertificate.Thumbprint, out X509Certificate2? certificate2))
                 {
                     if (Utils.IsEqual(certificate2.RawData, serverCertificate.RawData))
                     {
@@ -1567,7 +1584,7 @@ namespace Opc.Ua
                 }
             }
 
-            Uri endpointUrl = endpoint?.EndpointUrl;
+            Uri? endpointUrl = endpoint?.EndpointUrl;
             if (endpointUrl != null && !FindDomain(serverCertificate, endpointUrl))
             {
                 bool accept = false;
@@ -1605,7 +1622,7 @@ namespace Opc.Ua
         /// Returns an error if the chain status elements indicate an error.
         /// </summary>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1502:AvoidExcessiveComplexity")]
-        private static ServiceResult CheckChainStatus(X509ChainStatus status, CertificateIdentifier id, CertificateIdentifier issuer, bool isIssuer)
+        private static ServiceResult? CheckChainStatus(X509ChainStatus status, CertificateIdentifier id, CertificateIdentifier? issuer, bool isIssuer)
         {
             switch (status.Status)
             {
@@ -1871,7 +1888,7 @@ namespace Opc.Ua
         /// <param name="requiredKeySizeInBits">The required key size in bits.</param>
         public static bool IsECSecureForProfile(X509Certificate2 certificate, int requiredKeySizeInBits)
         {
-            using (ECDsa ecdsa = certificate.GetECDsaPublicKey())
+            using (ECDsa? ecdsa = certificate.GetECDsaPublicKey())
             {
                 if (ecdsa == null)
                 {
@@ -1886,7 +1903,7 @@ namespace Opc.Ua
                 {
                     ECCurve curve = ecdsa.ExportParameters(false).Curve;
 
-                    if (curve.IsNamed)
+                    if (curve.IsNamed && curve.Oid.Value != null)
                     {
                         if (NamedCurveBitSizes.TryGetValue(curve.Oid.Value, out int curveSize))
                         {
@@ -1903,7 +1920,7 @@ namespace Opc.Ua
             }
         }
 #endif
-#endregion
+        #endregion
 
         #region Private Enum
         /// <summary>
@@ -1926,13 +1943,13 @@ namespace Opc.Ua
         private readonly SemaphoreSlim m_semaphore = new SemaphoreSlim(1, 1);
         private readonly object m_callbackLock = new object();
         private readonly Dictionary<string, X509Certificate2> m_validatedCertificates;
-        private CertificateStoreIdentifier m_trustedCertificateStore;
-        private CertificateIdentifierCollection m_trustedCertificateList;
-        private CertificateStoreIdentifier m_issuerCertificateStore;
-        private CertificateIdentifierCollection m_issuerCertificateList;
-        private CertificateStoreIdentifier m_rejectedCertificateStore;
-        private event CertificateValidationEventHandler m_CertificateValidation;
-        private event CertificateUpdateEventHandler m_CertificateUpdate;
+        private CertificateStoreIdentifier? m_trustedCertificateStore;
+        private CertificateIdentifierCollection? m_trustedCertificateList;
+        private CertificateStoreIdentifier? m_issuerCertificateStore;
+        private CertificateIdentifierCollection? m_issuerCertificateList;
+        private CertificateStoreIdentifier? m_rejectedCertificateStore;
+        private event CertificateValidationEventHandler? m_CertificateValidation;
+        private event CertificateUpdateEventHandler? m_CertificateUpdate;
         private List<X509Certificate2> m_applicationCertificates;
         private ProtectFlags m_protectFlags;
         private bool m_autoAcceptUntrustedCertificates;
@@ -1995,7 +2012,7 @@ namespace Opc.Ua
         /// <summary>
         /// The custom error message from the application.
         /// </summary>
-        public string ApplicationErrorMsg
+        public string? ApplicationErrorMsg
         {
             get { return m_applicationErrorMsg; }
             set { m_applicationErrorMsg = value; }
@@ -2007,7 +2024,7 @@ namespace Opc.Ua
         private readonly X509Certificate2 m_certificate;
         private bool m_accept;
         private bool m_acceptAll;
-        private string m_applicationErrorMsg;
+        private string? m_applicationErrorMsg;
         #endregion
     }
 

--- a/Stack/Opc.Ua.Core/Security/Certificates/DirectoryCertificateStore.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/DirectoryCertificateStore.cs
@@ -10,6 +10,8 @@
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 */
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -87,10 +89,7 @@ namespace Opc.Ua
         /// <summary>
         /// The directory containing the certificate store.
         /// </summary>
-        public DirectoryInfo Directory
-        {
-            get { return m_directory; }
-        }
+        public DirectoryInfo? Directory => m_directory;
         #endregion
 
         #region ICertificateStore Members
@@ -138,7 +137,7 @@ namespace Opc.Ua
         public string StoreType => CertificateStoreType.Directory;
 
         /// <inheritdoc/>
-        public string StorePath { get; private set; }
+        public string? StorePath { get; private set; }
 
         /// <inheritdoc/>
         public bool NoPrivateKeys { get; private set; }
@@ -168,16 +167,16 @@ namespace Opc.Ua
         }
 
         /// <inheritdoc/>
-        public Task Add(X509Certificate2 certificate, string password = null)
+        public Task Add(X509Certificate2 certificate, string? password = null)
         {
             if (certificate == null) throw new ArgumentNullException(nameof(certificate));
 
             lock (m_lock)
             {
-                byte[] data = null;
+                byte[]? data = null;
 
                 // check for certificate file.
-                Entry entry = Find(certificate.Thumbprint);
+                Entry? entry = Find(certificate.Thumbprint);
 
                 if (entry != null)
                 {
@@ -233,7 +232,7 @@ namespace Opc.Ua
                         break;
                     }
 
-                    if (m_certificates.TryGetValue(certificate.Thumbprint, out Entry entry))
+                    if (m_certificates.TryGetValue(certificate.Thumbprint, out Entry? entry))
                     {
                         entry.LastWriteTimeUtc = now;
                     }
@@ -243,7 +242,7 @@ namespace Opc.Ua
                         string fileName = GetFileName(certificate);
 
                         // store is created if it does not exist
-                        var fileInfo = WriteFile(certificate.RawData, fileName, false, true);
+                        FileInfo? fileInfo = WriteFile(certificate.RawData, fileName, false, true);
 
                         // add entry
                         entry = new Entry {
@@ -265,8 +264,11 @@ namespace Opc.Ua
                 {
                     if (++entries > maxCertificates)
                     {
-                        m_certificates.Remove(entry.Certificate.Thumbprint);
-                        deleteEntryList.Add(entry);
+                        if (entry.Certificate?.Thumbprint != null)
+                        {
+                            m_certificates.Remove(entry.Certificate.Thumbprint);
+                            deleteEntryList.Add(entry);
+                        }
                     }
                 }
             }
@@ -277,7 +279,7 @@ namespace Opc.Ua
                 try
                 {
                     // try to delete 
-                    entry.CertificateFile.Delete();
+                    entry.CertificateFile?.Delete();
                 }
                 catch (IOException)
                 {
@@ -307,7 +309,7 @@ namespace Opc.Ua
             {
                 lock (m_lock)
                 {
-                    Entry entry = Find(thumbprint);
+                    Entry? entry = Find(thumbprint);
                     try
                     {
                         if (entry != null)
@@ -356,9 +358,9 @@ namespace Opc.Ua
 
             lock (m_lock)
             {
-                Entry entry = Find(thumbprint);
+                Entry? entry = Find(thumbprint);
 
-                if (entry != null)
+                if (entry != null && entry.Certificate != null)
                 {
                     if (entry.CertificateWithPrivateKey != null)
                     {
@@ -379,9 +381,9 @@ namespace Opc.Ua
         /// </summary>
         /// <param name="thumbprint">The thumbprint of the certificate.</param>
         /// <returns>The path.</returns>
-        public string GetPublicKeyFilePath(string thumbprint)
+        public string? GetPublicKeyFilePath(string thumbprint)
         {
-            Entry entry = Find(thumbprint);
+            Entry? entry = Find(thumbprint);
 
             if (entry == null)
             {
@@ -401,9 +403,9 @@ namespace Opc.Ua
         /// </summary>
         /// <param name="thumbprint">The thumbprint of the certificate.</param>
         /// <returns>The path.</returns>
-        public string GetPrivateKeyFilePath(string thumbprint)
+        public string? GetPrivateKeyFilePath(string thumbprint)
         {
-            Entry entry = Find(thumbprint);
+            Entry? entry = Find(thumbprint);
 
             if (entry == null)
             {
@@ -425,7 +427,7 @@ namespace Opc.Ua
         /// Loads the private key certificate with RSA signature from a PFX file in the certificate store.
         /// </summary>
         [Obsolete("Method is deprecated. Use only for RSA certificates, the replacing LoadPrivateKey with certificateType parameter should be used.")]
-        public Task<X509Certificate2> LoadPrivateKey(string thumbprint, string subjectName, string password)
+        public Task<X509Certificate2?> LoadPrivateKey(string? thumbprint, string? subjectName, string? password)
         {
             return LoadPrivateKey(thumbprint, subjectName, null, null, password);
         }
@@ -433,7 +435,7 @@ namespace Opc.Ua
         /// <summary>
         /// Loads the private key from a PFX file in the certificate store.
         /// </summary>
-        public async Task<X509Certificate2> LoadPrivateKey(string thumbprint, string subjectName, string applicationUri, NodeId certificateType, string password)
+        public async Task<X509Certificate2?> LoadPrivateKey(string? thumbprint, string? subjectName, string? applicationUri, NodeId? certificateType, string? password)
         {
             if (NoPrivateKeys || m_privateKeySubdir == null ||
                 m_certificateSubdir == null || !m_certificateSubdir.Exists)
@@ -453,7 +455,7 @@ namespace Opc.Ua
             while (retryCounter-- > 0)
             {
                 bool certificateFound = false;
-                Exception importException = null;
+                Exception? importException = null;
                 foreach (FileInfo file in m_certificateSubdir.GetFiles("*" + kCertExtension))
                 {
                     try
@@ -621,13 +623,14 @@ namespace Opc.Ua
             }
 
             // check for CRL.
-            if (m_crlSubdir.Exists)
+            m_crlSubdir?.Refresh();
+            if (m_crlSubdir?.Exists == true)
             {
                 bool crlExpired = true;
 
                 foreach (FileInfo file in m_crlSubdir.GetFiles("*" + kCrlExtension))
                 {
-                    X509CRL crl = null;
+                    X509CRL? crl = null;
 
                     try
                     {
@@ -680,8 +683,8 @@ namespace Opc.Ua
             var crls = new X509CRLCollection();
 
             // check for CRL.
-            m_crlSubdir.Refresh();
-            if (m_crlSubdir.Exists)
+            m_crlSubdir?.Refresh();
+            if (m_crlSubdir?.Exists == true)
             {
                 foreach (FileInfo file in m_crlSubdir.GetFiles("*" + kCrlExtension))
                 {
@@ -740,8 +743,8 @@ namespace Opc.Ua
                 throw new ArgumentNullException(nameof(crl));
             }
 
-            X509Certificate2 issuer = null;
-            X509Certificate2Collection certificates = null;
+            X509Certificate2? issuer = null;
+            X509Certificate2Collection? certificates = null;
             certificates = await Enumerate().ConfigureAwait(false);
             foreach (X509Certificate2 certificate in certificates)
             {
@@ -760,13 +763,18 @@ namespace Opc.Ua
                 throw new ServiceResultException(StatusCodes.BadCertificateInvalid, "Could not find issuer of the CRL.");
             }
 
+            if (m_crlSubdir == null)
+            {
+                throw new InvalidOperationException("Store Path is not initialized");
+            }
+
             var builder = new StringBuilder();
             builder.Append(m_crlSubdir.FullName).Append(Path.DirectorySeparatorChar);
             builder.Append(GetFileName(issuer)).Append(kCrlExtension);
 
             var fileInfo = new FileInfo(builder.ToString());
 
-            if (!fileInfo.Directory.Exists)
+            if (!fileInfo!.Directory!.Exists)
             {
                 fileInfo.Directory.Create();
             }
@@ -782,8 +790,8 @@ namespace Opc.Ua
                 throw new ArgumentNullException(nameof(crl));
             }
 
-            m_crlSubdir.Refresh();
-            if (m_crlSubdir.Exists)
+            m_crlSubdir?.Refresh();
+            if (m_crlSubdir?.Exists == true)
             {
                 foreach (FileInfo fileInfo in m_crlSubdir.GetFiles("*" + kCrlExtension))
                 {
@@ -808,7 +816,7 @@ namespace Opc.Ua
         /// <summary>
         /// Reads the current contents of the directory from disk.
         /// </summary>
-        private IDictionary<string, Entry> Load(string thumbprint)
+        private IDictionary<string, Entry> Load(string? thumbprint)
         {
             lock (m_lock)
             {
@@ -859,7 +867,7 @@ namespace Opc.Ua
                             string fileRoot = file.Name.Substring(0, entry.CertificateFile.Name.Length - entry.CertificateFile.Extension.Length);
 
                             var filePath = new StringBuilder()
-                                .Append(m_privateKeySubdir.FullName)
+                                .Append(m_privateKeySubdir!.FullName)
                                 .Append(Path.DirectorySeparatorChar)
                                 .Append(fileRoot);
 
@@ -882,8 +890,8 @@ namespace Opc.Ua
 
                         m_certificates[entry.Certificate.Thumbprint] = entry;
 
-                        if (!String.IsNullOrEmpty(thumbprint) &&
-                            thumbprint.Equals(entry.Certificate.Thumbprint, StringComparison.OrdinalIgnoreCase))
+                        if (!string.IsNullOrEmpty(thumbprint) &&
+                            thumbprint!.Equals(entry.Certificate.Thumbprint, StringComparison.OrdinalIgnoreCase))
                         {
                             incompleteSearch = true;
                             break;
@@ -907,11 +915,11 @@ namespace Opc.Ua
         /// <summary>
         /// Finds the public key for the certificate.
         /// </summary>
-        private Entry Find(string thumbprint)
+        private Entry? Find(string thumbprint)
         {
             IDictionary<string, Entry> certificates = Load(thumbprint);
 
-            Entry entry = null;
+            Entry? entry = null;
 
             if (!String.IsNullOrEmpty(thumbprint))
             {
@@ -984,9 +992,14 @@ namespace Opc.Ua
         /// <summary>
         /// Writes the data to a file.
         /// </summary>
-        private FileInfo WriteFile(byte[] data, string fileName, bool includePrivateKey, bool allowOverride = false)
+        private FileInfo? WriteFile(byte[] data, string fileName, bool includePrivateKey, bool allowOverride = false)
         {
             var filePath = new StringBuilder();
+
+            if (m_directory == null || m_certificateSubdir == null)
+            {
+                throw new InvalidOperationException("Store Path is not initialized");
+            }
 
             if (!m_directory.Exists)
             {
@@ -1020,8 +1033,8 @@ namespace Opc.Ua
             }
 
             // create the directory.
-            var fileInfo = new FileInfo(filePath.ToString());
-            if (!fileInfo.Directory.Exists)
+            FileInfo fileInfo = new FileInfo(filePath.ToString());
+            if (!fileInfo!.Directory!.Exists)
             {
                 fileInfo.Directory.Create();
             }
@@ -1039,7 +1052,7 @@ namespace Opc.Ua
                 writer.Dispose();
             }
 
-            m_certificateSubdir.Refresh();
+            m_certificateSubdir?.Refresh();
             m_privateKeySubdir?.Refresh();
 
             return fileInfo;
@@ -1049,10 +1062,10 @@ namespace Opc.Ua
         #region Private Class
         private class Entry
         {
-            public FileInfo CertificateFile;
-            public X509Certificate2 Certificate;
-            public FileInfo PrivateKeyFile;
-            public X509Certificate2 CertificateWithPrivateKey;
+            public FileInfo? CertificateFile;
+            public X509Certificate2? Certificate;
+            public FileInfo? PrivateKeyFile;
+            public X509Certificate2? CertificateWithPrivateKey;
             public DateTime LastWriteTimeUtc;
         }
         #endregion
@@ -1060,10 +1073,10 @@ namespace Opc.Ua
         #region Private Fields
         private readonly object m_lock = new object();
         private bool m_noSubDirs;
-        private DirectoryInfo m_directory;
-        private DirectoryInfo m_certificateSubdir;
-        private DirectoryInfo m_crlSubdir;
-        private DirectoryInfo m_privateKeySubdir;
+        private DirectoryInfo? m_directory;
+        private DirectoryInfo? m_certificateSubdir;
+        private DirectoryInfo? m_crlSubdir;
+        private DirectoryInfo? m_privateKeySubdir;
         private Dictionary<string, Entry> m_certificates;
         private DateTime m_lastDirectoryCheck;
         #endregion

--- a/Stack/Opc.Ua.Core/Security/Certificates/EncryptedData.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/EncryptedData.cs
@@ -10,6 +10,8 @@
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 */
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Xml;
@@ -26,7 +28,7 @@ namespace Opc.Ua
         /// <summary>
         /// The algorithm used to encrypt the data.
         /// </summary>
-        public string Algorithm
+        public string? Algorithm
         {
             get { return m_algorithm; }
             set { m_algorithm = value; }
@@ -35,7 +37,7 @@ namespace Opc.Ua
         /// <summary>
         /// The encrypted data.
         /// </summary>
-        public byte[] Data
+        public byte[]? Data
         {
             get { return m_data; }
             set { m_data = value; }
@@ -43,8 +45,8 @@ namespace Opc.Ua
         #endregion
 
         #region Private Members
-        private string m_algorithm;
-        private byte[] m_data;
+        private string? m_algorithm;
+        private byte[]? m_data;
         #endregion
     }
 }

--- a/Stack/Opc.Ua.Core/Security/Certificates/ICertificateStore.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/ICertificateStore.cs
@@ -10,6 +10,8 @@
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 */
 
+#nullable enable
+
 using System;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
@@ -45,7 +47,7 @@ namespace Opc.Ua
         /// <summary>
         /// The store path used to open the store.
         /// </summary>
-        string StorePath { get; }
+        string? StorePath { get; }
 
         /// <summary>
         /// Gets a value indicating whether any private keys are found in the store.
@@ -65,7 +67,7 @@ namespace Opc.Ua
         /// </summary>
         /// <param name="certificate">The certificate.</param>
         /// <param name="password">The certificate password.</param>
-        Task Add(X509Certificate2 certificate, string password = null);
+        Task Add(X509Certificate2 certificate, string? password = null);
 
         /// <summary>
         /// Adds a rejected certificate chain to the store.
@@ -103,7 +105,7 @@ namespace Opc.Ua
         /// <remarks>Returns always null if SupportsLoadPrivateKey returns false.</remarks>
         /// <returns>The matching certificate with private key</returns>
         [Obsolete("Method is deprecated. Use only for RSA certificates, the replacing LoadPrivateKey with certificateType parameter should be used.")]
-        Task<X509Certificate2> LoadPrivateKey(string thumbprint, string subjectName, string password);
+        Task<X509Certificate2?> LoadPrivateKey(string? thumbprint, string? subjectName, string? password);
 
         /// <summary>
         /// Finds the certificate with the specified thumbprint.
@@ -115,7 +117,7 @@ namespace Opc.Ua
         /// <param name="password">The certificate password.</param>
         /// <remarks>Returns always null if SupportsLoadPrivateKey returns false.</remarks>
         /// <returns>The matching certificate with private key</returns>
-        Task<X509Certificate2> LoadPrivateKey(string thumbprint, string subjectName, string applicationUri, NodeId certificateType, string password);
+        Task<X509Certificate2?> LoadPrivateKey(string? thumbprint, string? subjectName, string? applicationUri, NodeId? certificateType, string? password);
 
         /// <summary>
         /// Checks if issuer has revoked the certificate.

--- a/Stack/Opc.Ua.Core/Security/Certificates/ICertificateStoreType.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/ICertificateStoreType.cs
@@ -10,6 +10,8 @@
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 */
 
+#nullable enable
+
 namespace Opc.Ua
 {
     /// <summary>

--- a/Stack/Opc.Ua.Core/Security/Certificates/ICertificateValidator.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/ICertificateValidator.cs
@@ -10,6 +10,8 @@
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 */
 
+#nullable enable
+
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;

--- a/Stack/Opc.Ua.Core/Security/Certificates/RsaUtils.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/RsaUtils.cs
@@ -10,6 +10,8 @@
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 */
 
+#nullable enable
+
 using System;
 using System.IO;
 using System.Security.Cryptography;
@@ -48,7 +50,7 @@ namespace Opc.Ua
         /// </summary>
         internal static int GetPlainTextBlockSize(X509Certificate2 encryptingCertificate, Padding padding)
         {
-            using (RSA rsa = encryptingCertificate.GetRSAPublicKey())
+            using (RSA? rsa = encryptingCertificate.GetRSAPublicKey())
             {
                 return GetPlainTextBlockSize(rsa, padding);
             }
@@ -57,7 +59,7 @@ namespace Opc.Ua
         /// <summary>
         /// Return the plaintext block size for RSA OAEP encryption.
         /// </summary>
-        internal static int GetPlainTextBlockSize(RSA rsa, Padding padding)
+        internal static int GetPlainTextBlockSize(RSA? rsa, Padding padding)
         {
             if (rsa != null)
             {
@@ -76,7 +78,7 @@ namespace Opc.Ua
         /// </summary>
         internal static int GetCipherTextBlockSize(X509Certificate2 encryptingCertificate, Padding padding)
         {
-            using (RSA rsa = encryptingCertificate.GetRSAPublicKey())
+            using (RSA? rsa = encryptingCertificate.GetRSAPublicKey())
             {
                 return GetCipherTextBlockSize(rsa, padding);
             }
@@ -85,7 +87,7 @@ namespace Opc.Ua
         /// <summary>
         /// Return the ciphertext block size for RSA OAEP encryption.
         /// </summary>
-        internal static int GetCipherTextBlockSize(RSA rsa, Padding padding)
+        internal static int GetCipherTextBlockSize(RSA? rsa, Padding padding)
         {
             if (rsa != null)
             {
@@ -99,7 +101,7 @@ namespace Opc.Ua
         /// </summary>
         internal static int GetSignatureLength(X509Certificate2 signingCertificate)
         {
-            using (RSA rsa = signingCertificate.GetRSAPublicKey())
+            using (RSA? rsa = signingCertificate.GetRSAPublicKey())
             {
                 if (rsa == null)
                 {
@@ -119,7 +121,7 @@ namespace Opc.Ua
             RSASignaturePadding rsaSignaturePadding)
         {
             // extract the private key.
-            using (RSA rsa = signingCertificate.GetRSAPrivateKey())
+            using (RSA? rsa = signingCertificate.GetRSAPrivateKey())
             {
                 if (rsa == null)
                 {
@@ -127,7 +129,7 @@ namespace Opc.Ua
                 }
 
                 // create the signature.
-                return rsa.SignData(dataToSign.Array, dataToSign.Offset, dataToSign.Count, hashAlgorithm, rsaSignaturePadding);
+                return rsa.SignData(dataToSign.Array!, dataToSign.Offset, dataToSign.Count, hashAlgorithm, rsaSignaturePadding);
             }
         }
 
@@ -142,7 +144,7 @@ namespace Opc.Ua
             RSASignaturePadding rsaSignaturePadding)
         {
             // extract the public key.
-            using (RSA rsa = signingCertificate.GetRSAPublicKey())
+            using (RSA? rsa = signingCertificate.GetRSAPublicKey())
             {
                 if (rsa == null)
                 {
@@ -150,7 +152,7 @@ namespace Opc.Ua
                 }
 
                 // verify signature.
-                return rsa.VerifyData(dataToVerify.Array, dataToVerify.Offset, dataToVerify.Count, signature, hashAlgorithm, rsaSignaturePadding);
+                return rsa.VerifyData(dataToVerify.Array!, dataToVerify.Offset, dataToVerify.Count, signature, hashAlgorithm, rsaSignaturePadding);
             }
         }
 
@@ -162,7 +164,7 @@ namespace Opc.Ua
             X509Certificate2 encryptingCertificate,
             Padding padding)
         {
-            using (RSA rsa = encryptingCertificate.GetRSAPublicKey())
+            using (RSA? rsa = encryptingCertificate.GetRSAPublicKey())
             {
                 if (rsa == null)
                 {
@@ -211,11 +213,11 @@ namespace Opc.Ua
                 Utils.LogError("Message is not an integral multiple of the block size. Length = {0}, BlockSize = {1}.", dataToEncrypt.Count, inputBlockSize);
             }
 
-            byte[] encryptedBuffer = outputBuffer.Array;
+            byte[]? encryptedBuffer = outputBuffer.Array;
             RSAEncryptionPadding rsaPadding = GetRSAEncryptionPadding(padding);
 
             using (MemoryStream ostrm = new MemoryStream(
-                encryptedBuffer,
+                encryptedBuffer!,
                 outputBuffer.Offset,
                 outputBuffer.Count))
             {
@@ -224,7 +226,7 @@ namespace Opc.Ua
 
                 for (int ii = dataToEncrypt.Offset; ii < dataToEncrypt.Offset + dataToEncrypt.Count; ii += inputBlockSize)
                 {
-                    Array.Copy(dataToEncrypt.Array, ii, input, 0, input.Length);
+                    Array.Copy(dataToEncrypt.Array!, ii, input, 0, input.Length);
                     byte[] cipherText = rsa.Encrypt(input, rsaPadding);
                     ostrm.Write(cipherText, 0, cipherText.Length);
                 }
@@ -232,7 +234,7 @@ namespace Opc.Ua
 
             // return buffer
             return new ArraySegment<byte>(
-                encryptedBuffer,
+                encryptedBuffer!,
                 outputBuffer.Offset,
                 (dataToEncrypt.Count / inputBlockSize) * outputBlockSize);
         }
@@ -245,7 +247,7 @@ namespace Opc.Ua
             X509Certificate2 encryptingCertificate,
             Padding padding)
         {
-            using (RSA rsa = encryptingCertificate.GetRSAPrivateKey())
+            using (RSA? rsa = encryptingCertificate.GetRSAPrivateKey())
             {
                 if (rsa == null)
                 {
@@ -262,7 +264,7 @@ namespace Opc.Ua
                 // decode length.
                 int length = 0;
 
-                length += (((int)plainText.Array[plainText.Offset + 0]));
+                length += (((int)plainText.Array![plainText.Offset + 0]));
                 length += (((int)plainText.Array[plainText.Offset + 1]) << 8);
                 length += (((int)plainText.Array[plainText.Offset + 2]) << 16);
                 length += (((int)plainText.Array[plainText.Offset + 3]) << 24);
@@ -297,11 +299,11 @@ namespace Opc.Ua
                 Utils.LogError("Message is not an integral multiple of the block size. Length = {0}, BlockSize = {1}.", dataToDecrypt.Count, inputBlockSize);
             }
 
-            byte[] decryptedBuffer = outputBuffer.Array;
+            byte[]? decryptedBuffer = outputBuffer.Array;
             RSAEncryptionPadding rsaPadding = GetRSAEncryptionPadding(padding);
 
             using (MemoryStream ostrm = new MemoryStream(
-                decryptedBuffer,
+                decryptedBuffer!,
                 outputBuffer.Offset,
                 outputBuffer.Count))
             {
@@ -309,14 +311,14 @@ namespace Opc.Ua
                 byte[] input = new byte[inputBlockSize];
                 for (int ii = dataToDecrypt.Offset; ii < dataToDecrypt.Offset + dataToDecrypt.Count; ii += inputBlockSize)
                 {
-                    Array.Copy(dataToDecrypt.Array, ii, input, 0, input.Length);
+                    Array.Copy(dataToDecrypt.Array!, ii, input, 0, input.Length);
                     byte[] plainText = rsa.Decrypt(input, rsaPadding);
                     ostrm.Write(plainText, 0, plainText.Length);
                 }
             }
 
             // return buffers.
-            return new ArraySegment<byte>(decryptedBuffer, outputBuffer.Offset, (dataToDecrypt.Count / inputBlockSize) * outputBlockSize);
+            return new ArraySegment<byte>(decryptedBuffer!, outputBuffer.Offset, (dataToDecrypt.Count / inputBlockSize) * outputBlockSize);
         }
 
         /// <summary>

--- a/Stack/Opc.Ua.Core/Security/Certificates/X509CertificateStore/X509CertificateStore.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/X509CertificateStore/X509CertificateStore.cs
@@ -14,6 +14,8 @@
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 */
 
+#nullable enable
+
 using System;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
@@ -119,7 +121,7 @@ namespace Opc.Ua
         public string StoreType => CertificateStoreType.X509Store;
 
         /// <inheritdoc/>
-        public string StorePath => m_storePath;
+        public string? StorePath => m_storePath;
 
         /// <inheritdoc/>
         public bool NoPrivateKeys => m_noPrivateKeys;
@@ -135,7 +137,7 @@ namespace Opc.Ua
         }
 
         /// <inheritdoc/>
-        public Task Add(X509Certificate2 certificate, string password = null)
+        public Task Add(X509Certificate2 certificate, string? password = null)
         {
             if (certificate == null) throw new ArgumentNullException(nameof(certificate));
 
@@ -216,16 +218,16 @@ namespace Opc.Ua
         /// <inheritdoc/>
         /// <remarks>The LoadPrivateKey special handling is not necessary in this store.</remarks>
         [Obsolete("Method is deprecated. Use only for RSA certificates, the replacing LoadPrivateKey with certificateType parameter should be used.")]
-        public Task<X509Certificate2> LoadPrivateKey(string thumbprint, string subjectName, string password)
+        public Task<X509Certificate2?> LoadPrivateKey(string? thumbprint, string? subjectName, string? password)
         {
-            return Task.FromResult<X509Certificate2>(null);
+            return Task.FromResult<X509Certificate2?>(null);
         }
 
         /// <inheritdoc/>
         /// <remarks>The LoadPrivateKey special handling is not necessary in this store.</remarks>
-        public Task<X509Certificate2> LoadPrivateKey(string thumbprint, string subjectName, string applicationUri, NodeId certificateType, string password)
+        public Task<X509Certificate2?> LoadPrivateKey(string? thumbprint, string? subjectName, string? applicationUri, NodeId? certificateType, string? password)
         {
-            return Task.FromResult<X509Certificate2>(null);
+            return Task.FromResult<X509Certificate2?>(null);
         }
 
         /// <inheritdoc/>
@@ -369,9 +371,8 @@ namespace Opc.Ua
                 throw new ArgumentNullException(nameof(crl));
             }
 
-            X509Certificate2 issuer = null;
-            X509Certificate2Collection certificates = null;
-            certificates = await Enumerate().ConfigureAwait(false);
+            X509Certificate2? issuer = null;
+            X509Certificate2Collection certificates = await Enumerate().ConfigureAwait(false);
             foreach (X509Certificate2 certificate in certificates)
             {
                 if (X509Utils.CompareDistinguishedName(certificate.SubjectName, crl.IssuerName))
@@ -424,7 +425,7 @@ namespace Opc.Ua
 
         private bool m_noPrivateKeys;
         private string m_storeName;
-        private string m_storePath;
+        private string? m_storePath;
         private StoreLocation m_storeLocation;
     }
 }


### PR DESCRIPTION
## Proposed changes

Make
- CertificateValidator
- CertificateStores
- CertificateIdentifier
- CertificateTrustlist
- RSA Utils
nullable

## Related Issues

- Fixes #

## Types of changes


- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
