### PR TITLE
Fix XML Encoding of Null Variant to conform to spec

### DIFF
--- a/Stack/Opc.Ua.Core/Types/BuiltIn/Variant.cs
+++ b/Stack/Opc.Ua.Core/Types/BuiltIn/Variant.cs
@@ -778,6 +778,12 @@ namespace Opc.Ua
         {
             get
             {
+                // check for null.
+                if (m_value == null)
+                {
+                    return null;
+                }
+
                 // create encoder.
                 using (XmlEncoder encoder = new XmlEncoder(MessageContextExtension.CurrentContext))
                 {

--- a/Stack/Opc.Ua.Core/Types/Encoders/XmlEncoder.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/XmlEncoder.cs
@@ -1800,8 +1800,6 @@ namespace Opc.Ua
             // check for null.
             if (value == null)
             {
-                m_writer.WriteStartElement("Null", Namespaces.OpcUaXsd);
-                m_writer.WriteEndElement();
                 return;
             }
 

--- a/Stack/Opc.Ua.Core/Types/Encoders/XmlEncoder.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/XmlEncoder.cs
@@ -781,9 +781,9 @@ namespace Opc.Ua
                 {
                     PushNamespace(Namespaces.OpcUaXsd);
 
-                    m_writer.WriteStartElement("Value", Namespaces.OpcUaXsd);
-                    WriteVariantContents(value.Value, value.TypeInfo);
-                    m_writer.WriteEndElement();
+                        m_writer.WriteStartElement("Value", Namespaces.OpcUaXsd);
+                        WriteVariantContents(value.Value, value.TypeInfo);
+                        m_writer.WriteEndElement();
 
                     PopNamespace();
 
@@ -1800,6 +1800,7 @@ namespace Opc.Ua
             // check for null.
             if (value == null)
             {
+                m_writer.WriteAttributeString("nil", Namespaces.XmlSchemaInstance, "true");
                 return;
             }
 

--- a/Tests/Opc.Ua.Core.Tests/Types/Encoders/XmlEncoderTests.cs
+++ b/Tests/Opc.Ua.Core.Tests/Types/Encoders/XmlEncoderTests.cs
@@ -133,6 +133,45 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
             else
                 Assert.AreEqual(actualBinaryValue, binaryValue);
         }
+
+        // <summary>
+        /// Validate the encoding and decoding of the a variant that contains a null value
+        /// </summary>
+        [Test]
+        public void EncodeDecodeVariantNul()
+        {
+            
+            var variant = Variant.Null;
+
+            string expected = "<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n<uax:VariantTest xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:uax=\"http://opcfoundation.org/UA/2008/02/Types.xsd\">\r\n  <uax:Test>\r\n    <uax:Value />\r\n  </uax:Test>\r\n</uax:VariantTest>";
+
+            // Encode
+            var context = new ServiceMessageContext();
+            string actualXmlValue;
+            using (IEncoder xmlEncoder = new XmlEncoder(new XmlQualifiedName("VariantTest", Namespaces.OpcUaXsd), null, context))
+            {
+                xmlEncoder.PushNamespace(Namespaces.OpcUaXsd);
+                xmlEncoder.WriteVariant("Test", variant);
+                xmlEncoder.PopNamespace();
+                actualXmlValue = xmlEncoder.CloseAndReturnText();
+            }
+
+            // Check encode result against expected XML value
+            Assert.AreEqual(expected.Replace("\r", "").Replace("\n", ""), actualXmlValue.Replace("\r", "").Replace("\n", ""));
+
+            // Decode
+            Variant actualVariant;
+            using (XmlReader reader = XmlReader.Create(new StringReader(actualXmlValue)))
+            {
+                using (IDecoder xmlDecoder = new XmlDecoder(null, reader, context))
+                {
+                    actualVariant = xmlDecoder.ReadVariant("Test");
+                }
+            }
+
+            // Check decode result against input value
+            Assert.AreEqual(actualVariant, variant);
+        }
         #endregion
     }
 }

--- a/Tests/Opc.Ua.Core.Tests/Types/Encoders/XmlEncoderTests.cs
+++ b/Tests/Opc.Ua.Core.Tests/Types/Encoders/XmlEncoderTests.cs
@@ -186,7 +186,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
             
             var variant = Variant.Null;
 
-            string expected = "<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n<uax:VariantTest xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:uax=\"http://opcfoundation.org/UA/2008/02/Types.xsd\">\r\n  <uax:Test>\r\n    <uax:Value />\r\n  </uax:Test>\r\n</uax:VariantTest>";
+            string expected = "<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n<uax:VariantTest xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:uax=\"http://opcfoundation.org/UA/2008/02/Types.xsd\">\r\n  <uax:Test>\r\n    <uax:Value xsi:nil=\"true\" />\r\n  </uax:Test>\r\n</uax:VariantTest>";
 
             // Encode
             var context = new ServiceMessageContext();


### PR DESCRIPTION
## Proposed changes

Don´t write `<Null>` Node if a null variant is encoded instead write `<uax:Value xsi:nil=\"true\" />`

## Related Issues

- Fixes #3056

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments
