### PR TITLE
Fixed timer leaks in ChannelAsyncOperation.EndAsync

### DIFF
--- a/Stack/Opc.Ua.Core/Stack/Tcp/ChannelAsyncOperation.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/ChannelAsyncOperation.cs
@@ -262,7 +262,8 @@ namespace Opc.Ua.Bindings
 #else
                     if (timeout != int.MaxValue || ct != default)
                     {
-                        Task completedTask = await Task.WhenAny(m_tcs.Task, Task.Delay(timeout, ct))
+                        using var delayCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+                        Task completedTask = await Task.WhenAny(m_tcs.Task, Task.Delay(timeout, delayCts.Token))
                             .ConfigureAwait(false);
                         if (m_tcs.Task == completedTask)
                         {
@@ -270,6 +271,7 @@ namespace Opc.Ua.Bindings
                             {
                                 badRequestInterrupted = true;
                             }
+                            delayCts.Cancel();
                         }
                         else
                         {

--- a/Stack/Opc.Ua.Core/Stack/Tcp/ChannelAsyncOperation.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/ChannelAsyncOperation.cs
@@ -249,7 +249,6 @@ namespace Opc.Ua.Bindings
                 try
                 {
                     Task<bool> awaitableTask = m_tcs.Task;
-#if NET6_0_OR_GREATER
                     if (timeout != int.MaxValue)
                     {
                         awaitableTask = m_tcs.Task
@@ -259,33 +258,9 @@ namespace Opc.Ua.Bindings
                     {
                         awaitableTask = m_tcs.Task.WaitAsync(ct);
                     }
-#else
-                    if (timeout != int.MaxValue || ct != default)
+                    if (!await awaitableTask.ConfigureAwait(false))
                     {
-                        using var delayCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-                        Task completedTask = await Task.WhenAny(m_tcs.Task, Task.Delay(timeout, delayCts.Token))
-                            .ConfigureAwait(false);
-                        if (m_tcs.Task == completedTask)
-                        {
-                            if (!m_tcs.Task.Result)
-                            {
-                                badRequestInterrupted = true;
-                            }
-                            delayCts.Cancel();
-                        }
-                        else
-                        {
-                            m_tcs.TrySetCanceled(ct);
-                            badRequestInterrupted = true;
-                        }
-                    }
-                    else
-#endif
-                    {
-                        if (!await awaitableTask.ConfigureAwait(false))
-                        {
-                            badRequestInterrupted = true;
-                        }
+                        badRequestInterrupted = true;
                     }
                 }
                 catch (TimeoutException)

--- a/Stack/Opc.Ua.Types/Polyfills/System.Threading.Tasks.cs
+++ b/Stack/Opc.Ua.Types/Polyfills/System.Threading.Tasks.cs
@@ -34,6 +34,51 @@ namespace System.Threading.Tasks
     /// </summary>
     public static class PolyFills
     {
+#if !NET6_0_OR_GREATER
+        /// <summary>
+        /// Gets a System.Threading.Tasks.Task that will complete when this System.Threading.Tasks.Task
+        ///     completes, when the specified timeout expires, or when the specified System.Threading.CancellationToken
+        /// </summary>
+        /// <typeparam name="T">Task return type</typeparam>
+        /// <param name="task">The task to wait for. Can't be <see langword="null"></see></param>
+        /// <param name="timeout">
+        /// The timeout after which the System.Threading.Tasks.Task should be faulted with
+        /// <br></br>a System.TimeoutException if it hasn't otherwise completed.
+        /// </param>
+        /// <param name="ct">The System.Threading.CancellationToken to monitor for a cancellation request.</param>
+        /// <returns>The System.Threading.Tasks.Task representing the asynchronous wait. It may or
+        ///     may not be the same instance as the current instance.</returns>
+        /// <exception cref="ArgumentNullException"></exception>
+        /// <exception cref="TimeoutException"></exception>
+        public static async Task<T> WaitAsync<T>(this Task<T> task, TimeSpan timeout, CancellationToken ct = default)
+        {
+            if (task is null)
+            {
+                throw new ArgumentNullException(nameof(task));
+            }
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            cts.CancelAfter(timeout);
+            try
+            {
+                var tcs = new TaskCompletionSource<bool>();
+                using (cts.Token.Register(() => tcs.TrySetCanceled(), useSynchronizationContext: false))
+                {
+                    Task completedTask = await Task.WhenAny(task, tcs.Task).ConfigureAwait(false);
+                    if (task != completedTask)
+                    {
+                        ct.ThrowIfCancellationRequested();
+                        throw new TimeoutException("The operation has timed out.");
+                    }
+                }
+                return await task.ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+            {
+                throw new TimeoutException("The operation has timed out.");
+            }
+        }
+#endif
+
 #if !NET8_0_OR_GREATER
         // Copyright Stephen Cleary Nito.AsyncEx
 

--- a/Stack/Opc.Ua.Types/Polyfills/System.Threading.Tasks.cs
+++ b/Stack/Opc.Ua.Types/Polyfills/System.Threading.Tasks.cs
@@ -117,7 +117,7 @@ namespace System.Threading.Tasks
             Task task,
             CancellationToken cancellationToken)
         {
-            var cancelTaskSource =
+            using var cancelTaskSource =
                 new CancellationTokenTaskSource<object>(cancellationToken);
             await (await Task.WhenAny(task, cancelTaskSource.Task).ConfigureAwait(false))
                 .ConfigureAwait(false);


### PR DESCRIPTION
Fixed timer leaks in ChannelAsyncOperation.EndAsync

## Proposed changes

- Added linked cancellation token source for delay task (runtimes <= .NET 6.0)
- Added delay task cancellation (runtimes <= .NET 6.0)

## Related Issues

- Fixes #3668

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

-