### PR TITLE
[Client] Fix removal of Subscription if PublishResponse is received before CreateSubscriptionResponse

### DIFF
--- a/Libraries/Opc.Ua.Client/Subscription/Subscription.cs
+++ b/Libraries/Opc.Ua.Client/Subscription/Subscription.cs
@@ -811,7 +811,7 @@ namespace Opc.Ua.Client
                 revisedLifetimeCounter,
                 revisedKeepAliveCount,
                 m_maxNotificationsPerPublish,
-                m_publishingEnabled,
+                false,
                 m_priority,
                 out subscriptionId,
                 out revisedPublishingInterval,
@@ -821,6 +821,12 @@ namespace Opc.Ua.Client
             CreateSubscription(subscriptionId, revisedPublishingInterval, revisedKeepAliveCount, revisedLifetimeCounter);
 
             CreateItems();
+
+            // only enable publishing afer CreateSubscription is called to avoid race conditions with subscription cleanup.
+            if (m_publishingEnabled)
+            {
+                SetPublishingMode(m_publishingEnabled);
+            }
 
             ChangesCompleted();
 

--- a/Libraries/Opc.Ua.Client/Subscription/SubscriptionAsync.cs
+++ b/Libraries/Opc.Ua.Client/Subscription/SubscriptionAsync.cs
@@ -62,7 +62,7 @@ namespace Opc.Ua.Client
                 revisedLifetimeCount,
                 revisedMaxKeepAliveCount,
                 m_maxNotificationsPerPublish,
-                m_publishingEnabled,
+                false,
                 m_priority,
                 ct).ConfigureAwait(false);
 
@@ -73,6 +73,13 @@ namespace Opc.Ua.Client
                 response.RevisedLifetimeCount);
 
             await CreateItemsAsync(ct).ConfigureAwait(false);
+
+
+            // only enable publishing afer CreateSubscription is called to avoid race conditions with subscription cleanup.
+            if (m_publishingEnabled)
+            {
+                await SetPublishingModeAsync(m_publishingEnabled, ct).ConfigureAwait(false);
+            }
 
             ChangesCompleted();
         }


### PR DESCRIPTION
## Proposed changes

Fix removal of Subscription if PublishResponse is received before CreateSubscriptionResponse by creating subscription with PublishingEnabled = false first.

## Related Issues

- Fixes #2791

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
- [ ] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments