### PR TITLE
Fix XML Encoding and decoding of Matrix Element in Variant to conform to spec

### DIFF
--- a/Stack/Opc.Ua.Core/Types/Encoders/XmlDecoder.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/XmlDecoder.cs
@@ -2740,14 +2740,14 @@ namespace Opc.Ua
                 {
                     PushNamespace(Namespaces.OpcUaXsd);
 
+                    dimensions = ReadInt32Array("Dimensions");
+
                     if (BeginField("Elements", true))
                     {
-                        object contents = ReadVariantContents(out typeInfo);
-                        elements = contents as Array;
+                        typeInfo = MapElementTypeToTypeInfo(m_reader.LocalName);
+                        elements = ReadArray(null, typeInfo.ValueRank, typeInfo.BuiltInType, null);
                         EndField("Elements");
                     }
-
-                    dimensions = ReadInt32Array("Dimensions");
 
                     PopNamespace();
 
@@ -2780,6 +2780,41 @@ namespace Opc.Ua
             {
                 m_nestingLevel--;
             }
+        }
+
+        /// <summary>
+        /// Maps an element type name to its corresponding TypeInfo.Arrays value.
+        /// </summary>
+        /// <param name="elementTypeName">The name of the element type.</param>
+        /// <returns>The corresponding TypeInfo.Arrays value.</returns>
+        private TypeInfo MapElementTypeToTypeInfo(string elementTypeName)
+        {
+            return elementTypeName switch {
+                "Boolean" => TypeInfo.Arrays.Boolean,
+                "SByte" => TypeInfo.Arrays.SByte,
+                "Byte" => TypeInfo.Arrays.Byte,
+                "Int16" => TypeInfo.Arrays.Int16,
+                "UInt16" => TypeInfo.Arrays.UInt16,
+                "Int32" => TypeInfo.Arrays.Int32,
+                "UInt32" => TypeInfo.Arrays.UInt32,
+                "Int64" => TypeInfo.Arrays.Int64,
+                "UInt64" => TypeInfo.Arrays.UInt64,
+                "Float" => TypeInfo.Arrays.Float,
+                "Double" => TypeInfo.Arrays.Double,
+                "String" => TypeInfo.Arrays.String,
+                "DateTime" => TypeInfo.Arrays.DateTime,
+                "Guid" => TypeInfo.Arrays.Guid,
+                "ByteString" => TypeInfo.Arrays.ByteString,
+                "XmlElement" => TypeInfo.Arrays.XmlElement,
+                "NodeId" => TypeInfo.Arrays.NodeId,
+                "ExpandedNodeId" => TypeInfo.Arrays.ExpandedNodeId,
+                "StatusCode" => TypeInfo.Arrays.StatusCode,
+                "QualifiedName" => TypeInfo.Arrays.QualifiedName,
+                "LocalizedText" => TypeInfo.Arrays.LocalizedText,
+                "ExtensionObject" => TypeInfo.Arrays.ExtensionObject,
+                "Variant" => TypeInfo.Arrays.Variant,
+                _ => throw new ServiceResultException(StatusCodes.BadDecodingError, $"Unsupported element type: {elementTypeName}")
+            };
         }
 
         /// <summary>

--- a/Stack/Opc.Ua.Core/Types/Encoders/XmlDecoder.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/XmlDecoder.cs
@@ -2813,6 +2813,8 @@ namespace Opc.Ua
                 "LocalizedText" => TypeInfo.Arrays.LocalizedText,
                 "ExtensionObject" => TypeInfo.Arrays.ExtensionObject,
                 "Variant" => TypeInfo.Arrays.Variant,
+                "DataValue" => TypeInfo.Arrays.DataValue,
+                "DiagnosticInfo" => TypeInfo.Arrays.DiagnosticInfo,                
                 _ => throw new ServiceResultException(StatusCodes.BadDecodingError, $"Unsupported element type: {elementTypeName}")
             };
         }

--- a/Stack/Opc.Ua.Core/Types/Encoders/XmlEncoder.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/XmlEncoder.cs
@@ -2175,11 +2175,9 @@ namespace Opc.Ua
 
                 if (value != null)
                 {
-                    m_writer.WriteStartElement("Elements", Namespaces.OpcUaXsd);
-                    WriteVariantContents(value.Elements, new TypeInfo(value.TypeInfo.BuiltInType, ValueRanks.OneDimension));
-                    m_writer.WriteEndElement();
-
                     WriteInt32Array("Dimensions", value.Dimensions);
+
+                    WriteArray("Elements", value.Elements, ValueRanks.OneDimension, value.TypeInfo.BuiltInType);
                 }
 
                 PopNamespace();

