### PR TITLE
Server: Fix Subscription Keepalive being sent on first publish / Client: Disable Subscription cleanup if subscriptions are being created

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,9 +14,9 @@
     <PackageVersion Include="Microsoft.AspNetCore.Server.Kestrel.Https" Version="2.3.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets" Version="2.3.0" />
     <PackageVersion Include="Microsoft.Bcl.HashCode" Version="6.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.8" />
     <PackageVersion Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
@@ -28,9 +28,9 @@
     <PackageVersion Include="Nerdbank.GitVersioning" Version="3.7.115" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="Nito.AsyncEx" Version="5.1.2" />
-    <PackageVersion Include="NUnit" Version="4.3.2" />
+    <PackageVersion Include="NUnit" Version="4.4.0" />
     <PackageVersion Include="NUnit.Console" Version="3.20.1" />
-    <PackageVersion Include="NUnit3TestAdapter" Version="5.0.0" />
+    <PackageVersion Include="NUnit3TestAdapter" Version="5.1.0" />
     <PackageVersion Include="SharpFuzz" Version="2.2.0" />
     <PackageVersion Include="Serilog" Version="4.3.0" />
     <PackageVersion Include="Serilog.Expressions" Version="5.0.0" />

--- a/Libraries/Opc.Ua.Client/Session/Session.cs
+++ b/Libraries/Opc.Ua.Client/Session/Session.cs
@@ -5906,6 +5906,8 @@ namespace Opc.Ua.Client
                 }
             }
 
+            bool subscriptionCreationInProgress = false;
+
             lock (SyncRoot)
             {
                 // find the subscription.
@@ -5915,6 +5917,11 @@ namespace Opc.Ua.Client
                     {
                         subscription = current;
                         break;
+                    }
+                    if (current.Id == default)
+                    {
+                        // Subscription is being created, disable cleanup mechanism
+                        subscriptionCreationInProgress = true;
                     }
                 }
             }
@@ -5957,7 +5964,7 @@ namespace Opc.Ua.Client
             }
             else
             {
-                if (m_deleteSubscriptionsOnClose && !m_reconnecting)
+                if (m_deleteSubscriptionsOnClose && !m_reconnecting && !subscriptionCreationInProgress)
                 {
                     // Delete abandoned subscription from server.
                     Utils.LogWarning("Received Publish Response for Unknown SubscriptionId={0}. Deleting abandoned subscription from server.", subscriptionId);
@@ -6416,7 +6423,7 @@ namespace Opc.Ua.Client
                 }
             }
         }
-#endregion
+        #endregion
 
         #region Protected Fields
         /// <summary>

--- a/Libraries/Opc.Ua.Server/Subscription/Subscription.cs
+++ b/Libraries/Opc.Ua.Server/Subscription/Subscription.cs
@@ -69,7 +69,7 @@ namespace Opc.Ua.Server
             m_publishingEnabled = publishingEnabled;
             m_priority = priority;
             m_publishTimerExpiry = HiResClock.TickCount64 + (long)publishingInterval;
-            m_keepAliveCounter = maxKeepAliveCount;
+            m_keepAliveCounter = 0;
             m_lifetimeCounter = 0;
             m_waitingForPublish = false;
             m_maxMessageCount = maxMessageCount;
@@ -151,7 +151,7 @@ namespace Opc.Ua.Server
             m_publishingEnabled = false;
             m_priority = storedSubscription.Priority;
             m_publishTimerExpiry = HiResClock.TickCount64 + (long)storedSubscription.PublishingInterval;
-            m_keepAliveCounter = storedSubscription.MaxKeepaliveCount;
+            m_keepAliveCounter = 0;
             m_waitingForPublish = false;
             m_maxMessageCount = storedSubscription.MaxMessageCount;
             m_sentMessages = storedSubscription.SentMessages;

--- a/Tests/Opc.Ua.Client.Tests/DurableSubscriptionTest.cs
+++ b/Tests/Opc.Ua.Client.Tests/DurableSubscriptionTest.cs
@@ -199,7 +199,7 @@ namespace Opc.Ua.Client.Tests
             Dictionary<string, object> initialValues = GetValues(desiredNodeIds);
 
             uint revisedLifetimeInHours = 0;
-            Assert.True(subscription.SetSubscriptionDurable(requestedHours, out revisedLifetimeInHours));
+            Assert.True(subscription.SetSubscriptionDurable(requestedHours, out revisedLifetimeInHours), "SetSubscriptionDurable should return true");
 
             Assert.AreEqual(expectedHours, revisedLifetimeInHours);
 

--- a/Tests/Opc.Ua.Client.Tests/NodeCacheAsyncTest.cs
+++ b/Tests/Opc.Ua.Client.Tests/NodeCacheAsyncTest.cs
@@ -99,6 +99,8 @@ namespace Opc.Ua.Client.Tests
 
             // clear node cache
             Session.NodeCache.Clear();
+            // increase timeout for long read operations
+            Session.OperationTimeout = MaxTimeout * 5;
         }
 
         /// <summary>

--- a/Tests/Opc.Ua.Client.Tests/SubscriptionTest.cs
+++ b/Tests/Opc.Ua.Client.Tests/SubscriptionTest.cs
@@ -762,8 +762,6 @@ namespace Opc.Ua.Client.Tests
             const int subscriptions = 50;
             const int maxServerPublishRequest = 20;
 
