### PR TITLE
[Server] Fix Publishing moreNotifications being set to false near MaxMessageQueue size and filter Certificate StatusCodes

### DIFF
--- a/Applications/ConsoleReferenceServer/ConsoleReferenceServer.csproj
+++ b/Applications/ConsoleReferenceServer/ConsoleReferenceServer.csproj
@@ -21,7 +21,6 @@
     <ProjectReference Include="..\..\Stack\Opc.Ua.Core\Opc.Ua.Core.csproj" />
     <ProjectReference Include="..\..\Libraries\Opc.Ua.Configuration\Opc.Ua.Configuration.csproj" />
     <ProjectReference Include="..\..\Libraries\Opc.Ua.Server\Opc.Ua.Server.csproj" />
-    <ProjectReference Include="..\..\Libraries\Opc.Ua.Gds.Server.Common\Opc.Ua.Gds.Server.Common.csproj" />
     <ProjectReference Include="..\Quickstarts.Servers\Quickstarts.Servers.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/Applications/ConsoleReferenceServer/Ctt.ReferenceServer.Config.xml
+++ b/Applications/ConsoleReferenceServer/Ctt.ReferenceServer.Config.xml
@@ -101,24 +101,6 @@
       </ServerSecurityPolicy>
 
       <ServerSecurityPolicy>
-        <SecurityMode>Sign_2</SecurityMode>
-        <SecurityPolicyUri>http://opcfoundation.org/UA/SecurityPolicy#RSA_DH_AesGcm</SecurityPolicyUri>
-      </ServerSecurityPolicy>
-      <ServerSecurityPolicy>
-        <SecurityMode>SignAndEncrypt_3</SecurityMode>
-        <SecurityPolicyUri>http://opcfoundation.org/UA/SecurityPolicy#RSA_DH_AesGcm</SecurityPolicyUri>
-      </ServerSecurityPolicy>
-
-      <ServerSecurityPolicy>
-        <SecurityMode>Sign_2</SecurityMode>
-        <SecurityPolicyUri>http://opcfoundation.org/UA/SecurityPolicy#RSA_DH_ChaChaPoly</SecurityPolicyUri>
-      </ServerSecurityPolicy>
-      <ServerSecurityPolicy>
-        <SecurityMode>SignAndEncrypt_3</SecurityMode>
-        <SecurityPolicyUri>http://opcfoundation.org/UA/SecurityPolicy#RSA_DH_ChaChaPoly</SecurityPolicyUri>
-      </ServerSecurityPolicy>
-
-      <ServerSecurityPolicy>
         <SecurityMode>None_1</SecurityMode>
         <SecurityPolicyUri>http://opcfoundation.org/UA/SecurityPolicy#None</SecurityPolicyUri>
       </ServerSecurityPolicy>

--- a/Applications/Quickstarts.Servers/Quickstarts.Servers.csproj
+++ b/Applications/Quickstarts.Servers/Quickstarts.Servers.csproj
@@ -21,6 +21,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\Stack\Opc.Ua.Core\Opc.Ua.Core.csproj" />
     <ProjectReference Include="..\..\Libraries\Opc.Ua.Server\Opc.Ua.Server.csproj" />
+    <ProjectReference Include="..\..\Libraries\Opc.Ua.Gds.Server.Common\Opc.Ua.Gds.Server.Common.csproj" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Tools\Opc.Ua.SourceGeneration\Opc.Ua.SourceGeneration.csproj">

--- a/Applications/Quickstarts.Servers/ReferenceServer/ReferenceNodeManager.cs
+++ b/Applications/Quickstarts.Servers/ReferenceServer/ReferenceNodeManager.cs
@@ -246,14 +246,15 @@ namespace Quickstarts.ReferenceServer
                             "Duration",
                             DataTypeIds.Duration,
                             ValueRanks.Scalar));
-                    variables.Add(
-                        CreateVariable(
+                    var floatVal = CreateVariable(
                                 staticFolder,
                                 scalarStatic + "Float",
                                 "Float",
                                 DataTypeIds.Float,
                                 ValueRanks.Scalar)
-                            .MinimumSamplingInterval(100));
+                            .MinimumSamplingInterval(100);
+                    floatVal.Value = (float)5;
+                    variables.Add(floatVal);
                     variables.Add(
                         CreateVariable(
                             staticFolder,

--- a/Applications/Quickstarts.Servers/ReferenceServer/ReferenceServer.cs
+++ b/Applications/Quickstarts.Servers/ReferenceServer/ReferenceServer.cs
@@ -60,7 +60,7 @@ namespace Quickstarts.ReferenceServer
         public ReferenceServer(ITelemetryContext telemetry)
             : base(telemetry)
         {
-            m_userDatabase = new JsonUserDatabase("ReferenceServer_Users.json");
+            m_userDatabase = new LinqUserDatabase();
             m_userDatabase.CreateUser("sysadmin", "demo"u8, [Role.SecurityAdmin, Role.AuthenticatedUser]);
             m_userDatabase.CreateUser("user1", "password"u8, [Role.AuthenticatedUser]);
             m_userDatabase.CreateUser("user2", "password1"u8, [Role.AuthenticatedUser]);
@@ -571,6 +571,6 @@ namespace Quickstarts.ReferenceServer
         }
 
         private ICertificateValidator m_userCertificateValidator;
-        private readonly JsonUserDatabase m_userDatabase;
+        private readonly LinqUserDatabase m_userDatabase;
     }
 }

--- a/Applications/Quickstarts.Servers/ReferenceServer/ReferenceServer.cs
+++ b/Applications/Quickstarts.Servers/ReferenceServer/ReferenceServer.cs
@@ -29,9 +29,12 @@
 
 using System;
 using System.Collections.Generic;
+using System.Text;
 using Microsoft.Extensions.Logging;
 using Opc.Ua;
+using Opc.Ua.Gds.Server;
 using Opc.Ua.Server;
+using Opc.Ua.Server.UserDatabase;
 
 namespace Quickstarts.ReferenceServer
 {
@@ -57,6 +60,28 @@ namespace Quickstarts.ReferenceServer
         public ReferenceServer(ITelemetryContext telemetry)
             : base(telemetry)
         {
+            m_userDatabase = new JsonUserDatabase("ReferenceServer_Users.json");
+            m_userDatabase.CreateUser("sysadmin", "demo"u8, [Role.SecurityAdmin, Role.AuthenticatedUser]);
+            m_userDatabase.CreateUser("user1", "password"u8, [Role.AuthenticatedUser]);
+            m_userDatabase.CreateUser("user2", "password1"u8, [Role.AuthenticatedUser]);
+            m_userDatabase.CreateUser(
+                   "SystemAdmin",
+                   Encoding.UTF8.GetBytes("demo"),
+                   [GdsRole.CertificateAuthorityAdmin, GdsRole.DiscoveryAdmin, Role.SecurityAdmin,
+                       Role.ConfigureAdmin, Role.AuthenticatedUser]);
+            m_userDatabase.CreateUser(
+                "AppAdmin",
+                Encoding.UTF8.GetBytes("demo"),
+                [Role.AuthenticatedUser, GdsRole.CertificateAuthorityAdmin,
+                    GdsRole.DiscoveryAdmin, Role.AuthenticatedUser]);
+            m_userDatabase.CreateUser(
+                "DiscoveryAdmin",
+                Encoding.UTF8.GetBytes("demo"),
+                [Role.AuthenticatedUser, GdsRole.DiscoveryAdmin, Role.AuthenticatedUser]);
+            m_userDatabase.CreateUser(
+                "CertificateAuthorityAdmin",
+                Encoding.UTF8.GetBytes("demo"),
+                [Role.AuthenticatedUser, GdsRole.CertificateAuthorityAdmin, Role.AuthenticatedUser]);
         }
 
         /// <summary>
@@ -406,52 +431,37 @@ namespace Quickstarts.ReferenceServer
                     "Security token is not a valid username token. An empty password is not accepted.");
             }
 
-            // User with permission to configure server
-            if (userName == "sysadmin" && Utils.IsEqual(password, "demo"u8))
+            if (m_userDatabase.CheckCredentials(userName, password))
             {
-                var identity = new UserIdentity(userTokenHandler);
+                var userIdentity = new UserIdentity(userTokenHandler);
                 try
                 {
-                    return new SystemConfigurationIdentity(identity);
+                    ICollection<Role> roles = m_userDatabase.GetUserRoles(userName);
+                    return new RoleBasedIdentity(
+                        userIdentity,
+                        roles,
+                        ServerInternal.MessageContext.NamespaceUris);
                 }
                 catch
                 {
-                    identity.Dispose();
+                    userIdentity.Dispose();
                     throw;
                 }
             }
 
