### PR TITLE
Allow setting the context in a temporary using scope for IEncoder instances

### DIFF
--- a/Stack/Opc.Ua.Core/Types/BuiltIn/MessageContextExtension.cs
+++ b/Stack/Opc.Ua.Core/Types/BuiltIn/MessageContextExtension.cs
@@ -10,6 +10,9 @@
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 */
 
+using System;
+using System.Threading;
+
 namespace Opc.Ua
 {
     #region MessageContextExtension Class
@@ -29,7 +32,11 @@ namespace Opc.Ua
         /// <summary>
         /// Returns the message context associated with the current operation context.
         /// </summary>
-        public static MessageContextExtension Current => null;
+        public static MessageContextExtension Current
+        {
+            get => s_current.Value;
+            set => s_current.Value = value;
+        }
 
         /// <summary>
         /// Returns the message context associated with the current operation context.
@@ -53,6 +60,40 @@ namespace Opc.Ua
         /// The message context to use.
         /// </summary>
         public IServiceMessageContext MessageContext { get; private set; }
+
+        /// <summary>
+        /// Set the context for a specific using scope
+        /// </summary>
+        /// <param name="messageContext"></param>
+        /// <returns></returns>
+        public static IDisposable SetScopedContext(IServiceMessageContext messageContext)
+        {
+            var previousContext = Current;
+            Current = new MessageContextExtension(messageContext);
+
+            return new DisposableAction (() => Current = previousContext);
+        }
+
+        /// <summary>
+        /// Disposable wrapper for reseting the Current context to
+        /// the previous value on exiting the using scope
+        /// </summary>
+        private class DisposableAction : IDisposable
+        {
+            private readonly Action action;
+
+            public DisposableAction(Action action)
+            {
+                this.action = action;
+            }
+
+            public void Dispose()
+            {
+                action?.Invoke();
+            }
+        }
+
+        private static readonly AsyncLocal<MessageContextExtension> s_current = new AsyncLocal<MessageContextExtension>();
     }
     #endregion
 }

--- a/Stack/Opc.Ua.Core/Types/BuiltIn/MessageContextExtension.cs
+++ b/Stack/Opc.Ua.Core/Types/BuiltIn/MessageContextExtension.cs
@@ -35,7 +35,7 @@ namespace Opc.Ua
         public static MessageContextExtension Current
         {
             get => s_current.Value;
-            set => s_current.Value = value;
+            private set => s_current.Value = value;
         }
 
         /// <summary>


### PR DESCRIPTION
Allow setting the context in a temporary using scope for IEncoder instances.

## Proposed changes

If the encoding is not initiated from an `IEncoder` instance which contains the desired `ServiceMessageContext`, the encoding fails since the the default `ServiceMessageContext.GlobalContext` is used in the encoding process.
Ex: Serializing an `ExtensionObject ` initiated by calling `Newtonsoft.Json.JsonConvert.SerializeObject(ExtensionObject)`; that in turn triggers XML encoding.
This addition allows to temporarily pass a `ServiceMessageContext ` instance inside a using scope through the convenience method  `public static IDisposable SetScopedContext(IServiceMessageContext messageContext)` belonging to `MessageContextExtension` class, thus avoiding the necessity to add the `namespaceURI ` to the  default `ServiceMessageContext.GlobalContext'

## Related Issues

- Fixes issue #3024

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- [x] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
