### PR TITLE
[Server] INodeManager: Propagate MonitoredItemId using Class MonitoredItemIdFactory instead of ref globalIdCounter

### DIFF
--- a/Applications/Quickstarts.Servers/MemoryBuffer/MemoryBufferNodeManager.cs
+++ b/Applications/Quickstarts.Servers/MemoryBuffer/MemoryBufferNodeManager.cs
@@ -262,7 +262,7 @@ namespace MemoryBuffer
             TimestampsToReturn timestampsToReturn,
             MonitoredItemCreateRequest itemToCreate,
             bool createDurable,
-            MonitoredItemIds monitoredItemId,
+            MonitoredItemIdFactory monitoredItemIdFactory,
             out MonitoringFilterResult filterError,
             out IMonitoredItem monitoredItem)
         {
@@ -281,7 +281,7 @@ namespace MemoryBuffer
                     timestampsToReturn,
                     itemToCreate,
                     createDurable,
-                    monitoredItemId,
+                    monitoredItemIdFactory,
                     out filterError,
                     out monitoredItem);
             }
@@ -349,7 +349,7 @@ namespace MemoryBuffer
                 context as ServerSystemContext,
                 tag,
                 subscriptionId,
-                monitoredItemId.Next(),
+                monitoredItemIdFactory.GetNextId(),
                 itemToCreate.ItemToMonitor,
                 diagnosticsMasks,
                 timestampsToReturn,

--- a/Applications/Quickstarts.Servers/MemoryBuffer/MemoryBufferNodeManager.cs
+++ b/Applications/Quickstarts.Servers/MemoryBuffer/MemoryBufferNodeManager.cs
@@ -262,7 +262,7 @@ namespace MemoryBuffer
             TimestampsToReturn timestampsToReturn,
             MonitoredItemCreateRequest itemToCreate,
             bool createDurable,
-            MonitoredItemId monitoredItemId,
+            MonitoredItemIds monitoredItemId,
             out MonitoringFilterResult filterError,
             out IMonitoredItem monitoredItem)
         {

--- a/Applications/Quickstarts.Servers/MemoryBuffer/MemoryBufferNodeManager.cs
+++ b/Applications/Quickstarts.Servers/MemoryBuffer/MemoryBufferNodeManager.cs
@@ -262,7 +262,7 @@ namespace MemoryBuffer
             TimestampsToReturn timestampsToReturn,
             MonitoredItemCreateRequest itemToCreate,
             bool createDurable,
-            ref long globalIdCounter,
+            Func<uint> getNextMonitoredItemId,
             out MonitoringFilterResult filterError,
             out IMonitoredItem monitoredItem)
         {
@@ -281,7 +281,7 @@ namespace MemoryBuffer
                     timestampsToReturn,
                     itemToCreate,
                     createDurable,
-                    ref globalIdCounter,
+                    getNextMonitoredItemId,
                     out filterError,
                     out monitoredItem);
             }
@@ -336,9 +336,6 @@ namespace MemoryBuffer
                 return StatusCodes.BadInternalError;
             }
 
-            // create a globally unique identifier.
-            uint monitoredItemId = Utils.IncrementIdentifier(ref globalIdCounter);
-
             // determine the sampling interval.
             double samplingInterval = itemToCreate.RequestedParameters.SamplingInterval;
 
@@ -352,7 +349,7 @@ namespace MemoryBuffer
                 context as ServerSystemContext,
                 tag,
                 subscriptionId,
-                monitoredItemId,
+                getNextMonitoredItemId(),
                 itemToCreate.ItemToMonitor,
                 diagnosticsMasks,
                 timestampsToReturn,

--- a/Applications/Quickstarts.Servers/MemoryBuffer/MemoryBufferNodeManager.cs
+++ b/Applications/Quickstarts.Servers/MemoryBuffer/MemoryBufferNodeManager.cs
@@ -262,7 +262,7 @@ namespace MemoryBuffer
             TimestampsToReturn timestampsToReturn,
             MonitoredItemCreateRequest itemToCreate,
             bool createDurable,
-            Func<uint> getNextMonitoredItemId,
+            MonitoredItemId monitoredItemId,
             out MonitoringFilterResult filterError,
             out IMonitoredItem monitoredItem)
         {
@@ -281,7 +281,7 @@ namespace MemoryBuffer
                     timestampsToReturn,
                     itemToCreate,
                     createDurable,
-                    getNextMonitoredItemId,
+                    monitoredItemId,
                     out filterError,
                     out monitoredItem);
             }
@@ -349,7 +349,7 @@ namespace MemoryBuffer
                 context as ServerSystemContext,
                 tag,
                 subscriptionId,
-                getNextMonitoredItemId(),
+                monitoredItemId.Next(),
                 itemToCreate.ItemToMonitor,
                 diagnosticsMasks,
                 timestampsToReturn,

--- a/Applications/Quickstarts.Servers/SampleNodeManager/SampleNodeManager.cs
+++ b/Applications/Quickstarts.Servers/SampleNodeManager/SampleNodeManager.cs
@@ -2157,7 +2157,7 @@ namespace Opc.Ua.Sample
             IList<MonitoringFilterResult> filterErrors,
             IList<IMonitoredItem> monitoredItems,
             bool createDurable,
-            MonitoredItemId monitoredItemId)
+            MonitoredItemIds monitoredItemId)
         {
             ServerSystemContext systemContext = SystemContext.Copy(context);
             IDictionary<NodeId, NodeState> operationCache = new NodeIdDictionary<NodeState>();
@@ -2567,7 +2567,7 @@ namespace Opc.Ua.Sample
             TimestampsToReturn timestampsToReturn,
             MonitoredItemCreateRequest itemToCreate,
             bool createDurable,
-            MonitoredItemId monitoredItemId,
+            MonitoredItemIds monitoredItemId,
             out MonitoringFilterResult filterError,
             out IMonitoredItem monitoredItem)
         {

--- a/Applications/Quickstarts.Servers/SampleNodeManager/SampleNodeManager.cs
+++ b/Applications/Quickstarts.Servers/SampleNodeManager/SampleNodeManager.cs
@@ -2157,7 +2157,7 @@ namespace Opc.Ua.Sample
             IList<MonitoringFilterResult> filterErrors,
             IList<IMonitoredItem> monitoredItems,
             bool createDurable,
-            ref long globalIdCounter)
+            Func<uint> getNextMonitoredItemId)
         {
             ServerSystemContext systemContext = SystemContext.Copy(context);
             IDictionary<NodeId, NodeState> operationCache = new NodeIdDictionary<NodeState>();
@@ -2211,7 +2211,7 @@ namespace Opc.Ua.Sample
                         timestampsToReturn,
                         itemToCreate,
                         createDurable,
-                        ref globalIdCounter,
+                        getNextMonitoredItemId,
                         out MonitoringFilterResult filterError,
                         out IMonitoredItem monitoredItem);
 
@@ -2255,7 +2255,7 @@ namespace Opc.Ua.Sample
                         timestampsToReturn,
                         itemToCreate,
                         createDurable,
-                        ref globalIdCounter,
+                        getNextMonitoredItemId,
                         out MonitoringFilterResult filterError,
                         out IMonitoredItem monitoredItem);
 
@@ -2567,7 +2567,7 @@ namespace Opc.Ua.Sample
             TimestampsToReturn timestampsToReturn,
             MonitoredItemCreateRequest itemToCreate,
             bool createDurable,
-            ref long globalIdCounter,
+            Func<uint> getNextMonitoredItemId,
             out MonitoringFilterResult filterError,
             out IMonitoredItem monitoredItem)
         {
@@ -2634,9 +2634,6 @@ namespace Opc.Ua.Sample
                 source.Handle = monitoredNode = new MonitoredNode(Server, this, source);
             }
 
-            // create a globally unique identifier.
-            uint monitoredItemId = Utils.IncrementIdentifier(ref globalIdCounter);
-
             // determine the sampling interval.
             double samplingInterval = itemToCreate.RequestedParameters.SamplingInterval;
 
@@ -2662,7 +2659,7 @@ namespace Opc.Ua.Sample
             // create the item.
             DataChangeMonitoredItem datachangeItem = monitoredNode.CreateDataChangeItem(
                 context,
-                monitoredItemId,
+                getNextMonitoredItemId(),
                 itemToCreate.ItemToMonitor.AttributeId,
                 itemToCreate.ItemToMonitor.ParsedIndexRange,
                 itemToCreate.ItemToMonitor.DataEncoding,

--- a/Applications/Quickstarts.Servers/SampleNodeManager/SampleNodeManager.cs
+++ b/Applications/Quickstarts.Servers/SampleNodeManager/SampleNodeManager.cs
@@ -2157,7 +2157,7 @@ namespace Opc.Ua.Sample
             IList<MonitoringFilterResult> filterErrors,
             IList<IMonitoredItem> monitoredItems,
             bool createDurable,
-            MonitoredItemIds monitoredItemId)
+            MonitoredItemIdFactory monitoredItemIdFactory)
         {
             ServerSystemContext systemContext = SystemContext.Copy(context);
             IDictionary<NodeId, NodeState> operationCache = new NodeIdDictionary<NodeState>();
@@ -2211,7 +2211,7 @@ namespace Opc.Ua.Sample
                         timestampsToReturn,
                         itemToCreate,
                         createDurable,
-                        monitoredItemId,
+                        monitoredItemIdFactory,
                         out MonitoringFilterResult filterError,
                         out IMonitoredItem monitoredItem);
 
@@ -2255,7 +2255,7 @@ namespace Opc.Ua.Sample
                         timestampsToReturn,
                         itemToCreate,
                         createDurable,
-                        monitoredItemId,
+                        monitoredItemIdFactory,
                         out MonitoringFilterResult filterError,
                         out IMonitoredItem monitoredItem);
 
@@ -2567,7 +2567,7 @@ namespace Opc.Ua.Sample
             TimestampsToReturn timestampsToReturn,
             MonitoredItemCreateRequest itemToCreate,
             bool createDurable,
