### PR TITLE
Make RelativePath.Parse throw SRE if NamespaceIndexes cannot be found.

### DIFF
--- a/Stack/Opc.Ua.Core/Types/Utils/RelativePath.cs
+++ b/Stack/Opc.Ua.Core/Types/Utils/RelativePath.cs
@@ -354,6 +354,12 @@ namespace Opc.Ua
                     {
                         element.ReferenceTypeName = new QualifiedName(qname.Name, (ushort)mappings[qname.NamespaceIndex]);
                     }
+                    else
+                    {
+                        throw new ServiceResultException(
+                            StatusCodes.BadIndexRangeInvalid,
+                            Utils.Format("Cannot translate namespace index '{0}' to target namespace table.", qname.NamespaceIndex));
+                    }
                 }
 
                 qname = element.TargetName;
@@ -363,6 +369,12 @@ namespace Opc.Ua
                     if (qname.NamespaceIndex < mappings.Length && mappings[qname.NamespaceIndex] > 0)
                     {
                         element.TargetName = new QualifiedName(qname.Name, (ushort)mappings[qname.NamespaceIndex]);
+                    }
+                    else
+                    {
+                        throw new ServiceResultException(
+                            StatusCodes.BadIndexRangeInvalid,
+                            Utils.Format("Cannot translate namespace index '{0}' to target namespace table.", qname.NamespaceIndex));
                     }
                 }
             }

--- a/Tests/Opc.Ua.Core.Tests/Types/Utils/UtilsTests.cs
+++ b/Tests/Opc.Ua.Core.Tests/Types/Utils/UtilsTests.cs
@@ -328,6 +328,11 @@ namespace Opc.Ua.Core.Tests.Types.UtilsTests
         )]
         [TestCase(
             new string[] { Namespaces.OpcUa, "2", Namespaces.OpcUaGds },
+            new string[] { Namespaces.OpcUa, "2", "3" },
+            "<#2:HasChild>"
+        )]
+        [TestCase(
+            new string[] { Namespaces.OpcUa, "2", Namespaces.OpcUaGds },
             new string[] { Namespaces.OpcUa, "2", "3", "4", "5" },
             "/1:abc/4:def"
         )]

--- a/Tests/Opc.Ua.Core.Tests/Types/Utils/UtilsTests.cs
+++ b/Tests/Opc.Ua.Core.Tests/Types/Utils/UtilsTests.cs
@@ -299,6 +299,52 @@ namespace Opc.Ua.Core.Tests.Types.UtilsTests
         }
 
         /// <summary>
+        /// Parse deep path string containing two Namespaces, translate indexes
+        /// </summary>
+        [Test]
+        public void RelativePathParseTranslateNamespaceIndex()
+        {
+            var currentTable = new NamespaceTable(new List<string>() { Namespaces.OpcUa, "1", Namespaces.OpcUaGds });
+            var targetTable = new NamespaceTable(new List<string>() { Namespaces.OpcUa, "1", "2", Namespaces.OpcUaGds });
+
+            TypeTable typeTable = new TypeTable(new NamespaceTable());
+            string str = "/1:abc/2:def";
+            string result = "/1:abc/3:def";
+            Assert.AreEqual(result, RelativePath.Parse(str, typeTable, currentTable, targetTable).Format(typeTable));
+        }
+
+        /// <summary>
+        /// Parse deep path string containing two Namespaces, with targetTable missing the right namespace
+        /// </summary>
+        [Test]
+        public void RelativePathParseInvalidNamespaceIndex()
+        {
+            var currentTable = new NamespaceTable(new List<string>() { Namespaces.OpcUa, "2", Namespaces.OpcUaGds });
+            var targetTable = new NamespaceTable(new List<string>() { Namespaces.OpcUa, "2", "3" });
+
+            TypeTable typeTable = new TypeTable(new NamespaceTable());
+            string str = "/1:abc/2:def";
+            var sre = Assert.Throws<ServiceResultException>(() => RelativePath.Parse(str, typeTable, currentTable, targetTable).Format(typeTable));
+            Assert.AreEqual((StatusCode)StatusCodes.BadIndexRangeInvalid, (StatusCode)sre.StatusCode);
+        }
+
+        /// <summary>
+        /// Parse deep path string containing two Namespaces, with currentTable missing the right namespace
+        /// </summary>
+        [Test]
+        public void RelativePathParseInvalidNamespaceIndexCurrentTable()
+        {
+            var currentTable = new NamespaceTable(new List<string>() { Namespaces.OpcUa, "2", Namespaces.OpcUaGds });
+            var targetTable = new NamespaceTable(new List<string>() { Namespaces.OpcUa, "2", "3", "4", "5" });
+
+            TypeTable typeTable = new TypeTable(new NamespaceTable());
+            string str = "/1:abc/4:def";
+            var sre = Assert.Throws<ServiceResultException>(() => RelativePath.Parse(str, typeTable, currentTable, targetTable).Format(typeTable));
+            Assert.AreEqual((StatusCode)StatusCodes.BadIndexRangeInvalid, (StatusCode)sre.StatusCode);
+        }
+
+
+        /// <summary>
         /// Validate that XmlDocument DtdProcessing is protected against
         /// exponential entity expansion in this version of .NET.
         /// </summary>

