### PR TITLE
Immutable Encodeable factory and lookup performance improvements

### DIFF
--- a/Fuzzing/Encoders/Fuzz/FuzzableCode.XmlDecoder.cs
+++ b/Fuzzing/Encoders/Fuzz/FuzzableCode.XmlDecoder.cs
@@ -124,7 +124,7 @@ namespace Opc.Ua.Fuzzing
                         string typeName = reader.LocalName;
                         string namespaceUri = reader.NamespaceURI;
                         systemType = MessageContext
-                            .Factory.KnownTypes
+                            .Factory.KnownTypeIds
                                 .Select(MessageContext.Factory.GetSystemType)
                                 .FirstOrDefault(entry => entry.Name == typeName
                                     /* && entry.Key.NamespaceUri == namespaceUri*/);

--- a/Fuzzing/Encoders/Fuzz/FuzzableCode.XmlDecoder.cs
+++ b/Fuzzing/Encoders/Fuzz/FuzzableCode.XmlDecoder.cs
@@ -124,11 +124,10 @@ namespace Opc.Ua.Fuzzing
                         string typeName = reader.LocalName;
                         string namespaceUri = reader.NamespaceURI;
                         systemType = MessageContext
-                            .Factory.EncodeableTypes.Where(entry =>
-                                entry.Value
-                                    .Name == typeName /* && entry.Key.NamespaceUri == namespaceUri*/)
-                            .Select(entry => entry.Value)
-                            .FirstOrDefault();
+                            .Factory.KnownTypes
+                                .Select(MessageContext.Factory.GetSystemType)
+                                .FirstOrDefault(entry => entry.Name == typeName
+                                    /* && entry.Key.NamespaceUri == namespaceUri*/);
                     }
                     catch (XmlException ex)
                     {

--- a/Libraries/Opc.Ua.Client.ComplexTypes/ComplexTypeSystem.cs
+++ b/Libraries/Opc.Ua.Client.ComplexTypes/ComplexTypeSystem.cs
@@ -208,6 +208,8 @@ namespace Opc.Ua.Client.ComplexTypes
                         }
                     }
                 }
+                // Commit the changes to the factory
+                m_complexTypeResolver.FactoryBuilder.Commit();
                 return GetSystemType(nodeId);
             }
             catch (Exception ex)
@@ -271,6 +273,8 @@ namespace Opc.Ua.Client.ComplexTypes
                     return await LoadDictionaryDataTypesAsync(serverEnumTypes, false, ct)
                         .ConfigureAwait(false);
                 }
+                // Commit the changes to the factory
+                m_complexTypeResolver.FactoryBuilder.Commit();
                 return true;
             }
             catch (Exception ex)
@@ -343,6 +347,8 @@ namespace Opc.Ua.Client.ComplexTypes
                     return await LoadDictionaryDataTypesAsync(serverEnumTypes, true, ct)
                         .ConfigureAwait(false);
                 }
+                // Commit the changes to the factory
+                m_complexTypeResolver.FactoryBuilder.Commit();
                 return true;
             }
             catch (Exception ex)
@@ -1064,7 +1070,7 @@ namespace Opc.Ua.Client.ComplexTypes
             {
                 nodeId = NormalizeExpandedNodeId(nodeId);
             }
-            return m_complexTypeResolver.Factory.GetSystemType(nodeId);
+            return m_complexTypeResolver.FactoryBuilder.GetSystemType(nodeId);
         }
 
         /// <summary>
@@ -1154,7 +1160,7 @@ namespace Opc.Ua.Client.ComplexTypes
             }
             ExpandedNodeId internalNodeId = NormalizeExpandedNodeId(nodeId);
             m_logger.LogDebug("Adding Type {DataType} as: {NodeId}", type.FullName, internalNodeId);
-            m_complexTypeResolver.Factory.AddEncodeableType(internalNodeId, type);
+            m_complexTypeResolver.FactoryBuilder.AddEncodeableType(internalNodeId, type);
         }
 
         /// <summary>
@@ -1336,7 +1342,7 @@ namespace Opc.Ua.Client.ComplexTypes
 
             Type fieldType =
                 field.DataType.NamespaceIndex == 0
-                    ? TypeInfo.GetSystemType(field.DataType, m_complexTypeResolver.Factory)
+                    ? TypeInfo.GetSystemType(field.DataType, m_complexTypeResolver.FactoryBuilder)
                     : GetSystemType(field.DataType);
 
             if (fieldType == null)

--- a/Libraries/Opc.Ua.Client.ComplexTypes/IComplexTypeResolver.cs
+++ b/Libraries/Opc.Ua.Client.ComplexTypes/IComplexTypeResolver.cs
@@ -46,7 +46,7 @@ namespace Opc.Ua.Client.ComplexTypes
         /// <summary>
         /// Gets the factory used to create encodeable objects that the server understands.
         /// </summary>
-        IEncodeableFactory Factory { get; }
+        IEncodeableFactoryBuilder FactoryBuilder { get; }
 
         /// <summary>
         /// The loaded data type dictionaries

--- a/Libraries/Opc.Ua.Client.ComplexTypes/TypeResolver/NodeCacheResolver.cs
+++ b/Libraries/Opc.Ua.Client.ComplexTypes/TypeResolver/NodeCacheResolver.cs
@@ -89,6 +89,7 @@ namespace Opc.Ua.Client.ComplexTypes
             m_session = lruNodeCache.Session;
             m_lruNodeCache = lruNodeCache;
             m_logger = telemetry.CreateLogger<NodeCacheResolver>();
+            FactoryBuilder = m_session.Factory.Builder;
         }
 #else
         /// <summary>
@@ -98,6 +99,7 @@ namespace Opc.Ua.Client.ComplexTypes
         {
             m_session = session;
             m_logger = telemetry.CreateLogger<NodeCacheResolver>();
+            FactoryBuilder = m_session.Factory.Builder;
         }
 #endif
 
@@ -105,7 +107,7 @@ namespace Opc.Ua.Client.ComplexTypes
         public NamespaceTable NamespaceUris => m_session.NamespaceUris;
 
         /// <inheritdoc/>
-        public IEncodeableFactory Factory => m_session.Factory;
+        public IEncodeableFactoryBuilder FactoryBuilder { get; }
 
         /// <inheritdoc/>
         public NodeIdDictionary<DataDictionary> DataTypeSystem { get; } = [];

--- a/Libraries/Opc.Ua.Client.ComplexTypes/Types/BaseComplexType.cs
+++ b/Libraries/Opc.Ua.Client.ComplexTypes/Types/BaseComplexType.cs
@@ -775,7 +775,7 @@ namespace Opc.Ua.Client.ComplexTypes
             {
                 if (m_xmlName == null)
                 {
-                    m_xmlName = EncodeableFactory.GetXmlName(GetType());
+                    m_xmlName = TypeInfo.GetXmlName(GetType());
                 }
 
                 return m_xmlName != null ? m_xmlName.Namespace : string.Empty;

--- a/Libraries/Opc.Ua.Client/Session/Session.cs
+++ b/Libraries/Opc.Ua.Client/Session/Session.cs
@@ -1155,7 +1155,7 @@ namespace Opc.Ua.Client
             }
 
             // create message context.
-            IServiceMessageContext messageContext = configuration.CreateMessageContext(true);
+            ServiceMessageContext messageContext = configuration.CreateMessageContext(true);
 
             // update endpoint description using the discovery endpoint.
             if (endpoint.UpdateBeforeConnect && connection == null)
@@ -7239,7 +7239,7 @@ namespace Opc.Ua.Client
 #endif
         private List<Subscription> m_subscriptions;
         private uint m_maxRequestMessageSize;
-        private SystemContext m_systemContext;
+        private readonly SystemContext m_systemContext;
         private NodeCache m_nodeCache;
         private List<IUserIdentity> m_identityHistory;
         private byte[] m_serverNonce;

--- a/Libraries/Opc.Ua.Client/Session/Session.cs
+++ b/Libraries/Opc.Ua.Client/Session/Session.cs
@@ -226,7 +226,7 @@ namespace Opc.Ua.Client
             m_sessionTimeout = 0;
             NamespaceUris = new NamespaceTable();
             ServerUris = new StringTable();
-            Factory = new EncodeableFactory(m_telemetry);
+            Factory = EncodeableFactory.Create();
             m_configuration = null;
             m_instanceCertificate = null;
             m_endpoint = null;

--- a/Libraries/Opc.Ua.Client/Subscription/Subscription.cs
+++ b/Libraries/Opc.Ua.Client/Subscription/Subscription.cs
@@ -53,7 +53,8 @@ namespace Opc.Ua.Client
         /// Create subscription
         /// </summary>
         [Obsolete("Use Subscription(TelemetryContext) instead")]
-        public Subscription() : this(null)
+        public Subscription()
+            : this(null)
         {
         }
 

--- a/Libraries/Opc.Ua.Gds.Client.Common/GlobalDiscoveryServerClient.cs
+++ b/Libraries/Opc.Ua.Gds.Client.Common/GlobalDiscoveryServerClient.cs
@@ -48,13 +48,11 @@ namespace Opc.Ua.Gds.Client
         /// </summary>
         /// <param name="configuration">The application configuration.</param>
         /// <param name="endpointUrl">The endpoint Url.</param>
-        /// <param name="telemetry">The telemetry context to use to create obvservability instruments</param>
         /// <param name="adminUserIdentity">The user identity for the administrator.</param>
         /// <param name="sessionFactory">Used to create session to the server</param>
         public GlobalDiscoveryServerClient(
             ApplicationConfiguration configuration,
             string endpointUrl,
-            ITelemetryContext telemetry,
             IUserIdentity adminUserIdentity = null,
             ISessionFactory sessionFactory = null)
         {
@@ -62,7 +60,7 @@ namespace Opc.Ua.Gds.Client
             MessageContext = configuration.CreateMessageContext(true);
             EndpointUrl = endpointUrl;
             m_logger = MessageContext.Telemetry.CreateLogger<GlobalDiscoveryServerClient>();
-            m_sessionFactory = sessionFactory ?? new DefaultSessionFactory(telemetry);
+            m_sessionFactory = sessionFactory ?? new DefaultSessionFactory(MessageContext.Telemetry);
             // preset admin
             AdminCredentials = adminUserIdentity;
         }

--- a/Libraries/Opc.Ua.Gds.Client.Common/LocalDiscoveryServerClient.cs
+++ b/Libraries/Opc.Ua.Gds.Client.Common/LocalDiscoveryServerClient.cs
@@ -532,7 +532,7 @@ namespace Opc.Ua.Gds.Client
                 throw new ArgumentException("Not a valid URL.", nameof(endpointUrl));
             }
 
-            IServiceMessageContext context = ApplicationConfiguration.CreateMessageContext();
+            ServiceMessageContext context = ApplicationConfiguration.CreateMessageContext();
 
             var configuration = EndpointConfiguration.Create(ApplicationConfiguration);
 

--- a/Libraries/Opc.Ua.Gds.Server.Common/CertificateGroup.cs
+++ b/Libraries/Opc.Ua.Gds.Server.Common/CertificateGroup.cs
@@ -72,7 +72,8 @@ namespace Opc.Ua.Gds.Server
         protected string SubjectName { get; }
 
         [Obsolete("Use CertificateGroup(TelemetryContext) instead")]
-        public CertificateGroup() : this(null)
+        public CertificateGroup()
+            : this(null)
         {
         }
 

--- a/Libraries/Opc.Ua.Server/Aggregates/AggregateCalculator.cs
+++ b/Libraries/Opc.Ua.Server/Aggregates/AggregateCalculator.cs
@@ -49,7 +49,7 @@ namespace Opc.Ua.Server
             double processingInterval,
             bool stepped,
             AggregateConfiguration configuration)
-            : this (aggregateId, startTime, endTime, processingInterval, stepped, configuration, null)
+            : this(aggregateId, startTime, endTime, processingInterval, stepped, configuration, null)
         {
         }
 

--- a/Stack/Opc.Ua.Bindings.Https/Stack/Https/HttpsTransportListener.cs
+++ b/Stack/Opc.Ua.Bindings.Https/Stack/Https/HttpsTransportListener.cs
@@ -286,10 +286,9 @@ namespace Opc.Ua.Bindings
                     : ClientCertificateMode.NoCertificate,
                 // note: this is the TLS certificate!
                 ServerCertificate = serverCertificate,
-                ClientCertificateValidation = ValidateClientCertificate
+                ClientCertificateValidation = ValidateClientCertificate,
+                SslProtocols = SslProtocols.None
             };
-
-            httpsOptions.SslProtocols = SslProtocols.None;
 
             UriHostNameType hostType = Uri.CheckHostName(EndpointUrl.Host);
             if (hostType is UriHostNameType.Dns or UriHostNameType.Unknown or UriHostNameType.Basic)

--- a/Stack/Opc.Ua.Core/Security/Certificates/CertificateValidator.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/CertificateValidator.cs
@@ -39,7 +39,8 @@ namespace Opc.Ua
         /// Create validator
         /// </summary>
         [Obsolete("Use CertificateValidator(ITelemetryContext) instead.")]
-        public CertificateValidator() : this(null)
+        public CertificateValidator()
+            : this(null)
         {
         }
 

--- a/Stack/Opc.Ua.Core/Stack/Client/DiscoveryClient.cs
+++ b/Stack/Opc.Ua.Core/Stack/Client/DiscoveryClient.cs
@@ -70,6 +70,7 @@ namespace Opc.Ua
         /// <summary>
         /// Creates a binding for to use for discovering servers.
         /// </summary>
+        /// <exception cref="ArgumentNullException"><paramref name="application"/> is <c>null</c>.</exception>
         public static DiscoveryClient Create(
             ApplicationConfiguration application,
             Uri discoveryUrl)
@@ -80,7 +81,7 @@ namespace Opc.Ua
             }
 
             var configuration = EndpointConfiguration.Create();
-            IServiceMessageContext messageContext = application.CreateMessageContext();
+            ServiceMessageContext messageContext = application.CreateMessageContext();
             ITransportChannel channel = DiscoveryChannel.Create(
                 application,
                 discoveryUrl,
@@ -92,6 +93,7 @@ namespace Opc.Ua
         /// <summary>
         /// Creates a binding for to use for discovering servers.
         /// </summary>
+        /// <exception cref="ArgumentNullException"><paramref name="application"/> is <c>null</c>.</exception>
         public static DiscoveryClient Create(
             ApplicationConfiguration application,
             Uri discoveryUrl,
@@ -104,7 +106,7 @@ namespace Opc.Ua
 
             configuration ??= EndpointConfiguration.Create();
 
-            IServiceMessageContext messageContext = application.CreateMessageContext();
+            ServiceMessageContext messageContext = application.CreateMessageContext();
             ITransportChannel channel = DiscoveryChannel.Create(
                 application,
                 discoveryUrl,
@@ -116,6 +118,7 @@ namespace Opc.Ua
         /// <summary>
         /// Creates a binding for to use for discovering servers.
         /// </summary>
+        /// <exception cref="ArgumentNullException"><paramref name="application"/> is <c>null</c>.</exception>
         public static DiscoveryClient Create(
             ApplicationConfiguration application,
             ITransportWaitingConnection connection,
@@ -128,7 +131,7 @@ namespace Opc.Ua
 
             configuration ??= EndpointConfiguration.Create();
 
-            IServiceMessageContext messageContext = application.CreateMessageContext();
+            ServiceMessageContext messageContext = application.CreateMessageContext();
             ITransportChannel channel = DiscoveryChannel.Create(
                 application,
                 connection,
@@ -143,6 +146,7 @@ namespace Opc.Ua
         /// <param name="discoveryUrl">The discovery URL.</param>
         /// <param name="endpointConfiguration">The endpoint configuration.</param>
         /// <param name="applicationConfiguration">The application configuration.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="applicationConfiguration"/> is <c>null</c>.</exception>
         public static DiscoveryClient Create(
             Uri discoveryUrl,
             EndpointConfiguration endpointConfiguration,
@@ -158,7 +162,7 @@ namespace Opc.Ua
             // check if application configuration contains instance certificate.
             X509Certificate2 clientCertificate = null;
 
-            IServiceMessageContext messageContext = applicationConfiguration.CreateMessageContext();
+            ServiceMessageContext messageContext = applicationConfiguration.CreateMessageContext();
             try
             {
                 // Will always use the first certificate

--- a/Stack/Opc.Ua.Core/Stack/Client/UserIdentity.cs
+++ b/Stack/Opc.Ua.Core/Stack/Client/UserIdentity.cs
@@ -17,7 +17,6 @@ using System.Security.Principal;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
-using Microsoft.Extensions.Logging;
 
 namespace Opc.Ua
 {
@@ -49,7 +48,7 @@ namespace Opc.Ua
         /// <param name="username">The user name.</param>
         /// <param name="password">The password.</param>
         public UserIdentity(string username, string password)
-            : this (new UserNameIdentityToken
+            : this(new UserNameIdentityToken
             {
                 UserName = username,
                 DecryptedPassword = password
@@ -79,7 +78,7 @@ namespace Opc.Ua
         /// </summary>
         [Obsolete("Use UserIdentityToken(X509IdentityToken, ITelemetryContext) instead.")]
         public UserIdentity(X509IdentityToken x509Token)
-            : this (x509Token, null)
+            : this(x509Token, null)
         {
         }
 

--- a/Stack/Opc.Ua.Core/Stack/Configuration/ApplicationConfiguration.cs
+++ b/Stack/Opc.Ua.Core/Stack/Configuration/ApplicationConfiguration.cs
@@ -170,12 +170,6 @@ namespace Opc.Ua
                 messageContext.MaxDecoderRecoveries = TransportQuotas.MaxDecoderRecoveries;
             }
 
-            messageContext.NamespaceUris = new NamespaceTable();
-            messageContext.ServerUris = new StringTable();
-            if (clonedFactory)
-            {
-                messageContext.Factory = new EncodeableFactory(m_telemetry);
-            }
             return messageContext;
         }
 

--- a/Stack/Opc.Ua.Core/Stack/Configuration/SecurityConfigurationManager.cs
+++ b/Stack/Opc.Ua.Core/Stack/Configuration/SecurityConfigurationManager.cs
@@ -28,7 +28,8 @@ namespace Opc.Ua.Security
         /// Obsolete default constructor
         /// </summary>
         [Obsolete("Use SecurityConfigurationManager(ITelemetryContext) instead.")]
-        public SecurityConfigurationManager() : this (null)
+        public SecurityConfigurationManager()
+            : this(null)
         {
         }
 

--- a/Stack/Opc.Ua.Core/Types/BuiltIn/LocalizedText.cs
+++ b/Stack/Opc.Ua.Core/Types/BuiltIn/LocalizedText.cs
@@ -13,7 +13,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Runtime.Serialization;

--- a/Stack/Opc.Ua.Core/Types/Encoders/IEncodeableFactory.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/IEncodeableFactory.cs
@@ -33,49 +33,49 @@ namespace Opc.Ua
     /// FrozenDictionary depending on the target runtime.
     /// </para>
     /// </summary>
-    public interface IImmutableEncodeableDictionary
+    public interface IEncodeableFactory
     {
-        /// <summary>
-        /// Create a new immutable factory based on this one and modified
-        /// by the builder action.
-        /// </summary>
-        /// <param name="builder">The builder is passed the state of
-        /// this encodeable factory which then can be modified</param>
-        /// <returns>An immutable reference to the factory</returns>
-        IImmutableEncodeableDictionary Update(Action<IImmutableEncodeableDictionaryBuilder> builder);
-
-        /// <summary>
-        /// Try get the system type for the specified type id.
-        /// </summary>
-        /// <param name="typeId">The type id to return the system-type of</param>
-        /// <param name="type">The system type found</param>
-        /// <returns>True if the type was found</returns>
-        bool TryGetSystemType(ExpandedNodeId typeId, [NotNullWhen(true)] out Type? type);
-
         /// <summary>
         /// The dictionary of encodeable types.
         /// </summary>
         IReadOnlyDictionary<ExpandedNodeId, Type> EncodeableTypes { get; }
+
+        /// <summary>
+        /// Get a factory builder.
+        /// </summary>
+        IEncodeableFactoryBuilder Builder { get; }
+
+        /// <summary>
+        /// Returns the system type for the specified type id.
+        /// </summary>
+        /// <param name="typeId">The type id to return the type of</param>
+        /// <param name="systemType">The returned system type if found</param>
+        /// <returns><code>True</code> if found.</returns>
+        bool TryGetSystemType(
+            ExpandedNodeId typeId,
+            [NotNullWhen(true)] out Type? systemType);
     }
 
     /// <summary>
     /// <para>
-    /// Encodeable factory builder acts as a builder of a immutable encodeable
-    /// factory.
+    /// Encodeable factory builder acts as a builder of a immutable
+    /// encodeable factory.
     /// </para>
     /// <para>
-    /// You can manually add types. You can also import all types from an assembly.
-    /// The builder can then be used to create an immutable encodeable factory.
+    /// You can manually add types. You can also import all types
+    /// from an assembly. The builder can then be used to create an
+    /// immutable encodeable factory.
     /// </para>
     /// </summary>
-    public interface IImmutableEncodeableDictionaryBuilder
+    public interface IEncodeableFactoryBuilder
     {
         /// <summary>
         /// Adds an extension type to the factory builder.
         /// </summary>
         /// <param name="systemType">The underlying system type to add to
         /// the factory builder</param>
-        void AddEncodeableType(Type systemType);
+        IEncodeableFactoryBuilder AddEncodeableType(
+            Type systemType);
 
         /// <summary>
         /// Associates an encodeable type with an encoding id.
@@ -84,7 +84,9 @@ namespace Opc.Ua
         /// node</param>
         /// <param name="systemType">The system type to use for the
         /// specified encoding.</param>
-        void AddEncodeableType(ExpandedNodeId encodingId, Type systemType);
+        IEncodeableFactoryBuilder AddEncodeableType(
+            ExpandedNodeId encodingId,
+            Type systemType);
 
         /// <summary>
         /// <para>
@@ -92,38 +94,37 @@ namespace Opc.Ua
         /// factory builder.
         /// </para>
         /// <para>
-        /// This method uses reflection on the specified assembly to export
-        /// all of the types the assembly exposes, and automatically adds
-        /// all types that implement the <see cref="IEncodeable"/> interface,
-        /// to the factory builder.
+        /// This method uses reflection on the specified assembly to
+        /// export all of the types the assembly exposes, and
+        /// automatically adds all types that implement the
+        /// <see cref="IEncodeable"/> interface, to the factory builder.
         /// </para>
         /// </summary>
-        /// <param name="assembly">The assembly containing the types to add to the
-        /// factory</param>
-        void AddEncodeableTypes(Assembly assembly);
+        /// <param name="assembly">The assembly containing the types
+        /// to add to the factory</param>
+        IEncodeableFactoryBuilder AddEncodeableTypes(Assembly assembly);
 
         /// <summary>
-        /// Adds an enumerable of extension types to the factory builder.
+        /// Commit the changes to the encodeable factory.
         /// </summary>
-        /// <param name="systemTypes">The underlying system types to add
-        /// to the factory builder</param>
-        void AddEncodeableTypes(IEnumerable<Type> systemTypes);
+        void Commit();
     }
 
     /// <summary>
-    /// Extensions for the encodeable factory builder.
+    /// Obsolete methods on the IEncodeableFactory interface.
     /// </summary>
-    public static class ImmutableEncodeableDictionaryExtensions
+    public static class EncodeableFactoryExtensions
     {
         /// <summary>
         /// Adds an extension type to the factory builder.
         /// </summary>
         /// <typeparam name="T">The underlying system type to add to
         /// the factory builder</typeparam>
-        public static void AddEncodeableType<T>(this IImmutableEncodeableDictionaryBuilder builder)
+        public static IEncodeableFactoryBuilder AddEncodeableType<T>(
+            this IEncodeableFactoryBuilder builder)
             where T : IEncodeable
         {
-            builder.AddEncodeableType(typeof(T));
+            return builder.AddEncodeableType(typeof(T));
         }
 
         /// <summary>
@@ -132,26 +133,61 @@ namespace Opc.Ua
         /// <param name="factory"></param>
         /// <param name="typeId"></param>
         /// <returns></returns>
-        public static Type? GetSystemType(this IImmutableEncodeableDictionary factory, ExpandedNodeId typeId)
+        public static Type? GetSystemType(
+            this IEncodeableFactory factory,
+            ExpandedNodeId typeId)
         {
-            return factory.TryGetSystemType(typeId, out Type? type) ? type : null;
+            return factory.TryGetSystemType(typeId, out Type? type)
+                ? type
+                : null;
         }
-    }
-
-    /// <summary>
-    /// Encodeable factory which can be cloned.
-    /// </summary>
-    public interface IEncodeableFactory : IImmutableEncodeableDictionaryBuilder, ICloneable
-    {
-        /// <summary>
-        /// Returns the system type for the specified type id.
-        /// </summary>
-        /// <param name="typeId">The type id to return the system-type of</param>
-        Type? GetSystemType(ExpandedNodeId typeId);
 
         /// <summary>
-        /// The dictionary of encodeable types.
+        /// Adds an extension type to the factory builder.
         /// </summary>
-        IReadOnlyDictionary<ExpandedNodeId, Type> EncodeableTypes { get; }
+        public static void AddEncodeableType(
+            this IEncodeableFactory factory,
+            Type systemType)
+        {
+            factory.Builder.AddEncodeableType(systemType).Commit();
+        }
+
+        /// <summary>
+        /// Associates an encodeable type with an encoding id.
+        /// </summary>
+        public static void AddEncodeableType(
+            this IEncodeableFactory factory,
+            ExpandedNodeId encodingId,
+            Type systemType)
+        {
+
+            factory.Builder.AddEncodeableType(systemType).Commit();
+        }
+
+        /// <summary>
+        /// Adds all encodeable types exported from an assembly
+        /// to the factory builder.
+        /// </summary>
+        public static void AddEncodeableTypes(
+            this IEncodeableFactory factory,
+            Assembly assembly)
+        {
+            factory.Builder.AddEncodeableTypes(assembly).Commit();
+        }
+
+        /// <summary>
+        /// Adds an enumerable of extension types to the factory builder.
+        /// </summary>
+        public static void AddEncodeableTypes(
+            this IEncodeableFactory factory,
+            IEnumerable<Type> systemTypes)
+        {
+            var builder = factory.Builder;
+            foreach (var systemType in systemTypes)
+            {
+                builder.AddEncodeableType(systemType);
+            }
+            builder.Commit();
+        }
     }
 }

--- a/Stack/Opc.Ua.Core/Types/Encoders/IEncodeableFactory.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/IEncodeableFactory.cs
@@ -50,22 +50,26 @@ namespace Opc.Ua
     /// Represents a real encodeable object factory managed
     /// by the encodeable factory registry.
     /// </summary>
+    [Experimental("UA_NETStandard_1")]
     public interface IEncodeableType
     {
         /// <summary>
-        /// System type of the encodeable.
+        /// System type (either enum or reference type)
+        /// Used when using reflection emit to emit other
+        /// encodeable types.
         /// </summary>
         Type Type { get; }
 
         /// <summary>
-        /// Create instance of type
+        /// Create instance of structure type during
+        /// decoding. Will change in future iterations.
         /// </summary>
         /// <returns></returns>
         IEncodeable CreateInstance();
     }
 
     /// <summary>
-    /// Lookup encodeable types by type id.
+    /// Lookup encodeable types by type or encoding id.
     /// </summary>
     public interface IEncodeableTypeLookup
     {

--- a/Stack/Opc.Ua.Core/Types/Encoders/IEncodeableFactory.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/IEncodeableFactory.cs
@@ -10,69 +10,144 @@
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 */
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 
 namespace Opc.Ua
 {
     /// <summary>
-    /// Creates encodeable objects based on the type id.
+    /// <para>
+    /// Immutable factory for encodeable objects based on the type id.
+    /// The factory is used to store and retrieve underlying OPC UA
+    /// system types.
+    /// </para>
+    /// <para>
+    /// Use Update call to populate the factory. The immutable factory
+    /// can be shared as it is thread safe (it can only be changed by
+    /// producing a new reference to a new factory). Lookup is optimized
+    /// internally for fast access using a ImmutableDictionary or
+    /// FrozenDictionary depending on the target runtime.
+    /// </para>
     /// </summary>
-    /// <remarks>
-    /// <para>
-    /// This factory is used to store and retrieve underlying OPC UA system types.
-    /// <br/></para>
-    /// <para>
-    /// You can manually add types. You can also import all types from a specified assembly.
-    /// Once the types exist within the factory, these types can be then easily queried.
-    /// <br/></para>
-    /// </remarks>
-    public interface IEncodeableFactory : ICloneable
+    public interface IImmutableEncodeableDictionary
     {
         /// <summary>
-        /// Adds an extension type to the factory.
+        /// Create a new immutable factory based on this one and modified
+        /// by the builder action.
         /// </summary>
-        /// <param name="systemType">The underlying system type to add to the factory</param>
+        /// <param name="builder">The builder is passed the state of
+        /// this encodeable factory which then can be modified</param>
+        /// <returns>An immutable reference to the factory</returns>
+        IImmutableEncodeableDictionary Update(Action<IImmutableEncodeableDictionaryBuilder> builder);
+
+        /// <summary>
+        /// Try get the system type for the specified type id.
+        /// </summary>
+        /// <param name="typeId">The type id to return the system-type of</param>
+        /// <param name="type">The system type found</param>
+        /// <returns>True if the type was found</returns>
+        bool TryGetSystemType(ExpandedNodeId typeId, [NotNullWhen(true)] out Type? type);
+
+        /// <summary>
+        /// The dictionary of encodeable types.
+        /// </summary>
+        IReadOnlyDictionary<ExpandedNodeId, Type> EncodeableTypes { get; }
+    }
+
+    /// <summary>
+    /// <para>
+    /// Encodeable factory builder acts as a builder of a immutable encodeable
+    /// factory.
+    /// </para>
+    /// <para>
+    /// You can manually add types. You can also import all types from an assembly.
+    /// The builder can then be used to create an immutable encodeable factory.
+    /// </para>
+    /// </summary>
+    public interface IImmutableEncodeableDictionaryBuilder
+    {
+        /// <summary>
+        /// Adds an extension type to the factory builder.
+        /// </summary>
+        /// <param name="systemType">The underlying system type to add to
+        /// the factory builder</param>
         void AddEncodeableType(Type systemType);
 
         /// <summary>
         /// Associates an encodeable type with an encoding id.
         /// </summary>
-        /// <param name="encodingId">A NodeId for a Data Type Encoding node</param>
-        /// <param name="systemType">The system type to use for the specified encoding.</param>
+        /// <param name="encodingId">A NodeId for a Data Type Encoding
+        /// node</param>
+        /// <param name="systemType">The system type to use for the
+        /// specified encoding.</param>
         void AddEncodeableType(ExpandedNodeId encodingId, Type systemType);
 
         /// <summary>
-        /// Adds all encodeable types exported from an assembly to the factory.
+        /// <para>
+        /// Adds all encodeable types exported from an assembly to the
+        /// factory builder.
+        /// </para>
+        /// <para>
+        /// This method uses reflection on the specified assembly to export
+        /// all of the types the assembly exposes, and automatically adds
+        /// all types that implement the <see cref="IEncodeable"/> interface,
+        /// to the factory builder.
+        /// </para>
         /// </summary>
-        /// <remarks>
-        /// <para>
-        /// Adds all encodeable types exported from an assembly to the factory.
-        /// <br/></para>
-        /// <para>
-        /// This method uses reflection on the specified assembly to export all of the
-        /// types the assembly exposes, and automatically adds all types that implement
-        /// the <see cref="IEncodeable"/> interface, to the factory.
-        /// <br/></para>
-        /// </remarks>
-        /// <param name="assembly">The assembly containing the types to add to the factory</param>
+        /// <param name="assembly">The assembly containing the types to add to the
+        /// factory</param>
         void AddEncodeableTypes(Assembly assembly);
 
         /// <summary>
-        /// Adds an enumerable of extension types to the factory.
+        /// Adds an enumerable of extension types to the factory builder.
         /// </summary>
-        /// <param name="systemTypes">The underlying system types to add to the factory</param>
+        /// <param name="systemTypes">The underlying system types to add
+        /// to the factory builder</param>
         void AddEncodeableTypes(IEnumerable<Type> systemTypes);
+    }
 
+    /// <summary>
+    /// Extensions for the encodeable factory builder.
+    /// </summary>
+    public static class ImmutableEncodeableDictionaryExtensions
+    {
+        /// <summary>
+        /// Adds an extension type to the factory builder.
+        /// </summary>
+        /// <typeparam name="T">The underlying system type to add to
+        /// the factory builder</typeparam>
+        public static void AddEncodeableType<T>(this IImmutableEncodeableDictionaryBuilder builder)
+            where T : IEncodeable
+        {
+            builder.AddEncodeableType(typeof(T));
+        }
+
+        /// <summary>
+        /// Get system type
+        /// </summary>
+        /// <param name="factory"></param>
+        /// <param name="typeId"></param>
+        /// <returns></returns>
+        public static Type? GetSystemType(this IImmutableEncodeableDictionary factory, ExpandedNodeId typeId)
+        {
+            return factory.TryGetSystemType(typeId, out Type? type) ? type : null;
+        }
+    }
+
+    /// <summary>
+    /// Encodeable factory which can be cloned.
+    /// </summary>
+    public interface IEncodeableFactory : IImmutableEncodeableDictionaryBuilder, ICloneable
+    {
         /// <summary>
         /// Returns the system type for the specified type id.
         /// </summary>
-        /// <remarks>
-        /// Returns the system type for the specified type id.
-        /// </remarks>
         /// <param name="typeId">The type id to return the system-type of</param>
-        Type GetSystemType(ExpandedNodeId typeId);
+        Type? GetSystemType(ExpandedNodeId typeId);
 
         /// <summary>
         /// The dictionary of encodeable types.

--- a/Stack/Opc.Ua.Core/Types/Encoders/XmlDecoder.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/XmlDecoder.cs
@@ -64,7 +64,7 @@ namespace Opc.Ua
 
             if (systemType != null)
             {
-                XmlQualifiedName typeName = EncodeableFactory.GetXmlName(systemType);
+                XmlQualifiedName typeName = TypeInfo.GetXmlName(systemType);
                 ns = typeName.Namespace;
                 name = typeName.Name;
             }
@@ -659,7 +659,7 @@ namespace Opc.Ua
                 throw new ArgumentNullException(nameof(expectedType));
             }
 
-            XmlQualifiedName typeName = EncodeableFactory.GetXmlName(expectedType);
+            XmlQualifiedName typeName = TypeInfo.GetXmlName(expectedType);
             string ns = typeName.Namespace;
             string name = typeName.Name;
 
@@ -1444,7 +1444,7 @@ namespace Opc.Ua
             {
                 if (BeginField(fieldName, true))
                 {
-                    XmlQualifiedName xmlName = EncodeableFactory.GetXmlName(value, Context);
+                    XmlQualifiedName xmlName = TypeInfo.GetXmlName(value, Context);
 
                     PushNamespace(xmlName.Namespace);
                     value.Decode(this);
@@ -2357,7 +2357,7 @@ namespace Opc.Ua
 
             if (BeginField(fieldName, true, out bool isNil))
             {
-                XmlQualifiedName xmlName = EncodeableFactory.GetXmlName(systemType);
+                XmlQualifiedName xmlName = TypeInfo.GetXmlName(systemType);
                 PushNamespace(xmlName.Namespace);
 
                 while (MoveToElement(xmlName.Name))
@@ -2405,7 +2405,7 @@ namespace Opc.Ua
 
             if (BeginField(fieldName, true, out bool isNil))
             {
-                XmlQualifiedName xmlName = EncodeableFactory.GetXmlName(enumType);
+                XmlQualifiedName xmlName = TypeInfo.GetXmlName(enumType);
                 PushNamespace(xmlName.Namespace);
 
                 while (MoveToElement(xmlName.Name))

--- a/Stack/Opc.Ua.Core/Types/Encoders/XmlEncoder.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/XmlEncoder.cs
@@ -49,7 +49,7 @@ namespace Opc.Ua
         /// Initializes the object with a system type to encode and a XML writer.
         /// </summary>
         public XmlEncoder(Type systemType, XmlWriter writer, IServiceMessageContext context)
-            : this(EncodeableFactory.GetXmlName(systemType), writer, context)
+            : this(TypeInfo.GetXmlName(systemType), writer, context)
         {
         }
 
@@ -1749,7 +1749,7 @@ namespace Opc.Ua
 
                 // get name for type being encoded.
                 XmlQualifiedName xmlName =
-                    EncodeableFactory.GetXmlName(systemType)
+                    TypeInfo.GetXmlName(systemType)
                     ?? new XmlQualifiedName("IEncodeable", Namespaces.OpcUaXsd);
 
                 PushNamespace(xmlName.Namespace);
@@ -1799,7 +1799,7 @@ namespace Opc.Ua
 
                 // get name for type being encoded.
                 XmlQualifiedName xmlName =
-                    EncodeableFactory.GetXmlName(systemType) ??
+                    TypeInfo.GetXmlName(systemType) ??
                     new XmlQualifiedName("Enumerated", Namespaces.OpcUaXsd);
 
                 PushNamespace(xmlName.Namespace);
@@ -2107,7 +2107,7 @@ namespace Opc.Ua
             }
 
             // encode extension object in xml.
-            XmlQualifiedName xmlName = EncodeableFactory.GetXmlName(encodeable, Context);
+            XmlQualifiedName xmlName = TypeInfo.GetXmlName(encodeable, Context);
             m_writer.WriteStartElement(xmlName.Name, xmlName.Namespace);
             encodeable.Encode(this);
             m_writer.WriteEndElement();

--- a/Stack/Opc.Ua.Core/Types/Utils/DataComparer.cs
+++ b/Stack/Opc.Ua.Core/Types/Utils/DataComparer.cs
@@ -1036,7 +1036,7 @@ namespace Opc.Ua.Test
 
             if (body is XmlElement xml)
             {
-                XmlQualifiedName xmlName = Ua.TypeInfo.GetXmlName(expectedType);
+                XmlQualifiedName xmlName = TypeInfo.GetXmlName(expectedType);
                 using (var decoder = new XmlDecoder(xml, m_context))
                 {
                     decoder.PushNamespace(xmlName.Namespace);

--- a/Stack/Opc.Ua.Core/Types/Utils/DataGenerator.cs
+++ b/Stack/Opc.Ua.Core/Types/Utils/DataGenerator.cs
@@ -129,7 +129,8 @@ namespace Opc.Ua.Test
         /// Obsolete constructor
         /// </summary>
         [Obsolete("Use DataGenerator(ITelemetryContext) instead.")]
-        public DataGenerator(IRandomSource random) : this(random, null)
+        public DataGenerator(IRandomSource random)
+            : this(random, null)
         {
         }
 

--- a/Stack/Opc.Ua.Core/Types/Utils/ServiceMessageContext.cs
+++ b/Stack/Opc.Ua.Core/Types/Utils/ServiceMessageContext.cs
@@ -41,7 +41,7 @@ namespace Opc.Ua
             MaxDecoderRecoveries = DefaultEncodingLimits.MaxDecoderRecoveries;
             m_namespaceUris = new NamespaceTable();
             m_serverUris = new StringTable();
-            m_factory = new EncodeableFactory(telemetry);
+            m_factory = EncodeableFactory.Create();
         }
 
         /// <summary>
@@ -60,7 +60,7 @@ namespace Opc.Ua
             MaxDecoderRecoveries = context.MaxDecoderRecoveries;
             m_namespaceUris = new NamespaceTable(context.NamespaceUris);
             m_serverUris = new StringTable(context.ServerUris);
-            m_factory = new EncodeableFactory(context.Factory, telemetry);
+            m_factory = context.Factory;
         }
 
         /// <summary>
@@ -141,7 +141,7 @@ namespace Opc.Ua
             {
                 if (value == null)
                 {
-                    m_factory = new EncodeableFactory(Telemetry);
+                    m_factory = EncodeableFactory.Create();
                     return;
                 }
 

--- a/Stack/Opc.Ua.Core/Types/Utils/ServiceMessageContext.cs
+++ b/Stack/Opc.Ua.Core/Types/Utils/ServiceMessageContext.cs
@@ -23,7 +23,8 @@ namespace Opc.Ua
         /// Initializes the object with default values.
         /// </summary>
         [Obsolete("Use ServiceMessageContext(ITelemetryContext) instead.")]
-        public ServiceMessageContext() : this(null)
+        public ServiceMessageContext()
+            : this(null)
         {
         }
 

--- a/Stack/Opc.Ua.Core/Types/Utils/TypeInfo.cs
+++ b/Stack/Opc.Ua.Core/Types/Utils/TypeInfo.cs
@@ -19,7 +19,6 @@ using System.Xml;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 
-
 #if NET8_0_OR_GREATER
 using System.Collections.Frozen;
 #else
@@ -617,7 +616,7 @@ namespace Opc.Ua
         /// <param name="datatypeId">The datatype id.</param>
         /// <param name="factory">The factory used to store and retrieve underlying OPC UA system types.</param>
         /// <returns>The system type for the <paramref name="datatypeId"/>.</returns>
-        public static Type GetSystemType(ExpandedNodeId datatypeId, ISystemTypeLookup factory)
+        public static Type GetSystemType(ExpandedNodeId datatypeId, IEncodeableTypeLookup factory)
         {
             if (datatypeId == null)
             {

--- a/Stack/Opc.Ua.Core/Types/Utils/TypeInfo.cs
+++ b/Stack/Opc.Ua.Core/Types/Utils/TypeInfo.cs
@@ -617,7 +617,7 @@ namespace Opc.Ua
         /// <param name="datatypeId">The datatype id.</param>
         /// <param name="factory">The factory used to store and retrieve underlying OPC UA system types.</param>
         /// <returns>The system type for the <paramref name="datatypeId"/>.</returns>
-        public static Type GetSystemType(ExpandedNodeId datatypeId, IEncodeableFactory factory)
+        public static Type GetSystemType(ExpandedNodeId datatypeId, ISystemTypeLookup factory)
         {
             if (datatypeId == null)
             {

--- a/Stack/Opc.Ua.Core/Types/Utils/TypeInfo.cs
+++ b/Stack/Opc.Ua.Core/Types/Utils/TypeInfo.cs
@@ -17,6 +17,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
 using System.Collections.Generic;
+using System.Runtime.Serialization;
+
 
 #if NET8_0_OR_GREATER
 using System.Collections.Frozen;
@@ -736,6 +738,92 @@ namespace Opc.Ua
         /// </summary>
         /// <value>The constant representing an unknown type.</value>
         public static TypeInfo Unknown { get; } = new TypeInfo();
+
+        /// <summary>
+        /// Returns the xml qualified name for the specified system type id.
+        /// </summary>
+        /// <remarks>
+        /// Returns the xml qualified name for the specified system type id.
+        /// </remarks>
+        /// <param name="systemType">The underlying type to query and return the Xml qualified name of</param>
+        public static XmlQualifiedName GetXmlName(Type systemType)
+        {
+            if (systemType == null)
+            {
+                return null;
+            }
+
+            object[] attributes =
+            [
+                .. systemType.GetTypeInfo().GetCustomAttributes(typeof(DataContractAttribute), true)
+            ];
+
+            if (attributes != null)
+            {
+                for (int ii = 0; ii < attributes.Length; ii++)
+                {
+                    if (attributes[ii] is DataContractAttribute contract)
+                    {
+                        if (string.IsNullOrEmpty(contract.Name))
+                        {
+                            return new XmlQualifiedName(systemType.Name, contract.Namespace);
+                        }
+
+                        return new XmlQualifiedName(contract.Name, contract.Namespace);
+                    }
+                }
+            }
+
+            attributes =
+            [
+                .. systemType.GetTypeInfo()
+                    .GetCustomAttributes(typeof(CollectionDataContractAttribute), true)
+            ];
+
+            if (attributes != null)
+            {
+                for (int ii = 0; ii < attributes.Length; ii++)
+                {
+                    if (attributes[ii] is CollectionDataContractAttribute contract)
+                    {
+                        if (string.IsNullOrEmpty(contract.Name))
+                        {
+                            return new XmlQualifiedName(systemType.Name, contract.Namespace);
+                        }
+
+                        return new XmlQualifiedName(contract.Name, contract.Namespace);
+                    }
+                }
+            }
+
+            if (systemType == typeof(byte[]))
+            {
+                return new XmlQualifiedName("ByteString");
+            }
+
+            return new XmlQualifiedName(systemType.FullName);
+        }
+
+        /// <summary>
+        /// Returns the xml qualified name for the specified object.
+        /// </summary>
+        /// <remarks>
+        /// Returns the xml qualified name for the specified object.
+        /// </remarks>
+        /// <param name="value">The object to query and return the Xml qualified name of</param>
+        /// <param name="context">Context</param>
+        public static XmlQualifiedName GetXmlName(object value, IServiceMessageContext context)
+        {
+            if (value is IDynamicComplexTypeInstance xmlEncodeable)
+            {
+                XmlQualifiedName xmlName = xmlEncodeable.GetXmlName(context);
+                if (xmlName != null)
+                {
+                    return xmlName;
+                }
+            }
+            return GetXmlName(value?.GetType());
+        }
 
         /// <summary>
         /// The built-in type.

--- a/Stack/Opc.Ua.Core/Types/Utils/Utils.cs
+++ b/Stack/Opc.Ua.Core/Types/Utils/Utils.cs
@@ -15,7 +15,6 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -30,7 +29,6 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
-using Microsoft.Extensions.Logging;
 #if !NETFRAMEWORK
 using Opc.Ua.Security.Certificates;
 #endif

--- a/Stack/Opc.Ua.Core/Types/Utils/Utils.cs
+++ b/Stack/Opc.Ua.Core/Types/Utils/Utils.cs
@@ -2142,7 +2142,7 @@ namespace Opc.Ua
             if (elementName == null)
             {
                 // get qualified name from the data contract attribute.
-                XmlQualifiedName qname = EncodeableFactory.GetXmlName(typeof(T));
+                XmlQualifiedName qname = TypeInfo.GetXmlName(typeof(T));
 
                 elementName =
                     qname ??
@@ -2229,7 +2229,7 @@ namespace Opc.Ua
             if (elementName == null)
             {
                 // get qualified name from the data contract attribute.
-                XmlQualifiedName qname = EncodeableFactory.GetXmlName(typeof(T));
+                XmlQualifiedName qname = TypeInfo.GetXmlName(typeof(T));
 
                 elementName =
                     qname ??

--- a/Tests/Opc.Ua.Client.ComplexTypes.Tests/Types/JsonEncoderTests.cs
+++ b/Tests/Opc.Ua.Client.ComplexTypes.Tests/Types/JsonEncoderTests.cs
@@ -59,8 +59,6 @@ namespace Opc.Ua.Client.ComplexTypes.Tests.Types
         {
             Telemetry = NUnitTelemetryContext.Create();
             EncoderContext = new ServiceMessageContext(Telemetry);
-            // create private copy of factory
-            EncoderContext.Factory = new EncodeableFactory(EncoderContext.Factory, Telemetry);
             EncoderContext.NamespaceUris.Append("urn:This:is:my:test:encoder");
             EncoderContext.NamespaceUris.Append("urn:This:is:another:namespace");
             EncoderContext.NamespaceUris.Append(Namespaces.OpcUaEncoderTests);

--- a/Tests/Opc.Ua.Client.ComplexTypes.Tests/Types/MockResolver.cs
+++ b/Tests/Opc.Ua.Client.ComplexTypes.Tests/Types/MockResolver.cs
@@ -47,7 +47,8 @@ namespace Opc.Ua.Client.ComplexTypes.Tests.Types
         {
             DataTypeSystem = [];
             DataTypeNodes = [];
-            m_factory = new EncodeableFactory(telemetry);
+            Factory = EncodeableFactory.Create();
+            FactoryBuilder = Factory.Builder;
             NamespaceUris = new NamespaceTable();
 
             NamespaceUris.Append("urn:This:is:my:test:encoder");
@@ -55,6 +56,8 @@ namespace Opc.Ua.Client.ComplexTypes.Tests.Types
             NamespaceUris.Append(Namespaces.OpcUaEncoderTests);
             NamespaceUris.Append(Namespaces.MockResolverUrl);
         }
+
+        internal IEncodeableFactory Factory { get; }
 
         public NodeIdDictionary<INode> DataTypeNodes { get; }
 
@@ -65,7 +68,7 @@ namespace Opc.Ua.Client.ComplexTypes.Tests.Types
         public NamespaceTable NamespaceUris { get; }
 
         /// <inheritdoc/>
-        public IEncodeableFactory Factory => m_factory;
+        public IEncodeableFactoryBuilder FactoryBuilder { get; }
 
         /// <inheritdoc/>
         public Task<IReadOnlyDictionary<NodeId, DataDictionary>> LoadDataTypeSystem(
@@ -240,7 +243,5 @@ namespace Opc.Ua.Client.ComplexTypes.Tests.Types
             var nodeId = ExpandedNodeId.ToNodeId(expandedNodeId, NamespaceUris);
             return NodeId.ToExpandedNodeId(nodeId, NamespaceUris);
         }
-
-        private readonly EncodeableFactory m_factory;
     }
 }

--- a/Tests/Opc.Ua.Client.ComplexTypes.Tests/Types/MockResolverTests.cs
+++ b/Tests/Opc.Ua.Client.ComplexTypes.Tests/Types/MockResolverTests.cs
@@ -348,7 +348,7 @@ namespace Opc.Ua.Client.ComplexTypes.Tests.Types
 
             // only enumerable types in the encodeable factory are stored as Enum in a structure.
             AddEncodeableType(
-                mockResolver.Factory,
+                mockResolver.FactoryBuilder,
                 mockResolver.NamespaceUris,
                 DataTypeIds.NamingRuleType,
                 typeof(NamingRuleType));
@@ -592,7 +592,7 @@ namespace Opc.Ua.Client.ComplexTypes.Tests.Types
 
             // only enumerable types in the encodeable factory are stored as Enum in a structure.
             AddEncodeableType(
-                mockResolver.Factory,
+                mockResolver.FactoryBuilder,
                 mockResolver.NamespaceUris,
                 DataTypeIds.NamingRuleType,
                 typeof(NamingRuleType));
@@ -668,7 +668,7 @@ namespace Opc.Ua.Client.ComplexTypes.Tests.Types
             TestContext.Out.WriteLine(testType.ToString());
 
             object value;
-            Type valueType = TypeInfo.GetSystemType(field.DataType, mockResolver.Factory);
+            Type valueType = TypeInfo.GetSystemType(field.DataType, mockResolver.FactoryBuilder);
             BuiltInType builtInType = TypeInfo.GetBuiltInType(field.DataType);
             if (valueRank == ValueRanks.Scalar)
             {
@@ -910,7 +910,7 @@ namespace Opc.Ua.Client.ComplexTypes.Tests.Types
         }
 
         protected void AddEncodeableType(
-            IEncodeableFactory factory,
+            IEncodeableFactoryBuilder factory,
             NamespaceTable namespaceUris,
             ExpandedNodeId typeId,
             Type enumType)

--- a/Tests/Opc.Ua.Core.Tests/Types/Encoders/EncodeableFactoryTests.cs
+++ b/Tests/Opc.Ua.Core.Tests/Types/Encoders/EncodeableFactoryTests.cs
@@ -1,0 +1,718 @@
+/* Copyright (c) 1996-2022 The OPC Foundation. All rights reserved.
+   The source code in this file is covered under a dual-license scenario:
+     - RCL: for OPC Foundation Corporate Members in good-standing
+     - GPL V2: everybody else
+   RCL license terms accompanied with this source code. See http://opcfoundation.org/License/RCL/1.00/
+   GNU General Public License as published by the Free Software Foundation;
+   version 2 of the License are accompanied with this source code. See http://opcfoundation.org/License/GPLv2
+   This source code is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using BenchmarkDotNet.Attributes;
+using NUnit.Framework;
+using Opc.Ua.Tests;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
+
+namespace Opc.Ua.Core.Tests.Types.Encoders
+{
+    /// <summary>
+    /// Test class for encodeable objects used in factory tests.
+    /// </summary>
+    public class TestEncodeable : IEncodeable
+    {
+        public TestEncodeable() { }
+
+        public TestEncodeable(string value)
+        {
+            Value = value;
+        }
+
+        public string Value { get; set; }
+
+        public virtual ExpandedNodeId TypeId => new(1000);
+        public ExpandedNodeId BinaryEncodingId => new(1001);
+        public ExpandedNodeId XmlEncodingId => new(1002);
+
+        public void Encode(IEncoder encoder) { }
+        public void Decode(IDecoder decoder) { }
+        public bool IsEqual(IEncodeable encodeable)
+        {
+            return encodeable is TestEncodeable test && test.Value == Value;
+        }
+
+        public virtual object Clone()
+        {
+            return new TestEncodeable(Value);
+        }
+    }
+
+    /// <summary>
+    /// Test class for JSON encodeable objects used in factory tests.
+    /// </summary>
+    public class TestJsonEncodeable : TestEncodeable, IJsonEncodeable
+    {
+        public TestJsonEncodeable() { }
+        public TestJsonEncodeable(string value) : base(value) { }
+
+        public override ExpandedNodeId TypeId => new(1004);
+
+        public ExpandedNodeId JsonEncodingId => new(1003);
+
+        public override object Clone()
+        {
+            return new TestJsonEncodeable(Value);
+        }
+    }
+
+    /// <summary>
+    /// Abstract test encodeable for testing abstract types.
+    /// </summary>
+    public abstract class AbstractTestEncodeable : IEncodeable
+    {
+        public abstract ExpandedNodeId TypeId { get; }
+        public abstract ExpandedNodeId BinaryEncodingId { get; }
+        public abstract ExpandedNodeId XmlEncodingId { get; }
+
+        public virtual void Encode(IEncoder encoder) { }
+        public virtual void Decode(IDecoder decoder) { }
+        public virtual bool IsEqual(IEncodeable encodeable)
+        {
+            return false;
+        }
+
+        public virtual object Clone()
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    /// <summary>
+    /// Tests for the EncodeableFactory class.
+    /// </summary>
+    [TestFixture]
+    [Category("EncodeableFactory")]
+    [SetCulture("en-us")]
+    [SetUICulture("en-us")]
+    [Parallelizable]
+    public class EncodeableFactoryTests
+    {
+        /// <summary>
+        /// Benchmark for lookup using dictionary
+        /// </summary>
+        [Benchmark(Baseline = true)]
+        [Test]
+        public void EncodeableFactoryLookupUsingDictionary()
+        {
+            IEncodeableFactory encodeableFactory = EncodeableFactory.Create();
+            IEncodeableFactoryBuilder builder = encodeableFactory.Builder.AddEncodeableTypes(encodeableFactory.GetType().Assembly);
+
+            // lookup a type that exists
+            for (int i = 0; i < 100000; i++)
+            {
+                _ = builder.TryGetSystemType(new ExpandedNodeId(ObjectIds.ReadRequest_Encoding_DefaultBinary), out Type systemType);
+                Assert.NotNull(systemType);
+            }
+
+            builder.Commit();
+        }
+
+        /// <summary>
+        /// Benchmark for lookup using frozen dictionary
+        /// </summary>
+        [Benchmark]
+        [Test]
+        public void EncodeableFactoryLookupUsingFrozenDictionary()
+        {
+            IEncodeableFactory encodeableFactory = EncodeableFactory.Create();
+            IEncodeableFactoryBuilder builder = encodeableFactory.Builder.AddEncodeableTypes(encodeableFactory.GetType().Assembly);
+            builder.Commit();
+
+            // lookup a type that exists
+            for (int i = 0; i < 100000; i++)
+            {
+                _ = encodeableFactory.TryGetSystemType(new ExpandedNodeId(ObjectIds.ReadRequest_Encoding_DefaultBinary), out Type systemType);
+                Assert.NotNull(systemType);
+            }
+        }
+
+        [Test]
+        public void Create_ReturnsFactoryWithKnownTypes()
+        {
+            // Act
+            IEncodeableFactory factory = EncodeableFactory.Create();
+
+            // Assert
+            Assert.NotNull(factory);
+            Assert.NotNull(factory.KnownTypes);
+            Assert.Greater(factory.KnownTypes.Count(), 0);
+        }
+
+        [Test]
+        public void KnownTypes_ReturnsEmptyForNewFactory()
+        {
+            // Arrange - Create factory has pre-loaded types, so test the interface contract
+            IEncodeableFactory factory = EncodeableFactory.Create();
+
+            // Act
+            IEnumerable<ExpandedNodeId> knownTypes = factory.KnownTypes;
+
+            // Assert
+            Assert.NotNull(knownTypes);
+            // Note: Since Create() pre-loads types, we expect many types, not 0
+            Assert.Greater(knownTypes.Count(), 0);
+        }
+
+        [Test]
+        public void TryGetSystemType_WithUnknownType_ReturnsFalse()
+        {
+            // Arrange
+            IEncodeableFactory factory = EncodeableFactory.Create();
+            var unknownTypeId = new ExpandedNodeId(9999);
+
+            // Act
+            bool result = factory.TryGetSystemType(unknownTypeId, out Type systemType);
+
+            // Assert
+            Assert.False(result);
+            Assert.Null(systemType);
+        }
+
+        [Test]
+        public void Builder_ReturnsNonNullBuilder()
+        {
+            // Arrange
+            IEncodeableFactory factory = EncodeableFactory.Create();
+
+            // Act
+            IEncodeableFactoryBuilder builder = factory.Builder;
+
+            // Assert
+            Assert.NotNull(builder);
+        }
+
+        [Test]
+        public void Builder_AddEncodeableType_AddsTypeSuccessfully()
+        {
+            // Arrange
+            IEncodeableFactory factory = EncodeableFactory.Create();
+            IEncodeableFactoryBuilder builder = factory.Builder;
+
+            // Act
+            builder.AddEncodeableType(typeof(TestEncodeable));
+            builder.Commit();
+
+            // Assert
+            bool found = factory.TryGetSystemType(new ExpandedNodeId(1000), out Type systemType);
+            Assert.True(found);
+            Assert.AreEqual(typeof(TestEncodeable), systemType);
+        }
+
+        [Test]
+        public void Builder_AddEncodeableType_WithExpandedNodeId_AddsTypeSuccessfully()
+        {
+            // Arrange
+            IEncodeableFactory factory = EncodeableFactory.Create();
+            IEncodeableFactoryBuilder builder = factory.Builder;
+            var typeId = new ExpandedNodeId(5000);
+
+            // Act
+            builder.AddEncodeableType(typeId, typeof(TestEncodeable));
+            builder.Commit();
+
+            // Assert
+            bool found = factory.TryGetSystemType(typeId, out Type systemType);
+            Assert.True(found);
+            Assert.AreEqual(typeof(TestEncodeable), systemType);
+        }
+
+        [Test]
+        public void Builder_AddEncodeableType_ReturnsBuilderForChaining()
+        {
+            // Arrange
+            IEncodeableFactory factory = EncodeableFactory.Create();
+            IEncodeableFactoryBuilder builder = factory.Builder;
+
+            // Act & Assert
+            IEncodeableFactoryBuilder result = builder.AddEncodeableType(typeof(TestEncodeable));
+            Assert.AreSame(builder, result);
+        }
+
+        [Test]
+        public void Builder_AddEncodeableType_WithExpandedNodeId_ReturnsBuilderForChaining()
+        {
+            // Arrange
+            IEncodeableFactory factory = EncodeableFactory.Create();
+            IEncodeableFactoryBuilder builder = factory.Builder;
+
+            // Act & Assert
+            IEncodeableFactoryBuilder result = builder.AddEncodeableType(new ExpandedNodeId(1000), typeof(TestEncodeable));
+            Assert.AreSame(builder, result);
+        }
+
+        [Test]
+        public void Builder_CanLookupTypeBeforeCommit()
+        {
+            // Arrange
+            IEncodeableFactory factory = EncodeableFactory.Create();
+            IEncodeableFactoryBuilder builder = factory.Builder;
+            var typeId = new ExpandedNodeId(7000); // Use unique ID to avoid conflicts with pre-loaded types
+
+            // Act
+            builder.AddEncodeableType(typeId, typeof(TestEncodeable));
+            bool foundInBuilder = builder.TryGetSystemType(typeId, out Type builderType);
+            bool foundInFactory = factory.TryGetSystemType(typeId, out Type factoryType);
+
+            // Assert
+            Assert.True(foundInBuilder);
+            Assert.AreEqual(typeof(TestEncodeable), builderType);
+            Assert.False(foundInFactory);
+            Assert.Null(factoryType);
+        }
+
+        [Test]
+        public void Builder_CommitMultipleTimes_OnlyCommitsOnce()
+        {
+            // Arrange
+            IEncodeableFactory factory = EncodeableFactory.Create();
+            IEncodeableFactoryBuilder builder = factory.Builder;
+            var typeId = new ExpandedNodeId(8000); // Use unique ID
+
+            // Act
+            builder.AddEncodeableType(typeId, typeof(TestEncodeable));
+            builder.Commit();
+            builder.Commit(); // Second commit should be no-op
+
+            // Assert
+            bool found = factory.TryGetSystemType(typeId, out Type systemType);
+            Assert.True(found);
+            Assert.AreEqual(typeof(TestEncodeable), systemType);
+        }
+
+        [Test]
+        public void Builder_AddEncodeableTypes_WithNullAssembly_ReturnsBuilder()
+        {
+            // Arrange
+            IEncodeableFactory factory = EncodeableFactory.Create();
+            IEncodeableFactoryBuilder builder = factory.Builder;
+
+            // Act
+            IEncodeableFactoryBuilder result = builder.AddEncodeableTypes(null);
+
+            // Assert
+            Assert.AreSame(builder, result);
+        }
+
+        [Test]
+        public void Builder_AddEncodeableTypes_WithValidAssembly_AddsTypes()
+        {
+            // Arrange
+            IEncodeableFactory factory = EncodeableFactory.Create();
+            IEncodeableFactoryBuilder builder = factory.Builder;
+            Assembly currentAssembly = Assembly.GetExecutingAssembly();
+
+            // Act
+            builder.AddEncodeableTypes(currentAssembly);
+            builder.Commit();
+
+            // Assert - Should add our test types
+            bool foundTest = factory.TryGetSystemType(new ExpandedNodeId(1000), out Type testType);
+            Assert.True(foundTest);
+            Assert.AreEqual(typeof(TestEncodeable), testType);
+        }
+
+        [Test]
+        public void Builder_AddEncodeableTypes_SkipsAbstractTypes()
+        {
+            // Arrange
+            IEncodeableFactory factory = EncodeableFactory.Create();
+            IEncodeableFactoryBuilder builder = factory.Builder;
+
+            // Act
+            builder.AddEncodeableTypes(Assembly.GetExecutingAssembly());
+            builder.Commit();
+
+            // Abstract types should not be added, so we can't verify this directly
+            // but the test passes if no exceptions are thrown
+            Assert.Pass("Abstract types were skipped successfully");
+        }
+
+        [Test]
+        public void Builder_AddJsonEncodeableType_AddsJsonEncodingId()
+        {
+            // Arrange
+            IEncodeableFactory factory = EncodeableFactory.Create();
+            IEncodeableFactoryBuilder builder = factory.Builder;
+
+            // Act
+            builder.AddEncodeableType(typeof(TestJsonEncodeable));
+            builder.Commit();
+
+            // Assert - Should be able to find by JSON encoding ID
+            bool foundByJson = factory.TryGetSystemType(new ExpandedNodeId(1003), out Type jsonType);
+            Assert.True(foundByJson);
+            Assert.AreEqual(typeof(TestJsonEncodeable), jsonType);
+        }
+
+        [Test]
+        public void Builder_MultipleTypes_AllTypesAdded()
+        {
+            // Arrange
+            IEncodeableFactory factory = EncodeableFactory.Create();
+            IEncodeableFactoryBuilder builder = factory.Builder;
+
+            // Act
+            builder.AddEncodeableType(typeof(TestEncodeable))
+                   .AddEncodeableType(typeof(TestJsonEncodeable));
+            builder.Commit();
+
+            // Assert
+            bool foundTest = factory.TryGetSystemType(new ExpandedNodeId(1000), out Type testType);
+            bool foundJsonTest = factory.TryGetSystemType(new ExpandedNodeId(1004), out Type jsonTestType);
+
+            Assert.True(foundTest);
+            Assert.True(foundJsonTest);
+            Assert.AreEqual(typeof(TestEncodeable), testType);
+        }
+
+        [Test]
+        [Category("ThreadSafety")]
+        public void Builder_ConcurrentAccess_ThreadSafety()
+        {
+            // Arrange
+            IEncodeableFactory factory = EncodeableFactory.Create();
+            var exceptions = new List<Exception>();
+            const int threadCount = 10;
+            const int operationsPerThread = 100;
+
+            // Act
+            var threads = new System.Threading.Thread[threadCount];
+            for (uint i = 0; i < threadCount; i++)
+            {
+                uint threadId = i;
+                threads[i] = new System.Threading.Thread(() =>
+                {
+                    try
+                    {
+                        for (uint j = 0; j < operationsPerThread; j++)
+                        {
+                            IEncodeableFactoryBuilder builder = factory.Builder;
+                            builder.AddEncodeableType(new ExpandedNodeId((threadId * 1000) + j + 10000), typeof(TestEncodeable));
+                            builder.Commit();
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        lock (exceptions)
+                        {
+                            exceptions.Add(ex);
+                        }
+                    }
+                });
+                threads[i].Start();
+            }
+
+            foreach (System.Threading.Thread thread in threads)
+            {
+                thread.Join();
+            }
+
+            // Assert
+            Assert.AreEqual(0, exceptions.Count, $"Exceptions occurred: {string.Join(", ", exceptions.Select(e => e.Message))}");
+            Assert.Greater(factory.KnownTypes.Count(), 0);
+        }
+
+        [Test]
+        public void Clone_ReturnsDeepCopy()
+        {
+            // Arrange
+            IEncodeableFactory factory = EncodeableFactory.Create();
+            var typeId = new ExpandedNodeId(9001); // Use unique ID
+            factory.Builder.AddEncodeableType(typeId, typeof(TestEncodeable)).Commit();
+
+            // Act - Cast to concrete type to access Clone method
+            var concreteFactory = (EncodeableFactory)factory;
+            var clonedFactory = (EncodeableFactory)concreteFactory.Clone();
+
+            // Assert
+            Assert.NotNull(clonedFactory);
+            Assert.AreNotSame(factory, clonedFactory);
+
+            // Should have same types
+            bool originalHasType = factory.TryGetSystemType(typeId, out Type originalType);
+            bool clonedHasType = clonedFactory.TryGetSystemType(typeId, out Type clonedType);
+
+            Assert.True(originalHasType);
+            Assert.True(clonedHasType);
+            Assert.AreEqual(originalType, clonedType);
+        }
+
+        [Test]
+        public void MemberwiseClone_ReturnsDeepCopy()
+        {
+            // Arrange
+            IEncodeableFactory factory = EncodeableFactory.Create();
+            var typeId = new ExpandedNodeId(9002); // Use unique ID
+            factory.Builder.AddEncodeableType(typeId, typeof(TestEncodeable)).Commit();
+
+            // Act - Cast to concrete type to access MemberwiseClone method
+            var concreteFactory = (EncodeableFactory)factory;
+            var clonedFactory = (EncodeableFactory)concreteFactory.MemberwiseClone();
+
+            // Assert
+            Assert.NotNull(clonedFactory);
+            Assert.AreNotSame(factory, clonedFactory);
+
+            // Should have same types
+            bool originalHasType = factory.TryGetSystemType(typeId, out Type originalType);
+            bool clonedHasType = clonedFactory.TryGetSystemType(typeId, out Type clonedType);
+
+            Assert.True(originalHasType);
+            Assert.True(clonedHasType);
+            Assert.AreEqual(originalType, clonedType);
+        }
+
+        [Test]
+        public void Clone_IndependentOfOriginal()
+        {
+            // Arrange
+            IEncodeableFactory factory = EncodeableFactory.Create();
+            var initialTypeId = new ExpandedNodeId(9003);
+            var newTypeId = new ExpandedNodeId(9004);
+            factory.Builder.AddEncodeableType(initialTypeId, typeof(TestEncodeable)).Commit();
+
+            // Act - Cast to concrete type to access Clone method
+            var concreteFactory = (EncodeableFactory)factory;
+            var clonedFactory = (EncodeableFactory)concreteFactory.Clone();
+
+            // Add type to original
+            factory.Builder.AddEncodeableType(newTypeId, typeof(TestJsonEncodeable)).Commit();
+
+            // Assert - Clone should not have the new type
+            bool originalHasNewType = factory.TryGetSystemType(newTypeId, out _);
+            bool clonedHasNewType = clonedFactory.TryGetSystemType(newTypeId, out _);
+
+            Assert.True(originalHasNewType);
+            Assert.False(clonedHasNewType);
+        }
+
+        [Test]
+        public void Builder_AddEncodeableType_WithNullType_HandlesGracefully()
+        {
+            // Arrange
+            IEncodeableFactory factory = EncodeableFactory.Create();
+            IEncodeableFactoryBuilder builder = factory.Builder;
+
+            // Act & Assert - The implementation may handle null types gracefully rather than throwing
+            Assert.DoesNotThrow(() => builder.AddEncodeableType((Type)null));
+        }
+
+        [Test]
+        public void Builder_AddEncodeableType_WithNullExpandedNodeId_HandlesGracefully()
+        {
+            // Arrange
+            IEncodeableFactory factory = EncodeableFactory.Create();
+            IEncodeableFactoryBuilder builder = factory.Builder;
+
+            // Act & Assert - The implementation may handle null NodeIds gracefully rather than throwing
+            Assert.DoesNotThrow(() => builder.AddEncodeableType(null, typeof(TestEncodeable)));
+        }
+
+        [Test]
+        public void Builder_AddEncodeableType_WithNonEncodeableType_DoesNotAdd()
+        {
+            // Arrange
+            IEncodeableFactory factory = EncodeableFactory.Create();
+            IEncodeableFactoryBuilder builder = factory.Builder;
+            int initialCount = factory.KnownTypes.Count();
+
+            // Act
+            builder.AddEncodeableType(typeof(string)); // string is not IEncodeable
+            builder.Commit();
+
+            // Assert - No new types should be added
+            Assert.AreEqual(initialCount, factory.KnownTypes.Count());
+        }
+
+        [Test]
+        public void Builder_AddEncodeableType_WithTypeWithoutDefaultConstructor_HandlesGracefully()
+        {
+            // This test verifies that types without parameterless constructors are handled gracefully
+            // We can't easily create such a test type, so we'll use a mock approach
+
+            // Arrange
+            IEncodeableFactory factory = EncodeableFactory.Create();
+            IEncodeableFactoryBuilder builder = factory.Builder;
+
+            // Act & Assert - Should not throw
+            Assert.DoesNotThrow(() =>
+            {
+                builder.AddEncodeableTypes(Assembly.GetExecutingAssembly());
+                builder.Commit();
+            });
+        }
+
+        [Test]
+        public void Integration_BuilderWithCoreAssembly_AddsKnownOpcUaTypes()
+        {
+            // Arrange
+            IEncodeableFactory factory = EncodeableFactory.Create();
+            IEncodeableFactoryBuilder builder = factory.Builder;
+
+            // Act
+            builder.AddEncodeableTypes(typeof(EncodeableFactory).Assembly);
+            builder.Commit();
+
+            // Assert - Should have many OPC UA types
+            Assert.Greater(factory.KnownTypes.Count(), 100); // OPC UA has many built-in types
+        }
+
+        [Test]
+        public void Integration_CreateFactoryHasPreloadedTypes()
+        {
+            // Act
+            IEncodeableFactory factory = EncodeableFactory.Create();
+
+            // Assert - Create() should return factory with preloaded types
+            Assert.Greater(factory.KnownTypes.Count(), 100);
+
+            // Should be able to find common OPC UA types like ReadRequest
+            var knownTypesList = factory.KnownTypes.ToList();
+            Assert.Greater(knownTypesList.Count, 0);
+        }
+
+        [Test]
+        public void Integration_FactoryCanResolveReadRequest()
+        {
+            // Arrange
+            IEncodeableFactory factory = EncodeableFactory.Create();
+
+            // Act - Try to find ReadRequest type using proper ExpandedNodeId - wrap the uint constant
+            var readRequestEncodingId = new ExpandedNodeId(ObjectIds.ReadRequest_Encoding_DefaultBinary);
+            bool found = factory.TryGetSystemType(readRequestEncodingId, out Type systemType);
+
+            // Assert
+            Assert.True(found);
+            Assert.AreEqual(typeof(ReadRequest), systemType);
+        }
+
+        [Test]
+        public void Integration_DefaultNamespaceHandling()
+        {
+            // Arrange
+            IEncodeableFactory factory = EncodeableFactory.Create();
+            IEncodeableFactoryBuilder builder = factory.Builder;
+
+            // Create a type with default namespace
+            var typeIdWithDefaultNs = new ExpandedNodeId(9100, Namespaces.OpcUa);
+            var typeIdWithoutNs = new ExpandedNodeId(9100);
+
+            // Act
+            builder.AddEncodeableType(typeIdWithDefaultNs, typeof(TestEncodeable));
+            builder.Commit();
+
+            // Assert - Should be findable with both NodeId forms
+            bool foundWithNs = factory.TryGetSystemType(typeIdWithDefaultNs, out Type typeWithNs);
+            bool foundWithoutNs = factory.TryGetSystemType(typeIdWithoutNs, out Type typeWithoutNs);
+
+            Assert.True(foundWithNs);
+            Assert.False(foundWithoutNs);
+            Assert.AreEqual(typeof(TestEncodeable), typeWithNs);
+            Assert.Null(typeWithoutNs);
+        }
+
+        [Test]
+        public void Builder_EmptyCommit_DoesNotThrow()
+        {
+            // Arrange
+            IEncodeableFactory factory = EncodeableFactory.Create();
+            IEncodeableFactoryBuilder builder = factory.Builder;
+
+            // Act & Assert
+            Assert.DoesNotThrow(builder.Commit);
+            Assert.Greater(factory.KnownTypes.Count(), 0); // Should have pre-loaded types
+        }
+
+        [Test]
+        public void Builder_MultipleEncodingIds_AllRegistered()
+        {
+            // Arrange
+            IEncodeableFactory factory = EncodeableFactory.Create();
+            IEncodeableFactoryBuilder builder = factory.Builder;
+
+            // Act
+            builder.AddEncodeableType(typeof(TestJsonEncodeable));
+            builder.Commit();
+
+            // Assert - Should find type by all encoding IDs
+            bool foundByBinary = factory.TryGetSystemType(new ExpandedNodeId(1001), out Type typeByBinaryId);
+            bool foundByXml = factory.TryGetSystemType(new ExpandedNodeId(1002), out Type typeByXmlId);
+            bool foundByJson = factory.TryGetSystemType(new ExpandedNodeId(1003), out Type typeByJsonId);
+            bool foundByType = factory.TryGetSystemType(new ExpandedNodeId(1004), out Type typeByTypeId);
+
+            Assert.True(foundByType);
+            Assert.True(foundByBinary);
+            Assert.True(foundByXml);
+            Assert.True(foundByJson);
+
+            Assert.AreEqual(typeof(TestJsonEncodeable), typeByTypeId);
+            Assert.AreEqual(typeof(TestJsonEncodeable), typeByBinaryId);
+            Assert.AreEqual(typeof(TestJsonEncodeable), typeByXmlId);
+            Assert.AreEqual(typeof(TestJsonEncodeable), typeByJsonId);
+        }
+
+        [Test]
+        public void Builder_ReuseAfterCommit_CanAddMoreTypes()
+        {
+            // Arrange
+            IEncodeableFactory factory = EncodeableFactory.Create();
+            IEncodeableFactoryBuilder builder = factory.Builder;
+
+            // Act
+            builder.AddEncodeableType(new ExpandedNodeId(9200), typeof(TestEncodeable)).Commit();
+            builder.AddEncodeableType(new ExpandedNodeId(9201), typeof(TestJsonEncodeable)).Commit();
+
+            // Assert
+            bool foundFirst = factory.TryGetSystemType(new ExpandedNodeId(9200), out Type firstType);
+            bool foundSecond = factory.TryGetSystemType(new ExpandedNodeId(9201), out Type secondType);
+
+            Assert.True(foundFirst);
+            Assert.True(foundSecond);
+            Assert.AreEqual(typeof(TestEncodeable), firstType);
+            Assert.AreEqual(typeof(TestJsonEncodeable), secondType);
+        }
+
+        [Test]
+        public void TryGetSystemType_WithNullNodeId_ReturnsFalse()
+        {
+            // Arrange
+            IEncodeableFactory factory = EncodeableFactory.Create();
+
+            // Act
+            bool result = factory.TryGetSystemType(null, out Type systemType);
+
+            // Assert
+            Assert.False(result);
+            Assert.Null(systemType);
+        }
+
+        [Test]
+        public void TryGetSystemType_WithExpandedNodeIdNull_ReturnsFalse()
+        {
+            // Arrange
+            IEncodeableFactory factory = EncodeableFactory.Create();
+
+            // Act
+            bool result = factory.TryGetSystemType(ExpandedNodeId.Null, out Type systemType);
+
+            // Assert
+            Assert.False(result);
+            Assert.Null(systemType);
+        }
+    }
+}

--- a/Tests/Opc.Ua.Core.Tests/Types/Encoders/EncodeableFactoryTests.cs
+++ b/Tests/Opc.Ua.Core.Tests/Types/Encoders/EncodeableFactoryTests.cs
@@ -1,14 +1,31 @@
-/* Copyright (c) 1996-2022 The OPC Foundation. All rights reserved.
-   The source code in this file is covered under a dual-license scenario:
-     - RCL: for OPC Foundation Corporate Members in good-standing
-     - GPL V2: everybody else
-   RCL license terms accompanied with this source code. See http://opcfoundation.org/License/RCL/1.00/
-   GNU General Public License as published by the Free Software Foundation;
-   version 2 of the License are accompanied with this source code. See http://opcfoundation.org/License/GPLv2
-   This source code is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-*/
+/* ========================================================================
+ * Copyright (c) 2005-2021 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
 
 using System;
 using System.Collections.Generic;
@@ -22,77 +39,6 @@ using Assert = NUnit.Framework.Legacy.ClassicAssert;
 namespace Opc.Ua.Core.Tests.Types.Encoders
 {
     /// <summary>
-    /// Test class for encodeable objects used in factory tests.
-    /// </summary>
-    public class TestEncodeable : IEncodeable
-    {
-        public TestEncodeable() { }
-
-        public TestEncodeable(string value)
-        {
-            Value = value;
-        }
-
-        public string Value { get; set; }
-
-        public virtual ExpandedNodeId TypeId => new(1000);
-        public ExpandedNodeId BinaryEncodingId => new(1001);
-        public ExpandedNodeId XmlEncodingId => new(1002);
-
-        public void Encode(IEncoder encoder) { }
-        public void Decode(IDecoder decoder) { }
-        public bool IsEqual(IEncodeable encodeable)
-        {
-            return encodeable is TestEncodeable test && test.Value == Value;
-        }
-
-        public virtual object Clone()
-        {
-            return new TestEncodeable(Value);
-        }
-    }
-
-    /// <summary>
-    /// Test class for JSON encodeable objects used in factory tests.
-    /// </summary>
-    public class TestJsonEncodeable : TestEncodeable, IJsonEncodeable
-    {
-        public TestJsonEncodeable() { }
-        public TestJsonEncodeable(string value) : base(value) { }
-
-        public override ExpandedNodeId TypeId => new(1004);
-
-        public ExpandedNodeId JsonEncodingId => new(1003);
-
-        public override object Clone()
-        {
-            return new TestJsonEncodeable(Value);
-        }
-    }
-
-    /// <summary>
-    /// Abstract test encodeable for testing abstract types.
-    /// </summary>
-    public abstract class AbstractTestEncodeable : IEncodeable
-    {
-        public abstract ExpandedNodeId TypeId { get; }
-        public abstract ExpandedNodeId BinaryEncodingId { get; }
-        public abstract ExpandedNodeId XmlEncodingId { get; }
-
-        public virtual void Encode(IEncoder encoder) { }
-        public virtual void Decode(IDecoder decoder) { }
-        public virtual bool IsEqual(IEncodeable encodeable)
-        {
-            return false;
-        }
-
-        public virtual object Clone()
-        {
-            throw new NotImplementedException();
-        }
-    }
-
-    /// <summary>
     /// Tests for the EncodeableFactory class.
     /// </summary>
     [TestFixture]
@@ -100,26 +46,42 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
     [SetCulture("en-us")]
     [SetUICulture("en-us")]
     [Parallelizable]
+    [MemoryDiagnoser]
+    [DisassemblyDiagnoser]
     public class EncodeableFactoryTests
     {
+        private IEncodeableFactoryBuilder _builder;
+        private IEncodeableFactory _encodeableFactory;
+
+        [OneTimeSetUp]
+        [GlobalSetup]
+        public void OneTimeAndGlobalSetUp()
+        {
+            IEncodeableFactory encodeableFactory = EncodeableFactory.Create();
+            _builder = encodeableFactory.Builder.AddEncodeableTypes(encodeableFactory.GetType().Assembly);
+            _encodeableFactory = EncodeableFactory.Create();
+            _encodeableFactory.Builder.AddEncodeableTypes(encodeableFactory.GetType().Assembly).Commit();
+        }
+
         /// <summary>
         /// Benchmark for lookup using dictionary
         /// </summary>
         [Benchmark(Baseline = true)]
         [Test]
-        public void EncodeableFactoryLookupUsingDictionary()
+        public void EncodeableFactoryLookupFromBuilder()
         {
-            IEncodeableFactory encodeableFactory = EncodeableFactory.Create();
-            IEncodeableFactoryBuilder builder = encodeableFactory.Builder.AddEncodeableTypes(encodeableFactory.GetType().Assembly);
-
-            // lookup a type that exists
-            for (int i = 0; i < 100000; i++)
+            // lookup a type that exists and one that does not
+            for (int i = 0; i < 1000; i++)
             {
-                _ = builder.TryGetSystemType(new ExpandedNodeId(ObjectIds.ReadRequest_Encoding_DefaultBinary), out Type systemType);
-                Assert.NotNull(systemType);
+                _ = _builder.TryGetEncodeableType(
+                    new ExpandedNodeId(ObjectIds.ReadRequest_Encoding_DefaultBinary),
+                    out IEncodeableType encodeableType);
+                Assert.NotNull(encodeableType);
+                _ = _builder.TryGetEncodeableType(
+                    new ExpandedNodeId(Guid.NewGuid()),
+                    out encodeableType);
+                Assert.Null(encodeableType);
             }
-
-            builder.Commit();
         }
 
         /// <summary>
@@ -127,17 +89,19 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
         /// </summary>
         [Benchmark]
         [Test]
-        public void EncodeableFactoryLookupUsingFrozenDictionary()
+        public void EncodeableFactoryLookupFromEncodeableFactory()
         {
-            IEncodeableFactory encodeableFactory = EncodeableFactory.Create();
-            IEncodeableFactoryBuilder builder = encodeableFactory.Builder.AddEncodeableTypes(encodeableFactory.GetType().Assembly);
-            builder.Commit();
-
-            // lookup a type that exists
-            for (int i = 0; i < 100000; i++)
+            // lookup a type that exists and one that does not
+            for (int i = 0; i < 1000; i++)
             {
-                _ = encodeableFactory.TryGetSystemType(new ExpandedNodeId(ObjectIds.ReadRequest_Encoding_DefaultBinary), out Type systemType);
-                Assert.NotNull(systemType);
+                _ = _encodeableFactory.TryGetEncodeableType(
+                    new ExpandedNodeId(ObjectIds.ReadRequest_Encoding_DefaultBinary),
+                    out IEncodeableType encodeableType);
+                Assert.NotNull(encodeableType);
+                _ = _encodeableFactory.TryGetEncodeableType(
+                    new ExpandedNodeId(Guid.NewGuid()),
+                    out encodeableType);
+                Assert.Null(encodeableType);
             }
         }
 
@@ -149,8 +113,8 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
 
             // Assert
             Assert.NotNull(factory);
-            Assert.NotNull(factory.KnownTypes);
-            Assert.Greater(factory.KnownTypes.Count(), 0);
+            Assert.NotNull(factory.KnownTypeIds);
+            Assert.Greater(factory.KnownTypeIds.Count(), 0);
         }
 
         [Test]
@@ -160,7 +124,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
             IEncodeableFactory factory = EncodeableFactory.Create();
 
             // Act
-            IEnumerable<ExpandedNodeId> knownTypes = factory.KnownTypes;
+            IEnumerable<ExpandedNodeId> knownTypes = factory.KnownTypeIds;
 
             // Assert
             Assert.NotNull(knownTypes);
@@ -169,18 +133,18 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
         }
 
         [Test]
-        public void TryGetSystemType_WithUnknownType_ReturnsFalse()
+        public void TryGetEncodeableType_WithUnknownType_ReturnsFalse()
         {
             // Arrange
             IEncodeableFactory factory = EncodeableFactory.Create();
             var unknownTypeId = new ExpandedNodeId(9999);
 
             // Act
-            bool result = factory.TryGetSystemType(unknownTypeId, out Type systemType);
+            bool result = factory.TryGetEncodeableType(unknownTypeId, out IEncodeableType encodeableType);
 
             // Assert
             Assert.False(result);
-            Assert.Null(systemType);
+            Assert.Null(encodeableType);
         }
 
         [Test]
@@ -208,9 +172,9 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
             builder.Commit();
 
             // Assert
-            bool found = factory.TryGetSystemType(new ExpandedNodeId(1000), out Type systemType);
+            bool found = factory.TryGetEncodeableType(new ExpandedNodeId(100000), out IEncodeableType encodeableType);
             Assert.True(found);
-            Assert.AreEqual(typeof(TestEncodeable), systemType);
+            Assert.AreEqual(typeof(TestEncodeable), encodeableType.Type);
         }
 
         [Test]
@@ -226,9 +190,9 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
             builder.Commit();
 
             // Assert
-            bool found = factory.TryGetSystemType(typeId, out Type systemType);
+            bool found = factory.TryGetEncodeableType(typeId, out IEncodeableType encodeableType);
             Assert.True(found);
-            Assert.AreEqual(typeof(TestEncodeable), systemType);
+            Assert.AreEqual(typeof(TestEncodeable), encodeableType.Type);
         }
 
         [Test]
@@ -251,7 +215,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
             IEncodeableFactoryBuilder builder = factory.Builder;
 
             // Act & Assert
-            IEncodeableFactoryBuilder result = builder.AddEncodeableType(new ExpandedNodeId(1000), typeof(TestEncodeable));
+            IEncodeableFactoryBuilder result = builder.AddEncodeableType(new ExpandedNodeId(100000), typeof(TestEncodeable));
             Assert.AreSame(builder, result);
         }
 
@@ -265,12 +229,12 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
 
             // Act
             builder.AddEncodeableType(typeId, typeof(TestEncodeable));
-            bool foundInBuilder = builder.TryGetSystemType(typeId, out Type builderType);
-            bool foundInFactory = factory.TryGetSystemType(typeId, out Type factoryType);
+            bool foundInBuilder = builder.TryGetEncodeableType(typeId, out IEncodeableType builderType);
+            bool foundInFactory = factory.TryGetEncodeableType(typeId, out IEncodeableType factoryType);
 
             // Assert
             Assert.True(foundInBuilder);
-            Assert.AreEqual(typeof(TestEncodeable), builderType);
+            Assert.AreEqual(typeof(TestEncodeable), builderType.Type);
             Assert.False(foundInFactory);
             Assert.Null(factoryType);
         }
@@ -289,9 +253,9 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
             builder.Commit(); // Second commit should be no-op
 
             // Assert
-            bool found = factory.TryGetSystemType(typeId, out Type systemType);
+            bool found = factory.TryGetEncodeableType(typeId, out IEncodeableType encodeableType);
             Assert.True(found);
-            Assert.AreEqual(typeof(TestEncodeable), systemType);
+            Assert.AreEqual(typeof(TestEncodeable), encodeableType.Type);
         }
 
         [Test]
@@ -321,25 +285,31 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
             builder.Commit();
 
             // Assert - Should add our test types
-            bool foundTest = factory.TryGetSystemType(new ExpandedNodeId(1000), out Type testType);
+            bool foundTest = factory.TryGetEncodeableType(new ExpandedNodeId(100000), out IEncodeableType testType);
             Assert.True(foundTest);
-            Assert.AreEqual(typeof(TestEncodeable), testType);
+            Assert.AreEqual(typeof(TestEncodeable), testType.Type);
         }
 
         [Test]
-        public void Builder_AddEncodeableTypes_SkipsAbstractTypes()
+        public void Builder_AddEncodeableTypes_SkipsAbstractAndNonDefaultConstructorTypes()
         {
             // Arrange
             IEncodeableFactory factory = EncodeableFactory.Create();
+            int knownTypesCount = factory.KnownTypeIds.Count();
             IEncodeableFactoryBuilder builder = factory.Builder;
 
             // Act
             builder.AddEncodeableTypes(Assembly.GetExecutingAssembly());
             builder.Commit();
 
-            // Abstract types should not be added, so we can't verify this directly
-            // but the test passes if no exceptions are thrown
-            Assert.Pass("Abstract types were skipped successfully");
+            // Assert - Should add our concrete test types but skip abstract and no-default-constructor types
+            int addedTypes = factory.KnownTypeIds.Count() - knownTypesCount;
+            Assert.Greater(addedTypes, 0); // Should have added some types
+            
+            // Verify abstract types are not added
+            Assert.False(factory.TryGetEncodeableType(new ExpandedNodeId(110000), out _));
+            Assert.False(factory.TryGetEncodeableType(new ExpandedNodeId(110001), out _));
+            Assert.False(factory.TryGetEncodeableType(new ExpandedNodeId(110002), out _));
         }
 
         [Test]
@@ -354,9 +324,9 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
             builder.Commit();
 
             // Assert - Should be able to find by JSON encoding ID
-            bool foundByJson = factory.TryGetSystemType(new ExpandedNodeId(1003), out Type jsonType);
+            bool foundByJson = factory.TryGetEncodeableType(new ExpandedNodeId(100003), out IEncodeableType jsonType);
             Assert.True(foundByJson);
-            Assert.AreEqual(typeof(TestJsonEncodeable), jsonType);
+            Assert.AreEqual(typeof(TestJsonEncodeable), jsonType.Type);
         }
 
         [Test]
@@ -372,12 +342,12 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
             builder.Commit();
 
             // Assert
-            bool foundTest = factory.TryGetSystemType(new ExpandedNodeId(1000), out Type testType);
-            bool foundJsonTest = factory.TryGetSystemType(new ExpandedNodeId(1004), out Type jsonTestType);
+            bool foundTest = factory.TryGetEncodeableType(new ExpandedNodeId(100000), out IEncodeableType testType);
+            bool foundJsonTest = factory.TryGetEncodeableType(new ExpandedNodeId(100004), out IEncodeableType jsonTestType);
 
             Assert.True(foundTest);
             Assert.True(foundJsonTest);
-            Assert.AreEqual(typeof(TestEncodeable), testType);
+            Assert.AreEqual(typeof(TestEncodeable), testType.Type);
         }
 
         [Test]
@@ -424,7 +394,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
 
             // Assert
             Assert.AreEqual(0, exceptions.Count, $"Exceptions occurred: {string.Join(", ", exceptions.Select(e => e.Message))}");
-            Assert.Greater(factory.KnownTypes.Count(), 0);
+            Assert.Greater(factory.KnownTypeIds.Count(), 0);
         }
 
         [Test]
@@ -444,8 +414,8 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
             Assert.AreNotSame(factory, clonedFactory);
 
             // Should have same types
-            bool originalHasType = factory.TryGetSystemType(typeId, out Type originalType);
-            bool clonedHasType = clonedFactory.TryGetSystemType(typeId, out Type clonedType);
+            bool originalHasType = factory.TryGetEncodeableType(typeId, out IEncodeableType originalType);
+            bool clonedHasType = clonedFactory.TryGetEncodeableType(typeId, out IEncodeableType clonedType);
 
             Assert.True(originalHasType);
             Assert.True(clonedHasType);
@@ -469,8 +439,8 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
             Assert.AreNotSame(factory, clonedFactory);
 
             // Should have same types
-            bool originalHasType = factory.TryGetSystemType(typeId, out Type originalType);
-            bool clonedHasType = clonedFactory.TryGetSystemType(typeId, out Type clonedType);
+            bool originalHasType = factory.TryGetEncodeableType(typeId, out IEncodeableType originalType);
+            bool clonedHasType = clonedFactory.TryGetEncodeableType(typeId, out IEncodeableType clonedType);
 
             Assert.True(originalHasType);
             Assert.True(clonedHasType);
@@ -494,8 +464,8 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
             factory.Builder.AddEncodeableType(newTypeId, typeof(TestJsonEncodeable)).Commit();
 
             // Assert - Clone should not have the new type
-            bool originalHasNewType = factory.TryGetSystemType(newTypeId, out _);
-            bool clonedHasNewType = clonedFactory.TryGetSystemType(newTypeId, out _);
+            bool originalHasNewType = factory.TryGetEncodeableType(newTypeId, out _);
+            bool clonedHasNewType = clonedFactory.TryGetEncodeableType(newTypeId, out _);
 
             Assert.True(originalHasNewType);
             Assert.False(clonedHasNewType);
@@ -529,14 +499,14 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
             // Arrange
             IEncodeableFactory factory = EncodeableFactory.Create();
             IEncodeableFactoryBuilder builder = factory.Builder;
-            int initialCount = factory.KnownTypes.Count();
+            int initialCount = factory.KnownTypeIds.Count();
 
             // Act
             builder.AddEncodeableType(typeof(string)); // string is not IEncodeable
             builder.Commit();
 
             // Assert - No new types should be added
-            Assert.AreEqual(initialCount, factory.KnownTypes.Count());
+            Assert.AreEqual(initialCount, factory.KnownTypeIds.Count());
         }
 
         [Test]
@@ -569,7 +539,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
             builder.Commit();
 
             // Assert - Should have many OPC UA types
-            Assert.Greater(factory.KnownTypes.Count(), 100); // OPC UA has many built-in types
+            Assert.Greater(factory.KnownTypeIds.Count(), 100); // OPC UA has many built-in types
         }
 
         [Test]
@@ -579,10 +549,10 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
             IEncodeableFactory factory = EncodeableFactory.Create();
 
             // Assert - Create() should return factory with preloaded types
-            Assert.Greater(factory.KnownTypes.Count(), 100);
+            Assert.Greater(factory.KnownTypeIds.Count(), 100);
 
             // Should be able to find common OPC UA types like ReadRequest
-            var knownTypesList = factory.KnownTypes.ToList();
+            var knownTypesList = factory.KnownTypeIds.ToList();
             Assert.Greater(knownTypesList.Count, 0);
         }
 
@@ -594,11 +564,11 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
 
             // Act - Try to find ReadRequest type using proper ExpandedNodeId - wrap the uint constant
             var readRequestEncodingId = new ExpandedNodeId(ObjectIds.ReadRequest_Encoding_DefaultBinary);
-            bool found = factory.TryGetSystemType(readRequestEncodingId, out Type systemType);
+            bool found = factory.TryGetEncodeableType(readRequestEncodingId, out IEncodeableType encodeableType);
 
             // Assert
             Assert.True(found);
-            Assert.AreEqual(typeof(ReadRequest), systemType);
+            Assert.AreEqual(typeof(ReadRequest), encodeableType.Type);
         }
 
         [Test]
@@ -617,12 +587,12 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
             builder.Commit();
 
             // Assert - Should be findable with both NodeId forms
-            bool foundWithNs = factory.TryGetSystemType(typeIdWithDefaultNs, out Type typeWithNs);
-            bool foundWithoutNs = factory.TryGetSystemType(typeIdWithoutNs, out Type typeWithoutNs);
+            bool foundWithNs = factory.TryGetEncodeableType(typeIdWithDefaultNs, out IEncodeableType typeWithNs);
+            bool foundWithoutNs = factory.TryGetEncodeableType(typeIdWithoutNs, out IEncodeableType typeWithoutNs);
 
             Assert.True(foundWithNs);
             Assert.False(foundWithoutNs);
-            Assert.AreEqual(typeof(TestEncodeable), typeWithNs);
+            Assert.AreEqual(typeof(TestEncodeable), typeWithNs.Type);
             Assert.Null(typeWithoutNs);
         }
 
@@ -635,7 +605,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
 
             // Act & Assert
             Assert.DoesNotThrow(builder.Commit);
-            Assert.Greater(factory.KnownTypes.Count(), 0); // Should have pre-loaded types
+            Assert.Greater(factory.KnownTypeIds.Count(), 0); // Should have pre-loaded types
         }
 
         [Test]
@@ -650,20 +620,20 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
             builder.Commit();
 
             // Assert - Should find type by all encoding IDs
-            bool foundByBinary = factory.TryGetSystemType(new ExpandedNodeId(1001), out Type typeByBinaryId);
-            bool foundByXml = factory.TryGetSystemType(new ExpandedNodeId(1002), out Type typeByXmlId);
-            bool foundByJson = factory.TryGetSystemType(new ExpandedNodeId(1003), out Type typeByJsonId);
-            bool foundByType = factory.TryGetSystemType(new ExpandedNodeId(1004), out Type typeByTypeId);
+            bool foundByBinary = factory.TryGetEncodeableType(new ExpandedNodeId(100001), out IEncodeableType typeByBinaryId);
+            bool foundByXml = factory.TryGetEncodeableType(new ExpandedNodeId(100002), out IEncodeableType typeByXmlId);
+            bool foundByJson = factory.TryGetEncodeableType(new ExpandedNodeId(100003), out IEncodeableType typeByJsonId);
+            bool foundByType = factory.TryGetEncodeableType(new ExpandedNodeId(100004), out IEncodeableType typeByTypeId);
 
             Assert.True(foundByType);
             Assert.True(foundByBinary);
             Assert.True(foundByXml);
             Assert.True(foundByJson);
 
-            Assert.AreEqual(typeof(TestJsonEncodeable), typeByTypeId);
-            Assert.AreEqual(typeof(TestJsonEncodeable), typeByBinaryId);
-            Assert.AreEqual(typeof(TestJsonEncodeable), typeByXmlId);
-            Assert.AreEqual(typeof(TestJsonEncodeable), typeByJsonId);
+            Assert.AreEqual(typeof(TestJsonEncodeable), typeByTypeId.Type);
+            Assert.AreEqual(typeof(TestJsonEncodeable), typeByBinaryId.Type);
+            Assert.AreEqual(typeof(TestJsonEncodeable), typeByXmlId.Type);
+            Assert.AreEqual(typeof(TestJsonEncodeable), typeByJsonId.Type);
         }
 
         [Test]
@@ -678,41 +648,617 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
             builder.AddEncodeableType(new ExpandedNodeId(9201), typeof(TestJsonEncodeable)).Commit();
 
             // Assert
-            bool foundFirst = factory.TryGetSystemType(new ExpandedNodeId(9200), out Type firstType);
-            bool foundSecond = factory.TryGetSystemType(new ExpandedNodeId(9201), out Type secondType);
+            bool foundFirst = factory.TryGetEncodeableType(new ExpandedNodeId(9200), out IEncodeableType firstType);
+            bool foundSecond = factory.TryGetEncodeableType(new ExpandedNodeId(9201), out IEncodeableType secondType);
 
             Assert.True(foundFirst);
             Assert.True(foundSecond);
-            Assert.AreEqual(typeof(TestEncodeable), firstType);
-            Assert.AreEqual(typeof(TestJsonEncodeable), secondType);
+            Assert.AreEqual(typeof(TestEncodeable), firstType.Type);
+            Assert.AreEqual(typeof(TestJsonEncodeable), secondType.Type);
         }
 
         [Test]
-        public void TryGetSystemType_WithNullNodeId_ReturnsFalse()
+        public void TryGetEncodeableType_WithNullNodeId_ReturnsFalse()
         {
             // Arrange
             IEncodeableFactory factory = EncodeableFactory.Create();
 
             // Act
-            bool result = factory.TryGetSystemType(null, out Type systemType);
+            bool result = factory.TryGetEncodeableType(null, out IEncodeableType encodeableType);
 
             // Assert
             Assert.False(result);
-            Assert.Null(systemType);
+            Assert.Null(encodeableType);
         }
 
         [Test]
-        public void TryGetSystemType_WithExpandedNodeIdNull_ReturnsFalse()
+        public void TryGetEncodeableType_WithExpandedNodeIdNull_ReturnsFalse()
         {
             // Arrange
             IEncodeableFactory factory = EncodeableFactory.Create();
 
             // Act
-            bool result = factory.TryGetSystemType(ExpandedNodeId.Null, out Type systemType);
+            bool result = factory.TryGetEncodeableType(ExpandedNodeId.Null, out IEncodeableType encodeableType);
 
             // Assert
             Assert.False(result);
-            Assert.Null(systemType);
+            Assert.Null(encodeableType);
+        }
+
+        /// <summary>
+        /// Test class for encodeable objects used in factory tests.
+        /// </summary>
+        public class TestEncodeable : IEncodeable
+        {
+            public TestEncodeable() { }
+
+            public TestEncodeable(string value)
+            {
+                Value = value;
+            }
+
+            public string Value { get; set; }
+
+            public virtual ExpandedNodeId TypeId => new(100000);
+            public ExpandedNodeId BinaryEncodingId => new(100001);
+            public ExpandedNodeId XmlEncodingId => new(100002);
+
+            public void Encode(IEncoder encoder) { }
+            public void Decode(IDecoder decoder) { }
+            public bool IsEqual(IEncodeable encodeable)
+            {
+                return encodeable is TestEncodeable test && test.Value == Value;
+            }
+
+            public virtual object Clone()
+            {
+                return new TestEncodeable(Value);
+            }
+        }
+
+        /// <summary>
+        /// Test class for JSON encodeable objects used in factory tests.
+        /// </summary>
+        public class TestJsonEncodeable : TestEncodeable, IJsonEncodeable
+        {
+            public TestJsonEncodeable() { }
+            public TestJsonEncodeable(string value) : base(value) { }
+
+            public override ExpandedNodeId TypeId => new(100004);
+
+            public ExpandedNodeId JsonEncodingId => new(100003);
+
+            public override object Clone()
+            {
+                return new TestJsonEncodeable(Value);
+            }
+        }
+
+        public class TestNoDefaultConstructorEncodeable : IEncodeable
+        {
+            public TestNoDefaultConstructorEncodeable(string value)
+            {
+                Value = value;
+            }
+            public string Value { get; set; }
+            public ExpandedNodeId TypeId => new(110000);
+            public ExpandedNodeId BinaryEncodingId => new(110001);
+            public ExpandedNodeId XmlEncodingId => new(110002);
+            public void Encode(IEncoder encoder) { }
+            public void Decode(IDecoder decoder) { }
+            public bool IsEqual(IEncodeable encodeable)
+            {
+                return encodeable is TestNoDefaultConstructorEncodeable test && test.Value == Value;
+            }
+            public object Clone()
+            {
+                return new TestNoDefaultConstructorEncodeable(Value);
+            }
+        }
+
+        /// <summary>
+        /// Abstract test encodeable for testing abstract types.
+        /// </summary>
+        public abstract class AbstractTestEncodeable : IEncodeable
+        {
+            public abstract ExpandedNodeId TypeId { get; }
+            public abstract ExpandedNodeId BinaryEncodingId { get; }
+            public abstract ExpandedNodeId XmlEncodingId { get; }
+
+            public virtual void Encode(IEncoder encoder) { }
+            public virtual void Decode(IDecoder decoder) { }
+            public virtual bool IsEqual(IEncodeable encodeable)
+            {
+                return false;
+            }
+
+            public virtual object Clone()
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        /// <summary>
+        /// Test implementation of IEncodeableType for testing purposes.
+        /// </summary>
+        public class TestEncodeableType : IEncodeableType
+        {
+            public TestEncodeableType(Type type)
+            {
+                Type = type;
+            }
+
+            public Type Type { get; }
+
+            public IEncodeable CreateInstance()
+            {
+                return (IEncodeable)Activator.CreateInstance(Type);
+            }
+
+            public override bool Equals(object obj)
+            {
+                return Type.Equals((obj as IEncodeableType)?.Type);
+            }
+
+            public override int GetHashCode()
+            {
+                return Type.GetHashCode();
+            }
+
+            public override string ToString()
+            {
+                return Type.FullName ?? Type.Name;
+            }
+        }
+
+        /// <summary>
+        /// Test implementation of IEncodeableType that throws on CreateInstance.
+        /// </summary>
+        public class FaultyEncodeableType : IEncodeableType
+        {
+            public Type Type => typeof(TestEncodeable);
+
+            public IEncodeable CreateInstance()
+            {
+                throw new InvalidOperationException("Cannot create instance");
+            }
+        }
+
+        /// <summary>
+        /// Test implementation of IEncodeableType that returns null on CreateInstance.
+        /// </summary>
+        public class NullReturningEncodeableType : IEncodeableType
+        {
+            public Type Type => typeof(TestEncodeable);
+
+            public IEncodeable CreateInstance()
+            {
+                return null;
+            }
+        }
+
+        [Test]
+        public void Builder_AddEncodeableType_WithIEncodeableType_AddsTypeSuccessfully()
+        {
+            // Arrange
+            IEncodeableFactory factory = EncodeableFactory.Create();
+            IEncodeableFactoryBuilder builder = factory.Builder;
+            var encodeableType = new TestEncodeableType(typeof(TestEncodeable));
+
+            // Act
+            builder.AddEncodeableType(encodeableType);
+            builder.Commit();
+
+            // Assert
+            bool found = factory.TryGetEncodeableType(new ExpandedNodeId(100000), out IEncodeableType resultType);
+            Assert.True(found);
+            Assert.AreEqual(typeof(TestEncodeable), resultType.Type);
+        }
+
+        [Test]
+        public void Builder_AddEncodeableType_WithIEncodeableType_ReturnsBuilderForChaining()
+        {
+            // Arrange
+            IEncodeableFactory factory = EncodeableFactory.Create();
+            IEncodeableFactoryBuilder builder = factory.Builder;
+            var encodeableType = new TestEncodeableType(typeof(TestEncodeable));
+
+            // Act & Assert
+            IEncodeableFactoryBuilder result = builder.AddEncodeableType(encodeableType);
+            Assert.AreSame(builder, result);
+        }
+
+        [Test]
+        public void Builder_AddEncodeableType_WithExpandedNodeIdAndIEncodeableType_AddsTypeSuccessfully()
+        {
+            // Arrange
+            IEncodeableFactory factory = EncodeableFactory.Create();
+            IEncodeableFactoryBuilder builder = factory.Builder;
+            var typeId = new ExpandedNodeId(50000);
+            var encodeableType = new TestEncodeableType(typeof(TestEncodeable));
+
+            // Act
+            builder.AddEncodeableType(typeId, encodeableType);
+            builder.Commit();
+
+            // Assert
+            bool found = factory.TryGetEncodeableType(typeId, out IEncodeableType resultType);
+            Assert.True(found);
+            Assert.AreEqual(typeof(TestEncodeable), resultType.Type);
+        }
+
+        [Test]
+        public void Builder_AddEncodeableType_WithExpandedNodeIdAndIEncodeableType_ReturnsBuilderForChaining()
+        {
+            // Arrange
+            IEncodeableFactory factory = EncodeableFactory.Create();
+            IEncodeableFactoryBuilder builder = factory.Builder;
+            var typeId = new ExpandedNodeId(50001);
+            var encodeableType = new TestEncodeableType(typeof(TestEncodeable));
+
+            // Act & Assert
+            IEncodeableFactoryBuilder result = builder.AddEncodeableType(typeId, encodeableType);
+            Assert.AreSame(builder, result);
+        }
+
+        [Test]
+        public void Builder_AddEncodeableType_WithNullIEncodeableType_ThrowsArgumentNullException()
+        {
+            // Arrange
+            IEncodeableFactory factory = EncodeableFactory.Create();
+            IEncodeableFactoryBuilder builder = factory.Builder;
+
+            // Act & Assert
+            Assert.Throws<ArgumentNullException>(() => builder.AddEncodeableType((IEncodeableType)null));
+        }
+
+        [Test]
+        public void Builder_AddEncodeableType_WithNullExpandedNodeIdAndIEncodeableType_ThrowsArgumentNullException()
+        {
+            // Arrange
+            IEncodeableFactory factory = EncodeableFactory.Create();
+            IEncodeableFactoryBuilder builder = factory.Builder;
+            var encodeableType = new TestEncodeableType(typeof(TestEncodeable));
+
+            // Act & Assert
+            Assert.Throws<ArgumentNullException>(() => builder.AddEncodeableType(null, encodeableType));
+        }
+
+        [Test]
+        public void Builder_AddEncodeableType_WithExpandedNodeIdAndNullIEncodeableType_ThrowsArgumentNullException()
+        {
+            // Arrange
+            IEncodeableFactory factory = EncodeableFactory.Create();
+            IEncodeableFactoryBuilder builder = factory.Builder;
+            var typeId = new ExpandedNodeId(50002);
+
+            // Act & Assert
+            Assert.Throws<ArgumentNullException>(() => builder.AddEncodeableType(typeId, (IEncodeableType)null));
+        }
+
+        [Test]
+        public void Builder_AddEncodeableType_WithFaultyIEncodeableType_ThrowsException()
+        {
+            // Arrange
+            IEncodeableFactory factory = EncodeableFactory.Create();
+            IEncodeableFactoryBuilder builder = factory.Builder;
+            var faultyType = new FaultyEncodeableType();
+
+            // Act & Assert
+            Assert.Throws<InvalidOperationException>(() => builder.AddEncodeableType(faultyType));
+        }
+
+        [Test]
+        public void Builder_AddEncodeableType_WithNullReturningIEncodeableType_ThrowsException()
+        {
+            // Arrange
+            IEncodeableFactory factory = EncodeableFactory.Create();
+            IEncodeableFactoryBuilder builder = factory.Builder;
+            var nullReturningType = new NullReturningEncodeableType();
+
+            // Act & Assert
+            Assert.Throws<InvalidOperationException>(() => builder.AddEncodeableType(nullReturningType));
+        }
+
+        [Test]
+        public void Builder_AddEncodeableType_WithIEncodeableTypeNotSupportingXmlEncoding_HandlesGracefully()
+        {
+            // Arrange
+            IEncodeableFactory factory = EncodeableFactory.Create();
+            IEncodeableFactoryBuilder builder = factory.Builder;
+            var encodeableType = new TestEncodeableType(typeof(TestEncodeableWithoutXml));
+
+            // Act & Assert - Should not throw even if XmlEncodingId throws NotSupportedException
+            Assert.DoesNotThrow(() =>
+            {
+                builder.AddEncodeableType(encodeableType);
+                builder.Commit();
+            });
+
+            // Should still be able to find by other encoding IDs
+            bool found = factory.TryGetEncodeableType(new ExpandedNodeId(120000), out IEncodeableType resultType);
+            Assert.True(found);
+            Assert.AreEqual(typeof(TestEncodeableWithoutXml), resultType.Type);
+        }
+
+        [Test]
+        public void Builder_AddEncodeableType_WithIEncodeableTypeNotSupportingJsonEncoding_HandlesGracefully()
+        {
+            // Arrange
+            IEncodeableFactory factory = EncodeableFactory.Create();
+            IEncodeableFactoryBuilder builder = factory.Builder;
+            var encodeableType = new TestEncodeableType(typeof(TestEncodeableWithoutJson));
+
+            // Act & Assert - Should not throw even if JsonEncodingId throws NotSupportedException
+            Assert.DoesNotThrow(() =>
+            {
+                builder.AddEncodeableType(encodeableType);
+                builder.Commit();
+            });
+
+            // Should still register other encoding IDs
+            bool found = factory.TryGetEncodeableType(new ExpandedNodeId(130000), out IEncodeableType resultType);
+            Assert.True(found);
+            Assert.AreEqual(typeof(TestEncodeableWithoutJson), resultType.Type);
+        }
+
+        [Test]
+        public void Builder_AddEncodeableType_WithIEncodeableTypeHavingJsonEncoding_RegistersAllEncodingIds()
+        {
+            // Arrange
+            IEncodeableFactory factory = EncodeableFactory.Create();
+            IEncodeableFactoryBuilder builder = factory.Builder;
+            var encodeableType = new TestEncodeableType(typeof(TestJsonEncodeable));
+
+            // Act
+            builder.AddEncodeableType(encodeableType);
+            builder.Commit();
+
+            // Assert - Should find type by all encoding IDs
+            bool foundByType = factory.TryGetEncodeableType(new ExpandedNodeId(100004), out IEncodeableType typeByTypeId);
+            bool foundByBinary = factory.TryGetEncodeableType(new ExpandedNodeId(100001), out IEncodeableType typeByBinaryId);
+            bool foundByXml = factory.TryGetEncodeableType(new ExpandedNodeId(100002), out IEncodeableType typeByXmlId);
+            bool foundByJson = factory.TryGetEncodeableType(new ExpandedNodeId(100003), out IEncodeableType typeByJsonId);
+
+            Assert.True(foundByType);
+            Assert.True(foundByBinary);
+            Assert.True(foundByXml);
+            Assert.True(foundByJson);
+
+            Assert.AreEqual(typeof(TestJsonEncodeable), typeByTypeId.Type);
+            Assert.AreEqual(typeof(TestJsonEncodeable), typeByBinaryId.Type);
+            Assert.AreEqual(typeof(TestJsonEncodeable), typeByXmlId.Type);
+            Assert.AreEqual(typeof(TestJsonEncodeable), typeByJsonId.Type);
+        }
+
+        [Test]
+        public void Builder_AddEncodeableType_WithDefaultNamespaceNormalization_HandlesCorrectly()
+        {
+            // Arrange
+            IEncodeableFactory factory = EncodeableFactory.Create();
+            IEncodeableFactoryBuilder builder = factory.Builder;
+            var encodeableType = new TestEncodeableType(typeof(TestEncodeableWithDefaultNamespace));
+
+            // Act
+            builder.AddEncodeableType(encodeableType);
+            builder.Commit();
+
+            // Assert - Should be findable with normalized NodeId (without namespace URI)
+            bool foundWithoutNs = factory.TryGetEncodeableType(new ExpandedNodeId(140000), out IEncodeableType typeWithoutNs);
+            bool foundWithNs = factory.TryGetEncodeableType(new ExpandedNodeId(140000, Namespaces.OpcUa), out IEncodeableType typeWithNs);
+
+            Assert.True(foundWithoutNs);
+            Assert.False(foundWithNs);
+            Assert.AreEqual(typeof(TestEncodeableWithDefaultNamespace), typeWithoutNs.Type);
+        }
+
+        [Test]
+        public void Builder_TryGetEncodeableType_FallsBackToFactory()
+        {
+            // Arrange
+            IEncodeableFactory factory = EncodeableFactory.Create();
+            IEncodeableFactoryBuilder builder = factory.Builder;
+
+            // Pre-populate factory with a type
+            factory.Builder.AddEncodeableType(new ExpandedNodeId(60000), typeof(TestEncodeable)).Commit();
+
+            // Act - Try to find type that's only in the factory, not in the builder
+            bool found = builder.TryGetEncodeableType(new ExpandedNodeId(60000), out IEncodeableType encodeableType);
+
+            // Assert
+            Assert.True(found);
+            Assert.AreEqual(typeof(TestEncodeable), encodeableType.Type);
+        }
+
+        [Test]
+        public void Builder_TryGetEncodeableType_PrefersBuilderOverFactory()
+        {
+            // Arrange
+            IEncodeableFactory factory = EncodeableFactory.Create();
+            var typeId = new ExpandedNodeId(61000);
+
+            // Add one type to factory
+            factory.Builder.AddEncodeableType(typeId, typeof(TestEncodeable)).Commit();
+
+            // Add different type to builder with same ID
+            IEncodeableFactoryBuilder builder = factory.Builder;
+            builder.AddEncodeableType(typeId, typeof(TestJsonEncodeable));
+
+            // Act
+            bool found = builder.TryGetEncodeableType(typeId, out IEncodeableType encodeableType);
+
+            // Assert - Should prefer builder's type over factory's type
+            Assert.True(found);
+            Assert.AreEqual(typeof(TestJsonEncodeable), encodeableType.Type);
+        }
+
+        /// <summary>
+        /// Test encodeable that throws NotSupportedException for XmlEncodingId.
+        /// </summary>
+        public class TestEncodeableWithoutXml : IEncodeable
+        {
+            public ExpandedNodeId TypeId => new(120000);
+            public ExpandedNodeId BinaryEncodingId => new(120001);
+            public ExpandedNodeId XmlEncodingId => throw new NotSupportedException("XML encoding not supported");
+
+            public void Encode(IEncoder encoder) { }
+            public void Decode(IDecoder decoder) { }
+            public bool IsEqual(IEncodeable encodeable) => encodeable is TestEncodeableWithoutXml;
+            public object Clone() => new TestEncodeableWithoutXml();
+        }
+
+        /// <summary>
+        /// Test encodeable that throws NotSupportedException for JsonEncodingId.
+        /// </summary>
+        public class TestEncodeableWithoutJson : IEncodeable, IJsonEncodeable
+        {
+            public ExpandedNodeId TypeId => new(130000);
+            public ExpandedNodeId BinaryEncodingId => new(130001);
+            public ExpandedNodeId XmlEncodingId => new(130002);
+            public ExpandedNodeId JsonEncodingId => throw new NotSupportedException("JSON encoding not supported");
+
+            public void Encode(IEncoder encoder) { }
+            public void Decode(IDecoder decoder) { }
+            public bool IsEqual(IEncodeable encodeable) => encodeable is TestEncodeableWithoutJson;
+            public object Clone() => new TestEncodeableWithoutJson();
+        }
+
+        /// <summary>
+        /// Test encodeable with default OPC UA namespace.
+        /// </summary>
+        public class TestEncodeableWithDefaultNamespace : IEncodeable
+        {
+            public ExpandedNodeId TypeId => new(140000, Namespaces.OpcUa);
+            public ExpandedNodeId BinaryEncodingId => new(140001, Namespaces.OpcUa);
+            public ExpandedNodeId XmlEncodingId => new(140002, Namespaces.OpcUa);
+
+            public void Encode(IEncoder encoder) { }
+            public void Decode(IDecoder decoder) { }
+            public bool IsEqual(IEncodeable encodeable) => encodeable is TestEncodeableWithDefaultNamespace;
+            public object Clone() => new TestEncodeableWithDefaultNamespace();
+        }
+
+        [Test]
+        public void Builder_AddEncodeableTypes_ResolvesJsonEncodingIdsFromObjectIds()
+        {
+            // Arrange - Create a minimal assembly structure to test JSON ID resolution
+            IEncodeableFactory factory = EncodeableFactory.Create();
+            IEncodeableFactoryBuilder builder = factory.Builder;
+            
+            // Act - Add types from current assembly which should include our test types
+            builder.AddEncodeableTypes(Assembly.GetExecutingAssembly());
+            builder.Commit();
+
+            // Assert - Our test types should be registered
+            Assert.True(factory.TryGetEncodeableType(new ExpandedNodeId(100000), out IEncodeableType testType));
+            Assert.AreEqual(typeof(TestEncodeable), testType.Type);
+        }
+
+        [Test]
+        public void Builder_AddEncodeableTypes_HandlesJsonEncodingSuffixParsing()
+        {
+            // This test verifies the JSON encoding suffix parsing logic in AddEncodeableTypes
+            // The method looks for fields ending with "_Encoding_DefaultJson" in ObjectIds classes
+            
+            // Arrange
+            IEncodeableFactory factory = EncodeableFactory.Create();
+            IEncodeableFactoryBuilder builder = factory.Builder;
+            
+            // Act - This should process ObjectIds classes and parse JSON encoding suffixes
+            builder.AddEncodeableTypes(typeof(EncodeableFactory).Assembly);
+            builder.Commit();
+
+            // Assert - Should have many types including core OPC UA types
+            Assert.Greater(factory.KnownTypeIds.Count(), 1000);
+        }
+
+        [Test]
+        public void Integration_FactorySupportsComplexTypeRegistration()
+        {
+            // Arrange
+            IEncodeableFactory factory = EncodeableFactory.Create();
+            IEncodeableFactoryBuilder builder = factory.Builder;
+
+            // Act - Register multiple types with different encoding patterns
+            builder.AddEncodeableType(typeof(TestEncodeable))
+                   .AddEncodeableType(typeof(TestJsonEncodeable))
+                   .AddEncodeableType(new ExpandedNodeId(99999), typeof(TestEncodeableWithDefaultNamespace));
+            builder.Commit();
+
+            // Assert - All types should be accessible
+            Assert.True(factory.TryGetEncodeableType(new ExpandedNodeId(100000), out IEncodeableType type1));
+            Assert.True(factory.TryGetEncodeableType(new ExpandedNodeId(100004), out IEncodeableType type2));
+            Assert.True(factory.TryGetEncodeableType(new ExpandedNodeId(99999), out IEncodeableType type3));
+
+            Assert.AreEqual(typeof(TestEncodeable), type1.Type);
+            Assert.AreEqual(typeof(TestJsonEncodeable), type2.Type);
+            Assert.AreEqual(typeof(TestEncodeableWithDefaultNamespace), type3.Type);
+        }
+
+        [Test]
+        public void Builder_AddEncodeableType_WithNullNodeIds_SkipsGracefully()
+        {
+            // Test the behavior when an encodeable type returns null NodeIds
+            
+            // Arrange
+            IEncodeableFactory factory = EncodeableFactory.Create();
+            IEncodeableFactoryBuilder builder = factory.Builder;
+            var encodeableType = new TestEncodeableType(typeof(TestEncodeableWithNullIds));
+
+            // Act & Assert - Should not throw
+            Assert.DoesNotThrow(() =>
+            {
+                builder.AddEncodeableType(encodeableType);
+                builder.Commit();
+            });
+
+            // Should not be findable since all IDs are null
+            bool found = factory.TryGetEncodeableType(ExpandedNodeId.Null, out _);
+            Assert.False(found);
+        }
+
+        [Test] 
+        public void EncodeableFactory_FrozenDictionary_Performance_CharacteristicsVerification()
+        {
+            // This test verifies that the FrozenDictionary is actually being used
+            // and has the expected performance characteristics mentioned in the comments
+            
+            // Arrange
+            IEncodeableFactory factory = EncodeableFactory.Create();
+            
+            // Act - Perform multiple lookups to verify frozen dictionary performance
+            var readRequestId = new ExpandedNodeId(ObjectIds.ReadRequest_Encoding_DefaultBinary);
+            var nonExistentId = new ExpandedNodeId(Guid.NewGuid());
+            
+            // Time the lookups (though we won't assert on timing, just verify functionality)
+            bool found1 = factory.TryGetEncodeableType(readRequestId, out IEncodeableType type1);
+            bool found2 = factory.TryGetEncodeableType(nonExistentId, out IEncodeableType type2);
+            
+            // Assert
+            Assert.True(found1);
+            Assert.NotNull(type1);
+            Assert.AreEqual(typeof(ReadRequest), type1.Type);
+            
+            Assert.False(found2);
+            Assert.Null(type2);
+            
+            // Verify we have a substantial number of types (mentioned as ~1.5k in comments)
+            Assert.Greater(factory.KnownTypeIds.Count(), 1000);
+        }
+
+        /// <summary>
+        /// Test encodeable with null NodeIds to test edge case handling.
+        /// </summary>
+        public class TestEncodeableWithNullIds : IEncodeable
+        {
+            public ExpandedNodeId TypeId => ExpandedNodeId.Null;
+            public ExpandedNodeId BinaryEncodingId => ExpandedNodeId.Null;
+            public ExpandedNodeId XmlEncodingId => ExpandedNodeId.Null;
+
+            public void Encode(IEncoder encoder) { }
+            public void Decode(IDecoder decoder) { }
+            public bool IsEqual(IEncodeable encodeable) => encodeable is TestEncodeableWithNullIds;
+            public object Clone() => new TestEncodeableWithNullIds();
         }
     }
 }

--- a/Tests/Opc.Ua.Core.Tests/Types/Encoders/EncoderCommon.cs
+++ b/Tests/Opc.Ua.Core.Tests/Types/Encoders/EncoderCommon.cs
@@ -30,6 +30,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -1338,15 +1339,16 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
             private readonly bool m_resetCounter;
         }
 
-        protected class DynamicEncodeableFactory : EncodeableFactory
+        protected class DynamicEncodeableFactory : IEncodeableFactory
         {
-            private readonly Dictionary<ExpandedNodeId, DynamicEncodeable> m_dynamicEncodeables
-                = [];
-
-            public DynamicEncodeableFactory(IEncodeableFactory factory, ITelemetryContext telemetry)
-                : base(factory, telemetry)
+            public DynamicEncodeableFactory(IEncodeableFactory factory)
             {
+                m_inner = factory;
             }
+
+            public IEnumerable<ExpandedNodeId> KnownTypes => m_inner.KnownTypes;
+
+            public IEncodeableFactoryBuilder Builder => m_inner.Builder;
 
             public DynamicEncodeable GetDynamicEncodeableForEncoding(ExpandedNodeId typeId)
             {
@@ -1366,11 +1368,19 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
                 m_dynamicEncodeables[encodeable.JsonEncodingId] = encodeable;
                 m_dynamicEncodeables[encodeable.BinaryEncodingId] = encodeable;
                 m_dynamicEncodeables[encodeable.TypeId] = encodeable;
-                AddEncodeableType(encodeable.XmlEncodingId, typeof(DynamicEncodeable));
-                AddEncodeableType(encodeable.JsonEncodingId, typeof(DynamicEncodeable));
-                AddEncodeableType(encodeable.BinaryEncodingId, typeof(DynamicEncodeable));
-                AddEncodeableType(encodeable.TypeId, typeof(DynamicEncodeable));
+                m_inner.AddEncodeableType(encodeable.XmlEncodingId, typeof(DynamicEncodeable));
+                m_inner.AddEncodeableType(encodeable.JsonEncodingId, typeof(DynamicEncodeable));
+                m_inner.AddEncodeableType(encodeable.BinaryEncodingId, typeof(DynamicEncodeable));
+                m_inner.AddEncodeableType(encodeable.TypeId, typeof(DynamicEncodeable));
             }
+
+            public bool TryGetSystemType(ExpandedNodeId typeId, [NotNullWhen(true)] out Type systemType)
+            {
+                return m_inner.TryGetSystemType(typeId, out systemType);
+            }
+
+            private IEncodeableFactory m_inner;
+            private readonly Dictionary<ExpandedNodeId, DynamicEncodeable> m_dynamicEncodeables = [];
         }
     }
 }

--- a/Tests/Opc.Ua.Core.Tests/Types/Encoders/EncoderCommon.cs
+++ b/Tests/Opc.Ua.Core.Tests/Types/Encoders/EncoderCommon.cs
@@ -1346,7 +1346,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
                 m_inner = factory;
             }
 
-            public IEnumerable<ExpandedNodeId> KnownTypes => m_inner.KnownTypes;
+            public IEnumerable<ExpandedNodeId> KnownTypeIds => m_inner.KnownTypeIds;
 
             public IEncodeableFactoryBuilder Builder => m_inner.Builder;
 
@@ -1374,9 +1374,9 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
                 m_inner.AddEncodeableType(encodeable.TypeId, typeof(DynamicEncodeable));
             }
 
-            public bool TryGetSystemType(ExpandedNodeId typeId, [NotNullWhen(true)] out Type systemType)
+            public bool TryGetEncodeableType(ExpandedNodeId typeId, [NotNullWhen(true)] out IEncodeableType systemType)
             {
-                return m_inner.TryGetSystemType(typeId, out systemType);
+                return m_inner.TryGetEncodeableType(typeId, out systemType);
             }
 
             private IEncodeableFactory m_inner;

--- a/Tests/Opc.Ua.Core.Tests/Types/Encoders/JsonEncoderTests.cs
+++ b/Tests/Opc.Ua.Core.Tests/Types/Encoders/JsonEncoderTests.cs
@@ -1457,10 +1457,11 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
                     { "Foo", (1, "bar_1") },
                     { "Foo2", (2, "bar_2") } });
 
-            // Register in the context's Factory, make it a custom factory so the dynamic type can look up its type information when instantiated during encoding/decoding
+            // Register in the context's Factory, make it a custom factory so the dynamic type can
+            // look up its type information when instantiated during encoding/decoding
             var dynamicContext = new ServiceMessageContext(m_telemetry)
             {
-                Factory = new DynamicEncodeableFactory(Context.Factory, m_telemetry),
+                Factory = new DynamicEncodeableFactory(Context.Factory),
                 NamespaceUris = Context.NamespaceUris
             };
             (dynamicContext.Factory as DynamicEncodeableFactory)?.AddDynamicEncodeable(encodeable);

--- a/Tests/Opc.Ua.Gds.Tests/GlobalDiscoveryTestClient.cs
+++ b/Tests/Opc.Ua.Gds.Tests/GlobalDiscoveryTestClient.cs
@@ -171,8 +171,7 @@ namespace Opc.Ua.Gds.Tests
                 Configuration.ParseExtension<GlobalDiscoveryTestClientConfiguration>();
             GDSClient = new GlobalDiscoveryServerClient(
                 Configuration,
-                gdsClientConfiguration.GlobalDiscoveryServerUrl,
-                m_telemetry)
+                gdsClientConfiguration.GlobalDiscoveryServerUrl)
             {
                 EndpointUrl = TestUtils.PatchOnlyGDSEndpointUrlPort(
                     gdsClientConfiguration.GlobalDiscoveryServerUrl,


### PR DESCRIPTION
## Proposed changes

This PR introduces immutable encodeable factory with lookup performance improvements. The changes replace the existing mutable EncodeableFactory implementation with an immutable design that uses FrozenDictionary for optimized lookups and thread safety.

Key changes:
- Refactored EncodeableFactory to be immutable with a builder pattern for modifications
- Replaced ConcurrentDictionary with FrozenDictionary for 15-20% performance improvements in lookups
- Updated interfaces to separate factory creation from type lookup responsibilities

## Related Issues

- Fixes #

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [x] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