-            MonitoredItemIds monitoredItemId,
+            MonitoredItemIdFactory monitoredItemIdFactory,
             out MonitoringFilterResult filterError,
             out IMonitoredItem monitoredItem)
         {
@@ -2659,7 +2659,7 @@ namespace Opc.Ua.Sample
             // create the item.
             DataChangeMonitoredItem datachangeItem = monitoredNode.CreateDataChangeItem(
                 context,
-                monitoredItemId.Next(),
+                monitoredItemIdFactory.GetNextId(),
                 itemToCreate.ItemToMonitor.AttributeId,
                 itemToCreate.ItemToMonitor.ParsedIndexRange,
                 itemToCreate.ItemToMonitor.DataEncoding,

--- a/Applications/Quickstarts.Servers/SampleNodeManager/SampleNodeManager.cs
+++ b/Applications/Quickstarts.Servers/SampleNodeManager/SampleNodeManager.cs
@@ -2157,7 +2157,7 @@ namespace Opc.Ua.Sample
             IList<MonitoringFilterResult> filterErrors,
             IList<IMonitoredItem> monitoredItems,
             bool createDurable,
-            Func<uint> getNextMonitoredItemId)
+            MonitoredItemId monitoredItemId)
         {
             ServerSystemContext systemContext = SystemContext.Copy(context);
             IDictionary<NodeId, NodeState> operationCache = new NodeIdDictionary<NodeState>();
@@ -2211,7 +2211,7 @@ namespace Opc.Ua.Sample
                         timestampsToReturn,
                         itemToCreate,
                         createDurable,
-                        getNextMonitoredItemId,
+                        monitoredItemId,
                         out MonitoringFilterResult filterError,
                         out IMonitoredItem monitoredItem);
 
@@ -2255,7 +2255,7 @@ namespace Opc.Ua.Sample
                         timestampsToReturn,
                         itemToCreate,
                         createDurable,
-                        getNextMonitoredItemId,
+                        monitoredItemId,
                         out MonitoringFilterResult filterError,
                         out IMonitoredItem monitoredItem);
 
@@ -2567,7 +2567,7 @@ namespace Opc.Ua.Sample
             TimestampsToReturn timestampsToReturn,
             MonitoredItemCreateRequest itemToCreate,
             bool createDurable,
-            Func<uint> getNextMonitoredItemId,
+            MonitoredItemId monitoredItemId,
             out MonitoringFilterResult filterError,
             out IMonitoredItem monitoredItem)
         {
@@ -2659,7 +2659,7 @@ namespace Opc.Ua.Sample
             // create the item.
             DataChangeMonitoredItem datachangeItem = monitoredNode.CreateDataChangeItem(
                 context,
-                getNextMonitoredItemId(),
+                monitoredItemId.Next(),
                 itemToCreate.ItemToMonitor.AttributeId,
                 itemToCreate.ItemToMonitor.ParsedIndexRange,
                 itemToCreate.ItemToMonitor.DataEncoding,

--- a/Libraries/Opc.Ua.Server/Diagnostics/CustomNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/Diagnostics/CustomNodeManager.cs
@@ -3651,7 +3651,7 @@ namespace Opc.Ua.Server
             IList<MonitoringFilterResult> filterErrors,
             IList<IMonitoredItem> monitoredItems,
             bool createDurable,
-            MonitoredItemId monitoredItemId)
+            MonitoredItemIds monitoredItemId)
         {
             ServerSystemContext systemContext = SystemContext.Copy(context);
             IDictionary<NodeId, NodeState> operationCache = new NodeIdDictionary<NodeState>();
@@ -3779,7 +3779,7 @@ namespace Opc.Ua.Server
             TimestampsToReturn timestampsToReturn,
             MonitoredItemCreateRequest itemToCreate,
             bool createDurable,
-            MonitoredItemId monitoredItemId,
+            MonitoredItemIds monitoredItemId,
             out MonitoringFilterResult filterResult,
             out IMonitoredItem monitoredItem)
         {

--- a/Libraries/Opc.Ua.Server/Diagnostics/CustomNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/Diagnostics/CustomNodeManager.cs
@@ -3651,7 +3651,7 @@ namespace Opc.Ua.Server
             IList<MonitoringFilterResult> filterErrors,
             IList<IMonitoredItem> monitoredItems,
             bool createDurable,
-            Func<uint> getNextMonitoredItemId)
+            MonitoredItemId monitoredItemId)
         {
             ServerSystemContext systemContext = SystemContext.Copy(context);
             IDictionary<NodeId, NodeState> operationCache = new NodeIdDictionary<NodeState>();
@@ -3727,7 +3727,7 @@ namespace Opc.Ua.Server
                         timestampsToReturn,
                         itemToCreate,
                         createDurable,
-                        getNextMonitoredItemId,
+                        monitoredItemId,
                         out filterResult,
                         out monitoredItem);
                 }
@@ -3779,7 +3779,7 @@ namespace Opc.Ua.Server
             TimestampsToReturn timestampsToReturn,
             MonitoredItemCreateRequest itemToCreate,
             bool createDurable,
-            Func<uint> getNextMonitoredItemId,
+            MonitoredItemId monitoredItemId,
             out MonitoringFilterResult filterResult,
             out IMonitoredItem monitoredItem)
         {
@@ -3858,7 +3858,7 @@ namespace Opc.Ua.Server
                     samplingInterval,
                     revisedQueueSize,
                     createDurable,
-                    getNextMonitoredItemId(),
+                    monitoredItemId.Next(),
                     AddNodeToComponentCache);
 
             monitoredItem = dataChangeMonitoredItem;

--- a/Libraries/Opc.Ua.Server/Diagnostics/CustomNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/Diagnostics/CustomNodeManager.cs
@@ -3651,7 +3651,7 @@ namespace Opc.Ua.Server
             IList<MonitoringFilterResult> filterErrors,
             IList<IMonitoredItem> monitoredItems,
             bool createDurable,
