### PR TITLE
Allow non OPC-UA conform SubjectName values to AddSecurityConfigurationStores

### DIFF
--- a/Stack/Opc.Ua.Core/Security/Certificates/CertificateFactory.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/CertificateFactory.cs
@@ -595,6 +595,11 @@ namespace Opc.Ua
                 subjectName = Utils.Format("CN={0}", subjectName);
             }
 
+            if (!subjectName.Contains("O=", StringComparison.Ordinal))
+            {
+                subjectName += Utils.Format(", O={0}", "OPC Foundation");
+            }
+
             if (domainNames != null && domainNames.Count > 0)
             {
                 if (!subjectName.Contains("DC=", StringComparison.Ordinal) &&

--- a/Stack/Opc.Ua.Core/Security/Certificates/CertificateIdentifier.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/CertificateIdentifier.cs
@@ -403,9 +403,9 @@ namespace Opc.Ua
                 var simpleNameMatches = collection.Find(X509FindType.FindBySubjectName, subjectName, false)
                     .Cast<X509Certificate2>()
                     .Where(cert => string.Equals(
-                        cert.GetNameInfo(X509NameType.SimpleName, forIssuer:false),
+                        cert.GetNameInfo(X509NameType.SimpleName, forIssuer: false),
                         subjectName,
-                        StringComparison.OrdinalIgnoreCase))
+                        StringComparison.Ordinal))
                     .ToArray();
 
                 if (simpleNameMatches.Length > 0)


### PR DESCRIPTION
## Proposed changes

When a certificate SubjectName is provided in a non OPC-UA accepted format (simple-string with no CN and O attributes) as input to `AddSecurityConfigurationStores()`, in the context of an `ApplicationInstance` certificate creation, the created certificate's `SubjectName` is populated with a default CN=simple-string and omits the O attribute (which it should also include).
A subsequent `public static X509Certificate2 Find()` call,  in the context of an additional `ApplicationInstance` certificate creation, taking as input a `SubjectName` that is a substring  of the previously created certificate with CN=simple-string, would match the previously created application certificate and throw due to a call to `X509Certificate2Collection.Find(X509FindType.FindBySubjectName, subjectName, false)`  that seams to perform a FuzzySearch     on the collection.

This PR attempts to remedy the above miss-behavior even in this special case were the provided SubjectName is not in the OPC-UA accepted format and does not contain the CN and O attributes.

## Related Issues

- Fixes #3216 

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