-            // standard users for CTT verification
-            if (!((userName == "user1" && Utils.IsEqual(password, "password"u8)) ||
-                (userName == "user2" && Utils.IsEqual(password, "password1"u8))))
-            {
-                // construct translation object with default text.
-                var info = new TranslationInfo(
-                    "InvalidPassword",
-                    "en-US",
-                    "Invalid username or password.",
-                    userName);
+            // construct translation object with default text.
+            var info = new TranslationInfo(
+                "InvalidPassword",
+                "en-US",
+                "Invalid username or password.",
+                userName);
 
-                // create an exception with a vendor defined sub-code.
-                throw new ServiceResultException(
-                    new ServiceResult(
-                        LoadServerProperties().ProductUri,
-                        new StatusCode(StatusCodes.BadUserAccessDenied.Code, "InvalidPassword"),
-                        new LocalizedText(info)));
-            }
-            var userIdentity = new UserIdentity(userTokenHandler);
-            try
-            {
-                return new RoleBasedIdentity(
-                    userIdentity,
-                    [Role.AuthenticatedUser],
-                    ServerInternal.MessageContext.NamespaceUris);
-            }
-            catch
-            {
-                userIdentity.Dispose();
-                throw;
-            }
+            // create an exception with a vendor defined sub-code.
+            throw new ServiceResultException(
+                new ServiceResult(
+                    LoadServerProperties().ProductUri,
+                    new StatusCode(StatusCodes.BadUserAccessDenied.Code, "InvalidPassword"),
+                    new LocalizedText(info)));
         }
 
         /// <summary>
@@ -561,5 +571,6 @@ namespace Quickstarts.ReferenceServer
         }
 
         private ICertificateValidator m_userCertificateValidator;
+        private readonly JsonUserDatabase m_userDatabase;
     }
 }

--- a/Libraries/Opc.Ua.Server/Diagnostics/AuditEvents.cs
+++ b/Libraries/Opc.Ua.Server/Diagnostics/AuditEvents.cs
@@ -1633,7 +1633,13 @@ namespace Opc.Ua.Server
                     new LocalizedText(message),
                     exception == null,
                     actionTimestamp
-                ); // initializes Status, ActionTimeStamp, ServerId, ClientAuditEntryId, ClientUserId
+                ); // initializes Status, ActionTimeStamp, ServerId, ClientUserId
+
+                e.SetChildValue(
+                    systemContext,
+                    BrowseNames.ClientAuditEntryId,
+                    request?.RequestHeader?.AuditEntryId,
+                    false);
 
                 e.SetChildValue(
                     systemContext,

--- a/Libraries/Opc.Ua.Server/Server/StandardServer.cs
+++ b/Libraries/Opc.Ua.Server/Server/StandardServer.cs
@@ -2474,7 +2474,20 @@ namespace Opc.Ua.Server
             ByteString clientCertificate,
             ServiceResult result)
         {
-            throw new ServiceResultException(result);
+            // see https://reference.opcfoundation.org/Core/Part4/v105/docs/6.1.3
+            StatusCode resultCode = result.StatusCode;
+            if (resultCode == StatusCodes.BadCertificateInvalid ||
+                resultCode == StatusCodes.BadCertificateRevoked ||
+                resultCode == StatusCodes.BadCertificateUntrusted ||
+                resultCode == StatusCodes.BadCertificateIssuerRevoked ||
+                resultCode == StatusCodes.BadCertificateRevocationUnknown ||
+                resultCode == StatusCodes.BadCertificateChainIncomplete ||
+                resultCode == StatusCodes.BadCertificateIssuerRevocationUnknown)
+            {
+                resultCode = StatusCodes.BadSecurityChecksFailed;
+            }
+
+            throw new ServiceResultException(new ServiceResult(resultCode, result));
         }
 
         /// <summary>

--- a/Libraries/Opc.Ua.Server/Subscription/Subscription.cs
+++ b/Libraries/Opc.Ua.Server/Subscription/Subscription.cs
@@ -888,8 +888,8 @@ namespace Opc.Ua.Server
                     availableSequenceNumberList.Add(m_sentMessages[ii].SequenceNumber);
                 }
 
-                moreNotifications = m_waitingForPublish = m_lastSentMessage < m_sentMessages.Count -
-                    1;
+                moreNotifications = m_waitingForPublish = (m_lastSentMessage < m_sentMessages.Count - 1) ||
+                    m_itemsToPublish.Count > 0;
 
                 // TraceState(LogLevel.Trace, TraceStateId.Items, "PUBLISH QUEUED MESSAGE");
                 availableSequenceNumbers = availableSequenceNumberList;

--- a/Tests/Opc.Ua.Server.Tests/SubscriptionTests.cs
+++ b/Tests/Opc.Ua.Server.Tests/SubscriptionTests.cs
@@ -256,5 +256,78 @@ namespace Opc.Ua.Server.Tests
             // Verify IsReadyToTrigger on A was reset to false
             Assert.That(itemAMock.Object.IsReadyToTrigger, Is.False, "IsReadyToTrigger should be reset");
         }
+
+        private static void AddMonitoredItemToPublish(Subscription subscription, IMonitoredItem item)
+        {
+            FieldInfo itemsToPublishField = typeof(Subscription).GetField("m_itemsToPublish", BindingFlags.NonPublic | BindingFlags.Instance)
+                ?? throw new InvalidOperationException("Field m_itemsToPublish not found");
+            var itemsToPublish = (LinkedList<IMonitoredItem>)itemsToPublishField.GetValue(subscription);
+            itemsToPublish.AddLast(item);
+        }
+
+        [Test]
+        public void Publish_MultipleTimes_WithMaxMessageCount()
+        {
+            using var subscription = new Subscription(m_serverMock.Object, m_sessionMock.Object, 1, 100, 1000, 10, 1, 0, true, 2);
+            var itemMock = new Mock<IDataChangeMonitoredItem2>();
+
+            var values = new List<MonitoredItemNotification>
+            {
+                new MonitoredItemNotification { Value = new DataValue(1) },
+                new MonitoredItemNotification { Value = new DataValue(2) },
+                new MonitoredItemNotification { Value = new DataValue(3) }
+            };
+
+            int counter = 0;
+            itemMock.Setup(i => i.Publish(
+                It.IsAny<OperationContext>(),
+                It.IsAny<Queue<MonitoredItemNotification>>(),
+                It.IsAny<Queue<DiagnosticInfo>>(),
+                It.IsAny<uint>(),
+                It.IsAny<Microsoft.Extensions.Logging.ILogger>()))
+                .Returns<OperationContext, Queue<MonitoredItemNotification>, Queue<DiagnosticInfo>, uint, Microsoft.Extensions.Logging.ILogger>(
+                (ctx, nq, dq, max, logger) =>
+                {
+                    if (counter < values.Count)
+                    {
+                        nq.Enqueue(values[counter++]);
+                        dq.Enqueue(new DiagnosticInfo());
+                        itemMock.SetupGet(x => x.IsReadyToPublish).Returns(counter < values.Count);
+                        return counter < values.Count;
+                    }
+                    return false;
+                });
+            itemMock.SetupGet(i => i.Id).Returns(1);
+            itemMock.SetupGet(i => i.IsReadyToPublish).Returns(true);
+            itemMock.SetupGet(i => i.AttributeId).Returns(Attributes.Value);
+            itemMock.SetupGet(i => i.MonitoredItemType).Returns(MonitoredItemTypeMask.DataChange);
+
+            AddMonitoredItem(subscription, itemMock.Object);
+            SetExpiryTime(subscription, HiResClock.TickCount64 - 100);
+            PublishingState state = subscription.PublishTimerExpired();
+
+            AddMonitoredItemToPublish(subscription, itemMock.Object);
+
+            var messages = new List<NotificationMessage>();
+
+            // First publish
+            var ctx1 = new OperationContext(m_sessionMock.Object, new DiagnosticsMasks());
+            var message = subscription.Publish(ctx1, out var availableSequenceNumbers, out bool moreNotifications1);
+            messages.Add(message);
+
+            // Should be more because we generated multiple notifications and limit the max per publish to 1 for tests.
+            Assert.That(moreNotifications1, Is.True);
+
+            // Second publish
+            var message2 = subscription.Publish(ctx1, out availableSequenceNumbers, out bool moreNotifications2);
+
+            // third publish
+            var message3 = subscription.Publish(ctx1, out availableSequenceNumbers, out bool moreNotifications3);
+            
+            Assert.That(message2, Is.Not.Null);
+            Assert.That(message3, Is.Not.Null);
+            Assert.That(moreNotifications2, Is.True);
+            Assert.That(moreNotifications3, Is.False);
+        }
     }
 }


### PR DESCRIPTION
## Proposed changes

- filter CertifiicateStatusCodes before returing to client https://reference.opcfoundation.org/Core/Part4/v105/docs/6.1.3
- fix ClientAuditEntryId for ReportAuditOpenSecureChannelEvent
- fix subscription publish bug wrongly reporting moreNotifications as false
## Related Issues

- Fixes #3733
- Fixes #3722

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.