-            ref long globalIdCounter)
+            Func<uint> getNextMonitoredItemId)
         {
             ServerSystemContext systemContext = SystemContext.Copy(context);
             IDictionary<NodeId, NodeState> operationCache = new NodeIdDictionary<NodeState>();
@@ -3727,7 +3727,7 @@ namespace Opc.Ua.Server
                         timestampsToReturn,
                         itemToCreate,
                         createDurable,
-                        ref globalIdCounter,
+                        getNextMonitoredItemId,
                         out filterResult,
                         out monitoredItem);
                 }
@@ -3779,7 +3779,7 @@ namespace Opc.Ua.Server
             TimestampsToReturn timestampsToReturn,
             MonitoredItemCreateRequest itemToCreate,
             bool createDurable,
-            ref long globalIdCounter,
+            Func<uint> getNextMonitoredItemId,
             out MonitoringFilterResult filterResult,
             out IMonitoredItem monitoredItem)
         {
@@ -3794,9 +3794,6 @@ namespace Opc.Ua.Server
             {
                 return StatusCodes.BadAttributeIdInvalid;
             }
-
-            // create a globally unique identifier.
-            uint monitoredItemId = Utils.IncrementIdentifier(ref globalIdCounter);
 
             // determine the sampling interval.
             double samplingInterval = itemToCreate.RequestedParameters.SamplingInterval;
@@ -3861,7 +3858,7 @@ namespace Opc.Ua.Server
                     samplingInterval,
                     revisedQueueSize,
                     createDurable,
-                    monitoredItemId,
+                    getNextMonitoredItemId(),
                     AddNodeToComponentCache);
 
             monitoredItem = dataChangeMonitoredItem;

--- a/Libraries/Opc.Ua.Server/Diagnostics/CustomNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/Diagnostics/CustomNodeManager.cs
@@ -3651,7 +3651,7 @@ namespace Opc.Ua.Server
             IList<MonitoringFilterResult> filterErrors,
             IList<IMonitoredItem> monitoredItems,
             bool createDurable,
-            MonitoredItemIds monitoredItemId)
+            MonitoredItemIdFactory monitoredItemIdFactory)
         {
             ServerSystemContext systemContext = SystemContext.Copy(context);
             IDictionary<NodeId, NodeState> operationCache = new NodeIdDictionary<NodeState>();
@@ -3727,7 +3727,7 @@ namespace Opc.Ua.Server
                         timestampsToReturn,
                         itemToCreate,
                         createDurable,
-                        monitoredItemId,
+                        monitoredItemIdFactory,
                         out filterResult,
                         out monitoredItem);
                 }
@@ -3779,7 +3779,7 @@ namespace Opc.Ua.Server
             TimestampsToReturn timestampsToReturn,
             MonitoredItemCreateRequest itemToCreate,
             bool createDurable,
-            MonitoredItemIds monitoredItemId,
+            MonitoredItemIdFactory monitoredItemId,
             out MonitoringFilterResult filterResult,
             out IMonitoredItem monitoredItem)
         {
@@ -3858,7 +3858,7 @@ namespace Opc.Ua.Server
                     samplingInterval,
                     revisedQueueSize,
                     createDurable,
-                    monitoredItemId.Next(),
+                    monitoredItemId.GetNextId(),
                     AddNodeToComponentCache);
 
             monitoredItem = dataChangeMonitoredItem;

--- a/Libraries/Opc.Ua.Server/NodeManager/CoreNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/NodeManager/CoreNodeManager.cs
@@ -1233,7 +1233,7 @@ namespace Opc.Ua.Server
             IList<MonitoringFilterResult> filterErrors,
             IList<IMonitoredItem> monitoredItems,
             bool createDurable,
-            Func<uint> getNextMonitoredItemId)
+            MonitoredItemId monitoredItemId)
         {
             if (context == null)
             {
@@ -1363,7 +1363,7 @@ namespace Opc.Ua.Server
                             subscriptionId,
                             publishingInterval,
                             timestampsToReturn,
-                            getNextMonitoredItemId(),
+                            monitoredItemId.Next(),
                             node,
                             itemToCreate,
                             range,

--- a/Libraries/Opc.Ua.Server/NodeManager/CoreNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/NodeManager/CoreNodeManager.cs
@@ -1233,7 +1233,7 @@ namespace Opc.Ua.Server
             IList<MonitoringFilterResult> filterErrors,
             IList<IMonitoredItem> monitoredItems,
             bool createDurable,
-            MonitoredItemIds monitoredItemId)
+            MonitoredItemIdFactory monitoredItemIdFactory)
         {
             if (context == null)
             {
@@ -1363,7 +1363,7 @@ namespace Opc.Ua.Server
                             subscriptionId,
                             publishingInterval,
                             timestampsToReturn,
-                            monitoredItemId.Next(),
+                            monitoredItemIdFactory.GetNextId(),
                             node,
                             itemToCreate,
                             range,

--- a/Libraries/Opc.Ua.Server/NodeManager/CoreNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/NodeManager/CoreNodeManager.cs
@@ -1233,7 +1233,7 @@ namespace Opc.Ua.Server
             IList<MonitoringFilterResult> filterErrors,
             IList<IMonitoredItem> monitoredItems,
             bool createDurable,
-            MonitoredItemId monitoredItemId)
+            MonitoredItemIds monitoredItemId)
         {
             if (context == null)
             {

--- a/Libraries/Opc.Ua.Server/NodeManager/CoreNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/NodeManager/CoreNodeManager.cs
@@ -1233,7 +1233,7 @@ namespace Opc.Ua.Server
             IList<MonitoringFilterResult> filterErrors,
             IList<IMonitoredItem> monitoredItems,
             bool createDurable,
-            ref long globalIdCounter)
+            Func<uint> getNextMonitoredItemId)
         {
             if (context == null)
             {
@@ -1337,9 +1337,6 @@ namespace Opc.Ua.Server
                         }
                     }
 
