### PR TITLE
[Server] Fix TranslateBrowsePath to NodeIds sync path in MasterNodeManager

### DIFF
--- a/Libraries/Opc.Ua.Server/NodeManager/MasterNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/NodeManager/MasterNodeManager.cs
@@ -770,8 +770,16 @@ namespace Opc.Ua.Server
                 // need to trap unexpected exceptions to handle bugs in the node managers.
                 try
                 {
-                    error = await TranslateBrowsePathAsync(context, browsePath, result, cancellationToken)
-                        .ConfigureAwait(false);
+                    if (sync)
+                    {
+                        error = TranslateBrowsePathAsync(context, browsePath, result, cancellationToken)
+                            .AsTask().GetAwaiter().GetResult();
+                    }
+                    else
+                    {
+                        error = await TranslateBrowsePathAsync(context, browsePath, result, cancellationToken)
+                            .ConfigureAwait(false);
+                    }
                 }
                 catch (Exception e)
                 {

--- a/Tests/Opc.Ua.Client.Tests/SubscriptionTest.cs
+++ b/Tests/Opc.Ua.Client.Tests/SubscriptionTest.cs
@@ -1280,7 +1280,7 @@ namespace Opc.Ua.Client.Tests
             TestContext.Out.WriteLine("Waiting for keep alive");
 
             const int delay = 2000;
-            Thread.Sleep(delay);
+            await Task.Delay(delay).ConfigureAwait(false);
             OutputSubscriptionInfo(TestContext.Out, subscription);
 
             // expect at least half number of keep alive notifications

--- a/Tests/Opc.Ua.Client.Tests/SubscriptionTest.cs
+++ b/Tests/Opc.Ua.Client.Tests/SubscriptionTest.cs
@@ -1293,7 +1293,7 @@ namespace Opc.Ua.Client.Tests
             bool resendData = await subscription.ResendDataAsync().ConfigureAwait(false);
             Assert.True(resendData);
 
-            Thread.Sleep(delay);
+            await Task.Delay(delay).ConfigureAwait(false);
             OutputSubscriptionInfo(TestContext.Out, subscription);
 
             Assert.AreEqual(2, numOfDataChangeNotifications);


### PR DESCRIPTION
## Proposed changes

In the current state of MasterNodeManager sync paths are still needed, but not called when the server is in operation with our default request queue.
This PR fixes an issue in the sync path, where await was used although the method was expected to finish synchronously.