### PR TITLE
Enforce Valid Certificate Store configuration

### DIFF
--- a/Applications/ConsoleReferenceClient/Quickstarts.ReferenceClient.Config.xml
+++ b/Applications/ConsoleReferenceClient/Quickstarts.ReferenceClient.Config.xml
@@ -80,12 +80,17 @@
     <AddAppCertToTrustedStore>false</AddAppCertToTrustedStore>
     <SendCertificateChain>true</SendCertificateChain>
 
+
+    <UserIssuerCertificates>
+      <StoreType>Directory</StoreType>
+      <StorePath>%LocalApplicationData%/OPC Foundation/pki/userIssuer</StorePath>
+    </UserIssuerCertificates>
+    
     <!-- Where the User trust list is stored-->
     <TrustedUserCertificates>
       <StoreType>Directory</StoreType>
       <StorePath>%LocalApplicationData%/OPC Foundation/pki/trustedUser</StorePath>
     </TrustedUserCertificates>
-
   </SecurityConfiguration>
   
   <TransportConfigurations></TransportConfigurations>

--- a/Applications/ConsoleReferenceClient/Quickstarts.ReferenceClient.Config.xml
+++ b/Applications/ConsoleReferenceClient/Quickstarts.ReferenceClient.Config.xml
@@ -80,7 +80,7 @@
     <AddAppCertToTrustedStore>false</AddAppCertToTrustedStore>
     <SendCertificateChain>true</SendCertificateChain>
 
-
+    <!-- Where the User issers list is stored-->
     <UserIssuerCertificates>
       <StoreType>Directory</StoreType>
       <StorePath>%LocalApplicationData%/OPC Foundation/pki/userIssuer</StorePath>

--- a/Libraries/Opc.Ua.Server/Configuration/ConfigurationNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/Configuration/ConfigurationNodeManager.cs
@@ -573,16 +573,19 @@ namespace Opc.Ua.Server
                         ICertificateStore issuerStore = certificateGroup.IssuerStore.OpenStore();
                         try
                         {
-                            foreach (var issuer in updateCertificate.IssuerCollection)
+                            if (issuerStore != null)
                             {
-                                try
+                                foreach (var issuer in updateCertificate.IssuerCollection)
                                 {
-                                    Utils.LogCertificate(Utils.TraceMasks.Security, "Add new issuer certificate: ", issuer);
-                                    issuerStore?.Add(issuer).Wait();
-                                }
-                                catch (ArgumentException)
-                                {
-                                    // ignore error if issuer cert already exists
+                                    try
+                                    {
+                                        Utils.LogCertificate(Utils.TraceMasks.Security, "Add new issuer certificate: ", issuer);
+                                        issuerStore.Add(issuer).Wait();
+                                    }
+                                    catch (ArgumentException)
+                                    {
+                                        // ignore error if issuer cert already exists
+                                    }
                                 }
                             }
                         }

