### PR TITLE
[Client] Fix closing of shared Transport Channel in Recreate Scenario / Add missing event Handler to Session Constructor / Call RenewUserIdentity on Session.ReCreate

### DIFF
--- a/Libraries/Opc.Ua.Client/Session/ISession.cs
+++ b/Libraries/Opc.Ua.Client/Session/ISession.cs
@@ -608,6 +608,17 @@ namespace Opc.Ua.Client
         void Open(string sessionName, uint sessionTimeout, IUserIdentity identity, IList<string> preferredLocales, bool checkDomain);
 
         /// <summary>
+        /// Establishes a session with the server.
+        /// </summary>
+        /// <param name="sessionName">The name to assign to the session.</param>
+        /// <param name="sessionTimeout">The session timeout.</param>
+        /// <param name="identity">The user identity.</param>
+        /// <param name="preferredLocales">The list of preferred locales.</param>
+        /// <param name="checkDomain">If set to <c>true</c> then the domain in the certificate must match the endpoint used.</param>
+        /// <param name="closeChannel">If set to <c>true</c> then the channel is closed when the Open fails.</param>
+        void Open(string sessionName, uint sessionTimeout, IUserIdentity identity, IList<string> preferredLocales, bool checkDomain, bool closeChannel);
+
+        /// <summary>
         /// Updates the preferred locales used for the session.
         /// </summary>
         /// <param name="preferredLocales">The preferred locales.</param>

--- a/Libraries/Opc.Ua.Client/Session/ISession.cs
+++ b/Libraries/Opc.Ua.Client/Session/ISession.cs
@@ -681,6 +681,18 @@ namespace Opc.Ua.Client
         Task OpenAsync(string sessionName, uint sessionTimeout, IUserIdentity identity, IList<string> preferredLocales, bool checkDomain, CancellationToken ct);
 
         /// <summary>
+        /// Establishes a session with the server.
+        /// </summary>
+        /// <param name="sessionName">The name to assign to the session.</param>
+        /// <param name="sessionTimeout">The session timeout.</param>
+        /// <param name="identity">The user identity.</param>
+        /// <param name="preferredLocales">The list of preferred locales.</param>
+        /// <param name="checkDomain">If set to <c>true</c> then the domain in the certificate must match the endpoint used.</param>
+        /// <param name="closeChannel">If set to <c>true</c> then the channel is closed when the Open fails.</param>
+        /// <param name="ct">The cancellation token.</param>
+        Task OpenAsync(string sessionName, uint sessionTimeout, IUserIdentity identity, IList<string> preferredLocales, bool checkDomain, bool closeChannel, CancellationToken ct);
+
+        /// <summary>
         /// Reads the values for the node attributes and returns a node object collection.
         /// </summary>
         /// <remarks>

--- a/Libraries/Opc.Ua.Client/Session/Session.cs
+++ b/Libraries/Opc.Ua.Client/Session/Session.cs
@@ -153,6 +153,7 @@ namespace Opc.Ua.Client
                 m_SubscriptionsChanged = template.m_SubscriptionsChanged;
                 m_SessionClosing = template.m_SessionClosing;
                 m_SessionConfigurationChanged = template.m_SessionConfigurationChanged;
+                m_RenewUserIdentity = template.m_RenewUserIdentity;
             }
 
             foreach (Subscription subscription in template.Subscriptions)
@@ -1355,7 +1356,8 @@ namespace Opc.Ua.Client
                     (uint)template.m_sessionTimeout,
                     template.m_identity,
                     template.m_preferredLocales,
-                    template.m_checkDomain);
+                    template.m_checkDomain,
+                    false);
 
                 // create the subscriptions.
                 foreach (Subscription subscription in session.Subscriptions)
@@ -2286,7 +2288,17 @@ namespace Opc.Ua.Client
             IUserIdentity identity,
             IList<string> preferredLocales)
         {
-            Open(sessionName, sessionTimeout, identity, preferredLocales, true);
+            Open(sessionName, sessionTimeout, identity, preferredLocales, true, true);
+        }
+        /// <inheritdoc/>
+        public void Open(
+            string sessionName,
+            uint sessionTimeout,
+            IUserIdentity identity,
+            IList<string> preferredLocales,
+            bool checkDomain)
+        {
+            Open(sessionName, sessionTimeout, identity, preferredLocales, true, true);
         }
 
         /// <inheritdoc/>
