### PR TITLE
[Server] [Client] Return BadIdentityTokenInvalid if use of anonymous identity token is not allowed

### DIFF
--- a/Libraries/Opc.Ua.Client/Session/Session.cs
+++ b/Libraries/Opc.Ua.Client/Session/Session.cs
@@ -5425,7 +5425,7 @@ namespace Opc.Ua.Client
                 if (identityPolicy == null)
                 {
                     throw ServiceResultException.Create(
-                        StatusCodes.BadIdentityTokenInvalid,
+                        StatusCodes.BadIdentityTokenRejected,
                         "Endpoint does not support the user identity type provided.");
                 }
 

--- a/Libraries/Opc.Ua.Client/Session/Session.cs
+++ b/Libraries/Opc.Ua.Client/Session/Session.cs
@@ -5425,7 +5425,7 @@ namespace Opc.Ua.Client
                 if (identityPolicy == null)
                 {
                     throw ServiceResultException.Create(
-                        StatusCodes.BadUserAccessDenied,
+                        StatusCodes.BadIdentityTokenInvalid,
                         "Endpoint does not support the user identity type provided.");
                 }
 

--- a/Libraries/Opc.Ua.Server/Session/Session.cs
+++ b/Libraries/Opc.Ua.Server/Session/Session.cs
@@ -902,7 +902,7 @@ namespace Opc.Ua.Server
 
                     if (!found)
                     {
-                        throw ServiceResultException.Create(StatusCodes.BadUserAccessDenied, "Anonymous user token policy not supported.");
+                        throw ServiceResultException.Create(StatusCodes.BadIdentityTokenInvalid, "Anonymous user token policy not supported.");
                     }
                 }
 

--- a/Libraries/Opc.Ua.Server/Session/Session.cs
+++ b/Libraries/Opc.Ua.Server/Session/Session.cs
@@ -902,7 +902,7 @@ namespace Opc.Ua.Server
 
                     if (!found)
                     {
-                        throw ServiceResultException.Create(StatusCodes.BadIdentityTokenInvalid, "Anonymous user token policy not supported.");
+                        throw ServiceResultException.Create(StatusCodes.BadIdentityTokenRejected, "Anonymous user token policy not supported.");
                     }
                 }
 


### PR DESCRIPTION
## Proposed changes

Return StatusCode.BadIdentityTokenInvalid instead of BadUserAccessDenied if the Client sends an AnonymousIdentityToken or no identity Token at all. This makes the Server pass UA CTT SessionService -> SessionBase -> TestCases -> Err-009

Make the Client throw a ServiceResultException BadIdentityTokenInvalid instead of BadUserAccessDenied to be consistent with the response a server would send. This is relevant as our client does a "pre-check" if the endpoint supports the provided policy before sending the request to the server

## Related Issues

- Fixes #3001
- Fixes #2900

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.