--- a/Tests/Opc.Ua.Core.Tests/Types/Encoders/XmlEncoderTests.cs
+++ b/Tests/Opc.Ua.Core.Tests/Types/Encoders/XmlEncoderTests.cs
@@ -161,7 +161,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
             }
 
             // Check encode result against expected XML value
-            Assert.AreEqual(expected.Replace("/r", "").Replace("/n", ""), actualXmlValue.Replace("/r", "").Replace("/n", ""));
+            Assert.AreEqual(expected.Replace("\r", "").Replace("\n", ""), actualXmlValue.Replace("\r", "").Replace("\n", ""));
 
             // Decode
             Variant actualVariant;

--- a/Tests/Opc.Ua.Core.Tests/Types/Encoders/XmlEncoderTests.cs
+++ b/Tests/Opc.Ua.Core.Tests/Types/Encoders/XmlEncoderTests.cs
@@ -133,6 +133,49 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
             else
                 Assert.AreEqual(actualBinaryValue, binaryValue);
         }
+
+        /// <summary>
+        /// Validate the encoding and decoding of the a variant that consists of a matrix.
+        /// </summary>
+        [Test]
+        public void EncodeDecodeVariantMatrix()
+        {
+            var value = new Matrix(
+                new int[] { 1, 2, 3, 4 },
+                BuiltInType.Int32,
+                new int[] { 2, 2 }
+            );
+            var variant = new Variant(value);
+
+            string expected = "<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n<uax:VariantTest xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:uax=\"http://opcfoundation.org/UA/2008/02/Types.xsd\">\r\n  <uax:Test>\r\n    <uax:Value>\r\n      <uax:Matrix>\r\n        <uax:Dimensions>\r\n          <uax:Int32>2</uax:Int32>\r\n          <uax:Int32>2</uax:Int32>\r\n        </uax:Dimensions>\r\n        <uax:Elements>\r\n          <uax:Int32>1</uax:Int32>\r\n          <uax:Int32>2</uax:Int32>\r\n          <uax:Int32>3</uax:Int32>\r\n          <uax:Int32>4</uax:Int32>\r\n        </uax:Elements>\r\n      </uax:Matrix>\r\n    </uax:Value>\r\n  </uax:Test>\r\n</uax:VariantTest>";
+
+            // Encode
+            var context = new ServiceMessageContext();
+            string actualXmlValue;
+            using (IEncoder xmlEncoder = new XmlEncoder(new XmlQualifiedName("VariantTest", Namespaces.OpcUaXsd), null, context))
+            {
+                xmlEncoder.PushNamespace(Namespaces.OpcUaXsd);
+                xmlEncoder.WriteVariant("Test", variant);
+                xmlEncoder.PopNamespace();
+                actualXmlValue = xmlEncoder.CloseAndReturnText();
+            }
+
+            // Check encode result against expected XML value
+            Assert.AreEqual(expected, actualXmlValue);
+
+            // Decode
+            Variant actualVariant;
+            using (XmlReader reader = XmlReader.Create(new StringReader(actualXmlValue)))
+            {
+                using (IDecoder xmlDecoder = new XmlDecoder(null, reader, context))
+                {
+                    actualVariant = xmlDecoder.ReadVariant("Test");
+                }
+            }
+
+            // Check decode result against input value
+            Assert.AreEqual(actualVariant, variant);
+        }
         #endregion
     }
 }

--- a/Tests/Opc.Ua.Core.Tests/Types/Encoders/XmlEncoderTests.cs
+++ b/Tests/Opc.Ua.Core.Tests/Types/Encoders/XmlEncoderTests.cs
@@ -161,7 +161,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
             }
 
             // Check encode result against expected XML value
-            Assert.AreEqual(expected, actualXmlValue);
+            Assert.AreEqual(expected.Replace("/r", "").Replace("/n", ""), actualXmlValue.Replace("/r", "").Replace("/n", ""));
 
             // Decode
             Variant actualVariant;


### PR DESCRIPTION
## Proposed changes

A Variant containing a multi dimensional array needs to be encoded with a specified syntax.
The XML Encoder / Decoder of the stack did only follow this Spec for the ReadArray / WriteArray implementation but not ReadVariant/WriteVariant

https://reference.opcfoundation.org/Core/Part6/v105/docs/5.3.1.17

This PR fixes JsonEncoder & Decoder & introduces a test case.

#3045

## Related Issues

- Fixes #3045

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
