### PR TITLE
[Server] Extend IMonitoredItem Interface and ensure it is used throughout the stack

### DIFF
--- a/Applications/Quickstarts.Servers/Alarms/AlarmNodeManager.cs
+++ b/Applications/Quickstarts.Servers/Alarms/AlarmNodeManager.cs
@@ -836,8 +836,7 @@ namespace Alarms
 
             for (int ii = 0; ii < monitoredItems.Count; ii++)
             {
-                // the IEventMonitoredItem should always be MonitoredItems since they are created by the MasterNodeManager.
-                MonitoredItem monitoredItem = monitoredItems[ii] as MonitoredItem;
+                IEventMonitoredItem monitoredItem = monitoredItems[ii];
 
                 if (monitoredItem == null)
                 {

--- a/Applications/Quickstarts.Servers/SampleNodeManager/DataChangeMonitoredItem.cs
+++ b/Applications/Quickstarts.Servers/SampleNodeManager/DataChangeMonitoredItem.cs
@@ -71,6 +71,7 @@ namespace Opc.Ua.Sample
             m_readyToTrigger = false;
             m_resendData = false;
             m_alwaysReportUpdates = alwaysReportUpdates;
+            m_nodeId = source.Node.NodeId;
         }
 
         /// <summary>
@@ -114,6 +115,7 @@ namespace Opc.Ua.Sample
             m_filter = filter;
             m_range = 0;
             m_alwaysReportUpdates = alwaysReportUpdates;
+            m_nodeId = source.Node.NodeId;
 
             if (range != null)
             {
@@ -159,6 +161,7 @@ namespace Opc.Ua.Sample
             m_alwaysReportUpdates = storedMonitoredItem.AlwaysReportUpdates;
             m_lastValue = storedMonitoredItem.LastValue;
             m_lastError = storedMonitoredItem.LastError;
+            m_nodeId = storedMonitoredItem.NodeId;
 
             if (storedMonitoredItem.QueueSize > 1)
             {
@@ -761,6 +764,8 @@ namespace Opc.Ua.Sample
 
         public bool IsDurable => false;
 
+        public NodeId NodeId => m_nodeId;
+
         /// <summary>
         /// Increments the sample time to the next interval.
         /// </summary>
@@ -963,6 +968,7 @@ namespace Opc.Ua.Sample
         private bool m_semanticsChanged;
         private bool m_structureChanged;
         private bool m_resendData;
+        private NodeId m_nodeId;
         #endregion
     }
 }

--- a/Applications/Quickstarts.Servers/TestData/TestDataNodeManager.cs
+++ b/Applications/Quickstarts.Servers/TestData/TestDataNodeManager.cs
@@ -661,7 +661,7 @@ namespace TestData
         protected override void OnMonitoredItemCreated(
             ServerSystemContext context,
             NodeHandle handle,
-            MonitoredItem monitoredItem)
+            ISampledDataChangeMonitoredItem monitoredItem)
         {
             if (SystemScanRequired(handle.MonitoredNode, monitoredItem))
             {
@@ -684,7 +684,7 @@ namespace TestData
         protected override void OnMonitoredItemModified(
             ServerSystemContext context,
             NodeHandle handle,
-            MonitoredItem monitoredItem)
+            ISampledDataChangeMonitoredItem monitoredItem)
         {
             if (SystemScanRequired(handle.MonitoredNode, monitoredItem))
             {
@@ -706,7 +706,7 @@ namespace TestData
         protected override void OnMonitoredItemDeleted(
             ServerSystemContext context,
             NodeHandle handle,
-            MonitoredItem monitoredItem)
+            ISampledDataChangeMonitoredItem monitoredItem)
         {
             // check for variables that need to be scanned.
             if (SystemScanRequired(handle.MonitoredNode, monitoredItem))
@@ -726,7 +726,7 @@ namespace TestData
         protected override void OnMonitoringModeChanged(
             ServerSystemContext context,
             NodeHandle handle,
-            MonitoredItem monitoredItem,
+            ISampledDataChangeMonitoredItem monitoredItem,
             MonitoringMode previousMode,
             MonitoringMode monitoringMode)
         {

--- a/Libraries/Opc.Ua.Server/Diagnostics/CustomNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/Diagnostics/CustomNodeManager.cs
@@ -3334,7 +3334,7 @@ namespace Opc.Ua.Server
             for (int ii = 0; ii < monitoredItems.Count; ii++)
             {
                 // the IEventMonitoredItem should always be MonitoredItems since they are created by the MasterNodeManager.
-                MonitoredItem monitoredItem = monitoredItems[ii] as MonitoredItem;
+                IEventMonitoredItem monitoredItem = monitoredItems[ii];
 
                 if (monitoredItem == null)
                 {
@@ -3518,7 +3518,7 @@ namespace Opc.Ua.Server
             storedMonitoredItem.QueueSize = SubscriptionManager.CalculateRevisedQueueSize(storedMonitoredItem.IsDurable, storedMonitoredItem.QueueSize, m_maxQueueSize, m_maxDurableQueueSize);
 
             // create the item.
-            MonitoredItem datachangeItem = new MonitoredItem(
+            ISampledDataChangeMonitoredItem datachangeItem = new MonitoredItem(
                 Server,
                 this,
                 handle,
@@ -3752,7 +3752,7 @@ namespace Opc.Ua.Server
             }
 
             // create the item.
-            MonitoredItem datachangeItem = new MonitoredItem(
+            ISampledDataChangeMonitoredItem datachangeItem = new MonitoredItem(
                 Server,
                 this,
                 handle,
@@ -3837,7 +3837,7 @@ namespace Opc.Ua.Server
         protected virtual void OnMonitoredItemCreated(
             ServerSystemContext context,
             NodeHandle handle,
-            MonitoredItem monitoredItem)
+            ISampledDataChangeMonitoredItem monitoredItem)
         {
             // overridden by the sub-class.
         }
@@ -4177,7 +4177,7 @@ namespace Opc.Ua.Server
             filterResult = null;
 
             // check for valid monitored item.
-            MonitoredItem datachangeItem = monitoredItem as MonitoredItem;
+            ISampledDataChangeMonitoredItem datachangeItem = monitoredItem as ISampledDataChangeMonitoredItem;
 
             // validate parameters.
             MonitoringParameters parameters = itemToModify.RequestedParameters;
@@ -4262,7 +4262,7 @@ namespace Opc.Ua.Server
         protected virtual void OnMonitoredItemModified(
             ServerSystemContext context,
             NodeHandle handle,
-            MonitoredItem monitoredItem)
+            ISampledDataChangeMonitoredItem monitoredItem)
         {
             // overridden by the sub-class.
         }
@@ -4352,7 +4352,7 @@ namespace Opc.Ua.Server
             NodeHandle handle)
         {
             // check for valid monitored item.
-            MonitoredItem datachangeItem = monitoredItem as MonitoredItem;
+            ISampledDataChangeMonitoredItem datachangeItem = monitoredItem as ISampledDataChangeMonitoredItem;
 
             // check if the node is already being monitored.
             MonitoredNode2 monitoredNode = null;
@@ -4383,7 +4383,7 @@ namespace Opc.Ua.Server
         protected virtual void OnMonitoredItemDeleted(
             ServerSystemContext context,
             NodeHandle handle,
-            MonitoredItem monitoredItem)
+            ISampledDataChangeMonitoredItem monitoredItem)
         {
             // overridden by the sub-class.
         }
@@ -4545,7 +4545,7 @@ namespace Opc.Ua.Server
             NodeHandle handle)
         {
             // check for valid monitored item.
-            MonitoredItem datachangeItem = monitoredItem as MonitoredItem;
+            ISampledDataChangeMonitoredItem datachangeItem = monitoredItem as ISampledDataChangeMonitoredItem;
 
             // update monitoring mode.
             MonitoringMode previousMode = datachangeItem.SetMonitoringMode(monitoringMode);
@@ -4581,7 +4581,7 @@ namespace Opc.Ua.Server
         protected virtual void OnMonitoringModeChanged(
             ServerSystemContext context,
             NodeHandle handle,
-            MonitoredItem monitoredItem,
+            ISampledDataChangeMonitoredItem monitoredItem,
             MonitoringMode previousMode,
             MonitoringMode monitoringMode)
         {

--- a/Libraries/Opc.Ua.Server/Diagnostics/DiagnosticsNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/Diagnostics/DiagnosticsNodeManager.cs
@@ -64,7 +64,7 @@ namespace Opc.Ua.Server
             m_subscriptions = new List<SubscriptionDiagnosticsData>();
             m_diagnosticsEnabled = true;
             m_doScanBusy = false;
-            m_sampledItems = new List<MonitoredItem>();
+            m_sampledItems = new List<ISampledDataChangeMonitoredItem>();
             m_minimumSamplingInterval = 100;
             m_durableSubscriptionsEnabled = configuration.ServerConfiguration?.DurableSubscriptionsEnabled ?? false;
         }
@@ -1716,7 +1716,7 @@ namespace Opc.Ua.Server
         protected override void OnMonitoredItemCreated(
             ServerSystemContext context,
             NodeHandle handle,
-            MonitoredItem monitoredItem)
+            ISampledDataChangeMonitoredItem monitoredItem)
         {
             // check if the variable needs to be sampled.
             if (monitoredItem.AttributeId == Attributes.Value)
@@ -1757,7 +1757,7 @@ namespace Opc.Ua.Server
         protected override void OnMonitoredItemDeleted(
             ServerSystemContext context,
             NodeHandle handle,
-            MonitoredItem monitoredItem)
+            ISampledDataChangeMonitoredItem monitoredItem)
         {
             // check if diagnostics collection needs to be turned off.
             if (IsDiagnosticsNode(handle.Node))
@@ -1802,7 +1802,7 @@ namespace Opc.Ua.Server
         protected override void OnMonitoringModeChanged(
             ServerSystemContext context,
             NodeHandle handle,
-            MonitoredItem monitoredItem,
+            ISampledDataChangeMonitoredItem monitoredItem,
             MonitoringMode previousMode,
             MonitoringMode monitoringMode)
         {
@@ -2027,7 +2027,7 @@ namespace Opc.Ua.Server
         /// <summary>
         /// Creates a new sampled item.
         /// </summary>
-        private void CreateSampledItem(double samplingInterval, MonitoredItem monitoredItem)
+        private void CreateSampledItem(double samplingInterval, ISampledDataChangeMonitoredItem monitoredItem)
         {
             m_sampledItems.Add(monitoredItem);
 
@@ -2040,7 +2040,7 @@ namespace Opc.Ua.Server
         /// <summary>
         /// Deletes a sampled item.
         /// </summary>
-        private void DeleteSampledItem(MonitoredItem monitoredItem)
+        private void DeleteSampledItem(ISampledDataChangeMonitoredItem monitoredItem)
         {
             for (int ii = 0; ii < m_sampledItems.Count; ii++)
             {
@@ -2072,7 +2072,7 @@ namespace Opc.Ua.Server
                 {
                     for (int ii = 0; ii < m_sampledItems.Count; ii++)
                     {
-                        MonitoredItem monitoredItem = m_sampledItems[ii];
+                        ISampledDataChangeMonitoredItem monitoredItem = m_sampledItems[ii];
 
                         // get the handle.
                         NodeHandle handle = monitoredItem.ManagerHandle as NodeHandle;
@@ -2132,7 +2132,7 @@ namespace Opc.Ua.Server
         private List<SubscriptionDiagnosticsData> m_subscriptions;
         private NodeId m_serverLockHolder;
         private Timer m_samplingTimer;
-        private List<MonitoredItem> m_sampledItems;
+        private List<ISampledDataChangeMonitoredItem> m_sampledItems;
         private double m_minimumSamplingInterval;
         private HistoryServerCapabilitiesState m_historyCapabilities;
         #endregion

--- a/Libraries/Opc.Ua.Server/Diagnostics/MonitoredNode.cs
+++ b/Libraries/Opc.Ua.Server/Diagnostics/MonitoredNode.cs
@@ -78,7 +78,7 @@ namespace Opc.Ua.Server
         /// <summary>
         /// Gets the current list of data change MonitoredItems.
         /// </summary>
-        public List<MonitoredItem> DataChangeMonitoredItems
+        public List<IDataChangeMonitoredItem2> DataChangeMonitoredItems
         {
             get { return m_dataChangeMonitoredItems; }
             private set { m_dataChangeMonitoredItems = value; }
@@ -121,11 +121,11 @@ namespace Opc.Ua.Server
         /// Adds the specified data change monitored item.
         /// </summary>
         /// <param name="datachangeItem">The monitored item.</param>
-        public void Add(MonitoredItem datachangeItem)
+        public void Add(IDataChangeMonitoredItem2 datachangeItem)
         {
             if (DataChangeMonitoredItems == null)
             {
-                DataChangeMonitoredItems = new List<MonitoredItem>();
+                DataChangeMonitoredItems = new List<IDataChangeMonitoredItem2>();
                 Node.OnStateChanged = OnMonitoredNodeChanged;
             }
 
@@ -136,7 +136,7 @@ namespace Opc.Ua.Server
         /// Removes the specified data change monitored item.
         /// </summary>
         /// <param name="datachangeItem">The monitored item.</param>
-        public void Remove(MonitoredItem datachangeItem)
+        public void Remove(IDataChangeMonitoredItem2 datachangeItem)
         {
             for (int ii = 0; ii < DataChangeMonitoredItems.Count; ii++)
             {
@@ -295,7 +295,7 @@ namespace Opc.Ua.Server
 
                 for (int ii = 0; ii < DataChangeMonitoredItems.Count; ii++)
                 {
-                    MonitoredItem monitoredItem = DataChangeMonitoredItems[ii];
+                    IDataChangeMonitoredItem2 monitoredItem = DataChangeMonitoredItems[ii];
 
                     if (monitoredItem.AttributeId == Attributes.Value && (changes & NodeStateChangeMasks.Value) != 0)
                     {
@@ -327,7 +327,7 @@ namespace Opc.Ua.Server
         public void QueueValue(
             ISystemContext context,
             NodeState node,
-            MonitoredItem monitoredItem)
+            IDataChangeMonitoredItem2 monitoredItem)
         {
             DataValue value = new DataValue();
 
@@ -366,7 +366,7 @@ namespace Opc.Ua.Server
         /// <param name="monitoredItem">The monitored item.</param>
         /// <param name="context">The system context.</param>
         /// <returns>The cached or newly created context.</returns>
-        private ServerSystemContext GetOrCreateContext(ServerSystemContext context, MonitoredItem monitoredItem)
+        private ServerSystemContext GetOrCreateContext(ServerSystemContext context, IDataChangeMonitoredItem2 monitoredItem)
         {
             uint monitoredItemId = monitoredItem.Id;
             int currentTicks = HiResClock.TickCount;
@@ -402,7 +402,7 @@ namespace Opc.Ua.Server
         #region Private Fields
         private CustomNodeManager2 m_nodeManager;
         private NodeState m_node;
-        private List<MonitoredItem> m_dataChangeMonitoredItems;
+        private List<IDataChangeMonitoredItem2> m_dataChangeMonitoredItems;
         private List<IEventMonitoredItem> m_eventMonitoredItems;
         private readonly ConcurrentDictionary<uint, (ServerSystemContext Context, int CreatedAtTicks)> m_contextCache = new();
         private readonly int m_cacheLifetimeTicks = (int)TimeSpan.FromMinutes(5).TotalMilliseconds;

--- a/Libraries/Opc.Ua.Server/NodeManager/CoreNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/NodeManager/CoreNodeManager.cs
@@ -60,7 +60,7 @@ namespace Opc.Ua.Server
                   
             m_server                         = server;
             m_nodes                          = new NodeTable(server.NamespaceUris, server.ServerUris, server.TypeTree);
-            m_monitoredItems                 = new Dictionary<uint,MonitoredItem>();
+            m_monitoredItems                 = new Dictionary<uint, ISampledDataChangeMonitoredItem>();
             m_defaultMinimumSamplingInterval = 1000;
             m_namespaceUris                  = new List<string>();
             m_dynamicNamespaceIndex = dynamicNamespaceIndex;
@@ -1247,7 +1247,7 @@ namespace Opc.Ua.Server
                     }
                     
                     // create monitored item.
-                    MonitoredItem monitoredItem = m_samplingGroupManager.CreateMonitoredItem(
+                    ISampledDataChangeMonitoredItem monitoredItem = m_samplingGroupManager.CreateMonitoredItem(
                         context,
                         subscriptionId,
                         publishingInterval,
@@ -1327,7 +1327,7 @@ namespace Opc.Ua.Server
                     item.IsRestored = true;
 
                     // create monitored item.
-                    MonitoredItem monitoredItem = m_samplingGroupManager.RestoreMonitoredItem(
+                    ISampledDataChangeMonitoredItem monitoredItem = m_samplingGroupManager.RestoreMonitoredItem(
                         node,
                         item,
                         savedOwnerIdentity
@@ -1412,9 +1412,9 @@ namespace Opc.Ua.Server
                                         
                     // owned by this node manager.
                     itemToModify.Processed = true;
-                    
+
                     // validate monitored item.
-                    MonitoredItem monitoredItem = null;
+                    ISampledDataChangeMonitoredItem monitoredItem = null;
 
                     if (!m_monitoredItems.TryGetValue(monitoredItems[ii].Id, out monitoredItem))
                     {
@@ -1523,9 +1523,9 @@ namespace Opc.Ua.Server
 
                     // owned by this node manager.
                     processedItems[ii]  = true;
-                    
+
                     // validate monitored item.
-                    MonitoredItem monitoredItem = null;
+                    ISampledDataChangeMonitoredItem monitoredItem = null;
 
                     if (!m_monitoredItems.TryGetValue(monitoredItems[ii].Id, out monitoredItem))
                     {
@@ -1645,9 +1645,9 @@ namespace Opc.Ua.Server
 
                     // owned by this node manager.
                     processedItems[ii]  = true;
-                    
+
                     // validate monitored item.
-                    MonitoredItem monitoredItem = null;
+                    ISampledDataChangeMonitoredItem monitoredItem = null;
 
                     if (!m_monitoredItems.TryGetValue(monitoredItems[ii].Id, out monitoredItem))
                     {
@@ -3327,7 +3327,7 @@ namespace Opc.Ua.Server
         private NodeTable m_nodes;
         private long m_lastId;
         private SamplingGroupManager m_samplingGroupManager;
-        private Dictionary<uint, MonitoredItem> m_monitoredItems;
+        private Dictionary<uint, ISampledDataChangeMonitoredItem> m_monitoredItems;
         private double m_defaultMinimumSamplingInterval;
         private List<string> m_namespaceUris;
         private ushort m_dynamicNamespaceIndex;

--- a/Libraries/Opc.Ua.Server/NodeManager/EventManager.cs
+++ b/Libraries/Opc.Ua.Server/NodeManager/EventManager.cs
@@ -104,34 +104,7 @@ namespace Opc.Ua.Server
         /// <summary>
         /// Creates a set of monitored items.
         /// </summary>
-        [Obsolete("Replaced by variant that includes the publishingInterval")]
-        public MonitoredItem CreateMonitoredItem(
-            OperationContext context,
-            INodeManager nodeManager,
-            object handle,
-            uint subscriptionId,
-            uint monitoredItemId,
-            TimestampsToReturn timestampsToReturn,
-            MonitoredItemCreateRequest itemToCreate,
-            EventFilter filter)
-        {
-            return CreateMonitoredItem(
-                context,
-                nodeManager,
-                handle,
-                subscriptionId,
-                monitoredItemId,
-                timestampsToReturn,
-                0,
-                itemToCreate,
-                filter,
-                false);
-        }
-
-        /// <summary>
-        /// Creates a set of monitored items.
-        /// </summary>
-        public MonitoredItem CreateMonitoredItem(
+        public IEventMonitoredItem CreateMonitoredItem(
             OperationContext context,
             INodeManager nodeManager,
             object handle,
@@ -157,7 +130,7 @@ namespace Opc.Ua.Server
                 uint revisedQueueSize = CalculateRevisedQueueSize(createDurable, itemToCreate.RequestedParameters.QueueSize);
 
                 // create the monitored item.
-                MonitoredItem monitoredItem = new MonitoredItem(
+                IEventMonitoredItem monitoredItem = new MonitoredItem(
                     m_server,
                     nodeManager,
                     handle,
@@ -186,7 +159,7 @@ namespace Opc.Ua.Server
         /// <summary>
         /// Restore a MonitoredItem after a restart
         /// </summary>
-        public MonitoredItem RestoreMonitoredItem(
+        public IEventMonitoredItem RestoreMonitoredItem(
             INodeManager nodeManager,
             object handle,
             IStoredMonitoredItem storedMonitoredItem)
@@ -197,7 +170,7 @@ namespace Opc.Ua.Server
                 storedMonitoredItem.QueueSize = CalculateRevisedQueueSize(storedMonitoredItem.IsDurable, storedMonitoredItem.QueueSize);
 
                 // create the monitored item.
-                MonitoredItem monitoredItem = new MonitoredItem(
+                IEventMonitoredItem monitoredItem = new MonitoredItem(
                     m_server,
                     nodeManager,
                     handle,

--- a/Libraries/Opc.Ua.Server/NodeManager/MasterNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/NodeManager/MasterNodeManager.cs
@@ -2357,7 +2357,7 @@ namespace Opc.Ua.Server
                     // create a globally unique identifier.
                     uint monitoredItemId = Utils.IncrementIdentifier(ref globalIdCounter);
 
-                    MonitoredItem monitoredItem = m_server.EventManager.CreateMonitoredItem(
+                    IEventMonitoredItem monitoredItem = m_server.EventManager.CreateMonitoredItem(
                         context,
                         nodeManager,
                         handle,
@@ -2471,7 +2471,7 @@ namespace Opc.Ua.Server
                         continue;
                     }
 
-                    MonitoredItem monitoredItem = m_server.EventManager.RestoreMonitoredItem(
+                    IEventMonitoredItem monitoredItem = m_server.EventManager.RestoreMonitoredItem(
                         nodeManager,
                         handle,
                         item);

--- a/Libraries/Opc.Ua.Server/NodeManager/ResourceManager.cs
+++ b/Libraries/Opc.Ua.Server/NodeManager/ResourceManager.cs
@@ -167,24 +167,6 @@ namespace Opc.Ua.Server
         }
 
         /// <summary>
-        /// Returns the locales supported by the resource manager.
-        /// </summary>
-        [Obsolete("preferredLocales argument is ignored.")]
-        public string[] GetAvailableLocales(IEnumerable<string> preferredLocales)
-        {
-            return GetAvailableLocales();
-        }
-
-        /// <summary>
-        /// Returns the localized form of the text that best matches the preferred locales.
-        /// </summary>
-        [Obsolete("Replaced by the overrideable ITranslationManager methods.")]
-        public LocalizedText GetText(IList<string> preferredLocales, string textId, string defaultText, params object[] args)
-        {
-            return Translate(preferredLocales, textId, defaultText, args);
-        }
-
-        /// <summary>
         /// Adds a translation to the resource manager.
         /// </summary>
         public void Add(string key, string locale, string text)
@@ -302,15 +284,6 @@ namespace Opc.Ua.Server
         #endregion
 
         #region Protected Methods
-        /// <summary>
-        /// Returns the text for the specified locale (null if the locale is not supported).
-        /// </summary>
-        [Obsolete("Replaced by the overrideable methods on Translate(IList<string>, LocalizedText, TranslationInfo)")]
-        protected virtual string GetTextForLocale(string locale, string textId, string defaultText, params object[] args)
-        {
-            return null;
-        }
-
         /// <summary>
         /// Translates the text provided.
         /// </summary>

--- a/Libraries/Opc.Ua.Server/NodeManager/SamplingGroupManager.cs
+++ b/Libraries/Opc.Ua.Server/NodeManager/SamplingGroupManager.cs
@@ -111,7 +111,7 @@ namespace Opc.Ua.Server
                     Utils.SilentDispose(samplingGroup);
                 }
 
-                foreach (MonitoredItem monitoredItem in monitoredItems)
+                foreach (ISampledDataChangeMonitoredItem monitoredItem in monitoredItems)
                 {
                     Utils.SilentDispose(monitoredItem);
                 }
@@ -141,7 +141,7 @@ namespace Opc.Ua.Server
         /// <summary>
         /// Creates a new monitored item and calls StartMonitoring().
         /// </summary>
-        public virtual MonitoredItem CreateMonitoredItem(
+        public virtual ISampledDataChangeMonitoredItem CreateMonitoredItem(
             OperationContext           context,
             uint                       subscriptionId,
             double                     publishingInterval,
@@ -196,7 +196,7 @@ namespace Opc.Ua.Server
             }
 
             // create monitored item.
-            MonitoredItem monitoredItem = CreateMonitoredItem(
+            ISampledDataChangeMonitoredItem monitoredItem = CreateMonitoredItem(
                 m_server,
                 m_nodeManager,
                 managerHandle,
@@ -247,7 +247,7 @@ namespace Opc.Ua.Server
         /// <param name="minimumSamplingInterval">The minimum sampling interval.</param>
         /// <param name="createDurable">True if a durable monitored item should be created.</param>
         /// <returns>The monitored item.</returns>
-        protected virtual MonitoredItem CreateMonitoredItem(
+        protected virtual ISampledDataChangeMonitoredItem CreateMonitoredItem(
             IServerInternal     server,
             INodeManager        nodeManager,
             object              managerHandle,
@@ -292,13 +292,13 @@ namespace Opc.Ua.Server
         /// <summary>
         /// Restores a monitored item after a server restart and calls StartMonitoring().
         /// </summary>
-        public virtual MonitoredItem RestoreMonitoredItem(
+        public virtual ISampledDataChangeMonitoredItem RestoreMonitoredItem(
             object managerHandle,
             IStoredMonitoredItem storedMonitoredItem,
             IUserIdentity savedOwnerIdentity)
         {
             // create monitored item.
-            MonitoredItem monitoredItem = new MonitoredItem(m_server, m_nodeManager, managerHandle, storedMonitoredItem);
+            ISampledDataChangeMonitoredItem monitoredItem = new MonitoredItem(m_server, m_nodeManager, managerHandle, storedMonitoredItem);
 
             // start sampling.
             StartMonitoring(new OperationContext(monitoredItem), monitoredItem, savedOwnerIdentity);

--- a/Libraries/Opc.Ua.Server/Session/SessionManager.cs
+++ b/Libraries/Opc.Ua.Server/Session/SessionManager.cs
@@ -258,42 +258,6 @@ namespace Opc.Ua.Server
         }
 
         /// <summary>
-        /// Creates a new session.
-        /// </summary>
-        [Obsolete("Use CreateSession that passes X509Certificate2Collection)")]
-        public virtual Session CreateSession(
-            OperationContext context,
-            X509Certificate2 serverCertificate,
-            string sessionName,
-            byte[] clientNonce,
-            ApplicationDescription clientDescription,
-            string endpointUrl,
-            X509Certificate2 clientCertificate,
-            double requestedSessionTimeout,
-            uint maxResponseMessageSize,
-            out NodeId sessionId,
-            out NodeId authenticationToken,
-            out byte[] serverNonce,
-            out double revisedSessionTimeout)
-        {
-            return CreateSession(
-              context,
-              serverCertificate,
-              sessionName,
-              clientNonce,
-              clientDescription,
-              endpointUrl,
-              clientCertificate,
-              null,
-              requestedSessionTimeout,
-              maxResponseMessageSize,
-              out sessionId,
-              out authenticationToken,
-              out serverNonce,
-              out revisedSessionTimeout);
-        }
-
-        /// <summary>
         /// Activates an existing session
         /// </summary>
         public virtual bool ActivateSession(

--- a/Libraries/Opc.Ua.Server/Subscription/MonitoredItem/IMonitoredItem.cs
+++ b/Libraries/Opc.Ua.Server/Subscription/MonitoredItem/IMonitoredItem.cs
@@ -111,6 +111,11 @@ namespace Opc.Ua.Server
         bool IsResendData { get; }
 
         /// <summary>
+        /// The node id being monitored.
+        /// </summary>
+        NodeId NodeId { get; }
+
+        /// <summary>
         /// Set the resend data trigger flag.
         /// </summary>
         void SetupResendDataTrigger();
@@ -139,6 +144,12 @@ namespace Opc.Ua.Server
         /// Return a <see cref="IStoredMonitoredItem"/> for restore a after a server restart
         /// </summary>
         IStoredMonitoredItem ToStorableMonitoredItem();
+
+        /// <summary>
+        /// Changes the monitoring mode for the item.
+        /// returns the previous monitoring mode.
+        /// </summary>
+        MonitoringMode SetMonitoringMode(MonitoringMode monitoringMode);
     }
 
     /// <summary>
@@ -174,6 +185,11 @@ namespace Opc.Ua.Server
         void QueueEvent(IFilterTarget instance);
 
         /// <summary>
+        /// Adds an event to the queue.
+        /// </summary>
+        void QueueEvent(IFilterTarget instance, bool bypassFilter);
+
+        /// <summary>
         /// The filter used by the monitored item.
         /// </summary>
         EventFilter EventFilter { get; }
@@ -197,11 +213,6 @@ namespace Opc.Ua.Server
             double samplingInterval,
             uint queueSize,
             bool discardOldest);
-
-        /// <summary>
-        /// Changes the monitoring mode for the item.
-        /// </summary>
-        void SetMonitoringMode(MonitoringMode monitoringMode);
     }
 
     /// <summary>
@@ -251,6 +262,27 @@ namespace Opc.Ua.Server
         QualifiedName DataEncoding { get; }
 
         /// <summary>
+        /// Whether the monitored item should report a value without checking if it was changed.
+        /// </summary>
+        public bool AlwaysReportUpdates { get; set; }
+
+        /// <summary>
+        /// Sets a flag indicating that the semantics for the monitored node have changed.
+        /// </summary>
+        /// <remarks>
+        /// The StatusCode for next value reported by the monitored item will have the SemanticsChanged bit set.
+        /// </remarks>
+        void SetSemanticsChanged();
+
+        /// <summary>
+        /// Sets a flag indicating that the structure of the monitored node has changed.
+        /// </summary>
+        /// <remarks>
+        /// The StatusCode for next value reported by the monitored item will have the StructureChanged bit set.
+        /// </remarks>
+        void SetStructureChanged();
+
+        /// <summary>
         /// Updates the queue with a data value or an error.
         /// </summary>
         void QueueValue(DataValue value, ServiceResult error, bool ignoreFilters);
@@ -277,6 +309,11 @@ namespace Opc.Ua.Server
         double MinimumSamplingInterval { get; }
 
         /// <summary>
+        /// The number of milliseconds until the next sample.
+        /// </summary>
+        public int TimeToNextSample { get; }
+
+        /// <summary>
         /// Used to check whether the item is ready to sample.
         /// </summary>
         bool SamplingIntervalExpired();
@@ -299,11 +336,6 @@ namespace Opc.Ua.Server
             double samplingInterval,
             uint queueSize,
             bool discardOldest);
-
-        /// <summary>
-        /// Changes the monitoring mode for the item.
-        /// </summary>
-        void SetMonitoringMode(MonitoringMode monitoringMode);
 
         /// <summary>
         /// Updates the sampling interval for an item.

--- a/Libraries/Opc.Ua.Server/Subscription/MonitoredItem/MonitoredItem.cs
+++ b/Libraries/Opc.Ua.Server/Subscription/MonitoredItem/MonitoredItem.cs
@@ -43,36 +43,6 @@ namespace Opc.Ua.Server
         /// <summary>
         /// Initializes the object with its node type.
         /// </summary>
-        [Obsolete("Use MonitoredItem constructor without the session parameter.")]
-        public MonitoredItem(
-            IServerInternal server,
-            INodeManager nodeManager,
-            object managerHandle,
-            uint subscriptionId,
-            uint id,
-            Session session,
-            ReadValueId itemToMonitor,
-            DiagnosticsMasks diagnosticsMasks,
-            TimestampsToReturn timestampsToReturn,
-            MonitoringMode monitoringMode,
-            uint clientHandle,
-            MonitoringFilter originalFilter,
-            MonitoringFilter filterToUse,
-            Range range,
-            double samplingInterval,
-            uint queueSize,
-            bool discardOldest,
-            double sourceSamplingInterval)
-         : this(server, nodeManager, managerHandle, subscriptionId,
-            id, itemToMonitor, diagnosticsMasks, timestampsToReturn, monitoringMode,
-            clientHandle, originalFilter, filterToUse, range, samplingInterval,
-            queueSize, discardOldest, sourceSamplingInterval)
-        {
-        }
-
-        /// <summary>
-        /// Initializes the object with its node type.
-        /// </summary>
         public MonitoredItem(
             IServerInternal server,
             INodeManager nodeManager,
@@ -211,7 +181,6 @@ namespace Opc.Ua.Server
             m_sourceSamplingInterval = storedMonitoredItem.SourceSamplingInterval;
             m_calculator = null;
             m_nextSamplingTime = HiResClock.TickCount64;
-            m_alwaysReportUpdates = false;
             m_monitoredItemQueueFactory = m_server.MonitoredItemQueueFactory;
             m_subscriptionStore = m_server.SubscriptionStore;
             m_isDurable = storedMonitoredItem.IsDurable;
@@ -786,22 +755,6 @@ namespace Opc.Ua.Server
         /// <summary>
         /// Changes the monitoring mode for the item.
         /// </summary>
-        void ISampledDataChangeMonitoredItem.SetMonitoringMode(MonitoringMode monitoringMode)
-        {
-            SetMonitoringMode(monitoringMode);
-        }
-
-        /// <summary>
-        /// Changes the monitoring mode for the item.
-        /// </summary>
-        void IEventMonitoredItem.SetMonitoringMode(MonitoringMode monitoringMode)
-        {
-            SetMonitoringMode(monitoringMode);
-        }
-
-        /// <summary>
-        /// Changes the monitoring mode for the item.
-        /// </summary>
         public MonitoringMode SetMonitoringMode(MonitoringMode monitoringMode)
         {
             lock (m_lock)
@@ -1174,28 +1127,6 @@ namespace Opc.Ua.Server
             }
 
             return m_filteredRetainConditionIds;
-        }
-
-
-        /// <summary>
-        /// Whether the item has notifications that are ready to publish.
-        /// </summary>
-        [Obsolete("Not used - Use IsReadyToPublish")]
-        public virtual bool ReadyToPublish
-        {
-            get
-            {
-                lock (m_lock)
-                {
-                    // only publish if reporting.
-                    if (m_monitoringMode != MonitoringMode.Reporting)
-                    {
-                        return false;
-                    }
-
-                    return m_readyToPublish;
-                }
-            }
         }
 
         /// <summary>

--- a/Libraries/Opc.Ua.Server/Subscription/Subscription.cs
+++ b/Libraries/Opc.Ua.Server/Subscription/Subscription.cs
@@ -2222,7 +2222,7 @@ namespace Opc.Ua.Server
                 // build list of items to refresh.
                 foreach (LinkedListNode<IMonitoredItem> monitoredItem in m_monitoredItems.Values)
                 {
-                    MonitoredItem eventMonitoredItem = monitoredItem.Value as MonitoredItem;
+                    IEventMonitoredItem eventMonitoredItem = monitoredItem.Value as IEventMonitoredItem;
 
                     if (eventMonitoredItem != null && eventMonitoredItem.EventFilter != null)
                     {
@@ -2255,7 +2255,7 @@ namespace Opc.Ua.Server
                 {
                     LinkedListNode<IMonitoredItem> monitoredItem = m_monitoredItems[monitoredItemId];
 
-                    MonitoredItem eventMonitoredItem = monitoredItem.Value as MonitoredItem;
+                    IEventMonitoredItem eventMonitoredItem = monitoredItem.Value as IEventMonitoredItem;
 
                     if (eventMonitoredItem != null && eventMonitoredItem.EventFilter != null)
                     {
@@ -2317,7 +2317,7 @@ namespace Opc.Ua.Server
                 // build list of items to refresh.
                 foreach (IEventMonitoredItem monitoredItem in monitoredItems)
                 {
-                    MonitoredItem eventMonitoredItem = monitoredItem as MonitoredItem;
+                    IEventMonitoredItem eventMonitoredItem = monitoredItem;
 
                     if (eventMonitoredItem != null && eventMonitoredItem.EventFilter != null)
                     {
@@ -2371,7 +2371,7 @@ namespace Opc.Ua.Server
                 // send refresh end event.
                 for (int ii = 0; ii < monitoredItems.Count; ii++)
                 {
-                    MonitoredItem monitoredItem = monitoredItems[ii] as MonitoredItem;
+                    IEventMonitoredItem monitoredItem = monitoredItems[ii];
 
                     if (monitoredItem.EventFilter != null)
                     {


### PR DESCRIPTION
## Proposed changes
Currently the Server is tightly coupled to the MonitoredItem Class, this PR  removes this coupling by using and extending the existing IMonitoreditemInterface.
It also removes obsolete Constructors from the Server.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

