### PR TITLE
[Server] Handle ApplicationCertificate updates using events: close channels on update and block new Connections / Requests

### DIFF
--- a/Libraries/Opc.Ua.Gds.Client.Common/GlobalDiscoveryServerClient.cs
+++ b/Libraries/Opc.Ua.Gds.Client.Common/GlobalDiscoveryServerClient.cs
@@ -376,6 +376,7 @@ namespace Opc.Ua.Gds.Client
                 }
                 catch (ServiceResultException e) when ((e.StatusCode is
                     StatusCodes.BadServerHalted or
+                    StatusCodes.BadConnectionClosed or
                     StatusCodes.BadSecureChannelClosed or
                     StatusCodes.BadNoCommunication) &&
                     attempt < maxAttempts)
@@ -432,6 +433,7 @@ namespace Opc.Ua.Gds.Client
                 catch (ServiceResultException e) when ((e.StatusCode is
                     StatusCodes.BadServerHalted or
                     StatusCodes.BadSecureChannelClosed or
+                    StatusCodes.BadConnectionClosed or
                     StatusCodes.BadNoCommunication) &&
                     attempt < maxAttempts)
                 {

--- a/Libraries/Opc.Ua.Gds.Client.Common/ServerPushConfigurationClient.cs
+++ b/Libraries/Opc.Ua.Gds.Client.Common/ServerPushConfigurationClient.cs
@@ -290,6 +290,7 @@ namespace Opc.Ua.Gds.Client
                 catch (ServiceResultException e) when ((e.StatusCode is
                     StatusCodes.BadServerHalted or
                     StatusCodes.BadSecureChannelClosed or
+                    StatusCodes.BadConnectionClosed or
                     StatusCodes.BadNoCommunication) &&
                     attempt < maxAttempts)
                 {
@@ -345,6 +346,7 @@ namespace Opc.Ua.Gds.Client
                 catch (ServiceResultException e) when ((e.StatusCode is
                     StatusCodes.BadServerHalted or
                     StatusCodes.BadSecureChannelClosed or
+                    StatusCodes.BadConnectionClosed or
                     StatusCodes.BadNoCommunication) &&
                     attempt < maxAttempts)
                 {

--- a/Libraries/Opc.Ua.Server/Server/StandardServer.cs
+++ b/Libraries/Opc.Ua.Server/Server/StandardServer.cs
@@ -3398,6 +3398,9 @@ namespace Opc.Ua.Server
                     Utils.SilentDispose(m_serverInternal);
                     m_serverInternal = null;
                 }
+
+                CertificateValidator.CertificateUpdate -= OnCertificateUpdateAsync;
+                CertificateValidator.CertificateUpdateStarted -= OnCertificateUpdateStartedAsync;
             }
         }
 

--- a/Libraries/Opc.Ua.Server/Server/StandardServer.cs
+++ b/Libraries/Opc.Ua.Server/Server/StandardServer.cs
@@ -3340,6 +3340,7 @@ namespace Opc.Ua.Server
             }
 
             CertificateValidator.CertificateUpdate += OnCertificateUpdateAsync;
+            CertificateValidator.CertificateUpdateStarted += OnCertificateUpdateStartedAsync;
         }
 
         /// <summary>

--- a/Stack/Opc.Ua.Bindings.Https/Stack/Https/HttpsTransportListener.cs
+++ b/Stack/Opc.Ua.Bindings.Https/Stack/Https/HttpsTransportListener.cs
@@ -615,7 +615,7 @@ namespace Opc.Ua.Bindings
         /// <inheritdoc/>
         public void CloseAllChannels(string reason)
         {
-            // nothing to do
+            Stop();
         }
 
         private EndpointDescriptionCollection m_descriptions;

--- a/Stack/Opc.Ua.Bindings.Https/Stack/Https/HttpsTransportListener.cs
+++ b/Stack/Opc.Ua.Bindings.Https/Stack/Https/HttpsTransportListener.cs
@@ -354,6 +354,9 @@ namespace Opc.Ua.Bindings
         /// </summary>
         public async Task SendAsync(HttpContext context)
         {
+            // wait for certificate update to complete before processing requests.
+            m_quotas.CertificateValidator.CertificateUpdateInProgress.WaitOne();
+
             string message = string.Empty;
             CancellationToken ct = context.RequestAborted;
             try
@@ -606,6 +609,13 @@ namespace Opc.Ua.Bindings
             }
 
             return true;
+        }
+
+
+        /// <inheritdoc/>
+        public void CloseAllChannels(string reason)
+        {
+            // nothing to do
         }
 
         private EndpointDescriptionCollection m_descriptions;

--- a/Stack/Opc.Ua.Core/Security/Certificates/ICertificateValidator.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/ICertificateValidator.cs
@@ -49,7 +49,8 @@ namespace Opc.Ua
         event CertificateUpdateEventHandler CertificateUpdateStarted;
 
         /// <summary>
-        /// An event that signals that a certificate update is in progress.
+        /// A wait handle that is signaled when no certificate update is in progress
+        /// and unsignaled while a certificate update is in progress.
         /// </summary>
         WaitHandle CertificateUpdateInProgress { get; }
 

--- a/Stack/Opc.Ua.Core/Security/Certificates/ICertificateValidator.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/ICertificateValidator.cs
@@ -39,6 +39,29 @@ namespace Opc.Ua
     public interface ICertificateValidator
     {
         /// <summary>
+        /// Raised when an application certificate update occurs.
+        /// </summary>
+        event CertificateUpdateEventHandler CertificateUpdate;
+
+        /// <summary>
+        /// Raised before an application certificate update occurs.
+        /// </summary>
+        event CertificateUpdateEventHandler CertificateUpdateStarted;
+
+        /// <summary>
+        /// An event that signals that a certificate update is in progress.
+        /// </summary>
+        WaitHandle CertificateUpdateInProgress { get; }
+
+        /// <summary>
+        /// Updates the validator with a new application certificate.
+        /// </summary>
+        Task UpdateCertificateAsync(
+            SecurityConfiguration securityConfiguration,
+            string applicationUri = null,
+            CancellationToken ct = default);
+
+        /// <summary>
         /// Validates a certificate.
         /// </summary>
         Task ValidateAsync(X509Certificate2 certificate, CancellationToken ct);

--- a/Stack/Opc.Ua.Core/Stack/Server/ServerBase.cs
+++ b/Stack/Opc.Ua.Core/Stack/Server/ServerBase.cs
@@ -771,7 +771,7 @@ namespace Opc.Ua
         /// <summary>
         /// Called after the application certificate update.
         /// </summary>
-        protected virtual async void OnCertificateUpdateAsync(object sender, CertificateUpdateEventArgs e)
+        protected virtual async Task OnCertificateUpdateAsync(object sender, CertificateUpdateEventArgs e)
         {
             try
             {
@@ -808,6 +808,25 @@ namespace Opc.Ua
             {
                 m_logger.LogError(ex, "Failed to update Instance Certificates: {EventArgs}", e);
             }
+        }
+
+        /// <summary>
+        /// Called before the application certificate update.
+        /// </summary>
+        protected virtual Task OnCertificateUpdateStartedAsync(object sender, CertificateUpdateEventArgs e)
+        {
+            try
+            {
+                foreach (ITransportListener listener in TransportListeners)
+                {
+                    listener.CloseAllChannels("Update of ApplicationCertificate");
+                }
+            }
+            catch (Exception ex)
+            {
+                m_logger.LogError(ex, "Failed to close all channels on certificate update: {EventArgs}", e);
+            }
+            return Task.CompletedTask;
         }
 
         /// <summary>

--- a/Stack/Opc.Ua.Core/Stack/Tcp/TcpTransportListener.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/TcpTransportListener.cs
@@ -816,12 +816,11 @@ namespace Opc.Ua.Bindings
             {
                 bool isBlocked = false;
 
-                // Add null check before accessing CertificateValidator
                 ICertificateValidator certificateValidator = m_quotas?.CertificateValidator;
                 if (certificateValidator == null)
                 {
-                    // Listener is being disposed, don't process this connection
-                    m_logger?.LogDebug("OnAccept: CertificateValidator is null, listener likely disposed.");
+                    // Listener is closed, don't process this connection
+                    m_logger?.LogDebug("OnAccept: CertificateValidator is null, listener is closed.");
                     e?.Dispose();
                     return;
                 }

--- a/Stack/Opc.Ua.Core/Stack/Tcp/TcpTransportListener.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/TcpTransportListener.cs
@@ -816,8 +816,18 @@ namespace Opc.Ua.Bindings
             {
                 bool isBlocked = false;
 
+                // Add null check before accessing CertificateValidator
+                ICertificateValidator certificateValidator = m_quotas?.CertificateValidator;
+                if (certificateValidator == null)
+                {
+                    // Listener is being disposed, don't process this connection
+                    m_logger?.LogDebug("OnAccept: CertificateValidator is null, listener likely disposed.");
+                    e?.Dispose();
+                    return;
+                }
+
                 // wait for certificate update to complete
-                m_quotas.CertificateValidator.CertificateUpdateInProgress.WaitOne();
+                certificateValidator.CertificateUpdateInProgress.WaitOne();
 
                 // Track potential problematic client behavior only if Basic128Rsa15 security policy is offered
                 if (m_activeClientTracker != null)

--- a/Stack/Opc.Ua.Core/Stack/Tcp/TcpTransportListener.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/TcpTransportListener.cs
@@ -402,6 +402,15 @@ namespace Opc.Ua.Bindings
         }
 
         /// <inheritdoc/>
+        public void CloseAllChannels(string reason)
+        {
+            foreach (TcpListenerChannel channel in m_channels.Values.ToList())
+            {
+                channel.ForceClose(reason);
+            }
+        }
+
+        /// <inheritdoc/>
         public void UpdateChannelLastActiveTime(string globalChannelId)
         {
             try
@@ -806,6 +815,9 @@ namespace Opc.Ua.Bindings
             do
             {
                 bool isBlocked = false;
+
+                // wait for certificate update to complete
+                m_quotas.CertificateValidator.CertificateUpdateInProgress.WaitOne();
 
                 // Track potential problematic client behavior only if Basic128Rsa15 security policy is offered
                 if (m_activeClientTracker != null)

--- a/Stack/Opc.Ua.Core/Stack/Transport/ITransportListener.cs
+++ b/Stack/Opc.Ua.Core/Stack/Transport/ITransportListener.cs
@@ -75,6 +75,11 @@ namespace Opc.Ua
         void Close();
 
         /// <summary>
+        /// Closes all connections of the listener.
+        /// </summary>
+        void CloseAllChannels(string reason);
+
+        /// <summary>
         /// Updates the application certificate for a listener.
         /// </summary>
         void CertificateUpdate(

--- a/Tests/Opc.Ua.Client.Tests/ClientFixture.cs
+++ b/Tests/Opc.Ua.Client.Tests/ClientFixture.cs
@@ -241,6 +241,7 @@ namespace Opc.Ua.Client.Tests
                 catch (ServiceResultException e) when ((e.StatusCode is
                     StatusCodes.BadServerHalted or
                     StatusCodes.BadSecureChannelClosed or
+                    StatusCodes.BadConnectionClosed or
                     StatusCodes.BadNoCommunication) &&
                     attempt < maxAttempts)
                 {
@@ -286,6 +287,7 @@ namespace Opc.Ua.Client.Tests
                 catch (ServiceResultException e) when ((e.StatusCode is
                     StatusCodes.BadServerHalted or
                     StatusCodes.BadSecureChannelClosed or
+                    StatusCodes.BadConnectionClosed or
                     StatusCodes.BadNoCommunication) &&
                     attempt < maxAttempts)
                 {

--- a/Tests/Opc.Ua.Core.Tests/Security/Certificates/CertificateValidatorTest.cs
+++ b/Tests/Opc.Ua.Core.Tests/Security/Certificates/CertificateValidatorTest.cs
@@ -2073,8 +2073,9 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
             }
         }
 
-        private void OnCertificateUpdate(object sender, CertificateUpdateEventArgs e)
+        private Task OnCertificateUpdate(object sender, CertificateUpdateEventArgs e)
         {
+            return Task.CompletedTask;
         }
 
         private void OnCertificateValidation(object sender, CertificateValidationEventArgs e)

--- a/Tests/Opc.Ua.Security.Certificates.Tests/Pkcs10CertificationRequestTests.cs
+++ b/Tests/Opc.Ua.Security.Certificates.Tests/Pkcs10CertificationRequestTests.cs
@@ -293,6 +293,8 @@ namespace Opc.Ua.Security.Certificates.Tests
             Assert.Greater(requestInfo.Length, 0);
         }
 
+        private static readonly string[] domainNames = new[] { "localhost" };
+
         /// <summary>
         /// Test parsing multiple CSRs in sequence.
         /// </summary>
@@ -310,7 +312,7 @@ namespace Opc.Ua.Security.Certificates.Tests
                 using X509Certificate2 certificate = CertificateBuilder.Create(subject)
                     .SetNotBefore(DateTime.UtcNow.AddDays(-1))
                     .SetLifeTime(TimeSpan.FromDays(30))
-                    .AddExtension(new X509SubjectAltNameExtension(applicationUri, new[] { "localhost" }))
+                    .AddExtension(new X509SubjectAltNameExtension(applicationUri, domainNames))
                     .CreateForRSA();
 
                 byte[] csrData = CertificateFactory.CreateSigningRequest(certificate);

--- a/Tests/Opc.Ua.Server.Tests/CreateSessionApplicationUriValidationTests.cs
+++ b/Tests/Opc.Ua.Server.Tests/CreateSessionApplicationUriValidationTests.cs
@@ -341,6 +341,7 @@ namespace Opc.Ua.Server.Tests
                     catch (ServiceResultException e) when ((e.StatusCode is
                         StatusCodes.BadServerHalted or
                         StatusCodes.BadSecureChannelClosed or
+                        StatusCodes.BadConnectionClosed or
                         StatusCodes.BadNoCommunication or
                         StatusCodes.BadNotConnected) &&
                         attempt < maxAttempts)


### PR DESCRIPTION
## Proposed changes

Introduce async certificate update events (`Started`/`Completed`) in `CertificateValidator` and `ICertificateValidator`. Add `CertificateUpdateInProgress` wait handle for synchronization. Implement `CloseAllChannels` in transport listeners to force-close connections before certificate updates, and add `ForceClose` to `TcpListenerChannel`. Update server logic to close all channels before updating certificates. Refactor and update tests for new async events and certificate update sequencing. Improves security and reliability during certificate rollover.

The behaviour of the Server in case of a Certficate Update now follows the spec more closely:
For each [CertificateGroup](https://reference.opcfoundation.org/search/468?t=CertificateGroup) it may be necessary to call [ApplyChanges](https://reference.opcfoundation.org/search/468?t=ApplyChanges) once the Certificate Update workflow completes. [ApplyChanges ](https://reference.opcfoundation.org/search/468?t=ApplyChanges)is required if one or more of the [Methods](https://reference.opcfoundation.org/search/468?t=Methods) calls returns applyChangesRequired=TRUE.

This step may cause the [Server](https://reference.opcfoundation.org/search/468?t=Server) to close its [Endpoints](https://reference.opcfoundation.org/search/468?t=Endpoints) and force all [Clients](https://reference.opcfoundation.org/search/468?t=Clients) to reconnect. If this happens the [CertificateManager](https://reference.opcfoundation.org/search/468?t=CertificateManager) may need to use the new [Certificate](https://reference.opcfoundation.org/search/468?t=Certificate) to re-establish a [Session](https://reference.opcfoundation.org/search/468?t=Session) with the [Server](https://reference.opcfoundation.org/search/468?t=Server).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.
