### PR TITLE
[Server] Handle unsent requests on closed SecureChannel to be sent on new channel of the same session

### DIFF
--- a/Libraries/Opc.Ua.Server/Server/StandardServer.cs
+++ b/Libraries/Opc.Ua.Server/Server/StandardServer.cs
@@ -2556,9 +2556,9 @@ namespace Opc.Ua.Server
                 Utils.LogError(e, "Unexpected exception handling registration timer.");
             }
         }
-#endregion
+        #endregion
 
-#region Protected Members used for Request Processing
+        #region Protected Members used for Request Processing
         /// <summary>
         /// The synchronization object.
         /// </summary>
@@ -2814,9 +2814,9 @@ namespace Opc.Ua.Server
                 m_serverInternal.RequestManager.RequestCompleted(context);
             }
         }
-#endregion
+        #endregion
 
-#region Protected Members used for Initialization
+        #region Protected Members used for Initialization
         /// <summary>
         /// Raised when the configuration changes.
         /// </summary>
@@ -3230,6 +3230,27 @@ namespace Opc.Ua.Server
         }
 
         /// <summary>
+        /// Trys to get the secure channel id for an AuthenticationToken.
+        /// The ChannelId is known to the sessions of the Server.
+        /// Each session has an AuthenticationToken which can be used to identify the session.
+        /// </summary>
+        /// <param name="authenticationToken">The AuthenticationToken from the RequestHeader</param>
+        /// <param name="channelId">The Channel id</param>
+        /// <returns>returns true if a channelId was found for the provided AuthenticationToken</returns>
+        public override bool TryGetSecureChannelIdForAuthenticationToken(NodeId authenticationToken, out uint channelId)
+        {
+            Session session = ServerInternal.SessionManager.GetSession(authenticationToken);
+
+            if (session == null)
+            {
+                channelId = 0;
+                return false;
+            }
+
+            return uint.TryParse(session.SecureChannelId, out channelId);
+        }
+
+        /// <summary>
         /// Implements the server shutdown delay if session are connected.
         /// </summary>
         protected void ShutDownDelay()
@@ -3425,7 +3446,7 @@ namespace Opc.Ua.Server
         /// <returns>Returns a (durable) monitored item queue factory for a server, the return type is <seealso cref="IMonitoredItemQueueFactory"/>.</returns>
         protected virtual IMonitoredItemQueueFactory CreateMonitoredItemQueueFactory(IServerInternal server, ApplicationConfiguration configuration)
         {
-           return new MonitoredItemQueueFactory();
+            return new MonitoredItemQueueFactory();
         }
 
         /// <summary>
@@ -3482,7 +3503,7 @@ namespace Opc.Ua.Server
         {
             m_nodeManagerFactories.Remove(nodeManagerFactory);
         }
-#endregion
+        #endregion
 
         #region Private Methods
         /// <summary>
@@ -3504,9 +3525,9 @@ namespace Opc.Ua.Server
 
         #region Private Properties
         private OperationLimitsState OperationLimits => ServerInternal.ServerObject.ServerCapabilities.OperationLimits;
-#endregion
+        #endregion
 
-#region Private Fields
+        #region Private Fields
         private readonly object m_lock = new object();
         private readonly object m_registrationLock = new object();
         private ServerInternalData m_serverInternal;

--- a/Stack/Opc.Ua.Core/Stack/Server/EndpointBase.cs
+++ b/Stack/Opc.Ua.Core/Stack/Server/EndpointBase.cs
@@ -125,6 +125,20 @@ namespace Opc.Ua
         {
             return ProcessRequestAsyncResult.WaitForComplete(result, false);
         }
+
+        /// <summary>
+        /// Trys to get the secure channel id for an AuthenticationToken.
+        /// The ChannelId is known to the sessions of the Server.
+        /// Each session has an AuthenticationToken which can be used to identify the session.
+        /// </summary>
+        /// <param name="authenticationToken">The AuthenticationToken from the RequestHeader</param>
+        /// <param name="channelId">The Channel id</param>
+        /// <returns>returns true if a channelId was found for the provided AuthenticationToken</returns>
+        public bool TryGetSecureChannelIdForAuthenticationToken(NodeId authenticationToken, out uint channelId)
+        {
+            return m_server.TryGetSecureChannelIdForAuthenticationToken(authenticationToken, out channelId);
+        }
+
         #endregion
 
         #region IAuditEventCallback Members

--- a/Stack/Opc.Ua.Core/Stack/Server/IServerBase.cs
+++ b/Stack/Opc.Ua.Core/Stack/Server/IServerBase.cs
@@ -47,6 +47,16 @@ namespace Opc.Ua
         /// </summary>
         /// <param name="request">The request.</param>
         void ScheduleIncomingRequest(IEndpointIncomingRequest request);
+
+        /// <summary>
+        /// Trys to get the secure channel id for an AuthenticationToken.
+        /// The ChannelId is known to the sessions of the Server.
+        /// Each session has an AuthenticationToken which can be used to identify the session.
+        /// </summary>
+        /// <param name="authenticationToken">The AuthenticationToken from the RequestHeader</param>
+        /// <param name="channelId">The Channel id</param>
+        /// <returns>returns true if a channelId was found for the provided AuthenticationToken</returns>
+        bool TryGetSecureChannelIdForAuthenticationToken(NodeId authenticationToken, out uint channelId);
     }
 
     /// <summary>

--- a/Stack/Opc.Ua.Core/Stack/Server/ServerBase.cs
+++ b/Stack/Opc.Ua.Core/Stack/Server/ServerBase.cs
@@ -155,6 +155,20 @@ namespace Opc.Ua
             m_requestQueue.ScheduleIncomingRequest(request);
         }
 
+        /// <summary>
+        /// Trys to get the secure channel id for an AuthenticationToken.
+        /// The ChannelId is known to the sessions of the Server.
+        /// Each session has an AuthenticationToken which can be used to identify the session.
+        /// </summary>
+        /// <param name="authenticationToken">The AuthenticationToken from the RequestHeader</param>
+        /// <param name="channelId">The Channel id</param>
+        /// <returns>returns true if a channelId was found for the provided AuthenticationToken</returns>
+        public virtual bool TryGetSecureChannelIdForAuthenticationToken(NodeId authenticationToken, out uint channelId)
+        {
+            channelId = 0;
+            return false;
+        }
+
         #region IAuditEventCallback Members
         /// <inheritdoc/>
         public virtual void ReportAuditOpenSecureChannelEvent(

--- a/Stack/Opc.Ua.Core/Stack/Tcp/TcpServerChannel.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/TcpServerChannel.cs
@@ -1047,6 +1047,12 @@ namespace Opc.Ua.Bindings
                     return;
                 }
 
+                // if the channel is closed no response can be sent, throw exception to end processing in this specific channel.
+                if (State == TcpChannelState.Closed)
+                {
+                    throw new ServiceResultException(StatusCodes.BadSecureChannelClosed, "Cannot send response over a closed channel.");
+                }
+
                 Utils.EventLog.SendResponse((int)ChannelId, (int)requestId);
 
                 BufferCollection buffers = null;

--- a/Stack/Opc.Ua.Core/Stack/Tcp/TcpTransportListener.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/TcpTransportListener.cs
@@ -1063,8 +1063,12 @@ namespace Opc.Ua.Bindings
                             {
                                 var serverChannel = (TcpServerChannel)newChannel;
 
-                                serverChannel.SendResponse((uint)args[1], response);
-                                return;
+                                // if the channel is not the same as the one we started with, send the response over the new channel
+                                if (serverChannel != channel)
+                                {
+                                    serverChannel.SendResponse((uint)args[1], response);
+                                    return;
+                                }
                             }
                         }
                         // if we could not find a new channel, just log the error

--- a/Stack/Opc.Ua.Core/Stack/Tcp/TcpTransportListener.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/TcpTransportListener.cs
@@ -1064,8 +1064,11 @@ namespace Opc.Ua.Bindings
                                 var serverChannel = (TcpServerChannel)newChannel;
 
                                 serverChannel.SendResponse((uint)args[1], response);
+                                return;
                             }
                         }
+                        // if we could not find a new channel, just log the error
+                        throw;
                     }
                 }
             }

--- a/Stack/Opc.Ua.Core/Stack/Tcp/TcpTransportListener.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/TcpTransportListener.cs
@@ -138,15 +138,13 @@ namespace Opc.Ua.Bindings
 
             m_activeClients.AddOrUpdate(ipAddress,
                 // If client is new , create a new entry
-                key => new ActiveClient
-                {
+                key => new ActiveClient {
                     LastActionTicks = currentTicks,
                     ActiveActionCount = 1,
                     BlockedUntilTicks = 0
                 },
                 // If the client exists, update its entry
-                (key, existingEntry) =>
-                {
+                (key, existingEntry) => {
                     // If IP currently blocked simply do nothing
                     if (IsBlockedTicks(existingEntry.BlockedUntilTicks, currentTicks))
                     {
@@ -362,8 +360,7 @@ namespace Opc.Ua.Bindings
 
             // initialize the quotas.
             m_quotas = new ChannelQuotas();
-            var messageContext = new ServiceMessageContext()
-            {
+            var messageContext = new ServiceMessageContext() {
                 NamespaceUris = settings.NamespaceUris,
                 ServerUris = new StringTable(),
                 Factory = settings.Factory
@@ -1044,7 +1041,32 @@ namespace Opc.Ua.Bindings
                 {
                     TcpServerChannel channel = (TcpServerChannel)args[0];
                     IServiceResponse response = m_callback.EndProcessRequest(result);
-                    channel.SendResponse((uint)args[1], response);
+
+                    try
+                    {
+                        channel.SendResponse((uint)args[1], response);
+                    }
+                    catch (ServiceResultException sre)
+                    {
+                        //handle only the case where the secure channel was closed
+                        if (sre.StatusCode != StatusCodes.BadSecureChannelClosed)
+                        {
+                            throw;
+                        }
+                        //try to find the new channel id for the authentication token to send response over new channel
+                        IServiceRequest request = (IServiceRequest)args[2];
+                        NodeId AuthenticationToken = request.RequestHeader.AuthenticationToken;
+
+                        if (m_callback?.TryGetSecureChannelIdForAuthenticationToken(AuthenticationToken, out uint channelId) == true)
+                        {
+                            if (m_channels.TryGetValue(channelId, out TcpListenerChannel newChannel))
+                            {
+                                var serverChannel = (TcpServerChannel)newChannel;
+
+                                serverChannel.SendResponse((uint)args[1], response);
+                            }
+                        }
+                    }
                 }
             }
             catch (Exception e)

--- a/Stack/Opc.Ua.Core/Stack/Transport/ITransportListenerCallback.cs
+++ b/Stack/Opc.Ua.Core/Stack/Transport/ITransportListenerCallback.cs
@@ -45,5 +45,15 @@ namespace Opc.Ua
         /// <returns>The response to return over the secure channel.</returns>
         /// <seealso cref="BeginProcessRequest" />
         IServiceResponse EndProcessRequest(IAsyncResult result);
+
+        /// <summary>
+        /// Trys to get the secure channel id for an authentication token.
+        /// The ChannelId is known to the sessions of the Server.
+        /// Each session has an AuthenticationToken which can be used to identify the session.
+        /// </summary>
+        /// <param name="AuthenticationToken">The AuthenticationToken from the RequestHeader</param>
+        /// <param name="channelId">The Channel id</param>
+        /// <returns>returns true if a channelId was found for the provided AuthenticationToken</returns>
+        bool TryGetSecureChannelIdForAuthenticationToken(NodeId AuthenticationToken, out uint channelId);
     }
 }


### PR DESCRIPTION
## Proposed changes

Currently if a SecureChannel is closed and after that a response is ready to be sent (due to async handling) the response is discared.
This shall not happen if the session that created the request did open (& activiate) a new channel in the meantime.

Extend the TcpTransportListener to catch requests that failed to get sent by a TcpServerChannel because the channel was closed. The TcpTransportListener asks the ServerCallback for the new ChannelID of the Session. The Session is identitfied by the AuthenticationToken.

## Related Issues

- Fixes #3127 

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist


- [ ] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

Is the old channel closed by the session only after the new one was activated or do the responses need to be saved some time to wait for session activation?

<img width="1961" height="363" alt="image" src="https://github.com/user-attachments/assets/ccfee9e0-e812-46e3-9c96-218a9fd2a0b1" />