-                    // create a globally unique identifier.
-                    uint monitoredItemId = Utils.IncrementIdentifier(ref globalIdCounter);
-
                     // limit the sampling rate for non-value attributes.
                     double minimumSamplingInterval = m_defaultMinimumSamplingInterval;
 
@@ -1366,7 +1363,7 @@ namespace Opc.Ua.Server
                             subscriptionId,
                             publishingInterval,
                             timestampsToReturn,
-                            monitoredItemId,
+                            getNextMonitoredItemId(),
                             node,
                             itemToCreate,
                             range,

--- a/Libraries/Opc.Ua.Server/NodeManager/INodeManager.cs
+++ b/Libraries/Opc.Ua.Server/NodeManager/INodeManager.cs
@@ -290,7 +290,7 @@ namespace Opc.Ua.Server
             IList<MonitoringFilterResult> filterErrors,
             IList<IMonitoredItem> monitoredItems,
             bool createDurable,
-            MonitoredItemIds monitoredItemId);
+            MonitoredItemIdFactory monitoredItemIdFactory);
 
         /// <summary>
         /// Restore a set of monitored items after a restart.

--- a/Libraries/Opc.Ua.Server/NodeManager/INodeManager.cs
+++ b/Libraries/Opc.Ua.Server/NodeManager/INodeManager.cs
@@ -290,7 +290,7 @@ namespace Opc.Ua.Server
             IList<MonitoringFilterResult> filterErrors,
             IList<IMonitoredItem> monitoredItems,
             bool createDurable,
-            ref long globalIdCounter);
+            Func<uint> getNextMonitoredItemId);
 
         /// <summary>
         /// Restore a set of monitored items after a restart.

--- a/Libraries/Opc.Ua.Server/NodeManager/INodeManager.cs
+++ b/Libraries/Opc.Ua.Server/NodeManager/INodeManager.cs
@@ -290,7 +290,7 @@ namespace Opc.Ua.Server
             IList<MonitoringFilterResult> filterErrors,
             IList<IMonitoredItem> monitoredItems,
             bool createDurable,
-            MonitoredItemId monitoredItemId);
+            MonitoredItemIds monitoredItemId);
 
         /// <summary>
         /// Restore a set of monitored items after a restart.

--- a/Libraries/Opc.Ua.Server/NodeManager/INodeManager.cs
+++ b/Libraries/Opc.Ua.Server/NodeManager/INodeManager.cs
@@ -290,7 +290,7 @@ namespace Opc.Ua.Server
             IList<MonitoringFilterResult> filterErrors,
             IList<IMonitoredItem> monitoredItems,
             bool createDurable,
-            Func<uint> getNextMonitoredItemId);
+            MonitoredItemId monitoredItemId);
 
         /// <summary>
         /// Restore a set of monitored items after a restart.

--- a/Libraries/Opc.Ua.Server/NodeManager/MasterNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/NodeManager/MasterNodeManager.cs
@@ -4310,7 +4310,6 @@ namespace Opc.Ua.Server
     /// items. It is designed to ensure thread-safe incrementation of the identifier.</remarks>
     public class MonitoredItemIdFactory
     {
-
         /// <summary>
         /// Initialize the MonitoredItemIdFactory with a new start value the ids start incrementing from.
         /// </summary>

--- a/Libraries/Opc.Ua.Server/NodeManager/MasterNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/NodeManager/MasterNodeManager.cs
@@ -2902,6 +2902,8 @@ namespace Opc.Ua.Server
             // call each node manager.
             if (validItems)
             {
+                uint GetNextMonitoredItemId() => Utils.IncrementIdentifier(ref m_lastMonitoredItemId);
+
                 // create items for event filters.
                 CreateMonitoredItemsForEvents(
                     context,
@@ -2913,7 +2915,7 @@ namespace Opc.Ua.Server
                     filterResults,
                     monitoredItems,
                     createDurable,
-                    ref m_lastMonitoredItemId);
+                    GetNextMonitoredItemId);
 
                 // create items for data access.
                 foreach (INodeManager nodeManager in m_nodeManagers)
@@ -2928,7 +2930,7 @@ namespace Opc.Ua.Server
                         filterResults,
                         monitoredItems,
                         createDurable,
-                        ref m_lastMonitoredItemId);
+                        GetNextMonitoredItemId);
                 }
 
                 // fill results for unknown nodes.
@@ -2955,7 +2957,7 @@ namespace Opc.Ua.Server
             IList<MonitoringFilterResult> filterResults,
             IList<IMonitoredItem> monitoredItems,
             bool createDurable,
-            ref long globalIdCounter)
+            Func<uint> getNextMonitoredItemId)
         {
             for (int ii = 0; ii < itemsToCreate.Count; ii++)
             {
@@ -3036,15 +3038,12 @@ namespace Opc.Ua.Server
                         continue;
                     }
 
-                    // create a globally unique identifier.
-                    uint monitoredItemId = Utils.IncrementIdentifier(ref globalIdCounter);
-
                     IEventMonitoredItem monitoredItem = Server.EventManager.CreateMonitoredItem(
                         context,
                         nodeManager,
                         handle,
                         subscriptionId,
-                        monitoredItemId,
+                        getNextMonitoredItemId(),
                         timestampsToReturn,
                         publishingInterval,
                         itemToCreate,

--- a/Libraries/Opc.Ua.Server/NodeManager/MasterNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/NodeManager/MasterNodeManager.cs
@@ -4328,14 +4328,18 @@ namespace Opc.Ua.Server
         }
 
         /// <summary>
-        /// Get the next uniqe monitored item id.
+        /// Get the next unique monitored item id.
         /// </summary>
-        /// <returns>an uint that can be used as an id for a montiored item</returns>
+        /// <returns>an uint that can be used as an id for a monitored item</returns>
         public uint Next()
         {
-            return Utils.IncrementIdentifier(ref m_lastMonitoredItemId);
+            lock (m_lock)
+            {
+                return Utils.IncrementIdentifier(ref m_lastMonitoredItemId);
+            }
         }
 
+        private readonly Lock m_lock = new Lock();
         private long m_lastMonitoredItemId;
     }
 }

--- a/Libraries/Opc.Ua.Server/NodeManager/MasterNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/NodeManager/MasterNodeManager.cs
@@ -2913,7 +2913,7 @@ namespace Opc.Ua.Server
                     filterResults,
                     monitoredItems,
                     createDurable,
-                    m_monitoredItemId);
+                    m_monitoredItemIds);
 
                 // create items for data access.
                 foreach (INodeManager nodeManager in m_nodeManagers)
@@ -2928,7 +2928,7 @@ namespace Opc.Ua.Server
                         filterResults,
                         monitoredItems,
                         createDurable,
-                        m_monitoredItemId);
+                        m_monitoredItemIds);
                 }
 
                 // fill results for unknown nodes.
@@ -2955,7 +2955,7 @@ namespace Opc.Ua.Server
             IList<MonitoringFilterResult> filterResults,
             IList<IMonitoredItem> monitoredItems,
             bool createDurable,
-            MonitoredItemId monitoredItemId)
+            MonitoredItemIds monitoredItemId)
         {
             for (int ii = 0; ii < itemsToCreate.Count; ii++)
             {
@@ -3132,7 +3132,7 @@ namespace Opc.Ua.Server
                     savedOwnerIdentity);
             }
 
-            m_monitoredItemId = new MonitoredItemId(itemsToRestore.Max(i => i.Id));
+            m_monitoredItemIds.SetStartValue(itemsToRestore.Max(i => i.Id));
         }
 
         /// <summary>
@@ -4256,7 +4256,7 @@ namespace Opc.Ua.Server
         private readonly Lock m_lock = new();
         private readonly List<INodeManager> m_nodeManagers;
         private readonly List<IAsyncNodeManager> m_asyncNodeManagers;
-        private MonitoredItemId m_monitoredItemId = new();
+        private readonly MonitoredItemIds m_monitoredItemIds = new();
         private readonly uint m_maxContinuationPointsPerBrowse;
         private readonly SemaphoreSlim m_namespaceManagersSemaphoreSlim = new(1);
     }
@@ -4308,21 +4308,14 @@ namespace Opc.Ua.Server
     /// </summary>
     /// <remarks>This class provides a mechanism to generate sequential ids for monitored
     /// items. It is designed to ensure thread-safe incrementation of the identifier.</remarks>
-    public class MonitoredItemId
+    public class MonitoredItemIds
     {
-        /// <summary>
-        /// Initialize the MonitoredItem Id class starting from 0.
-        /// </summary>
-        public MonitoredItemId()
-        {
-            m_lastMonitoredItemId = default;
-        }
 
         /// <summary>
-        /// Initialize the monitoredItem with a start value.
+        /// Initialize the monitoredItemIds with a new start value the ids start incrementing from.
         /// </summary>
         /// <param name="firstId"></param>
-        public MonitoredItemId(uint firstId)
+        public void SetStartValue(uint firstId)
         {
             m_lastMonitoredItemId = firstId;
         }
@@ -4333,13 +4326,9 @@ namespace Opc.Ua.Server
         /// <returns>an uint that can be used as an id for a monitored item</returns>
         public uint Next()
         {
-            lock (m_lock)
-            {
-                return Utils.IncrementIdentifier(ref m_lastMonitoredItemId);
-            }
+            return Utils.IncrementIdentifier(ref m_lastMonitoredItemId);
         }
 
-        private readonly Lock m_lock = new Lock();
         private long m_lastMonitoredItemId;
     }
 }

--- a/Libraries/Opc.Ua.Server/NodeManager/MasterNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/NodeManager/MasterNodeManager.cs
@@ -2913,7 +2913,7 @@ namespace Opc.Ua.Server
                     filterResults,
                     monitoredItems,
                     createDurable,
-                    m_monitoredItemIds);
+                    m_monitoredItemIdFactory);
 
                 // create items for data access.
                 foreach (INodeManager nodeManager in m_nodeManagers)
@@ -2928,7 +2928,7 @@ namespace Opc.Ua.Server
                         filterResults,
                         monitoredItems,
                         createDurable,
-                        m_monitoredItemIds);
+                        m_monitoredItemIdFactory);
                 }
 
                 // fill results for unknown nodes.
