### PR TITLE
Fixed bug #3173   handle leak in complex type system

### DIFF
--- a/Applications/ConsoleReferenceClient/ClientSamples.cs
+++ b/Applications/ConsoleReferenceClient/ClientSamples.cs
@@ -1100,7 +1100,7 @@ namespace Quickstarts
             var stopWatch = new Stopwatch();
             stopWatch.Start();
 
-            var complexTypeSystem = new ComplexTypeSystem(session);
+            var complexTypeSystem = new ComplexTypeSystem(session, m_complexTypeBuilderFactory);
             await complexTypeSystem.LoadAsync().ConfigureAwait(false);
 
             stopWatch.Stop();
@@ -1133,6 +1133,8 @@ namespace Quickstarts
 
             return complexTypeSystem;
         }
+
+        private static readonly ComplexTypeBuilderFactory m_complexTypeBuilderFactory = new ComplexTypeBuilderFactory();
 
         /// <summary>
         /// Read all ReferenceTypeIds from the server that are not known by the client.

--- a/Libraries/Opc.Ua.Client.ComplexTypes/ComplexTypeSystem.cs
+++ b/Libraries/Opc.Ua.Client.ComplexTypes/ComplexTypeSystem.cs
@@ -65,6 +65,7 @@ namespace Opc.Ua.Client.ComplexTypes
 
         /// <summary>
         /// Initializes the type system with a session to load the custom types.
+        /// May cause a handle leak when called repeatedly; to avoid it, use the form which takes IComplexTypeFactory and create ComplexTypeBuilderFactory just once (see bug #3173).
         /// </summary>
         public ComplexTypeSystem(ISession session)
         {


### PR DESCRIPTION
## Proposed changes

Using different constructor for ComplexTypeSystem to prevent a handle leak.

## Related Issues

- Fixes #3173

## Types of changes

- [x ] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

