### PR TITLE
Fix a case where NodeId.Null is modified

### DIFF
--- a/Stack/Opc.Ua.Core/Types/BuiltIn/ExtensionObject.cs
+++ b/Stack/Opc.Ua.Core/Types/BuiltIn/ExtensionObject.cs
@@ -717,7 +717,7 @@ namespace Opc.Ua
                 // check for null Id.
                 if (m_typeId.IsNull)
                 {
-                    return NodeId.Null;
+                    return new NodeId();
                 }
 
                 return ExpandedNodeId.ToNodeId(m_typeId, m_context.NamespaceUris);

--- a/Stack/Opc.Ua.Core/Types/BuiltIn/Matrix.cs
+++ b/Stack/Opc.Ua.Core/Types/BuiltIn/Matrix.cs
@@ -30,7 +30,6 @@ namespace Opc.Ua
 
             m_elements = Utils.FlattenArray(value);
             m_typeInfo = new TypeInfo(builtInType, m_dimensions.Length);
-
         }
 
         /// <summary>
@@ -61,7 +60,6 @@ namespace Opc.Ua
 
             SanityCheckArrayElements(m_elements, builtInType);
         }
-
         #endregion
 
         #region Public Members

--- a/Stack/Opc.Ua.Core/Types/BuiltIn/Matrix.cs
+++ b/Stack/Opc.Ua.Core/Types/BuiltIn/Matrix.cs
@@ -1,6 +1,17 @@
+/* Copyright (c) 1996-2022 The OPC Foundation. All rights reserved.
+   The source code in this file is covered under a dual-license scenario:
+     - RCL: for OPC Foundation Corporate Members in good-standing
+     - GPL V2: everybody else
+   RCL license terms accompanied with this source code. See http://opcfoundation.org/License/RCL/1.00/
+   GNU General Public License as published by the Free Software Foundation;
+   version 2 of the License are accompanied with this source code. See http://opcfoundation.org/License/GPLv2
+   This source code is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+*/
+
 using System;
 using System.Diagnostics;
-using System.Globalization;
 using System.Runtime.Serialization;
 using System.Text;
 
@@ -240,16 +251,14 @@ namespace Opc.Ua
         /// <param name="builtInType">The builtInType used for the elements.</param>
         [Conditional("DEBUG")]
         private static void SanityCheckArrayElements(Array elements, BuiltInType builtInType)
-
-
         {
 #if DEBUG
             TypeInfo sanityCheck = TypeInfo.Construct(elements);
             Debug.Assert(sanityCheck.BuiltInType == builtInType || builtInType == BuiltInType.Enumeration ||
-                    (sanityCheck.BuiltInType == BuiltInType.ExtensionObject && builtInType == BuiltInType.Null) ||
-                    (sanityCheck.BuiltInType == BuiltInType.Int32 && builtInType == BuiltInType.Enumeration) ||
-                    (sanityCheck.BuiltInType == BuiltInType.ByteString && builtInType == BuiltInType.Byte) ||
-                    (builtInType == BuiltInType.Variant));
+                (sanityCheck.BuiltInType == BuiltInType.ExtensionObject && builtInType == BuiltInType.Null) ||
+                (sanityCheck.BuiltInType == BuiltInType.Int32 && builtInType == BuiltInType.Enumeration) ||
+                (sanityCheck.BuiltInType == BuiltInType.ByteString && builtInType == BuiltInType.Byte) ||
+                (builtInType == BuiltInType.Variant));
 #endif																				 
         }
         #endregion

--- a/Stack/Opc.Ua.Core/Types/BuiltIn/NodeId.cs
+++ b/Stack/Opc.Ua.Core/Types/BuiltIn/NodeId.cs
@@ -866,8 +866,11 @@ namespace Opc.Ua
         /// Returns an instance of a null NodeId.
         /// </summary>
         public static NodeId Null => s_Null;
-
+#if DEBUG
+        private static readonly NodeId s_Null = new ImmutableNodeId();
+#else
         private static readonly NodeId s_Null = new NodeId();
+#endif
         #endregion
 
         #region Public Methods (and some Internals)
@@ -1001,6 +1004,7 @@ namespace Opc.Ua
         /// </summary>
         internal void SetNamespaceIndex(ushort value)
         {
+            ValidateImmutableNodeIdIsNotModified();
             m_namespaceIndex = value;
         }
 
@@ -1009,6 +1013,7 @@ namespace Opc.Ua
         /// </summary>
         internal void SetIdentifier(IdType idType, object value)
         {
+            ValidateImmutableNodeIdIsNotModified();
             m_identifierType = idType;
 
             switch (idType)
@@ -1038,6 +1043,8 @@ namespace Opc.Ua
         /// </summary>
         internal void SetIdentifier(string value, IdType idType)
         {
+            ValidateImmutableNodeIdIsNotModified();
+
             m_identifierType = idType;
             SetIdentifier(IdType.String, value);
         }
@@ -1495,6 +1502,8 @@ namespace Opc.Ua
             }
             set
             {
+                ValidateImmutableNodeIdIsNotModified();
+
                 NodeId nodeId = NodeId.Parse(value);
 
                 m_namespaceIndex = nodeId.NamespaceIndex;
@@ -1859,6 +1868,21 @@ namespace Opc.Ua
                 }
             }
         }
+
+        /// <summary>
+        /// Validate that an immutable NodeId is not overwritten.
+        /// </summary>
+        /// <exception cref="InvalidOperationException"></exception>
+        [Conditional("DEBUG")]
+        private void ValidateImmutableNodeIdIsNotModified()
+        {
+#if DEBUG
+            if (this is ImmutableNodeId)
+            {
+                throw new InvalidOperationException("Cannot modify the immutable NodeId.Null.");
+            }
+#endif
+        }
         #endregion
 
         #region Private Fields
@@ -1867,6 +1891,20 @@ namespace Opc.Ua
         private object m_identifier;
         #endregion
     }
+
+#if DEBUG
+    #region ImmutableNodeId
+    /// <summary>
+    /// A NodeId class as helper to catch if the immutable NodeId.Null is being modified.
+    /// </summary>
+    internal class ImmutableNodeId : NodeId
+    {
+        internal ImmutableNodeId()
+        {
+        }
+    }
+    #endregion
+#endif
 
     #region NodeIdCollection Class
     /// <summary>
@@ -1993,6 +2031,7 @@ namespace Opc.Ua
         /// </summary>
         public ushort[] ServerMappings { get; set; }
     }
+
     #region NodeIdComparer Class
     /// <summary>
     /// Helper which implements a NodeId IEqualityComparer for Linq queries.

--- a/Tests/Opc.Ua.Core.Tests/Types/Encoders/EncoderCommon.cs
+++ b/Tests/Opc.Ua.Core.Tests/Types/Encoders/EncoderCommon.cs
@@ -79,7 +79,6 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
         protected BufferManager BufferManager { get; private set; }
         protected RecyclableMemoryStreamManager RecyclableMemoryManager { get; private set; }
 
-
         #region Test Setup
         [OneTimeSetUp]
         protected void OneTimeSetUp()
@@ -112,6 +111,8 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
         [TearDown]
         protected void TearDown()
         {
+            // ensure after every test that the Null NodeId was not modified
+            Assert.True(NodeId.Null.IsNullNodeId);
         }
 
         /// <summary>

--- a/Tests/Opc.Ua.Core.Tests/Types/Encoders/EncoderTests.cs
+++ b/Tests/Opc.Ua.Core.Tests/Types/Encoders/EncoderTests.cs
@@ -973,6 +973,30 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
                 Assert.AreEqual((StatusCode)StatusCodes.BadEncodingLimitsExceeded, (StatusCode)sre.StatusCode, sre.Message);
             }
         }
+
+        /// <summary>
+        /// Test if deserializing an extensionObject alters the Null NodeId.
+        /// </summary>
+        /// <remarks>
+        /// Issue was raised in github #2974.
+        /// </remarks>
+        [Test]
+        public void EnsureNodeIdNullIsNotModified()
+        {
+            var text1 = "[{\"Body\":{\"KeyValuePair\":{\"@xmlns\":\"http://opcfoundation.org/UA/2008/02/Types.xsd\"," +
+                "\"Key\":{\"Name\":\"o\",\"NamespaceIndex\":\"0\"},\"Value\":{\"Value\":" +
+                "{\"ListOfExtensionObject\":{\"ExtensionObject\":[" +
+                "{\"Body\":{\"KeyValuePair\":{\"Key\":{\"Name\":\"stringProp\",\"NamespaceIndex\":\"0\"},\"Value\":{\"Value\":" +
+                "{\"String\":\"EinString\"}}}},\"TypeId\":{\"Identifier\":\"i=14801\"}},{\"Body\":{\"KeyValuePair\":{\"Key\":" +
+                "{\"Name\":\"intProp\",\"NamespaceIndex\":\"0\"},\"Value\":{\"Value\":{\"Int32\":\"1\"}}}},\"TypeId\":" +
+                "{\"Identifier\":\"i=14802\"}}]}}}}},\"TypeId\":" +
+                "{\"Identifier\":\"i=14803\"}}]";
+
+            JsonConvert.DeserializeObject<ExtensionObject[]>(text1);
+
+            Assert.NotNull(NodeId.Null);
+            Assert.True(NodeId.Null.IsNullNodeId);
+        }
         #endregion
 
         #region Private Methods


### PR DESCRIPTION
## Proposed changes

- Fix for decoding an ExtensionObject NodeId.Null is modified.
- Add test case and checks to catch modifcations of NodeId.Null
- Add DEBUG tests in NodeId to throw InvalidOperationException if NodeId.Null is modified

## Related Issues

- Fixes #2974 

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
