### PR TITLE
[Client] Allow to modify sensitivity of KeepAliveStopped

### DIFF
--- a/Libraries/Opc.Ua.Client/Session/ISession.cs
+++ b/Libraries/Opc.Ua.Client/Session/ISession.cs
@@ -241,7 +241,7 @@ namespace Opc.Ua.Client
         /// Returns true if the session is not receiving keep alives.
         /// </summary>
         /// <remarks>
-        /// Set to true if the server does not respond for 2 times the KeepAliveInterval.
+        /// Set to true if the server does not respond for the KeepAliveInterval times a configurable factor + a configurable guard band.
         /// Set to false is communication recovers.
         /// </remarks>
         bool KeepAliveStopped { get; }

--- a/Libraries/Opc.Ua.Client/Session/Session.cs
+++ b/Libraries/Opc.Ua.Client/Session/Session.cs
@@ -58,7 +58,6 @@ namespace Opc.Ua.Client
         private const int kMinPublishRequestCountMax = 100;
         private const int kMaxPublishRequestCountMax = ushort.MaxValue;
         private const int kDefaultPublishRequestCount = 1;
-        private const int kKeepAliveGuardBand = 1000;
         private const int kPublishRequestSequenceNumberOutOfOrderThreshold = 10;
         private const int kPublishRequestSequenceNumberOutdatedThreshold = 100;
 
@@ -705,7 +704,8 @@ namespace Opc.Ua.Client
         /// Returns true if the session is not receiving keep alives.
         /// </summary>
         /// <remarks>
-        /// Set to true if the server does not respond for 2 times the KeepAliveInterval
+        /// Set to true if the server does not respond for the KeepAliveInterval * 1 (KeepaliveIntervalFactor) + 1 Second (KeepAliveGuardBand) *
+        /// To change the senstivity of the keep alive check, set the <see cref="m_keepAliveIntervalFactor"/> / <see cref="m_keepAliveGuardBand"/> fields. 
         /// or if another error was reported.
         /// Set to false is communication is ok or recovered.
         /// </remarks>
@@ -719,7 +719,7 @@ namespace Opc.Ua.Client
                     int delta = HiResClock.TickCount - m_lastKeepAliveTickCount;
 
                     // add a guard band to allow for network lag.
-                    return (m_keepAliveInterval + kKeepAliveGuardBand) <= delta;
+                    return (m_keepAliveInterval * m_keepAliveIntervalFactor + m_keepAliveGuardBand) <= delta;
                 }
 
                 // another error was reported which caused keep alive to stop.
@@ -6648,6 +6648,16 @@ namespace Opc.Ua.Client
         /// The user identity currently used for the session.
         /// </summary>
         protected IUserIdentity m_identity;
+
+        /// <summary>
+        /// Factor appiled to the <see cref="m_keepAliveInterval"/> before <see cref="KeepAliveStopped"/> is set to true
+        /// </summary>
+        protected int m_keepAliveIntervalFactor = 1;
+
+        /// <summary>
+        /// Time in milliseconds added to <see cref="m_keepAliveInterval"/> before <see cref="KeepAliveStopped"/> is set to true
+        /// </summary>
+        protected int m_keepAliveGuardBand = 1000;
         #endregion
 
         #region Private Fields


### PR DESCRIPTION
## Proposed changes

Allow to modify sensitivity of KeepAliveStopped with a factor and a guard band.

## Related Issues

- Fixes #2859

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments
