### PR TITLE
Fix PrioritizedChannel polyfill missing Count/CanCount overrides

### DIFF
--- a/Libraries/Opc.Ua.Client/Utils/PrioritizedChannel.cs
+++ b/Libraries/Opc.Ua.Client/Utils/PrioritizedChannel.cs
@@ -207,6 +207,21 @@ namespace System.Threading.Channels
                 m_channel = channel;
             }
 
+            /// <inheritdoc/>
+            public override bool CanCount => true;
+
+            /// <inheritdoc/>
+            public override int Count
+            {
+                get
+                {
+                    lock (m_channel.m_lock)
+                    {
+                        return m_channel.m_heap.Count;
+                    }
+                }
+            }
+
             public override bool TryRead(out T item)
             {
                 lock (m_channel.m_lock)

--- a/Tests/Opc.Ua.Client.Tests/Utils/PrioritizedChannelTests.cs
+++ b/Tests/Opc.Ua.Client.Tests/Utils/PrioritizedChannelTests.cs
@@ -252,6 +252,32 @@ namespace Opc.Ua.Types.Polyfills.Tests
             Assert.That(channel.Reader.TryRead(out int item), Is.True);
             Assert.That(item, Is.EqualTo(7));
         }
+
+        /// <summary>
+        /// Regression test: the reader must support Count / CanCount the same
+        /// way the framework's UnboundedPrioritizedChannel does. Without these
+        /// the SubscriptionManager publish worker (which calls
+        /// <c>m_acks.Reader.Count</c>) would throw NotSupportedException on
+        /// runtimes that fall back to this polyfill, leading to a tight loop
+        /// of worker re-creation.
+        /// </summary>
+        [Test]
+        public void ReaderSupportsCount()
+        {
+            Channel<int> channel = CreateChannel();
+
+            Assert.That(channel.Reader.CanCount, Is.True);
+            Assert.That(channel.Reader.Count, Is.EqualTo(0));
+
+            Assert.That(channel.Writer.TryWrite(1), Is.True);
+            Assert.That(channel.Writer.TryWrite(2), Is.True);
+            Assert.That(channel.Writer.TryWrite(3), Is.True);
+            Assert.That(channel.Reader.Count, Is.EqualTo(3));
+
+            Assert.That(channel.Reader.TryRead(out int item), Is.True);
+            Assert.That(item, Is.EqualTo(1));
+            Assert.That(channel.Reader.Count, Is.EqualTo(2));
+        }
     }
 }
 #endif


### PR DESCRIPTION
Fixes failures on the master CI run for `Tests-Opc.Ua.Client.Tests-windows` (net48) introduced after PR #3747 was merged.

## Problem

The `SubscriptionManager` publish worker calls `m_acks.Reader.Count` outside its inner `try` block. On runtimes that fall back to the `PrioritizedChannel` polyfill (net48), the base `ChannelReader<T>.Count` throws `NotSupportedException` because `PrioritizedReader` did not override `CanCount` / `Count`.

Result: every publish worker iteration crashes immediately at `GetAcksReadyToSend`, the worker task completes, the controller recreates the worker, and the cycle repeats as a tight loop. This prevents any actual publish from happening and causes integration tests that wait for subscription data to time out:

- `SubscriptionRecoversAfterAutomaticReconnect`
- `SubscriptionRecoversAfterFailover`
- `TransferSubscriptionsKeepsV2SubscriptionWorkingAfterReconnect`
- `BuilderTransferSubscriptionsOnRecreateOptInAppliesToV2Manager`

The framework's `UnboundedPrioritizedChannel<T>` reader (used on .NET 9+) overrides `Count` to expose the underlying queue count; the polyfill must do the same.

## Fix

Add `CanCount` / `Count` overrides to `PrioritizedReader` that read the underlying heap count under the channel lock.

## Test

Added `PrioritizedChannelTests.ReaderSupportsCount` regression test. Verified all 4 previously-failing reconnect integration tests pass on net48 locally (28s total).