### PR TITLE
Improve thread safe Utils methods for incrementing identifiers

### DIFF
--- a/Applications/Quickstarts.Servers/Boiler/BoilerNodeManager.cs
+++ b/Applications/Quickstarts.Servers/Boiler/BoilerNodeManager.cs
@@ -285,7 +285,7 @@ namespace Boiler
         }
 
         private readonly ushort m_namespaceIndex;
-        private long m_lastUsedId;
+        private uint m_lastUsedId;
         private readonly List<BoilerState> m_boilers;
     }
 }

--- a/Applications/Quickstarts.Servers/TestData/TestDataNodeManager.cs
+++ b/Applications/Quickstarts.Servers/TestData/TestDataNodeManager.cs
@@ -868,7 +868,7 @@ namespace TestData
         private ushort m_namespaceIndex;
         private ushort m_typeNamespaceIndex;
         private readonly TestDataSystem m_system;
-        private long m_lastUsedId;
+        private uint m_lastUsedId;
 #if CONDITION_SAMPLES
         private Timer m_systemStatusTimer;
         private TestSystemConditionState m_systemStatusCondition;

--- a/Libraries/Opc.Ua.Client/Session/Session.cs
+++ b/Libraries/Opc.Ua.Client/Session/Session.cs
@@ -7198,14 +7198,14 @@ namespace Opc.Ua.Client
         private byte[] m_serverNonce;
         private byte[] m_previousServerNonce;
         private X509Certificate2 m_serverCertificate;
-        private long m_publishCounter;
+        private uint m_publishCounter;
         private int m_tooManyPublishRequests;
         private long m_lastKeepAliveTime;
         private StatusCode m_lastKeepAliveErrorStatusCode;
         private ServerState m_serverState;
         private int m_keepAliveInterval;
         private Timer m_keepAliveTimer;
-        private long m_keepAliveCounter;
+        private uint m_keepAliveCounter;
         private bool m_reconnecting;
         private SemaphoreSlim m_reconnectLock;
         private int m_minPublishRequestCount;

--- a/Libraries/Opc.Ua.Client/Subscription/MonitoredItem.cs
+++ b/Libraries/Opc.Ua.Client/Subscription/MonitoredItem.cs
@@ -745,7 +745,7 @@ namespace Opc.Ua.Client
         public void SetTransferResult(uint clientHandle)
         {
             // ensure the global counter is not duplicating future handle ids
-            Utils.LowerLimitIdentifier(ref s_globalClientHandle, clientHandle);
+            Utils.SetIdentifierToAtLeast(ref s_globalClientHandle, clientHandle);
             ClientHandle = clientHandle;
             Status.SetTransferResult(this);
             AttributesModified = false;
@@ -1087,7 +1087,7 @@ namespace Opc.Ua.Client
         private MonitoringFilter m_filter;
         private uint m_queueSize;
         private bool m_discardOldest;
-        private static long s_globalClientHandle;
+        private static uint s_globalClientHandle;
 
         private Lock m_cache = new();
         private MonitoredItemDataCache m_dataCache;

--- a/Libraries/Opc.Ua.Server/Diagnostics/DiagnosticsNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/Diagnostics/DiagnosticsNodeManager.cs
@@ -55,7 +55,7 @@ namespace Opc.Ua.Server
             SetNamespaces(namespaceUris);
 
             m_namespaceIndex = Server.NamespaceUris.GetIndexOrAppend(namespaceUris[1]);
-            m_lastUsedId = DateTime.UtcNow.Ticks & 0x7FFFFFFF;
+            m_lastUsedId = (uint)DateTime.UtcNow.Ticks & 0x7FFFFFFF;
             m_sessions = [];
             m_subscriptions = [];
             DiagnosticsEnabled = true;
@@ -2132,7 +2132,7 @@ namespace Opc.Ua.Server
         }
 
         private readonly ushort m_namespaceIndex;
-        private long m_lastUsedId;
+        private uint m_lastUsedId;
         private Timer m_diagnosticsScanTimer;
         private int m_diagnosticsMonitoringCount;
         private bool m_doScanBusy;

--- a/Libraries/Opc.Ua.Server/NodeManager/CoreNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/NodeManager/CoreNodeManager.cs
@@ -3653,7 +3653,7 @@ namespace Opc.Ua.Server
         }
 
         private readonly NodeTable m_nodes;
-        private long m_lastId;
+        private uint m_lastId;
         private readonly SamplingGroupManager m_samplingGroupManager;
         private readonly Dictionary<uint, ISampledDataChangeMonitoredItem> m_monitoredItems;
         private readonly double m_defaultMinimumSamplingInterval;

--- a/Libraries/Opc.Ua.Server/NodeManager/MasterNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/NodeManager/MasterNodeManager.cs
@@ -4247,7 +4247,7 @@ namespace Opc.Ua.Server
         /// <param name="firstId"></param>
         public void SetStartValue(uint firstId)
         {
-            m_lastMonitoredItemId = firstId;
+            Utils.SetIdentifier(ref m_lastMonitoredItemId, firstId);
         }
 
         /// <summary>
@@ -4259,6 +4259,6 @@ namespace Opc.Ua.Server
             return Utils.IncrementIdentifier(ref m_lastMonitoredItemId);
         }
 
-        private long m_lastMonitoredItemId;
+        private uint m_lastMonitoredItemId;
     }
 }

--- a/Libraries/Opc.Ua.Server/Server/OperationContext.cs
+++ b/Libraries/Opc.Ua.Server/Server/OperationContext.cs
@@ -275,6 +275,6 @@ namespace Opc.Ua.Server
         public string AuditEntryId { get; }
 
         private long m_operationStatus;
-        private static long s_lastRequestId;
+        private static uint s_lastRequestId;
     }
 }

--- a/Libraries/Opc.Ua.Server/Session/SessionManager.cs
+++ b/Libraries/Opc.Ua.Server/Session/SessionManager.cs
@@ -63,7 +63,7 @@ namespace Opc.Ua.Server
                 .MaxHistoryContinuationPoints;
 
             m_sessions = new NodeIdDictionary<ISession>(m_maxSessionCount);
-            m_lastSessionId = BitConverter.ToInt64(Nonce.CreateRandomNonceData(sizeof(long)), 0);
+            m_lastSessionId = BitConverter.ToUInt32(Nonce.CreateRandomNonceData(sizeof(uint)), 0);
 
             // create a event to signal shutdown.
             m_shutdownEvent = new ManualResetEvent(true);
@@ -637,7 +637,7 @@ namespace Opc.Ua.Server
         private readonly Lock m_lock = new();
         private readonly IServerInternal m_server;
         private readonly NodeIdDictionary<ISession> m_sessions;
-        private long m_lastSessionId;
+        private uint m_lastSessionId;
         private readonly ManualResetEvent m_shutdownEvent;
 
         private readonly int m_minSessionTimeout;

--- a/Libraries/Opc.Ua.Server/Subscription/Persistence/IStoredSubscription.cs
+++ b/Libraries/Opc.Ua.Server/Subscription/Persistence/IStoredSubscription.cs
@@ -99,7 +99,7 @@ namespace Opc.Ua.Server
         /// <summary>
         /// The sequence number
         /// </summary>
-        long SequenceNumber { get; set; }
+        uint SequenceNumber { get; set; }
 
         /// <summary>
         /// The user identity of the subscription

--- a/Libraries/Opc.Ua.Server/Subscription/Persistence/StoredSubscription.cs
+++ b/Libraries/Opc.Ua.Server/Subscription/Persistence/StoredSubscription.cs
@@ -68,7 +68,7 @@ namespace Opc.Ua.Server
         public bool IsDurable { get; set; }
 
         /// <inheritdoc/>
-        public long SequenceNumber { get; set; }
+        public uint SequenceNumber { get; set; }
 
         /// <inheritdoc/>
         public List<NotificationMessage> SentMessages { get; set; }

--- a/Libraries/Opc.Ua.Server/Subscription/Subscription.cs
+++ b/Libraries/Opc.Ua.Server/Subscription/Subscription.cs
@@ -113,7 +113,7 @@ namespace Opc.Ua.Server
                 MonitoredItemCount = 0,
                 DisabledMonitoredItemCount = 0,
                 MonitoringQueueOverflowCount = 0,
-                NextSequenceNumber = (uint)m_sequenceNumber
+                NextSequenceNumber = m_sequenceNumber
             };
 
             ServerSystemContext systemContext = m_server.DefaultSystemContext.Copy(session);
@@ -194,7 +194,7 @@ namespace Opc.Ua.Server
                 MonitoredItemCount = 0,
                 DisabledMonitoredItemCount = 0,
                 MonitoringQueueOverflowCount = 0,
-                NextSequenceNumber = (uint)m_sequenceNumber
+                NextSequenceNumber = m_sequenceNumber
             };
 
             ServerSystemContext systemContext = m_server.DefaultSystemContext.Copy();
@@ -781,7 +781,7 @@ namespace Opc.Ua.Server
 
                 message = new NotificationMessage
                 {
-                    SequenceNumber = (uint)m_sequenceNumber,
+                    SequenceNumber = m_sequenceNumber,
                     PublishTime = DateTime.UtcNow
                 };
 
