### PR TITLE
Make ICertificateStore use Async suffixes for methods returning a Task

### DIFF
--- a/Libraries/Opc.Ua.Configuration/ApplicationInstance.cs
+++ b/Libraries/Opc.Ua.Configuration/ApplicationInstance.cs
@@ -992,7 +992,7 @@ namespace Opc.Ua.Configuration
                     {
                         try
                         {
-                            bool deleted = await store.Delete(thumbprint).ConfigureAwait(false);
+                            bool deleted = await store.DeleteAsync(thumbprint).ConfigureAwait(false);
                             if (deleted)
                             {
                                 Utils.LogInfo(TraceMasks.Security, "Application Instance Certificate [{0}] deleted from trusted store.", thumbprint);
@@ -1011,7 +1011,7 @@ namespace Opc.Ua.Configuration
             {
                 using (ICertificateStore store = id.OpenStore())
                 {
-                    bool deleted = await store.Delete(certificate.Thumbprint).ConfigureAwait(false);
+                    bool deleted = await store.DeleteAsync(certificate.Thumbprint).ConfigureAwait(false);
                     if (deleted)
                     {
                         Utils.LogCertificate(TraceMasks.Security, "Application certificate and private key deleted.", certificate);
@@ -1059,7 +1059,7 @@ namespace Opc.Ua.Configuration
                 try
                 {
                     // check if it already exists.
-                    X509Certificate2Collection existingCertificates = await store.FindByThumbprint(certificate.Thumbprint).ConfigureAwait(false);
+                    X509Certificate2Collection existingCertificates = await store.FindByThumbprintAsync(certificate.Thumbprint).ConfigureAwait(false);
 
                     if (existingCertificates.Count > 0)
                     {
@@ -1071,7 +1071,7 @@ namespace Opc.Ua.Configuration
                     List<string> subjectName = X509Utils.ParseDistinguishedName(certificate.Subject);
 
                     // check for old certificate.
-                    X509Certificate2Collection certificates = await store.Enumerate().ConfigureAwait(false);
+                    X509Certificate2Collection certificates = await store.EnumerateAsync().ConfigureAwait(false);
 
                     for (int ii = 0; ii < certificates.Count; ii++)
                     {
@@ -1098,7 +1098,7 @@ namespace Opc.Ua.Configuration
                             if (deleteCert)
                             {
                                 Utils.LogCertificate("Delete Certificate from trusted store.", certificate);
-                                await store.Delete(certificates[ii].Thumbprint).ConfigureAwait(false);
+                                await store.DeleteAsync(certificates[ii].Thumbprint).ConfigureAwait(false);
                                 break;
                             }
                         }
@@ -1107,7 +1107,7 @@ namespace Opc.Ua.Configuration
                     // add new certificate.
                     X509Certificate2 publicKey = X509CertificateLoader.LoadCertificate(certificate.RawData);
 
-                    await store.Add(publicKey).ConfigureAwait(false);
+                    await store.AddAsync(publicKey).ConfigureAwait(false);
 
                     Utils.LogInfo("Added application certificate to trusted peer store.");
                 }

--- a/Libraries/Opc.Ua.Gds.Server.Common/ApplicationsNodeManager.cs
+++ b/Libraries/Opc.Ua.Gds.Server.Common/ApplicationsNodeManager.cs
@@ -715,7 +715,7 @@ namespace Opc.Ua.Gds.Server
                 {
                     try
                     {
-                        chain.ChainPolicy.ExtraStore.AddRange(store.Enumerate().GetAwaiter().GetResult());
+                        chain.ChainPolicy.ExtraStore.AddRange(store.EnumerateAsync().GetAwaiter().GetResult());
                     }
                     finally
                     {
@@ -1356,7 +1356,7 @@ namespace Opc.Ua.Gds.Server
             var certificateStoreIdentifier = new CertificateStoreIdentifier(m_globalDiscoveryServerConfiguration.ApplicationCertificatesStorePath);
             using (ICertificateStore store = certificateStoreIdentifier.OpenStore())
             {
-                store?.Add(certificate).Wait();
+                store?.AddAsync(certificate).Wait();
             }
 
             m_database.SetApplicationCertificate(applicationId, m_certTypeMap[certificateTypeNodeId], signedCertificate);

--- a/Libraries/Opc.Ua.Gds.Server.Common/GlobalDiscoverySampleServer.cs
+++ b/Libraries/Opc.Ua.Gds.Server.Common/GlobalDiscoverySampleServer.cs
@@ -254,7 +254,7 @@ namespace Opc.Ua.Gds.Server
             var certificateStoreIdentifier = new CertificateStoreIdentifier(configuration.ApplicationCertificatesStorePath);
             using (ICertificateStore ApplicationsStore = certificateStoreIdentifier.OpenStore())
             {
-                var matchingCerts = ApplicationsStore.FindByThumbprint(applicationInstanceCertificate.Thumbprint).Result;
+                var matchingCerts = ApplicationsStore.FindByThumbprintAsync(applicationInstanceCertificate.Thumbprint).Result;
 
                 if (matchingCerts.Contains(applicationInstanceCertificate))
                 {
@@ -270,7 +270,7 @@ namespace Opc.Ua.Gds.Server
             certificateStoreIdentifier = new CertificateStoreIdentifier(configuration.AuthoritiesStorePath);
             using (ICertificateStore AuthoritiesStore = certificateStoreIdentifier.OpenStore())
             {
-                var crls = AuthoritiesStore.EnumerateCRLs().Result;
+                var crls = AuthoritiesStore.EnumerateCRLsAsync().Result;
                 foreach (X509CRL crl in crls)
                 {
                     if (crl.IsRevoked(applicationInstanceCertificate))

--- a/Libraries/Opc.Ua.Server/Configuration/ConfigurationNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/Configuration/ConfigurationNodeManager.cs
@@ -571,10 +571,10 @@ namespace Opc.Ua.Server
                             }
 
                             Utils.LogCertificate(Utils.TraceMasks.Security, "Delete application certificate: ", existingCertIdentifier.Certificate);
-                            appStore.Delete(existingCertIdentifier.Thumbprint).Wait();
+                            appStore.DeleteAsync(existingCertIdentifier.Thumbprint).Wait();
                             Utils.LogCertificate(Utils.TraceMasks.Security, "Add new application certificate: ", updateCertificate.CertificateWithPrivateKey);
                             var passwordProvider = m_configuration.SecurityConfiguration.CertificatePasswordProvider;
-                            appStore.Add(updateCertificate.CertificateWithPrivateKey, passwordProvider?.GetPassword(existingCertIdentifier)).Wait();
+                            appStore.AddAsync(updateCertificate.CertificateWithPrivateKey, passwordProvider?.GetPassword(existingCertIdentifier)).Wait();
                             // keep only track of cert without private key
                             var certOnly = X509CertificateLoader.LoadCertificate(updateCertificate.CertificateWithPrivateKey.RawData);
                             updateCertificate.CertificateWithPrivateKey.Dispose();
@@ -596,7 +596,7 @@ namespace Opc.Ua.Server
                                 try
                                 {
                                     Utils.LogCertificate(Utils.TraceMasks.Security, "Add new issuer certificate: ", issuer);
-                                    issuerStore.Add(issuer).Wait();
+                                    issuerStore.AddAsync(issuer).Wait();
                                 }
                                 catch (ArgumentException)
                                 {
@@ -789,7 +789,7 @@ namespace Opc.Ua.Server
             {
                 if (store != null)
                 {
-                    X509Certificate2Collection collection = store.Enumerate().Result;
+                    X509Certificate2Collection collection = store.EnumerateAsync().Result;
                     List<byte[]> rawList = new List<byte[]>();
                     foreach (var cert in collection)
                     {

--- a/Libraries/Opc.Ua.Server/Configuration/TrustList.cs
+++ b/Libraries/Opc.Ua.Server/Configuration/TrustList.cs
@@ -151,7 +151,7 @@ namespace Opc.Ua.Server
 
                     if ((masks & TrustListMasks.TrustedCertificates) != 0)
                     {
-                        X509Certificate2Collection certificates = store.Enumerate().GetAwaiter().GetResult();
+                        X509Certificate2Collection certificates = store.EnumerateAsync().GetAwaiter().GetResult();
                         foreach (var certificate in certificates)
                         {
                             trustList.TrustedCertificates.Add(certificate.RawData);
@@ -160,7 +160,7 @@ namespace Opc.Ua.Server
 
                     if ((masks & TrustListMasks.TrustedCrls) != 0)
                     {
-                        foreach (var crl in store.EnumerateCRLs().GetAwaiter().GetResult())
+                        foreach (var crl in store.EnumerateCRLsAsync().GetAwaiter().GetResult())
                         {
                             trustList.TrustedCrls.Add(crl.RawData);
                         }
@@ -183,7 +183,7 @@ namespace Opc.Ua.Server
 
                     if ((masks & TrustListMasks.IssuerCertificates) != 0)
                     {
-                        X509Certificate2Collection certificates = store.Enumerate().GetAwaiter().GetResult();
+                        X509Certificate2Collection certificates = store.EnumerateAsync().GetAwaiter().GetResult();
                         foreach (var certificate in certificates)
                         {
                             trustList.IssuerCertificates.Add(certificate.RawData);
@@ -192,7 +192,7 @@ namespace Opc.Ua.Server
 
                     if ((masks & TrustListMasks.IssuerCrls) != 0)
                     {
-                        foreach (var crl in store.EnumerateCRLs().GetAwaiter().GetResult())
+                        foreach (var crl in store.EnumerateCRLsAsync().GetAwaiter().GetResult())
                         {
                             trustList.IssuerCrls.Add(crl.RawData);
                         }
@@ -490,7 +490,7 @@ namespace Opc.Ua.Server
                     {
                         if (cert != null && store != null)
                         {
-                            store.Add(cert).GetAwaiter().GetResult();
+                            store.AddAsync(cert).GetAwaiter().GetResult();
                         }
                     }
                     finally
@@ -542,7 +542,7 @@ namespace Opc.Ua.Server
                             throw new ServiceResultException(StatusCodes.BadConfigurationError, "Failed to open certificate store.");
                         }
 
-                        var certCollection = store.FindByThumbprint(thumbprint).GetAwaiter().GetResult();
+                        var certCollection = store.FindByThumbprintAsync(thumbprint).GetAwaiter().GetResult();
 
                         if (certCollection.Count == 0)
                         {
@@ -552,7 +552,7 @@ namespace Opc.Ua.Server
                         {
                             // delete all CRLs signed by cert
                             var crlsToDelete = new X509CRLCollection();
-                            foreach (var crl in store.EnumerateCRLs().GetAwaiter().GetResult())
+                            foreach (var crl in store.EnumerateCRLsAsync().GetAwaiter().GetResult())
                             {
                                 foreach (var cert in certCollection)
                                 {
@@ -565,7 +565,7 @@ namespace Opc.Ua.Server
                                 }
                             }
 
-                            if (!store.Delete(thumbprint).GetAwaiter().GetResult())
+                            if (!store.DeleteAsync(thumbprint).GetAwaiter().GetResult())
                             {
                                 result = StatusCodes.BadInvalidArgument;
                             }
@@ -573,7 +573,7 @@ namespace Opc.Ua.Server
                             {
                                 foreach (var crl in crlsToDelete)
                                 {
-                                    if (!store.DeleteCRL(crl).GetAwaiter().GetResult())
+                                    if (!store.DeleteCRLAsync(crl).GetAwaiter().GetResult())
                                     {
                                         // intentionally ignore errors, try best effort
                                         Utils.LogError("RemoveCertificate: Failed to delete CRL {0}.", crl.ToString());
@@ -646,12 +646,12 @@ namespace Opc.Ua.Server
                         throw new ServiceResultException(StatusCodes.BadConfigurationError, "Failed to open certificate store.");
                     }
 
-                    var storeCrls = await store.EnumerateCRLs().ConfigureAwait(false);
+                    var storeCrls = await store.EnumerateCRLsAsync().ConfigureAwait(false);
                     foreach (var crl in storeCrls)
                     {
                         if (!updatedCrls.Contains(crl))
                         {
-                            if (!await store.DeleteCRL(crl).ConfigureAwait(false))
+                            if (!await store.DeleteCRLAsync(crl).ConfigureAwait(false))
                             {
                                 result = false;
                             }
@@ -663,7 +663,7 @@ namespace Opc.Ua.Server
                     }
                     foreach (var crl in updatedCrls)
                     {
-                        await store.AddCRL(crl).ConfigureAwait(false);
+                        await store.AddCRLAsync(crl).ConfigureAwait(false);
                     }
                 }
                 finally
@@ -693,12 +693,12 @@ namespace Opc.Ua.Server
                         throw new ServiceResultException(StatusCodes.BadConfigurationError, "Failed to open certificate store.");
                     }
 
-                    var storeCerts = await store.Enumerate().ConfigureAwait(false);
+                    var storeCerts = await store.EnumerateAsync().ConfigureAwait(false);
                     foreach (var cert in storeCerts)
                     {
                         if (!updatedCerts.Contains(cert))
                         {
-                            if (!await store.Delete(cert.Thumbprint).ConfigureAwait(false))
+                            if (!await store.DeleteAsync(cert.Thumbprint).ConfigureAwait(false))
                             {
                                 result = false;
                             }
@@ -710,7 +710,7 @@ namespace Opc.Ua.Server
                     }
                     foreach (var cert in updatedCerts)
                     {
-                        await store.Add(cert).ConfigureAwait(false);
+                        await store.AddAsync(cert).ConfigureAwait(false);
                     }
                 }
                 finally

--- a/Stack/Opc.Ua.Core/Security/Certificates/CertificateIdentifier.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/CertificateIdentifier.cs
@@ -200,12 +200,12 @@ namespace Opc.Ua
                     if (store?.SupportsLoadPrivateKey == true)
                     {
                         string password = passwordProvider?.GetPassword(this);
-                        m_certificate = await store.LoadPrivateKey(this.Thumbprint, this.SubjectName, null, this.CertificateType, password).ConfigureAwait(false);
+                        m_certificate = await store.LoadPrivateKeyAsync(this.Thumbprint, this.SubjectName, null, this.CertificateType, password).ConfigureAwait(false);
 
                         //find certificate by applicationUri instead of subjectName, as the subjectName could have changed after a certificate update
                         if (m_certificate == null && !string.IsNullOrEmpty(applicationUri))
                         {
-                            m_certificate = await store.LoadPrivateKey(this.Thumbprint, null, applicationUri, this.CertificateType, password).ConfigureAwait(false);
+                            m_certificate = await store.LoadPrivateKeyAsync(this.Thumbprint, null, applicationUri, this.CertificateType, password).ConfigureAwait(false);
                         }
 
                         return m_certificate;
@@ -258,7 +258,7 @@ namespace Opc.Ua
                         return null;
                     }
 
-                    X509Certificate2Collection collection = await store.Enumerate().ConfigureAwait(false);
+                    X509Certificate2Collection collection = await store.EnumerateAsync().ConfigureAwait(false);
 
                     certificate = Find(collection, m_thumbprint, m_subjectName, applicationUri, m_certificateType, needPrivateKey);
 
@@ -828,7 +828,14 @@ namespace Opc.Ua
         public bool NoPrivateKeys => true;
 
         /// <inheritdoc/>
-        public async Task<X509Certificate2Collection> Enumerate()
+        [Obsolete("Use EnumerateAsync instead")]
+        public Task<X509Certificate2Collection> Enumerate()
+        {
+            return EnumerateAsync();
+        }
+
+        /// <inheritdoc/>
+        public async Task<X509Certificate2Collection> EnumerateAsync()
         {
             X509Certificate2Collection collection = new X509Certificate2Collection();
 
@@ -846,7 +853,13 @@ namespace Opc.Ua
         }
 
         /// <inheritdoc/>
-        public async Task Add(X509Certificate2 certificate, string password = null)
+        public Task Add(X509Certificate2 certificate, string password = null)
+        {
+            return AddAsync(certificate, password);
+        }
+
+        /// <inheritdoc/>
+        public async Task AddAsync(X509Certificate2 certificate, string password = null)
         {
             if (certificate == null) throw new ArgumentNullException(nameof(certificate));
 
@@ -868,7 +881,14 @@ namespace Opc.Ua
         }
 
         /// <inheritdoc/>
-        public async Task<bool> Delete(string thumbprint)
+        [Obsolete("Use DeleteAsync instead.")]
+        public Task<bool> Delete(string thumbprint)
+        {
+            return DeleteAsync(thumbprint);
+        }
+
+        /// <inheritdoc/>
+        public async Task<bool> DeleteAsync(string thumbprint)
         {
             if (String.IsNullOrEmpty(thumbprint))
             {
@@ -890,7 +910,14 @@ namespace Opc.Ua
         }
 
         /// <inheritdoc/>
-        public async Task<X509Certificate2Collection> FindByThumbprint(string thumbprint)
+        [Obsolete("Use FindByThumbprintAsync instead.")]
+        public Task<X509Certificate2Collection> FindByThumbprint(string thumbprint)
+        {
+            return FindByThumbprintAsync(thumbprint);
+        }
+
+        /// <inheritdoc/>
+        public async Task<X509Certificate2Collection> FindByThumbprintAsync(string thumbprint)
         {
             if (String.IsNullOrEmpty(thumbprint))
             {
@@ -913,6 +940,8 @@ namespace Opc.Ua
         /// <inheritdoc/>
         public bool SupportsLoadPrivateKey => false;
 
+
+
         /// <inheritdoc/>
         public Task<X509Certificate2> LoadPrivateKey(string thumbprint, string subjectName, string password)
         {
@@ -920,7 +949,15 @@ namespace Opc.Ua
         }
 
         /// <inheritdoc/>
+        /// <remarks>The LoadPrivateKey special handling is not necessary in this store.</remarks>
+        [Obsolete("Use LoadPrivateKeyAsync instead.")]
         public Task<X509Certificate2> LoadPrivateKey(string thumbprint, string subjectName, string applicationUri, NodeId certificateType, string password)
+        {
+            return LoadPrivateKeyAsync(thumbprint, subjectName, applicationUri, certificateType, password);
+        }
+
+        /// <inheritdoc/>
+        public Task<X509Certificate2> LoadPrivateKeyAsync(string thumbprint, string subjectName, string applicationUri, NodeId certificateType, string password)
         {
             return Task.FromResult<X509Certificate2>(null);
         }
@@ -929,37 +966,79 @@ namespace Opc.Ua
         public bool SupportsCRLs => false;
 
         /// <inheritdoc/>
+        [Obsolete("Use IsRevokedAsync instead.")]
         public Task<StatusCode> IsRevoked(X509Certificate2 issuer, X509Certificate2 certificate)
+        {
+            return IsRevokedAsync(issuer, certificate);
+        }
+
+        /// <inheritdoc/>
+        public Task<StatusCode> IsRevokedAsync(X509Certificate2 issuer, X509Certificate2 certificate)
         {
             return Task.FromResult((StatusCode)StatusCodes.BadNotSupported);
         }
 
         /// <inheritdoc/>
+        [Obsolete("Use EnumerateCRLsAsync instead.")]
         public Task<X509CRLCollection> EnumerateCRLs()
         {
-            return Task.FromResult(new X509CRLCollection());
+            return EnumerateCRLsAsync();
         }
 
         /// <inheritdoc/>
-        public Task<X509CRLCollection> EnumerateCRLs(X509Certificate2 issuer, bool validateUpdateTime = true)
+        public Task<X509CRLCollection> EnumerateCRLsAsync()
         {
             return Task.FromResult(new X509CRLCollection());
         }
 
         /// <inheritdoc/>
+        [Obsolete("Use EnumerateCRLsAsync instead.")]
+        public Task<X509CRLCollection> EnumerateCRLs(X509Certificate2 issuer, bool validateUpdateTime = true)
+        {
+            return EnumerateCRLsAsync(issuer, validateUpdateTime);
+        }
+
+        /// <inheritdoc/>
+        public Task<X509CRLCollection> EnumerateCRLsAsync(X509Certificate2 issuer, bool validateUpdateTime = true)
+        {
+            return Task.FromResult(new X509CRLCollection());
+        }
+
+        /// <inheritdoc/>
+        [Obsolete("Use AddCRLAsync instead")]
         public Task AddCRL(X509CRL crl)
         {
             throw new ServiceResultException(StatusCodes.BadNotSupported);
         }
 
         /// <inheritdoc/>
-        public Task<bool> DeleteCRL(X509CRL crl)
+        public Task AddCRLAsync(X509CRL crl)
         {
             throw new ServiceResultException(StatusCodes.BadNotSupported);
         }
 
         /// <inheritdoc/>
+        [Obsolete("Use DeleteCRLAsync instead.")]
+        public Task<bool> DeleteCRL(X509CRL crl)
+        {
+            return DeleteCRLAsync(crl);
+        }
+
+        /// <inheritdoc/>
+        public Task<bool> DeleteCRLAsync(X509CRL crl)
+        {
+            throw new ServiceResultException(StatusCodes.BadNotSupported);
+        }
+
+        /// <inheritdoc/>
+        [Obsolete("Use AddRejectedAsync instead.")]
         public Task AddRejected(X509Certificate2Collection certificates, int maxCertificates)
+        {
+            return Task.CompletedTask;
+        }
+
+        /// <inheritdoc/>
+        public Task AddRejectedAsync(X509Certificate2Collection certificates, int maxCertificates)
         {
             return Task.CompletedTask;
         }

--- a/Stack/Opc.Ua.Core/Security/Certificates/CertificateTrustList.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/CertificateTrustList.cs
@@ -69,7 +69,7 @@ namespace Opc.Ua
                         throw new ServiceResultException(StatusCodes.BadConfigurationError, "Failed to open certificate store.");
                     }
 
-                    collection = await store.Enumerate().ConfigureAwait(false);
+                    collection = await store.EnumerateAsync().ConfigureAwait(false);
 
                 }
                 catch (Exception)

--- a/Stack/Opc.Ua.Core/Security/Certificates/CertificateValidator.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/CertificateValidator.cs
@@ -911,7 +911,7 @@ namespace Opc.Ua
                         if (store != null)
                         {
                             // number of certs for history + current chain
-                            await store.AddRejected(certificateChain, m_maxRejectedCertificates).ConfigureAwait(false);
+                            await store.AddRejectedAsync(certificateChain, m_maxRejectedCertificates).ConfigureAwait(false);
                         }
                     }
                     finally
@@ -960,7 +960,7 @@ namespace Opc.Ua
                 {
                     try
                     {
-                        X509Certificate2Collection trusted = await store.FindByThumbprint(certificate.Thumbprint).ConfigureAwait(false);
+                        X509Certificate2Collection trusted = await store.FindByThumbprintAsync(certificate.Thumbprint).ConfigureAwait(false);
 
                         for (int ii = 0; ii < trusted.Count; ii++)
                         {
@@ -1097,7 +1097,7 @@ namespace Opc.Ua
                         return (null, null);
                     }
 
-                    X509Certificate2Collection certificates = await store.Enumerate().ConfigureAwait(false);
+                    X509Certificate2Collection certificates = await store.EnumerateAsync().ConfigureAwait(false);
 
                     for (int ii = 0; ii < certificates.Count; ii++)
                     {
@@ -1116,7 +1116,7 @@ namespace Opc.Ua
 
                                 if (checkRecovationStatus)
                                 {
-                                    StatusCode status = await store.IsRevoked(issuer, certificate).ConfigureAwait(false);
+                                    StatusCode status = await store.IsRevokedAsync(issuer, certificate).ConfigureAwait(false);
 
                                     if (StatusCode.IsBad(status) && status != StatusCodes.BadNotSupported)
                                     {

--- a/Stack/Opc.Ua.Core/Security/Certificates/DirectoryCertificateStore.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/DirectoryCertificateStore.cs
@@ -146,7 +146,14 @@ namespace Opc.Ua
         public bool NoPrivateKeys { get; private set; }
 
         /// <inheritdoc/>
+        [Obsolete("Use EnumerateAsync instead.")]
         public Task<X509Certificate2Collection> Enumerate()
+        {
+            return EnumerateAsync();
+        }
+
+        /// <inheritdoc/>
+        public Task<X509Certificate2Collection> EnumerateAsync()
         {
             lock (m_lock)
             {
@@ -170,7 +177,14 @@ namespace Opc.Ua
         }
 
         /// <inheritdoc/>
+        [Obsolete("Use AddAsync instead.")]
         public Task Add(X509Certificate2 certificate, string password = null)
+        {
+            return AddAsync(certificate, password);
+        }
+
+        /// <inheritdoc/>
+        public Task AddAsync(X509Certificate2 certificate, string password = null)
         {
             if (certificate == null) throw new ArgumentNullException(nameof(certificate));
 
@@ -215,7 +229,14 @@ namespace Opc.Ua
         }
 
         /// <inheritdoc/>
+        [Obsolete("Use AddRejectedAsync instead.")]
         public Task AddRejected(X509Certificate2Collection certificates, int maxCertificates)
+        {
+            return AddRejectedAsync(certificates, maxCertificates);
+        }
+
+        /// <inheritdoc/>
+        public Task AddRejectedAsync(X509Certificate2Collection certificates, int maxCertificates)
         {
             if (certificates == null) throw new ArgumentNullException(nameof(certificates));
 
@@ -297,7 +318,14 @@ namespace Opc.Ua
         }
 
         /// <inheritdoc/>
-        public async Task<bool> Delete(string thumbprint)
+        [Obsolete("Use DeleteAsync instead.")]
+        public Task<bool> Delete(string thumbprint)
+        {
+            return DeleteAsync(thumbprint);
+        }
+
+        /// <inheritdoc/>
+        public async Task<bool> DeleteAsync(string thumbprint)
         {
             const int kRetries = 5;
             const int kRetryDelay = 100;
@@ -389,7 +417,14 @@ namespace Opc.Ua
         }
 
         /// <inheritdoc/>
+        [Obsolete("Use FindByThumbprintAsync instead.")]
         public Task<X509Certificate2Collection> FindByThumbprint(string thumbprint)
+        {
+            return FindByThumbprintAsync(thumbprint);
+        }
+
+        /// <inheritdoc/>
+        public Task<X509Certificate2Collection> FindByThumbprintAsync(string thumbprint)
         {
             var certificates = new X509Certificate2Collection();
 
@@ -460,10 +495,17 @@ namespace Opc.Ua
         /// <inheritdoc/>
         public bool SupportsLoadPrivateKey => true;
 
+        /// <inheritdoc/>
+        [Obsolete("Use LoadPrivateKeyAsync instead.")]
+        public Task<X509Certificate2> LoadPrivateKey(string thumbprint, string subjectName, string applicationUri, NodeId certificateType, string password)
+        {
+            return LoadPrivateKeyAsync(thumbprint, subjectName, applicationUri, certificateType, password);
+        }
+
         /// <summary>
         /// Loads the private key from a PFX file in the certificate store.
         /// </summary>
-        public async Task<X509Certificate2> LoadPrivateKey(string thumbprint, string subjectName, string applicationUri, NodeId certificateType, string password)
+        public async Task<X509Certificate2> LoadPrivateKeyAsync(string thumbprint, string subjectName, string applicationUri, NodeId certificateType, string password)
         {
             if (NoPrivateKeys || m_privateKeySubdir == null ||
                 m_certificateSubdir == null || !m_certificateSubdir.Exists)
@@ -669,7 +711,14 @@ namespace Opc.Ua
         }
 
         /// <inheritdoc/>
+        [Obsolete("Use IsRevokedAsync instead.")]
         public Task<StatusCode> IsRevoked(X509Certificate2 issuer, X509Certificate2 certificate)
+        {
+            return IsRevokedAsync(issuer, certificate);
+        }
+
+        /// <inheritdoc/>
+        public Task<StatusCode> IsRevokedAsync(X509Certificate2 issuer, X509Certificate2 certificate)
         {
             if (issuer == null)
             {
@@ -736,7 +785,14 @@ namespace Opc.Ua
         public bool SupportsCRLs { get { return true; } }
 
         /// <inheritdoc/>
+        [Obsolete("Use EnumerateCRLsAsync instead.")]
         public Task<X509CRLCollection> EnumerateCRLs()
+        {
+            return EnumerateCRLsAsync();
+        }
+
+        /// <inheritdoc/>
+        public Task<X509CRLCollection> EnumerateCRLsAsync()
         {
             var crls = new X509CRLCollection();
 
@@ -763,7 +819,14 @@ namespace Opc.Ua
         }
 
         /// <inheritdoc/>
-        public async Task<X509CRLCollection> EnumerateCRLs(X509Certificate2 issuer, bool validateUpdateTime = true)
+        [Obsolete("Use EnumerateCRLsAsync instead.")]
+        public Task<X509CRLCollection> EnumerateCRLs(X509Certificate2 issuer, bool validateUpdateTime = true)
+        {
+            return EnumerateCRLsAsync(issuer, validateUpdateTime);
+        }
+
+        /// <inheritdoc/>
+        public async Task<X509CRLCollection> EnumerateCRLsAsync(X509Certificate2 issuer, bool validateUpdateTime = true)
         {
             if (issuer == null)
             {
@@ -771,7 +834,7 @@ namespace Opc.Ua
             }
 
             var crls = new X509CRLCollection();
-            foreach (X509CRL crl in await EnumerateCRLs().ConfigureAwait(false))
+            foreach (X509CRL crl in await EnumerateCRLsAsync().ConfigureAwait(false))
             {
                 if (!X509Utils.CompareDistinguishedName(crl.IssuerName, issuer.SubjectName))
                 {
@@ -794,7 +857,14 @@ namespace Opc.Ua
         }
 
         /// <inheritdoc/>
-        public async Task AddCRL(X509CRL crl)
+        [Obsolete("Use AddCRLAsync instead.")]
+        public Task AddCRL(X509CRL crl)
+        {
+            return AddCRLAsync(crl);
+        }
+
+        /// <inheritdoc/>
+        public async Task AddCRLAsync(X509CRL crl)
         {
             if (crl == null)
             {
@@ -803,7 +873,7 @@ namespace Opc.Ua
 
             X509Certificate2 issuer = null;
             X509Certificate2Collection certificates = null;
-            certificates = await Enumerate().ConfigureAwait(false);
+            certificates = await EnumerateAsync().ConfigureAwait(false);
             foreach (X509Certificate2 certificate in certificates)
             {
                 if (X509Utils.CompareDistinguishedName(certificate.SubjectName, crl.IssuerName))
@@ -836,7 +906,14 @@ namespace Opc.Ua
         }
 
         /// <inheritdoc/>
+        [Obsolete("Use DeleteCRLAsync instead.")]
         public Task<bool> DeleteCRL(X509CRL crl)
+        {
+            return DeleteCRLAsync(crl);
+        }
+
+        /// <inheritdoc/>
+        public Task<bool> DeleteCRLAsync(X509CRL crl)
         {
             if (crl == null)
             {

--- a/Stack/Opc.Ua.Core/Security/Certificates/ICertificateStore.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/ICertificateStore.cs
@@ -58,14 +58,28 @@ namespace Opc.Ua
         /// <summary>
         /// Enumerates the certificates in the store.
         /// </summary>
+        [Obsolete("Use EnumerateAsync instead.")]
         Task<X509Certificate2Collection> Enumerate();
+
+        /// <summary>
+        /// Enumerates the certificates in the store.
+        /// </summary>
+        Task<X509Certificate2Collection> EnumerateAsync();
 
         /// <summary>
         /// Adds a certificate to the store.
         /// </summary>
         /// <param name="certificate">The certificate.</param>
         /// <param name="password">The certificate password.</param>
+        [Obsolete("Use AddAsync instead.")]
         Task Add(X509Certificate2 certificate, string password = null);
+
+        /// <summary>
+        /// Adds a certificate to the store.
+        /// </summary>
+        /// <param name="certificate">The certificate.</param>
+        /// <param name="password">The certificate password.</param>
+        Task AddAsync(X509Certificate2 certificate, string password = null);
 
         /// <summary>
         /// Adds a rejected certificate chain to the store.
@@ -73,21 +87,46 @@ namespace Opc.Ua
         /// <param name="certificates">The certificate collection.</param>
         /// <param name="maxCertificates">The max number of rejected certificates to keep in the store.
         /// A negative number keeps no history, 0 is unlimited.</param>
+        [Obsolete("Use AddRejectedAsync instead.")]
         Task AddRejected(X509Certificate2Collection certificates, int maxCertificates);
+
+        /// <summary>
+        /// Adds a rejected certificate chain to the store.
+        /// </summary>
+        /// <param name="certificates">The certificate collection.</param>
+        /// <param name="maxCertificates">The max number of rejected certificates to keep in the store.
+        /// A negative number keeps no history, 0 is unlimited.</param>
+        Task AddRejectedAsync(X509Certificate2Collection certificates, int maxCertificates);
 
         /// <summary>
         /// Deletes a certificate from the store.
         /// </summary>
         /// <param name="thumbprint">The thumbprint.</param>
         /// <returns>True if the certificate exists.</returns>
+        [Obsolete("Use DeleteAsync instead.")]
         Task<bool> Delete(string thumbprint);
+
+        /// <summary>
+        /// Deletes a certificate from the store.
+        /// </summary>
+        /// <param name="thumbprint">The thumbprint.</param>
+        /// <returns>True if the certificate exists.</returns>
+        Task<bool> DeleteAsync(string thumbprint);
 
         /// <summary>
         /// Finds the certificate with the specified thumbprint.
         /// </summary>
         /// <param name="thumbprint">The thumbprint.</param>
         /// <returns>The matching certificate</returns>
+        [Obsolete("Use FindByThumbprintAsync instead.")]
         Task<X509Certificate2Collection> FindByThumbprint(string thumbprint);
+
+        /// <summary>
+        /// Finds the certificate with the specified thumbprint.
+        /// </summary>
+        /// <param name="thumbprint">The thumbprint.</param>
+        /// <returns>The matching certificate</returns>
+        Task<X509Certificate2Collection> FindByThumbprintAsync(string thumbprint);
 
         /// <summary>
         /// If the store supports the LoadPrivateKey operation.
@@ -104,12 +143,31 @@ namespace Opc.Ua
         /// <param name="password">The certificate password.</param>
         /// <remarks>Returns always null if SupportsLoadPrivateKey returns false.</remarks>
         /// <returns>The matching certificate with private key</returns>
+        [Obsolete("Use LoadPrivateKeyAsync instead.")]
         Task<X509Certificate2> LoadPrivateKey(string thumbprint, string subjectName, string applicationUri, NodeId certificateType, string password);
+
+        /// <summary>
+        /// Finds the certificate with the specified thumbprint.
+        /// </summary>
+        /// <param name="thumbprint">The thumbprint.</param>
+        /// <param name="subjectName">The certificate subject.</param>
+        /// <param name="applicationUri">The application uri in the cert extension.</param>
+        /// <param name="certificateType">The certificate type to load.</param>
+        /// <param name="password">The certificate password.</param>
+        /// <remarks>Returns always null if SupportsLoadPrivateKey returns false.</remarks>
+        /// <returns>The matching certificate with private key</returns>
+        Task<X509Certificate2> LoadPrivateKeyAsync(string thumbprint, string subjectName, string applicationUri, NodeId certificateType, string password);
 
         /// <summary>
         /// Checks if issuer has revoked the certificate.
         /// </summary>
+        [Obsolete("Use IsRevokedAsync instead.")]
         Task<StatusCode> IsRevoked(X509Certificate2 issuer, X509Certificate2 certificate);
+
+        /// <summary>
+        /// Checks if issuer has revoked the certificate.
+        /// </summary>
+        Task<StatusCode> IsRevokedAsync(X509Certificate2 issuer, X509Certificate2 certificate);
 
         /// <summary>
         /// Whether the store supports CRLs.
@@ -119,21 +177,45 @@ namespace Opc.Ua
         /// <summary>
         /// Returns the CRLs in the store.
         /// </summary>
+        [Obsolete("Use EnumerateCRLsAsync instead.")]
         Task<X509CRLCollection> EnumerateCRLs();
+
+        /// <summary>
+        /// Returns the CRLs in the store.
+        /// </summary>
+        Task<X509CRLCollection> EnumerateCRLsAsync();
 
         /// <summary>
         /// Returns the CRLs for the issuer.
         /// </summary>
+        [Obsolete("Use EnumerateCRLsAsync instead.")]
         Task<X509CRLCollection> EnumerateCRLs(X509Certificate2 issuer, bool validateUpdateTime = true);
+
+        /// <summary>
+        /// Returns the CRLs for the issuer.
+        /// </summary>
+        Task<X509CRLCollection> EnumerateCRLsAsync(X509Certificate2 issuer, bool validateUpdateTime = true);
 
         /// <summary>
         /// Adds a CRL to the store.
         /// </summary>
+        [Obsolete("Use AddCRLAsync instead.")]
         Task AddCRL(X509CRL crl);
+
+        /// <summary>
+        /// Adds a CRL to the store.
+        /// </summary>
+        Task AddCRLAsync(X509CRL crl);
 
         /// <summary>
         /// Removes a CRL from the store.
         /// </summary>
+        [Obsolete("Use DeleteCRLAsync instead.")]
         Task<bool> DeleteCRL(X509CRL crl);
+
+        /// <summary>
+        /// Removes a CRL from the store.
+        /// </summary>
+        Task<bool> DeleteCRLAsync(X509CRL crl);
     };
 }

--- a/Stack/Opc.Ua.Core/Security/Certificates/X509CertificateStore/X509CertificateStore.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/X509CertificateStore/X509CertificateStore.cs
@@ -125,7 +125,14 @@ namespace Opc.Ua
         public bool NoPrivateKeys => m_noPrivateKeys;
 
         /// <inheritdoc/>
+        [Obsolete("Use EnumerateAsync instead.")]
         public Task<X509Certificate2Collection> Enumerate()
+        {
+            return EnumerateAsync();
+        }
+
+        /// <inheritdoc/>
+        public Task<X509Certificate2Collection> EnumerateAsync()
         {
             using (X509Store store = new X509Store(m_storeName, m_storeLocation))
             {
@@ -135,7 +142,14 @@ namespace Opc.Ua
         }
 
         /// <inheritdoc/>
+        [Obsolete("Use AddAsync instead.")]
         public Task Add(X509Certificate2 certificate, string password = null)
+        {
+            return AddAsync(certificate, password);
+        }
+
+        /// <inheritdoc/>
+        public Task AddAsync(X509Certificate2 certificate, string password = null)
         {
             if (certificate == null) throw new ArgumentNullException(nameof(certificate));
 
@@ -171,7 +185,14 @@ namespace Opc.Ua
         }
 
         /// <inheritdoc/>
+        [Obsolete("Use DeleteAsync instead.")]
         public Task<bool> Delete(string thumbprint)
+        {
+            return DeleteAsync(thumbprint);
+        }
+
+        /// <inheritdoc/>
+        public Task<bool> DeleteAsync(string thumbprint)
         {
             using (X509Store store = new X509Store(m_storeName, m_storeLocation))
             {
@@ -190,7 +211,14 @@ namespace Opc.Ua
         }
 
         /// <inheritdoc/>
+        [Obsolete("Use FindByThumbprintAsync instead.")]
         public Task<X509Certificate2Collection> FindByThumbprint(string thumbprint)
+        {
+            return FindByThumbprintAsync(thumbprint);
+        }
+
+        /// <inheritdoc/>
+        public Task<X509Certificate2Collection> FindByThumbprintAsync(string thumbprint)
         {
             using (X509Store store = new X509Store(m_storeName, m_storeLocation))
             {
@@ -215,7 +243,15 @@ namespace Opc.Ua
 
         /// <inheritdoc/>
         /// <remarks>The LoadPrivateKey special handling is not necessary in this store.</remarks>
+        [Obsolete("Use LoadPrivateKeyAsync instead.")]
         public Task<X509Certificate2> LoadPrivateKey(string thumbprint, string subjectName, string applicationUri, NodeId certificateType, string password)
+        {
+            return Task.FromResult<X509Certificate2>(null);
+        }
+
+        /// <inheritdoc/>
+        /// <remarks>The LoadPrivateKey special handling is not necessary in this store.</remarks>
+        public Task<X509Certificate2> LoadPrivateKeyAsync(string thumbprint, string subjectName, string applicationUri, NodeId certificateType, string password)
         {
             return Task.FromResult<X509Certificate2>(null);
         }
@@ -224,11 +260,17 @@ namespace Opc.Ua
         /// <remarks>CRLs are only supported on Windows Platform.</remarks>
         public bool SupportsCRLs => PlatformHelper.IsWindowsWithCrlSupport();
 
-
+        /// <inheritdoc/>
+        /// <remarks>CRLs are only supported on Windows Platform.</remarks>
+        [Obsolete("Use IsRevokedAsync instead.")]
+        public Task<StatusCode> IsRevoked(X509Certificate2 issuer, X509Certificate2 certificate)
+        {
+            return IsRevokedAsync(issuer, certificate);
+        }
 
         /// <inheritdoc/>
         /// <remarks>CRLs are only supported on Windows Platform.</remarks>
-        public async Task<StatusCode> IsRevoked(X509Certificate2 issuer, X509Certificate2 certificate)
+        public async Task<StatusCode> IsRevokedAsync(X509Certificate2 issuer, X509Certificate2 certificate)
         {
             if (!SupportsCRLs)
             {
@@ -245,7 +287,7 @@ namespace Opc.Ua
                 throw new ArgumentNullException(nameof(certificate));
             }
 
-            X509CRLCollection crls = await EnumerateCRLs().ConfigureAwait(false);
+            X509CRLCollection crls = await EnumerateCRLsAsync().ConfigureAwait(false);
             // check for CRL.
 
             bool crlExpired = true;
@@ -285,7 +327,15 @@ namespace Opc.Ua
 
         /// <inheritdoc/>
         /// <remarks>CRLs are only supported on Windows Platform.</remarks>
+        [Obsolete("Use EnumerateCRLsAsync instead.")]
         public Task<X509CRLCollection> EnumerateCRLs()
+        {
+            return EnumerateCRLsAsync();
+        }
+
+        /// <inheritdoc/>
+        /// <remarks>CRLs are only supported on Windows Platform.</remarks>
+        public Task<X509CRLCollection> EnumerateCRLsAsync()
         {
             if (!SupportsCRLs)
             {
@@ -315,7 +365,15 @@ namespace Opc.Ua
 
         /// <inheritdoc/>
         /// <remarks>CRLs are only supported on Windows Platform.</remarks>
-        public async Task<X509CRLCollection> EnumerateCRLs(X509Certificate2 issuer, bool validateUpdateTime = true)
+        [Obsolete("Use EnumerateCRLsAsync instead.")]
+        public Task<X509CRLCollection> EnumerateCRLs(X509Certificate2 issuer, bool validateUpdateTime = true)
+        {
+            return EnumerateCRLsAsync(issuer, validateUpdateTime);
+        }
+
+        /// <inheritdoc/>
+        /// <remarks>CRLs are only supported on Windows Platform.</remarks>
+        public async Task<X509CRLCollection> EnumerateCRLsAsync(X509Certificate2 issuer, bool validateUpdateTime = true)
         {
             if (!SupportsCRLs)
             {
@@ -326,7 +384,7 @@ namespace Opc.Ua
                 throw new ArgumentNullException(nameof(issuer));
             }
             var crls = new X509CRLCollection();
-            foreach (X509CRL crl in await EnumerateCRLs().ConfigureAwait(false))
+            foreach (X509CRL crl in await EnumerateCRLsAsync().ConfigureAwait(false))
             {
                 if (!X509Utils.CompareDistinguishedName(crl.IssuerName, issuer.SubjectName))
                 {
@@ -350,7 +408,15 @@ namespace Opc.Ua
 
         /// <inheritdoc/>
         /// <remarks>CRLs are only supported on Windows Platform.</remarks>
-        public async Task AddCRL(X509CRL crl)
+        [Obsolete("Use AddCRLAsync instead.")]
+        public Task AddCRL(X509CRL crl)
+        {
+            return AddCRLAsync(crl);
+        }
+
+        /// <inheritdoc/>
+        /// <remarks>CRLs are only supported on Windows Platform.</remarks>
+        public async Task AddCRLAsync(X509CRL crl)
         {
             if (!SupportsCRLs)
             {
@@ -363,7 +429,7 @@ namespace Opc.Ua
 
             X509Certificate2 issuer = null;
             X509Certificate2Collection certificates = null;
-            certificates = await Enumerate().ConfigureAwait(false);
+            certificates = await EnumerateAsync().ConfigureAwait(false);
             foreach (X509Certificate2 certificate in certificates)
             {
                 if (X509Utils.CompareDistinguishedName(certificate.SubjectName, crl.IssuerName))
@@ -390,7 +456,15 @@ namespace Opc.Ua
 
         /// <inheritdoc/>
         /// <remarks>CRLs are only supported on Windows Platform.</remarks>
+        [Obsolete("Use DeleteCRLAsync instead.")]
         public Task<bool> DeleteCRL(X509CRL crl)
+        {
+            return DeleteCRLAsync(crl);
+        }
+
+        /// <inheritdoc/>
+        /// <remarks>CRLs are only supported on Windows Platform.</remarks>
+        public Task<bool> DeleteCRLAsync(X509CRL crl)
         {
             if (!SupportsCRLs)
             {
@@ -409,7 +483,14 @@ namespace Opc.Ua
         }
 
         /// <inheritdoc/>
+        [Obsolete("Use AddRejectedAsync instead.")]
         public Task AddRejected(X509Certificate2Collection certificates, int maxCertificates)
+        {
+            return Task.CompletedTask;
+        }
+
+        /// <inheritdoc/>
+        public Task AddRejectedAsync(X509Certificate2Collection certificates, int maxCertificates)
         {
             return Task.CompletedTask;
         }

--- a/Stack/Opc.Ua.Core/Security/Certificates/X509Utils.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/X509Utils.cs
@@ -609,7 +609,7 @@ namespace Opc.Ua
             X500DistinguishedName issuer,
             string serialnumber)
         {
-            X509Certificate2Collection certificates = await store.Enumerate().ConfigureAwait(false);
+            X509Certificate2Collection certificates = await store.EnumerateAsync().ConfigureAwait(false);
 
             foreach (var certificate in certificates)
             {
@@ -653,7 +653,7 @@ namespace Opc.Ua
                     }
 
                     store.Open(storePath, false);
-                    store.Add(certificate, password).Wait();
+                    store.AddAsync(certificate, password).Wait();
                     store.Close();
                 }
             }
@@ -687,7 +687,7 @@ namespace Opc.Ua
                         throw new ArgumentException("Invalid store type");
                     }
 
-                    store.Add(certificate, password).Wait();
+                    store.AddAsync(certificate, password).Wait();
                 }
                 finally
                 {
@@ -727,7 +727,7 @@ namespace Opc.Ua
                         throw new ArgumentException("Invalid store type");
                     }
 
-                    await store.Add(certificate, password).ConfigureAwait(false);
+                    await store.AddAsync(certificate, password).ConfigureAwait(false);
                     store.Close();
                 }
             }
@@ -761,7 +761,7 @@ namespace Opc.Ua
                     {
                         throw new ArgumentException("Invalid store type");
                     }
-                    await store.Add(certificate, password).ConfigureAwait(false);
+                    await store.AddAsync(certificate, password).ConfigureAwait(false);
                 }
                 finally
                 {

--- a/Tests/Opc.Ua.Configuration.Tests/ApplicationInstanceTests.cs
+++ b/Tests/Opc.Ua.Configuration.Tests/ApplicationInstanceTests.cs
@@ -374,12 +374,12 @@ namespace Opc.Ua.Configuration.Tests
                 var thumbprint = applicationCertificate.Certificate.Thumbprint;
                 using (ICertificateStore store = applicationCertificate.OpenStore())
                 {
-                    bool success = await store.Delete(thumbprint).ConfigureAwait(false);
+                    bool success = await store.DeleteAsync(thumbprint).ConfigureAwait(false);
                     Assert.IsTrue(success);
                 }
                 using (ICertificateStore store = applicationInstance.ApplicationConfiguration.SecurityConfiguration.TrustedPeerCertificates.OpenStore())
                 {
-                    bool success = await store.Delete(thumbprint).ConfigureAwait(false);
+                    bool success = await store.DeleteAsync(thumbprint).ConfigureAwait(false);
                     Assert.IsTrue(success);
                 }
             }
@@ -621,7 +621,7 @@ namespace Opc.Ua.Configuration.Tests
                 //Act
                 await applicationInstance.AddOwnCertificateToTrustedStoreAsync(cert, new CancellationToken()).ConfigureAwait(false);
                 ICertificateStore store = configuration.SecurityConfiguration.TrustedPeerCertificates.OpenStore();
-                var storedCertificates = await store.FindByThumbprint(cert.Thumbprint).ConfigureAwait(false);
+                var storedCertificates = await store.FindByThumbprintAsync(cert.Thumbprint).ConfigureAwait(false);
 
                 //Assert
                 Assert.IsTrue(storedCertificates.Contains(cert));

--- a/Tests/Opc.Ua.Configuration.Tests/CertificateStoreTypeTest.cs
+++ b/Tests/Opc.Ua.Configuration.Tests/CertificateStoreTypeTest.cs
@@ -123,7 +123,7 @@ namespace Opc.Ua.Configuration.Tests
             using (ICertificateStore trustListStore = trustList.OpenStore())
             {
                 var certs = trustListStore.Enumerate();
-                var crls = trustListStore.EnumerateCRLs();
+                var crls = trustListStore.EnumerateCRLsAsync();
                 trustListStore.Close();
             }
         }
@@ -195,25 +195,51 @@ namespace Opc.Ua.Configuration.Tests
         /// <inheritdoc/>
         public Task Add(X509Certificate2 certificate, string password = null)
         {
-            return m_innerStore.Add(certificate, password);
+            return m_innerStore.AddAsync(certificate, password);
         }
 
         /// <inheritdoc/>
+        public Task AddAsync(X509Certificate2 certificate, string password = null)
+        {
+            return m_innerStore.AddAsync(certificate, password);
+        }
+
+        /// <inheritdoc/>
+        [Obsolete("Use DeleteAsync instead.")]
         public Task<bool> Delete(string thumbprint)
         {
-            return m_innerStore.Delete(thumbprint);
+            return DeleteAsync(thumbprint);
+        }
+
+        /// <inheritdoc/>
+        public Task<bool> DeleteAsync(string thumbprint)
+        {
+            return m_innerStore.DeleteAsync(thumbprint);
         }
 
         /// <inheritdoc/>
         public Task<X509Certificate2Collection> Enumerate()
         {
-            return m_innerStore.Enumerate();
+            return m_innerStore.EnumerateAsync();
         }
 
         /// <inheritdoc/>
+        public Task<X509Certificate2Collection> EnumerateAsync()
+        {
+            return m_innerStore.EnumerateAsync();
+        }
+
+        /// <inheritdoc/>
+        [Obsolete("Use FindByThumbprintAsync instead.")]
         public Task<X509Certificate2Collection> FindByThumbprint(string thumbprint)
         {
-            return m_innerStore.FindByThumbprint(thumbprint);
+            return FindByThumbprintAsync(thumbprint);
+        }
+
+        /// <inheritdoc/>
+        public Task<X509Certificate2Collection> FindByThumbprintAsync(string thumbprint)
+        {
+            return m_innerStore.FindByThumbprintAsync(thumbprint);
         }
 
         /// <inheritdoc/>
@@ -222,34 +248,80 @@ namespace Opc.Ua.Configuration.Tests
 
         /// <inheritdoc/>
         public Task AddCRL(X509CRL crl)
-            => m_innerStore.AddCRL(crl);
+            => m_innerStore.AddCRLAsync(crl);
 
         /// <inheritdoc/>
+        public Task AddCRLAsync(X509CRL crl)
+            => m_innerStore.AddCRLAsync(crl);
+
+        /// <inheritdoc/>
+        [Obsolete("Use DeleteCRLAsync instead.")]
         public Task<bool> DeleteCRL(X509CRL crl)
-            => m_innerStore.DeleteCRL(crl);
+        {
+            return DeleteCRLAsync(crl);
+        }
 
         /// <inheritdoc/>
+        public Task<bool> DeleteCRLAsync(X509CRL crl)
+            => m_innerStore.DeleteCRLAsync(crl);
+
+        /// <inheritdoc/>
+        [Obsolete("Use EnumerateCRLsAsync instead.")]
         public Task<X509CRLCollection> EnumerateCRLs()
-            => m_innerStore.EnumerateCRLs();
+        {
+            return EnumerateCRLsAsync();
+        }
 
         /// <inheritdoc/>
+        public Task<X509CRLCollection> EnumerateCRLsAsync()
+            => m_innerStore.EnumerateCRLsAsync();
+
+        /// <inheritdoc/>
+        [Obsolete("Use EnumerateCRLsAsync instead.")]
         public Task<X509CRLCollection> EnumerateCRLs(X509Certificate2 issuer, bool validateUpdateTime = true)
-            => m_innerStore.EnumerateCRLs(issuer, validateUpdateTime);
+        {
+            return EnumerateCRLsAsync(issuer, validateUpdateTime);
+        }
 
         /// <inheritdoc/>
+        public Task<X509CRLCollection> EnumerateCRLsAsync(X509Certificate2 issuer, bool validateUpdateTime = true)
+            => m_innerStore.EnumerateCRLsAsync(issuer, validateUpdateTime);
+
+        /// <inheritdoc/>
+        [Obsolete("Use IsRevokedAsync instead.")]
         public Task<StatusCode> IsRevoked(X509Certificate2 issuer, X509Certificate2 certificate)
-            => m_innerStore.IsRevoked(issuer, certificate);
+        {
+            return IsRevokedAsync(issuer, certificate);
+        }
+
+        /// <inheritdoc/>
+        public Task<StatusCode> IsRevokedAsync(X509Certificate2 issuer, X509Certificate2 certificate)
+            => m_innerStore.IsRevokedAsync(issuer, certificate);
 
         /// <inheritdoc/>
         public bool SupportsLoadPrivateKey => m_innerStore.SupportsLoadPrivateKey;
 
         /// <inheritdoc/>
+        [Obsolete("Use LoadPrivateKeyAsync instead.")]
         public Task<X509Certificate2> LoadPrivateKey(string thumbprint, string subjectName, string applicationUri, NodeId certificateType, string password)
-            => m_innerStore.LoadPrivateKey(thumbprint, subjectName, applicationUri, certificateType, password);
+        {
+            return LoadPrivateKeyAsync(thumbprint, subjectName, applicationUri, certificateType, password);
+        }
 
         /// <inheritdoc/>
+        public Task<X509Certificate2> LoadPrivateKeyAsync(string thumbprint, string subjectName, string applicationUri, NodeId certificateType, string password)
+            => m_innerStore.LoadPrivateKeyAsync(thumbprint, subjectName, applicationUri, certificateType, password);
+
+        /// <inheritdoc/>
+        [Obsolete("Use AddRejectedAsync instead.")]
         public Task AddRejected(X509Certificate2Collection certificates, int maxCertificates)
-            => m_innerStore.AddRejected(certificates, maxCertificates);
+        {
+            return AddRejectedAsync(certificates, maxCertificates);
+        }
+
+        /// <inheritdoc/>
+        public Task AddRejectedAsync(X509Certificate2Collection certificates, int maxCertificates)
+            => m_innerStore.AddRejectedAsync(certificates, maxCertificates);
 
         public static int InstancesCreated => s_instancesCreated;
 

--- a/Tests/Opc.Ua.Core.Tests/Security/Certificates/CertificateStoreTest.cs
+++ b/Tests/Opc.Ua.Core.Tests/Security/Certificates/CertificateStoreTest.cs
@@ -71,30 +71,30 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
                 using (var x509Store = new X509CertificateStore())
                 {
                     x509Store.Open(certStore);
-                    var collection = await x509Store.Enumerate().ConfigureAwait(false);
+                    var collection = await x509Store.EnumerateAsync().ConfigureAwait(false);
                     foreach (var cert in collection)
                     {
                         if (X509Utils.CompareDistinguishedName(X509StoreSubject, cert.Subject))
                         {
-                            await x509Store.Delete(cert.Thumbprint).ConfigureAwait(false);
+                            await x509Store.DeleteAsync(cert.Thumbprint).ConfigureAwait(false);
                         }
                         if (X509Utils.CompareDistinguishedName(X509StoreSubject2, cert.Issuer))
                         {
-                            await x509Store.Delete(cert.Thumbprint).ConfigureAwait(false);
+                            await x509Store.DeleteAsync(cert.Thumbprint).ConfigureAwait(false);
                         }
                     }
                     if (x509Store.SupportsCRLs)
                     {
-                        X509CRLCollection crls = x509Store.EnumerateCRLs().Result;
+                        X509CRLCollection crls = x509Store.EnumerateCRLsAsync().Result;
                         foreach (X509CRL crl in crls)
                         {
                             if (X509Utils.CompareDistinguishedName(X509StoreSubject, crl.Issuer))
                             {
-                                await x509Store.DeleteCRL(crl).ConfigureAwait(false);
+                                await x509Store.DeleteCRLAsync(crl).ConfigureAwait(false);
                             }
                             if (X509Utils.CompareDistinguishedName(X509StoreSubject2, crl.Issuer))
                             {
-                                await x509Store.DeleteCRL(crl).ConfigureAwait(false);
+                                await x509Store.DeleteCRLAsync(crl).ConfigureAwait(false);
                             }
                         }
                     }
@@ -137,7 +137,7 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
                 using (var x509Store = new X509CertificateStore())
                 {
                     x509Store.Open(storePath);
-                    await x509Store.Delete(publicKey.Thumbprint).ConfigureAwait(false);
+                    await x509Store.DeleteAsync(publicKey.Thumbprint).ConfigureAwait(false);
                 }
             }
         }
@@ -202,7 +202,7 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
                 using (ICertificateStore store = Opc.Ua.CertificateStoreIdentifier.CreateStore(storeType))
                 {
                     store.Open(storePath, false);
-                    await store.Delete(publicKey.Thumbprint).ConfigureAwait(false);
+                    await store.DeleteAsync(publicKey.Thumbprint).ConfigureAwait(false);
                 }
             }
         }
@@ -236,7 +236,7 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
                 //Add Test PEM Chain
                 File.Copy(TestUtils.EnumerateTestAssets("Test_chain.pem").First(), certPath + Path.DirectorySeparatorChar + "Test_chain.pem");
 
-                var certificates = await store.Enumerate().ConfigureAwait(false);
+                var certificates = await store.EnumerateAsync().ConfigureAwait(false);
 
                 Assert.AreEqual(3, certificates.Count);
 
@@ -244,22 +244,22 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
                 File.WriteAllBytes(privatePath + Path.DirectorySeparatorChar + "Test_chain.pem", DecryptKeyPairPemBase64());
 
                 //refresh store to obtain private key
-                await store.Enumerate().ConfigureAwait(false);
+                await store.EnumerateAsync().ConfigureAwait(false);
 
 
                 //Load private key
-                var cert = await store.LoadPrivateKey("14A630438BF775E19169D3279069BBF20419EF84", null, null, null, null).ConfigureAwait(false);
+                var cert = await store.LoadPrivateKeyAsync("14A630438BF775E19169D3279069BBF20419EF84", null, null, null, null).ConfigureAwait(false);
 
                 Assert.NotNull(cert);
                 Assert.True(cert.HasPrivateKey);
 
                 // remove leaf cert
-                await store.Delete("14A630438BF775E19169D3279069BBF20419EF84").ConfigureAwait(false);
+                await store.DeleteAsync("14A630438BF775E19169D3279069BBF20419EF84").ConfigureAwait(false);
 
                 //remove private key
                 File.Delete(privatePath + Path.DirectorySeparatorChar + "Test_chain.pem");
 
-                certificates = await store.Enumerate().ConfigureAwait(false);
+                certificates = await store.EnumerateAsync().ConfigureAwait(false);
 
                 Assert.AreEqual(2, certificates.Count);
                 Assert.IsEmpty(certificates.Find(X509FindType.FindByThumbprint, "14A630438BF775E19169D3279069BBF20419EF84", false));
@@ -299,19 +299,19 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
                 // Add leaf cert with private key
                 File.WriteAllBytes(certPath + Path.DirectorySeparatorChar + "Test_keyPair.pem", DecryptKeyPairPemBase64());
 
-                var certificates = await store.Enumerate().ConfigureAwait(false);
+                var certificates = await store.EnumerateAsync().ConfigureAwait(false);
 
                 Assert.AreEqual(1, certificates.Count);
 
                 Assert.NotNull(certificates.Find(X509FindType.FindByThumbprint, "14A630438BF775E19169D3279069BBF20419EF84", false));
                 //Load private key
-                var cert = await store.LoadPrivateKey("14A630438BF775E19169D3279069BBF20419EF84", null, null, null, null).ConfigureAwait(false);
+                var cert = await store.LoadPrivateKeyAsync("14A630438BF775E19169D3279069BBF20419EF84", null, null, null, null).ConfigureAwait(false);
 
                 Assert.NotNull(cert);
                 Assert.True(cert.HasPrivateKey);
 
                 // remove leaf cert
-                await store.Delete("14A630438BF775E19169D3279069BBF20419EF84").ConfigureAwait(false);
+                await store.DeleteAsync("14A630438BF775E19169D3279069BBF20419EF84").ConfigureAwait(false);
 
                 //ensure private key is removed
                 Assert.False(File.Exists(certPath + Path.DirectorySeparatorChar + "Test_keyPair.pem"));
@@ -352,7 +352,7 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
                 if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 {
                     Assert.False(x509Store.SupportsCRLs);
-                    Assert.Throws<ServiceResultException>(() => x509Store.EnumerateCRLs());
+                    Assert.Throws<ServiceResultException>(() => x509Store.EnumerateCRLsAsync());
                 }
                 else
                 {
@@ -379,15 +379,15 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
                 Assert.True(x509Store.SupportsCRLs);
 
                 //add issuer to store
-                await x509Store.Add(GetTestCert()).ConfigureAwait(false);
+                await x509Store.AddAsync(GetTestCert()).ConfigureAwait(false);
                 //add Crl
                 var crlBuilder = CrlBuilder.Create(GetTestCert().SubjectName);
                 crlBuilder.AddRevokedCertificate(GetTestCert());
                 var crl = new X509CRL(crlBuilder.CreateForRSA(GetTestCert()));
-                await x509Store.AddCRL(crl).ConfigureAwait(false);
+                await x509Store.AddCRLAsync(crl).ConfigureAwait(false);
 
                 //enumerate Crls
-                X509CRLCollection crls = await x509Store.EnumerateCRLs().ConfigureAwait(false);
+                X509CRLCollection crls = await x509Store.EnumerateCRLsAsync().ConfigureAwait(false);
 
                 Assert.AreEqual(1, crls.Count);
                 Assert.AreEqual(crl.RawData, crls[0].RawData);
@@ -395,7 +395,7 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
                     crls[0].RevokedCertificates.First().SerialNumber);
 
                 //TestRevocation
-                var statusCode = await x509Store.IsRevoked(GetTestCert(), GetTestCert()).ConfigureAwait(false);
+                var statusCode = await x509Store.IsRevokedAsync(GetTestCert(), GetTestCert()).ConfigureAwait(false);
                 Assert.AreEqual((StatusCode)StatusCodes.BadCertificateRevoked, statusCode);
 
 
@@ -417,25 +417,25 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
             {
                 x509Store.Open(storePath);
                 //enumerate Crls
-                X509CRL crl = (await x509Store.EnumerateCRLs().ConfigureAwait(false)).First();
+                X509CRL crl = (await x509Store.EnumerateCRLsAsync().ConfigureAwait(false)).First();
 
                 //Test Revocation before adding cert
-                var statusCode = await x509Store.IsRevoked(GetTestCert(), GetTestCert2()).ConfigureAwait(false);
+                var statusCode = await x509Store.IsRevokedAsync(GetTestCert(), GetTestCert2()).ConfigureAwait(false);
                 Assert.AreEqual((StatusCode)StatusCodes.Good, statusCode);
 
                 var crlBuilder = CrlBuilder.Create(crl);
 
                 crlBuilder.AddRevokedCertificate(GetTestCert2());
                 var updatedCrl = new X509CRL(crlBuilder.CreateForRSA(GetTestCert()));
-                await x509Store.AddCRL(updatedCrl).ConfigureAwait(false);
+                await x509Store.AddCRLAsync(updatedCrl).ConfigureAwait(false);
 
-                X509CRLCollection crls = await x509Store.EnumerateCRLs().ConfigureAwait(false);
+                X509CRLCollection crls = await x509Store.EnumerateCRLsAsync().ConfigureAwait(false);
 
                 Assert.AreEqual(1, crls.Count);
 
                 Assert.AreEqual(2, crls[0].RevokedCertificates.Count);
                 //Test Revocation after adding cert
-                var statusCode2 = await x509Store.IsRevoked(GetTestCert(), GetTestCert2()).ConfigureAwait(false);
+                var statusCode2 = await x509Store.IsRevokedAsync(GetTestCert(), GetTestCert2()).ConfigureAwait(false);
                 Assert.AreEqual((StatusCode)StatusCodes.BadCertificateRevoked, statusCode2);
             }
         }
@@ -455,15 +455,15 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
             {
                 x509Store.Open(storePath);
                 //add issuer to store
-                await x509Store.Add(GetTestCert2()).ConfigureAwait(false);
+                await x509Store.AddAsync(GetTestCert2()).ConfigureAwait(false);
                 //add Crl
                 var crlBuilder = CrlBuilder.Create(GetTestCert2().SubjectName);
                 crlBuilder.AddRevokedCertificate(GetTestCert2());
                 var crl = new X509CRL(crlBuilder.CreateForRSA(GetTestCert2()));
-                await x509Store.AddCRL(crl).ConfigureAwait(false);
+                await x509Store.AddCRLAsync(crl).ConfigureAwait(false);
 
                 //enumerate Crls
-                X509CRLCollection crls = await x509Store.EnumerateCRLs().ConfigureAwait(false);
+                X509CRLCollection crls = await x509Store.EnumerateCRLsAsync().ConfigureAwait(false);
 
                 Assert.AreEqual(2, crls.Count);
                 Assert.NotNull(crls.SingleOrDefault(c => c.Issuer == crl.Issuer));
@@ -486,23 +486,23 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
                 x509Store.Open(storePath);
 
                 //Delete first crl with revoked certificates
-                X509CRL crl = (await x509Store.EnumerateCRLs().ConfigureAwait(false)).Single(c => c.Issuer == X509StoreSubject);
-                await x509Store.DeleteCRL(crl).ConfigureAwait(false);
+                X509CRL crl = (await x509Store.EnumerateCRLsAsync().ConfigureAwait(false)).Single(c => c.Issuer == X509StoreSubject);
+                await x509Store.DeleteCRLAsync(crl).ConfigureAwait(false);
 
-                X509CRLCollection crlsAfterFirstDelete = await x509Store.EnumerateCRLs().ConfigureAwait(false);
+                X509CRLCollection crlsAfterFirstDelete = await x509Store.EnumerateCRLsAsync().ConfigureAwait(false);
 
                 //check the right crl was deleted
                 Assert.AreEqual(1, crlsAfterFirstDelete.Count);
                 Assert.Null(crlsAfterFirstDelete.FirstOrDefault(c => c == crl));
 
                 //make shure IsRevoked can't find crl anymore
-                var statusCode = await x509Store.IsRevoked(GetTestCert(), GetTestCert()).ConfigureAwait(false);
+                var statusCode = await x509Store.IsRevokedAsync(GetTestCert(), GetTestCert()).ConfigureAwait(false);
                 Assert.AreEqual((StatusCode)StatusCodes.BadCertificateRevocationUnknown, statusCode);
 
                 //Delete second (empty) crl from store
-                await x509Store.DeleteCRL(crlsAfterFirstDelete.First()).ConfigureAwait(false);
+                await x509Store.DeleteCRLAsync(crlsAfterFirstDelete.First()).ConfigureAwait(false);
 
-                X509CRLCollection crlsAfterSecondDelete = await x509Store.EnumerateCRLs().ConfigureAwait(false);
+                X509CRLCollection crlsAfterSecondDelete = await x509Store.EnumerateCRLsAsync().ConfigureAwait(false);
 
                 //make shure no crls remain in store
                 Assert.AreEqual(0, crlsAfterSecondDelete.Count);
@@ -535,9 +535,9 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
                 x509Store.Open(storePath);
                 if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 {
-                    Assert.ThrowsAsync<ServiceResultException>(() => x509Store.AddCRL(new X509CRL()));
-                    Assert.ThrowsAsync<ServiceResultException>(() => x509Store.EnumerateCRLs());
-                    Assert.ThrowsAsync<ServiceResultException>(() => x509Store.DeleteCRL(new X509CRL()));
+                    Assert.ThrowsAsync<ServiceResultException>(() => x509Store.AddCRLAsync(new X509CRL()));
+                    Assert.ThrowsAsync<ServiceResultException>(() => x509Store.EnumerateCRLsAsync());
+                    Assert.ThrowsAsync<ServiceResultException>(() => x509Store.DeleteCRLAsync(new X509CRL()));
                 }
                 else
                 {

--- a/Tests/Opc.Ua.Core.Tests/Security/Certificates/CertificateStoreTypeTest.cs
+++ b/Tests/Opc.Ua.Core.Tests/Security/Certificates/CertificateStoreTypeTest.cs
@@ -107,25 +107,51 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
         /// <inheritdoc/>
         public Task Add(X509Certificate2 certificate, string password = null)
         {
-            return m_innerStore.Add(certificate, password);
+            return m_innerStore.AddAsync(certificate, password);
         }
 
         /// <inheritdoc/>
+        public Task AddAsync(X509Certificate2 certificate, string password = null)
+        {
+            return m_innerStore.AddAsync(certificate, password);
+        }
+
+        /// <inheritdoc/>
+        [Obsolete("Use DeleteAsync instead.")]
         public Task<bool> Delete(string thumbprint)
         {
-            return m_innerStore.Delete(thumbprint);
+            return DeleteAsync(thumbprint);
+        }
+
+        /// <inheritdoc/>
+        public Task<bool> DeleteAsync(string thumbprint)
+        {
+            return m_innerStore.DeleteAsync(thumbprint);
         }
 
         /// <inheritdoc/>
         public Task<X509Certificate2Collection> Enumerate()
         {
-            return m_innerStore.Enumerate();
+            return m_innerStore.EnumerateAsync();
         }
 
         /// <inheritdoc/>
+        public Task<X509Certificate2Collection> EnumerateAsync()
+        {
+            return m_innerStore.EnumerateAsync();
+        }
+
+        /// <inheritdoc/>
+        [Obsolete("Use FindByThumbprintAsync instead.")]
         public Task<X509Certificate2Collection> FindByThumbprint(string thumbprint)
         {
-            return m_innerStore.FindByThumbprint(thumbprint);
+            return FindByThumbprintAsync(thumbprint);
+        }
+
+        /// <inheritdoc/>
+        public Task<X509Certificate2Collection> FindByThumbprintAsync(string thumbprint)
+        {
+            return m_innerStore.FindByThumbprintAsync(thumbprint);
         }
 
         /// <inheritdoc/>
@@ -133,35 +159,81 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
             => m_innerStore.SupportsCRLs;
 
         /// <inheritdoc/>
+        [Obsolete("Use AddCRLAsync instead.")]
         public Task AddCRL(X509CRL crl)
-            => m_innerStore.AddCRL(crl);
+            => m_innerStore.AddCRLAsync(crl);
 
         /// <inheritdoc/>
+        public Task AddCRLAsync(X509CRL crl)
+            => m_innerStore.AddCRLAsync(crl);
+
+        /// <inheritdoc/>
+        [Obsolete("Use DeleteCRLAsync instead.")]
         public Task<bool> DeleteCRL(X509CRL crl)
-            => m_innerStore.DeleteCRL(crl);
+        {
+            return DeleteCRLAsync(crl);
+        }
 
         /// <inheritdoc/>
+        public Task<bool> DeleteCRLAsync(X509CRL crl)
+            => m_innerStore.DeleteCRLAsync(crl);
+
+        /// <inheritdoc/>
+        [Obsolete("Use EnumerateCRLsAsync instead.")]
         public Task<X509CRLCollection> EnumerateCRLs()
-            => m_innerStore.EnumerateCRLs();
+        {
+            return EnumerateCRLsAsync();
+        }
 
         /// <inheritdoc/>
+        public Task<X509CRLCollection> EnumerateCRLsAsync()
+            => m_innerStore.EnumerateCRLsAsync();
+
+        /// <inheritdoc/>
+        [Obsolete("Use EnumerateCRLsAsync instead.")]
         public Task<X509CRLCollection> EnumerateCRLs(X509Certificate2 issuer, bool validateUpdateTime = true)
-            => m_innerStore.EnumerateCRLs(issuer, validateUpdateTime);
+        {
+            return EnumerateCRLsAsync(issuer, validateUpdateTime);
+        }
 
         /// <inheritdoc/>
+        public Task<X509CRLCollection> EnumerateCRLsAsync(X509Certificate2 issuer, bool validateUpdateTime = true)
+            => m_innerStore.EnumerateCRLsAsync(issuer, validateUpdateTime);
+
+        /// <inheritdoc/>
+        [Obsolete("Use IsRevokedAsync instead.")]
         public Task<StatusCode> IsRevoked(X509Certificate2 issuer, X509Certificate2 certificate)
-            => m_innerStore.IsRevoked(issuer, certificate);
+        {
+            return IsRevokedAsync(issuer, certificate);
+        }
+
+        /// <inheritdoc/>
+        public Task<StatusCode> IsRevokedAsync(X509Certificate2 issuer, X509Certificate2 certificate)
+            => m_innerStore.IsRevokedAsync(issuer, certificate);
 
         /// <inheritdoc/>
         public bool SupportsLoadPrivateKey => m_innerStore.SupportsLoadPrivateKey;
 
         /// <inheritdoc/>
+        [Obsolete("Use LoadPrivateKeyAsync instead.")]
         public Task<X509Certificate2> LoadPrivateKey(string thumbprint, string subjectName, string applicationUri, NodeId certificateType, string password)
-            => m_innerStore.LoadPrivateKey(thumbprint, subjectName, applicationUri, certificateType, password);
+        {
+            return LoadPrivateKeyAsync(thumbprint, subjectName, applicationUri, certificateType, password);
+        }
+        /// <inheritdoc/>
+        public Task<X509Certificate2> LoadPrivateKeyAsync(string thumbprint, string subjectName, string applicationUri, NodeId certificateType, string password)
+            => m_innerStore.LoadPrivateKeyAsync(thumbprint, subjectName, applicationUri, certificateType, password);
 
         /// <inheritdoc/>
+        [Obsolete("Use AddRejectedAsync instead.")]
         public Task AddRejected(X509Certificate2Collection certificates, int maxCertificates)
-            => m_innerStore.AddRejected(certificates, maxCertificates);
+        {
+            return AddRejectedAsync(certificates, maxCertificates);
+        }
+
+        /// <inheritdoc/>
+        public Task AddRejectedAsync(X509Certificate2Collection certificates, int maxCertificates)
+            => m_innerStore.AddRejectedAsync(certificates, maxCertificates);
 
         public static int InstancesCreated => s_instancesCreated;
 

--- a/Tests/Opc.Ua.Core.Tests/Security/Certificates/CertificateValidatorAlternate.cs
+++ b/Tests/Opc.Ua.Core.Tests/Security/Certificates/CertificateValidatorAlternate.cs
@@ -117,8 +117,8 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
 
             // create cert validator for test, add trusted root cert
             m_validator = TemporaryCertValidator.Create();
-            await m_validator.TrustedStore.Add(m_rootCert).ConfigureAwait(false);
-            await m_validator.TrustedStore.AddCRL(m_rootCrl).ConfigureAwait(false);
+            await m_validator.TrustedStore.AddAsync(m_rootCert).ConfigureAwait(false);
+            await m_validator.TrustedStore.AddCRLAsync(m_rootCrl).ConfigureAwait(false);
             m_certValidator = m_validator.Update();
 
             // create a root with same serial number but modified Subject / key pair
@@ -337,8 +337,8 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
                 // validate cert chain
                 using (var validator = TemporaryCertValidator.Create())
                 {
-                    await validator.IssuerStore.Add(rootCert).ConfigureAwait(false);
-                    await validator.TrustedStore.Add(subCACert).ConfigureAwait(false);
+                    await validator.IssuerStore.AddAsync(rootCert).ConfigureAwait(false);
+                    await validator.TrustedStore.AddAsync(subCACert).ConfigureAwait(false);
                     var certValidator = validator.Update();
                     certValidator.Validate(leafCert);
                 }
@@ -360,8 +360,8 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
                 // validate using cert chain in issuer and trusted store
                 using (var validator = TemporaryCertValidator.Create())
                 {
-                    await validator.IssuerStore.Add(rootReverseCert).ConfigureAwait(false);
-                    await validator.TrustedStore.Add(subCACert).ConfigureAwait(false);
+                    await validator.IssuerStore.AddAsync(rootReverseCert).ConfigureAwait(false);
+                    await validator.TrustedStore.AddAsync(subCACert).ConfigureAwait(false);
                     var certValidator = validator.Update();
                     var result = Assert.Throws<ServiceResultException>(() => certValidator.Validate(collection));
 

--- a/Tests/Opc.Ua.Core.Tests/Security/Certificates/CertificateValidatorTest.cs
+++ b/Tests/Opc.Ua.Core.Tests/Security/Certificates/CertificateValidatorTest.cs
@@ -237,7 +237,7 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
                 }
 
                 Thread.Sleep(1000);
-                Assert.AreEqual(m_appSelfSignedCerts.Count, validator.RejectedStore.Enumerate().GetAwaiter().GetResult().Count);
+                Assert.AreEqual(m_appSelfSignedCerts.Count, validator.RejectedStore.EnumerateAsync().GetAwaiter().GetResult().Count);
 
                 // add auto approver
                 var approver = new CertValidationApprover(new StatusCode[] { StatusCodes.BadCertificateUntrusted });
@@ -267,13 +267,13 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
                 {
                     if (i == kCaChainCount / 2)
                     {
-                        await validator.TrustedStore.Add(m_caChain[i]).ConfigureAwait(false);
-                        await validator.TrustedStore.AddCRL(m_crlChain[i]).ConfigureAwait(false);
+                        await validator.TrustedStore.AddAsync(m_caChain[i]).ConfigureAwait(false);
+                        await validator.TrustedStore.AddCRLAsync(m_crlChain[i]).ConfigureAwait(false);
                     }
                     else
                     {
-                        await validator.IssuerStore.Add(m_caChain[i]).ConfigureAwait(false);
-                        await validator.IssuerStore.AddCRL(m_crlChain[i]).ConfigureAwait(false);
+                        await validator.IssuerStore.AddAsync(m_caChain[i]).ConfigureAwait(false);
+                        await validator.IssuerStore.AddCRLAsync(m_crlChain[i]).ConfigureAwait(false);
                     }
                 }
 
@@ -299,9 +299,9 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
                 {
                     foreach (var cert in m_appSelfSignedCerts)
                     {
-                        await validator.IssuerStore.Add(cert).ConfigureAwait(false);
+                        await validator.IssuerStore.AddAsync(cert).ConfigureAwait(false);
                     }
-                    Assert.AreEqual(m_appSelfSignedCerts.Count, validator.IssuerStore.Enumerate().Result.Count);
+                    Assert.AreEqual(m_appSelfSignedCerts.Count, validator.IssuerStore.EnumerateAsync().Result.Count);
                     var certValidator = validator.Update();
                     foreach (var cert in m_appSelfSignedCerts)
                     {
@@ -310,7 +310,7 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
                     }
 
                     await Task.Delay(1000).ConfigureAwait(false);
-                    Assert.AreEqual(m_appSelfSignedCerts.Count, validator.RejectedStore.Enumerate().Result.Count);
+                    Assert.AreEqual(m_appSelfSignedCerts.Count, validator.RejectedStore.EnumerateAsync().Result.Count);
                 }
             }
         }
@@ -329,9 +329,9 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
             {
                 foreach (var cert in m_appSelfSignedCerts)
                 {
-                    await validator.IssuerStore.Add(cert).ConfigureAwait(false);
+                    await validator.IssuerStore.AddAsync(cert).ConfigureAwait(false);
                 }
-                X509Certificate2Collection certificates = await validator.IssuerStore.Enumerate().ConfigureAwait(false);
+                X509Certificate2Collection certificates = await validator.IssuerStore.EnumerateAsync().ConfigureAwait(false);
                 Assert.AreEqual(m_appSelfSignedCerts.Count, certificates.Count);
 
                 var certValidator = validator.Update();
@@ -357,7 +357,7 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
                     }
 
                     await Task.Delay(1000).ConfigureAwait(false);
-                    certificates = await validator.RejectedStore.Enumerate().ConfigureAwait(false);
+                    certificates = await validator.RejectedStore.EnumerateAsync().ConfigureAwait(false);
                     Assert.GreaterOrEqual(m_caChain.Length + kNumberOfRejectCertsHistory + 1, certificates.Count);
 
                     foreach (var cert in m_appSelfSignedCerts)
@@ -367,7 +367,7 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
                     }
 
                     await Task.Delay(1000).ConfigureAwait(false);
-                    certificates = await validator.RejectedStore.Enumerate().ConfigureAwait(false);
+                    certificates = await validator.RejectedStore.EnumerateAsync().ConfigureAwait(false);
                     Assert.GreaterOrEqual(kNumberOfRejectCertsHistory + 1, certificates.Count);
 
                     // override with the same content
@@ -378,25 +378,25 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
                     }
 
                     await Task.Delay(1000).ConfigureAwait(false);
-                    certificates = await validator.RejectedStore.Enumerate().ConfigureAwait(false);
+                    certificates = await validator.RejectedStore.EnumerateAsync().ConfigureAwait(false);
                     Assert.GreaterOrEqual(kNumberOfRejectCertsHistory + 1, certificates.Count);
 
                     // test setter if overflow certs are not deleted
                     certValidator.MaxRejectedCertificates = 300;
                     await Task.Delay(1000).ConfigureAwait(false);
-                    certificates = await validator.RejectedStore.Enumerate().ConfigureAwait(false);
+                    certificates = await validator.RejectedStore.EnumerateAsync().ConfigureAwait(false);
                     Assert.GreaterOrEqual(kNumberOfRejectCertsHistory + 1, certificates.Count);
 
                     // test setter if overflow certs are deleted
                     certValidator.MaxRejectedCertificates = 3;
                     await Task.Delay(1000).ConfigureAwait(false);
-                    certificates = await validator.RejectedStore.Enumerate().ConfigureAwait(false);
+                    certificates = await validator.RejectedStore.EnumerateAsync().ConfigureAwait(false);
                     Assert.GreaterOrEqual(3, certificates.Count);
 
                     // test setter if allcerts are deleted
                     certValidator.MaxRejectedCertificates = -1;
                     await Task.Delay(1000).ConfigureAwait(false);
-                    certificates = await validator.RejectedStore.Enumerate().ConfigureAwait(false);
+                    certificates = await validator.RejectedStore.EnumerateAsync().ConfigureAwait(false);
                     Assert.LessOrEqual(0, certificates.Count);
 
                     // ensure no certs are added to the rejected store
@@ -406,7 +406,7 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
                         Assert.AreEqual((StatusCode)StatusCodes.BadCertificateUntrusted, (StatusCode)serviceResultException.StatusCode, serviceResultException.Message);
                     }
                     await Task.Delay(1000).ConfigureAwait(false);
-                    certificates = await validator.RejectedStore.Enumerate().ConfigureAwait(false);
+                    certificates = await validator.RejectedStore.EnumerateAsync().ConfigureAwait(false);
                     Assert.LessOrEqual(0, certificates.Count);
                 }
                 finally
@@ -427,9 +427,9 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
             {
                 foreach (var cert in m_appSelfSignedCerts)
                 {
-                    await validator.TrustedStore.Add(cert).ConfigureAwait(false);
+                    await validator.TrustedStore.AddAsync(cert).ConfigureAwait(false);
                 }
-                Assert.AreEqual(m_appSelfSignedCerts.Count, validator.TrustedStore.Enumerate().Result.Count);
+                Assert.AreEqual(m_appSelfSignedCerts.Count, validator.TrustedStore.EnumerateAsync().Result.Count);
                 var certValidator = validator.Update();
                 foreach (var cert in m_appSelfSignedCerts)
                 {
@@ -449,8 +449,8 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
             {
                 foreach (var cert in m_appSelfSignedCerts)
                 {
-                    await validator.TrustedStore.Add(cert).ConfigureAwait(false);
-                    await validator.IssuerStore.Add(cert).ConfigureAwait(false);
+                    await validator.TrustedStore.AddAsync(cert).ConfigureAwait(false);
+                    await validator.IssuerStore.AddAsync(cert).ConfigureAwait(false);
                 }
                 var certValidator = validator.Update();
                 foreach (var cert in m_appSelfSignedCerts)
@@ -479,8 +479,8 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
                     for (int i = 0; i < kCaChainCount; i++)
                     {
                         ICertificateStore store = i == v ? validator.TrustedStore : validator.IssuerStore;
-                        await store.Add(m_caChain[i]).ConfigureAwait(false);
-                        await store.AddCRL(m_crlChain[i]).ConfigureAwait(false);
+                        await store.AddAsync(m_caChain[i]).ConfigureAwait(false);
+                        await store.AddCRLAsync(m_crlChain[i]).ConfigureAwait(false);
                     }
                     TestContext.Out.WriteLine($"AddChains: {stopWatch.ElapsedMilliseconds - start}");
                     var certValidator = validator.Update();
@@ -509,8 +509,8 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
                     for (int i = 0; i < kCaChainCount; i++)
                     {
                         ICertificateStore store = (i != v || kCaChainCount == 1) ? validator.TrustedStore : validator.IssuerStore;
-                        await store.Add(m_caChain[i]).ConfigureAwait(false);
-                        await store.AddCRL(m_crlChain[i]).ConfigureAwait(false);
+                        await store.AddAsync(m_caChain[i]).ConfigureAwait(false);
+                        await store.AddCRLAsync(m_crlChain[i]).ConfigureAwait(false);
                     }
                     var certValidator = validator.Update();
                     foreach (var app in m_goodApplicationTestSet)
@@ -536,8 +536,8 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
                     {
                         if (i != v)
                         {
-                            await validator.TrustedStore.Add(m_caChain[i]).ConfigureAwait(false);
-                            await validator.TrustedStore.AddCRL(m_crlChain[i]).ConfigureAwait(false);
+                            await validator.TrustedStore.AddAsync(m_caChain[i]).ConfigureAwait(false);
+                            await validator.TrustedStore.AddCRLAsync(m_crlChain[i]).ConfigureAwait(false);
                         }
                     }
                     var certValidator = validator.Update();
@@ -565,13 +565,13 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
                     {
                         if (i != v)
                         {
-                            await validator.TrustedStore.Add(m_caChain[i]).ConfigureAwait(false);
-                            await validator.TrustedStore.AddCRL(m_crlChain[i]).ConfigureAwait(false);
+                            await validator.TrustedStore.AddAsync(m_caChain[i]).ConfigureAwait(false);
+                            await validator.TrustedStore.AddCRLAsync(m_crlChain[i]).ConfigureAwait(false);
                         }
                         else
                         {
-                            await validator.TrustedStore.Add(m_caDupeChain[i]).ConfigureAwait(false);
-                            await validator.TrustedStore.AddCRL(m_crlDupeChain[i]).ConfigureAwait(false);
+                            await validator.TrustedStore.AddAsync(m_caDupeChain[i]).ConfigureAwait(false);
+                            await validator.TrustedStore.AddCRLAsync(m_crlDupeChain[i]).ConfigureAwait(false);
                         }
                     }
                     var certValidator = validator.Update();
@@ -598,10 +598,10 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
                     for (int i = 0; i < kCaChainCount; i++)
                     {
                         ICertificateStore store = i == v ? validator.TrustedStore : validator.IssuerStore;
-                        await store.Add(m_caChain[i]).ConfigureAwait(false);
-                        await store.AddCRL(m_crlChain[i]).ConfigureAwait(false);
-                        await store.Add(m_caDupeChain[i]).ConfigureAwait(false);
-                        await store.AddCRL(m_crlDupeChain[i]).ConfigureAwait(false);
+                        await store.AddAsync(m_caChain[i]).ConfigureAwait(false);
+                        await store.AddCRLAsync(m_crlChain[i]).ConfigureAwait(false);
+                        await store.AddAsync(m_caDupeChain[i]).ConfigureAwait(false);
+                        await store.AddCRLAsync(m_crlDupeChain[i]).ConfigureAwait(false);
                     }
                     var certValidator = validator.Update();
                     foreach (var app in m_goodApplicationTestSet)
@@ -627,13 +627,13 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
                     {
                         if (i == v)
                         {
-                            await validator.TrustedStore.Add(m_caChain[i]).ConfigureAwait(false);
-                            await validator.TrustedStore.AddCRL(m_crlRevokedChain[i]).ConfigureAwait(false);
+                            await validator.TrustedStore.AddAsync(m_caChain[i]).ConfigureAwait(false);
+                            await validator.TrustedStore.AddCRLAsync(m_crlRevokedChain[i]).ConfigureAwait(false);
                         }
                         else
                         {
-                            await validator.IssuerStore.Add(m_caChain[i]).ConfigureAwait(false);
-                            await validator.IssuerStore.AddCRL(m_crlChain[i]).ConfigureAwait(false);
+                            await validator.IssuerStore.AddAsync(m_caChain[i]).ConfigureAwait(false);
+                            await validator.IssuerStore.AddCRLAsync(m_crlChain[i]).ConfigureAwait(false);
                         }
                     }
                     var certValidator = validator.Update();
@@ -661,13 +661,13 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
                     {
                         if (i == v)
                         {
-                            await validator.IssuerStore.Add(m_caChain[i]).ConfigureAwait(false);
-                            await validator.IssuerStore.AddCRL(m_crlRevokedChain[i]).ConfigureAwait(false);
+                            await validator.IssuerStore.AddAsync(m_caChain[i]).ConfigureAwait(false);
+                            await validator.IssuerStore.AddCRLAsync(m_crlRevokedChain[i]).ConfigureAwait(false);
                         }
                         else
                         {
-                            await validator.TrustedStore.Add(m_caChain[i]).ConfigureAwait(false);
-                            await validator.TrustedStore.AddCRL(m_crlChain[i]).ConfigureAwait(false);
+                            await validator.TrustedStore.AddAsync(m_caChain[i]).ConfigureAwait(false);
+                            await validator.TrustedStore.AddCRLAsync(m_crlChain[i]).ConfigureAwait(false);
                         }
                     }
                     var certValidator = validator.Update();
@@ -695,18 +695,18 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
                     {
                         if (i == v)
                         {
-                            await validator.IssuerStore.Add(m_caChain[i]).ConfigureAwait(false);
-                            await validator.IssuerStore.AddCRL(m_crlRevokedChain[i]).ConfigureAwait(false);
+                            await validator.IssuerStore.AddAsync(m_caChain[i]).ConfigureAwait(false);
+                            await validator.IssuerStore.AddCRLAsync(m_crlRevokedChain[i]).ConfigureAwait(false);
                         }
                         else
                         {
-                            await validator.IssuerStore.Add(m_caChain[i]).ConfigureAwait(false);
-                            await validator.IssuerStore.AddCRL(m_crlChain[i]).ConfigureAwait(false);
+                            await validator.IssuerStore.AddAsync(m_caChain[i]).ConfigureAwait(false);
+                            await validator.IssuerStore.AddCRLAsync(m_crlChain[i]).ConfigureAwait(false);
                         }
                     }
                     foreach (var app in m_goodApplicationTestSet)
                     {
-                        await validator.TrustedStore.Add(X509CertificateLoader.LoadCertificate(app.Certificate)).ConfigureAwait(false);
+                        await validator.TrustedStore.AddAsync(X509CertificateLoader.LoadCertificate(app.Certificate)).ConfigureAwait(false);
                     }
                     var certValidator = validator.Update();
                     foreach (var app in m_goodApplicationTestSet)
@@ -731,14 +731,14 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
                 {
                     for (int i = 0; i < kCaChainCount; i++)
                     {
-                        await validator.TrustedStore.Add(m_caChain[i]).ConfigureAwait(false);
+                        await validator.TrustedStore.AddAsync(m_caChain[i]).ConfigureAwait(false);
                         if (i == v)
                         {
-                            await validator.TrustedStore.AddCRL(m_crlRevokedChain[i]).ConfigureAwait(false);
+                            await validator.TrustedStore.AddCRLAsync(m_crlRevokedChain[i]).ConfigureAwait(false);
                         }
                         else
                         {
-                            await validator.TrustedStore.AddCRL(m_crlChain[i]).ConfigureAwait(false);
+                            await validator.TrustedStore.AddCRLAsync(m_crlChain[i]).ConfigureAwait(false);
                         }
                     }
                     var certValidator = validator.Update();
@@ -764,19 +764,19 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
                 {
                     for (int i = 0; i < kCaChainCount; i++)
                     {
-                        await validator.TrustedStore.Add(m_caChain[i]).ConfigureAwait(false);
+                        await validator.TrustedStore.AddAsync(m_caChain[i]).ConfigureAwait(false);
                         if (i == v)
                         {
-                            await validator.TrustedStore.AddCRL(m_crlRevokedChain[i]).ConfigureAwait(false);
+                            await validator.TrustedStore.AddCRLAsync(m_crlRevokedChain[i]).ConfigureAwait(false);
                         }
                         else
                         {
-                            await validator.TrustedStore.AddCRL(m_crlChain[i]).ConfigureAwait(false);
+                            await validator.TrustedStore.AddCRLAsync(m_crlChain[i]).ConfigureAwait(false);
                         }
                     }
                     foreach (var app in m_goodApplicationTestSet)
                     {
-                        await validator.TrustedStore.Add(X509CertificateLoader.LoadCertificate(app.Certificate)).ConfigureAwait(false);
+                        await validator.TrustedStore.AddAsync(X509CertificateLoader.LoadCertificate(app.Certificate)).ConfigureAwait(false);
                     }
                     var certValidator = validator.Update();
                     foreach (var app in m_goodApplicationTestSet)
@@ -800,14 +800,14 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
                 // issuer chain
                 for (int i = 0; i < kCaChainCount; i++)
                 {
-                    await validator.IssuerStore.Add(m_caChain[i]).ConfigureAwait(false);
-                    await validator.IssuerStore.AddCRL(m_crlChain[i]).ConfigureAwait(false);
+                    await validator.IssuerStore.AddAsync(m_caChain[i]).ConfigureAwait(false);
+                    await validator.IssuerStore.AddCRLAsync(m_crlChain[i]).ConfigureAwait(false);
                 }
 
                 // all app certs are trusted
                 foreach (var app in m_goodApplicationTestSet)
                 {
-                    await validator.TrustedStore.Add(X509CertificateLoader.LoadCertificate(app.Certificate)).ConfigureAwait(false);
+                    await validator.TrustedStore.AddAsync(X509CertificateLoader.LoadCertificate(app.Certificate)).ConfigureAwait(false);
                 }
 
                 var certValidator = validator.Update();
@@ -834,15 +834,15 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
                     {
                         if (i != v)
                         {
-                            await validator.IssuerStore.Add(m_caChain[i]).ConfigureAwait(false);
-                            await validator.IssuerStore.AddCRL(m_crlChain[i]).ConfigureAwait(false);
+                            await validator.IssuerStore.AddAsync(m_caChain[i]).ConfigureAwait(false);
+                            await validator.IssuerStore.AddCRLAsync(m_crlChain[i]).ConfigureAwait(false);
                         }
                     }
 
                     // all app certs are trusted
                     foreach (var app in m_goodApplicationTestSet)
                     {
-                        await validator.TrustedStore.Add(X509CertificateLoader.LoadCertificate(app.Certificate)).ConfigureAwait(false);
+                        await validator.TrustedStore.AddAsync(X509CertificateLoader.LoadCertificate(app.Certificate)).ConfigureAwait(false);
                     }
 
                     var certValidator = validator.Update();
@@ -952,11 +952,11 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
             var validator = TemporaryCertValidator.Create();
             if (!trusted)
             {
-                await validator.IssuerStore.Add(cert).ConfigureAwait(false);
+                await validator.IssuerStore.AddAsync(cert).ConfigureAwait(false);
             }
             else
             {
-                await validator.TrustedStore.Add(cert).ConfigureAwait(false);
+                await validator.TrustedStore.AddAsync(cert).ConfigureAwait(false);
             }
             var certValidator = validator.Update();
             var serviceResultException = Assert.Throws<ServiceResultException>(() => certValidator.Validate(cert));
@@ -996,11 +996,11 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
             var validator = TemporaryCertValidator.Create();
             if (!trusted)
             {
-                await validator.IssuerStore.Add(cert).ConfigureAwait(false);
+                await validator.IssuerStore.AddAsync(cert).ConfigureAwait(false);
             }
             else
             {
-                await validator.TrustedStore.Add(cert).ConfigureAwait(false);
+                await validator.TrustedStore.AddAsync(cert).ConfigureAwait(false);
             }
             var certValidator = validator.Update();
             var serviceResultException = Assert.Throws<ServiceResultException>(() => certValidator.Validate(cert));
@@ -1035,11 +1035,11 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
             var validator = TemporaryCertValidator.Create();
             if (!trusted)
             {
-                await validator.IssuerStore.Add(cert).ConfigureAwait(false);
+                await validator.IssuerStore.AddAsync(cert).ConfigureAwait(false);
             }
             else
             {
-                await validator.TrustedStore.Add(cert).ConfigureAwait(false);
+                await validator.TrustedStore.AddAsync(cert).ConfigureAwait(false);
             }
             var certValidator = validator.Update();
             var serviceResultException = Assert.Throws<ServiceResultException>(() => certValidator.Validate(cert));
@@ -1095,7 +1095,7 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
             var validator = TemporaryCertValidator.Create();
             if (trusted)
             {
-                await validator.TrustedStore.Add(cert).ConfigureAwait(false);
+                await validator.TrustedStore.AddAsync(cert).ConfigureAwait(false);
             }
             var certValidator = validator.Update();
             certValidator.RejectSHA1SignedCertificates = rejectSHA1;
@@ -1148,7 +1148,7 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
             var validator = TemporaryCertValidator.Create();
             if (trusted)
             {
-                await validator.TrustedStore.Add(cert).ConfigureAwait(false);
+                await validator.TrustedStore.AddAsync(cert).ConfigureAwait(false);
             }
             var certValidator = validator.Update();
             var serviceResultException = Assert.Throws<ServiceResultException>(() => certValidator.Validate(cert));
@@ -1192,7 +1192,7 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
             var validator = TemporaryCertValidator.Create();
             if (trusted)
             {
-                await validator.TrustedStore.Add(cert).ConfigureAwait(false);
+                await validator.TrustedStore.AddAsync(cert).ConfigureAwait(false);
             }
             var certValidator = validator.Update();
             var approver = new CertValidationApprover(new StatusCode[] { StatusCodes.BadCertificateUntrusted });
@@ -1240,7 +1240,7 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
             var validator = TemporaryCertValidator.Create();
             if (trusted)
             {
-                await validator.TrustedStore.Add(cert).ConfigureAwait(false);
+                await validator.TrustedStore.AddAsync(cert).ConfigureAwait(false);
             }
             var certValidator = validator.Update();
             var serviceResultException = Assert.Throws<ServiceResultException>(() => certValidator.Validate(cert));
@@ -1296,7 +1296,7 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
                     .CreateForECDsa();
 
                 var validator = TemporaryCertValidator.Create();
-                await validator.TrustedStore.Add(cert).ConfigureAwait(false);
+                await validator.TrustedStore.AddAsync(cert).ConfigureAwait(false);
                 var certValidator = validator.Update();
 
                 var serviceResultException = Assert.Throws<ServiceResultException>(() => certValidator.Validate(cert));
@@ -1320,7 +1320,7 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
             var validator = TemporaryCertValidator.Create();
             if (trusted)
             {
-                await validator.TrustedStore.Add(cert).ConfigureAwait(false);
+                await validator.TrustedStore.AddAsync(cert).ConfigureAwait(false);
             }
             var certValidator = validator.Update();
             certValidator.AutoAcceptUntrustedCertificates = autoAccept;
@@ -1403,12 +1403,12 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
                     {
                         if (i == v)
                         {
-                            await validator.TrustedStore.Add(m_caChain[i]).ConfigureAwait(false);
-                            await validator.TrustedStore.AddCRL(m_crlRevokedChain[i]).ConfigureAwait(false);
+                            await validator.TrustedStore.AddAsync(m_caChain[i]).ConfigureAwait(false);
+                            await validator.TrustedStore.AddCRLAsync(m_crlRevokedChain[i]).ConfigureAwait(false);
                         }
                         else
                         {
-                            await validator.IssuerStore.Add(m_caChain[i]).ConfigureAwait(false);
+                            await validator.IssuerStore.AddAsync(m_caChain[i]).ConfigureAwait(false);
                         }
                     }
                     var certValidator = validator.Update();
@@ -1447,11 +1447,11 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
                     {
                         if (i == v)
                         {
-                            await validator.TrustedStore.Add(m_caChain[i]).ConfigureAwait(false);
+                            await validator.TrustedStore.AddAsync(m_caChain[i]).ConfigureAwait(false);
                         }
                         else
                         {
-                            await validator.IssuerStore.Add(m_caChain[i]).ConfigureAwait(false);
+                            await validator.IssuerStore.AddAsync(m_caChain[i]).ConfigureAwait(false);
                         }
                     }
                     var certValidator = validator.Update();
@@ -1506,12 +1506,12 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
                     {
                         if (i == v)
                         {
-                            await validator.TrustedStore.Add(m_caChain[i]).ConfigureAwait(false);
+                            await validator.TrustedStore.AddAsync(m_caChain[i]).ConfigureAwait(false);
                         }
                         else
                         {
-                            await validator.IssuerStore.Add(m_caChain[i]).ConfigureAwait(false);
-                            await validator.IssuerStore.AddCRL(m_crlChain[i]).ConfigureAwait(false);
+                            await validator.IssuerStore.AddAsync(m_caChain[i]).ConfigureAwait(false);
+                            await validator.IssuerStore.AddCRLAsync(m_crlChain[i]).ConfigureAwait(false);
                         }
                     }
                     var certValidator = validator.Update();
@@ -1553,7 +1553,7 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
                     {
                         if (i != v)
                         {
-                            await validator.TrustedStore.Add(m_caChain[i]).ConfigureAwait(false);
+                            await validator.TrustedStore.AddAsync(m_caChain[i]).ConfigureAwait(false);
                         }
                     }
                     var certValidator = validator.Update();
@@ -1587,13 +1587,13 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
                     {
                         if (i != v || kCaChainCount == 1)
                         {
-                            await validator.TrustedStore.Add(X509CertificateLoader.LoadCertificate(m_caChain[i].RawData)).ConfigureAwait(false);
-                            await validator.TrustedStore.AddCRL(m_crlChain[i]).ConfigureAwait(false);
+                            await validator.TrustedStore.AddAsync(X509CertificateLoader.LoadCertificate(m_caChain[i].RawData)).ConfigureAwait(false);
+                            await validator.TrustedStore.AddCRLAsync(m_crlChain[i]).ConfigureAwait(false);
                         }
                         else
                         {
-                            await validator.IssuerStore.Add(X509CertificateLoader.LoadCertificate(m_caChain[i].RawData)).ConfigureAwait(false);
-                            await validator.IssuerStore.AddCRL(m_crlChain[i]).ConfigureAwait(false);
+                            await validator.IssuerStore.AddAsync(X509CertificateLoader.LoadCertificate(m_caChain[i].RawData)).ConfigureAwait(false);
+                            await validator.IssuerStore.AddCRLAsync(m_crlChain[i]).ConfigureAwait(false);
                         }
                     }
                     var certValidator = validator.Update();
@@ -1628,11 +1628,11 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
                     {
                         if (i != v || kCaChainCount == 1)
                         {
-                            await validator.TrustedStore.Add(m_caChain[i]).ConfigureAwait(false);
+                            await validator.TrustedStore.AddAsync(m_caChain[i]).ConfigureAwait(false);
                         }
                         else
                         {
-                            await validator.IssuerStore.Add(m_caChain[i]).ConfigureAwait(false);
+                            await validator.IssuerStore.AddAsync(m_caChain[i]).ConfigureAwait(false);
                         }
                     }
                     var certValidator = validator.Update();
@@ -1690,10 +1690,10 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
                 {
                     for (int i = 0; i < kCaChainCount; i++)
                     {
-                        await validator.IssuerStore.Add(m_caChain[i]).ConfigureAwait(false);
+                        await validator.IssuerStore.AddAsync(m_caChain[i]).ConfigureAwait(false);
                         if (i != v)
                         {
-                            await validator.IssuerStore.AddCRL(m_crlChain[i]).ConfigureAwait(false);
+                            await validator.IssuerStore.AddCRLAsync(m_crlChain[i]).ConfigureAwait(false);
                         }
                     }
                     var certValidator = validator.Update();

--- a/Tests/Opc.Ua.Core.Tests/Security/Certificates/TestUtils.cs
+++ b/Tests/Opc.Ua.Core.Tests/Security/Certificates/TestUtils.cs
@@ -58,17 +58,17 @@ namespace Opc.Ua.Core.Tests
         {
             if (store != null)
             {
-                var certs = await store.Enumerate().ConfigureAwait(false);
+                var certs = await store.EnumerateAsync().ConfigureAwait(false);
                 foreach (var cert in certs)
                 {
-                    await store.Delete(cert.Thumbprint).ConfigureAwait(false);
+                    await store.DeleteAsync(cert.Thumbprint).ConfigureAwait(false);
                 }
                 if (store.SupportsCRLs)
                 {
-                    var crls = await store.EnumerateCRLs().ConfigureAwait(false);
+                    var crls = await store.EnumerateCRLsAsync().ConfigureAwait(false);
                     foreach (var crl in crls)
                     {
-                        await store.DeleteCRL(crl).ConfigureAwait(false);
+                        await store.DeleteCRLAsync(crl).ConfigureAwait(false);
                     }
                 }
                 if (dispose)

--- a/Tests/Opc.Ua.Gds.Tests/CertificateGroupTests.cs
+++ b/Tests/Opc.Ua.Gds.Tests/CertificateGroupTests.cs
@@ -60,7 +60,7 @@ namespace Opc.Ua.Gds.Tests
             var certificateStoreIdentifier = new CertificateStoreIdentifier(configuration.TrustedListPath);
             using (ICertificateStore trustedStore = certificateStoreIdentifier.OpenStore())
             {
-                X509Certificate2Collection certs = await trustedStore.FindByThumbprint(certificate.Thumbprint).ConfigureAwait(false);
+                X509Certificate2Collection certs = await trustedStore.FindByThumbprintAsync(certificate.Thumbprint).ConfigureAwait(false);
                 Assert.IsTrue(certs.Count == 1);
             }
         }
@@ -81,9 +81,9 @@ namespace Opc.Ua.Gds.Tests
             Assert.NotNull(certificate);
             using (ICertificateStore trustedStore = applicatioConfiguration.SecurityConfiguration.TrustedIssuerCertificates.OpenStore())
             {
-                X509Certificate2Collection certs = await trustedStore.FindByThumbprint(certificate.Thumbprint).ConfigureAwait(false);
+                X509Certificate2Collection certs = await trustedStore.FindByThumbprintAsync(certificate.Thumbprint).ConfigureAwait(false);
                 Assert.IsTrue(certs.Count == 1);
-                X509CRLCollection crls = await trustedStore.EnumerateCRLs(certificate).ConfigureAwait(false);
+                X509CRLCollection crls = await trustedStore.EnumerateCRLsAsync(certificate).ConfigureAwait(false);
                 Assert.AreEqual(1, crls.Count);
             }
 
@@ -91,9 +91,9 @@ namespace Opc.Ua.Gds.Tests
             Assert.NotNull(certificateUpdated);
             using (ICertificateStore trustedStore = applicatioConfiguration.SecurityConfiguration.TrustedIssuerCertificates.OpenStore())
             {
-                X509Certificate2Collection certs = await trustedStore.FindByThumbprint(certificate.Thumbprint).ConfigureAwait(false);
+                X509Certificate2Collection certs = await trustedStore.FindByThumbprintAsync(certificate.Thumbprint).ConfigureAwait(false);
                 Assert.IsTrue(certs.Count == 1);
-                X509CRLCollection crls = await trustedStore.EnumerateCRLs(certificateUpdated).ConfigureAwait(false);
+                X509CRLCollection crls = await trustedStore.EnumerateCRLsAsync(certificateUpdated).ConfigureAwait(false);
                 Assert.AreEqual(1, crls.Count);
             }
         }

--- a/Tests/Opc.Ua.Gds.Tests/Common.cs
+++ b/Tests/Opc.Ua.Gds.Tests/Common.cs
@@ -296,17 +296,17 @@ namespace Opc.Ua.Gds.Tests
 
         public static async Task CleanupTrustList(ICertificateStore store, bool dispose = true)
         {
-            var certs = await store.Enumerate().ConfigureAwait(false);
+            var certs = await store.EnumerateAsync().ConfigureAwait(false);
             foreach (var cert in certs)
             {
-                await store.Delete(cert.Thumbprint).ConfigureAwait(false);
+                await store.DeleteAsync(cert.Thumbprint).ConfigureAwait(false);
             }
             if (store.SupportsCRLs)
             {
-                var crls = await store.EnumerateCRLs().ConfigureAwait(false);
+                var crls = await store.EnumerateCRLsAsync().ConfigureAwait(false);
                 foreach (var crl in crls)
                 {
-                    await store.DeleteCRL(crl).ConfigureAwait(false);
+                    await store.DeleteCRLAsync(crl).ConfigureAwait(false);
                 }
             }
             if (dispose)

--- a/Tests/Opc.Ua.Gds.Tests/GlobalDiscoveryTestClient.cs
+++ b/Tests/Opc.Ua.Gds.Tests/GlobalDiscoveryTestClient.cs
@@ -216,7 +216,7 @@ namespace Opc.Ua.Gds.Tests
                 var certWithPrivateKey = CertificateFactory.CreateCertificateWithPEMPrivateKey(x509, privateKey);
                 m_client.Configuration.SecurityConfiguration.ApplicationCertificate = new CertificateIdentifier(certWithPrivateKey);
                 var store = m_client.Configuration.SecurityConfiguration.ApplicationCertificate.OpenStore();
-                await store.Add(certWithPrivateKey).ConfigureAwait(false);
+                await store.AddAsync(certWithPrivateKey).ConfigureAwait(false);
             }
         }
 

--- a/Tests/Opc.Ua.Gds.Tests/GlobalDiscoveryTestServer.cs
+++ b/Tests/Opc.Ua.Gds.Tests/GlobalDiscoveryTestServer.cs
@@ -79,7 +79,7 @@ namespace Opc.Ua.Gds.Tests
                 {
                     using (var store = Config.SecurityConfiguration.ApplicationCertificate.OpenStore())
                     {
-                        await store.Delete(thumbprint).ConfigureAwait(false);
+                        await store.DeleteAsync(thumbprint).ConfigureAwait(false);
                     }
                 }
 

--- a/Tests/Opc.Ua.Gds.Tests/PushTest.cs
+++ b/Tests/Opc.Ua.Gds.Tests/PushTest.cs
@@ -864,12 +864,12 @@ namespace Opc.Ua.Gds.Tests
             try
             {
                 store = trustList.OpenStore();
-                var storeCrls = await store.EnumerateCRLs().ConfigureAwait(false);
+                var storeCrls = await store.EnumerateCRLsAsync().ConfigureAwait(false);
                 foreach (var crl in storeCrls)
                 {
                     if (!updatedCrls.Remove(crl))
                     {
-                        if (!await store.DeleteCRL(crl).ConfigureAwait(false))
+                        if (!await store.DeleteCRLAsync(crl).ConfigureAwait(false))
                         {
                             result = false;
                         }
@@ -877,7 +877,7 @@ namespace Opc.Ua.Gds.Tests
                 }
                 foreach (var crl in updatedCrls)
                 {
-                    await store.AddCRL(crl).ConfigureAwait(false);
+                    await store.AddCRLAsync(crl).ConfigureAwait(false);
                 }
             }
             catch
@@ -900,12 +900,12 @@ namespace Opc.Ua.Gds.Tests
             try
             {
                 store = trustList.OpenStore();
-                var storeCerts = await store.Enumerate().ConfigureAwait(false);
+                var storeCerts = await store.EnumerateAsync().ConfigureAwait(false);
                 foreach (var cert in storeCerts)
                 {
                     if (!updatedCerts.Contains(cert))
                     {
-                        if (!store.Delete(cert.Thumbprint).Result)
+                        if (!store.DeleteAsync(cert.Thumbprint).Result)
                         {
                             result = false;
                         }
@@ -917,7 +917,7 @@ namespace Opc.Ua.Gds.Tests
                 }
                 foreach (var cert in updatedCerts)
                 {
-                    await store.Add(cert).ConfigureAwait(false);
+                    await store.AddAsync(cert).ConfigureAwait(false);
                 }
             }
             catch
@@ -977,18 +977,18 @@ namespace Opc.Ua.Gds.Tests
             {
                 using (ICertificateStore store = storeIdentifier.OpenStore())
                 {
-                    var storeCerts = store.Enumerate().Result;
+                    var storeCerts = store.EnumerateAsync().Result;
                     foreach (var cert in storeCerts)
                     {
-                        if (!store.Delete(cert.Thumbprint).Result)
+                        if (!store.DeleteAsync(cert.Thumbprint).Result)
                         {
                             result = false;
                         }
                     }
-                    var storeCrls = store.EnumerateCRLs().Result;
+                    var storeCrls = store.EnumerateCRLsAsync().Result;
                     foreach (var crl in storeCrls)
                     {
-                        if (!store.DeleteCRL(crl).Result)
+                        if (!store.DeleteCRLAsync(crl).Result)
                         {
                             result = false;
                         }


### PR DESCRIPTION
## Proposed changes

Make ICertificateStore use Async suffixes for methods returning a Task

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.
