### PR TITLE
[Client] Use TransportQuotas from ApplicationConfiguration in CoreClientUtils for creating EndpointConfiguration

### DIFF
--- a/Libraries/Opc.Ua.Client/CoreClientUtils.cs
+++ b/Libraries/Opc.Ua.Client/CoreClientUtils.cs
@@ -131,7 +131,7 @@ namespace Opc.Ua.Client
             bool useSecurity,
             int discoverTimeout)
         {
-            var endpointConfiguration = EndpointConfiguration.Create();
+            var endpointConfiguration = EndpointConfiguration.Create(application);
             endpointConfiguration.OperationTimeout = discoverTimeout > 0
                 ? discoverTimeout
                 : DefaultDiscoverTimeout;
@@ -175,7 +175,7 @@ namespace Opc.Ua.Client
             int discoverTimeout)
         {
             Uri uri = GetDiscoveryUrl(discoveryUrl);
-            var endpointConfiguration = EndpointConfiguration.Create();
+            var endpointConfiguration = EndpointConfiguration.Create(application);
             endpointConfiguration.OperationTimeout = discoverTimeout;
 
             using var client = DiscoveryClient.Create(application, uri, endpointConfiguration);


### PR DESCRIPTION
## Proposed changes

Use TransportQuotas from ApplicationConfiguration in CoreClientUtils for creating EndpointConfiguration.
This fixes that TransportQuotas from ApplicationConfiguration are not used for the created Endpoints.

For the Discovery Client the default TransportQuotas are still used.

## Related Issues

- Fixes #

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.


