### PR TITLE
Make UserIdentityToken internally use byte Array instead of string for storing unencrypted  password.

### DIFF
--- a/Stack/Opc.Ua.Core/Stack/Types/UserIdentityToken.cs
+++ b/Stack/Opc.Ua.Core/Stack/Types/UserIdentityToken.cs
@@ -96,9 +96,20 @@ namespace Opc.Ua
         /// </summary>
         public string DecryptedPassword
         {
-            get { return m_decryptedPassword; }
-            set { m_decryptedPassword = value; }
+            get
+            {
+                if (m_decryptedPassword != null)
+                {
+                    return new UTF8Encoding().GetString(m_decryptedPassword);
+                }
+                return null;
+            }
+            set
+            {
+                m_decryptedPassword = new UTF8Encoding().GetBytes(value);
+            }
         }
+
         #endregion
 
         #region Public Methods
@@ -141,7 +152,8 @@ namespace Opc.Ua
             // handle no encryption.
             if (String.IsNullOrEmpty(securityPolicyUri) || securityPolicyUri == SecurityPolicies.None)
             {
-                m_password = new UTF8Encoding().GetBytes(m_decryptedPassword);
+
+                m_password = m_decryptedPassword;
                 m_encryptionAlgorithm = null;
                 return;
             }
@@ -149,7 +161,8 @@ namespace Opc.Ua
             // handle RSA encryption.
             if (!EccUtils.IsEccPolicy(securityPolicyUri))
             {
-                byte[] dataToEncrypt = Utils.Append(new UTF8Encoding().GetBytes(m_decryptedPassword), receiverNonce);
+                byte[] dataToEncrypt = Utils.Append(m_decryptedPassword, receiverNonce);
+                
 
                 EncryptedData encryptedData = SecurityPolicies.Encrypt(
                     receiverCertificate,
@@ -191,8 +204,7 @@ namespace Opc.Ua
                 secret.SenderIssuerCertificates = senderIssuerCertificates;
                 secret.SenderNonce = Nonce.CreateNonce(securityPolicyUri);
 
-                var utf8 = new UTF8Encoding(false).GetBytes(m_decryptedPassword);
-                m_password = secret.Encrypt(utf8, receiverNonce);
+                m_password = secret.Encrypt(m_decryptedPassword, receiverNonce);
                 m_encryptionAlgorithm = null;
 #else
                 throw new NotSupportedException("Platform does not support ECC curves");
@@ -215,7 +227,7 @@ namespace Opc.Ua
             // handle no encryption.
             if (String.IsNullOrEmpty(securityPolicyUri) || securityPolicyUri == SecurityPolicies.None)
             {
-                m_decryptedPassword = new UTF8Encoding().GetString(m_password, 0, m_password.Length);
+                m_decryptedPassword = m_password;
                 return;
             }
 
@@ -256,7 +268,7 @@ namespace Opc.Ua
                 }
 
                 // convert to UTF-8.
-                m_decryptedPassword = new UTF8Encoding().GetString(decryptedPassword, 0, startOfNonce);
+                Array.Copy(decryptedPassword, 0, m_decryptedPassword, 0, startOfNonce);
             }
             // handle ECC encryption.
             else
@@ -271,8 +283,7 @@ namespace Opc.Ua
                 secret.ReceiverNonce = ephemeralKey;
                 secret.SecurityPolicyUri = securityPolicyUri;
 
-                var plainText = secret.Decrypt(DateTime.UtcNow.AddHours(-1), receiverNonce.Data, m_password, 0, m_password.Length);
-                m_decryptedPassword = new UTF8Encoding().GetString(plainText);
+                m_decryptedPassword = secret.Decrypt(DateTime.UtcNow.AddHours(-1), receiverNonce.Data, m_password, 0, m_password.Length);
 #else
                 throw new NotSupportedException("Platform does not support ECC curves");
 #endif
@@ -282,7 +293,7 @@ namespace Opc.Ua
         #endregion
 
         #region Private Fields
-        private string m_decryptedPassword;
+        private byte[] m_decryptedPassword;
         #endregion
     }
 


### PR DESCRIPTION
## Proposed changes

Make UserIdentityToken internally use byte Array instead of string for storing unencrypted password.

## Related Issues

- Fixes #

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist


- [ ] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

