### PR TITLE
[Server] Make IAsyncNodeManager interface composable

### DIFF
--- a/Libraries/Opc.Ua.Gds.Server.Common/ApplicationsNodeManager.cs
+++ b/Libraries/Opc.Ua.Gds.Server.Common/ApplicationsNodeManager.cs
@@ -45,7 +45,7 @@ namespace Opc.Ua.Gds.Server
     /// <summary>
     /// A node manager for a global discovery server
     /// </summary>
-    public class ApplicationsNodeManager : CustomNodeManager2, IAsyncNodeManager
+    public class ApplicationsNodeManager : CustomNodeManager2, ICallAsyncNodeManager
     {
         private readonly NodeId m_defaultApplicationGroupId;
         private readonly NodeId m_defaultHttpsGroupId;

--- a/Libraries/Opc.Ua.Server/Configuration/ConfigurationNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/Configuration/ConfigurationNodeManager.cs
@@ -59,7 +59,7 @@ namespace Opc.Ua.Server
     /// <summary>
     /// The Server Configuration Node Manager.
     /// </summary>
-    public class ConfigurationNodeManager : DiagnosticsNodeManager, IAsyncNodeManager
+    public class ConfigurationNodeManager : DiagnosticsNodeManager, ICallAsyncNodeManager
     {
         /// <summary>
         /// Initializes the configuration and diagnostics manager.

--- a/Libraries/Opc.Ua.Server/Diagnostics/CustomNodeManagerAsync.cs
+++ b/Libraries/Opc.Ua.Server/Diagnostics/CustomNodeManagerAsync.cs
@@ -35,7 +35,7 @@ namespace Opc.Ua.Server
 {
     /// <summary>
     /// Second part of the see<see cref="CustomNodeManager2"/> class."/>
-    /// Implementation of the <see cref="IAsyncNodeManager"/> interface for custom node management.
+    /// Implementation of the <see cref="ICallAsyncNodeManager"/> interface for custom node management.
     /// The interface is not implmented by default to ensure consistent behaviour in existing NodeManagers, but can be implemented in a derived class.
     /// </summary>
     public partial class CustomNodeManager2

--- a/Libraries/Opc.Ua.Server/NodeManager/AsyncNodeManagerAdapter.cs
+++ b/Libraries/Opc.Ua.Server/NodeManager/AsyncNodeManagerAdapter.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Opc.Ua.Server
+{
+    /// <summary>
+    /// The factory for an <see cref="AsyncNodeManagerAdapter"/>
+    /// </summary>
+    public static class AsyncNodeManagerAdapterFactory
+    {
+        /// <summary>
+        /// returns an instace of <see cref="IAsyncNodeManager"/>
+        /// if the nodeManager does not implement the interface uses the <see cref="AsyncNodeManagerAdapter"/>
+        /// to create an IASyncNodeManager compatible object
+        /// </summary>
+        public static IAsyncNodeManager ToAsyncNodeManager(this INodeManager nodeManager)
+        {
+            if (nodeManager is IAsyncNodeManager asyncNodeManager)
+            {
+                return asyncNodeManager;
+            }
+            return new AsyncNodeManagerAdapter(nodeManager);
+        }
+    }
+
+    /// <summary>
+    /// An adapter that makes a synchronous INodeManager conform to the IAsyncNodeManager interface.
+    /// </summary>
+    /// <remarks>
+    /// This allows synchronous, or only partially asynchronous node managers to be treated as asynchronous, which can help
+    /// unify the calling logic within the MasterNodeManager.
+    /// </remarks>
+    public class AsyncNodeManagerAdapter : IAsyncNodeManager
+    {
+        private readonly INodeManager m_nodeManager;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AsyncNodeManagerAdapter"/> class.
+        /// </summary>
+        /// <param name="nodeManager">The synchronous node manager to wrap.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="nodeManager"/> is <c>null</c>.</exception>
+        public AsyncNodeManagerAdapter(INodeManager nodeManager)
+        {
+            m_nodeManager = nodeManager ?? throw new ArgumentNullException(nameof(nodeManager));
+        }
+
+        /// <inheritdoc/>
+        public ValueTask CallAsync(
+            OperationContext context,
+            IList<CallMethodRequest> methodsToCall,
+            IList<CallMethodResult> results,
+            IList<ServiceResult> errors,
+            CancellationToken cancellationToken = default)
+        {
+            if (m_nodeManager is ICallAsyncNodeManager asyncNodeManager)
+            {
+                return asyncNodeManager.CallAsync(context, methodsToCall, results, errors, cancellationToken);
+            }
+
+            m_nodeManager.Call(context, methodsToCall, results, errors);
+
+            // Return a completed ValueTask since the underlying call is synchronous.
+            return default;
+        }
+    }
+}

--- a/Libraries/Opc.Ua.Server/NodeManager/INodeManager.cs
+++ b/Libraries/Opc.Ua.Server/NodeManager/INodeManager.cs
@@ -375,9 +375,9 @@ namespace Opc.Ua.Server
     }
 
     /// <summary>
-    /// An asynchronous verson of the <see cref="INodeManager2"/> interface.
+    /// An asynchronous verson of the "Call" method defined on the <see cref="INodeManager2"/> interface.
     /// </summary>
-    public interface IAsyncNodeManager : INodeManager2
+    public interface ICallAsyncNodeManager
     {
         /// <summary>
         /// Asycnhronously calls a method defined on an object.
@@ -389,6 +389,12 @@ namespace Opc.Ua.Server
             IList<ServiceResult> errors,
             CancellationToken cancellationToken = default);
     }
+
+
+    /// <summary>
+    /// An asynchronous verson of the <see cref="INodeManager2"/> interface.
+    /// </summary>
+    public interface IAsyncNodeManager : ICallAsyncNodeManager;
 
     /// <summary>
     /// Stores metadata required to process requests related to a node.

--- a/Libraries/Opc.Ua.Server/NodeManager/MasterNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/NodeManager/MasterNodeManager.cs
@@ -92,8 +92,9 @@ namespace Opc.Ua.Server
 
             // add the core node manager second because the diagnostics node manager takes priority.
             // always add the core node manager to the second of the list.
-            m_nodeManagers.Add(
-                new CoreNodeManager(Server, configuration, (ushort)dynamicNamespaceIndex));
+            var coreNodeManager = new CoreNodeManager(Server, configuration, (ushort)dynamicNamespaceIndex);
+            m_nodeManagers.Add(coreNodeManager);
+            m_asyncNodeManagers.Add(coreNodeManager.ToAsyncNodeManager());
 
             // register core node manager for default UA namespace.
             namespaceManagers[0].Add(m_nodeManagers[1]);
@@ -131,6 +132,7 @@ namespace Opc.Ua.Server
             Dictionary<int, List<INodeManager>> namespaceManagers)
         {
             m_nodeManagers.Add(nodeManager);
+            m_asyncNodeManagers.Add(nodeManager.ToAsyncNodeManager());
 
             // ensure the NamespaceUris supported by the NodeManager are in the Server's NamespaceTable.
             if (nodeManager.NamespaceUris != null)
@@ -178,6 +180,7 @@ namespace Opc.Ua.Server
                 {
                     nodeManagers = [.. m_nodeManagers];
                     m_nodeManagers.Clear();
+                    m_asyncNodeManagers.Clear();
                 }
 
                 foreach (INodeManager nodeManager in nodeManagers)
@@ -2263,36 +2266,31 @@ namespace Opc.Ua.Server
             // call each node manager.
             if (validItems)
             {
-                foreach (INodeManager nodeManager in m_nodeManagers)
+                foreach (IAsyncNodeManager asyncNodeManager in m_asyncNodeManagers)
                 {
-                    if (nodeManager is IAsyncNodeManager asyncNodeManager)
+                    if (sync)
                     {
-                        // call async node manager
-                        if (sync)
+                        if (asyncNodeManager is not AsyncNodeManagerAdapter)
                         {
                             Utils.LogWarning(
                                 "Async Method called sychronously. Prefer using CallAsync for best performance. NodeManager={0}",
-                                nodeManager);
-                            asyncNodeManager.CallAsync(
-                                context,
-                                methodsToCall,
-                                results,
-                                errors,
-                                cancellationToken).AsTask().GetAwaiter().GetResult();
+                                asyncNodeManager);
                         }
-                        else
-                        {
-                            await asyncNodeManager.CallAsync(
-                                context,
-                                methodsToCall,
-                                results,
-                                errors,
-                                cancellationToken).ConfigureAwait(false);
-                        }
+                        asyncNodeManager.CallAsync(
+                            context,
+                            methodsToCall,
+                            results,
+                            errors,
+                            cancellationToken).AsTask().GetAwaiter().GetResult();
                     }
                     else
                     {
-                        nodeManager.Call(context, methodsToCall, results, errors);
+                        await asyncNodeManager.CallAsync(
+                            context,
+                            methodsToCall,
+                            results,
+                            errors,
+                            cancellationToken).ConfigureAwait(false);
                     }
                 }
             }
@@ -3179,7 +3177,7 @@ namespace Opc.Ua.Server
         /// <summary>
         /// The node managers being managed.
         /// </summary>
-        public IList<INodeManager> NodeManagers => m_nodeManagers;
+        public IReadOnlyList<INodeManager> NodeManagers => m_nodeManagers;
 
         /// <summary>
         /// The namespace managers being managed
@@ -3784,6 +3782,7 @@ namespace Opc.Ua.Server
 
         private readonly Lock m_lock = new();
         private readonly List<INodeManager> m_nodeManagers;
+        private readonly List<IAsyncNodeManager> m_asyncNodeManagers;
         private long m_lastMonitoredItemId;
         private readonly uint m_maxContinuationPointsPerBrowse;
         private readonly ReaderWriterLockSlim m_readWriterLockSlim = new();


### PR DESCRIPTION
## Proposed changes

Make the IAsyncNodeManager interface composable by extracting each serviceCall into an own sub-interface.
This allows users to only implement some of the methods asynchronously.

Also the IAsyncNodeManager interface can be extended with more supported service calls as the implementation progresses.

## Related Issues

- Fixes #

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.