--- a/Libraries/Opc.Ua.Server/Configuration/ConfigurationNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/Configuration/ConfigurationNodeManager.cs
@@ -578,7 +578,7 @@ namespace Opc.Ua.Server
                                 try
                                 {
                                     Utils.LogCertificate(Utils.TraceMasks.Security, "Add new issuer certificate: ", issuer);
-                                    issuerStore.Add(issuer).Wait();
+                                    issuerStore?.Add(issuer).Wait();
                                 }
                                 catch (ArgumentException)
                                 {
@@ -769,13 +769,16 @@ namespace Opc.Ua.Server
             ICertificateStore store = m_rejectedStore.OpenStore();
             try
             {
-                X509Certificate2Collection collection = store.Enumerate().Result;
-                List<byte[]> rawList = new List<byte[]>();
-                foreach (var cert in collection)
+                if (store != null)
                 {
-                    rawList.Add(cert.RawData);
+                    X509Certificate2Collection collection = store.Enumerate().Result;
+                    List<byte[]> rawList = new List<byte[]>();
+                    foreach (var cert in collection)
+                    {
+                        rawList.Add(cert.RawData);
+                    }
+                    certificates = rawList.ToArray();
                 }
-                certificates = rawList.ToArray();
             }
             finally
             {

--- a/Stack/Opc.Ua.Core/Schema/ApplicationConfiguration.cs
+++ b/Stack/Opc.Ua.Core/Schema/ApplicationConfiguration.cs
@@ -884,7 +884,7 @@ namespace Opc.Ua
         /// <summary>
         /// The store containing any additional issuer certificates.
         /// </summary>
-        [DataMember(IsRequired = false, EmitDefaultValue = false, Order = 2)]
+        [DataMember(IsRequired = true, EmitDefaultValue = false, Order = 2)]
         public CertificateTrustList TrustedIssuerCertificates
         {
             get
@@ -901,7 +901,7 @@ namespace Opc.Ua
         /// <summary>
         /// The trusted certificate store.
         /// </summary>
-        [DataMember(IsRequired = false, EmitDefaultValue = false, Order = 4)]
+        [DataMember(IsRequired = true, EmitDefaultValue = false, Order = 4)]
         public CertificateTrustList TrustedPeerCertificates
         {
             get
@@ -2052,7 +2052,7 @@ namespace Opc.Ua
         /// Enable / disable support for durable subscriptions
         /// </summary>
         /// <value><c>true</c> if durable subscriptions are enabled; otherwise, <c>false</c>.</value>
-        [DataMember(IsRequired = false, EmitDefaultValue = false, Order = 38)]
+        [DataMember(IsRequired = false, EmitDefaultValue = false, Order = 39)]
         public bool DurableSubscriptionsEnabled
         {
             get { return m_DurableSubscriptionsEnabled; }
@@ -2063,7 +2063,7 @@ namespace Opc.Ua
         /// The maximum number of notifications saved in the durable queue for each monitored item.
         /// </summary>
         /// <value>The maximum size of the durable notification queue.</value>
-        [DataMember(IsRequired = false, Order = 39)]
+        [DataMember(IsRequired = false, Order = 40)]
         public int MaxDurableNotificationQueueSize
         {
             get { return m_maxDurableNotificationQueueSize; }
@@ -2074,7 +2074,7 @@ namespace Opc.Ua
         /// The max size of the durable event queue.
         /// </summary>
         /// <value>The max size of the durable event queue.</value>
-        [DataMember(IsRequired = false, Order = 40)]
+        [DataMember(IsRequired = false, Order = 41)]
         public int MaxDurableEventQueueSize
         {
             get { return m_maxDurableEventQueueSize; }
@@ -2085,7 +2085,7 @@ namespace Opc.Ua
         /// How long the durable subscriptions will remain open without a publish from the client.
         /// </summary>
         /// <value>The maximum durable subscription lifetime.</value>
-        [DataMember(IsRequired = false, Order = 41)]
+        [DataMember(IsRequired = false, Order = 42)]
         public int MaxDurableSubscriptionLifetimeInHours
         {
             get { return m_maxDurableSubscriptionLifetimeInHours; }

--- a/Stack/Opc.Ua.Core/Schema/ApplicationConfiguration.cs
+++ b/Stack/Opc.Ua.Core/Schema/ApplicationConfiguration.cs
@@ -2975,28 +2975,6 @@ namespace Opc.Ua
         }
 
         /// <summary>
-        /// The name of the certificate store that contains the trusted certificates. 
-        /// </summary>
-        [DataMember(IsRequired = false, EmitDefaultValue = false, Order = 2)]
-        [Obsolete("Use StoreType/StorePath instead")]
-        public string StoreName
-        {
-            get { return m_storeName; }
-            set { m_storeName = value; }
-        }
-
-        /// <summary>
-        /// The location of the certificate store that contains the trusted certificates. 
-        /// </summary>
-        [DataMember(IsRequired = false, EmitDefaultValue = false, Order = 3)]
-        [Obsolete("Use StoreType/StorePath instead")]
-        public string StoreLocation
-        {
-            get { return m_storeLocation; }
-            set { m_storeLocation = value; }
-        }
-
-        /// <summary>
         /// Options that can be used to suppress certificate validation errors.
         /// </summary>
         [DataMember(Name = "ValidationOptions", IsRequired = false, EmitDefaultValue = false, Order = 4)]

--- a/Stack/Opc.Ua.Core/Schema/ApplicationConfiguration.cs
+++ b/Stack/Opc.Ua.Core/Schema/ApplicationConfiguration.cs
@@ -2920,11 +2920,6 @@ namespace Opc.Ua
         {
             get
             {
-                if (!String.IsNullOrEmpty(m_storeName))
-                {
-                    return CertificateStoreType.X509Store;
-                }
-
                 return m_storeType;
             }
 
@@ -2947,16 +2942,6 @@ namespace Opc.Ua
         {
             get
             {
-                if (!String.IsNullOrEmpty(m_storeName))
-                {
-                    if (String.IsNullOrEmpty(m_storeLocation))
-                    {
-                        return CurrentUser + m_storeName;
-                    }
-
-                    return Utils.Format("{0}\\{1}", m_storeLocation, m_storeName);
-                }
-
                 return m_storePath;
             }
 
@@ -2988,8 +2973,6 @@ namespace Opc.Ua
         #region Private Fields
         private string m_storeType;
         private string m_storePath;
-        private string m_storeLocation;
-        private string m_storeName;
         private CertificateValidationOptions m_validationOptions;
         #endregion
     }

--- a/Stack/Opc.Ua.Core/Schema/ApplicationConfiguration.xsd
+++ b/Stack/Opc.Ua.Core/Schema/ApplicationConfiguration.xsd
@@ -6,420 +6,431 @@
     xmlns:xs="http://www.w3.org/2001/XMLSchema"
     xmlns:ua="http://opcfoundation.org/UA/2008/02/Types.xsd"
 >
-  <xs:import namespace="http://opcfoundation.org/UA/2008/02/Types.xsd" schemaLocation="./Opc.Ua.Types.xsd"/>
+    <xs:import namespace="http://opcfoundation.org/UA/2008/02/Types.xsd" schemaLocation="./Opc.Ua.Types.xsd"/>
 
-  <xs:complexType name="ApplicationConfiguration">
-    <xs:sequence>
-      <xs:element name="ApplicationName" type="xs:string" />
-      <xs:element name="ApplicationUri" type="xs:string"/>
-      <xs:element name="ProductUri" type="xs:string" minOccurs="0" nillable="true" />
-      <xs:element name="ApplicationType" type="ua:ApplicationType" />
-      <xs:element name="SecurityConfiguration" type="SecurityConfiguration" minOccurs="0" nillable="true" />
-      <xs:element name="TransportConfigurations" type="ListOfTransportConfiguration" minOccurs="0" nillable="true" />
-      <xs:element name="TransportQuotas" type="TransportQuotas" minOccurs="0" nillable="true" />
-      <xs:element name="ServerConfiguration" type="ServerConfiguration" minOccurs="0" />
-      <xs:element name="ClientConfiguration" type="ClientConfiguration" minOccurs="0" />
-      <xs:element name="DiscoveryServerConfiguration" type="DiscoveryServerConfiguration" minOccurs="0" />
-      <xs:element name="Extensions" type="ua:ListOfXmlElement" minOccurs="0"  />
-      <xs:element name="TraceConfiguration" type="TraceConfiguration" minOccurs="0" />
-      <xs:element name="DisableHiResClock" type="xs:boolean" minOccurs="0">
-        <xs:annotation>
-          <xs:appinfo>
-            <DefaultValue EmitDefaultValue="false" xmlns="http://schemas.microsoft.com/2003/10/Serialization/" />
-          </xs:appinfo>
-        </xs:annotation>
-      </xs:element>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:element name="ApplicationConfiguration" type="ApplicationConfiguration" />
-
-  <xs:complexType name="SecurityConfiguration">
-    <xs:sequence>
-      <xs:element name="ApplicationCertificate" type="CertificateIdentifier" />
-      <xs:element name="TrustedIssuerCertificates" type="CertificateTrustList" minOccurs="0" />
-      <xs:element name="TrustedPeerCertificates" type="CertificateTrustList" minOccurs="0" />
-      <xs:element name="NonceLength" type="xs:int" minOccurs="0">
-        <xs:annotation>
-          <xs:appinfo>
-            <DefaultValue EmitDefaultValue="false" xmlns="http://schemas.microsoft.com/2003/10/Serialization/" />
-          </xs:appinfo>
-        </xs:annotation>
-      </xs:element>
-      <xs:element name="RejectedCertificateStore" type="CertificateStoreIdentifier" minOccurs="0" />
-      <xs:element name="MaxRejectedCertificates" type="xs:int" minOccurs="0" />
-      <xs:element name="AutoAcceptUntrustedCertificates" type="xs:boolean" minOccurs="0" />
-      <xs:element name="UserRoleDirectory" type="xs:string"  minOccurs="0" nillable="true" />
-      <xs:element name="RejectSHA1SignedCertificates" type="xs:boolean" minOccurs="0" />
-      <xs:element name="RejectUnknownRevocationStatus" type="xs:boolean" minOccurs="0" />
-      <xs:element name="MinimumCertificateKeySize" type="xs:unsignedShort" minOccurs="0" />
-      <xs:element name="UseValidatedCertificates" type="xs:boolean" minOccurs="0" />
-      <xs:element name="AddAppCertToTrustedStore" type="xs:boolean" minOccurs="0" />
-      <xs:element name="SendCertificateChain" type="xs:boolean" minOccurs="0" />
-      <xs:element name="UserIssuerCertificates" type="CertificateTrustList" minOccurs="0" />
-      <xs:element name="TrustedUserCertificates" type="CertificateTrustList" minOccurs="0" />
-      <xs:element name="HttpsIssuerCertificates" type="CertificateTrustList" minOccurs="0" />
-      <xs:element name="TrustedHttpsCertificates" type="CertificateTrustList" minOccurs="0" />
-      <xs:element name="SuppressNonceValidationErrors" type="xs:boolean" minOccurs="0" />
-    </xs:sequence>
-  </xs:complexType>
-
-  <xs:complexType name="ListOfTransportConfiguration">
-    <xs:sequence>
-      <xs:element name="TransportConfiguration" type="TransportConfiguration" minOccurs="0" maxOccurs="unbounded" />
-    </xs:sequence>
-  </xs:complexType>
-
-  <xs:complexType name="TransportConfiguration">
-    <xs:sequence>
-      <xs:element name="UriScheme" type="xs:string" />
-      <xs:element name="TypeName" type="xs:string" />
-    </xs:sequence>
-  </xs:complexType>
-
-  <xs:complexType name="TransportQuotas">
-    <xs:sequence>
-      <xs:element name="OperationTimeout" type="xs:int" minOccurs="0" />
-      <xs:element name="MaxStringLength" type="xs:int" minOccurs="0" />
-      <xs:element name="MaxByteStringLength" type="xs:int" minOccurs="0" />
-      <xs:element name="MaxArrayLength" type="xs:int" minOccurs="0" />
-      <xs:element name="MaxMessageSize" type="xs:int" minOccurs="0" />
-      <xs:element name="MaxBufferSize" type="xs:int" minOccurs="0" />
-      <xs:element name="MaxEncodingNestingLevels" type="xs:int" minOccurs="0" />
-      <xs:element name="MaxDecoderRecoveries" type="xs:int" minOccurs="0" />
-      <xs:element name="ChannelLifetime" type="xs:int" minOccurs="0" />
-      <xs:element name="SecurityTokenLifetime" type="xs:int" minOccurs="0" />
-    </xs:sequence>
-  </xs:complexType>
-
-  <xs:complexType name="ServerBaseConfiguration">
-    <xs:sequence>
-      <xs:element name="BaseAddresses" type="ua:ListOfString" minOccurs="0" nillable="true" />
-      <xs:element name="AlternateBaseAddresses" type="ua:ListOfString" minOccurs="0" nillable="true" />
-      <xs:element name="SecurityPolicies" type="ListOfServerSecurityPolicy" minOccurs="0" nillable="true" />
-      <xs:element name="MinRequestThreadCount" type="xs:int" minOccurs="0" />
-      <xs:element name="MaxRequestThreadCount" type="xs:int" minOccurs="0" />
-      <xs:element name="MaxQueuedRequestCount" type="xs:int" minOccurs="0" />
-    </xs:sequence>
-  </xs:complexType>
-
-  <xs:complexType name="ListOfServerSecurityPolicy">
-    <xs:sequence>
-      <xs:element name="ServerSecurityPolicy" type="ServerSecurityPolicy" minOccurs="0" maxOccurs="unbounded" />
-    </xs:sequence>
-  </xs:complexType>
-
-  <xs:complexType name="ServerSecurityPolicy">
-    <xs:sequence>
-      <xs:element name="SecurityMode" type="ua:MessageSecurityMode" minOccurs="0" />
-      <xs:element name="SecurityPolicyUri" type="xs:string" minOccurs="0"  nillable="true" />
-    </xs:sequence>
-  </xs:complexType>
-
-  <xs:complexType name="ListOfSamplingRateGroup">
-    <xs:sequence>
-      <xs:element name="SamplingRateGroup" type="SamplingRateGroup" minOccurs="0" maxOccurs="unbounded" />
-    </xs:sequence>
-  </xs:complexType>
-
-  <xs:complexType name="SamplingRateGroup">
-    <xs:sequence>
-      <xs:element name="Start" type="xs:double" minOccurs="0" />
-      <xs:element name="Increment" type="xs:double" minOccurs="0" />
-      <xs:element name="Count" type="xs:int" minOccurs="0" />
-    </xs:sequence>
-  </xs:complexType>
-
-  <xs:complexType name="ServerConfiguration">
-    <xs:complexContent mixed="false">
-      <xs:extension base="ServerBaseConfiguration">
+    <xs:complexType name="ApplicationConfiguration">
         <xs:sequence>
-          <xs:element name="UserTokenPolicies" type="ua:ListOfUserTokenPolicy" minOccurs="0" />
-          <xs:element name="DiagnosticsEnabled" type="xs:boolean" minOccurs="0" />
-          <xs:element name="MaxSessionCount" type="xs:int" minOccurs="0" />
-          <xs:element name="MaxChannelCount" type="xs:int" minOccurs="0" />
-          <xs:element name="MinSessionTimeout" type="xs:int" minOccurs="0" />
-          <xs:element name="MaxSessionTimeout" type="xs:int" minOccurs="0" />
-          <xs:element name="MaxBrowseContinuationPoints" type="xs:int" minOccurs="0" />
-          <xs:element name="MaxQueryContinuationPoints" type="xs:int" minOccurs="0" />
-          <xs:element name="MaxHistoryContinuationPoints" type="xs:int" minOccurs="0" />
-          <xs:element name="MaxRequestAge" type="xs:int" minOccurs="0" />
-          <xs:element name="MinPublishingInterval" type="xs:int" minOccurs="0" />
-          <xs:element name="MaxPublishingInterval" type="xs:int" minOccurs="0" />
-          <xs:element name="PublishingResolution" type="xs:int" minOccurs="0" />
-          <xs:element name="MaxSubscriptionLifetime" type="xs:int" minOccurs="0" />
-          <xs:element name="MaxMessageQueueSize" type="xs:int" minOccurs="0" />
-          <xs:element name="MaxNotificationQueueSize" type="xs:int" minOccurs="0" />
-          <xs:element name="MaxNotificationsPerPublish" type="xs:int" minOccurs="0" />
-          <xs:element name="MinMetadataSamplingInterval" type="xs:int" minOccurs="0" />
-          <xs:element name="AvailableSamplingRates" type="ListOfSamplingRateGroup" minOccurs="0" />
-          <xs:element name="RegistrationEndpoint" type="ua:EndpointDescription" minOccurs="0" />
-          <xs:element name="MaxRegistrationInterval" type="xs:int" minOccurs="0" />
-          <xs:element name="NodeManagerSaveFile" type="xs:string" minOccurs="0" nillable="true" />
-          <xs:element name="MinSubscriptionLifetime" type="xs:int" minOccurs="0" />
-          <xs:element name="MaxPublishRequestCount" type="xs:int" minOccurs="0" />
-          <xs:element name="MaxSubscriptionCount" type="xs:int" minOccurs="0" />
-          <xs:element name="MaxEventQueueSize" type="xs:int" minOccurs="0" />
-          <xs:element name="ServerProfileArray" type="ua:ListOfString" minOccurs="0" nillable="true" />
-          <xs:element name="ShutdownDelay" type="xs:int" minOccurs="0" />
-          <xs:element name="ServerCapabilities" type="ua:ListOfString" minOccurs="0" nillable="true" />
-          <xs:element name="SupportedPrivateKeyFormats" type="ua:ListOfString" minOccurs="0" nillable="true" />
-          <xs:element name="MaxTrustListSize" type="xs:int" minOccurs="0" />
-          <xs:element name="MultiCastDnsEnabled" type="xs:boolean" minOccurs="0" />
-          <xs:element name="ReverseConnect" type="ReverseConnectServerConfiguration" minOccurs="0" />
-          <xs:element name="OperationLimits" type="OperationLimits" minOccurs="0" />
-          <xs:element name="AuditingEnabled" type="xs:boolean" minOccurs="0" />
-          <xs:element name="HttpsMutualTls" type="xs:boolean" minOccurs="0" />
+            <xs:element name="ApplicationName" type="xs:string" />
+            <xs:element name="ApplicationUri" type="xs:string"/>
+            <xs:element name="ProductUri" type="xs:string" minOccurs="0" nillable="true" />
+            <xs:element name="ApplicationType" type="ua:ApplicationType" />
+            <xs:element name="SecurityConfiguration" type="SecurityConfiguration" minOccurs="0" nillable="true" />
+            <xs:element name="TransportConfigurations" type="ListOfTransportConfiguration" minOccurs="0" nillable="true" />
+            <xs:element name="TransportQuotas" type="TransportQuotas" minOccurs="0" nillable="true" />
+            <xs:element name="ServerConfiguration" type="ServerConfiguration" minOccurs="0" />
+            <xs:element name="ClientConfiguration" type="ClientConfiguration" minOccurs="0" />
+            <xs:element name="DiscoveryServerConfiguration" type="DiscoveryServerConfiguration" minOccurs="0" />
+            <xs:element name="Extensions" type="ua:ListOfXmlElement" minOccurs="0"  />
+            <xs:element name="TraceConfiguration" type="TraceConfiguration" minOccurs="0" />
+            <xs:element name="DisableHiResClock" type="xs:boolean" minOccurs="0">
+                <xs:annotation>
+                    <xs:appinfo>
+                        <DefaultValue EmitDefaultValue="false" xmlns="http://schemas.microsoft.com/2003/10/Serialization/" />
+                    </xs:appinfo>
+                </xs:annotation>
+            </xs:element>
         </xs:sequence>
-      </xs:extension>
-    </xs:complexContent>
-  </xs:complexType>
+    </xs:complexType>
+    <xs:element name="ApplicationConfiguration" type="ApplicationConfiguration" />
 
-  <xs:complexType name="ReverseConnectServerConfiguration">
-    <xs:sequence>
-      <xs:element name="Clients" type="ListOfReverseConnectClient" minOccurs="0" nillable="true" />
-      <xs:element name="ConnectInterval" type="xs:int" minOccurs="0" />
-      <xs:element name="ConnectTimeout" type="xs:int" minOccurs="0" />
-      <xs:element name="RejectTimeout" type="xs:int" minOccurs="0" />
-    </xs:sequence>
-  </xs:complexType>
-
-  <xs:complexType name="ListOfReverseConnectClient">
-    <xs:sequence>
-      <xs:element name="ReverseConnectClient" type="ReverseConnectClient" minOccurs="0" maxOccurs="unbounded" />
-    </xs:sequence>
-  </xs:complexType>
-
-  <xs:complexType name="ReverseConnectClient">
-    <xs:sequence>
-      <xs:element name="EndpointUrl" type="xs:string" minOccurs="0" nillable="true" />
-      <xs:element name="Timeout" type="xs:int" minOccurs="0" />
-      <xs:element name="MaxSessionCount" type="xs:int" minOccurs="0" />
-      <xs:element name="Enabled" type="xs:boolean" minOccurs="0" />
-    </xs:sequence>
-  </xs:complexType>
-  
-  <xs:complexType name="OperationLimits">
-    <xs:sequence>
-      <xs:element name="MaxNodesPerRead" type="xs:int" minOccurs="0" />
-      <xs:element name="MaxNodesPerHistoryReadData" type="xs:int" minOccurs="0" />
-      <xs:element name="MaxNodesPerHistoryReadEvents" type="xs:int" minOccurs="0" />
-      <xs:element name="MaxNodesPerWrite" type="xs:int" minOccurs="0" />
-      <xs:element name="MaxNodesPerHistoryUpdateData" type="xs:int" minOccurs="0" />
-      <xs:element name="MaxNodesPerHistoryUpdateEvents" type="xs:int" minOccurs="0" />
-      <xs:element name="MaxNodesPerMethodCall" type="xs:int" minOccurs="0" />
-      <xs:element name="MaxNodesPerBrowse" type="xs:int" minOccurs="0" />
-      <xs:element name="MaxNodesPerRegisterNodes" type="xs:int" minOccurs="0" />
-      <xs:element name="MaxNodesPerTranslateBrowsePathsToNodeIds" type="xs:int" minOccurs="0" />
-      <xs:element name="MaxNodesPerNodeManagement" type="xs:int" minOccurs="0" />
-      <xs:element name="MaxMonitoredItemsPerCall" type="xs:int" minOccurs="0" />
-    </xs:sequence>
-  </xs:complexType>
-
-  <xs:complexType name="DiscoveryServerConfiguration">
-    <xs:complexContent mixed="false">
-      <xs:extension base="ServerBaseConfiguration">
+    <xs:complexType name="SecurityConfiguration">
         <xs:sequence>
-          <xs:element name="ServerNames" type="ua:ListOfLocalizedText" minOccurs="0" />
-          <xs:element name="DiscoveryServerCacheFile" type="xs:string" minOccurs="0" nillable="true" />
-          <xs:element name="ServerRegistrations" type="ListOfServerRegistration" minOccurs="0" />
+            <xs:sequence minOccurs="1">
+            <xs:element name="ApplicationCertificate" type="CertificateIdentifier" minOccurs="0"/>
+            <xs:element name="ApplicationCertificates" type="ListOfCertificateIdentifier" minOccurs="0"/>
+            </xs:sequence>
+            <xs:element name="TrustedIssuerCertificates" type="CertificateTrustList" />
+            <xs:element name="TrustedPeerCertificates" type="CertificateTrustList" />
+            <xs:element name="NonceLength" type="xs:int" minOccurs="0">
+                <xs:annotation>
+                    <xs:appinfo>
+                        <DefaultValue EmitDefaultValue="false" xmlns="http://schemas.microsoft.com/2003/10/Serialization/" />
+                    </xs:appinfo>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="RejectedCertificateStore" type="CertificateStoreIdentifier" minOccurs="0" />
+            <xs:element name="MaxRejectedCertificates" type="xs:int" minOccurs="0" />
+            <xs:element name="AutoAcceptUntrustedCertificates" type="xs:boolean" minOccurs="0" />
+            <xs:element name="UserRoleDirectory" type="xs:string"  minOccurs="0" nillable="true" />
+            <xs:element name="RejectSHA1SignedCertificates" type="xs:boolean" minOccurs="0" />
+            <xs:element name="RejectUnknownRevocationStatus" type="xs:boolean" minOccurs="0" />
+            <xs:element name="MinimumCertificateKeySize" type="xs:unsignedShort" minOccurs="0" />
+            <xs:element name="UseValidatedCertificates" type="xs:boolean" minOccurs="0" />
+            <xs:element name="AddAppCertToTrustedStore" type="xs:boolean" minOccurs="0" />
+            <xs:element name="SendCertificateChain" type="xs:boolean" minOccurs="0" />
+            <xs:sequence minOccurs="0">
+                <xs:element name="UserIssuerCertificates" type="CertificateTrustList"/>
+                <xs:element name="TrustedUserCertificates" type="CertificateTrustList"/>
+            </xs:sequence>
+            <xs:sequence minOccurs="0">
+                <xs:element name="HttpsIssuerCertificates" type="CertificateTrustList" />
+                <xs:element name="TrustedHttpsCertificates" type="CertificateTrustList" />
+            </xs:sequence>
+            <xs:element name="SuppressNonceValidationErrors" type="xs:boolean" minOccurs="0" />
         </xs:sequence>
-      </xs:extension>
-    </xs:complexContent>
-  </xs:complexType>
+    </xs:complexType>
 
-  <xs:complexType name="ListOfServerRegistration">
-    <xs:sequence>
-      <xs:element name="ServerRegistration" type="ServerRegistration" minOccurs="0" maxOccurs="unbounded" />
-    </xs:sequence>
-  </xs:complexType>
-
-  <xs:complexType name="ServerRegistration">
-    <xs:sequence>
-      <xs:element name="ApplicationUri" type="xs:string" minOccurs="0" />
-      <xs:element name="AlternateDiscoveryUrls" type="ua:ListOfString" minOccurs="0" />
-    </xs:sequence>
-  </xs:complexType>
-
-  <xs:complexType name="ClientConfiguration">
-    <xs:sequence>
-      <xs:element name="DefaultSessionTimeout" type="xs:int" minOccurs="0" />
-      <xs:element name="WellKnownDiscoveryUrls" type="ua:ListOfString" minOccurs="0" />
-      <xs:element name="DiscoveryServers" type="ua:ListOfEndpointDescription" minOccurs="0" />
-      <xs:element name="EndpointCacheFilePath" type="xs:string" minOccurs="0" nillable="true" />
-      <xs:element name="MinSubscriptionLifetime" type="xs:int" minOccurs="0" />
-      <xs:element name="ReverseConnect" type="ReverseConnectClientConfiguration" minOccurs="0" />
-      <xs:element name="OperationLimits" type="OperationLimits" minOccurs="0" />
-    </xs:sequence>
-  </xs:complexType>
-
-  <xs:complexType name="ReverseConnectClientConfiguration">
-    <xs:sequence>
-      <xs:element name="ClientEndpoints" type="ListOfReverseConnectClientEndpoint" minOccurs="0" nillable="true" />
-      <xs:element name="HoldTime" type="xs:int" minOccurs="0" />
-      <xs:element name="WaitTimeout" type="xs:int" minOccurs="0" />
-    </xs:sequence>
-  </xs:complexType>
-
-  <xs:complexType name="ListOfReverseConnectClientEndpoint">
-    <xs:sequence>
-      <xs:element name="ClientEndpoint" type="ReverseConnectClientEndpoint" minOccurs="0" maxOccurs="unbounded" />
-    </xs:sequence>
-  </xs:complexType>
-
-  <xs:complexType name="ReverseConnectClientEndpoint">
-    <xs:sequence>
-      <xs:element name="EndpointUrl" type="xs:string" minOccurs="0" nillable="true" />
-    </xs:sequence>
-  </xs:complexType>
-
-  <xs:complexType name="TraceConfiguration">
-    <xs:sequence>
-      <xs:element name="OutputFilePath" type="xs:string" minOccurs="0" nillable="true" />
-      <xs:element name="DeleteOnLoad" type="xs:boolean" minOccurs="0" />
-      <xs:element name="TraceMasks" type="xs:int" minOccurs="0" />
-    </xs:sequence>
-  </xs:complexType>
-
-  <xs:complexType name="CertificateIdentifier">
-    <xs:sequence>
-      <xs:element name="StoreType" type="xs:string" minOccurs="0" />
-      <xs:element name="StorePath" type="xs:string" minOccurs="0" />
-      <xs:element name="StoreName" type="xs:string" minOccurs="0" />
-      <xs:element name="StoreLocation" type="xs:string" minOccurs="0" />
-      <xs:element name="SubjectName" type="xs:string" minOccurs="0" />
-      <xs:element name="Thumbprint" type="xs:string" minOccurs="0" />
-      <xs:element name="RawData" type="xs:base64Binary" minOccurs="0" />
-      <xs:element name="ValidationOptions" type="xs:int" minOccurs="0">
-        <xs:annotation>
-          <xs:appinfo>
-            <DefaultValue EmitDefaultValue="false" xmlns="http://schemas.microsoft.com/2003/10/Serialization/" />
-          </xs:appinfo>
-        </xs:annotation>
-      </xs:element>
-    </xs:sequence>
-  </xs:complexType>
-
-  <xs:complexType name="ListOfCertificateIdentifier">
-    <xs:sequence>
-      <xs:element name="CertificateIdentifier" type="CertificateIdentifier"  minOccurs="0" maxOccurs="unbounded" />
-    </xs:sequence>
-  </xs:complexType>
-
-  <xs:complexType name="CertificateStoreIdentifier">
-    <xs:sequence>
-      <xs:element name="StoreType" type="xs:string" minOccurs="0" />
-      <xs:element name="StorePath" type="xs:string" minOccurs="0" />
-      <xs:element name="StoreName" type="xs:string" minOccurs="0" />
-      <xs:element name="StoreLocation" type="xs:string" minOccurs="0" />
-      <xs:element name="ValidationOptions" type="xs:int" minOccurs="0">
-        <xs:annotation>
-          <xs:appinfo>
-            <DefaultValue EmitDefaultValue="false" xmlns="http://schemas.microsoft.com/2003/10/Serialization/" />
-          </xs:appinfo>
-        </xs:annotation>
-      </xs:element>
-    </xs:sequence>
-  </xs:complexType>
-
-  <xs:complexType name="CertificateTrustList">
-    <xs:complexContent mixed="false">
-      <xs:extension base="CertificateStoreIdentifier">
+    <xs:complexType name="ListOfTransportConfiguration">
         <xs:sequence>
-          <xs:element name="TrustedCertificates" type="ListOfCertificateIdentifier" minOccurs="0" />
+            <xs:element name="TransportConfiguration" type="TransportConfiguration" minOccurs="0" maxOccurs="unbounded" />
         </xs:sequence>
-      </xs:extension>
-    </xs:complexContent>
-  </xs:complexType>
+    </xs:complexType>
 
-  <xs:complexType name="ConfiguredEndpointCollection">
-    <xs:sequence>
-      <xs:element name="KnownHosts" type="ua:ListOfString" minOccurs="0" nillable="true" />
-      <xs:element name="Endpoints" type="ListOfConfiguredEndpoint" minOccurs="0" nillable="true" />
-      <xs:element name="TcpProxyUrl" type="xs:anyURI" minOccurs="0" nillable="true" />
-    </xs:sequence>
-  </xs:complexType>
-  <xs:element name="ConfiguredEndpointCollection" type="ConfiguredEndpointCollection" />
+    <xs:complexType name="TransportConfiguration">
+        <xs:sequence>
+            <xs:element name="UriScheme" type="xs:string" />
+            <xs:element name="TypeName" type="xs:string" />
+        </xs:sequence>
+    </xs:complexType>
 
-  <xs:complexType name="ListOfConfiguredEndpoint">
-    <xs:sequence>
-      <xs:element name="ConfiguredEndpoint" type="ConfiguredEndpoint"  minOccurs="0" maxOccurs="unbounded" />
-    </xs:sequence>
-  </xs:complexType>
+    <xs:complexType name="TransportQuotas">
+        <xs:sequence>
+            <xs:element name="OperationTimeout" type="xs:int" minOccurs="0" />
+            <xs:element name="MaxStringLength" type="xs:int" minOccurs="0" />
+            <xs:element name="MaxByteStringLength" type="xs:int" minOccurs="0" />
+            <xs:element name="MaxArrayLength" type="xs:int" minOccurs="0" />
+            <xs:element name="MaxMessageSize" type="xs:int" minOccurs="0" />
+            <xs:element name="MaxBufferSize" type="xs:int" minOccurs="0" />
+            <xs:element name="MaxEncodingNestingLevels" type="xs:int" minOccurs="0" />
+            <xs:element name="MaxDecoderRecoveries" type="xs:int" minOccurs="0" />
+            <xs:element name="ChannelLifetime" type="xs:int" minOccurs="0" />
+            <xs:element name="SecurityTokenLifetime" type="xs:int" minOccurs="0" />
+        </xs:sequence>
+    </xs:complexType>
 
-  <xs:complexType name="ConfiguredEndpoint">
-    <xs:sequence>
-      <xs:element name="Endpoint" type="ua:EndpointDescription" minOccurs="0" />
-      <xs:element name="Configuration" type="ua:EndpointConfiguration" minOccurs="0" />
-      <xs:element name="UpdateBeforeConnect" type="xs:boolean" minOccurs="0" />
-      <xs:element name="BinaryEncodingSupport" type="BinaryEncodingSupport" minOccurs="0" />
-      <xs:element name="SelectedUserTokenPolicy" type="xs:int" minOccurs="0" />
-      <xs:element name="UserIdentity" type="ua:UserIdentityToken" minOccurs="0" />
-      <xs:element name="ComIdentity" type="EndpointComIdentity" minOccurs="0" />
-	    <xs:element name="ReverseConnect" type="ReverseConnectEndpoint" minOccurs="0" />
-      <xs:element name="Extensions" type="ua:ListOfXmlElement" minOccurs="0"  />
-    </xs:sequence>
-  </xs:complexType>
+    <xs:complexType name="ServerBaseConfiguration">
+        <xs:sequence>
+            <xs:element name="BaseAddresses" type="ua:ListOfString" minOccurs="0" nillable="true" />
+            <xs:element name="AlternateBaseAddresses" type="ua:ListOfString" minOccurs="0" nillable="true" />
+            <xs:element name="SecurityPolicies" type="ListOfServerSecurityPolicy" minOccurs="0" nillable="true" />
+            <xs:element name="MinRequestThreadCount" type="xs:int" minOccurs="0" />
+            <xs:element name="MaxRequestThreadCount" type="xs:int" minOccurs="0" />
+            <xs:element name="MaxQueuedRequestCount" type="xs:int" minOccurs="0" />
+        </xs:sequence>
+    </xs:complexType>
 
-  <xs:simpleType name="BinaryEncodingSupport">
-    <xs:restriction base="xs:string">
-      <xs:enumeration value="Optional" />
-      <xs:enumeration value="Required" />
-      <xs:enumeration value="None" />
-    </xs:restriction>
-  </xs:simpleType>
+    <xs:complexType name="ListOfServerSecurityPolicy">
+        <xs:sequence>
+            <xs:element name="ServerSecurityPolicy" type="ServerSecurityPolicy" minOccurs="0" maxOccurs="unbounded" />
+        </xs:sequence>
+    </xs:complexType>
 
-  <xs:complexType name="ReverseConnectEndpoint">
-    <xs:sequence>
-      <xs:element name="Enabled" type="xs:boolean" minOccurs="0" />
-      <xs:element name="ServerUri" type="xs:string" minOccurs="0" />
-      <xs:element name="Thumbprint" type="xs:string" minOccurs="0" />
-    </xs:sequence>
-  </xs:complexType>
+    <xs:complexType name="ServerSecurityPolicy">
+        <xs:sequence>
+            <xs:element name="SecurityMode" type="ua:MessageSecurityMode" minOccurs="0" />
+            <xs:element name="SecurityPolicyUri" type="xs:string" minOccurs="0"  nillable="true" />
+        </xs:sequence>
+    </xs:complexType>
 
-  <xs:complexType name="EndpointComIdentity">
-    <xs:sequence>
-      <xs:element name="Clsid" type="ua:Guid" minOccurs="0" />
-      <xs:element name="ProgId" type="xs:string" minOccurs="0" />
-      <xs:element name="Specification" type="ComSpecification" minOccurs="0" />
-    </xs:sequence>
-  </xs:complexType>
+    <xs:complexType name="ListOfSamplingRateGroup">
+        <xs:sequence>
+            <xs:element name="SamplingRateGroup" type="SamplingRateGroup" minOccurs="0" maxOccurs="unbounded" />
+        </xs:sequence>
+    </xs:complexType>
 
-  <xs:simpleType name="ComSpecification">
-    <xs:restriction base="xs:string">
-      <xs:enumeration value="DA" />
-      <xs:enumeration value="AE" />
-      <xs:enumeration value="HDA" />
-    </xs:restriction>
-  </xs:simpleType>
+    <xs:complexType name="SamplingRateGroup">
+        <xs:sequence>
+            <xs:element name="Start" type="xs:double" minOccurs="0" />
+            <xs:element name="Increment" type="xs:double" minOccurs="0" />
+            <xs:element name="Count" type="xs:int" minOccurs="0" />
+        </xs:sequence>
+    </xs:complexType>
 
-  <xs:complexType name="ApplicationAccessRule">
-    <xs:sequence>
-      <xs:element name="IdentityName" type="xs:string" minOccurs="0" />
-      <xs:element name="RuleType" type="AccessControlType" minOccurs="0" />
-      <xs:element name="Right" type="ApplicationAccessRight" minOccurs="0" />
-    </xs:sequence>
-  </xs:complexType>
+    <xs:complexType name="ServerConfiguration">
+        <xs:complexContent mixed="false">
+            <xs:extension base="ServerBaseConfiguration">
+                <xs:sequence>
+                    <xs:element name="UserTokenPolicies" type="ua:ListOfUserTokenPolicy" minOccurs="0" />
+                    <xs:element name="DiagnosticsEnabled" type="xs:boolean" minOccurs="0" />
+                    <xs:element name="MaxSessionCount" type="xs:int" minOccurs="0" />
+                    <xs:element name="MaxChannelCount" type="xs:int" minOccurs="0" />
+                    <xs:element name="MinSessionTimeout" type="xs:int" minOccurs="0" />
+                    <xs:element name="MaxSessionTimeout" type="xs:int" minOccurs="0" />
+                    <xs:element name="MaxBrowseContinuationPoints" type="xs:int" minOccurs="0" />
+                    <xs:element name="MaxQueryContinuationPoints" type="xs:int" minOccurs="0" />
+                    <xs:element name="MaxHistoryContinuationPoints" type="xs:int" minOccurs="0" />
+                    <xs:element name="MaxRequestAge" type="xs:int" minOccurs="0" />
+                    <xs:element name="MinPublishingInterval" type="xs:int" minOccurs="0" />
+                    <xs:element name="MaxPublishingInterval" type="xs:int" minOccurs="0" />
+                    <xs:element name="PublishingResolution" type="xs:int" minOccurs="0" />
+                    <xs:element name="MaxSubscriptionLifetime" type="xs:int" minOccurs="0" />
+                    <xs:element name="MaxMessageQueueSize" type="xs:int" minOccurs="0" />
+                    <xs:element name="MaxNotificationQueueSize" type="xs:int" minOccurs="0" />
+                    <xs:element name="MaxNotificationsPerPublish" type="xs:int" minOccurs="0" />
+                    <xs:element name="MinMetadataSamplingInterval" type="xs:int" minOccurs="0" />
+                    <xs:element name="AvailableSamplingRates" type="ListOfSamplingRateGroup" minOccurs="0" />
+                    <xs:element name="RegistrationEndpoint" type="ua:EndpointDescription" minOccurs="0" />
+                    <xs:element name="MaxRegistrationInterval" type="xs:int" minOccurs="0" />
+                    <xs:element name="NodeManagerSaveFile" type="xs:string" minOccurs="0" nillable="true" />
+                    <xs:element name="MinSubscriptionLifetime" type="xs:int" minOccurs="0" />
+                    <xs:element name="MaxPublishRequestCount" type="xs:int" minOccurs="0" />
+                    <xs:element name="MaxSubscriptionCount" type="xs:int" minOccurs="0" />
+                    <xs:element name="MaxEventQueueSize" type="xs:int" minOccurs="0" />
+                    <xs:element name="ServerProfileArray" type="ua:ListOfString" minOccurs="0" nillable="true" />
+                    <xs:element name="ShutdownDelay" type="xs:int" minOccurs="0" />
+                    <xs:element name="ServerCapabilities" type="ua:ListOfString" minOccurs="0" nillable="true" />
+                    <xs:element name="SupportedPrivateKeyFormats" type="ua:ListOfString" minOccurs="0" nillable="true" />
+                    <xs:element name="MaxTrustListSize" type="xs:int" minOccurs="0" />
+                    <xs:element name="MultiCastDnsEnabled" type="xs:boolean" minOccurs="0" />
+                    <xs:element name="ReverseConnect" type="ReverseConnectServerConfiguration" minOccurs="0" />
+                    <xs:element name="OperationLimits" type="OperationLimits" minOccurs="0" />
+                    <xs:element name="AuditingEnabled" type="xs:boolean" minOccurs="0" />
+                    <xs:element name="HttpsMutualTls" type="xs:boolean" minOccurs="0" />
+                    <xs:element name="DurableSubscriptionsEnabled" type="xs:boolean" minOccurs="0" />
+                    <xs:element name="MaxDurableNotificationQueueSize" type="xs:int" minOccurs="0" />
+                    <xs:element name="MaxDurableEventQueueSize" type="xs:int" minOccurs="0" />
+                    <xs:element name="MaxDurableSubscriptionLifetimeInHours" type="xs:int" minOccurs="0" />
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
 
-  <xs:complexType name="ListOfApplicationAccessRule">
-    <xs:sequence>
-      <xs:element name="ApplicationAccessRule" type="ApplicationAccessRule" minOccurs="0" maxOccurs="unbounded" />
-    </xs:sequence>
-  </xs:complexType>
+    <xs:complexType name="ReverseConnectServerConfiguration">
+        <xs:sequence>
+            <xs:element name="Clients" type="ListOfReverseConnectClient" minOccurs="0" nillable="true" />
+            <xs:element name="ConnectInterval" type="xs:int" minOccurs="0" />
+            <xs:element name="ConnectTimeout" type="xs:int" minOccurs="0" />
+            <xs:element name="RejectTimeout" type="xs:int" minOccurs="0" />
+        </xs:sequence>
+    </xs:complexType>
 
-  <xs:simpleType name="AccessControlType">
-    <xs:restriction base="xs:string">
-      <xs:enumeration value="Allow" />
-      <xs:enumeration value="Deny" />
-    </xs:restriction>
-  </xs:simpleType>
+    <xs:complexType name="ListOfReverseConnectClient">
+        <xs:sequence>
+            <xs:element name="ReverseConnectClient" type="ReverseConnectClient" minOccurs="0" maxOccurs="unbounded" />
+        </xs:sequence>
+    </xs:complexType>
 
-  <xs:simpleType name="ApplicationAccessRight">
-    <xs:restriction base="xs:string">
-      <xs:enumeration value="None" />
-      <xs:enumeration value="Run" />
-      <xs:enumeration value="Update" />
-      <xs:enumeration value="Configure" />
-    </xs:restriction>
-  </xs:simpleType>
+    <xs:complexType name="ReverseConnectClient">
+        <xs:sequence>
+            <xs:element name="EndpointUrl" type="xs:string" minOccurs="0" nillable="true" />
+            <xs:element name="Timeout" type="xs:int" minOccurs="0" />
+            <xs:element name="MaxSessionCount" type="xs:int" minOccurs="0" />
+            <xs:element name="Enabled" type="xs:boolean" minOccurs="0" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="OperationLimits">
+        <xs:sequence>
+            <xs:element name="MaxNodesPerRead" type="xs:int" minOccurs="0" />
+            <xs:element name="MaxNodesPerHistoryReadData" type="xs:int" minOccurs="0" />
+            <xs:element name="MaxNodesPerHistoryReadEvents" type="xs:int" minOccurs="0" />
+            <xs:element name="MaxNodesPerWrite" type="xs:int" minOccurs="0" />
+            <xs:element name="MaxNodesPerHistoryUpdateData" type="xs:int" minOccurs="0" />
+            <xs:element name="MaxNodesPerHistoryUpdateEvents" type="xs:int" minOccurs="0" />
+            <xs:element name="MaxNodesPerMethodCall" type="xs:int" minOccurs="0" />
+            <xs:element name="MaxNodesPerBrowse" type="xs:int" minOccurs="0" />
+            <xs:element name="MaxNodesPerRegisterNodes" type="xs:int" minOccurs="0" />
+            <xs:element name="MaxNodesPerTranslateBrowsePathsToNodeIds" type="xs:int" minOccurs="0" />
+            <xs:element name="MaxNodesPerNodeManagement" type="xs:int" minOccurs="0" />
+            <xs:element name="MaxMonitoredItemsPerCall" type="xs:int" minOccurs="0" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="DiscoveryServerConfiguration">
+        <xs:complexContent mixed="false">
+            <xs:extension base="ServerBaseConfiguration">
+                <xs:sequence>
+                    <xs:element name="ServerNames" type="ua:ListOfLocalizedText" minOccurs="0" />
+                    <xs:element name="DiscoveryServerCacheFile" type="xs:string" minOccurs="0" nillable="true" />
+                    <xs:element name="ServerRegistrations" type="ListOfServerRegistration" minOccurs="0" />
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="ListOfServerRegistration">
+        <xs:sequence>
+            <xs:element name="ServerRegistration" type="ServerRegistration" minOccurs="0" maxOccurs="unbounded" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="ServerRegistration">
+        <xs:sequence>
+            <xs:element name="ApplicationUri" type="xs:string" minOccurs="0" />
+            <xs:element name="AlternateDiscoveryUrls" type="ua:ListOfString" minOccurs="0" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="ClientConfiguration">
+        <xs:sequence>
+            <xs:element name="DefaultSessionTimeout" type="xs:int" minOccurs="0" />
+            <xs:element name="WellKnownDiscoveryUrls" type="ua:ListOfString" minOccurs="0" />
+            <xs:element name="DiscoveryServers" type="ua:ListOfEndpointDescription" minOccurs="0" />
+            <xs:element name="EndpointCacheFilePath" type="xs:string" minOccurs="0" nillable="true" />
+            <xs:element name="MinSubscriptionLifetime" type="xs:int" minOccurs="0" />
+            <xs:element name="ReverseConnect" type="ReverseConnectClientConfiguration" minOccurs="0" />
+            <xs:element name="OperationLimits" type="OperationLimits" minOccurs="0" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="ReverseConnectClientConfiguration">
+        <xs:sequence>
+            <xs:element name="ClientEndpoints" type="ListOfReverseConnectClientEndpoint" minOccurs="0" nillable="true" />
+            <xs:element name="HoldTime" type="xs:int" minOccurs="0" />
+            <xs:element name="WaitTimeout" type="xs:int" minOccurs="0" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="ListOfReverseConnectClientEndpoint">
+        <xs:sequence>
+            <xs:element name="ClientEndpoint" type="ReverseConnectClientEndpoint" minOccurs="0" maxOccurs="unbounded" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="ReverseConnectClientEndpoint">
+        <xs:sequence>
+            <xs:element name="EndpointUrl" type="xs:string" minOccurs="0" nillable="true" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="TraceConfiguration">
+        <xs:sequence>
+            <xs:element name="OutputFilePath" type="xs:string" minOccurs="0" nillable="true" />
+            <xs:element name="DeleteOnLoad" type="xs:boolean" minOccurs="0" />
+            <xs:element name="TraceMasks" type="xs:int" minOccurs="0" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="CertificateIdentifier">
+        <xs:sequence>
+            <xs:element name="StoreType" type="xs:string" minOccurs="0" />
+            <xs:element name="StorePath" type="xs:string" minOccurs="0" />
+            <xs:element name="StoreName" type="xs:string" minOccurs="0" />
+            <xs:element name="StoreLocation" type="xs:string" minOccurs="0" />
+            <xs:element name="SubjectName" type="xs:string" minOccurs="0" />
+            <xs:element name="Thumbprint" type="xs:string" minOccurs="0" />
+            <xs:element name="RawData" type="xs:base64Binary" minOccurs="0" />
+            <xs:element name="ValidationOptions" type="xs:int" minOccurs="0">
+                <xs:annotation>
+                    <xs:appinfo>
+                        <DefaultValue EmitDefaultValue="false" xmlns="http://schemas.microsoft.com/2003/10/Serialization/" />
+                    </xs:appinfo>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="ListOfCertificateIdentifier">
+        <xs:sequence>
+            <xs:element name="CertificateIdentifier" type="CertificateIdentifier"  minOccurs="0" maxOccurs="unbounded" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="CertificateStoreIdentifier">
+        <xs:sequence>
+            <xs:element name="StoreType" type="xs:string" minOccurs="0" />
+            <xs:element name="StorePath" type="xs:string" minOccurs="0" />
+            <xs:element name="StoreName" type="xs:string" minOccurs="0" />
+            <xs:element name="StoreLocation" type="xs:string" minOccurs="0" />
+            <xs:element name="ValidationOptions" type="xs:int" minOccurs="0">
+                <xs:annotation>
+                    <xs:appinfo>
+                        <DefaultValue EmitDefaultValue="false" xmlns="http://schemas.microsoft.com/2003/10/Serialization/" />
+                    </xs:appinfo>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="CertificateTrustList">
+        <xs:complexContent mixed="false">
+            <xs:extension base="CertificateStoreIdentifier">
+                <xs:sequence>
+                    <xs:element name="TrustedCertificates" type="ListOfCertificateIdentifier" minOccurs="0" />
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="ConfiguredEndpointCollection">
+        <xs:sequence>
+            <xs:element name="KnownHosts" type="ua:ListOfString" minOccurs="0" nillable="true" />
+            <xs:element name="Endpoints" type="ListOfConfiguredEndpoint" minOccurs="0" nillable="true" />
+            <xs:element name="TcpProxyUrl" type="xs:anyURI" minOccurs="0" nillable="true" />
+        </xs:sequence>
+    </xs:complexType>
+    <xs:element name="ConfiguredEndpointCollection" type="ConfiguredEndpointCollection" />
+
+    <xs:complexType name="ListOfConfiguredEndpoint">
+        <xs:sequence>
+            <xs:element name="ConfiguredEndpoint" type="ConfiguredEndpoint"  minOccurs="0" maxOccurs="unbounded" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="ConfiguredEndpoint">
+        <xs:sequence>
+            <xs:element name="Endpoint" type="ua:EndpointDescription" minOccurs="0" />
+            <xs:element name="Configuration" type="ua:EndpointConfiguration" minOccurs="0" />
+            <xs:element name="UpdateBeforeConnect" type="xs:boolean" minOccurs="0" />
+            <xs:element name="BinaryEncodingSupport" type="BinaryEncodingSupport" minOccurs="0" />
+            <xs:element name="SelectedUserTokenPolicy" type="xs:int" minOccurs="0" />
+            <xs:element name="UserIdentity" type="ua:UserIdentityToken" minOccurs="0" />
+            <xs:element name="ComIdentity" type="EndpointComIdentity" minOccurs="0" />
+            <xs:element name="ReverseConnect" type="ReverseConnectEndpoint" minOccurs="0" />
+            <xs:element name="Extensions" type="ua:ListOfXmlElement" minOccurs="0"  />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:simpleType name="BinaryEncodingSupport">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="Optional" />
+            <xs:enumeration value="Required" />
+            <xs:enumeration value="None" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="ReverseConnectEndpoint">
+        <xs:sequence>
+            <xs:element name="Enabled" type="xs:boolean" minOccurs="0" />
+            <xs:element name="ServerUri" type="xs:string" minOccurs="0" />
+            <xs:element name="Thumbprint" type="xs:string" minOccurs="0" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="EndpointComIdentity">
+        <xs:sequence>
+            <xs:element name="Clsid" type="ua:Guid" minOccurs="0" />
+            <xs:element name="ProgId" type="xs:string" minOccurs="0" />
+            <xs:element name="Specification" type="ComSpecification" minOccurs="0" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:simpleType name="ComSpecification">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="DA" />
+            <xs:enumeration value="AE" />
+            <xs:enumeration value="HDA" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="ApplicationAccessRule">
+        <xs:sequence>
+            <xs:element name="IdentityName" type="xs:string" minOccurs="0" />
+            <xs:element name="RuleType" type="AccessControlType" minOccurs="0" />
+            <xs:element name="Right" type="ApplicationAccessRight" minOccurs="0" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="ListOfApplicationAccessRule">
+        <xs:sequence>
+            <xs:element name="ApplicationAccessRule" type="ApplicationAccessRule" minOccurs="0" maxOccurs="unbounded" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:simpleType name="AccessControlType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="Allow" />
+            <xs:enumeration value="Deny" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="ApplicationAccessRight">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="None" />
+            <xs:enumeration value="Run" />
+            <xs:enumeration value="Update" />
+            <xs:enumeration value="Configure" />
+        </xs:restriction>
+    </xs:simpleType>
 
 </xs:schema>

--- a/Stack/Opc.Ua.Core/Security/Certificates/CertificateTrustList.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/CertificateTrustList.cs
@@ -53,7 +53,10 @@ namespace Opc.Ua
                 try
                 {
                     store = OpenStore();
-                    collection = await store.Enumerate().ConfigureAwait(false);
+                    if (store != null)
+                    {
+                        collection = await store.Enumerate().ConfigureAwait(false);
+                    }
                 }
                 catch (Exception)
                 {

--- a/Stack/Opc.Ua.Core/Security/Certificates/CertificateTrustList.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/CertificateTrustList.cs
@@ -47,16 +47,20 @@ namespace Opc.Ua
         {
             X509Certificate2Collection collection = new X509Certificate2Collection();
 
-            if (!String.IsNullOrEmpty(this.StorePath))
+            if (!string.IsNullOrEmpty(this.StorePath))
             {
                 ICertificateStore store = null;
                 try
                 {
                     store = OpenStore();
-                    if (store != null)
+
+                    if (store == null)
                     {
-                        collection = await store.Enumerate().ConfigureAwait(false);
+                        throw new ServiceResultException(StatusCodes.BadConfigurationError, "Failed to open certificate store.");
                     }
+
+                    collection = await store.Enumerate().ConfigureAwait(false);
+
                 }
                 catch (Exception)
                 {

--- a/Stack/Opc.Ua.Core/Security/Certificates/CertificateValidator.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/CertificateValidator.cs
@@ -1051,6 +1051,7 @@ namespace Opc.Ua
                 {
                     if (store == null)
                     {
+                        Utils.LogWarning("Failed to open issuer store: {0}", certificateStore);
                         // not a trusted issuer.
                         return (null, null);
                     }

--- a/Stack/Opc.Ua.Core/Security/Certificates/CertificateValidator.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/CertificateValidator.cs
@@ -867,12 +867,15 @@ namespace Opc.Ua
                     ICertificateStore store = rejectedCertificateStore.OpenStore();
                     try
                     {
-                        // number of certs for history + current chain
-                        await store.AddRejected(certificateChain, m_maxRejectedCertificates).ConfigureAwait(false);
+                        if (store != null)
+                        {
+                            // number of certs for history + current chain
+                            await store.AddRejected(certificateChain, m_maxRejectedCertificates).ConfigureAwait(false);
+                        }
                     }
                     finally
                     {
-                        store.Close();
+                        store?.Close();
                     }
                 }
                 finally
@@ -1046,6 +1049,12 @@ namespace Opc.Ua
 
                 try
                 {
+                    if (store == null)
+                    {
+                        // not a trusted issuer.
+                        return (null, null);
+                    }
+
                     X509Certificate2Collection certificates = await store.Enumerate().ConfigureAwait(false);
 
                     for (int ii = 0; ii < certificates.Count; ii++)
@@ -1103,7 +1112,7 @@ namespace Opc.Ua
                 }
                 finally
                 {
-                    store.Close();
+                    store?.Close();
                 }
             }
 
@@ -1902,7 +1911,7 @@ namespace Opc.Ua
             }
         }
 #endif
-#endregion
+        #endregion
 
         #region Private Enum
         /// <summary>

--- a/Stack/Opc.Ua.Core/Security/Certificates/SecurityConfiguration.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/SecurityConfiguration.cs
@@ -81,7 +81,6 @@ namespace Opc.Ua
                 ValidateStore(UserIssuerCertificates, nameof(UserIssuerCertificates));
             }
 
-
             if ((TrustedHttpsCertificates != null && HttpsIssuerCertificates == null)
                 || (HttpsIssuerCertificates != null && TrustedHttpsCertificates == null))
             {
@@ -116,13 +115,13 @@ namespace Opc.Ua
                 ICertificateStore store = storeIdentifier.OpenStore();
                 if (store == null)
                 {
-                    throw new Exception($"Failed top open {storeName} store");
+                    throw ServiceResultException.Create(StatusCodes.BadConfigurationError, $"Failed to open {storeName} store");
                 }
                 store?.Close();
             }
             catch (Exception ex)
             {
-                Utils.LogError(ex, "Failed top open {storeName} store", storeName);
+                Utils.LogError(ex, "Failed to open {storeName} store", storeName);
                 throw ServiceResultException.Create(StatusCodes.BadConfigurationError, storeName + " store is invalid.");
             }
         }
@@ -233,26 +232,6 @@ namespace Opc.Ua
             }
             return result;
         }
-
-        /// <summary>
-        /// Ensure valid trust lists.
-        /// </summary>
-        private CertificateTrustList CreateDefaultTrustList(CertificateTrustList trustList)
-        {
-            if (trustList != null)
-            {
-                if (trustList.StorePath != null)
-                {
-                    return trustList;
-                }
-            }
-
-            return new CertificateTrustList();
-        }
-
-
-
-
         #endregion
     }
     #endregion

--- a/Stack/Opc.Ua.Core/Security/Certificates/SecurityConfiguration.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/SecurityConfiguration.cs
@@ -107,9 +107,9 @@ namespace Opc.Ua
         /// </summary>
         private void ValidateStore(CertificateStoreIdentifier storeIdentifier, string storeName)
         {
-            if (storeIdentifier?.StorePath == null)
+            if (string.IsNullOrEmpty(storeIdentifier?.StorePath))
             {
-                throw ServiceResultException.Create(StatusCodes.BadConfigurationError, storeName + " store must be specified.");
+                throw ServiceResultException.Create(StatusCodes.BadConfigurationError, storeName + " StorePath must be specified.");
             }
             try
             {

--- a/Stack/Opc.Ua.Core/Security/Certificates/SecurityConfiguration.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/SecurityConfiguration.cs
@@ -64,32 +64,32 @@ namespace Opc.Ua
             ValidateStore(TrustedPeerCertificates, nameof(TrustedPeerCertificates));
 
             //ensure optional stores are valid if specified
-            if (TrustedHttpsCertificates.StorePath != null)
+            if (TrustedHttpsCertificates != null)
             {
                 ValidateStore(TrustedHttpsCertificates, nameof(TrustedHttpsCertificates));
             }
-            if (HttpsIssuerCertificates.StorePath != null)
+            if (HttpsIssuerCertificates != null)
             {
                 ValidateStore(HttpsIssuerCertificates, nameof(HttpsIssuerCertificates));
             }
-            if (TrustedUserCertificates.StorePath != null)
+            if (TrustedUserCertificates != null)
             {
                 ValidateStore(TrustedUserCertificates, nameof(TrustedUserCertificates));
             }
-            if (UserIssuerCertificates.StorePath != null)
+            if (UserIssuerCertificates != null)
             {
                 ValidateStore(UserIssuerCertificates, nameof(UserIssuerCertificates));
             }
 
 
-            if ((TrustedHttpsCertificates.StorePath != null && HttpsIssuerCertificates.StorePath == null)
-                || (HttpsIssuerCertificates.StorePath != null && TrustedHttpsCertificates.StorePath == null))
+            if ((TrustedHttpsCertificates != null && HttpsIssuerCertificates == null)
+                || (HttpsIssuerCertificates != null && TrustedHttpsCertificates == null))
             {
                 throw ServiceResultException.Create(StatusCodes.BadConfigurationError, "Either none or both of HttpsIssuerCertificates & TrustedHttpsCertificates stores must be specified.");
             }
 
-            if ((TrustedUserCertificates.StorePath != null && UserIssuerCertificates.StorePath == null)
-                || (UserIssuerCertificates.StorePath != null && TrustedUserCertificates.StorePath == null))
+            if ((TrustedUserCertificates != null && UserIssuerCertificates == null)
+                || (UserIssuerCertificates != null && TrustedUserCertificates == null))
             {
                 throw ServiceResultException.Create(StatusCodes.BadConfigurationError, "Either none or both of UserIssuerCertificates & TrustedUserCertificates stores must be specified.");
             }

--- a/Stack/Opc.Ua.Core/Security/Certificates/SecurityConfiguration.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/SecurityConfiguration.cs
@@ -60,8 +60,27 @@ namespace Opc.Ua
                 throw ServiceResultException.Create(StatusCodes.BadConfigurationError, "ApplicationCertificate must be specified.");
             }
 
-            TrustedIssuerCertificates = CreateDefaultTrustList(TrustedIssuerCertificates);
-            TrustedPeerCertificates = CreateDefaultTrustList(TrustedPeerCertificates);
+            if (TrustedIssuerCertificates?.StorePath == null)
+            {
+                throw ServiceResultException.Create(StatusCodes.BadConfigurationError, "TrustedIssuerCertificates store must be specified.");
+            }
+
+            if (TrustedPeerCertificates?.StorePath == null)
+            {
+                throw ServiceResultException.Create(StatusCodes.BadConfigurationError, "TrustedPeerCertificates store must be specified.");
+            }
+
+            if ((TrustedHttpsCertificates != null && HttpsIssuerCertificates == null)
+                || (HttpsIssuerCertificates != null && TrustedHttpsCertificates == null))
+            {
+                throw ServiceResultException.Create(StatusCodes.BadConfigurationError, "Either none or both of HttpsIssuerCertificates & TrustedHttpsCertificates stores must be specified.");
+            }
+
+            if ((TrustedUserCertificates != null && UserIssuerCertificates == null)
+                || (UserIssuerCertificates != null && TrustedUserCertificates == null))
+            {
+                throw ServiceResultException.Create(StatusCodes.BadConfigurationError, "Either none or both of UserIssuerCertificates & TrustedUserCertificates stores must be specified.");
+            }
 
 
             // replace subjectName DC=localhost with DC=hostname

--- a/Stack/Opc.Ua.Core/Security/Certificates/SecurityConfiguration.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/SecurityConfiguration.cs
@@ -63,7 +63,7 @@ namespace Opc.Ua
             ValidateStore(TrustedIssuerCertificates, nameof(TrustedIssuerCertificates));
             ValidateStore(TrustedPeerCertificates, nameof(TrustedPeerCertificates));
 
-            ///ensure optional stores are valid if specified
+            //ensure optional stores are valid if specified
             if (TrustedHttpsCertificates.StorePath != null)
             {
                 ValidateStore(TrustedHttpsCertificates, nameof(TrustedHttpsCertificates));

--- a/Tests/Opc.Ua.Configuration.Tests/SecurityConfigurationTests.cs
+++ b/Tests/Opc.Ua.Configuration.Tests/SecurityConfigurationTests.cs
@@ -1,0 +1,144 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ * 
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ * 
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace Opc.Ua.Configuration.Tests
+{
+    /// <summary>
+    /// Tests for the security configuration class.
+    /// </summary>
+    [TestFixture, Category("SecurityConfiguration")]
+    [SetCulture("en-us")]
+    public class SecurityConfigurationTests
+    {
+        [Test]
+        public void ValidConfgurationPasses()
+        {
+            var configuration = new SecurityConfiguration {
+                ApplicationCertificate = new CertificateIdentifier { RawData = Array.Empty<byte>() },
+                TrustedPeerCertificates = new CertificateTrustList { StorePath = "Test" },
+                TrustedIssuerCertificates = new CertificateTrustList { StorePath = "Test" },
+            };
+
+            configuration.Validate();
+        }
+
+        [TestCaseSource(nameof(GetInvalidConfigurations))]
+        public void InvalidConfigurationThrows(SecurityConfiguration configuration)
+        {
+            Assert.Throws<ServiceResultException>(() => configuration.Validate());
+        }
+
+        private static IEnumerable<TestCaseData> GetInvalidConfigurations()
+        {
+            yield return new TestCaseData(new SecurityConfiguration {
+                ApplicationCertificate = new CertificateIdentifier { RawData = Array.Empty<byte>() },
+            }).SetName("NoStores");
+
+            yield return new TestCaseData(new SecurityConfiguration {
+                ApplicationCertificate = new CertificateIdentifier { RawData = Array.Empty<byte>() },
+                TrustedPeerCertificates = new CertificateTrustList { StorePath = "" },
+                TrustedIssuerCertificates = new CertificateTrustList { StorePath = "Test" },
+            }).SetName("InvalidTrustedStore");
+
+            yield return new TestCaseData(new SecurityConfiguration {
+                ApplicationCertificate = new CertificateIdentifier { RawData = Array.Empty<byte>() },
+                TrustedPeerCertificates = new CertificateTrustList { StorePath = "Test" },
+                TrustedIssuerCertificates = new CertificateTrustList { StorePath = "" },
+            }).SetName("InvalidIssuerStore");
+
+            yield return new TestCaseData(new SecurityConfiguration {
+                ApplicationCertificate = new CertificateIdentifier { RawData = Array.Empty<byte>() },
+                TrustedPeerCertificates = new CertificateTrustList { StorePath = "Test" },
+                TrustedIssuerCertificates = new CertificateTrustList { StorePath = "Test" },
+                TrustedHttpsCertificates = new CertificateTrustList { StorePath = "Test" },
+            }).SetName("OnlyTrustedHttps");
+
+            yield return new TestCaseData(new SecurityConfiguration {
+                ApplicationCertificate = new CertificateIdentifier { RawData = Array.Empty<byte>() },
+                TrustedPeerCertificates = new CertificateTrustList { StorePath = "Test" },
+                TrustedIssuerCertificates = new CertificateTrustList { StorePath = "Test" },
+                HttpsIssuerCertificates = new CertificateTrustList { StorePath = "Test" },
+            }).SetName("OnlyIssuerHttps");
+
+            yield return new TestCaseData(new SecurityConfiguration {
+                ApplicationCertificate = new CertificateIdentifier { RawData = Array.Empty<byte>() },
+                TrustedPeerCertificates = new CertificateTrustList { StorePath = "Test" },
+                TrustedIssuerCertificates = new CertificateTrustList { StorePath = "Test" },
+                HttpsIssuerCertificates = new CertificateTrustList { StorePath = "" },
+                TrustedHttpsCertificates = new CertificateTrustList { StorePath = "Test" },
+            }).SetName("InvalidHttpsIssuer");
+
+            yield return new TestCaseData(new SecurityConfiguration {
+                ApplicationCertificate = new CertificateIdentifier { RawData = Array.Empty<byte>() },
+                TrustedPeerCertificates = new CertificateTrustList { StorePath = "Test" },
+                TrustedIssuerCertificates = new CertificateTrustList { StorePath = "Test" },
+                HttpsIssuerCertificates = new CertificateTrustList { StorePath = "Test" },
+                TrustedHttpsCertificates = new CertificateTrustList { StorePath = "" },
+            }).SetName("InvalidHttpsTrusted");
+
+            yield return new TestCaseData(new SecurityConfiguration {
+                ApplicationCertificate = new CertificateIdentifier { RawData = Array.Empty<byte>() },
+                TrustedPeerCertificates = new CertificateTrustList { StorePath = "Test" },
+                TrustedIssuerCertificates = new CertificateTrustList { StorePath = "Test" },
+                TrustedUserCertificates = new CertificateTrustList { StorePath = "Test" },
+            }).SetName("OnlyTrustedUser");
+
+            yield return new TestCaseData(new SecurityConfiguration {
+                ApplicationCertificate = new CertificateIdentifier { RawData = Array.Empty<byte>() },
+                TrustedPeerCertificates = new CertificateTrustList { StorePath = "Test" },
+                TrustedIssuerCertificates = new CertificateTrustList { StorePath = "Test" },
+                UserIssuerCertificates = new CertificateTrustList { StorePath = "Test" },
+            }).SetName("OnlyIssuerUser");
+
+            yield return new TestCaseData(new SecurityConfiguration {
+                ApplicationCertificate = new CertificateIdentifier { RawData = Array.Empty<byte>() },
+                TrustedPeerCertificates = new CertificateTrustList { StorePath = "Test" },
+                TrustedIssuerCertificates = new CertificateTrustList { StorePath = "Test" },
+                UserIssuerCertificates = new CertificateTrustList { StorePath = "" },
+                TrustedUserCertificates = new CertificateTrustList { StorePath = "Test" },
+            }).SetName("InvalidUserIssuer");
+
+            yield return new TestCaseData(new SecurityConfiguration {
+                ApplicationCertificate = new CertificateIdentifier { RawData = Array.Empty<byte>() },
+                TrustedPeerCertificates = new CertificateTrustList { StorePath = "Test" },
+                TrustedIssuerCertificates = new CertificateTrustList { StorePath = "Test" },
+                UserIssuerCertificates = new CertificateTrustList { StorePath = "Test" },
+                TrustedUserCertificates = new CertificateTrustList { StorePath = "" },
+            }).SetName("InvalidUserTrusted");
+        }
+    }
+}

--- a/Tests/Opc.Ua.Core.Tests/Security/Certificates/CertificateStoreTypeTestConfig.xml
+++ b/Tests/Opc.Ua.Core.Tests/Security/Certificates/CertificateStoreTypeTestConfig.xml
@@ -17,12 +17,17 @@
       <StorePath>testStoreType:CurrentUser\My</StorePath>
       <SubjectName>CN=CertStoreTypeTest, C=US, S=Arizona, O=OPC Foundation, DC=localhost</SubjectName>
     </ApplicationCertificate>
-
+  
     <!-- Where the issuer certificate are stored (certificate authorities) -->
     <TrustedIssuerCertificates>
       <StoreType>testStoreType</StoreType>
       <StorePath>testStoreType:CurrentUser\AuthRoot</StorePath>
     </TrustedIssuerCertificates>
+
+    <TrustedPeerCertificates>
+      <StoreType>testStoreType</StoreType>
+      <StorePath>testStoreType:CurrentUser\Trusted</StorePath>
+    </TrustedPeerCertificates>
 
   </SecurityConfiguration>
 

--- a/Tests/Opc.Ua.Core.Tests/Stack/Client/ClientTests.cs
+++ b/Tests/Opc.Ua.Core.Tests/Stack/Client/ClientTests.cs
@@ -100,9 +100,12 @@ namespace Opc.Ua.Core.Tests.Stack.Client
         {
             var appConfig = new ApplicationConfiguration() {
                 ApplicationName = "Test",
-                ClientConfiguration = new ClientConfiguration() {},
+                ClientConfiguration = new ClientConfiguration() { },
                 SecurityConfiguration = new SecurityConfiguration() {
-                    ApplicationCertificate = new CertificateIdentifier()
+                    ApplicationCertificate = new CertificateIdentifier(),
+                    TrustedPeerCertificates = new CertificateTrustList { StorePath = "" },
+                    TrustedIssuerCertificates = new CertificateTrustList { StorePath = "" },
+
                 }
             };
             Assert.DoesNotThrow(() => appConfig.Validate(ApplicationType.Client).GetAwaiter().GetResult());

--- a/Tests/Opc.Ua.Core.Tests/Stack/Client/ClientTests.cs
+++ b/Tests/Opc.Ua.Core.Tests/Stack/Client/ClientTests.cs
@@ -103,8 +103,8 @@ namespace Opc.Ua.Core.Tests.Stack.Client
                 ClientConfiguration = new ClientConfiguration() { },
                 SecurityConfiguration = new SecurityConfiguration() {
                     ApplicationCertificate = new CertificateIdentifier(),
-                    TrustedPeerCertificates = new CertificateTrustList { StorePath = "" },
-                    TrustedIssuerCertificates = new CertificateTrustList { StorePath = "" },
+                    TrustedPeerCertificates = new CertificateTrustList { StorePath = "Test" },
+                    TrustedIssuerCertificates = new CertificateTrustList { StorePath = "Test" },
 
                 }
             };

--- a/Tests/Opc.Ua.Gds.Tests/PushTest.cs
+++ b/Tests/Opc.Ua.Gds.Tests/PushTest.cs
@@ -762,7 +762,7 @@ namespace Opc.Ua.Gds.Tests
         private void VerifyNewPushServerCert(byte[] certificateBlob)
         {
             DisconnectPushClient();
-            Thread.Sleep(2000);
+            Thread.Sleep(10000);
             m_gdsClient.GDSClient.Connect(m_gdsClient.GDSClient.EndpointUrl).GetAwaiter().GetResult();
             m_pushClient.PushClient.Connect(m_pushClient.PushClient.EndpointUrl).GetAwaiter().GetResult();
             // compare leaf certificates, ServerCertificate might be a chain if sendCertChain is sets


### PR DESCRIPTION
## Proposed changes

If issuer store or rejected store are not configured null reference exceptions could occur.

To avoid these add checks on the Validate method of the Security Configuration to catch invalid configured certificate stores already on startup.

## Related Issues

- Fixes #3017

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments


