### PR TITLE
Allow to define a custom StringComparsion for Equals Operator

### DIFF
--- a/Stack/Opc.Ua.Core/Stack/Types/ContentFilter.Evaluate.cs
+++ b/Stack/Opc.Ua.Core/Stack/Types/ContentFilter.Evaluate.cs
@@ -413,11 +413,6 @@ namespace Opc.Ua
                 return value1 == null && value2 == null;
             }
 
-            if (value1 is DBNull || value2 is DBNull)
-            {
-                return value1 is DBNull && value2 is DBNull;
-            }
-
             if (value1.GetType() != value2.GetType())
             {
                 return false;
@@ -426,7 +421,6 @@ namespace Opc.Ua
             //check for strings
             if (value1 is string string1)
             {
-
                 if (value2 is not string string2)
                 {
                     return false;

--- a/Stack/Opc.Ua.Core/Stack/Types/ContentFilter.Evaluate.cs
+++ b/Stack/Opc.Ua.Core/Stack/Types/ContentFilter.Evaluate.cs
@@ -28,7 +28,7 @@ namespace Opc.Ua
         /// <summary>
         /// Set the default StringComparison to use when evaluating the Equals operator.
         /// </summary>
-        public static StringComparison EqualsOperatorDefaultStringComparison { get; set; } = StringComparison.CurrentCulture;
+        public static StringComparison EqualsOperatorDefaultStringComparison { get; set; } = StringComparison.Ordinal;
         #endregion
         #region Public functions
         /// <summary>
@@ -423,7 +423,18 @@ namespace Opc.Ua
                 return false;
             }
 
-            return Utils.IsEqual(value1, value2, EqualsOperatorDefaultStringComparison);
+            //check for strings
+            if (value1 is string string1)
+            {
+
+                if (value2 is not string string2)
+                {
+                    return false;
+                }
+                return string1.Equals(string2, EqualsOperatorDefaultStringComparison);
+            }
+
+            return Utils.IsEqual(value1, value2);
         }
 
         /// <summary>

--- a/Stack/Opc.Ua.Core/Stack/Types/ContentFilter.Evaluate.cs
+++ b/Stack/Opc.Ua.Core/Stack/Types/ContentFilter.Evaluate.cs
@@ -24,6 +24,12 @@ namespace Opc.Ua
     /// </summary>
     public partial class ContentFilter
     {
+        #region  Public Static Properties
+        /// <summary>
+        /// Set the default StringComparison to use when evaluating the Equals operator.
+        /// </summary>
+        public static StringComparison EqualsOperatorDefaultStringComparison { get; set; } = StringComparison.CurrentCulture;
+        #endregion
         #region Public functions
         /// <summary>
         /// Evaluates the first element in the ContentFilter. If the first or any 
@@ -417,7 +423,7 @@ namespace Opc.Ua
                 return false;
             }
 
-            return Utils.IsEqual(value1, value2);
+            return Utils.IsEqual(value1, value2, EqualsOperatorDefaultStringComparison);
         }
 
         /// <summary>

--- a/Stack/Opc.Ua.Core/Stack/Types/ContentFilter.Evaluate.cs
+++ b/Stack/Opc.Ua.Core/Stack/Types/ContentFilter.Evaluate.cs
@@ -27,9 +27,11 @@ namespace Opc.Ua
         #region  Public Static Properties
         /// <summary>
         /// Set the default StringComparison to use when evaluating the Equals operator.
+        /// This property is meant to be set as a config setting and not set / reset on a per context basis, to ensure consistency
         /// </summary>
         public static StringComparison EqualsOperatorDefaultStringComparison { get; set; } = StringComparison.Ordinal;
         #endregion
+
         #region Public functions
         /// <summary>
         /// Evaluates the first element in the ContentFilter. If the first or any 

--- a/Stack/Opc.Ua.Core/Types/Utils/Utils.cs
+++ b/Stack/Opc.Ua.Core/Types/Utils/Utils.cs
@@ -2068,7 +2068,7 @@ namespace Opc.Ua
         /// <summary>
         /// Checks if two values are equal.
         /// </summary>
-        public static bool IsEqual(object value1, object value2)
+        public static bool IsEqual(object value1, object value2, StringComparison stringComparison = StringComparison.CurrentCulture)
         {
             // check for reference equality.
             if (Object.ReferenceEquals(value1, value2))
@@ -2120,6 +2120,17 @@ namespace Opc.Ua
                 }
 
                 return encodeable1.IsEqual(encodeable2);
+            }
+
+            //check for strings
+            if (value1 is string string1)
+            {
+
+                if (value2 is not string string2)
+                {
+                    return false;
+                }
+                return string1.Equals(string2, stringComparison);
             }
 
             // check for XmlElement objects.
@@ -2631,7 +2642,7 @@ namespace Opc.Ua
                 extensions.Add(document.DocumentElement);
             }
         }
-#endregion
+        #endregion
 
         #region Reflection Helper Functions
         /// <summary>
@@ -2985,7 +2996,7 @@ namespace Opc.Ua
             [Obsolete("Use equivalent method from the Opc.Ua.Nonce class")]
             public static bool ValidateNonce(byte[] nonce, MessageSecurityMode securityMode, uint minNonceLength)
             {
-                return NewNonceImplementation.ValidateNonce(nonce,securityMode, minNonceLength);
+                return NewNonceImplementation.ValidateNonce(nonce, securityMode, minNonceLength);
             }
         }
 
@@ -3248,6 +3259,6 @@ namespace Opc.Ua
         {
             return s_isRunningOnMonoValue.Value;
         }
-#endregion
+        #endregion
     }
 }

--- a/Stack/Opc.Ua.Core/Types/Utils/Utils.cs
+++ b/Stack/Opc.Ua.Core/Types/Utils/Utils.cs
@@ -2068,7 +2068,7 @@ namespace Opc.Ua
         /// <summary>
         /// Checks if two values are equal.
         /// </summary>
-        public static bool IsEqual(object value1, object value2, StringComparison stringComparison = StringComparison.CurrentCulture)
+        public static bool IsEqual(object value1, object value2)
         {
             // check for reference equality.
             if (Object.ReferenceEquals(value1, value2))
@@ -2103,17 +2103,6 @@ namespace Opc.Ua
             if (value1 is DateTime time1)
             {
                 return Utils.IsEqual(time1, (DateTime)value2);
-            }
-
-            //check for strings
-            if (value1 is string string1)
-            {
-
-                if (value2 is not string string2)
-                {
-                    return false;
-                }
-                return string1.Equals(string2, stringComparison);
             }
 
             // check for compareable objects.

--- a/Stack/Opc.Ua.Core/Types/Utils/Utils.cs
+++ b/Stack/Opc.Ua.Core/Types/Utils/Utils.cs
@@ -2105,6 +2105,17 @@ namespace Opc.Ua
                 return Utils.IsEqual(time1, (DateTime)value2);
             }
 
+            //check for strings
+            if (value1 is string string1)
+            {
+
+                if (value2 is not string string2)
+                {
+                    return false;
+                }
+                return string1.Equals(string2, stringComparison);
+            }
+
             // check for compareable objects.
             if (value1 is IComparable comparable1)
             {
@@ -2120,17 +2131,6 @@ namespace Opc.Ua
                 }
 
                 return encodeable1.IsEqual(encodeable2);
-            }
-
-            //check for strings
-            if (value1 is string string1)
-            {
-
-                if (value2 is not string string2)
-                {
-                    return false;
-                }
-                return string1.Equals(string2, stringComparison);
             }
 
             // check for XmlElement objects.

--- a/Tests/Opc.Ua.Core.Tests/Types/ContentFilter/ContentFilterTests.cs
+++ b/Tests/Opc.Ua.Core.Tests/Types/ContentFilter/ContentFilterTests.cs
@@ -312,6 +312,29 @@ namespace Opc.Ua.Core.Tests.Types.ContentFilter
             Assert.AreEqual(expectedResult, result);
         }
 
+        [Test]
+        [TestCase("mainstation", "mainstation", StringComparison.Ordinal, true)]
+        [TestCase("mainstation", "Mainstation", StringComparison.Ordinal, false)]
+        [TestCase("mainstation", "Mainstation", StringComparison.OrdinalIgnoreCase, true)]
+        [TestCase("mainstation", "Mainstation", StringComparison.InvariantCultureIgnoreCase, true)]
+        [TestCase("mainstation", "Mainstation", StringComparison.InvariantCulture, false)]
+        [TestCase("mainstation", "mainstation", StringComparison.InvariantCulture, true)]
+        public void EqualsStringComparsion(string operandFirst1, string operandFirst2, StringComparison stringComparison, object expectedResult)
+        {
+            Opc.Ua.ContentFilter.EqualsOperatorDefaultStringComparison = stringComparison;
+            LiteralOperand loperand1 = new LiteralOperand { Value = new Variant(operandFirst1)};
+            LiteralOperand loperand2 = new LiteralOperand { Value = new Variant(operandFirst2)};
+
+            ContentFilterElement filterElement = new ContentFilterElement();
+            filterElement.FilterOperator = FilterOperator.Equals;
+            filterElement.SetOperands(new List<LiteralOperand>() { loperand1, loperand2 });
+            Filter.WhereClause.Elements = new[] { filterElement };
+
+            // apply filter.
+            object result = Filter.WhereClause.Evaluate(FilterContext, TestFilterTarget);
+            Assert.AreEqual(expectedResult, result);
+        }
+
 
         #endregion
     }


### PR DESCRIPTION
- Introduce static `EqualsOperatorDefaultStringComparison` Property in the `ContentFilter` class for customizable string comparison.
- Update `IsEqual` method in the `Utils` class to accept an optional `StringComparison` parameter.
- This also affects the `InList` Operator that internally uses `IsEqual`

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

 