### PR TITLE
Set default value for the ValueRank attribute of BaseVariableState and BaseVariableTypeState to ValueRanks.Any as in the specification

### DIFF
--- a/Stack/Opc.Ua.Core/Stack/State/BaseVariableState.cs
+++ b/Stack/Opc.Ua.Core/Stack/State/BaseVariableState.cs
@@ -33,11 +33,17 @@ namespace Opc.Ua
         /// <param name="parent">The parent node.</param>
         public BaseVariableState(NodeState parent) : base(NodeClass.Variable, parent)
         {
+            m_value = null;
+            m_statusCode = StatusCodes.BadWaitingForInitialData;
             m_timestamp = DateTime.MinValue;
+            m_dataType = DataTypeIds.BaseDataType;
+            m_valueRank = ValueRanks.Any;
+            m_arrayDimensions = null;
             m_accessLevel = m_userAccessLevel = AccessLevels.CurrentRead;
+            m_minimumSamplingInterval = MinimumSamplingIntervals.Continuous;
+            m_historizing = false;
             m_copyPolicy = VariableCopyPolicy.CopyOnRead;
             m_valueTouched = false;
-            m_statusCode = StatusCodes.BadWaitingForInitialData;
         }
         #endregion
 

--- a/Stack/Opc.Ua.Core/Stack/State/BaseVariableTypeState.cs
+++ b/Stack/Opc.Ua.Core/Stack/State/BaseVariableTypeState.cs
@@ -27,6 +27,7 @@ namespace Opc.Ua
         /// </summary>
         protected BaseVariableTypeState() : base(NodeClass.VariableType)
         {
+            m_valueRank = ValueRanks.Any;
         }
         #endregion
 

--- a/Tests/Opc.Ua.Core.Tests/Opc.Ua.Core.Tests.csproj
+++ b/Tests/Opc.Ua.Core.Tests/Opc.Ua.Core.Tests.csproj
@@ -52,6 +52,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\Libraries\Opc.Ua.Server\Opc.Ua.Server.csproj" />
     <ProjectReference Include="..\..\Stack\Opc.Ua.Core\Opc.Ua.Core.csproj" />
     <ProjectReference Include="..\..\Stack\Opc.Ua.Bindings.Https\Opc.Ua.Bindings.Https.csproj" />
     <ProjectReference Include="..\Opc.Ua.Security.Certificates.Tests\Opc.Ua.Security.Certificates.Tests.csproj" />

--- a/Tests/Opc.Ua.Core.Tests/Opc.Ua.Core.Tests.csproj
+++ b/Tests/Opc.Ua.Core.Tests/Opc.Ua.Core.Tests.csproj
@@ -52,7 +52,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\Libraries\Opc.Ua.Server\Opc.Ua.Server.csproj" />
     <ProjectReference Include="..\..\Stack\Opc.Ua.Core\Opc.Ua.Core.csproj" />
     <ProjectReference Include="..\..\Stack\Opc.Ua.Bindings.Https\Opc.Ua.Bindings.Https.csproj" />
     <ProjectReference Include="..\Opc.Ua.Security.Certificates.Tests\Opc.Ua.Security.Certificates.Tests.csproj" />

--- a/Tests/Opc.Ua.Core.Tests/Stack/State/BaseDataVariableTypeStateSerializationTest.cs
+++ b/Tests/Opc.Ua.Core.Tests/Stack/State/BaseDataVariableTypeStateSerializationTest.cs
@@ -1,0 +1,83 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Iced.Intel;
+using NUnit.Framework;
+using static Opc.Ua.NodeState;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
+
+namespace Opc.Ua.Core.Tests.Stack.State
+{
+    /// <summary>
+    /// Tests serialization and deserialization of ValueRank attribute for
+    /// BaseVariableState and BaseVariableTypeState.
+    /// The default ValueRank attribute value should be ValueRanks.Any as specified in the specification
+    /// Serialization of the attribute in case ValueRanks.Any is used is ommited thus saving space.
+    /// </summary>
+    [TestFixture]
+    [SetCulture("en-us"), SetUICulture("en-us")]
+    public class ValueRankSerializationTestForBaseVariableStateAndBaseVariableTypeState
+    {
+        [Test]
+        public void ValueRankPersistBaseVariableTypeState(
+            [Values(ValueRanks.ScalarOrOneDimension, ValueRanks.Any, ValueRanks.Scalar,
+            ValueRanks.OneOrMoreDimensions, ValueRanks.OneDimension, ValueRanks.TwoDimensions)] int valueRank)
+        {
+            var typeNode = new BaseDataVariableTypeState();
+            var serviceMessageContext = new ServiceMessageContext();
+            var systemContext = new SystemContext() { NamespaceUris = serviceMessageContext.NamespaceUris };
+            typeNode.Create(
+                    new SystemContext() { NamespaceUris = serviceMessageContext.NamespaceUris },
+                    VariableTypeIds.DataItemType,
+                    BrowseNames.DataItemType,
+                    new LocalizedText("DataItemType"),
+                    true);
+
+            typeNode.ValueRank = valueRank;
+            var loadedVariable = new BaseDataVariableTypeState();
+            using (MemoryStream stream = new MemoryStream())
+            {
+                typeNode.SaveAsBinary(systemContext, stream);
+                stream.Position = 0;
+                loadedVariable.LoadAsBinary(systemContext, stream);
+            }
+
+            Assert.AreEqual(valueRank, loadedVariable.ValueRank);
+        }
+
+       [Test]
+        public void ValueRankPersistBaseVariableState(
+            [Values(ValueRanks.ScalarOrOneDimension, ValueRanks.Any, ValueRanks.Scalar,
+            ValueRanks.OneOrMoreDimensions, ValueRanks.OneDimension, ValueRanks.TwoDimensions)] int valueRank)
+        {
+            // Here this type node is used just as support for the instanceNode to refer to
+            var typeNode = new BaseDataVariableTypeState();
+            var serviceMessageContext = new ServiceMessageContext();
+            var systemContext = new SystemContext() { NamespaceUris = serviceMessageContext.NamespaceUris };
+            typeNode.Create(
+                    new SystemContext() { NamespaceUris = serviceMessageContext.NamespaceUris },
+                    VariableTypeIds.DataItemType,
+                    BrowseNames.DataItemType,
+                    new LocalizedText("DataItemType"),
+                    true);
+
+
+            // The instance BaseAnalogState node is a subtype of BaseVariableState for
+            // which valueRank attribute is tested
+            var instanceNode = new BaseAnalogState(typeNode);
+            instanceNode.ValueRank = valueRank;
+            var loadedVariable = new BaseAnalogState(typeNode);
+            using (MemoryStream stream = new MemoryStream())
+            {
+                instanceNode.SaveAsBinary(systemContext, stream);
+                stream.Position = 0;
+                loadedVariable.LoadAsBinary(systemContext, stream);
+            }
+
+            Assert.AreEqual(valueRank, loadedVariable.ValueRank);
+        }
+    }
+}
+


### PR DESCRIPTION
Set default value for the ValueRank attribute of BaseVariableState and BaseVariableTypeState types and subtypes to ValueRanks.Any as specified in the specification.

## Proposed changes

The default value used for the ValueRank attribute for BaseVariableState and BaseVariableTypeState type and subtype instances should be ValueRanks.Any. The attribute is omitted during serialization for efficiency purpose when the value is the default ValueRanks.Any,  but must be set to the correct ValueRanks.Any value also when de-serialized in this specific case.

## Related Issues

- Fixes #3041 

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [x] I ran tests locally with my changes, all passed.
- [x] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

Many thanks to @saurla for finding the issue and providing valuable input and test case code.
