### PR TITLE
Fix string Contains polyfills to honor StringComparison parameter

### DIFF
--- a/Stack/Opc.Ua.Types/Polyfills/System.cs
+++ b/Stack/Opc.Ua.Types/Polyfills/System.cs
@@ -73,7 +73,7 @@ namespace System
         /// </summary>
         public static bool Contains(this string target, char value, StringComparison comparisonType)
         {
-            return target.Contains(value);
+            return target.IndexOf(value, comparisonType) >= 0;
         }
 
         /// <summary>
@@ -84,7 +84,7 @@ namespace System
             string value,
             StringComparison comparisonType)
         {
-            return target.Contains(value);
+            return target.IndexOf(value, comparisonType) >= 0;
         }
 
         /// <summary>


### PR DESCRIPTION
## Proposed changes

This PR fixes the String polyfill Contains(this string, char, StringComparison) overloads in System.cs for NETSTANDARD2_0 / NETFRAMEWORK so they correctly honor the StringComparison argument.

## What changed

- Updated Contains(this string target, char value, StringComparison comparisonType) to use comparison-aware lookup.
- Updated Contains(this string target, string value, StringComparison comparisonType) to use comparison-aware lookup.
- Behaviour now matches the intent of the API contract instead of ignoring the comparisonType parameter.

This is a non-breaking bug fix for legacy target frameworks.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [x] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

This change is intentionally minimal and scoped to the polyfill behaviour only. No public API surface was changed.