--- a/Tests/Opc.Ua.Core.Tests/Types/Utils/UtilsTests.cs
+++ b/Tests/Opc.Ua.Core.Tests/Types/Utils/UtilsTests.cs
@@ -299,47 +299,45 @@ namespace Opc.Ua.Core.Tests.Types.UtilsTests
         }
 
         /// <summary>
-        /// Parse deep path string containing two Namespaces, translate indexes
+        /// Parse path string containing two Namespaces, translate indexes
         /// </summary>
-        [Test]
-        public void RelativePathParseTranslateNamespaceIndex()
+        [Theory]
+        [TestCase("<#2:HasChild>", "<#3:HasChild>")]
+        [TestCase("<!2:HasChild>", "<!3:HasChild>")]
+        [TestCase(".2:NodeVersion", ".3:NodeVersion")]
+        [TestCase("/1:abc/2:def", "/1:abc/3:def")]
+        public void RelativePathParseTranslateNamespaceIndexReferenceType(string input, string output)
         {
             var currentTable = new NamespaceTable(new List<string>() { Namespaces.OpcUa, "1", Namespaces.OpcUaGds });
             var targetTable = new NamespaceTable(new List<string>() { Namespaces.OpcUa, "1", "2", Namespaces.OpcUaGds });
 
             TypeTable typeTable = new TypeTable(new NamespaceTable());
-            string str = "/1:abc/2:def";
-            string result = "/1:abc/3:def";
-            Assert.AreEqual(result, RelativePath.Parse(str, typeTable, currentTable, targetTable).Format(typeTable));
+            typeTable.AddReferenceSubtype(Opc.Ua.ReferenceTypeIds.HasChild, NodeId.Null, new QualifiedName("HasChild", 3));
+            Assert.AreEqual(output, RelativePath.Parse(input, typeTable, currentTable, targetTable).Format(typeTable));
         }
 
-        /// <summary>
-        /// Parse deep path string containing two Namespaces, with targetTable missing the right namespace
-        /// </summary>
-        [Test]
-        public void RelativePathParseInvalidNamespaceIndex()
-        {
-            var currentTable = new NamespaceTable(new List<string>() { Namespaces.OpcUa, "2", Namespaces.OpcUaGds });
-            var targetTable = new NamespaceTable(new List<string>() { Namespaces.OpcUa, "2", "3" });
-
-            TypeTable typeTable = new TypeTable(new NamespaceTable());
-            string str = "/1:abc/2:def";
-            var sre = Assert.Throws<ServiceResultException>(() => RelativePath.Parse(str, typeTable, currentTable, targetTable).Format(typeTable));
-            Assert.AreEqual((StatusCode)StatusCodes.BadIndexRangeInvalid, (StatusCode)sre.StatusCode);
-        }
 
         /// <summary>
-        /// Parse deep path string containing two Namespaces, with currentTable missing the right namespace
+        /// Parse path string containing two Namespaces with missing namespace indexes in either currentTable or targetTable.
         /// </summary>
-        [Test]
-        public void RelativePathParseInvalidNamespaceIndexCurrentTable()
+        [Theory]
+        [TestCase(
+            new string[] { Namespaces.OpcUa, "2", Namespaces.OpcUaGds },
+            new string[] { Namespaces.OpcUa, "2", "3" },
+            "/1:abc/2:def"
+        )]
+        [TestCase(
+            new string[] { Namespaces.OpcUa, "2", Namespaces.OpcUaGds },
+            new string[] { Namespaces.OpcUa, "2", "3", "4", "5" },
+            "/1:abc/4:def"
+        )]
+        public void RelativePathParseInvalidNamespaceIndex(string[] currentNamespaces, string[] targetNamespaces, string path)
         {
-            var currentTable = new NamespaceTable(new List<string>() { Namespaces.OpcUa, "2", Namespaces.OpcUaGds });
-            var targetTable = new NamespaceTable(new List<string>() { Namespaces.OpcUa, "2", "3", "4", "5" });
+            var currentTable = new NamespaceTable(new List<string>(currentNamespaces));
+            var targetTable = new NamespaceTable(new List<string>(targetNamespaces));
 
             TypeTable typeTable = new TypeTable(new NamespaceTable());
-            string str = "/1:abc/4:def";
-            var sre = Assert.Throws<ServiceResultException>(() => RelativePath.Parse(str, typeTable, currentTable, targetTable).Format(typeTable));
+            var sre = Assert.Throws<ServiceResultException>(() => RelativePath.Parse(path, typeTable, currentTable, targetTable).Format(typeTable));
             Assert.AreEqual((StatusCode)StatusCodes.BadIndexRangeInvalid, (StatusCode)sre.StatusCode);
         }
 


### PR DESCRIPTION
Make RelativePath.Parse throw SRE if NamespaceIndexes cannot be found or cannot be translated.
Add Tests to verify functionality.

## Proposed changes


## Related Issues

- Fixes #954

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments
