### PR TITLE
[PubSub] Renew cancelation token on IntervalRunner Start()

### DIFF
--- a/Libraries/Opc.Ua.PubSub/IntervalRunner.cs
+++ b/Libraries/Opc.Ua.PubSub/IntervalRunner.cs
@@ -104,6 +104,14 @@ namespace Opc.Ua.PubSub
         /// </summary>
         public void Start()
         {
+            lock (m_lock)
+            {
+                if (m_cancellationToken.IsCancellationRequested)
+                {
+                    m_cancellationToken.Dispose();
+                    m_cancellationToken = new CancellationTokenSource();
+                }
+            }
             Task.Run(ProcessAsync).ConfigureAwait(false);
             Utils.Trace("IntervalRunner with id: {0} was started.", Id);
         }


### PR DESCRIPTION
## Proposed changes

The cancelation token on the PubSub Interval runner is not renewed after the Stop() method is called thus any subsequent Start() will silently fail publishing data.

## Related Issues

- Fixes #2929

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [X] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [X] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
