### PR TITLE
Set Version 1.5.377 / Increase DurableSubscriptionTest Session Timeout

### DIFF
--- a/Tests/Opc.Ua.Client.Tests/DurableSubscriptionTest.cs
+++ b/Tests/Opc.Ua.Client.Tests/DurableSubscriptionTest.cs
@@ -139,7 +139,7 @@ namespace Opc.Ua.Client.Tests
             {
                 try
                 {
-                    ClientFixture.SessionTimeout = 1500;
+                    ClientFixture.SessionTimeout = 10000;
                     Session = await ClientFixture
                         .ConnectAsync(
                             ServerUrl,

--- a/version.json
+++ b/version.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.5.376-preview",
-  "versionHeightOffset": 200,
+  "version": "1.5.377-preview",
+  "versionHeightOffset": 0,
   "nugetPackageVersion": {
     "semVer": 2
   },


### PR DESCRIPTION
## Proposed changes

Set Version 1.5.377 & Increase DurableSubscriptionTest Session Timeout

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