@@ -789,7 +789,7 @@ namespace Opc.Ua.Server
 
                 lock (DiagnosticsWriteLock)
                 {
-                    Diagnostics.NextSequenceNumber = (uint)m_sequenceNumber;
+                    Diagnostics.NextSequenceNumber = m_sequenceNumber;
                 }
 
                 var notification = new StatusChangeNotification { Status = StatusCodes.BadTimeout };
@@ -810,7 +810,7 @@ namespace Opc.Ua.Server
             {
                 message = new NotificationMessage
                 {
-                    SequenceNumber = (uint)m_sequenceNumber,
+                    SequenceNumber = m_sequenceNumber,
                     PublishTime = DateTime.UtcNow
                 };
 
@@ -818,7 +818,7 @@ namespace Opc.Ua.Server
 
                 lock (DiagnosticsWriteLock)
                 {
-                    Diagnostics.NextSequenceNumber = (uint)m_sequenceNumber;
+                    Diagnostics.NextSequenceNumber = m_sequenceNumber;
                 }
 
                 var notification = new StatusChangeNotification
@@ -1010,7 +1010,7 @@ namespace Opc.Ua.Server
                 var message = new NotificationMessage
                 {
                     // use the sequence number for the next message.
-                    SequenceNumber = (uint)m_sequenceNumber,
+                    SequenceNumber = m_sequenceNumber,
                     PublishTime = DateTime.UtcNow
                 };
 
@@ -1101,7 +1101,7 @@ namespace Opc.Ua.Server
 
             var message = new NotificationMessage
             {
-                SequenceNumber = (uint)m_sequenceNumber,
+                SequenceNumber = m_sequenceNumber,
                 PublishTime = DateTime.UtcNow
             };
 
@@ -1109,7 +1109,7 @@ namespace Opc.Ua.Server
 
             lock (DiagnosticsWriteLock)
             {
-                Diagnostics.NextSequenceNumber = (uint)m_sequenceNumber;
+                Diagnostics.NextSequenceNumber = m_sequenceNumber;
             }
 
             // add events.
@@ -2714,7 +2714,7 @@ namespace Opc.Ua.Server
         private bool m_waitingForPublish;
         private readonly List<NotificationMessage> m_sentMessages;
         private int m_lastSentMessage;
-        private long m_sequenceNumber;
+        private uint m_sequenceNumber;
         private readonly uint m_maxMessageCount;
         private readonly Dictionary<uint, LinkedListNode<IMonitoredItem>> m_monitoredItems;
         private readonly LinkedList<IMonitoredItem> m_itemsToCheck;

--- a/Libraries/Opc.Ua.Server/Subscription/SubscriptionManager.cs
+++ b/Libraries/Opc.Ua.Server/Subscription/SubscriptionManager.cs
@@ -76,8 +76,8 @@ namespace Opc.Ua.Server
             m_subscriptions = [];
             m_publishQueues = [];
             m_statusMessages = [];
-            m_lastSubscriptionId = BitConverter.ToInt64(
-                Nonce.CreateRandomNonceData(sizeof(long)),
+            m_lastSubscriptionId = BitConverter.ToUInt32(
+                Nonce.CreateRandomNonceData(sizeof(uint)),
                 0);
 
             // create a event to signal shutdown.
@@ -2320,7 +2320,7 @@ namespace Opc.Ua.Server
         }
 
         private readonly Lock m_lock = new();
-        private long m_lastSubscriptionId;
+        private uint m_lastSubscriptionId;
         private readonly IServerInternal m_server;
         private readonly double m_minPublishingInterval;
         private readonly double m_maxPublishingInterval;

--- a/Stack/Opc.Ua.Core/Stack/Tcp/TcpListenerChannel.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/TcpListenerChannel.cs
@@ -578,7 +578,7 @@ namespace Opc.Ua.Bindings
         protected ReportAuditCertificateEventHandler ReportAuditCertificateEvent { get; private set; }
 
         private bool m_responseRequired;
-        private long m_lastTokenId;
+        private uint m_lastTokenId;
     }
 
     /// <summary>

--- a/Stack/Opc.Ua.Core/Stack/Tcp/UaSCBinaryClientChannel.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/UaSCBinaryClientChannel.cs
@@ -1756,7 +1756,7 @@ namespace Opc.Ua.Bindings
 
         private Uri m_url;
         private Uri m_via;
-        private long m_lastRequestId;
+        private uint m_lastRequestId;
         private readonly ConcurrentDictionary<uint, WriteOperation> m_requests;
         private WriteOperation m_handshakeOperation;
         private ChannelToken m_requestedToken;


### PR DESCRIPTION
## Proposed changes

- Improve thread safe Utils methods for incrementing identifiers
- Add Test for Wrapround of MonitoredItemIdFactory (this would fail before the improvements, with 0 included as id in as often as ever 3rd iteration)

Thanks to @marcschier for bringing this up.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.
