### PR TITLE
Implement support for "mul" locale in LocalizedText Class & ResourceManager

### DIFF
--- a/Libraries/Opc.Ua.Server/NodeManager/ResourceManager.cs
+++ b/Libraries/Opc.Ua.Server/NodeManager/ResourceManager.cs
@@ -349,7 +349,8 @@ namespace Opc.Ua.Server
             // get translation for multiLanguage request
             if (isMultilanguageRequested)
             {
-                var translations = defaultText?.Translations != null ? new Dictionary<string, string>(defaultText.Translations.ToDictionary(s => s.Key, s => s.Value)) : new Dictionary<string, string>();
+
+                var translations = (IDictionary<string, string>)(defaultText.Translations ?? new Dictionary<string, string>());
                 // If only mul/qst is requested, return all available translations for the key.
                 if (preferredLocales.Count == 1)
                 {
@@ -357,20 +358,20 @@ namespace Opc.Ua.Server
                     {
                         foreach (var table in m_translationTables)
                         {
-                            if (table.Translations.TryGetValue(info.Key ?? info.Text, out var t))
+                            if (table.Translations.TryGetValue(info.Key ?? info.Text, out string translation))
                             {
                                 // format translated text.
                                 if (info.Args?.Length > 0)
                                 {
                                     try
                                     {
-                                        t = string.Format(table.Locale, t, info.Args);
+                                        translation = string.Format(table.Locale, translation, info.Args);
                                     }
                                     catch
                                     { }
                                 }
 
-                                translations[table.Locale.Name] = t;
+                                translations[table.Locale.Name] = translation;
                             }
                         }
                     }
@@ -402,7 +403,7 @@ namespace Opc.Ua.Server
                         }
                     }
                 }
-                return new LocalizedText(translations);
+                return new LocalizedText((IReadOnlyDictionary<string, string>)translations);
             }
             // single locale requested.
             else

--- a/Libraries/Opc.Ua.Server/NodeManager/ResourceManager.cs
+++ b/Libraries/Opc.Ua.Server/NodeManager/ResourceManager.cs
@@ -29,13 +29,9 @@
 
 using System;
 using System.Collections.Generic;
-using System.Text;
-using System.Resources;
 using System.Globalization;
-using System.Xml;
-using System.Reflection;
 using System.Linq;
-using System.Collections.ObjectModel;
+using System.Xml;
 
 namespace Opc.Ua.Server
 {
@@ -363,6 +359,17 @@ namespace Opc.Ua.Server
                         {
                             if (table.Translations.TryGetValue(info.Key ?? info.Text, out var t))
                             {
+                                // format translated text.
+                                if (info.Args?.Length > 0)
+                                {
+                                    try
+                                    {
+                                        t = string.Format(table.Locale, t, info.Args);
+                                    }
+                                    catch
+                                    { }
+                                }
+
                                 translations[table.Locale.Name] = t;
                             }
                         }
@@ -382,19 +389,6 @@ namespace Opc.Ua.Server
                                 // format translated text.
                                 if (info.Args?.Length > 0)
                                 {
-                                    // get a culture to use for formatting
-                                    if (culture == null)
-                                    {
-                                        try
-                                        {
-                                            culture = new CultureInfo(info.Locale);
-                                        }
-                                        catch
-                                        {
-                                            culture = CultureInfo.InvariantCulture;
-                                        }
-                                    }
-
                                     try
                                     {
                                         translation = string.Format(culture, translation, info.Args);

--- a/Libraries/Opc.Ua.Server/NodeManager/ResourceManager.cs
+++ b/Libraries/Opc.Ua.Server/NodeManager/ResourceManager.cs
@@ -325,7 +325,7 @@ namespace Opc.Ua.Server
             bool isMultilanguageRequested = preferredLocales?.Count > 0 ? preferredLocales[0].ToLowerInvariant() is "mul" or "qst" : false;
 
             // check for trivial case.
-            if (info == null || String.IsNullOrEmpty(info.Text))
+            if (info == null || (string.IsNullOrEmpty(info.Text) && string.IsNullOrEmpty(info.Key)))
             {
                 return defaultText;
             }
@@ -353,7 +353,7 @@ namespace Opc.Ua.Server
             // get translation for multiLanguage request
             if (isMultilanguageRequested)
             {
-                var translations = new Dictionary<string, string>(defaultText.Translations.ToDictionary(s => s.Key, s => s.Value));
+                var translations = defaultText?.Translations != null ? new Dictionary<string, string>(defaultText.Translations.ToDictionary(s => s.Key, s => s.Value)) : new Dictionary<string, string>();
                 // If only mul/qst is requested, return all available translations for the key.
                 if (preferredLocales.Count == 1)
                 {

--- a/Libraries/Opc.Ua.Server/NodeManager/ResourceManager.cs
+++ b/Libraries/Opc.Ua.Server/NodeManager/ResourceManager.cs
@@ -349,7 +349,11 @@ namespace Opc.Ua.Server
             // get translation for multiLanguage request
             if (isMultilanguageRequested)
             {
+#if NETSTANDARD2_1_OR_GREATER || NET6_0_OR_GREATER
+                var translations = defaultText?.Translations != null ? new Dictionary<string, string>(defaultText.Translations) : new Dictionary<string, string>();
+#else
                 var translations = defaultText?.Translations != null ? new Dictionary<string, string>(defaultText.Translations.ToDictionary(s => s.Key, s => s.Value)) : new Dictionary<string, string>();
+#endif
                 // If only mul/qst is requested, return all available translations for the key.
                 if (preferredLocales.Count == 1)
                 {

--- a/Libraries/Opc.Ua.Server/NodeManager/ResourceManager.cs
+++ b/Libraries/Opc.Ua.Server/NodeManager/ResourceManager.cs
@@ -34,6 +34,8 @@ using System.Resources;
 using System.Globalization;
 using System.Xml;
 using System.Reflection;
+using System.Linq;
+using System.Collections.ObjectModel;
 
 namespace Opc.Ua.Server
 {
@@ -99,7 +101,6 @@ namespace Opc.Ua.Server
             {
                 return null;
             }
-
             // translate localized text.
             LocalizedText translatedText = result.LocalizedText;
 
@@ -319,6 +320,10 @@ namespace Opc.Ua.Server
         /// </summary>
         protected virtual LocalizedText Translate(IList<string> preferredLocales, LocalizedText defaultText, TranslationInfo info)
         {
+            defaultText = defaultText.FilterByPreferredLocales(preferredLocales);
+
+            bool isMultilanguageRequested = preferredLocales[0].ToLowerInvariant() is "mul" or "qst";
+
             // check for trivial case.
             if (info == null || String.IsNullOrEmpty(info.Text))
             {
@@ -328,7 +333,13 @@ namespace Opc.Ua.Server
             // check for exact match.
             if (preferredLocales != null && preferredLocales.Count > 0)
             {
-                if (defaultText != null && preferredLocales[0] == defaultText.Locale)
+                if (defaultText != null && !isMultilanguageRequested && preferredLocales[0] == defaultText.Locale)
+                {
+                    return defaultText;
+                }
+
+                // MultiLanguageText requested, specified numer of locales was found in the default text.
+                if (isMultilanguageRequested && preferredLocales.Count > 1 && defaultText?.Translations?.Count == preferredLocales.Count - 1)
                 {
                     return defaultText;
                 }
@@ -339,64 +350,120 @@ namespace Opc.Ua.Server
                 }
             }
 
-            // use the text as the key.
-            string key = info.Key;
-
-            if (key == null)
+            // get translation for multiLanguage request
+            if (isMultilanguageRequested)
             {
-                key = info.Text;
-            }
-
-            // find the best translation.
-            string translatedText = info.Text;
-            CultureInfo culture = CultureInfo.InvariantCulture;
-
-            lock (m_lock)
-            {
-                translatedText = FindBestTranslation(preferredLocales, key, out culture);
-
-                // use the default if no translation available.
-                if (translatedText == null)
+                var translations = new Dictionary<string, string>(defaultText.Translations.ToDictionary(s => s.Key, s => s.Value));
+                // If only mul/qst is requested, return all available translations for the key.
+                if (preferredLocales.Count == 1)
                 {
-                    return defaultText;
-                }
-
-                // get a culture to use for formatting
-                if (culture == null)
-                {
-                    if (info.Args != null && info.Args.Length > 0 && !String.IsNullOrEmpty(info.Locale))
+                    lock (m_lock)
                     {
-                        try
+                        foreach (var table in m_translationTables)
                         {
-                            culture = new CultureInfo(info.Locale);
-                        }
-                        catch
-                        {
-                            culture = CultureInfo.InvariantCulture;
+                            if (table.Translations.TryGetValue(info.Key ?? info.Text, out var t))
+                            {
+                                translations[table.Locale.Name] = t;
+                            }
                         }
                     }
                 }
+                else
+                {
+                    // mul/qst + specific locales: return only those translations
+                    lock (m_lock)
+                    {
+                        for (int i = 1; i < preferredLocales.Count; i++)
+                        {
+                            string translation = FindBestTranslation(new List<string>() { preferredLocales[i] }, info.Key ?? info.Text, out CultureInfo culture);
+
+                            if (translation != null)
+                            {
+                                // format translated text.
+                                if (info.Args?.Length > 0)
+                                {
+                                    // get a culture to use for formatting
+                                    if (culture == null)
+                                    {
+                                        try
+                                        {
+                                            culture = new CultureInfo(info.Locale);
+                                        }
+                                        catch
+                                        {
+                                            culture = CultureInfo.InvariantCulture;
+                                        }
+                                    }
+
+                                    try
+                                    {
+                                        translation = string.Format(culture, translation, info.Args);
+                                    }
+                                    catch
+                                    { }
+                                }
+
+                                translations[preferredLocales[i]] = translation;
+                            }
+                        }
+                    }
+                }
+                return new LocalizedText(translations);
             }
-
-            // format translated text.
-            string formattedText = translatedText;
-
-            if (info.Args != null && info.Args.Length > 0)
+            // single locale requested.
+            else
             {
-                try
-                {
-                    formattedText = string.Format(culture, translatedText, info.Args);
-                }
-                catch
-                {
-                    formattedText = translatedText;
-                }
-            }
+                // find the best translation.
+                string translatedText = info.Text;
+                CultureInfo culture = CultureInfo.InvariantCulture;
 
-            // construct translated localized text.
-            Opc.Ua.LocalizedText finalText = new LocalizedText(culture.Name, formattedText);
-            finalText.TranslationInfo = info;
-            return finalText;
+                lock (m_lock)
+                {
+                    translatedText = FindBestTranslation(preferredLocales, info.Key ?? info.Text, out culture);
+
+                    // use the default if no translation available.
+                    if (translatedText == null)
+                    {
+                        return defaultText;
+                    }
+
+                    // get a culture to use for formatting
+                    if (culture == null)
+                    {
+                        if (info.Args?.Length > 0 && !string.IsNullOrEmpty(info.Locale))
+                        {
+                            try
+                            {
+                                culture = new CultureInfo(info.Locale);
+                            }
+                            catch
+                            {
+                                culture = CultureInfo.InvariantCulture;
+                            }
+                        }
+                    }
+                }
+
+                // format translated text.
+                string formattedText = translatedText;
+
+                if (info.Args?.Length > 0)
+                {
+                    try
+                    {
+                        formattedText = string.Format(culture, translatedText, info.Args);
+                    }
+                    catch
+                    {
+                        formattedText = translatedText;
+                    }
+                }
+
+                // construct translated localized text.
+                Opc.Ua.LocalizedText finalText = new LocalizedText(culture.Name, formattedText);
+                finalText.TranslationInfo = info;
+                return finalText;
+            }
         }
         #endregion
 

--- a/Libraries/Opc.Ua.Server/NodeManager/ResourceManager.cs
+++ b/Libraries/Opc.Ua.Server/NodeManager/ResourceManager.cs
@@ -320,9 +320,9 @@ namespace Opc.Ua.Server
         /// </summary>
         protected virtual LocalizedText Translate(IList<string> preferredLocales, LocalizedText defaultText, TranslationInfo info)
         {
-            defaultText = defaultText.FilterByPreferredLocales(preferredLocales);
+            defaultText = defaultText?.FilterByPreferredLocales(preferredLocales);
 
-            bool isMultilanguageRequested = preferredLocales[0].ToLowerInvariant() is "mul" or "qst";
+            bool isMultilanguageRequested = preferredLocales?.Count > 0 ? preferredLocales[0].ToLowerInvariant() is "mul" or "qst" : false;
 
             // check for trivial case.
             if (info == null || String.IsNullOrEmpty(info.Text))
@@ -333,7 +333,7 @@ namespace Opc.Ua.Server
             // check for exact match.
             if (preferredLocales != null && preferredLocales.Count > 0)
             {
-                if (defaultText != null && !isMultilanguageRequested && preferredLocales[0] == defaultText.Locale)
+                if (defaultText != null && !isMultilanguageRequested && preferredLocales[0] == defaultText?.Locale)
                 {
                     return defaultText;
                 }

--- a/Libraries/Opc.Ua.Server/NodeManager/ResourceManager.cs
+++ b/Libraries/Opc.Ua.Server/NodeManager/ResourceManager.cs
@@ -349,8 +349,7 @@ namespace Opc.Ua.Server
             // get translation for multiLanguage request
             if (isMultilanguageRequested)
             {
-
-                var translations = (IDictionary<string, string>)(defaultText.Translations ?? new Dictionary<string, string>());
+                var translations = defaultText?.Translations != null ? new Dictionary<string, string>(defaultText.Translations.ToDictionary(s => s.Key, s => s.Value)) : new Dictionary<string, string>();
                 // If only mul/qst is requested, return all available translations for the key.
                 if (preferredLocales.Count == 1)
                 {

--- a/Stack/Opc.Ua.Core/Types/BuiltIn/LocalizedText.cs
+++ b/Stack/Opc.Ua.Core/Types/BuiltIn/LocalizedText.cs
@@ -64,8 +64,9 @@ namespace Opc.Ua
     [DataContract(Namespace = Namespaces.OpcUaXsd)]
     public partial class LocalizedText : ICloneable, IFormattable
     {
-        private const string MulLocale = "mul";
-        private const string MulLocaleDictionaryKey = "t";
+        private const string kMulLocale = "mul";
+        private const string kMulLocaleDictionaryKey = "t";
+
         #region Constructors
         /// <summary>
         /// Initializes the object with the default values.
@@ -284,7 +285,7 @@ namespace Opc.Ua
                 }
                 //Encode the dictionary to a mul locale.
                 m_translations = value;
-                m_locale = MulLocale;
+                m_locale = kMulLocale;
                 m_text = EncodeMulLocale(m_translations);
             }
         }
@@ -339,7 +340,7 @@ namespace Opc.Ua
         /// <summary>
         /// Returns true if this LocalizedText uses the "mul" special locale.
         /// </summary>
-        public bool IsMultiLanguage => string.Equals(m_locale, MulLocale, StringComparison.OrdinalIgnoreCase);
+        public bool IsMultiLanguage => string.Equals(m_locale, kMulLocale, StringComparison.OrdinalIgnoreCase);
         #endregion
 
         #region Overridden Methods
@@ -601,6 +602,7 @@ namespace Opc.Ua
             }
         }
         #endregion
+
         #region Private Methods
         /// <summary>
         /// Ecodes the translations to a JSON string according to the format specified in https://reference.opcfoundation.org/Core/Part3/v105/docs/8.5
@@ -616,7 +618,7 @@ namespace Opc.Ua
                 t.Add(new object[] { kvp.Key, kvp.Value });
             }
 
-            return JsonConvert.SerializeObject(new Dictionary<string, object> { { MulLocaleDictionaryKey, t } });
+            return JsonConvert.SerializeObject(new Dictionary<string, object> { { kMulLocaleDictionaryKey, t } });
         }
 
         /// <summary>
@@ -633,7 +635,7 @@ namespace Opc.Ua
             {
                 // The expected JSON structure is defined in https://reference.opcfoundation.org/Core/Part3/v105/docs/8.5
                 var json = JsonConvert.DeserializeObject<Dictionary<string, object>>(m_text);
-                if (json != null && json.TryGetValue(MulLocaleDictionaryKey, out var tValue) && tValue is Newtonsoft.Json.Linq.JArray tArray)
+                if (json != null && json.TryGetValue(kMulLocaleDictionaryKey, out var tValue) && tValue is Newtonsoft.Json.Linq.JArray tArray)
                 {
                     foreach (var pairToken in tArray)
                     {
@@ -652,6 +654,7 @@ namespace Opc.Ua
             catch
             {
                 Utils.Trace("Failed to parse mul locale JSON text: {0}", m_text);
+                return null; // Return null if parsing fails
             }
             return new ReadOnlyDictionary<string, string>(result);
         }

--- a/Stack/Opc.Ua.Core/Types/BuiltIn/LocalizedText.cs
+++ b/Stack/Opc.Ua.Core/Types/BuiltIn/LocalizedText.cs
@@ -12,6 +12,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Globalization;
 using System.Runtime.Serialization;
 using Newtonsoft.Json;
@@ -197,7 +198,7 @@ namespace Opc.Ua
         /// Results in a localized text using the "mul" locale.
         /// </summary>
         /// <param name="translations">key = locale, value = text</param>
-        public LocalizedText(IDictionary<string, string> translations)
+        public LocalizedText(IReadOnlyDictionary<string, string> translations)
         {
             Translations = translations;
         }
@@ -234,13 +235,13 @@ namespace Opc.Ua
         /// If the translations property is set a mul locale will be created.
         /// Key = locale, value = text.
         /// </summary>
-        public IDictionary<string, string> Translations
+        public IReadOnlyDictionary<string, string> Translations
         {
             get
             {
                 if (m_translations == null && m_locale != null)
                 {
-                    return new Dictionary<string, string> { { m_locale, m_text } };
+                    return new ReadOnlyDictionary<string, string>(new Dictionary<string, string> { { m_locale, m_text } });
                 }
                 return m_translations;
             }
@@ -512,11 +513,12 @@ namespace Opc.Ua
             return String.IsNullOrEmpty(value.m_text);
         }
         #endregion
+
         #region private Methods
         /// <summary>
         /// Ecodes the translations to a JSON string according to the format specified in https://reference.opcfoundation.org/Core/Part3/v105/docs/8.5
         /// </summary>
-        private string EncodeMulLocale(IDictionary<string, string> translations)
+        private string EncodeMulLocale(IReadOnlyDictionary<string, string> translations)
         {
             if (translations == null) throw new ArgumentNullException(nameof(translations));
             if (translations.Count == 0) throw new ArgumentException("The translations dictionary must not be empty.", nameof(translations));
@@ -534,7 +536,7 @@ namespace Opc.Ua
         /// If this is a "mul" locale, returns a dictionary of locale/text pairs from the JSON Text.
         /// Otherwise, returns null.
         /// </summary>
-        private IDictionary<string, string> DecodeMulLocale()
+        private IReadOnlyDictionary<string, string> DecodeMulLocale()
         {
             if (!IsMultiLanguage || string.IsNullOrWhiteSpace(m_text))
                 return null;
@@ -564,14 +566,15 @@ namespace Opc.Ua
             {
                 Utils.Trace("Failed to parse mul locale JSON text: {0}", m_text);
             }
-            return result;
+            return new ReadOnlyDictionary<string, string>(result);
         }
         #endregion
+
         #region Private Fields
         private string m_locale;
         private string m_text;
         private TranslationInfo m_translationInfo;
-        private IDictionary<string, string> m_translations;
+        private IReadOnlyDictionary<string, string> m_translations;
         #endregion
     }
 

--- a/Stack/Opc.Ua.Core/Types/BuiltIn/LocalizedText.cs
+++ b/Stack/Opc.Ua.Core/Types/BuiltIn/LocalizedText.cs
@@ -14,6 +14,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Runtime.Serialization;
+using Newtonsoft.Json;
 
 namespace Opc.Ua
 {
@@ -61,6 +62,8 @@ namespace Opc.Ua
     [DataContract(Namespace = Namespaces.OpcUaXsd)]
     public partial class LocalizedText : ICloneable, IFormattable
     {
+        private const string MulLocale = "mul";
+        private const string MulLocaleDictionaryKey = "t";
         #region Constructors
         /// <summary>
         /// Initializes the object with the default values.
@@ -122,6 +125,7 @@ namespace Opc.Ua
             {
                 m_text = m_translationInfo.Text;
             }
+            m_translations = DecodeMulLocale();
         }
 
         /// <summary>
@@ -138,6 +142,7 @@ namespace Opc.Ua
 
             m_locale = value.m_locale;
             m_text = value.m_text;
+            m_translations = DecodeMulLocale();
         }
 
         /// <summary>
@@ -165,6 +170,7 @@ namespace Opc.Ua
         {
             m_locale = locale;
             m_text = text;
+            m_translations = DecodeMulLocale();
         }
 
         /// <summary>
@@ -182,6 +188,18 @@ namespace Opc.Ua
             {
                 m_translationInfo = new TranslationInfo(key, locale, text);
             }
+            m_translations = DecodeMulLocale();
+        }
+
+        /// <summary>
+        /// Creates a LocalizedText object from a dictionary of translations.
+        /// The dictionary must contain at least one entry.
+        /// Results in a localized text using the "mul" locale.
+        /// </summary>
+        /// <param name="translations">key = locale, value = text</param>
+        public LocalizedText(IDictionary<string, string> translations)
+        {
+            Translations = translations;
         }
         #endregion
 
@@ -209,6 +227,48 @@ namespace Opc.Ua
         /// The localized text.
         /// </remarks>
         public string Text => m_text;
+
+        /// <summary>
+        /// The decoded translations if the Localized Text is a mul locale.
+        /// If the LocalizedText is not a mul locale, this property will return a dictionary with one entry from the Text and Locale properties.
+        /// If the translations property is set a mul locale will be created.
+        /// Key = locale, value = text.
+        /// </summary>
+        public IDictionary<string, string> Translations
+        {
+            get
+            {
+                if (m_translations == null && m_locale != null)
+                {
+                    return new Dictionary<string, string> { { m_locale, m_text } };
+                }
+                return m_translations;
+            }
+
+            set
+            {
+                if (value == null || value.Count == 0)
+                {
+                    m_translations = null;
+                    return;
+                }
+                // if the dictionary contains only one entry, use the first entry as the locale and text.
+                if (value.Count == 1)
+                {
+                    foreach (var kvp in value)
+                    {
+                        m_locale = kvp.Key;
+                        m_text = kvp.Value;
+                        m_translations = null;
+                        return;
+                    }
+                }
+                //Encode the dictionary to a mul locale.
+                m_translations = value;
+                m_locale = MulLocale;
+                m_text = EncodeMulLocale(m_translations);
+            }
+        }
 
         /// <summary cref="LocalizedText.Text" />
         [DataMember(Name = "Text", Order = 2)]
@@ -256,6 +316,11 @@ namespace Opc.Ua
             get { return m_translationInfo; }
             set { m_translationInfo = value; }
         }
+
+        /// <summary>
+        /// Returns true if this LocalizedText uses the "mul" special locale.
+        /// </summary>
+        public bool IsMultiLanguage => string.Equals(m_locale, MulLocale, StringComparison.OrdinalIgnoreCase);
         #endregion
 
         #region Overridden Methods
@@ -447,11 +512,66 @@ namespace Opc.Ua
             return String.IsNullOrEmpty(value.m_text);
         }
         #endregion
+        #region private Methods
+        /// <summary>
+        /// Ecodes the translations to a JSON string according to the format specified in https://reference.opcfoundation.org/Core/Part3/v105/docs/8.5
+        /// </summary>
+        private string EncodeMulLocale(IDictionary<string, string> translations)
+        {
+            if (translations == null) throw new ArgumentNullException(nameof(translations));
+            if (translations.Count == 0) throw new ArgumentException("The translations dictionary must not be empty.", nameof(translations));
 
+            var t = new List<object[]>();
+            foreach (var kvp in translations)
+            {
+                t.Add(new object[] { kvp.Key, kvp.Value });
+            }
+
+            return JsonConvert.SerializeObject(new Dictionary<string, object> { { MulLocaleDictionaryKey, t } });
+        }
+
+        /// <summary>
+        /// If this is a "mul" locale, returns a dictionary of locale/text pairs from the JSON Text.
+        /// Otherwise, returns null.
+        /// </summary>
+        private IDictionary<string, string> DecodeMulLocale()
+        {
+            if (!IsMultiLanguage || string.IsNullOrWhiteSpace(m_text))
+                return null;
+
+            var result = new Dictionary<string, string>();
+            try
+            {
+                // The expected JSON structure is defined in https://reference.opcfoundation.org/Core/Part3/v105/docs/8.5
+                var json = JsonConvert.DeserializeObject<Dictionary<string, object>>(m_text);
+                if (json != null && json.TryGetValue(MulLocaleDictionaryKey, out var tValue) && tValue is Newtonsoft.Json.Linq.JArray tArray)
+                {
+                    foreach (var pairToken in tArray)
+                    {
+                        if (pairToken is Newtonsoft.Json.Linq.JArray pair && pair.Count == 2)
+                        {
+                            var locale = pair[0]?.ToString();
+                            var text = pair[1]?.ToString();
+                            if (!string.IsNullOrEmpty(locale) && text != null)
+                            {
+                                result[locale] = text;
+                            }
+                        }
+                    }
+                }
+            }
+            catch
+            {
+                Utils.Trace("Failed to parse mul locale JSON text: {0}", m_text);
+            }
+            return result;
+        }
+        #endregion
         #region Private Fields
         private string m_locale;
         private string m_text;
         private TranslationInfo m_translationInfo;
+        private IDictionary<string, string> m_translations;
         #endregion
     }
 

--- a/Stack/Opc.Ua.Core/Types/BuiltIn/LocalizedText.cs
+++ b/Stack/Opc.Ua.Core/Types/BuiltIn/LocalizedText.cs
@@ -203,6 +203,23 @@ namespace Opc.Ua
         {
             Translations = translations;
         }
+
+        /// <summary>
+        /// Creates a LocalizedText object from a dictionary of translations.
+        /// The dictionary must contain at least one entry.
+        /// Results in a localized text using the "mul" locale.
+        /// </summary>
+        /// <param name="translations">key = locale, value = text</param>
+        /// <param name="key">A key used to look up the text for different locales</param>
+        public LocalizedText(string key, IReadOnlyDictionary<string, string> translations)
+        {
+            Translations = translations;
+
+            if (!string.IsNullOrEmpty(key))
+            {
+                m_translationInfo = new TranslationInfo(key, m_locale, m_text);
+            }
+        }
         #endregion
 
         #region Public Properties

--- a/Tests/Opc.Ua.Core.Tests/Types/BuiltIn/LocalizedTextTests.cs
+++ b/Tests/Opc.Ua.Core.Tests/Types/BuiltIn/LocalizedTextTests.cs
@@ -97,5 +97,52 @@ namespace Opc.Ua.Core.Tests.Types.BuiltIn
             Assert.AreEqual("Hallo", localizedText.Translations["de-DE"]);
             Assert.AreEqual("Bonjour", localizedText.Translations["fr-FR"]);
         }
+
+        [Test]
+        public void LocalizedText_MulLocale_ReturnsPreferredTranslations()
+        {
+            // Arrange
+            const string mulLocale = "mul";
+            const string jsonText = "{\"t\":[[\"en-US\",\"Hello\"],[\"de-DE\",\"Hallo\"],[\"fr-FR\",\"Bonjour\"]]}";
+
+            // Act
+            var localizedText = new LocalizedText(mulLocale, jsonText);
+
+            // Assert
+            Assert.IsTrue(localizedText.IsMultiLanguage, "Should be mul locale");
+
+            //found locale returned
+            var singleUS = localizedText.FilterByPreferredLocales(new[] { "en-US", "de-DE" });
+            Assert.AreEqual("en-US", singleUS.Locale, "Locale should be 'en-US'");
+            Assert.AreEqual("Hello", singleUS.Text, "Text should be 'Hello'");
+
+            //found locale returned
+            var singleDE = localizedText.FilterByPreferredLocales(new[] { "en-GB", "de-DE" });
+            Assert.AreEqual("de-DE", singleDE.Locale, "Locale should be 'de-DE'");
+            Assert.AreEqual("Hallo", singleDE.Text, "Text should be 'Hallo'");
+
+            //first locale returned
+            var singleFR = localizedText.FilterByPreferredLocales(new[] { "en-GB" });
+            Assert.AreEqual("en-US", singleFR.Locale, "Locale should be 'en-US'");
+            Assert.AreEqual("Hello", singleFR.Text, "Text should be 'Hello'");
+
+            // Default locale returned
+            var mulGB = localizedText.FilterByPreferredLocales(new[] { "mul", "en-GB" });
+            Assert.AreEqual("en-US", mulGB.Locale, "Locale should be 'en-US'");
+            Assert.AreEqual("Hello", mulGB.Text, "Text should be 'Hello'");
+
+            // All locales returned
+            var mul = localizedText.FilterByPreferredLocales(new[] { "mul" });
+            Assert.IsTrue(mul.IsMultiLanguage, "Should be mul locale");
+            Assert.AreEqual(3, mul.Translations.Count, "Translations should have 3 entries");
+            Assert.AreEqual("Hello", mul.Translations["en-US"]);
+            Assert.AreEqual("Hallo", mul.Translations["de-DE"]);
+            Assert.AreEqual("Bonjour", mul.Translations["fr-FR"]);
+
+            //matching locale returned
+            var mulFr = localizedText.FilterByPreferredLocales(new[] { "mul", "fr-FR" });
+            Assert.AreEqual("fr-FR", mulFr.Locale, "Locale should be 'fr-FR'");
+            Assert.AreEqual("Bonjour", mulFr.Text, "Text should be 'Bonjour'");
+        }
     }
 }

--- a/Tests/Opc.Ua.Core.Tests/Types/BuiltIn/LocalizedTextTests.cs
+++ b/Tests/Opc.Ua.Core.Tests/Types/BuiltIn/LocalizedTextTests.cs
@@ -144,5 +144,68 @@ namespace Opc.Ua.Core.Tests.Types.BuiltIn
             Assert.AreEqual("fr-FR", mulFr.Locale, "Locale should be 'fr-FR'");
             Assert.AreEqual("Bonjour", mulFr.Text, "Text should be 'Bonjour'");
         }
+
+        [Test]
+        public void LocalizedText_SingleLocale_ReturnsPreferredTranslations()
+        {
+            // Act
+            var localizedText = new LocalizedText("de-DE", "Hallo");
+
+            // Assert
+            Assert.IsFalse(localizedText.IsMultiLanguage, "Should be mul locale");
+
+            //found locale returned
+            var singleDE = localizedText.FilterByPreferredLocales(new[] { "en-US", "de-DE" });
+            Assert.AreEqual("de-DE", singleDE.Locale, "Locale should be 'de-DE'");
+            Assert.AreEqual("Hallo", singleDE.Text, "Text should be 'Hallo'");
+
+            //nonexisting locale, default locale returned
+            var singleUS = localizedText.FilterByPreferredLocales(new[] { "en-GB", "en-US" });
+            Assert.AreEqual("de-DE", singleUS.Locale, "Locale should be 'de-DE'");
+            Assert.AreEqual("Hallo", singleUS.Text, "Text should be 'Hallo'");
+
+            // Default locale returned
+            var mulGB = localizedText.FilterByPreferredLocales(new[] { "mul", "en-GB" });
+            Assert.AreEqual("de-DE", mulGB.Locale, "Locale should be 'de-DE'");
+            Assert.AreEqual("Hallo", mulGB.Text, "Text should be 'Hallo'");
+        }
+
+        [Test]
+        public void LocalizedText_MulLocale_InvalidJson()
+        {
+            // Arrange
+            const string mulLocale = "mul";
+            const string jsonText = "{\"t\":[[\"en-US\"],[\"de-DE\",\"Hallo\", \"fr-FR\"],[]]}";
+
+            // Act
+            var localizedText = new LocalizedText(mulLocale, jsonText);
+
+            // Assert
+            Assert.IsTrue(localizedText.IsMultiLanguage, "Should be mul locale");
+            Assert.AreEqual(jsonText, localizedText.Text);
+            Assert.IsNotNull(localizedText.Translations, "Translations should not be null");
+        }
+
+        [Test]
+        public void LocalizedText_MulLocale_DeepCopy()
+        {
+            // Arrange
+            const string mulLocale = "mul";
+            const string jsonText = "{\"t\":[[\"en-US\",\"Hello\"],[\"de-DE\",\"Hallo\"],[\"fr-FR\",\"Bonjour\"]]}";
+
+            // Act
+            var localizedText = new LocalizedText(mulLocale, jsonText);
+            var deepCopy = new LocalizedText(localizedText);
+
+            //Assert
+            Assert.IsTrue(localizedText.IsMultiLanguage, "Should be mul locale");
+            Assert.IsTrue(deepCopy.IsMultiLanguage, "Should be mul locale");
+            Assert.AreEqual(localizedText.Locale, deepCopy.Locale, "Locale should be the same");
+            Assert.AreEqual(localizedText.Text, deepCopy.Text, "Text should be the same");
+            Assert.AreEqual(localizedText.Translations.Count, deepCopy.Translations.Count, "Translations count should be the same");
+            Assert.AreEqual(localizedText.Translations["en-US"], deepCopy.Translations["en-US"], "English translation should be the same");
+            Assert.AreEqual(localizedText.Translations["de-DE"], deepCopy.Translations["de-DE"], "German translation should be the same");
+            Assert.AreEqual(localizedText.Translations["fr-FR"], deepCopy.Translations["fr-FR"], "French translation should be the same");
+        }
     }
 }

--- a/Tests/Opc.Ua.Core.Tests/Types/BuiltIn/LocalizedTextTests.cs
+++ b/Tests/Opc.Ua.Core.Tests/Types/BuiltIn/LocalizedTextTests.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
+
+namespace Opc.Ua.Core.Tests.Types.BuiltIn
+{
+    /// <summary>
+    /// Tests for the LocalizedText Class.
+    /// </summary>
+    [TestFixture, Category("BuiltIn")]
+    [SetCulture("en-us"), SetUICulture("en-us")]
+    [Parallelizable]
+    public class LocalizedTextTests
+    {
+        [Test]
+        public void MultiLanguageDictionaryCreatesCorretMulLocale()
+        {
+            // Arrange
+            var translations = new Dictionary<string, string>
+            {
+                { "en-US", "Hello" },
+                { "de-DE", "Hallo" }
+            };
+
+            // Act
+            var localizedText = new LocalizedText(translations);
+
+            // Assert
+            Assert.IsTrue(localizedText.IsMultiLanguage, "Should be mul locale");
+            Assert.AreEqual("mul", localizedText.Locale, "Locale should be 'mul'");
+            Assert.IsNotNull(localizedText.Text, "Text should not be null");
+            Assert.AreEqual(2, localizedText.Translations.Count, "Translations should have 2 entries");
+            Assert.AreEqual("Hello", localizedText.Translations["en-US"]);
+            Assert.AreEqual("Hallo", localizedText.Translations["de-DE"]);
+
+            const string expectedJson = "{\"t\":[[\"en-US\",\"Hello\"],[\"de-DE\",\"Hallo\"]]}";
+            Assert.AreEqual(expectedJson, localizedText.Text);
+        }
+
+        [Test]
+        public void EmptyDictionaryCreatesNullText()
+        {
+            // Arrange
+            var translations = new Dictionary<string, string>();
+
+            // Act
+            var localizedText = new LocalizedText(translations);
+
+            // Assert
+            Assert.IsFalse(localizedText.IsMultiLanguage, "Should not be mul locale");
+            Assert.IsNull(localizedText.Translations, "Translations should be null for empty dictionary");
+            Assert.IsNull(localizedText.Text, "Text should be null for empty dictionary");
+            Assert.IsNull(localizedText.Locale, "Locale should be null for empty dictionary");
+        }
+
+        [Test]
+        public void SingleLocaleDictionaryCreatesLocaleAndTextDirectly()
+        {
+            // Arrange
+            var translations = new Dictionary<string, string>
+            {
+                { "fr-FR", "Bonjour" }
+            };
+
+            // Act
+            var localizedText = new LocalizedText(translations);
+
+            // Assert
+            Assert.IsFalse(localizedText.IsMultiLanguage, "Should not be mul locale for single entry");
+            Assert.AreEqual("fr-FR", localizedText.Locale, "Locale should be 'fr-FR'");
+            Assert.AreEqual("Bonjour", localizedText.Text, "Text should be 'Bonjour'");
+            Assert.AreEqual(1, localizedText.Translations.Count, "Translations should have 1 entry");
+            Assert.AreEqual("Bonjour", localizedText.Translations["fr-FR"]);
+        }
+
+        [Test]
+        public void LocalizedText_MulLocale_WithThreeTranslations_ParsesCorrectly()
+        {
+            // Arrange
+            const string mulLocale = "mul";
+            const string jsonText = "{\"t\":[[\"en-US\",\"Hello\"],[\"de-DE\",\"Hallo\"],[\"fr-FR\",\"Bonjour\"]]}";
+
+            // Act
+            var localizedText = new LocalizedText(mulLocale, jsonText);
+
+            // Assert
+            Assert.IsTrue(localizedText.IsMultiLanguage, "Should be mul locale");
+            Assert.AreEqual("mul", localizedText.Locale, "Locale should be 'mul'");
+            Assert.AreEqual(jsonText, localizedText.Text, "Text should match the input JSON exactly");
+            Assert.IsNotNull(localizedText.Translations, "Translations should not be null");
+            Assert.AreEqual(3, localizedText.Translations.Count, "Translations should have 3 entries");
+            Assert.AreEqual("Hello", localizedText.Translations["en-US"]);
+            Assert.AreEqual("Hallo", localizedText.Translations["de-DE"]);
+            Assert.AreEqual("Bonjour", localizedText.Translations["fr-FR"]);
+        }
+    }
+}

--- a/Tests/Opc.Ua.Server.Tests/ResourceManagerTests.cs
+++ b/Tests/Opc.Ua.Server.Tests/ResourceManagerTests.cs
@@ -31,6 +31,34 @@ namespace Opc.Ua.Server.Tests
             // Assert
             Assert.AreEqual(defaultText, resultText);
         }
+        [Test]
+        public void TranslateSingleLanguageWithInfoExactMatch()
+        {
+            // Arrange
+            var resourceManager = new ResourceManager(new Mock<IServerInternal>().Object, new Mock<ApplicationConfiguration>().Object);
+            var defaultText = new LocalizedText("greeting", "en-US", "Hello");
+
+            //Act
+            var resultText = resourceManager.Translate(new List<string> { "en-US", "de-DE" }, defaultText);
+
+            // Assert
+            Assert.AreEqual(defaultText, resultText);
+        }
+
+        [Test]
+        public void TranslateSingleLanguageWithArguments()
+        {
+            // Arrange
+            var resourceManager = new ResourceManager(new Mock<IServerInternal>().Object, new Mock<ApplicationConfiguration>().Object);
+            resourceManager.Add("greeting", "en-US", "Hello {0}");
+
+            //Act
+            var resultText = resourceManager.Translate(new List<string> { "en-US", "de-DE" }, "greeting", "Hello {0}", "User");
+
+            // Assert
+            Assert.AreEqual("Hello User", resultText.Text);
+            Assert.AreEqual("en-US", resultText.Locale);
+        }
 
         [Test]
         public void TranslateMultiLanguageExactMatchMulRequested()
@@ -42,7 +70,7 @@ namespace Opc.Ua.Server.Tests
                 { "en-US", "Hello" },
                 { "de-DE", "Hallo" }
             };
-            var defaultText = new LocalizedText(translations);
+            var defaultText = new LocalizedText("greeting", translations);
 
             //Act
             var resultText = resourceManager.Translate(new List<string> { "mul", "de-DE", "en-US" }, defaultText);
@@ -62,7 +90,7 @@ namespace Opc.Ua.Server.Tests
                 { "de-DE", "Hallo" },
                 { "fr-FR", "Bonjour" }
             };
-            var defaultText = new LocalizedText(translations);
+            var defaultText = new LocalizedText("greeting", translations);
 
             //Act
             var resultText = resourceManager.Translate(new List<string> { "mul", "de-DE", "en-US" }, defaultText);
@@ -81,6 +109,20 @@ namespace Opc.Ua.Server.Tests
 
             //Act
             var resultText = resourceManager.Translate(new List<string> { "mul", "de-DE", "en-US" }, defaultText);
+
+            // Assert
+            Assert.AreEqual(defaultText, resultText);
+        }
+
+        [Test]
+        public void TranslateNoLocalesRequestedDefaultTextReturned()
+        {
+            // Arrange
+            var resourceManager = new ResourceManager(new Mock<IServerInternal>().Object, new Mock<ApplicationConfiguration>().Object);
+            var defaultText = new LocalizedText("greeting", "en-US", "Hello");
+
+            //Act
+            var resultText = resourceManager.Translate(null, defaultText);
 
             // Assert
             Assert.AreEqual(defaultText, resultText);
@@ -132,6 +174,22 @@ namespace Opc.Ua.Server.Tests
 
             // Assert
             Assert.AreEqual("{\"t\":[[\"de-DE\",\"Hallo\"],[\"en-US\",\"Hello\"]]}", resultText.Text);
+            Assert.AreEqual("mul", resultText.Locale);
+        }
+
+        [Test]
+        public void TranslateKeyMulRequestedTranslationWithParameters()
+        {
+            // Arrange
+            var resourceManager = new ResourceManager(new Mock<IServerInternal>().Object, new Mock<ApplicationConfiguration>().Object);
+            resourceManager.Add("greeting", "de-DE", "Hallo {0}");
+            resourceManager.Add("greeting", "en-US", "Hello {0}");
+
+            //Act
+            var resultText = resourceManager.Translate(new List<string> { "mul" }, "greeting", null, "User");
+
+            // Assert
+            Assert.AreEqual("{\"t\":[[\"de-DE\",\"Hallo User\"],[\"en-US\",\"Hello User\"]]}", resultText.Text);
             Assert.AreEqual("mul", resultText.Locale);
         }
     }

--- a/Tests/Opc.Ua.Server.Tests/ResourceManagerTests.cs
+++ b/Tests/Opc.Ua.Server.Tests/ResourceManagerTests.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using Moq;
+using NUnit.Framework;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
+
+namespace Opc.Ua.Server.Tests
+{// <summary>
+    /// Test ResourceManager
+    /// </summary>
+    [TestFixture, Category("ResourceManager")]
+    [Parallelizable]
+    [SetCulture("en-us"), SetUICulture("en-us")]
+    public class ResourceManagerTests
+    {
+
+        [Test]
+        public void TranslateSingleLanguageExactMatch()
+        {
+            // Arrange
+            var resourceManager = new ResourceManager(new Mock<IServerInternal>().Object, new Mock<ApplicationConfiguration>().Object);
+            var defaultText = new LocalizedText("en-US", "Hello");
+
+            //Act
+            var resultText = resourceManager.Translate(new List<string> { "en-US", "de-DE" }, defaultText);
+
+            // Assert
+            Assert.AreEqual(defaultText, resultText);
+        }
+
+        [Test]
+        public void TranslateMultiLanguageExactMatchMulRequested()
+        {
+            // Arrange
+            var resourceManager = new ResourceManager(new Mock<IServerInternal>().Object, new Mock<ApplicationConfiguration>().Object);
+            var translations = new Dictionary<string, string>
+           {
+                { "en-US", "Hello" },
+                { "de-DE", "Hallo" }
+            };
+            var defaultText = new LocalizedText(translations);
+
+            //Act
+            var resultText = resourceManager.Translate(new List<string> { "mul", "de-DE", "en-US" }, defaultText);
+
+            // Assert
+            Assert.AreEqual(defaultText, resultText);
+        }
+
+        [Test]
+        public void TranslateMultiLanguageMulRequested()
+        {
+            // Arrange
+            var resourceManager = new ResourceManager(new Mock<IServerInternal>().Object, new Mock<ApplicationConfiguration>().Object);
+            var translations = new Dictionary<string, string>
+           {
+                { "en-US", "Hello" },
+                { "de-DE", "Hallo" },
+                { "fr-FR", "Bonjour" }
+            };
+            var defaultText = new LocalizedText(translations);
+
+            //Act
+            var resultText = resourceManager.Translate(new List<string> { "mul", "de-DE", "en-US" }, defaultText);
+
+            // Assert
+            Assert.AreEqual("{\"t\":[[\"en-US\",\"Hello\"],[\"de-DE\",\"Hallo\"]]}", resultText.Text);
+            Assert.AreEqual("mul", resultText.Locale);
+        }
+
+        [Test]
+        public void TranslateSingleLanguageMulRequested()
+        {
+            // Arrange
+            var resourceManager = new ResourceManager(new Mock<IServerInternal>().Object, new Mock<ApplicationConfiguration>().Object);
+            var defaultText = new LocalizedText("greeting", "en-US", "Hello");
+
+            //Act
+            var resultText = resourceManager.Translate(new List<string> { "mul", "de-DE", "en-US" }, defaultText);
+
+            // Assert
+            Assert.AreEqual(defaultText, resultText);
+        }
+
+        [Test]
+        public void TranslateSingleLanguageMulRequestedWithTranslation()
+        {
+            // Arrange
+            var resourceManager = new ResourceManager(new Mock<IServerInternal>().Object, new Mock<ApplicationConfiguration>().Object);
+            var defaultText = new LocalizedText("greeting", "en-US", "Hello");
+            resourceManager.Add("greeting", "de-DE", "Hallo");
+            resourceManager.Add("greeting", "fr-FR", "Bonjour");
+
+            //Act
+            var resultText = resourceManager.Translate(new List<string> { "mul", "de-DE", "en-US" }, defaultText);
+
+            // Assert
+            Assert.AreEqual("{\"t\":[[\"en-US\",\"Hello\"],[\"de-DE\",\"Hallo\"]]}", resultText.Text);
+            Assert.AreEqual("mul", resultText.Locale);
+        }
+
+        [Test]
+        public void TranslateKeyMulRequestedWithTranslation()
+        {
+            // Arrange
+            var resourceManager = new ResourceManager(new Mock<IServerInternal>().Object, new Mock<ApplicationConfiguration>().Object);
+            resourceManager.Add("greeting", "de-DE", "Hallo");
+            resourceManager.Add("greeting", "en-US", "Hello");
+
+            //Act
+            var resultText = resourceManager.Translate(new List<string> { "mul", "de-DE", "en-US" }, "greeting", null);
+
+            // Assert
+            Assert.AreEqual("{\"t\":[[\"de-DE\",\"Hallo\"],[\"en-US\",\"Hello\"]]}", resultText.Text);
+            Assert.AreEqual("mul", resultText.Locale);
+        }
+
+        [Test]
+        public void TranslateKeyMulRequestedAllLanguagesWithTranslation()
+        {
+            // Arrange
+            var resourceManager = new ResourceManager(new Mock<IServerInternal>().Object, new Mock<ApplicationConfiguration>().Object);
+            resourceManager.Add("greeting", "de-DE", "Hallo");
+            resourceManager.Add("greeting", "en-US", "Hello");
+
+            //Act
+            var resultText = resourceManager.Translate(new List<string> { "mul" }, "greeting", null);
+
+            // Assert
+            Assert.AreEqual("{\"t\":[[\"de-DE\",\"Hallo\"],[\"en-US\",\"Hello\"]]}", resultText.Text);
+            Assert.AreEqual("mul", resultText.Locale);
+        }
+    }
+}


### PR DESCRIPTION
## Proposed changes

The OPC UA Spec Part 3 (https://reference.opcfoundation.org/Core/Part3/v105/docs/8.5) describes the Support for a special 'mul' locale. This PR adds support for this 'mul' locale.

If the LocalizedText class is now initialized with a 'mul' local the new Property  `IsMulitiLanguage` is set to true and the new Property `Translations` contains a Dictionary of strings with the different locales / texts extracted from the JSON in the `Text` Property.

Also a new Constructor was added which takes a dictionary of strings to initalize a new 'mul' locale text. This constructor automatically creates the needed json.
The `Translations` Property can also be set and a 'mul' locale with sufficient text is created.

Also the translation manager is adapted to return only requested locales if a 'mul' locale string is provided and also support 'mul' locae requests by the client, as described in https://reference.opcfoundation.org/Core/Part4/v105/docs/5.4.


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [x] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

