### PR TITLE
Fix Analyzer warnings (ConfigureAwait, CultureInfo)

### DIFF
--- a/Applications/ConsoleReferenceClient/ClientSamples.cs
+++ b/Applications/ConsoleReferenceClient/ClientSamples.cs
@@ -1363,11 +1363,11 @@ namespace Quickstarts
                                 string timeBetweenEvents = "";
                                 if (m_processedEvents > 1)
                                 {
-                                    timeBetweenEvents = ", time since last event = " + timeSpan.Seconds.ToString() + " seconds";
+                                    timeBetweenEvents = ", time since last event = " + timeSpan.Seconds.ToString(CultureInfo.InvariantCulture) + " seconds";
                                 }
 
                                 m_output.WriteLine("Event Received - total count = {0}{1}",
-                                    m_processedEvents.ToString(),
+                                    m_processedEvents.ToString(CultureInfo.InvariantCulture),
                                     timeBetweenEvents);
                             }
                             catch (Exception ex)
@@ -1377,7 +1377,7 @@ namespace Quickstarts
                         }
 
                         m_output.WriteLine("\tField [{0}] \"{1}\" = [{2}]",
-                            entry.Key.ToString(), fieldName, field.Value);
+                            entry.Key.ToString(CultureInfo.InvariantCulture), fieldName, field.Value);
                     }
                 }
             }

--- a/Applications/ConsoleReferenceClient/Program.cs
+++ b/Applications/ConsoleReferenceClient/Program.cs
@@ -235,7 +235,7 @@ namespace Quickstarts.ConsoleReferenceClient
                         {
                             CertificateIdentifier userCertificateIdentifier =
                                 await FindUserCertificateIdentifierAsync(userCertificateThumbprint,
-                                    application.ApplicationConfiguration.SecurityConfiguration.TrustedUserCertificates);
+                                    application.ApplicationConfiguration.SecurityConfiguration.TrustedUserCertificates).ConfigureAwait(true);
 
                             if (userCertificateIdentifier != null)
                             {
@@ -433,12 +433,12 @@ namespace Quickstarts.ConsoleReferenceClient
                                             await uaClient.DurableSubscriptionTransfer(
                                                 serverUrl.ToString(),
                                                 useSecurity: !noSecurity,
-                                                quitCTS.Token);
+                                                quitCTS.Token).ConfigureAwait(true);
                                         }
 
                                         if ( waitCounters > closeSessionTime && waitCounters < restartSessionTime )
                                         {
-                                            Console.WriteLine("No Communication Interval " + stopCount.ToString());
+                                            Console.WriteLine("No Communication Interval " + stopCount.ToString(CultureInfo.InvariantCulture));
                                             stopCount++;
                                         }
                                     }
@@ -483,7 +483,7 @@ namespace Quickstarts.ConsoleReferenceClient
             // get user certificate with matching thumbprint
             X509Certificate2Collection userCertifiactesWithMatchingThumbprint =
                 (await trustedUserCertificates
-                .GetCertificates())
+                .GetCertificates().ConfigureAwait(true))
                 .Find(X509FindType.FindByThumbprint, thumbprint, false);
 
             // create Certificate Identifier

--- a/Applications/ConsoleReferenceClient/UAClient.cs
+++ b/Applications/ConsoleReferenceClient/UAClient.cs
@@ -29,6 +29,7 @@
 
 using System;
 using System.Collections;
+using System.Globalization;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -137,11 +138,11 @@ namespace Quickstarts
             bool success = false;
             SubscriptionCollection subscriptions = new SubscriptionCollection(m_session.Subscriptions);
             m_session = null;
-            if (await ConnectAsync(serverUrl, useSecurity, ct))
+            if (await ConnectAsync(serverUrl, useSecurity, ct).ConfigureAwait(false))
             {
                 if (subscriptions != null && m_session != null)
                 {
-                    m_output.WriteLine("Transferring " + subscriptions.Count.ToString() +
+                    m_output.WriteLine("Transferring " + subscriptions.Count.ToString(CultureInfo.InvariantCulture) +
                         " subscriptions from old session to new session...");
                     success = m_session.TransferSubscriptions(subscriptions, true);
                     if (success)

--- a/Applications/ConsoleReferenceServer/UAServer.cs
+++ b/Applications/ConsoleReferenceServer/UAServer.cs
@@ -29,6 +29,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -241,18 +242,18 @@ namespace Quickstarts
             StringBuilder item = new StringBuilder();
             lock (session.DiagnosticsLock)
             {
-                item.AppendFormat("{0,9}:{1,20}:", reason, session.SessionDiagnostics.SessionName);
+                item.AppendFormat(CultureInfo.InvariantCulture, "{0,9}:{1,20}:", reason, session.SessionDiagnostics.SessionName);
                 if (lastContact)
                 {
-                    item.AppendFormat("Last Event:{0:HH:mm:ss}", session.SessionDiagnostics.ClientLastContactTime.ToLocalTime());
+                    item.AppendFormat(CultureInfo.InvariantCulture, "Last Event:{0:HH:mm:ss}", session.SessionDiagnostics.ClientLastContactTime.ToLocalTime());
                 }
                 else
                 {
                     if (session.Identity != null)
                     {
-                        item.AppendFormat(":{0,20}", session.Identity.DisplayName);
+                        item.AppendFormat(CultureInfo.InvariantCulture, ":{0,20}", session.Identity.DisplayName);
                     }
-                    item.AppendFormat(":{0}", session.Id);
+                    item.AppendFormat(CultureInfo.InvariantCulture, ":{0}", session.Id);
                 }
             }
             m_output.WriteLine(item.ToString());

--- a/Stack/Opc.Ua.Core/Stack/Tcp/UaSCBinaryClientChannel.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/UaSCBinaryClientChannel.cs
@@ -13,6 +13,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
@@ -653,7 +654,7 @@ namespace Opc.Ua.Bindings
                     throw new ServiceResultException(StatusCodes.BadNonceInvalid);
                 }
 
-                string implementation = String.Format(g_ImplementationString, m_socketFactory.Implementation);
+                string implementation = string.Format(CultureInfo.InvariantCulture, g_ImplementationString, m_socketFactory.Implementation);
 
                 // log security information.
                 if (State == TcpChannelState.Opening)

--- a/Stack/Opc.Ua.Core/Types/Encoders/BinaryEncoder.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/BinaryEncoder.cs
@@ -592,6 +592,7 @@ namespace Opc.Ua
         /// <summary>
         /// Writes a byte string to the stream.
         /// </summary>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2265:Do not compare Span<T> to 'null' or 'default'", Justification = "Null compare works with ReadOnlySpan<byte>")]
         public void WriteByteString(string fieldName, ReadOnlySpan<byte> value)
         {
             if (value == null)

--- a/Tests/Opc.Ua.Client.Tests/DurableSubscriptionTest.cs
+++ b/Tests/Opc.Ua.Client.Tests/DurableSubscriptionTest.cs
@@ -31,6 +31,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -208,7 +209,7 @@ namespace Opc.Ua.Client.Tests
             Assert.IsNotNull(maxLifetimeCountValue);
             Assert.IsNotNull(maxLifetimeCountValue.Value);
             Assert.AreEqual(expectedLifetime,
-                Convert.ToUInt32(maxLifetimeCountValue.Value));
+                Convert.ToUInt32(maxLifetimeCountValue.Value, CultureInfo.InvariantCulture));
 
             Assert.True(Session.RemoveSubscription(subscription));
         }
@@ -471,7 +472,7 @@ namespace Opc.Ua.Client.Tests
                         DateTime timestamp = pair.Value[index];
 
                         TimeSpan timeSpan = timestamp - previous;
-                        TestContext.Out.WriteLine($"Node: {pair.Key} Index: {index} Time: {DateTimeMs(timestamp)} Previous: {DateTimeMs(previous)} Timespan {timeSpan.TotalMilliseconds.ToString("000.")}");
+                        TestContext.Out.WriteLine($"Node: {pair.Key} Index: {index} Time: {DateTimeMs(timestamp)} Previous: {DateTimeMs(previous)} Timespan {timeSpan.TotalMilliseconds.ToString("000.", CultureInfo.InvariantCulture)}");
 
                         Assert.Less(Math.Abs(timeSpan.TotalMilliseconds), tolerance,
                             $"Node: {pair.Key} Index: {index} Timespan {timeSpan.TotalMilliseconds} ");
@@ -504,7 +505,7 @@ namespace Opc.Ua.Client.Tests
             DataValue dataValue = modifiedValues[desiredValue] as DataValue;
             Assert.IsNotNull(dataValue);
             Assert.IsNotNull(dataValue.Value);
-            Assert.AreEqual(expectedValue, Convert.ToUInt32(dataValue.Value));
+            Assert.AreEqual(expectedValue, Convert.ToUInt32(dataValue.Value, CultureInfo.InvariantCulture));
 
             return modifiedValues;
         }
@@ -580,7 +581,7 @@ namespace Opc.Ua.Client.Tests
             {
                 TestContext.Out.WriteLine("Initial Browse Reference {0}", reference.BrowseName.Name);
 
-                if (reference.BrowseName.Name == subscriptionId.ToString())
+                if (reference.BrowseName.Name == subscriptionId.ToString(CultureInfo.InvariantCulture))
                 {
                     ReferenceDescriptionCollection desiredReferences;
 
@@ -734,7 +735,7 @@ namespace Opc.Ua.Client.Tests
         private string DateTimeMs(DateTime dateTime)
         {
             string readable = dateTime.ToLongTimeString() + "." +
-                dateTime.Millisecond.ToString("D3");
+                dateTime.Millisecond.ToString("D3", CultureInfo.InvariantCulture);
 
             return readable;
         }

--- a/Tests/Opc.Ua.Core.Tests/Security/Certificates/CertificateStoreTest.cs
+++ b/Tests/Opc.Ua.Core.Tests/Security/Certificates/CertificateStoreTest.cs
@@ -236,7 +236,7 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
                 //Add Test PEM Chain
                 File.Copy(TestUtils.EnumerateTestAssets("Test_chain.pem").First(), certPath + Path.DirectorySeparatorChar + "Test_chain.pem");
 
-                var certificates = await store.Enumerate();
+                var certificates = await store.Enumerate().ConfigureAwait(false);
 
                 Assert.AreEqual(3, certificates.Count);
 
@@ -244,22 +244,22 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
                 File.WriteAllBytes(privatePath + Path.DirectorySeparatorChar + "Test_chain.pem", DecryptKeyPairPemBase64());
 
                 //refresh store to obtain private key
-                await store.Enumerate();
+                await store.Enumerate().ConfigureAwait(false);
 
 
                 //Load private key
-                var cert = await store.LoadPrivateKey("14A630438BF775E19169D3279069BBF20419EF84", null, null, null, null);
+                var cert = await store.LoadPrivateKey("14A630438BF775E19169D3279069BBF20419EF84", null, null, null, null).ConfigureAwait(false);
 
                 Assert.NotNull(cert);
                 Assert.True(cert.HasPrivateKey);
 
                 // remove leaf cert
-                await store.Delete("14A630438BF775E19169D3279069BBF20419EF84");
+                await store.Delete("14A630438BF775E19169D3279069BBF20419EF84").ConfigureAwait(false);
 
                 //remove private key
                 File.Delete(privatePath + Path.DirectorySeparatorChar + "Test_chain.pem");
 
-                certificates = await store.Enumerate();
+                certificates = await store.Enumerate().ConfigureAwait(false);
 
                 Assert.AreEqual(2, certificates.Count);
                 Assert.IsEmpty(certificates.Find(X509FindType.FindByThumbprint, "14A630438BF775E19169D3279069BBF20419EF84", false));
@@ -299,19 +299,19 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
                 // Add leaf cert with private key
                 File.WriteAllBytes(certPath + Path.DirectorySeparatorChar + "Test_keyPair.pem", DecryptKeyPairPemBase64());
 
-                var certificates = await store.Enumerate();
+                var certificates = await store.Enumerate().ConfigureAwait(false);
 
                 Assert.AreEqual(1, certificates.Count);
 
                 Assert.NotNull(certificates.Find(X509FindType.FindByThumbprint, "14A630438BF775E19169D3279069BBF20419EF84", false));
                 //Load private key
-                var cert = await store.LoadPrivateKey("14A630438BF775E19169D3279069BBF20419EF84", null, null, null, null);
+                var cert = await store.LoadPrivateKey("14A630438BF775E19169D3279069BBF20419EF84", null, null, null, null).ConfigureAwait(false);
 
                 Assert.NotNull(cert);
                 Assert.True(cert.HasPrivateKey);
 
                 // remove leaf cert
-                await store.Delete("14A630438BF775E19169D3279069BBF20419EF84");
+                await store.Delete("14A630438BF775E19169D3279069BBF20419EF84").ConfigureAwait(false);
 
                 //ensure private key is removed
                 Assert.False(File.Exists(certPath + Path.DirectorySeparatorChar + "Test_keyPair.pem"));

--- a/Tests/Opc.Ua.PubSub.Tests/Transport/UdpPubSubConnectionTests.cs
+++ b/Tests/Opc.Ua.PubSub.Tests/Transport/UdpPubSubConnectionTests.cs
@@ -34,6 +34,7 @@ using System.Linq;
 using System.Net;
 using System.Net.NetworkInformation;
 using System.Net.Sockets;
+using System.Runtime.InteropServices;
 using System.Threading;
 using NUnit.Framework;
 using Opc.Ua.PubSub.Encoding;
@@ -331,10 +332,14 @@ namespace Opc.Ua.PubSub.Tests.Transport
                 }
                 foreach (var uniIpAddrInfo in netI.GetIPProperties().UnicastAddresses.Where(x => netI.GetIPProperties().GatewayAddresses.Count > 0))
                 {
-                    if ((uniIpAddrInfo.Address.AddressFamily == AddressFamily.InterNetwork ||
-                        uniIpAddrInfo.Address.AddressFamily == AddressFamily.InterNetworkV6) &&
-                        uniIpAddrInfo.AddressPreferredLifetime != uint.MaxValue)
+                    if (uniIpAddrInfo.Address.AddressFamily == AddressFamily.InterNetwork ||
+                        uniIpAddrInfo.Address.AddressFamily == AddressFamily.InterNetworkV6)
                     {
+                        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) &&
+                           (uniIpAddrInfo.AddressPreferredLifetime == uint.MaxValue))
+                        {
+                            continue;
+                        }
                         addresses.Add(uniIpAddrInfo.Address);
                     }
                 }

--- a/Tests/Opc.Ua.Server.Tests/DurableMonitoredItemTests.cs
+++ b/Tests/Opc.Ua.Server.Tests/DurableMonitoredItemTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -1012,7 +1013,7 @@ namespace Opc.Ua.Server.Tests
             var statuscode2 = new ServiceResult(StatusCodes.Good);
             var dataValue2 = new DataValue(new Variant(false));
 
-            await Task.Delay(5);
+            await Task.Delay(5).ConfigureAwait(false);
 
             queueHandler.QueueValue(dataValue2, statuscode2);
 
@@ -1333,7 +1334,7 @@ namespace Opc.Ua.Server.Tests
 
             for (uint i = 0; i < 3000; i++)
             {
-                Assert.That(queue.Dequeue(out var value), string.Format("Dequeue operation failed for the {0}st item", i));
+                Assert.That(queue.Dequeue(out var value), string.Format(CultureInfo.InvariantCulture, "Dequeue operation failed for the {0}st item", i));
                 Assert.That(i, Is.EqualTo(value.ClientHandle));
 
                 //simulate publishing operation
@@ -1366,7 +1367,7 @@ namespace Opc.Ua.Server.Tests
 
             for (uint i = 0; i < 3000; i++)
             {
-                Assert.That(queue.Dequeue(out var value, out var _), string.Format("Dequeue operation failed for the {0}st item", i));
+                Assert.That(queue.Dequeue(out var value, out var _), string.Format(CultureInfo.InvariantCulture, "Dequeue operation failed for the {0}st item", i));
                 Assert.That(i, Is.EqualTo((uint)value.Value));
 
                 //simulate publishing operation


### PR DESCRIPTION
## Proposed changes

Fix Analyzer warnings (ConfigureAwait, CultureInfo)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.
