### PR TITLE
Fix ``TcpListenerChannel`` memory leak

### DIFF
--- a/Stack/Opc.Ua.Core/Stack/Tcp/TcpListenerChannel.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/TcpListenerChannel.cs
@@ -48,6 +48,8 @@ namespace Opc.Ua.Bindings
         /// </summary>
         protected override void Dispose(bool disposing)
         {
+            if (m_listener is IDisposable disposable)
+                disposable.Dispose();
             base.Dispose(disposing);
         }
         #endregion

--- a/Stack/Opc.Ua.Core/Stack/Tcp/TcpTransportListener.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/TcpTransportListener.cs
@@ -287,20 +287,33 @@ namespace Opc.Ua.Bindings
         }
 
         /// <summary>
+        /// finalizer
+        /// </summary>
+        ~TcpTransportListener()
+        {
+            // Finalizer calls Dispose(false)
+            Dispose(false);
+        }
+
+        /// <summary>
         /// An overrideable version of the Dispose.
         /// </summary>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2213:DisposableFieldsShouldBeDisposed", MessageId = "m_simulator")]
         protected virtual void Dispose(bool disposing)
         {
+            // Clean up the inactivity detection timer regardless of disposing flag,
+            // as timers typically wrap unmanaged resources that must always be released
+            if (m_inactivityDetectionTimer != null)
+            {
+                Utils.SilentDispose(m_inactivityDetectionTimer);
+                m_inactivityDetectionTimer = null;
+            }
+
             if (disposing)
             {
                 lock (m_lock)
                 {
-                    if (m_inactivityDetectionTimer != null)
-                    {
-                        Utils.SilentDispose(m_inactivityDetectionTimer);
-                        m_inactivityDetectionTimer = null;
-                    }
+
 
                     if (m_listeningSocket != null)
                     {


### PR DESCRIPTION
## Proposed changes

This pull request improves the resource cleanup logic for TCP transport components by ensuring proper disposal of internal resources and following the recommended .NET dispose pattern.

### Summary of changes:
- In `TcpListenerChannel.Dispose`, added a check to dispose `_listener` only if it implements `IDisposable`.
- In `TcpTransportListener`, added a finalizer to ensure unmanaged timer resources are cleaned up even if `Dispose` is not called.
- Moved `inactivityDetectionTimer` cleanup outside of the `disposing` check to prevent potential resource leaks.

These changes improve the stability and correctness of the transport layer, especially in long-running or high-load environments.

## Related Issues

None formally tracked, but addresses potential timer-related memory leaks.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)  
- [x] Enhancement (non-breaking change which adds functionality)  
- [ ] Test enhancement  
- [ ] Breaking change  
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.  
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).  
- [x] I ran tests locally with my changes, all passed.  
- [ ] I fixed all failing tests in the CI pipelines.  
- [ ] I fixed all introduced issues with CodeQL and LGTM.  
- [ ] I have added tests that prove my fix is effective or that my feature works.  
- [ ] I have added necessary documentation (if appropriate).  
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

These improvements follow .NET best practices for resource disposal and help prevent issues where timers or unmanaged resources are not released properly due to missing Dispose calls.