@@ -2955,7 +2955,7 @@ namespace Opc.Ua.Server
             IList<MonitoringFilterResult> filterResults,
             IList<IMonitoredItem> monitoredItems,
             bool createDurable,
-            MonitoredItemIds monitoredItemId)
+            MonitoredItemIdFactory monitoredItemIdFactory)
         {
             for (int ii = 0; ii < itemsToCreate.Count; ii++)
             {
@@ -3041,7 +3041,7 @@ namespace Opc.Ua.Server
                         nodeManager,
                         handle,
                         subscriptionId,
-                        monitoredItemId.Next(),
+                        monitoredItemIdFactory.GetNextId(),
                         timestampsToReturn,
                         publishingInterval,
                         itemToCreate,
@@ -3132,7 +3132,7 @@ namespace Opc.Ua.Server
                     savedOwnerIdentity);
             }
 
-            m_monitoredItemIds.SetStartValue(itemsToRestore.Max(i => i.Id));
+            m_monitoredItemIdFactory.SetStartValue(itemsToRestore.Max(i => i.Id));
         }
 
         /// <summary>
@@ -4256,7 +4256,7 @@ namespace Opc.Ua.Server
         private readonly Lock m_lock = new();
         private readonly List<INodeManager> m_nodeManagers;
         private readonly List<IAsyncNodeManager> m_asyncNodeManagers;
-        private readonly MonitoredItemIds m_monitoredItemIds = new();
+        private readonly MonitoredItemIdFactory m_monitoredItemIdFactory = new();
         private readonly uint m_maxContinuationPointsPerBrowse;
         private readonly SemaphoreSlim m_namespaceManagersSemaphoreSlim = new(1);
     }
@@ -4308,11 +4308,11 @@ namespace Opc.Ua.Server
     /// </summary>
     /// <remarks>This class provides a mechanism to generate sequential ids for monitored
     /// items. It is designed to ensure thread-safe incrementation of the identifier.</remarks>
-    public class MonitoredItemIds
+    public class MonitoredItemIdFactory
     {
 
         /// <summary>
-        /// Initialize the monitoredItemIds with a new start value the ids start incrementing from.
+        /// Initialize the MonitoredItemIdFactory with a new start value the ids start incrementing from.
         /// </summary>
         /// <param name="firstId"></param>
         public void SetStartValue(uint firstId)
@@ -4324,7 +4324,7 @@ namespace Opc.Ua.Server
         /// Get the next unique monitored item id.
         /// </summary>
         /// <returns>an uint that can be used as an id for a monitored item</returns>
-        public uint Next()
+        public uint GetNextId()
         {
             return Utils.IncrementIdentifier(ref m_lastMonitoredItemId);
         }

--- a/Tests/Opc.Ua.Server.Tests/MonitoredItemIdFactoryTests.cs
+++ b/Tests/Opc.Ua.Server.Tests/MonitoredItemIdFactoryTests.cs
@@ -1,0 +1,194 @@
+using NUnit.Framework;
+using System;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Opc.Ua.Server.Tests
+{
+    /// <summary>
+    /// Concurrency tests for the MonitoredItemIdFactory.
+    /// </summary>
+    [TestFixture]
+    public class MonitoredItemIdFactoryTests
+    {
+        /// <summary>
+        /// Verifies that no duplicate IDs are returned with concurrent calls.
+        /// </summary>
+        [Test]
+        public async Task GetNextId_ConcurrentCalls_ShouldNotReturnDuplicateIdsAsync()
+        {
+            // Arrange
+            var idFactory = new MonitoredItemIdFactory();
+            var generatedIds = new ConcurrentBag<uint>();
+            const int numTasks = 10;
+            const int idsPerTask = 1000;
+            var tasks = new Task[numTasks];
+            var startEvent = new ManualResetEventSlim(false);
+
+            // Act
+            for (int i = 0; i < numTasks; i++)
+            {
+                tasks[i] = Task.Run(() =>
+                {
+                    startEvent.Wait();
+                    for (int j = 0; j < idsPerTask; j++)
+                    {
+                        generatedIds.Add(idFactory.GetNextId());
+                    }
+                });
+            }
+
+            startEvent.Set();
+            await Task.WhenAll(tasks).ConfigureAwait(false);
+
+            // Assert
+            const int totalIds = numTasks * idsPerTask;
+            Assert.That(generatedIds.Count, Is.EqualTo(totalIds));
+            Assert.That(generatedIds.Distinct().Count(), Is.EqualTo(totalIds), "Duplicate IDs were generated.");
+        }
+
+        /// <summary>
+        /// Verifies that with a set start value, no smaller IDs are returned than the firstId.
+        /// </summary>
+        [Test]
+        public async Task GetNextId_WithSetStartValue_ShouldReturnIdsGreaterThanToStartValueAsync()
+        {
+            // Arrange
+            var idFactory = new MonitoredItemIdFactory();
+            var generatedIds = new ConcurrentBag<uint>();
+            const uint startValue = 10000;
+            idFactory.SetStartValue(startValue);
+
+            const int numTasks = 10;
+            const int idsPerTask = 1000;
+            var tasks = new Task[numTasks];
+            var startEvent = new ManualResetEventSlim(false);
+
+            // Act
+            for (int i = 0; i < numTasks; i++)
+            {
+                tasks[i] = Task.Run(() =>
+                {
+                    startEvent.Wait();
+                    for (int j = 0; j < idsPerTask; j++)
+                    {
+                        generatedIds.Add(idFactory.GetNextId());
+                    }
+                });
+            }
+
+            startEvent.Set();
+            await Task.WhenAll(tasks).ConfigureAwait(false);
+
+            // Assert
+            const int totalIds = numTasks * idsPerTask;
+            Assert.That(generatedIds.Count, Is.EqualTo(totalIds));
+            Assert.That(generatedIds.All(id => id > startValue), Is.True, "An ID smaller than or equal to the start value was generated.");
+        }
+
+        /// <summary>
+        /// Verifies that calling SetStartValue concurrently with GetNextId
+        /// results in IDs being generated from the new start value.
+        /// This test is non-deterministic but has a high probability of exercising the concurrent code paths.
+        /// </summary>
+        [Test]
+        public async Task GetNextId_SetStartValueCalledConcurrently_ShouldGenerateIdsFromNewStartValueAsync()
+        {
+            // Arrange
+            var idFactory = new MonitoredItemIdFactory();
+            var generatedIds = new ConcurrentBag<(uint Id, long BeforeTimestamp, long AfterTimestamp)>();
+            var resetEvents = new ConcurrentBag<(uint StartValue, long BeforeTimestamp, long AfterTimestamp)>();
+            const int numIdTasks = 10;
+            const int idsPerTask = 1000;
+            const int numResetTasks = 3;
+            var tasks = new Task[numIdTasks + numResetTasks];
+            var startEvent = new ManualResetEventSlim(false);
+            var random = new Random();
+
+            // Act
+            // Create tasks that will get IDs
+            for (int i = 0; i < numIdTasks; i++)
+            {
+                tasks[i] = Task.Run(() =>
+                {
+                    startEvent.Wait();
+                    for (int j = 0; j < idsPerTask; j++)
+                    {
+                        long before = Stopwatch.GetTimestamp();
+                        var id = idFactory.GetNextId();
+                        long after = Stopwatch.GetTimestamp();
+                        generatedIds.Add((id, before, after));
+                    }
+                });
+            }
+
+            // Create tasks that will reset the start value
+            for (int i = 0; i < numResetTasks; i++)
+            {
+                tasks[numIdTasks + i] = Task.Run(() =>
+                {
+                    startEvent.Wait();
+                    // Use a random start value to increase chances of interleaving
+                    uint startValue = (uint)random.Next(20000, 50000) * (uint)(i + 1);
+                    long before = Stopwatch.GetTimestamp();
+                    idFactory.SetStartValue(startValue);
+                    long after = Stopwatch.GetTimestamp();
+                    resetEvents.Add((startValue, before, after));
+                });
+            }
+
+            startEvent.Set(); // Signal all tasks to start
+            await Task.WhenAll(tasks).ConfigureAwait(false);
+
+            // Assert
+            const int totalIds = numIdTasks * idsPerTask;
+            Assert.That(generatedIds.Count, Is.EqualTo(totalIds), "Incorrect total number of IDs generated.");
+
+            if (!resetEvents.Any())
+            {
+                Assert.Warn("No reset events were captured, the test may not have exercised the concurrent reset logic.");
+                return;
+            }
+
+            var sortedResets = resetEvents.OrderBy(r => r.BeforeTimestamp).ToList();
+
+            for (int i = 0; i < sortedResets.Count; i++)
+            {
+                var currentReset = sortedResets[i];
+
+                // For each reset event, verify that all IDs generated *after* it
+                // are greater than the new start value.
+                var idsAfterReset = generatedIds
+                    .Where(g => g.BeforeTimestamp > currentReset.AfterTimestamp &&
+                    (i == sortedResets.Count - 1 || g.AfterTimestamp < sortedResets[i + 1].BeforeTimestamp))
+                    .OrderBy(g => g.Id)
+                    .Select(g => g.Id)
+                    .ToList();
+
+                if (idsAfterReset.Count != 0)
+                {
+
+                    // Due to the nature of concurrent operations, some IDs might be generated
+                    // after the reset timestamp but still use the old value. We find the first
+                    // ID that respects the new start value and verify that all subsequent IDs do as well.
+                    // Find the first ID that is greater than the start value.
+                    var firstValidIdIndex = idsAfterReset.FindIndex(id => id > currentReset.StartValue);
+
+                    // If a valid ID is found, all subsequent IDs must also be greater.
+                    if (firstValidIdIndex != -1)
+                    {
+                        var subsequentIds = idsAfterReset.Skip(firstValidIdIndex);
+                        Assert.That(subsequentIds.All(id => id > currentReset.StartValue), Is.True,
+                            $"An ID was generated that was not greater than the new start value {currentReset.StartValue} after a reset.");
+
+                        Assert.That(subsequentIds.Distinct().Count(), Is.EqualTo(subsequentIds.Count()),
+                       "Duplicate IDs were found in the set of IDs generated between resets.");
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Proposed changes
This pull request refactors the way monitored item IDs are generated throughout the OPC UA server node manager codebase. Instead of passing and incrementing a mutable `globalIdCounter`, the code now uses a calls `MonitoredItemIdFactory` with a method `GetNextId` to generate unique monitored item IDs. This change improves encapsulation, reduces mutable shared state, and makes the codebase easier to maintain and test. Also it makes it possible to introduce an async version of the method in a future PR, that can be called using an Adapter Class.

## Related Issues

- Fixes #

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.
