### PR TITLE
[Server] [Regression] fix Sampling Group disposing m_shutdownEvent in Shutdown Method. Fix double call of Shutdown Method

### DIFF
--- a/Libraries/Opc.Ua.Server/NodeManager/SamplingGroup.cs
+++ b/Libraries/Opc.Ua.Server/NodeManager/SamplingGroup.cs
@@ -101,6 +101,18 @@ namespace Opc.Ua.Server
                     m_shutdownEvent.Set();
                     m_samplingRates.Clear();
                 }
+
+                if (m_samplingTask != null)
+                {
+                    try
+                    {
+                        m_samplingTask.Wait();
+                    }
+                    catch (AggregateException) { /* Ignore exceptions on shutdown */ }
+                }
+
+                Utils.SilentDispose(m_samplingTask);
+                Utils.SilentDispose(m_shutdownEvent);
             }
         }
         #endregion

--- a/Libraries/Opc.Ua.Server/NodeManager/SamplingGroup.cs
+++ b/Libraries/Opc.Ua.Server/NodeManager/SamplingGroup.cs
@@ -100,8 +100,6 @@ namespace Opc.Ua.Server
                 {
                     m_shutdownEvent.Set();
                     m_samplingRates.Clear();
-                    Utils.SilentDispose(m_shutdownEvent);
-                    Utils.SilentDispose(m_samplingTask);
                 }
             }
         }

--- a/Libraries/Opc.Ua.Server/NodeManager/SamplingGroup.cs
+++ b/Libraries/Opc.Ua.Server/NodeManager/SamplingGroup.cs
@@ -100,6 +100,8 @@ namespace Opc.Ua.Server
                 {
                     m_shutdownEvent.Set();
                     m_samplingRates.Clear();
+                    Utils.SilentDispose(m_shutdownEvent);
+                    Utils.SilentDispose(m_samplingTask);
                 }
             }
         }
@@ -132,7 +134,6 @@ namespace Opc.Ua.Server
                 m_items.Clear();
                 Utils.SilentDispose(m_samplingTask);
                 m_samplingTask = null;
-                Utils.SilentDispose(m_shutdownEvent);
             }
         }
 

--- a/Libraries/Opc.Ua.Server/NodeManager/SamplingGroup.cs
+++ b/Libraries/Opc.Ua.Server/NodeManager/SamplingGroup.cs
@@ -132,7 +132,6 @@ namespace Opc.Ua.Server
             {
                 m_shutdownEvent.Set();
                 m_items.Clear();
-                Utils.SilentDispose(m_samplingTask);
                 m_samplingTask = null;
             }
         }

--- a/Libraries/Opc.Ua.Server/NodeManager/SamplingGroupManager.cs
+++ b/Libraries/Opc.Ua.Server/NodeManager/SamplingGroupManager.cs
@@ -506,7 +506,6 @@ namespace Opc.Ua.Server
                 // remove unused groups.
                 foreach (SamplingGroup samplingGroup in unusedGroups)
                 {
-                    samplingGroup.Shutdown();
                     m_samplingGroups.Remove(samplingGroup);
                 }
             }


### PR DESCRIPTION
- fix Sampling Group disposing m_shutdownEvent in Shutdown Method. 
- Dont dispose running task, will be cleaned up by GC once shutdown event is reached
- fix double call of Shutdown Method
- regression from #2984

## Related Issues

- Fixes #3065

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments
