### PR TITLE
By default set NoDelay=true and Lingerstate to 5 sec 

### DIFF
--- a/Stack/Opc.Ua.Core/Stack/Tcp/TcpMessageSocket.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/TcpMessageSocket.cs
@@ -670,35 +670,15 @@ namespace Opc.Ua.Bindings
         /// <summary>
         /// Try to connect to endpoint and do callback if connected successfully
         /// </summary>
-        /// <param name="address">Endpoint address</param>
-        /// <param name="addressFamily">Endpoint address family</param>
-        /// <param name="port">Endpoint port</param>
-        /// <param name="callback">Callback that must be executed if the connection would be established</param>
-        private SocketError BeginConnect(IPAddress address, AddressFamily addressFamily, int port, CallbackAction callback)
-        {
-            var socket = new Socket(addressFamily, SocketType.Stream, ProtocolType.Tcp);
-            var args = new SocketAsyncEventArgs() {
-                UserToken = callback,
-                RemoteEndPoint = new IPEndPoint(address, port),
-            };
-            args.Completed += OnSocketConnected;
-            if (!socket.ConnectAsync(args))
-            {
-                // I/O completed synchronously
-                OnSocketConnected(socket, args);
-                return args.SocketError;
-            }
-            return SocketError.InProgress;
-        }
-
-        /// <summary>
-        /// Try to connect to endpoint and do callback if connected successfully
-        /// </summary>
         /// <param name="endpoint">The DNS endpoint</param>
         /// <param name="callback">Callback that must be executed if the connection would be established</param>
         private SocketError BeginConnect(DnsEndPoint endpoint, CallbackAction callback)
         {
-            var socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
+            var socket = new Socket(SocketType.Stream, ProtocolType.Tcp){
+                NoDelay = true,
+                LingerState = new LingerOption(true, 5),
+            };
+
             var args = new SocketAsyncEventArgs() {
                 UserToken = callback,
                 RemoteEndPoint = endpoint,

--- a/Stack/Opc.Ua.Core/Stack/Tcp/TcpTransportListener.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/TcpTransportListener.cs
@@ -577,24 +577,18 @@ namespace Opc.Ua.Bindings
                     port = Utils.UaTcpDefaultPort;
                 }
 
-                bool bindToSpecifiedAddress = true;
                 UriHostNameType hostType = Uri.CheckHostName(m_uri.Host);
-                if (hostType == UriHostNameType.Dns || hostType == UriHostNameType.Unknown || hostType == UriHostNameType.Basic)
-                {
-                    bindToSpecifiedAddress = false;
-                }
-
-                IPAddress ipAddress = IPAddress.Any;
-                if (bindToSpecifiedAddress)
-                {
-                    ipAddress = IPAddress.Parse(m_uri.Host);
-                }
+                bool bindToSpecifiedAddress = hostType != UriHostNameType.Dns && hostType != UriHostNameType.Unknown && hostType != UriHostNameType.Basic;
+                IPAddress ipAddress = bindToSpecifiedAddress ? IPAddress.Parse(m_uri.Host) : IPAddress.Any;
 
                 // create IPv4 or IPv6 socket.
                 try
                 {
                     IPEndPoint endpoint = new IPEndPoint(ipAddress, port);
-                    m_listeningSocket = new Socket(endpoint.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
+                    m_listeningSocket = new Socket(endpoint.AddressFamily, SocketType.Stream, ProtocolType.Tcp) {
+                        NoDelay = true,
+                        LingerState = new LingerOption(true, 5),
+                    };
                     SocketAsyncEventArgs args = new SocketAsyncEventArgs();
                     args.Completed += OnAccept;
                     args.UserToken = m_listeningSocket;
@@ -628,12 +622,17 @@ namespace Opc.Ua.Bindings
                     try
                     {
                         IPEndPoint endpointIPv6 = new IPEndPoint(IPAddress.IPv6Any, port);
-                        m_listeningSocketIPv6 = new Socket(endpointIPv6.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
-                        SocketAsyncEventArgs args = new SocketAsyncEventArgs();
+                        m_listeningSocketIPv6 = new Socket(endpointIPv6.AddressFamily, SocketType.Stream, ProtocolType.Tcp) {
+                            NoDelay = true,
+                            LingerState = new LingerOption(true, 5),
+                        };
+                        SocketAsyncEventArgs args = new SocketAsyncEventArgs() {
+                            UserToken = m_listeningSocketIPv6
+                        };
                         args.Completed += OnAccept;
-                        args.UserToken = m_listeningSocketIPv6;
+
                         m_listeningSocketIPv6.Bind(endpointIPv6);
-                        m_listeningSocketIPv6.Listen(Int32.MaxValue);
+                        m_listeningSocketIPv6.Listen(kSocketBacklog);
                         if (!m_listeningSocketIPv6.AcceptAsync(args))
                         {
                             OnAccept(null, args);


### PR DESCRIPTION
## Proposed changes

Set NoDelay=true to disable the Nagle algorithm and set Lingerstate to 5 seconds by default.

After careful evaluation of the PR provided by @sxleixer in #2882 we found that the default setting of the socket with NoDelay=false can not only cause issues on the client side, but also on the server side.

Due to the nature of Nagle's implementation the issue only occurs when many small service requests or responses are sent over the network. In that case, when packets are still in flight, the secondary small packets are delayed and combined until the MTU is exceeded or the previous packages are acknoledged.

The expectation in the UA protocol is to not add additional latency in the client-server communication.

As a conclusion defaulting to NoDelay=true appears to be the better default option which works for all use cases. 
If there are new bandwidth issues related to more and larger packets imposed by this change, they should be solved at the UA application level by combining service requests of the same type.

Setting Lingerstate to 5 seconds should help to finish communications when sockets are closed.

## Related Issues

- Fixes #2882

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