-            Session.DeleteSubscriptionsOnClose = false;
-
             for (int i = 0; i < subscriptions; i++)
             {
                 var subscription = new TestableSubscription(Session.DefaultSubscription) {
@@ -817,8 +815,6 @@ namespace Opc.Ua.Client.Tests
                 var result = await Session.RemoveSubscriptionAsync(subscription).ConfigureAwait(false);
                 Assert.True(result);
             }
-
-            Session.DeleteSubscriptionsOnClose = true;
         }
 
         public enum TransferType

--- a/Tests/Opc.Ua.Client.Tests/SubscriptionTest.cs
+++ b/Tests/Opc.Ua.Client.Tests/SubscriptionTest.cs
@@ -806,7 +806,7 @@ namespace Opc.Ua.Client.Tests
             while (stopwatch.ElapsedMilliseconds < testWaitTime)
             {
                 // use the sample server default for max publish request count
-                Assert.GreaterOrEqual(Math.Max(maxServerPublishRequest, subscriptions), Session.GoodPublishRequestCount);
+                Assert.GreaterOrEqual(Math.Max(maxServerPublishRequest, subscriptions), Session.GoodPublishRequestCount, "No. of Good Publish Requests shall be at max count of subscriptions");
                 await Task.Delay(100).ConfigureAwait(false);
             }
 

--- a/Tests/Opc.Ua.Core.Tests/Security/Certificates/CertificateValidatorTest.cs
+++ b/Tests/Opc.Ua.Core.Tests/Security/Certificates/CertificateValidatorTest.cs
@@ -236,8 +236,8 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
                     Assert.AreEqual((StatusCode)StatusCodes.BadCertificateUntrusted, (StatusCode)serviceResultException.StatusCode, serviceResultException.Message);
                 }
 
-                Thread.Sleep(1000);
-                Assert.AreEqual(m_appSelfSignedCerts.Count, validator.RejectedStore.EnumerateAsync().GetAwaiter().GetResult().Count);
+                Thread.Sleep(1500);
+                Assert.AreEqual(m_appSelfSignedCerts.Count, validator.RejectedStore.EnumerateAsync().GetAwaiter().GetResult().Count, "All self signed certs shall be contained in the RejectedStore");
 
                 // add auto approver
                 var approver = new CertValidationApprover(new StatusCode[] { StatusCodes.BadCertificateUntrusted });
@@ -250,7 +250,7 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
                     }
                 }
                 // count certs written to rejected store
-                Assert.AreEqual(m_appSelfSignedCerts.Count, approver.AcceptedCount);
+                Assert.AreEqual(m_appSelfSignedCerts.Count, approver.AcceptedCount, "All self signed certs shall be accepted with StatusCode BadCertificateUntrusted");
             }
         }
 

--- a/Tests/Opc.Ua.Server.Tests/ReferenceServerTest.cs
+++ b/Tests/Opc.Ua.Server.Tests/ReferenceServerTest.cs
@@ -546,7 +546,7 @@ namespace Opc.Ua.Server.Tests
                         //If sampling groups are used, samplingInterval needs to be waited before values are queued
                         if (m_fixture.UseSamplingGroupsInReferenceNodeManager)
                         {
-                            Thread.Sleep((int)(100.0 * 1.5));
+                            Thread.Sleep((int)(100.0 * 1.7));
                         }
                         UpdateValues(testSet);
                     }

--- a/Tests/Opc.Ua.Server.Tests/ReferenceServerTest.cs
+++ b/Tests/Opc.Ua.Server.Tests/ReferenceServerTest.cs
@@ -546,13 +546,13 @@ namespace Opc.Ua.Server.Tests
                         //If sampling groups are used, samplingInterval needs to be waited before values are queued
                         if (m_fixture.UseSamplingGroupsInReferenceNodeManager)
                         {
-                            Thread.Sleep((int)(100.0 * 1.3));
+                            Thread.Sleep((int)(100.0 * 1.5));
                         }
                         UpdateValues(testSet);
                     }
 
                     // Wait a bit to ensure that the server has time to queue the values
-                    Thread.Sleep(500);
+                    Thread.Sleep(1000);
                 }
 
                 // call ResendData method from the same session context

--- a/Tests/Opc.Ua.Server.Tests/ReferenceServerTest.cs
+++ b/Tests/Opc.Ua.Server.Tests/ReferenceServerTest.cs
@@ -546,13 +546,13 @@ namespace Opc.Ua.Server.Tests
                         //If sampling groups are used, samplingInterval needs to be waited before values are queued
                         if (m_fixture.UseSamplingGroupsInReferenceNodeManager)
                         {
-                            Thread.Sleep((int)(100.0 * 1.1));
+                            Thread.Sleep((int)(100.0 * 1.3));
                         }
                         UpdateValues(testSet);
                     }
 
                     // Wait a bit to ensure that the server has time to queue the values
-                    Thread.Sleep(1000);
+                    Thread.Sleep(500);
                 }
 
                 // call ResendData method from the same session context


### PR DESCRIPTION
## Proposed changes

- Server: fix Subscription Keepalive being sent on first publish instead of after MaxKeepAliveCount
- Client: Disable Cleanup of unknown Subscription if subscriptions are being created at the time
- Improve flaky tests
- Update nuget packages

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.