### PR TITLE
[Client] Fixed excessive tasks spawning during session connection loss (cherry pick PR #3707)

### DIFF
--- a/Libraries/Opc.Ua.Client/Session/Session.cs
+++ b/Libraries/Opc.Ua.Client/Session/Session.cs
@@ -3370,6 +3370,12 @@ namespace Opc.Ua.Client
                 return false;
             }
 
+            if (KeepAliveStopped)
+            {
+                m_logger.LogWarning("Publish skipped due to session lost connection. Last successfull keepalive: {LastKeepAlive}", LastKeepAliveTime);
+                return false;
+            }
+
             // get event handler to modify ack list
             PublishSequenceNumbersToAcknowledgeEventHandler? callback
                 = m_PublishSequenceNumbersToAcknowledge;

--- a/Libraries/Opc.Ua.Client/Subscription/Subscription.cs
+++ b/Libraries/Opc.Ua.Client/Subscription/Subscription.cs
@@ -44,7 +44,6 @@ namespace Opc.Ua.Client
     /// </summary>
     public class Subscription : ISnapshotRestore<SubscriptionState>, IDisposable, ICloneable
     {
-        private const int kMinKeepAliveTimerInterval = 1000;
         private const int kKeepAliveTimerMargin = 1000;
         private const int kRepublishMessageExpiredTimeout = 10000;
 
@@ -52,6 +51,11 @@ namespace Opc.Ua.Client
         /// Duration to wait before republishing missed notification
         /// </summary>
         public const int RepublishMessageTimeout = 2500;
+
+        /// <summary>
+        /// Minimum keep alive interval
+        /// </summary>
+        public const int MinKeepAliveTimerInterval = 1000;
 
         /// <summary>
         /// Create subscription
@@ -2125,7 +2129,9 @@ namespace Opc.Ua.Client
 
             if (session != null &&
                 session.Connected &&
-                !session.Reconnecting)
+                !session.Reconnecting &&
+                !session.KeepAliveStopped
+                )
             {
                 TraceState("PUBLISHING STOPPED");
 
@@ -2219,7 +2225,7 @@ namespace Opc.Ua.Client
         {
             return Math.Max(
                 Math.Min(m_keepAliveInterval * 3, int.MaxValue),
-                kMinKeepAliveTimerInterval);
+                MinKeepAliveTimerInterval);
         }
 
         /// <summary>
@@ -2333,12 +2339,12 @@ namespace Opc.Ua.Client
         {
             int keepAliveInterval = (int)
                 Math.Min(CurrentPublishingInterval * (CurrentKeepAliveCount + 1), int.MaxValue);
-            if (keepAliveInterval < kMinKeepAliveTimerInterval)
+            if (keepAliveInterval < MinKeepAliveTimerInterval)
             {
                 keepAliveInterval = (int)Math.Min(
                     PublishingInterval * (KeepAliveCount + 1),
                     int.MaxValue);
-                keepAliveInterval = Math.Max(kMinKeepAliveTimerInterval, keepAliveInterval);
+                keepAliveInterval = Math.Max(MinKeepAliveTimerInterval, keepAliveInterval);
             }
             return keepAliveInterval;
         }

--- a/Tests/Opc.Ua.Client.Tests/SubscriptionUnitTests.cs
+++ b/Tests/Opc.Ua.Client.Tests/SubscriptionUnitTests.cs
@@ -42,7 +42,23 @@ namespace Opc.Ua.Client.Tests
     [Parallelizable]
     public class SubscriptionUnitTests
     {
-        private class SubscriptionContainer : IDisposable
+        private const PublishStateChangedMask kSessionNotConnected = PublishStateChangedMask.Stopped | PublishStateChangedMask.SessionNotConnected;
+
+        public record KeepAliveTestDataProvider(PublishStateChangedMask ExpectedPublishState) : IFormattable
+        {
+            public bool SessionConnected { get; init; }
+            public bool SessionReconnecting { get; init; }
+            public bool SessionKeepAliveStopped { get; init; }
+            public string ToString(string format, IFormatProvider formatProvider)
+            {
+                return $"Connected={SessionConnected}, " +
+                    $"reconnecting={SessionReconnecting}, " +
+                    $"keepAlive={SessionKeepAliveStopped}. " +
+                    $"Expected status:{ExpectedPublishState}";
+            }
+        }
+
+        private sealed class SubscriptionContainer : IDisposable
         {
             private readonly CancellationTokenRegistration m_tokedCancellation;
             public Subscription Subscription { get; }
@@ -73,28 +89,31 @@ namespace Opc.Ua.Client.Tests
             return Task.Delay(Subscription.RepublishMessageTimeout + 100, ct);
         }
 
-        private static ISession BuildSessionMock(Func<uint, uint, bool> republishHandler)
+        private static ISession BuildSessionMock(Func<uint, uint, bool> republishHandler = null, Action<Mock<ISession>> setup = null)
         {
             uint subscriptionIdSeed = 0u;
 
             var session = new Mock<ISession>();
-            session
-                .Setup(x => x.RepublishAsync(It.IsAny<uint>(), It.IsAny<uint>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync<uint, uint, CancellationToken, ISession, (bool, ServiceResult)>((
-                    subscriptionId,
-                    sequenceNumber,
-                    ct) =>
-                {
-                    if (subscriptionId > subscriptionIdSeed)
+            if (republishHandler is not null)
+            {
+                session
+                    .Setup(x => x.RepublishAsync(It.IsAny<uint>(), It.IsAny<uint>(), It.IsAny<CancellationToken>()))
+                    .ReturnsAsync<uint, uint, CancellationToken, ISession, (bool, ServiceResult)>((
+                        subscriptionId,
+                        sequenceNumber,
+                        ct) =>
                     {
-                        return (true, StatusCodes.BadSubscriptionIdInvalid);
-                    }
-                    if (republishHandler(subscriptionId, sequenceNumber))
-                    {
-                        return (true, ServiceResult.Good);
-                    }
-                    return (true, StatusCodes.BadMessageNotAvailable);
-                });
+                        if (subscriptionId > subscriptionIdSeed)
+                        {
+                            return (true, StatusCodes.BadSubscriptionIdInvalid);
+                        }
+                        if (republishHandler(subscriptionId, sequenceNumber))
+                        {
+                            return (true, ServiceResult.Good);
+                        }
+                        return (true, StatusCodes.BadMessageNotAvailable);
+                    });
+            }
             session
                 .Setup(x => x
                     .CreateSubscriptionAsync(
@@ -144,6 +163,7 @@ namespace Opc.Ua.Client.Tests
                         Results = [.. subscriptionIds.Select(id => id > subscriptionIdSeed ? StatusCodes.BadSubscriptionIdInvalid : StatusCodes.Good)],
                         DiagnosticInfos = [.. subscriptionIds.Select(_ => new DiagnosticInfo())]
                     });
+            setup?.Invoke(session);
             return session.Object;
         }
 
@@ -349,6 +369,49 @@ namespace Opc.Ua.Client.Tests
             {
                 Assert.That(subscription.Notifications, Is.EquivalentTo(messages.Skip(1)));
             }
+        }
+
+        [DatapointSource]
+        public IEnumerable<KeepAliveTestDataProvider> SubscriptionKeepAliveValues()
+        {
+            yield return new(PublishStateChangedMask.Stopped) { SessionConnected = true, SessionReconnecting = false, SessionKeepAliveStopped = false };
+
+            yield return new(kSessionNotConnected) { SessionConnected = false, SessionReconnecting = false, SessionKeepAliveStopped = false };
+            yield return new(kSessionNotConnected) { SessionConnected = false, SessionReconnecting = true, SessionKeepAliveStopped = false };
+            yield return new(kSessionNotConnected) { SessionConnected = false, SessionReconnecting = false, SessionKeepAliveStopped = true };
+            yield return new(kSessionNotConnected) { SessionConnected = false, SessionReconnecting = true, SessionKeepAliveStopped = true };
+
+            yield return new(kSessionNotConnected) { SessionConnected = true, SessionReconnecting = true, SessionKeepAliveStopped = false };
+            yield return new(kSessionNotConnected) { SessionConnected = true, SessionReconnecting = true, SessionKeepAliveStopped = true };
+
+            yield return new(kSessionNotConnected) { SessionConnected = true, SessionReconnecting = false, SessionKeepAliveStopped = true };
+        }
+
+        [Theory]
+        [CancelAfter(Subscription.MinKeepAliveTimerInterval * 10)]
+        public async Task RespectsStateOfSessionDuringKeepAliveCalls(KeepAliveTestDataProvider testData, CancellationToken ct)
+        {
+            var keepAliveCompleted = new TaskCompletionSource<PublishStateChangedMask>(TaskCreationOptions.RunContinuationsAsynchronously);
+            void KeepAliveHasTriggered(Subscription x, PublishStateChangedEventArgs y) => keepAliveCompleted.TrySetResult(y.Status);
+            ISession session = BuildSessionMock(
+                setup: mock =>
+                {
+                    mock.Setup(x => x.Connected).Returns(testData.SessionConnected);
+                    mock.Setup(x => x.Reconnecting).Returns(testData.SessionReconnecting);
+                    mock.Setup(x => x.KeepAliveStopped).Returns(testData.SessionKeepAliveStopped);
+                });
+
+            using var subscription = new Subscription(
+                NUnitTelemetryContext.Create(),
+                new() { PublishingEnabled = true })
+            {
+                Session = session
+            };
+            subscription.PublishStatusChanged += KeepAliveHasTriggered;
+            await subscription.CreateAsync(ct).ConfigureAwait(false);
+            await Task.WhenAny(keepAliveCompleted.Task, Task.Delay(-1, ct)).ConfigureAwait(false);
+
+            Assert.That(keepAliveCompleted.Task.Result, Is.EqualTo(testData.ExpectedPublishState));
         }
     }
 }


### PR DESCRIPTION
## Proposed changes

Cherry pick PR [#3707](https://github.com/OPCFoundation/UA-.NETStandard/pull/3707)
Was already merged into ```master```, but missing in ```master378```

Resolved conflicts:
	Tests/Opc.Ua.Client.Tests/SubscriptionUnitTests.cs

## Related Issues

- Cherry pick PR [#3707](https://github.com/OPCFoundation/UA-.NETStandard/pull/3707)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [x] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.