@@ -2296,7 +2308,8 @@ namespace Opc.Ua.Client
             uint sessionTimeout,
             IUserIdentity identity,
             IList<string> preferredLocales,
-            bool checkDomain)
+            bool checkDomain,
+            bool closeChannel)
         {
             OpenValidateIdentity(ref identity, out var identityToken, out var identityPolicy, out string securityPolicyUri, out bool requireEncryption);
 
@@ -2555,7 +2568,7 @@ namespace Opc.Ua.Client
             {
                 try
                 {
-                    Close(true);
+                    Close(closeChannel);
                 }
                 catch (Exception e)
                 {

--- a/Libraries/Opc.Ua.Client/Session/Session.cs
+++ b/Libraries/Opc.Ua.Client/Session/Session.cs
@@ -1269,6 +1269,7 @@ namespace Opc.Ua.Client
 
             try
             {
+                session.RecreateRenewUserIdentity();
                 // open the session.
                 session.Open(
                     template.SessionName,
@@ -1315,6 +1316,7 @@ namespace Opc.Ua.Client
 
             try
             {
+                session.RecreateRenewUserIdentity();
                 // open the session.
                 session.Open(
                     template.m_sessionName,
@@ -1350,6 +1352,7 @@ namespace Opc.Ua.Client
 
             try
             {
+                session.RecreateRenewUserIdentity();
                 // open the session.
                 session.Open(
                     template.m_sessionName,
@@ -5358,6 +5361,17 @@ namespace Opc.Ua.Client
             }
 
             return false;
+        }
+
+        /// <summary>
+        /// Helper to refresh the identity (reprompt for password, refresh token) in case of a Recreate of the Session.
+        /// </summary>
+        public virtual void RecreateRenewUserIdentity()
+        {
+            if (m_RenewUserIdentity != null)
+            {
+                m_identity = m_RenewUserIdentity(this, m_identity);
+            }
         }
         #endregion
 

--- a/Libraries/Opc.Ua.Client/Session/Session.cs
+++ b/Libraries/Opc.Ua.Client/Session/Session.cs
@@ -2291,7 +2291,7 @@ namespace Opc.Ua.Client
             IUserIdentity identity,
             IList<string> preferredLocales)
         {
-            Open(sessionName, sessionTimeout, identity, preferredLocales, true, true);
+            Open(sessionName, sessionTimeout, identity, preferredLocales, true);
         }
         /// <inheritdoc/>
         public void Open(
@@ -2301,7 +2301,7 @@ namespace Opc.Ua.Client
             IList<string> preferredLocales,
             bool checkDomain)
         {
-            Open(sessionName, sessionTimeout, identity, preferredLocales, true, true);
+            Open(sessionName, sessionTimeout, identity, preferredLocales, checkDomain, true);
         }
 
         /// <inheritdoc/>

--- a/Libraries/Opc.Ua.Client/Session/Session.cs
+++ b/Libraries/Opc.Ua.Client/Session/Session.cs
@@ -1274,7 +1274,7 @@ namespace Opc.Ua.Client
                 session.Open(
                     template.SessionName,
                     (uint)template.SessionTimeout,
-                    template.Identity,
+                    session.Identity,
                     template.PreferredLocales,
                     template.m_checkDomain);
 
@@ -1321,7 +1321,7 @@ namespace Opc.Ua.Client
                 session.Open(
                     template.m_sessionName,
                     (uint)template.m_sessionTimeout,
-                    template.m_identity,
+                    session.Identity,
                     template.m_preferredLocales,
                     template.m_checkDomain);
 
@@ -1357,7 +1357,7 @@ namespace Opc.Ua.Client
                 session.Open(
                     template.m_sessionName,
                     (uint)template.m_sessionTimeout,
-                    template.m_identity,
+                    session.Identity,
                     template.m_preferredLocales,
                     template.m_checkDomain,
                     false);

--- a/Libraries/Opc.Ua.Client/Session/SessionAsync.cs
+++ b/Libraries/Opc.Ua.Client/Session/SessionAsync.cs
@@ -68,12 +68,25 @@ namespace Opc.Ua.Client
         }
 
         /// <inheritdoc/>
+        public Task OpenAsync(
+            string sessionName,
+            uint sessionTimeout,
+            IUserIdentity identity,
+            IList<string> preferredLocales,
+            bool checkDomain,
+            CancellationToken ct)
+        {
+            return OpenAsync(sessionName, sessionTimeout, identity, preferredLocales, checkDomain, true, ct);
+        }
+
+        /// <inheritdoc/>
         public async Task OpenAsync(
             string sessionName,
             uint sessionTimeout,
             IUserIdentity identity,
             IList<string> preferredLocales,
             bool checkDomain,
+            bool closeChannel,
             CancellationToken ct)
         {
             OpenValidateIdentity(ref identity, out var identityToken, out var identityPolicy, out string securityPolicyUri, out bool requireEncryption);
@@ -322,7 +335,10 @@ namespace Opc.Ua.Client
                 try
                 {
                     await base.CloseSessionAsync(null, false, CancellationToken.None).ConfigureAwait(false);
-                    await CloseChannelAsync(CancellationToken.None).ConfigureAwait(false);
+                    if (closeChannel)
+                    {
+                        await CloseChannelAsync(CancellationToken.None).ConfigureAwait(false);
+                    }
                 }
                 catch (Exception e)
                 {

--- a/Libraries/Opc.Ua.Client/Session/SessionAsync.cs
+++ b/Libraries/Opc.Ua.Client/Session/SessionAsync.cs
@@ -1530,6 +1530,7 @@ namespace Opc.Ua.Client
 
             try
             {
+                session.RecreateRenewUserIdentity();
                 // open the session.
                 await session.OpenAsync(
                     sessionTemplate.SessionName,
@@ -1578,6 +1579,7 @@ namespace Opc.Ua.Client
 
             try
             {
+                session.RecreateRenewUserIdentity();
                 // open the session.
                 await session.OpenAsync(
                     sessionTemplate.m_sessionName,
@@ -1620,6 +1622,7 @@ namespace Opc.Ua.Client
 
             try
             {
+                session.RecreateRenewUserIdentity();
                 // open the session.
                 await session.OpenAsync(
                     sessionTemplate.m_sessionName,

--- a/Libraries/Opc.Ua.Client/Session/SessionAsync.cs
+++ b/Libraries/Opc.Ua.Client/Session/SessionAsync.cs
@@ -1627,6 +1627,7 @@ namespace Opc.Ua.Client
                     sessionTemplate.m_identity,
                     sessionTemplate.m_preferredLocales,
                     sessionTemplate.m_checkDomain,
+                    false,
                     ct).ConfigureAwait(false);
 
                 // create the subscriptions.

--- a/Libraries/Opc.Ua.Client/Session/SessionAsync.cs
+++ b/Libraries/Opc.Ua.Client/Session/SessionAsync.cs
@@ -1535,7 +1535,7 @@ namespace Opc.Ua.Client
                 await session.OpenAsync(
                     sessionTemplate.SessionName,
                     (uint)sessionTemplate.SessionTimeout,
-                    sessionTemplate.Identity,
+                    session.Identity,
                     sessionTemplate.PreferredLocales,
                     sessionTemplate.m_checkDomain,
                     ct).ConfigureAwait(false);
@@ -1584,7 +1584,7 @@ namespace Opc.Ua.Client
                 await session.OpenAsync(
                     sessionTemplate.m_sessionName,
                     (uint)sessionTemplate.m_sessionTimeout,
-                    sessionTemplate.m_identity,
+                    session.Identity,
                     sessionTemplate.m_preferredLocales,
                     sessionTemplate.m_checkDomain,
                     ct).ConfigureAwait(false);
@@ -1627,7 +1627,7 @@ namespace Opc.Ua.Client
                 await session.OpenAsync(
                     sessionTemplate.m_sessionName,
                     (uint)sessionTemplate.m_sessionTimeout,
-                    sessionTemplate.m_identity,
+                    session.Identity,
                     sessionTemplate.m_preferredLocales,
                     sessionTemplate.m_checkDomain,
                     false,

--- a/Libraries/Opc.Ua.Client/Session/TraceableSession.cs
+++ b/Libraries/Opc.Ua.Client/Session/TraceableSession.cs
@@ -627,6 +627,15 @@ namespace Opc.Ua.Client
         }
 
         /// <inheritdoc/>
+        public void Open(string sessionName, uint sessionTimeout, IUserIdentity identity, IList<string> preferredLocales, bool checkDomain, bool closeChannel)
+        {
+            using (Activity activity = ActivitySource.StartActivity())
+            {
+                m_session.Open(sessionName, sessionTimeout, identity, preferredLocales, checkDomain, closeChannel);
+            }
+        }
+
+        /// <inheritdoc/>
         public void ChangePreferredLocales(StringCollection preferredLocales)
         {
             using (Activity activity = ActivitySource.StartActivity())
@@ -704,6 +713,15 @@ namespace Opc.Ua.Client
             using (Activity activity = ActivitySource.StartActivity())
             {
                 await m_session.OpenAsync(sessionName, sessionTimeout, identity, preferredLocales, checkDomain, ct).ConfigureAwait(false);
+            }
+        }
+
+        /// <inheritdoc/>
+        public async Task OpenAsync(string sessionName, uint sessionTimeout, IUserIdentity identity, IList<string> preferredLocales, bool checkDomain, bool closeChannel, CancellationToken ct)
+        {
+            using (Activity activity = ActivitySource.StartActivity())
+            {
+                await m_session.OpenAsync(sessionName, sessionTimeout, identity, preferredLocales, checkDomain, closeChannel, ct).ConfigureAwait(false);
             }
         }
 

--- a/Tests/Opc.Ua.Client.Tests/ClientTest.cs
+++ b/Tests/Opc.Ua.Client.Tests/ClientTest.cs
@@ -49,7 +49,6 @@ using Opc.Ua.Security.Certificates.Tests;
 using System.Security.Cryptography;
 using System.Runtime.InteropServices;
 using Opc.Ua.Security.Certificates;
-using Opc.Ua.Server;
 
 namespace Opc.Ua.Client.Tests
 {
@@ -614,8 +613,7 @@ namespace Opc.Ua.Client.Tests
             var session2 = ClientFixture.CreateSession(channel, endpoint);
             session2.Open("Session2", null);
 
-
-           
+            _ = session1.ReadValue(VariableIds.Server_ServerStatus, typeof(ServerStatusDataType));
 
             session1.Close(closeChannel: false);
             session1.DetachChannel();

--- a/Tests/Opc.Ua.Client.Tests/ClientTest.cs
+++ b/Tests/Opc.Ua.Client.Tests/ClientTest.cs
@@ -49,6 +49,7 @@ using Opc.Ua.Security.Certificates.Tests;
 using System.Security.Cryptography;
 using System.Runtime.InteropServices;
 using Opc.Ua.Security.Certificates;
+using Opc.Ua.Server;
 
 namespace Opc.Ua.Client.Tests
 {
@@ -613,7 +614,8 @@ namespace Opc.Ua.Client.Tests
             var session2 = ClientFixture.CreateSession(channel, endpoint);
             session2.Open("Session2", null);
 
-            _ = session1.ReadValue(VariableIds.Server_ServerStatus, typeof(ServerStatusDataType));
+
+           
 
             session1.Close(closeChannel: false);
             session1.DetachChannel();
@@ -624,6 +626,12 @@ namespace Opc.Ua.Client.Tests
             session2.Close(closeChannel: false);
             session2.DetachChannel();
             session2.Dispose();
+
+
+            //Recreate session using same channel
+            var session3 = await ClientFixture.SessionFactory.RecreateAsync(session1, channel);
+
+            _ = session3.ReadValue(VariableIds.Server_ServerStatus, typeof(ServerStatusDataType));
 
             channel.Dispose();
         }

--- a/Tests/Opc.Ua.Client.Tests/ClientTest.cs
+++ b/Tests/Opc.Ua.Client.Tests/ClientTest.cs
@@ -627,7 +627,7 @@ namespace Opc.Ua.Client.Tests
 
 
             //Recreate session using same channel
-            var session3 = await ClientFixture.SessionFactory.RecreateAsync(session1, channel);
+            var session3 = await ClientFixture.SessionFactory.RecreateAsync(session1, channel).ConfigureAwait(false);
 
             _ = session3.ReadValue(VariableIds.Server_ServerStatus, typeof(ServerStatusDataType));
 


### PR DESCRIPTION
## Proposed changes

Some Session Methods have an overload to share an (expensive) channel between multiple session. However in some reconnect/recreate /fail to Open Session Scenario the shared transport channel is closed by the Open Mehtod of the Session. Therefore this PR Extends the Session.Open Method to select if the used Transport Channel shall be closed.

Also the Session Constructor taking a template missed to copy   the m_RenewUserIdentity event handler to the new session

The Session.ReCreate(Async) Methods now also fire the RenewUserIdentity Event before Session.Open is called to refresh an expired user identity token.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments
