### PR TITLE
Add API back as Obsolete for samples to compile (almost) unchanged.

### DIFF
--- a/Libraries/Opc.Ua.Client.ComplexTypes/ComplexTypeSystem.cs
+++ b/Libraries/Opc.Ua.Client.ComplexTypes/ComplexTypeSystem.cs
@@ -65,11 +65,10 @@ namespace Opc.Ua.Client.ComplexTypes
             => m_complexTypeResolver.DataTypeSystem;
 
         /// <summary>
-        /// Obsolete constructor
+        /// Initializes the type system with a session to load the custom types.
         /// </summary>
-        [Obsolete("Use ComplexTypeSystem(ISession, ITelemetryContext) instead.")]
         public ComplexTypeSystem(ISession session)
-            : this(session, (ITelemetryContext)null)
+            : this(session, session.MessageContext.Telemetry)
         {
         }
 
@@ -101,13 +100,12 @@ namespace Opc.Ua.Client.ComplexTypes
         }
 
         /// <summary>
-        /// Obsolete constructor
+        /// Create complex type system with session and custom type builder factory
         /// </summary>
-        [Obsolete("Use ComplexTypeSystem(IComplexTypeResolver, ITelemetryContext) instead.")]
         public ComplexTypeSystem(
             ISession session,
             IComplexTypeFactory complexTypeBuilderFactory)
-            : this(session, complexTypeBuilderFactory, null)
+            : this(session, complexTypeBuilderFactory, session.MessageContext.Telemetry)
         {
         }
 

--- a/Libraries/Opc.Ua.Client/Browser.cs
+++ b/Libraries/Opc.Ua.Client/Browser.cs
@@ -52,6 +52,14 @@ namespace Opc.Ua.Client
         /// <summary>
         /// Creates new instance of a browser and attaches it to a session.
         /// </summary>
+        public Browser(ISession session)
+            : this(session, session.MessageContext.Telemetry)
+        {
+        }
+
+        /// <summary>
+        /// Creates new instance of a browser and attaches it to a session.
+        /// </summary>
         public Browser(ISession session, ITelemetryContext telemetry)
         {
             m_telemetry = telemetry;

--- a/Libraries/Opc.Ua.Client/CoreClientUtils.cs
+++ b/Libraries/Opc.Ua.Client/CoreClientUtils.cs
@@ -127,6 +127,45 @@ namespace Opc.Ua.Client
         /// <summary>
         /// Finds the endpoint that best matches the current settings.
         /// </summary>
+        [Obsolete("Use SelectEndpointAsync with ITelemetryContext parameter instead.")]
+        public static ValueTask<EndpointDescription> SelectEndpointAsync(
+            ApplicationConfiguration application,
+            ITransportWaitingConnection connection,
+            bool useSecurity,
+            CancellationToken ct = default)
+        {
+            return SelectEndpointAsync(
+                application,
+                connection,
+                useSecurity,
+                DefaultDiscoverTimeout,
+                null,
+                ct);
+        }
+
+        /// <summary>
+        /// Finds the endpoint that best matches the current settings.
+        /// </summary>
+        [Obsolete("Use SelectEndpointAsync with ITelemetryContext parameter instead.")]
+        public static ValueTask<EndpointDescription> SelectEndpointAsync(
+            ApplicationConfiguration application,
+            ITransportWaitingConnection connection,
+            bool useSecurity,
+            int discoverTimeout,
+            CancellationToken ct = default)
+        {
+            return SelectEndpointAsync(
+                application,
+                connection,
+                useSecurity,
+                discoverTimeout,
+                null,
+                ct);
+        }
+
+        /// <summary>
+        /// Finds the endpoint that best matches the current settings.
+        /// </summary>
         public static ValueTask<EndpointDescription> SelectEndpointAsync(
             ApplicationConfiguration application,
             ITransportWaitingConnection connection,
@@ -162,8 +201,7 @@ namespace Opc.Ua.Client
             using var client = DiscoveryClient.Create(
                 application,
                 connection,
-                endpointConfiguration,
-                telemetry);
+                endpointConfiguration);
             var url = new Uri(client.Endpoint.EndpointUrl);
             EndpointDescriptionCollection endpoints =
                 await client.GetEndpointsAsync(null, ct).ConfigureAwait(false);
@@ -223,7 +261,7 @@ namespace Opc.Ua.Client
             var endpointConfiguration = EndpointConfiguration.Create(application);
             endpointConfiguration.OperationTimeout = discoverTimeout;
 
-            using var client = DiscoveryClient.Create(application, uri, endpointConfiguration, telemetry);
+            using var client = DiscoveryClient.Create(application, uri, endpointConfiguration);
             // Connect to the server's discovery endpoint and find the available configuration.
             var url = new Uri(client.Endpoint.EndpointUrl);
             EndpointDescriptionCollection endpoints =

--- a/Libraries/Opc.Ua.Client/Session/Factory/DefaultSessionFactory.cs
+++ b/Libraries/Opc.Ua.Client/Session/Factory/DefaultSessionFactory.cs
@@ -248,7 +248,6 @@ namespace Opc.Ua.Client
                 endpoint,
                 updateBeforeConnect,
                 checkDomain,
-                Telemetry,
                 ct);
         }
 
@@ -305,7 +304,7 @@ namespace Opc.Ua.Client
             ApplicationConfiguration configuration,
             ConfiguredEndpoint endpoint)
         {
-            return new Session(channel, configuration, endpoint, Telemetry);
+            return new Session(channel, configuration, endpoint);
         }
 
         /// <inheritdoc/>
@@ -322,7 +321,6 @@ namespace Opc.Ua.Client
                 configuration,
                 endpoint,
                 clientCertificate,
-                Telemetry,
                 availableEndpoints,
                 discoveryProfileUris);
         }

--- a/Libraries/Opc.Ua.Client/Session/SessionClientBatched.cs
+++ b/Libraries/Opc.Ua.Client/Session/SessionClientBatched.cs
@@ -42,8 +42,8 @@ namespace Opc.Ua
         /// <summary>
         /// Intializes the object with a channel and default operation limits.
         /// </summary>
-        public SessionClientBatched(ITransportChannel channel)
-            : base(channel, channel.MessageContext.Telemetry)
+        public SessionClientBatched(ITransportChannel channel, ITelemetryContext telemetry)
+            : base(channel, telemetry)
         {
             m_operationLimits = new OperationLimits();
         }

--- a/Libraries/Opc.Ua.Client/Session/SessionClientBatched.cs
+++ b/Libraries/Opc.Ua.Client/Session/SessionClientBatched.cs
@@ -42,8 +42,8 @@ namespace Opc.Ua
         /// <summary>
         /// Intializes the object with a channel and default operation limits.
         /// </summary>
-        public SessionClientBatched(ITransportChannel channel, ITelemetryContext telemetry)
-            : base(channel, telemetry)
+        public SessionClientBatched(ITransportChannel channel)
+            : base(channel, channel.MessageContext.Telemetry)
         {
             m_operationLimits = new OperationLimits();
         }

--- a/Libraries/Opc.Ua.Client/Subscription/Subscription.cs
+++ b/Libraries/Opc.Ua.Client/Subscription/Subscription.cs
@@ -50,6 +50,14 @@ namespace Opc.Ua.Client
         private const int kRepublishMessageExpiredTimeout = 10000;
 
         /// <summary>
+        /// Create subscription
+        /// </summary>
+        [Obsolete("Use Subscription(TelemetryContext) instead")]
+        public Subscription() : this(null)
+        {
+        }
+
+        /// <summary>
         /// Creates a empty object.
         /// </summary>
         public Subscription(ITelemetryContext telemetry)

--- a/Libraries/Opc.Ua.Gds.Client.Common/GlobalDiscoveryServerClient.cs
+++ b/Libraries/Opc.Ua.Gds.Client.Common/GlobalDiscoveryServerClient.cs
@@ -59,9 +59,9 @@ namespace Opc.Ua.Gds.Client
             ISessionFactory sessionFactory = null)
         {
             Configuration = configuration;
+            MessageContext = configuration.CreateMessageContext(true);
             EndpointUrl = endpointUrl;
-            m_telemetry = telemetry;
-            m_logger = telemetry.CreateLogger<GlobalDiscoveryServerClient>();
+            m_logger = MessageContext.Telemetry.CreateLogger<GlobalDiscoveryServerClient>();
             m_sessionFactory = sessionFactory ?? new DefaultSessionFactory(telemetry);
             // preset admin
             AdminCredentials = adminUserIdentity;
@@ -70,17 +70,16 @@ namespace Opc.Ua.Gds.Client
         /// <summary>
         /// Gets the application.
         /// </summary>
-        /// <value>
-        /// The application.
-        /// </value>
         public ApplicationConfiguration Configuration { get; }
+
+        /// <summary>
+        /// Message context
+        /// </summary>
+        public IServiceMessageContext MessageContext { get; }
 
         /// <summary>
         /// Gets or sets the admin credentials.
         /// </summary>
-        /// <value>
-        /// The admin credentials.
-        /// </value>
         public IUserIdentity AdminCredentials { get; set; }
 
         /// <summary>
@@ -93,27 +92,16 @@ namespace Opc.Ua.Gds.Client
         /// <summary>
         /// Gets the session.
         /// </summary>
-        /// <value>
-        /// The session.
-        /// </value>
         public ISession Session { get; private set; }
 
         /// <summary>
         /// Gets or sets the endpoint URL.
         /// </summary>
-        /// <value>
-        /// The endpoint URL.
-        /// </value>
         public string EndpointUrl { get; set; }
-
-        private readonly ITelemetryContext m_telemetry;
 
         /// <summary>
         /// Gets the endpoint.
         /// </summary>
-        /// <value>
-        /// The endpoint.
-        /// </value>
         /// <exception cref="InvalidOperationException"></exception>
         public ConfiguredEndpoint Endpoint
         {
@@ -190,7 +178,7 @@ namespace Opc.Ua.Gds.Client
 
             try
             {
-                lds ??= new LocalDiscoveryServerClient(Configuration, m_telemetry);
+                lds ??= new LocalDiscoveryServerClient(Configuration);
 
                 (List<ServerOnNetwork> servers, DateTime _) = await lds.FindServersOnNetworkAsync(
                     0,
@@ -250,7 +238,7 @@ namespace Opc.Ua.Gds.Client
 
             try
             {
-                lds ??= new LocalDiscoveryServerClient(Configuration, m_telemetry);
+                lds ??= new LocalDiscoveryServerClient(Configuration);
 
                 (List<ServerOnNetwork> servers, DateTime _) = await lds.FindServersOnNetworkAsync(
                     0,
@@ -335,7 +323,7 @@ namespace Opc.Ua.Gds.Client
                             Configuration,
                             endpointUrl,
                             true,
-                            m_telemetry,
+                            MessageContext.Telemetry,
                             ct).ConfigureAwait(false);
                     var endpointConfiguration = EndpointConfiguration.Create(Configuration);
                     var endpoint = new ConfiguredEndpoint(

--- a/Libraries/Opc.Ua.Gds.Client.Common/LocalDiscoveryServerClient.cs
+++ b/Libraries/Opc.Ua.Gds.Client.Common/LocalDiscoveryServerClient.cs
@@ -37,10 +37,8 @@ namespace Opc.Ua.Gds.Client
     public class LocalDiscoveryServerClient
     {
         public LocalDiscoveryServerClient(
-            ApplicationConfiguration configuration,
-            ITelemetryContext telemetry)
+            ApplicationConfiguration configuration)
         {
-            m_telemetry = telemetry;
             ApplicationConfiguration = configuration;
             MessageContext = configuration.CreateMessageContext();
 
@@ -546,13 +544,11 @@ namespace Opc.Ua.Gds.Client
             ITransportChannel channel = DiscoveryChannel.Create(
                 new Uri(endpointUrl),
                 configuration,
-                context,
-                m_telemetry);
+                context);
 
-            return new DiscoveryClient(channel, m_telemetry);
+            return new DiscoveryClient(channel, context.Telemetry);
         }
 
-        private readonly ITelemetryContext m_telemetry;
         private const string kDefaultUrl = "opc.tcp://localhost:4840";
     }
 }

--- a/Libraries/Opc.Ua.Gds.Client.Common/ServerPushConfigurationClient.cs
+++ b/Libraries/Opc.Ua.Gds.Client.Common/ServerPushConfigurationClient.cs
@@ -47,17 +47,15 @@ namespace Opc.Ua.Gds.Client
         /// Initializes a new instance of the <see cref="ServerPushConfigurationClient"/> class.
         /// </summary>
         /// <param name="configuration">The application configuration.</param>
-        /// <param name="telemetry">The telemetry context to use to create obvservability instruments</param>
         /// <param name="sessionFactory">Used to create session to the server.</param>
         public ServerPushConfigurationClient(
             ApplicationConfiguration configuration,
-            ITelemetryContext telemetry,
             ISessionFactory sessionFactory = null)
         {
             Configuration = configuration;
-            m_logger = telemetry.CreateLogger<ServerPushConfigurationClient>();
-            m_sessionFactory = sessionFactory ?? new DefaultSessionFactory(telemetry);
-            m_telemetry = telemetry;
+            MessageContext = configuration.CreateMessageContext(true);
+            m_logger = MessageContext.Telemetry.CreateLogger<ServerPushConfigurationClient>();
+            m_sessionFactory = sessionFactory ?? new DefaultSessionFactory(MessageContext.Telemetry);
         }
 
         public NodeId DefaultApplicationGroup { get; private set; }
@@ -71,25 +69,21 @@ namespace Opc.Ua.Gds.Client
         /// <summary>
         /// Gets the application instance.
         /// </summary>
-        /// <value>
-        /// The application instance.
-        /// </value>
         public ApplicationConfiguration Configuration { get; }
+
+        /// <summary>
+        /// Message context
+        /// </summary>
+        public IServiceMessageContext MessageContext { get; }
 
         /// <summary>
         /// Gets or sets the admin credentials.
         /// </summary>
-        /// <value>
-        /// The admin credentials.
-        /// </value>
         public IUserIdentity AdminCredentials { get; set; }
 
         /// <summary>
         /// Gets or sets the endpoint URL.
         /// </summary>
-        /// <value>
-        /// The endpoint URL.
-        /// </value>
         public string EndpointUrl { get; set; }
 
         /// <summary>
@@ -105,33 +99,24 @@ namespace Opc.Ua.Gds.Client
         /// <summary>
         /// Gets or sets the preferred locales.
         /// </summary>
-        /// <value>
-        /// The preferred locales.
-        /// </value>
         public string[] PreferredLocales { get; set; }
 
         /// <summary>
         /// Gets a value indicating whether the session is connected.
         /// </summary>
         /// <value>
-        ///   <c>true</c> if the session is connected; otherwise, <c>false</c>.
+        /// <c>true</c> if the session is connected; otherwise, <c>false</c>.
         /// </value>
         public bool IsConnected => Session != null && Session.Connected;
 
         /// <summary>
         /// Gets the session.
         /// </summary>
-        /// <value>
-        /// The session.
-        /// </value>
         public ISession Session { get; private set; }
 
         /// <summary>
         /// Gets the endpoint.
         /// </summary>
-        /// <value>
-        /// The endpoint.
-        /// </value>
         /// <exception cref="InvalidOperationException"></exception>
         public ConfiguredEndpoint Endpoint
         {
@@ -229,7 +214,7 @@ namespace Opc.Ua.Gds.Client
                 Configuration,
                 endpointUrl,
                 true,
-                m_telemetry,
+                MessageContext.Telemetry,
                 ct).ConfigureAwait(false);
             var endpointConfiguration = EndpointConfiguration.Create(Configuration);
             var endpoint = new ConfiguredEndpoint(null, endpointDescription, endpointConfiguration);
@@ -1126,7 +1111,6 @@ namespace Opc.Ua.Gds.Client
             }
         }
 
-        private readonly ITelemetryContext m_telemetry;
         private readonly ISessionFactory m_sessionFactory;
         private readonly ILogger m_logger;
         private ConfiguredEndpoint m_endpoint;

--- a/Libraries/Opc.Ua.Gds.Server.Common/CertificateGroup.cs
+++ b/Libraries/Opc.Ua.Gds.Server.Common/CertificateGroup.cs
@@ -71,6 +71,11 @@ namespace Opc.Ua.Gds.Server
 
         protected string SubjectName { get; }
 
+        [Obsolete("Use CertificateGroup(TelemetryContext) instead")]
+        public CertificateGroup() : this(null)
+        {
+        }
+
         public CertificateGroup(ITelemetryContext telemetry)
         {
             m_telemetry = telemetry;

--- a/Libraries/Opc.Ua.Server/Aggregates/AggregateCalculator.cs
+++ b/Libraries/Opc.Ua.Server/Aggregates/AggregateCalculator.cs
@@ -39,6 +39,21 @@ namespace Opc.Ua.Server
     public class AggregateCalculator : IAggregateCalculator
     {
         /// <summary>
+        /// Create calculator
+        /// </summary>
+        [Obsolete("Use constructor with ITelemetryContext")]
+        public AggregateCalculator(
+            NodeId aggregateId,
+            DateTime startTime,
+            DateTime endTime,
+            double processingInterval,
+            bool stepped,
+            AggregateConfiguration configuration)
+            : this (aggregateId, startTime, endTime, processingInterval, stepped, configuration, null)
+        {
+        }
+
+        /// <summary>
         /// Initializes the calculation stream.
         /// </summary>
         /// <param name="aggregateId">The aggregate function to apply.</param>

--- a/Libraries/Opc.Ua.Server/Aggregates/Aggregators.cs
+++ b/Libraries/Opc.Ua.Server/Aggregates/Aggregators.cs
@@ -324,6 +324,28 @@ namespace Opc.Ua.Server
         /// <summary>
         /// Creates a calculator for one of the standard aggregates.
         /// </summary>
+        [Obsolete("Use CreateStandardCalculator with telemetry context.")]
+        public static IAggregateCalculator CreateStandardCalculator(
+            NodeId aggregateId,
+            DateTime startTime,
+            DateTime endTime,
+            double processingInterval,
+            bool stepped,
+            AggregateConfiguration configuration)
+        {
+            return CreateStandardCalculator(
+                aggregateId,
+                startTime,
+                endTime,
+                processingInterval,
+                stepped,
+                configuration,
+                null);
+        }
+
+        /// <summary>
+        /// Creates a calculator for one of the standard aggregates.
+        /// </summary>
         public static IAggregateCalculator CreateStandardCalculator(
             NodeId aggregateId,
             DateTime startTime,

--- a/Libraries/Opc.Ua.Server/ServerUtils.cs
+++ b/Libraries/Opc.Ua.Server/ServerUtils.cs
@@ -465,6 +465,18 @@ namespace Opc.Ua.Server
         /// <summary>
         /// Creates the diagnostic info and translates any strings.
         /// </summary>
+        [Obsolete("Use CreateDiagnosticInfo with ILogger")]
+        public static DiagnosticInfo CreateDiagnosticInfo(
+            IServerInternal server,
+            OperationContext context,
+            ServiceResult error)
+        {
+            return CreateDiagnosticInfo(server, context, error, Utils.Fallback.Logger);
+        }
+
+        /// <summary>
+        /// Creates the diagnostic info and translates any strings.
+        /// </summary>
         /// <param name="server">The server.</param>
         /// <param name="context">The context containing the string stable.</param>
         /// <param name="error">The error to translate.</param>

--- a/Stack/Opc.Ua.Core/Security/Certificates/CertificateFactory.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/CertificateFactory.cs
@@ -52,6 +52,28 @@ namespace Opc.Ua
         /// <summary>
         /// Creates a certificate from a buffer with DER encoded certificate.
         /// </summary>
+        [Obsolete("Use Create(ReadOnlyMemory<byte>, bool, ITelemetryContext) instead")]
+        public static X509Certificate2 Create(
+            ReadOnlyMemory<byte> encodedData,
+            bool useCache)
+        {
+            return Create(encodedData, useCache, null);
+        }
+
+        /// <summary>
+        /// Loads the cached version of a certificate.
+        /// </summary>
+        [Obsolete("Use Load(X509Certificate2, bool, ITelemetryContext) instead")]
+        public static X509Certificate2 Load(
+            X509Certificate2 certificate,
+            bool ensurePrivateKeyAccessible)
+        {
+            return Load(certificate, ensurePrivateKeyAccessible, null);
+        }
+
+        /// <summary>
+        /// Creates a certificate from a buffer with DER encoded certificate.
+        /// </summary>
         /// <param name="encodedData">The encoded data.</param>
         /// <param name="useCache">if set to <c>true</c> the copy of the certificate
         /// in the cache is used.</param>

--- a/Stack/Opc.Ua.Core/Security/Certificates/CertificateIdentifier.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/CertificateIdentifier.cs
@@ -454,6 +454,15 @@ namespace Opc.Ua
         }
 
         /// <summary>
+        /// Obsoleted open call
+        /// </summary>
+        [Obsolete("Use OpenStore(ITelemetryContext) instead")]
+        public ICertificateStore OpenStore()
+        {
+            return OpenStore(null);
+        }
+
+        /// <summary>
         /// Returns an object to access the store containing the certificate.
         /// </summary>
         /// <remarks>

--- a/Stack/Opc.Ua.Core/Security/Certificates/CertificateValidator.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/CertificateValidator.cs
@@ -36,6 +36,14 @@ namespace Opc.Ua
         private const int kDefaultMaxRejectedCertificates = 5;
 
         /// <summary>
+        /// Create validator
+        /// </summary>
+        [Obsolete("Use CertificateValidator(ITelemetryContext) instead.")]
+        public CertificateValidator() : this(null)
+        {
+        }
+
+        /// <summary>
         /// The default constructor.
         /// </summary>
         public CertificateValidator(ITelemetryContext telemetry)

--- a/Stack/Opc.Ua.Core/Stack/Client/RegistrationClient.cs
+++ b/Stack/Opc.Ua.Core/Stack/Client/RegistrationClient.cs
@@ -95,8 +95,7 @@ namespace Opc.Ua
                 description,
                 endpointConfiguration,
                 clientCertificate,
-                messageContext,
-                telemetry);
+                messageContext);
 
             // create a registration channel.
             if (channel == null)

--- a/Stack/Opc.Ua.Core/Stack/Client/SessionChannel.cs
+++ b/Stack/Opc.Ua.Core/Stack/Client/SessionChannel.cs
@@ -27,14 +27,12 @@ namespace Opc.Ua
         /// <param name="endpointConfiguration">The configuration to use with the endpoint.</param>
         /// <param name="clientCertificate">The client certificate.</param>
         /// <param name="messageContext">The message context to use when serializing the messages.</param>
-        /// <param name="telemetry">Telemetry context to use</param>
         public static ITransportChannel Create(
             ApplicationConfiguration configuration,
             EndpointDescription description,
             EndpointConfiguration endpointConfiguration,
             X509Certificate2 clientCertificate,
-            IServiceMessageContext messageContext,
-            ITelemetryContext telemetry)
+            IServiceMessageContext messageContext)
         {
             return Create(
                 configuration,
@@ -42,8 +40,7 @@ namespace Opc.Ua
                 endpointConfiguration,
                 clientCertificate,
                 null,
-                messageContext,
-                telemetry);
+                messageContext);
         }
 
         /// <summary>
@@ -55,15 +52,13 @@ namespace Opc.Ua
         /// <param name="clientCertificate">The client certificate.</param>
         /// <param name="clientCertificateChain">The client certificate chain.</param>
         /// <param name="messageContext">The message context to use when serializing the messages.</param>
-        /// <param name="telemetry">Telemetry context to use</param>
         public static ITransportChannel Create(
             ApplicationConfiguration configuration,
             EndpointDescription description,
             EndpointConfiguration endpointConfiguration,
             X509Certificate2 clientCertificate,
             X509Certificate2Collection clientCertificateChain,
-            IServiceMessageContext messageContext,
-            ITelemetryContext telemetry)
+            IServiceMessageContext messageContext)
         {
             // create a UA binary channel.
             return CreateUaBinaryChannel(
@@ -72,8 +67,7 @@ namespace Opc.Ua
                 endpointConfiguration,
                 clientCertificate,
                 clientCertificateChain,
-                messageContext,
-                telemetry);
+                messageContext);
         }
 
         /// <summary>
@@ -86,7 +80,6 @@ namespace Opc.Ua
         /// <param name="clientCertificate">The client certificate.</param>
         /// <param name="clientCertificateChain">The client certificate chain.</param>
         /// <param name="messageContext">The message context to use when serializing the messages.</param>
-        /// <param name="telemetry">Telemetry context to use</param>
         public static ITransportChannel Create(
             ApplicationConfiguration configuration,
             ITransportWaitingConnection connection,
@@ -94,8 +87,7 @@ namespace Opc.Ua
             EndpointConfiguration endpointConfiguration,
             X509Certificate2 clientCertificate,
             X509Certificate2Collection clientCertificateChain,
-            IServiceMessageContext messageContext,
-            ITelemetryContext telemetry)
+            IServiceMessageContext messageContext)
         {
             // create a UA binary channel.
             return CreateUaBinaryChannel(
@@ -105,8 +97,7 @@ namespace Opc.Ua
                 endpointConfiguration,
                 clientCertificate,
                 clientCertificateChain,
-                messageContext,
-                telemetry);
+                messageContext);
         }
     }
 }

--- a/Stack/Opc.Ua.Core/Stack/Client/UaChannelBase.cs
+++ b/Stack/Opc.Ua.Core/Stack/Client/UaChannelBase.cs
@@ -750,13 +750,12 @@ namespace Opc.Ua
             EndpointConfiguration endpointConfiguration,
             X509Certificate2 clientCertificate,
             X509Certificate2Collection clientCertificateChain,
-            IServiceMessageContext messageContext,
-            ITelemetryContext telemetry)
+            IServiceMessageContext messageContext)
         {
             // initialize the channel which will be created with the server.
             string uriScheme = new Uri(description.EndpointUrl).Scheme;
             ITransportChannel channel =
-                TransportBindings.Channels.GetChannel(uriScheme, telemetry)
+                TransportBindings.Channels.GetChannel(uriScheme, messageContext.Telemetry)
                 ?? throw ServiceResultException.Create(
                     StatusCodes.BadProtocolVersionUnsupported,
                     "Unsupported transport profile for scheme {0}.",
@@ -775,7 +774,7 @@ namespace Opc.Ua
             {
                 settings.ServerCertificate = Utils.ParseCertificateBlob(
                     description.ServerCertificate,
-                    telemetry);
+                    messageContext.Telemetry);
             }
 
             if (configuration != null)
@@ -801,14 +800,12 @@ namespace Opc.Ua
         /// <param name="endpointConfiguration">The configuration to use with the endpoint.</param>
         /// <param name="clientCertificate">The client certificate.</param>
         /// <param name="messageContext">The message context to use when serializing the messages.</param>
-        /// <param name="telemetry">Telemetry context to use</param>
         public static ITransportChannel CreateUaBinaryChannel(
             ApplicationConfiguration configuration,
             EndpointDescription description,
             EndpointConfiguration endpointConfiguration,
             X509Certificate2 clientCertificate,
-            IServiceMessageContext messageContext,
-            ITelemetryContext telemetry)
+            IServiceMessageContext messageContext)
         {
             return CreateUaBinaryChannel(
                 configuration,
@@ -816,8 +813,7 @@ namespace Opc.Ua
                 endpointConfiguration,
                 clientCertificate,
                 null,
-                messageContext,
-                telemetry);
+                messageContext);
         }
 
         /// <summary>
@@ -829,7 +825,6 @@ namespace Opc.Ua
         /// <param name="clientCertificate">The client certificate.</param>
         /// <param name="clientCertificateChain">The client certificate chain.</param>
         /// <param name="messageContext">The message context to use when serializing the messages.</param>
-        /// <param name="telemetry">Telemetry context to use</param>
         /// <exception cref="ServiceResultException"></exception>
         public static ITransportChannel CreateUaBinaryChannel(
             ApplicationConfiguration configuration,
@@ -837,8 +832,7 @@ namespace Opc.Ua
             EndpointConfiguration endpointConfiguration,
             X509Certificate2 clientCertificate,
             X509Certificate2Collection clientCertificateChain,
-            IServiceMessageContext messageContext,
-            ITelemetryContext telemetry)
+            IServiceMessageContext messageContext)
         {
             string uriScheme = new Uri(description.EndpointUrl).Scheme;
 
@@ -857,7 +851,7 @@ namespace Opc.Ua
 
             // initialize the channel which will be created with the server.
             ITransportChannel channel =
-                TransportBindings.Channels.GetChannel(uriScheme, telemetry)
+                TransportBindings.Channels.GetChannel(uriScheme, messageContext.Telemetry)
                 ?? throw ServiceResultException.Create(
                     StatusCodes.BadProtocolVersionUnsupported,
                     "Unsupported transport profile for scheme {0}.",
@@ -876,7 +870,7 @@ namespace Opc.Ua
             {
                 settings.ServerCertificate = Utils.ParseCertificateBlob(
                     description.ServerCertificate,
-                    telemetry);
+                    messageContext.Telemetry);
             }
 
             if (configuration != null)

--- a/Stack/Opc.Ua.Core/Stack/Client/UserIdentity.cs
+++ b/Stack/Opc.Ua.Core/Stack/Client/UserIdentity.cs
@@ -31,9 +31,16 @@ namespace Opc.Ua
         /// Initializes the object as an anonymous user.
         /// </summary>
         public UserIdentity()
+            : this(new AnonymousIdentityToken())
         {
-            var token = new AnonymousIdentityToken();
-            Initialize(token);
+        }
+
+        /// <summary>
+        /// Initializes the object as an anonymous user.
+        /// </summary>
+        public UserIdentity(AnonymousIdentityToken anonymousIdentityToken)
+        {
+            Initialize(anonymousIdentityToken);
         }
 
         /// <summary>
@@ -42,13 +49,20 @@ namespace Opc.Ua
         /// <param name="username">The user name.</param>
         /// <param name="password">The password.</param>
         public UserIdentity(string username, string password)
-        {
-            var token = new UserNameIdentityToken
+            : this (new UserNameIdentityToken
             {
                 UserName = username,
                 DecryptedPassword = password
-            };
-            Initialize(token);
+            })
+        {
+        }
+
+        /// <summary>
+        /// Initializes the object with a username token.
+        /// </summary>
+        public UserIdentity(UserNameIdentityToken userNameToken)
+        {
+            Initialize(userNameToken);
         }
 
         /// <summary>
@@ -58,6 +72,15 @@ namespace Opc.Ua
         public UserIdentity(IssuedIdentityToken issuedToken)
         {
             Initialize(issuedToken);
+        }
+
+        /// <summary>
+        /// Initializes the object with an X509 certificate identifier
+        /// </summary>
+        [Obsolete("Use UserIdentityToken(X509IdentityToken, ITelemetryContext) instead.")]
+        public UserIdentity(X509IdentityToken x509Token)
+            : this (x509Token, null)
+        {
         }
 
         /// <summary>

--- a/Stack/Opc.Ua.Core/Stack/Configuration/ConfiguredEndpoints.cs
+++ b/Stack/Opc.Ua.Core/Stack/Configuration/ConfiguredEndpoints.cs
@@ -1087,13 +1087,47 @@ namespace Opc.Ua
         /// <summary>
         /// Updates an endpoint with information from the server's discovery endpoint.
         /// </summary>
-        public Task UpdateFromServerAsync(ITelemetryContext telemetry, CancellationToken ct = default)
+        [Obsolete("Use UpdateFromServerAsync with ITelemetryContext instead")]
+        public Task UpdateFromServerAsync(CancellationToken ct = default)
+        {
+            return UpdateFromServerAsync(null, ct);
+        }
+
+        /// <summary>
+        /// Updates an endpoint with information from the server's discovery endpoint.
+        /// </summary>
+        [Obsolete("Use UpdateFromServerAsync with ITelemetryContext instead")]
+        public Task UpdateFromServerAsync(
+            Uri endpointUrl,
+            ITransportWaitingConnection connection,
+            MessageSecurityMode securityMode,
+            string securityPolicyUri,
+            CancellationToken ct = default)
         {
             return UpdateFromServerAsync(
-                EndpointUrl,
-                m_description.SecurityMode,
-                m_description.SecurityPolicyUri,
-                telemetry,
+                endpointUrl,
+                connection,
+                securityMode,
+                securityPolicyUri,
+                null,
+                ct);
+        }
+
+        /// <summary>
+        /// Updates an endpoint with information from the server's discovery endpoint.
+        /// </summary>
+        [Obsolete("Use UpdateFromServerAsync with ITelemetryContext instead")]
+        public Task UpdateFromServerAsync(
+            Uri endpointUrl,
+            MessageSecurityMode securityMode,
+            string securityPolicyUri,
+            CancellationToken ct = default)
+        {
+            return UpdateFromServerAsync(
+                endpointUrl,
+                securityMode,
+                securityPolicyUri,
+                null,
                 ct);
         }
 
@@ -1108,6 +1142,19 @@ namespace Opc.Ua
             CancellationToken ct = default)
         {
             return UpdateFromServerAsync(endpointUrl, null, securityMode, securityPolicyUri, telemetry, ct);
+        }
+
+        /// <summary>
+        /// Updates an endpoint with information from the server's discovery endpoint.
+        /// </summary>
+        public Task UpdateFromServerAsync(ITelemetryContext telemetry, CancellationToken ct = default)
+        {
+            return UpdateFromServerAsync(
+                EndpointUrl,
+                m_description.SecurityMode,
+                m_description.SecurityPolicyUri,
+                telemetry,
+                ct);
         }
 
         /// <summary>

--- a/Stack/Opc.Ua.Core/Stack/Configuration/SecurityConfigurationManager.cs
+++ b/Stack/Opc.Ua.Core/Stack/Configuration/SecurityConfigurationManager.cs
@@ -25,6 +25,14 @@ namespace Opc.Ua.Security
     public class SecurityConfigurationManager : ISecurityConfigurationManager
     {
         /// <summary>
+        /// Obsolete default constructor
+        /// </summary>
+        [Obsolete("Use SecurityConfigurationManager(ITelemetryContext) instead.")]
+        public SecurityConfigurationManager() : this (null)
+        {
+        }
+
+        /// <summary>
         /// Create the security configuration manager.
         /// </summary>
         /// <param name="telemetry">The telemetry context to use to create obvservability instruments</param>

--- a/Stack/Opc.Ua.Core/Stack/Diagnostics/TelemetryExtensions.cs
+++ b/Stack/Opc.Ua.Core/Stack/Diagnostics/TelemetryExtensions.cs
@@ -204,7 +204,7 @@ namespace Opc.Ua
 
                     if (m_fileName == null)
                     {
-                        Debug.WriteLine(traceString);
+                        Debug.Fail(traceString);
                         return;
                     }
 

--- a/Stack/Opc.Ua.Core/Stack/Nodes/IFilterTarget.cs
+++ b/Stack/Opc.Ua.Core/Stack/Nodes/IFilterTarget.cs
@@ -119,6 +119,41 @@ namespace Opc.Ua
         /// <summary>
         /// Initializes the context.
         /// </summary>
+        [Obsolete("Use constructor with ITelemetryContext")]
+        public FilterContext(
+            NamespaceTable namespaceUris,
+            ITypeTable typeTree,
+            IOperationContext context)
+            : this(namespaceUris, typeTree, context, null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes the context.
+        /// </summary>
+        [Obsolete("Use constructor with ITelemetryContext")]
+        public FilterContext(
+            NamespaceTable namespaceUris,
+            ITypeTable typeTree)
+            : this(namespaceUris, typeTree, (ITelemetryContext)null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes the context.
+        /// </summary>
+        [Obsolete("Use constructor with ITelemetryContext")]
+        public FilterContext(
+            NamespaceTable namespaceUris,
+            ITypeTable typeTree,
+            IList<string> preferredLocales)
+            : this(namespaceUris, typeTree, preferredLocales, null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes the context.
+        /// </summary>
         /// <param name="namespaceUris">The namespace URIs.</param>
         /// <param name="typeTree">The type tree.</param>
         /// <param name="context">The context.</param>

--- a/Stack/Opc.Ua.Core/Types/BuiltIn/DiagnosticInfo.cs
+++ b/Stack/Opc.Ua.Core/Types/BuiltIn/DiagnosticInfo.cs
@@ -108,6 +108,32 @@ namespace Opc.Ua
         /// <summary>
         /// Initializes the object with a ServiceResult.
         /// </summary>
+        [Obsolete("Use DiagnosticInfo(ServiceResult, DiagnosticsMasks, bool, StringTable, ILogger) instead.")]
+        public DiagnosticInfo(
+            ServiceResult result,
+            DiagnosticsMasks diagnosticsMask,
+            bool serviceLevel,
+            StringTable stringTable)
+            : this(result, diagnosticsMask, serviceLevel, stringTable, 0, Utils.Fallback.Logger)
+        {
+        }
+
+        /// <summary>
+        /// Initializes the object with an exception.
+        /// </summary>
+        [Obsolete("Use DiagnosticInfo(Exception, DiagnosticsMasks, bool, StringTable, ILogger) instead.")]
+        public DiagnosticInfo(
+            Exception exception,
+            DiagnosticsMasks diagnosticsMask,
+            bool serviceLevel,
+            StringTable stringTable)
+            : this(exception, diagnosticsMask, serviceLevel, stringTable, Utils.Fallback.Logger)
+        {
+        }
+
+        /// <summary>
+        /// Initializes the object with a ServiceResult.
+        /// </summary>
         /// <param name="result">The overall transaction result</param>
         /// <param name="diagnosticsMask">The bitmask describing the diagnostic data</param>
         /// <param name="serviceLevel">The service level</param>

--- a/Stack/Opc.Ua.Core/Types/Utils/DataGenerator.cs
+++ b/Stack/Opc.Ua.Core/Types/Utils/DataGenerator.cs
@@ -126,6 +126,14 @@ namespace Opc.Ua.Test
     public class DataGenerator
     {
         /// <summary>
+        /// Obsolete constructor
+        /// </summary>
+        [Obsolete("Use DataGenerator(ITelemetryContext) instead.")]
+        public DataGenerator(IRandomSource random) : this(random, null)
+        {
+        }
+
+        /// <summary>
         /// Initializes the data generator.
         /// </summary>
         public DataGenerator(IRandomSource random, ITelemetryContext telemetry)

--- a/Stack/Opc.Ua.Core/Types/Utils/ServiceMessageContext.cs
+++ b/Stack/Opc.Ua.Core/Types/Utils/ServiceMessageContext.cs
@@ -22,6 +22,14 @@ namespace Opc.Ua
         /// <summary>
         /// Initializes the object with default values.
         /// </summary>
+        [Obsolete("Use ServiceMessageContext(ITelemetryContext) instead.")]
+        public ServiceMessageContext() : this(null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes the object with default values.
+        /// </summary>
         public ServiceMessageContext(ITelemetryContext telemetry)
         {
             Telemetry = telemetry;

--- a/Stack/Opc.Ua.Core/Types/Utils/UtilsObsolete.cs
+++ b/Stack/Opc.Ua.Core/Types/Utils/UtilsObsolete.cs
@@ -72,7 +72,7 @@ namespace Opc.Ua
         [Obsolete("Use ITelemetryContext.CreateLogger and ILogger.LogTrace instead.")]
         public static void Trace(string message)
         {
-            LogInformation(message);
+            LogInfo(message);
         }
 
         /// <summary>
@@ -81,7 +81,7 @@ namespace Opc.Ua
         [Obsolete("Use ITelemetryContext.CreateLogger and ILogger.LogTrace instead.")]
         public static void Trace(string format, params object[] args)
         {
-            LogInformation(format, args);
+            LogInfo(format, args);
         }
 
         /// <summary>
@@ -318,9 +318,9 @@ namespace Opc.Ua
         /// <param name="exception">The exception to log.</param>
         /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
         /// <param name="args">An object array that contains zero or more objects to format.</param>
-        /// <example>LogInformation(0, exception, "Error while processing request from {Address}", address)</example>
+        /// <example>LogInfo(0, exception, "Error while processing request from {Address}", address)</example>
         [Obsolete("Use ITelemetryContext ILoggerFactory and ILogger.LogInformation.")]
-        public static void LogInformation(
+        public static void LogInfo(
             EventId eventId,
             Exception exception,
             string message,
@@ -335,9 +335,9 @@ namespace Opc.Ua
         /// <param name="eventId">The event id associated with the log.</param>
         /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
         /// <param name="args">An object array that contains zero or more objects to format.</param>
-        /// <example>LogInformation(0, "Processing request from {Address}", address)</example>
+        /// <example>LogInfo(0, "Processing request from {Address}", address)</example>
         [Obsolete("Use ITelemetryContext ILoggerFactory and ILogger.LogInformation.")]
-        public static void LogInformation(EventId eventId, string message, params object[] args)
+        public static void LogInfo(EventId eventId, string message, params object[] args)
         {
             Log(LogLevel.Information, eventId, message, args);
         }
@@ -348,9 +348,9 @@ namespace Opc.Ua
         /// <param name="exception">The exception to log.</param>
         /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
         /// <param name="args">An object array that contains zero or more objects to format.</param>
-        /// <example>LogInformation(exception, "Error while processing request from {Address}", address)</example>
+        /// <example>LogInfo(exception, "Error while processing request from {Address}", address)</example>
         [Obsolete("Use ITelemetryContext ILoggerFactory and ILogger.LogInformation.")]
-        public static void LogInformation(Exception exception, string message, params object[] args)
+        public static void LogInfo(Exception exception, string message, params object[] args)
         {
             Log(LogLevel.Information, exception, message, args);
         }
@@ -360,9 +360,9 @@ namespace Opc.Ua
         /// </summary>
         /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
         /// <param name="args">An object array that contains zero or more objects to format.</param>
-        /// <example>LogInformation("Processing request from {Address}", address)</example>
+        /// <example>LogInfo("Processing request from {Address}", address)</example>
         [Obsolete("Use ITelemetryContext ILoggerFactory and ILogger.LogInformation.")]
-        public static void LogInformation(string message, params object[] args)
+        public static void LogInfo(string message, params object[] args)
         {
             Log(LogLevel.Information, message, args);
         }
@@ -640,7 +640,7 @@ namespace Opc.Ua
             }
             else if ((traceMask & informationMask) != 0)
             {
-                LogInformation(traceMask, format, args);
+                LogInfo(traceMask, format, args);
             }
             else
             {

--- a/Tests/Opc.Ua.Client.Tests/ClientTest.cs
+++ b/Tests/Opc.Ua.Client.Tests/ClientTest.cs
@@ -1668,7 +1668,7 @@ namespace Opc.Ua.Client.Tests
                 ApplicationConfiguration configuration,
                 ConfiguredEndpoint endpoint,
                 ITelemetryContext telemetry)
-                : base(channel, configuration, endpoint, telemetry)
+                : base(channel, configuration, endpoint)
             {
             }
 

--- a/Tests/Opc.Ua.Client.Tests/ReverseConnectTest.cs
+++ b/Tests/Opc.Ua.Client.Tests/ReverseConnectTest.cs
@@ -165,8 +165,7 @@ namespace Opc.Ua.Client.Tests
                 using var client = DiscoveryClient.Create(
                     config,
                     connection,
-                    endpointConfiguration,
-                    Telemetry);
+                    endpointConfiguration);
                 Endpoints = await client.GetEndpointsAsync(null, cancellationTokenSource.Token)
                     .ConfigureAwait(false);
                 await client.CloseAsync(cancellationTokenSource.Token).ConfigureAwait(false);

--- a/Tests/Opc.Ua.Client.Tests/TestableSession.cs
+++ b/Tests/Opc.Ua.Client.Tests/TestableSession.cs
@@ -97,7 +97,6 @@ namespace Opc.Ua.Client.Tests
                 configuration,
                 endpoint,
                 clientCertificate,
-                telemetry,
                 availableEndpoints,
                 discoveryProfileUris)
         {

--- a/Tests/Opc.Ua.Client.Tests/TraceableRequestHeaderClientSession.cs
+++ b/Tests/Opc.Ua.Client.Tests/TraceableRequestHeaderClientSession.cs
@@ -46,9 +46,8 @@ namespace Opc.Ua.Client
         public TraceableRequestHeaderClientSession(
             ISessionChannel channel,
             ApplicationConfiguration configuration,
-            ConfiguredEndpoint endpoint,
-            ITelemetryContext telemetry)
-            : this(channel as ITransportChannel, configuration, endpoint, null, telemetry)
+            ConfiguredEndpoint endpoint)
+            : this(channel as ITransportChannel, configuration, endpoint, null)
         {
         }
 
@@ -74,7 +73,6 @@ namespace Opc.Ua.Client
             ApplicationConfiguration configuration,
             ConfiguredEndpoint endpoint,
             X509Certificate2 clientCertificate,
-            ITelemetryContext telemetry,
             EndpointDescriptionCollection availableEndpoints = null,
             StringCollection discoveryProfileUris = null)
             : base(
@@ -82,7 +80,6 @@ namespace Opc.Ua.Client
                 configuration,
                 endpoint,
                 clientCertificate,
-                telemetry,
                 availableEndpoints,
                 discoveryProfileUris)
         {

--- a/Tests/Opc.Ua.Client.Tests/TraceableRequestHeaderClientSessionFactory.cs
+++ b/Tests/Opc.Ua.Client.Tests/TraceableRequestHeaderClientSessionFactory.cs
@@ -49,7 +49,7 @@ namespace Opc.Ua.Client
             ApplicationConfiguration configuration,
             ConfiguredEndpoint endpoint)
         {
-            return new TraceableRequestHeaderClientSession(channel, configuration, endpoint, Telemetry);
+            return new TraceableRequestHeaderClientSession(channel, configuration, endpoint);
         }
 
         /// <inheritdoc/>
@@ -66,7 +66,6 @@ namespace Opc.Ua.Client
                 configuration,
                 endpoint,
                 clientCertificate,
-                Telemetry,
                 availableEndpoints,
                 discoveryProfileUris);
         }

--- a/Tests/Opc.Ua.Gds.Tests/ServerConfigurationPushTestClient.cs
+++ b/Tests/Opc.Ua.Gds.Tests/ServerConfigurationPushTestClient.cs
@@ -130,7 +130,7 @@ namespace Opc.Ua.Gds.Tests
             ServerConfigurationPushTestClientConfiguration clientConfiguration =
                 application.ApplicationConfiguration
                     .ParseExtension<ServerConfigurationPushTestClientConfiguration>();
-            PushClient = new ServerPushConfigurationClient(application.ApplicationConfiguration, m_telemetry)
+            PushClient = new ServerPushConfigurationClient(application.ApplicationConfiguration)
             {
                 EndpointUrl = TestUtils.PatchOnlyGDSEndpointUrlPort(
                     clientConfiguration.ServerUrl,


### PR DESCRIPTION
## Proposed changes

Added obsoleted methods to ensure .net samples compile (almost) unchanged.

## Related Issues

- Fixes #

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
