### PR TITLE
Add OPC UA Server FileSystem (Part 20) and Local Discovery Server libraries

### DIFF
--- a/Applications/ConsoleLdsServer/ConsoleLdsServer.csproj
+++ b/Applications/ConsoleLdsServer/ConsoleLdsServer.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>$(AppTargetFrameWorks)</TargetFrameworks>
+    <AssemblyName>ConsoleLdsServer</AssemblyName>
+    <OutputType>Exe</OutputType>
+    <PackageId>ConsoleLdsServer</PackageId>
+    <Company>OPC Foundation</Company>
+    <Description>.NET Console Local Discovery Server (LDS / LDS-ME)</Description>
+    <Copyright>Copyright © 2004-2025 OPC Foundation, Inc</Copyright>
+    <RootNamespace>Opc.Ua.Lds.Server.Console</RootNamespace>
+    <PublishAot Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))">true</PublishAot>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Stack\Opc.Ua.Core\Opc.Ua.Core.csproj" />
+    <ProjectReference Include="..\..\Libraries\Opc.Ua.Configuration\Opc.Ua.Configuration.csproj" />
+    <ProjectReference Include="..\..\Libraries\Opc.Ua.Lds.Server\Opc.Ua.Lds.Server.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging" />
+    <PackageReference Include="System.CommandLine" />
+    <PackageReference Include="Serilog" />
+    <PackageReference Include="Serilog.Sinks.Console" />
+    <PackageReference Include="Serilog.Extensions.Logging" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Update="Lds.Server.Config.xml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+</Project>

--- a/Applications/ConsoleLdsServer/Lds.Server.Config.xml
+++ b/Applications/ConsoleLdsServer/Lds.Server.Config.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ApplicationConfiguration
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:ua="http://opcfoundation.org/UA/2008/02/Types.xsd"
+  xmlns="http://opcfoundation.org/UA/SDK/Configuration.xsd"
+>
+  <ApplicationName>OPC UA Local Discovery Server</ApplicationName>
+  <ApplicationUri>urn:localhost:UA:LocalDiscoveryServer</ApplicationUri>
+  <ProductUri>uri:opcfoundation.org:LocalDiscoveryServer</ProductUri>
+  <ApplicationType>DiscoveryServer_3</ApplicationType>
+  <SecurityConfiguration>
+    <ApplicationCertificates>
+      <CertificateIdentifier>
+        <StoreType>Directory</StoreType>
+        <StorePath>%LocalApplicationData%/OPC Foundation/pki/own</StorePath>
+        <SubjectName>CN=OPC UA Local Discovery Server, C=US, S=Arizona, O=OPC Foundation, DC=localhost</SubjectName>
+        <CertificateTypeString>RsaSha256</CertificateTypeString>
+      </CertificateIdentifier>
+    </ApplicationCertificates>
+    <TrustedIssuerCertificates>
+      <StoreType>Directory</StoreType>
+      <StorePath>%LocalApplicationData%/OPC Foundation/pki/issuer</StorePath>
+    </TrustedIssuerCertificates>
+    <TrustedPeerCertificates>
+      <StoreType>Directory</StoreType>
+      <StorePath>%LocalApplicationData%/OPC Foundation/pki/trusted</StorePath>
+    </TrustedPeerCertificates>
+    <RejectedCertificateStore>
+      <StoreType>Directory</StoreType>
+      <StorePath>%LocalApplicationData%/OPC Foundation/pki/rejected</StorePath>
+    </RejectedCertificateStore>
+    <MaxRejectedCertificates>5</MaxRejectedCertificates>
+    <AutoAcceptUntrustedCertificates>false</AutoAcceptUntrustedCertificates>
+    <RejectSHA1SignedCertificates>true</RejectSHA1SignedCertificates>
+    <RejectUnknownRevocationStatus>true</RejectUnknownRevocationStatus>
+    <MinimumCertificateKeySize>2048</MinimumCertificateKeySize>
+    <AddAppCertToTrustedStore>false</AddAppCertToTrustedStore>
+    <SendCertificateChain>true</SendCertificateChain>
+  </SecurityConfiguration>
+  <TransportConfigurations></TransportConfigurations>
+  <TransportQuotas>
+    <OperationTimeout>120000</OperationTimeout>
+    <MaxStringLength>1048576</MaxStringLength>
+    <MaxByteStringLength>1048576</MaxByteStringLength>
+    <MaxArrayLength>65535</MaxArrayLength>
+    <MaxMessageSize>4194304</MaxMessageSize>
+    <MaxBufferSize>65535</MaxBufferSize>
+    <ChannelLifetime>30000</ChannelLifetime>
+    <SecurityTokenLifetime>3600000</SecurityTokenLifetime>
+  </TransportQuotas>
+  <!--
+    Note: the LDS subclasses ServerBase via DiscoveryServerBase. Per Part 12 the
+    standard endpoint is opc.tcp://{host}:4840. We populate <ServerConfiguration>
+    (not <DiscoveryServerConfiguration>) because ServerBase startup paths read
+    SecurityPolicies, UserTokenPolicies, and ServerCapabilities from the former.
+  -->
+  <ServerConfiguration>
+    <BaseAddresses>
+      <ua:String>opc.tcp://localhost:4840</ua:String>
+    </BaseAddresses>
+    <SecurityPolicies>
+      <ServerSecurityPolicy>
+        <SecurityMode>None_1</SecurityMode>
+        <SecurityPolicyUri>http://opcfoundation.org/UA/SecurityPolicy#None</SecurityPolicyUri>
+      </ServerSecurityPolicy>
+      <ServerSecurityPolicy>
+        <SecurityMode>Sign_2</SecurityMode>
+        <SecurityPolicyUri>http://opcfoundation.org/UA/SecurityPolicy#Basic256Sha256</SecurityPolicyUri>
+      </ServerSecurityPolicy>
+      <ServerSecurityPolicy>
+        <SecurityMode>SignAndEncrypt_3</SecurityMode>
+        <SecurityPolicyUri>http://opcfoundation.org/UA/SecurityPolicy#Basic256Sha256</SecurityPolicyUri>
+      </ServerSecurityPolicy>
+    </SecurityPolicies>
+    <MinRequestThreadCount>5</MinRequestThreadCount>
+    <MaxRequestThreadCount>100</MaxRequestThreadCount>
+    <MaxQueuedRequestCount>2000</MaxQueuedRequestCount>
+    <UserTokenPolicies>
+      <ua:UserTokenPolicy>
+        <ua:TokenType>Anonymous_0</ua:TokenType>
+      </ua:UserTokenPolicy>
+    </UserTokenPolicies>
+    <DiagnosticsEnabled>false</DiagnosticsEnabled>
+    <MaxSessionCount>0</MaxSessionCount>
+    <MaxChannelCount>1000</MaxChannelCount>
+    <MaxRequestAge>600000</MaxRequestAge>
+    <ServerProfileArray>
+      <ua:String>http://opcfoundation.org/UA-Profile/Server/LocalDiscovery2017</ua:String>
+    </ServerProfileArray>
+    <ShutdownDelay>5</ShutdownDelay>
+    <ServerCapabilities>
+      <ua:String>LDS</ua:String>
+    </ServerCapabilities>
+    <SupportedPrivateKeyFormats>
+      <ua:String>PFX</ua:String>
+      <ua:String>PEM</ua:String>
+    </SupportedPrivateKeyFormats>
+    <MaxTrustListSize>0</MaxTrustListSize>
+    <MultiCastDnsEnabled>false</MultiCastDnsEnabled>
+  </ServerConfiguration>
+  <TraceConfiguration>
+    <OutputFilePath>%LocalApplicationData%/OPC Foundation/Logs/Opc.Ua.LocalDiscoveryServer.log.txt</OutputFilePath>
+    <DeleteOnLoad>true</DeleteOnLoad>
+    <TraceMasks>515</TraceMasks>
+  </TraceConfiguration>
+</ApplicationConfiguration>

--- a/Applications/ConsoleLdsServer/Program.cs
+++ b/Applications/ConsoleLdsServer/Program.cs
@@ -1,0 +1,197 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using System.CommandLine;
+using System.Diagnostics;
+using System.Globalization;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Opc.Ua;
+using Opc.Ua.Configuration;
+using Opc.Ua.Lds.Server;
+using Serilog;
+using Serilog.Events;
+
+namespace Opc.Ua.Lds.Server.Console
+{
+    /// <summary>
+    /// Console host for the OPC UA Local Discovery Server (LDS / LDS-ME).
+    /// </summary>
+    public static class Program
+    {
+        private const string ApplicationName = "ConsoleLdsServer";
+        private const string ConfigSectionName = "Lds.Server";
+
+        public static Task<int> Main(string[] args)
+        {
+            System.Console.WriteLine(".NET OPC UA Local Discovery Server");
+            System.Console.WriteLine(
+                "OPC UA library: {0} @ {1} -- {2}",
+                Utils.GetAssemblyBuildNumber(),
+                Utils.GetAssemblyTimestamp().ToString("G", CultureInfo.InvariantCulture),
+                Utils.GetAssemblySoftwareVersion());
+
+            var consoleOption = new Option<bool>("--console", "-c") { Description = "log to console" };
+            var autoAcceptOption = new Option<bool>("--autoaccept", "-a") { Description = "auto accept untrusted certificates (testing only)" };
+            var noMdnsOption = new Option<bool>("--no-mdns") { Description = "disable mDNS multicast (LDS-ME) advertisement" };
+            var loopbackMdnsOption = new Option<bool>("--mdns-loopback") { Description = "restrict mDNS to the loopback interface (testing)" };
+            var timeoutOption = new Option<int>("--timeout", "-t")
+            {
+                Description = "timeout in seconds before exiting (-1 = run until Ctrl+C)",
+                DefaultValueFactory = _ => -1
+            };
+
+            var rootCommand = new RootCommand($"Usage: dotnet {ApplicationName}.dll [OPTIONS]")
+            {
+                consoleOption,
+                autoAcceptOption,
+                noMdnsOption,
+                loopbackMdnsOption,
+                timeoutOption
+            };
+
+            rootCommand.SetAction(async (parseResult, cancellationToken) =>
+            {
+                bool logConsole = parseResult.GetValue(consoleOption);
+                bool autoAccept = parseResult.GetValue(autoAcceptOption);
+                bool noMdns = parseResult.GetValue(noMdnsOption);
+                bool loopbackMdns = parseResult.GetValue(loopbackMdnsOption);
+                int timeoutSec = parseResult.GetValue(timeoutOption);
+                int timeoutMs = timeoutSec >= 0 ? timeoutSec * 1000 : -1;
+
+                if (logConsole)
+                {
+                    Log.Logger = new LoggerConfiguration()
+                        .MinimumLevel.Information()
+                        .WriteTo.Console(restrictedToMinimumLevel: LogEventLevel.Information)
+                        .CreateLogger();
+                }
+
+                ITelemetryContext telemetry = DefaultTelemetry.Create(builder =>
+                {
+                    builder.SetMinimumLevel(LogLevel.Information);
+                    if (logConsole)
+                    {
+                        builder.AddSerilog(Log.Logger);
+                    }
+                });
+                Microsoft.Extensions.Logging.ILogger logger = telemetry.LoggerFactory.CreateLogger("Main");
+
+                var sw = Stopwatch.StartNew();
+                var application = new ApplicationInstance(telemetry)
+                {
+                    ApplicationName = ApplicationName,
+                    ApplicationType = ApplicationType.DiscoveryServer,
+                    ConfigSectionName = ConfigSectionName
+                };
+
+                try
+                {
+                    System.Console.WriteLine($"Loading configuration from {ConfigSectionName}.Config.xml.");
+                    await application
+                        .LoadApplicationConfigurationAsync(silent: false)
+                        .ConfigureAwait(false);
+
+                    System.Console.WriteLine("Checking the application certificate.");
+                    bool ok = await application
+                        .CheckApplicationInstanceCertificatesAsync(silent: false)
+                        .ConfigureAwait(false);
+                    if (!ok)
+                    {
+                        System.Console.Error.WriteLine("Application instance certificate invalid.");
+                        return 1;
+                    }
+
+                    if (autoAccept)
+                    {
+                        application.ApplicationConfiguration.SecurityConfiguration
+                            .AutoAcceptUntrustedCertificates = true;
+                    }
+
+                    var server = new LdsServer(telemetry);
+                    if (!noMdns)
+                    {
+                        server.MulticastFactory = lds => new MulticastDiscovery(
+                            lds.Store,
+                            loopbackOnly: loopbackMdns,
+                            logger: telemetry.LoggerFactory.CreateLogger<MulticastDiscovery>());
+                    }
+                    server.Store.StartPruneTimer();
+
+                    System.Console.WriteLine("Starting the LDS.");
+                    await application.StartAsync(server, cancellationToken).ConfigureAwait(false);
+
+                    foreach (EndpointDescription ep in server.GetEndpoints())
+                    {
+                        System.Console.WriteLine("  Endpoint: {0}", ep.EndpointUrl);
+                    }
+
+                    System.Console.WriteLine($"LDS started ({sw.ElapsedMilliseconds} ms). Press Ctrl-C to exit...");
+
+                    try
+                    {
+                        if (timeoutMs >= 0)
+                        {
+                            using CancellationTokenSource timeoutCts =
+                                CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                            timeoutCts.CancelAfter(timeoutMs);
+                            await Task.Delay(Timeout.Infinite, timeoutCts.Token).ConfigureAwait(false);
+                        }
+                        else
+                        {
+                            await Task.Delay(Timeout.Infinite, cancellationToken).ConfigureAwait(false);
+                        }
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        // expected — Ctrl-C or timeout.
+                    }
+
+                    System.Console.WriteLine("Stopping the LDS.");
+                    await application.StopAsync(default).ConfigureAwait(false);
+                    return 0;
+                }
+                catch (Exception ex)
+                {
+                    logger?.LogError(ex, "Fatal error starting LDS.");
+                    System.Console.Error.WriteLine(ex);
+                    return 2;
+                }
+                finally
+                {
+                    (telemetry as IDisposable)?.Dispose();
+                }
+            });
+
+            return rootCommand.Parse(args).InvokeAsync();
+        }
+    }
+}

--- a/Applications/Quickstarts.Servers/ReferenceServer/ReferenceServer.cs
+++ b/Applications/Quickstarts.Servers/ReferenceServer/ReferenceServer.cs
@@ -104,6 +104,26 @@ namespace Quickstarts.ReferenceServer
         public bool ProvisioningMode { get; set; }
 
         /// <summary>
+        /// If true, the server creates the FileSystem node manager that
+        /// exposes the configured <see cref="FileSystemProvider"/> under
+        /// the standard <c>Server.FileSystem</c> object (<c>i=16314</c>).
+        /// This materially grows the address space — only enable it in
+        /// tests / hosts that exercise FileSystem (Part 20). Default is
+        /// <c>false</c> so the standard test fixtures keep a small,
+        /// browse-friendly address space.
+        /// </summary>
+        public bool EnableFileSystemNodeManager { get; set; }
+
+        /// <summary>
+        /// Provider that backs the FileSystem node manager when
+        /// <see cref="EnableFileSystemNodeManager"/> is <c>true</c>.
+        /// When <c>null</c>, the server falls back to a
+        /// <see cref="Opc.Ua.Server.FileSystem.PhysicalFileSystemProvider"/>
+        /// rooted at <c>%TEMP%/OpcUaReferenceServerFs</c>.
+        /// </summary>
+        public Opc.Ua.Server.FileSystem.IFileSystemProvider? FileSystemProvider { get; set; }
+
+        /// <summary>
         /// Creates the node managers for the server.
         /// </summary>
         /// <remarks>
@@ -163,7 +183,33 @@ namespace Quickstarts.ReferenceServer
                 }
             }
 
+            if (EnableFileSystemNodeManager)
+            {
+                // FileSystem node manager — exposes the configured
+                // provider (defaults to a temp folder) under the standard
+                // Server.FileSystem object (i=16314).
+                Opc.Ua.Server.FileSystem.IFileSystemProvider provider =
+                    FileSystemProvider ?? CreateDefaultFileSystemProvider();
+                nodeManagers.Add(new Opc.Ua.Server.FileSystem.FileSystemNodeManager(
+                    server, configuration, provider));
+            }
+
             return new MasterNodeManager(server, configuration, null, asyncNodeManagers, nodeManagers);
+        }
+
+        /// <summary>
+        /// Returns a default <see cref="Opc.Ua.Server.FileSystem.PhysicalFileSystemProvider"/>
+        /// rooted at a per-process temp folder. Override
+        /// <see cref="FileSystemProvider"/> to mount a different backend.
+        /// </summary>
+        private static Opc.Ua.Server.FileSystem.IFileSystemProvider CreateDefaultFileSystemProvider()
+        {
+            string root = System.IO.Path.Combine(
+                System.IO.Path.GetTempPath(),
+                "OpcUaReferenceServerFs");
+            return new Opc.Ua.Server.FileSystem.PhysicalFileSystemProvider(
+                root,
+                mountName: "Temp");
         }
 
         protected override IMonitoredItemQueueFactory CreateMonitoredItemQueueFactory(

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,6 +9,7 @@
     <PackageVersion Include="coverlet.collector" Version="10.0.0" />
     <PackageVersion Include="DotNext" Version="5.26.3" />
     <PackageVersion Include="EmbedIO" Version="3.5.2" />
+    <PackageVersion Include="Makaretu.Dns.Multicast" Version="0.27.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Http" Version="2.3.9" />
     <PackageVersion Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.3.9" />
     <PackageVersion Include="Microsoft.AspNetCore.Server.Kestrel.Core" Version="2.3.9" />

--- a/Libraries/Opc.Ua.Client/FileSystem/FileSystemClient.cs
+++ b/Libraries/Opc.Ua.Client/FileSystem/FileSystemClient.cs
@@ -579,7 +579,7 @@ namespace Opc.Ua.Client.FileSystem
                         yield return info;
                     }
                 }
-                if (continuation.IsNull)
+                if (continuation.IsNull || continuation.Length == 0)
                 {
                     yield break;
                 }

--- a/Libraries/Opc.Ua.Lds.Server/LdsServer.cs
+++ b/Libraries/Opc.Ua.Lds.Server/LdsServer.cs
@@ -1,0 +1,536 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Opc.Ua.Bindings;
+using Opc.Ua.Security.Certificates;
+
+namespace Opc.Ua.Lds.Server
+{
+    /// <summary>
+    /// OPC UA Local Discovery Server (LDS / LDS-ME) implementation per Part 12.
+    /// </summary>
+    /// <remarks>
+    /// Subclasses <see cref="DiscoveryServerBase"/> so we get the discovery
+    /// service entry points (FindServers, FindServersOnNetwork, GetEndpoints,
+    /// RegisterServer, RegisterServer2) without inheriting Session,
+    /// Subscription, or NodeManager infrastructure from
+    /// <c>SessionServerBase</c>/<c>StandardServer</c>.
+    /// </remarks>
+    public class LdsServer : DiscoveryServerBase
+    {
+        private readonly ITelemetryContext m_telemetry;
+        private ILogger m_log;
+        private SemaphoreSlim m_lock;
+        private MulticastDiscovery m_multicast;
+
+        /// <summary>
+        /// Creates a new LDS server.
+        /// </summary>
+        /// <param name="telemetry">Telemetry context for logging.</param>
+        public LdsServer(ITelemetryContext telemetry = null)
+            : base(telemetry)
+        {
+            m_telemetry = telemetry;
+            m_lock = new SemaphoreSlim(1, 1);
+            Store = new RegisteredServerStore();
+        }
+
+        /// <summary>
+        /// In-memory database of registered servers and network records.
+        /// Exposed for tests so they can deterministically seed state.
+        /// </summary>
+        public RegisteredServerStore Store { get; }
+
+        /// <summary>
+        /// Optional multicast discovery layer (LDS-ME). Null when multicast
+        /// is disabled.
+        /// </summary>
+        public MulticastDiscovery Multicast => m_multicast;
+
+        /// <summary>
+        /// Optional hook tests use to plug in a multicast layer prior to
+        /// <see cref="ServerBase.StartAsync(ApplicationConfiguration, System.Threading.CancellationToken)"/>.
+        /// </summary>
+        public Func<LdsServer, MulticastDiscovery> MulticastFactory { get; set; }
+
+        /// <inheritdoc />
+        protected override void OnServerStarting(ApplicationConfiguration configuration)
+        {
+            base.OnServerStarting(configuration);
+
+            m_log = m_telemetry?.CreateLogger<LdsServer>()
+                ?? Microsoft.Extensions.Logging.Abstractions.NullLogger<LdsServer>.Instance;
+
+            // mark capabilities so this server self-advertises as an LDS / LDS-ME.
+            if (ServerCapabilities.IsNull || ServerCapabilities.Count == 0)
+            {
+                ServerCapabilities = new[] { "LDS" };
+            }
+
+            // wire up the optional multicast layer.
+            if (MulticastFactory != null)
+            {
+                m_multicast = MulticastFactory(this);
+            }
+        }
+
+        /// <inheritdoc />
+        protected override async ValueTask StartApplicationAsync(
+            ApplicationConfiguration configuration,
+            CancellationToken cancellationToken = default)
+        {
+            await base.StartApplicationAsync(configuration, cancellationToken).ConfigureAwait(false);
+
+            if (m_multicast != null)
+            {
+                IList<string> capabilities = ServerCapabilities.IsNull
+                    ? new List<string>()
+                    : ServerCapabilities.ToList();
+                IList<string> baseUris = BaseAddresses
+                    .Select(b => b.Url?.ToString())
+                    .Where(u => !string.IsNullOrEmpty(u))
+                    .ToList();
+                await m_multicast
+                    .StartAsync(configuration.ApplicationUri, baseUris, capabilities, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+        }
+
+        /// <inheritdoc />
+        protected override async ValueTask OnServerStoppingAsync(CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                if (m_multicast != null)
+                {
+                    await m_multicast.StopAsync(cancellationToken).ConfigureAwait(false);
+                }
+            }
+            finally
+            {
+                Store.Dispose();
+                await base.OnServerStoppingAsync(cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        /// <inheritdoc />
+        public override async ValueTask<FindServersResponse> FindServersAsync(
+            SecureChannelContext secureChannelContext,
+            RequestHeader requestHeader,
+            string endpointUrl,
+            ArrayOf<string> localeIds,
+            ArrayOf<string> serverUris,
+            RequestLifetime requestLifetime)
+        {
+            ValidateRequest(requestHeader);
+
+            var servers = new List<ApplicationDescription>();
+
+            await m_lock.WaitAsync(requestLifetime.CancellationToken).ConfigureAwait(false);
+            try
+            {
+                IList<BaseAddress> baseAddresses = BaseAddresses;
+
+                Uri parsedEndpointUrl = Utils.ParseUri(endpointUrl);
+                if (parsedEndpointUrl != null)
+                {
+                    baseAddresses = FilterByEndpointUrl(parsedEndpointUrl, baseAddresses);
+                }
+
+                ICollection<string> uriFilter = serverUris.IsNull
+                    ? Array.Empty<string>()
+                    : (ICollection<string>)serverUris.ToList();
+
+                // include the LDS itself unless filtered out.
+                if (baseAddresses.Count > 0
+                    && (uriFilter.Count == 0 || uriFilter.Contains(ServerDescription.ApplicationUri)))
+                {
+                    servers.Add(TranslateApplicationDescription(
+                        parsedEndpointUrl,
+                        ServerDescription,
+                        baseAddresses,
+                        ServerDescription.ApplicationName));
+                }
+
+                ICollection<string> requestedLocales = localeIds.IsNull
+                    ? Array.Empty<string>()
+                    : (ICollection<string>)localeIds.ToList();
+
+                // append registered servers that pass the filter.
+                foreach (ApplicationDescription registered in Store.Find(uriFilter, requestedLocales))
+                {
+                    servers.Add(registered);
+                }
+            }
+            finally
+            {
+                m_lock.Release();
+            }
+
+            return new FindServersResponse
+            {
+                ResponseHeader = CreateResponse(requestHeader, StatusCodes.Good),
+                Servers = servers
+            };
+        }
+
+        /// <inheritdoc />
+        public override async ValueTask<GetEndpointsResponse> GetEndpointsAsync(
+            SecureChannelContext secureChannelContext,
+            RequestHeader requestHeader,
+            string endpointUrl,
+            ArrayOf<string> localeIds,
+            ArrayOf<string> profileUris,
+            RequestLifetime requestLifetime)
+        {
+            ValidateRequest(requestHeader);
+
+            ArrayOf<EndpointDescription> endpoints;
+
+            await m_lock.WaitAsync(requestLifetime.CancellationToken).ConfigureAwait(false);
+            try
+            {
+                IList<BaseAddress> baseAddresses = FilterByProfile(profileUris, BaseAddresses);
+                endpoints = BuildEndpointDescriptions(endpointUrl, baseAddresses);
+            }
+            finally
+            {
+                m_lock.Release();
+            }
+
+            return new GetEndpointsResponse
+            {
+                ResponseHeader = CreateResponse(requestHeader, StatusCodes.Good),
+                Endpoints = endpoints
+            };
+        }
+
+        /// <inheritdoc />
+        public override async ValueTask<RegisterServerResponse> RegisterServerAsync(
+            SecureChannelContext secureChannelContext,
+            RequestHeader requestHeader,
+            RegisteredServer server,
+            RequestLifetime requestLifetime)
+        {
+            ValidateRequest(requestHeader);
+
+            ServiceResult validation = ValidateRegistration(secureChannelContext, server);
+            if (ServiceResult.IsBad(validation))
+            {
+                throw new ServiceResultException(validation);
+            }
+
+            _ = await Store
+                .RegisterAsync(server, mdnsConfig: null, requestLifetime.CancellationToken)
+                .ConfigureAwait(false);
+
+            return new RegisterServerResponse
+            {
+                ResponseHeader = CreateResponse(requestHeader, StatusCodes.Good)
+            };
+        }
+
+        /// <inheritdoc />
+        public override async ValueTask<RegisterServer2Response> RegisterServer2Async(
+            SecureChannelContext secureChannelContext,
+            RequestHeader requestHeader,
+            RegisteredServer server,
+            ArrayOf<ExtensionObject> discoveryConfiguration,
+            RequestLifetime requestLifetime)
+        {
+            ValidateRequest(requestHeader);
+
+            ServiceResult validation = ValidateRegistration(secureChannelContext, server);
+            if (ServiceResult.IsBad(validation))
+            {
+                throw new ServiceResultException(validation);
+            }
+
+            var configResults = new List<StatusCode>();
+
+            // gather mdns configurations; non-mdns configs are returned as Good but ignored.
+            var mdnsConfigs = new List<MdnsDiscoveryConfiguration>();
+            if (!discoveryConfiguration.IsNull)
+            {
+                foreach (ExtensionObject ext in discoveryConfiguration)
+                {
+                    if (!ext.IsNull && ext.TryGetValue(out MdnsDiscoveryConfiguration mdns))
+                    {
+                        mdnsConfigs.Add(mdns);
+                    }
+                    configResults.Add(StatusCodes.Good);
+                }
+            }
+
+            if (mdnsConfigs.Count == 0)
+            {
+                // no MdnsDiscoveryConfiguration provided — fall back to a plain registration.
+                _ = await Store
+                    .RegisterAsync(server, mdnsConfig: null, requestLifetime.CancellationToken)
+                    .ConfigureAwait(false);
+            }
+            else
+            {
+                foreach (MdnsDiscoveryConfiguration mdns in mdnsConfigs)
+                {
+                    _ = await Store
+                        .RegisterAsync(server, mdns, requestLifetime.CancellationToken)
+                        .ConfigureAwait(false);
+                }
+            }
+
+            return new RegisterServer2Response
+            {
+                ResponseHeader = CreateResponse(requestHeader, StatusCodes.Good),
+                ConfigurationResults = configResults
+            };
+        }
+
+        /// <inheritdoc />
+        public override async ValueTask<FindServersOnNetworkResponse> FindServersOnNetworkAsync(
+            SecureChannelContext secureChannelContext,
+            RequestHeader requestHeader,
+            uint startingRecordId,
+            uint maxRecordsToReturn,
+            ArrayOf<string> serverCapabilityFilter,
+            RequestLifetime requestLifetime)
+        {
+            ValidateRequest(requestHeader);
+
+            await Task.Yield();
+
+            ICollection<string> capFilter = serverCapabilityFilter.IsNull
+                ? Array.Empty<string>()
+                : (ICollection<string>)serverCapabilityFilter.ToList();
+
+            (IList<ServerOnNetwork> records, DateTime lastReset) =
+                Store.ListOnNetwork(startingRecordId, maxRecordsToReturn, capFilter);
+
+            return new FindServersOnNetworkResponse
+            {
+                ResponseHeader = CreateResponse(requestHeader, StatusCodes.Good),
+                LastCounterResetTime = lastReset,
+                Servers = records.ToArray()
+            };
+        }
+
+        /// <summary>
+        /// Validates a <see cref="RegisteredServer"/> against Part 12 §6.4.2/§6.4.5
+        /// requirements, returning the appropriate status code on failure.
+        /// </summary>
+        protected virtual ServiceResult ValidateRegistration(
+            SecureChannelContext secureChannelContext,
+            RegisteredServer server)
+        {
+            if (server == null)
+            {
+                throw new ArgumentNullException(nameof(server));
+            }
+
+            // Per Part 12 §6.4.2: registration must occur on a secure channel
+            // (Sign or SignAndEncrypt). None is rejected.
+            MessageSecurityMode mode = secureChannelContext?.EndpointDescription?.SecurityMode
+                ?? MessageSecurityMode.Invalid;
+            if (mode == MessageSecurityMode.None || mode == MessageSecurityMode.Invalid)
+            {
+                return new ServiceResult(StatusCodes.BadSecurityChecksFailed,
+                    new LocalizedText("RegisterServer requires a signed secure channel."));
+            }
+
+            if (string.IsNullOrEmpty(server.ServerUri))
+            {
+                return new ServiceResult(StatusCodes.BadServerUriInvalid,
+                    new LocalizedText("ServerUri is empty."));
+            }
+
+            if (server.ServerNames.IsNull || server.ServerNames.Count == 0)
+            {
+                return new ServiceResult(StatusCodes.BadServerNameMissing,
+                    new LocalizedText("ServerNames is empty."));
+            }
+
+            if (server.DiscoveryUrls.IsNull || server.DiscoveryUrls.Count == 0)
+            {
+                return new ServiceResult(StatusCodes.BadDiscoveryUrlMissing,
+                    new LocalizedText("DiscoveryUrls is empty."));
+            }
+
+            if (server.ServerType == ApplicationType.Client)
+            {
+                return new ServiceResult(StatusCodes.BadInvalidArgument,
+                    new LocalizedText("ServerType=Client is not allowed."));
+            }
+
+            if ((int)server.ServerType is < 0 or > (int)ApplicationType.DiscoveryServer)
+            {
+                return new ServiceResult(StatusCodes.BadInvalidArgument,
+                    new LocalizedText("ServerType is out of range."));
+            }
+
+            // Match the client cert ApplicationUri against the ServerUri.
+            if (secureChannelContext?.ClientChannelCertificate is { Length: > 0 } certBytes)
+            {
+                try
+                {
+                    using Certificate cert = Certificate.FromRawData(certBytes);
+                    IReadOnlyList<string> applicationUris = X509Utils.GetApplicationUrisFromCertificate(cert);
+                    if (applicationUris.Count > 0
+                        && !applicationUris.Any(uri => string.Equals(uri, server.ServerUri, StringComparison.Ordinal)))
+                    {
+                        return new ServiceResult(StatusCodes.BadServerUriInvalid,
+                            new LocalizedText("ServerUri does not match the certificate ApplicationUri."));
+                    }
+                }
+                catch (Exception ex)
+                {
+                    m_log?.LogDebug(ex, "Failed to inspect client cert ApplicationUri.");
+                }
+            }
+
+            return ServiceResult.Good;
+        }
+
+        private ArrayOf<EndpointDescription> BuildEndpointDescriptions(
+            string endpointUrl,
+            IList<BaseAddress> baseAddresses)
+        {
+            Uri parsedEndpointUrl = Utils.ParseUri(endpointUrl);
+            if (parsedEndpointUrl != null)
+            {
+                baseAddresses = FilterByEndpointUrl(parsedEndpointUrl, baseAddresses);
+            }
+
+            if (baseAddresses.Count == 0)
+            {
+                return new ArrayOf<EndpointDescription>(Array.Empty<EndpointDescription>());
+            }
+
+            ApplicationDescription application = TranslateApplicationDescription(
+                parsedEndpointUrl,
+                ServerDescription,
+                baseAddresses,
+                ServerDescription.ApplicationName);
+
+            return TranslateEndpointDescriptions(
+                parsedEndpointUrl,
+                baseAddresses,
+                Endpoints,
+                application);
+        }
+
+        /// <inheritdoc />
+        protected override IList<ServiceHost> InitializeServiceHosts(
+            ApplicationConfiguration configuration,
+            ITransportListenerBindings bindingFactory,
+            out ApplicationDescription serverDescription,
+            out ArrayOf<EndpointDescription> endpoints)
+        {
+            var hosts = new Dictionary<string, ServiceHost>();
+
+            // Mirror StandardServer's defaults so the LDS opens a real listener.
+            if (configuration.ServerConfiguration.SecurityPolicies.IsEmpty)
+            {
+                configuration.ServerConfiguration.SecurityPolicies =
+                    configuration.ServerConfiguration.SecurityPolicies.AddItem(new ServerSecurityPolicy());
+            }
+
+            if (configuration.ServerConfiguration.UserTokenPolicies.IsEmpty)
+            {
+                var userTokenPolicy = new UserTokenPolicy { TokenType = UserTokenType.Anonymous };
+                userTokenPolicy.PolicyId = userTokenPolicy.TokenType.ToString();
+
+                configuration.ServerConfiguration.UserTokenPolicies += userTokenPolicy;
+            }
+
+            serverDescription = new ApplicationDescription
+            {
+                ApplicationUri = configuration.ApplicationUri,
+                ApplicationName = new LocalizedText("en-US", configuration.ApplicationName),
+                ApplicationType = configuration.ApplicationType,
+                ProductUri = configuration.ProductUri,
+                DiscoveryUrls = GetDiscoveryUrls()
+            };
+
+            var endpointsList = new List<EndpointDescription>();
+            ArrayOf<string> baseAddresses = configuration.ServerConfiguration.BaseAddresses;
+            foreach (string scheme in Utils.DefaultUriSchemes)
+            {
+                bool hasAddress = false;
+                foreach (string a in baseAddresses)
+                {
+                    if (a.StartsWith(scheme, StringComparison.Ordinal))
+                    {
+                        hasAddress = true;
+                        break;
+                    }
+                }
+                if (!hasAddress)
+                {
+                    continue;
+                }
+
+                ITransportListenerFactory binding = bindingFactory.GetBinding(scheme, MessageContext.Telemetry);
+                if (binding != null)
+                {
+                    List<EndpointDescription> endpointsForHost = binding.CreateServiceHost(
+                        this,
+                        hosts,
+                        configuration,
+                        configuration.ServerConfiguration.BaseAddresses,
+                        serverDescription,
+                        configuration.ServerConfiguration.SecurityPolicies,
+                        CertificateManager,
+                        configuration.CertificateManager);
+                    endpointsList.AddRange(endpointsForHost);
+                }
+            }
+
+            endpoints = endpointsList.ToArray();
+            return hosts.Values.ToList();
+        }
+
+        /// <inheritdoc />
+        public override ServiceHost CreateServiceHost(ServerBase server, params Uri[] addresses)
+        {
+            return new ServiceHost(this, addresses);
+        }
+
+        /// <inheritdoc />
+        protected override EndpointBase GetEndpointInstance(ServerBase server)
+        {
+            return new DiscoveryEndpoint(server);
+        }
+    }
+}

--- a/Libraries/Opc.Ua.Lds.Server/MulticastDiscovery.cs
+++ b/Libraries/Opc.Ua.Lds.Server/MulticastDiscovery.cs
@@ -1,0 +1,372 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.NetworkInformation;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+using Makaretu.Dns;
+using Microsoft.Extensions.Logging;
+
+namespace Opc.Ua.Lds.Server
+{
+    /// <summary>
+    /// Multicast DNS wrapper that announces this LDS as an
+    /// <c>_opcua-tcp._tcp</c> service per OPC UA Part 12 §6.4.6 and observes
+    /// peer announcements, surfacing them to the
+    /// <see cref="RegisteredServerStore"/>.
+    /// </summary>
+    public sealed class MulticastDiscovery : IDisposable
+    {
+        /// <summary>
+        /// Standard mDNS service type for OPC UA discovery per Part 12.
+        /// </summary>
+        public const string OpcUaServiceType = "_opcua-tcp._tcp";
+
+        private readonly RegisteredServerStore m_store;
+        private readonly ILogger m_logger;
+        private readonly bool m_loopbackOnly;
+        private MulticastService m_service;
+        private ServiceDiscovery m_discovery;
+        private readonly List<ServiceProfile> m_profiles = [];
+        private bool m_started;
+        private bool m_disposed;
+
+        /// <summary>
+        /// Creates a new multicast wrapper.
+        /// </summary>
+        /// <param name="store">Store to publish observed peers into.</param>
+        /// <param name="loopbackOnly">When true, restricts announcements and
+        ///   queries to the loopback NIC. Used by in-process tests.</param>
+        /// <param name="logger">Optional logger.</param>
+        public MulticastDiscovery(
+            RegisteredServerStore store,
+            bool loopbackOnly = false,
+            ILogger logger = null)
+        {
+            if (store == null)
+            {
+                throw new ArgumentNullException(nameof(store));
+            }
+            m_store = store;
+            m_loopbackOnly = loopbackOnly;
+            m_logger = logger ?? Microsoft.Extensions.Logging.Abstractions.NullLogger.Instance;
+        }
+
+        /// <summary>
+        /// True after <see cref="StartAsync(string, IList{string}, IList{string}, CancellationToken)"/> has run.
+        /// </summary>
+        public bool IsRunning => m_started;
+
+        /// <summary>
+        /// Starts mDNS announcement and discovery.
+        /// </summary>
+        /// <param name="applicationUri">The LDS's ApplicationUri (used as the
+        ///   default mDNS instance name).</param>
+        /// <param name="discoveryUrls">The LDS's discovery URLs.</param>
+        /// <param name="capabilities">The LDS's server capabilities (e.g. LDS, LDS-ME).</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        public Task StartAsync(
+            string applicationUri,
+            IList<string> discoveryUrls,
+            IList<string> capabilities,
+            CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrEmpty(applicationUri))
+            {
+                throw new ArgumentException("Application URI must be provided.", nameof(applicationUri));
+            }
+            if (discoveryUrls == null)
+            {
+                throw new ArgumentNullException(nameof(discoveryUrls));
+            }
+            if (capabilities == null)
+            {
+                throw new ArgumentNullException(nameof(capabilities));
+            }
+
+            if (m_started)
+            {
+                return Task.CompletedTask;
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            Func<IEnumerable<NetworkInterface>, IEnumerable<NetworkInterface>> filter = m_loopbackOnly
+                ? nics => nics.Where(nic => nic.NetworkInterfaceType == NetworkInterfaceType.Loopback)
+                : null;
+
+            m_service = new MulticastService(filter);
+
+            m_discovery = new ServiceDiscovery(m_service);
+            m_discovery.ServiceInstanceDiscovered += OnServiceInstanceDiscovered;
+
+            foreach (string url in discoveryUrls)
+            {
+                ServiceProfile profile = TryBuildProfile(applicationUri, url, capabilities);
+                if (profile != null)
+                {
+                    m_profiles.Add(profile);
+                    m_discovery.Advertise(profile);
+                }
+            }
+
+            m_service.Start();
+            m_started = true;
+
+            // proactively probe for other LDS / OPC UA servers on the network.
+            try
+            {
+                m_discovery.QueryServiceInstances(OpcUaServiceType);
+            }
+            catch (Exception ex)
+            {
+                m_logger.LogDebug(ex, "Multicast initial query failed.");
+            }
+
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Stops mDNS announcement (sends goodbye packets where supported).
+        /// </summary>
+        public Task StopAsync(CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!m_started)
+            {
+                return Task.CompletedTask;
+            }
+
+            try
+            {
+                foreach (ServiceProfile profile in m_profiles)
+                {
+                    try
+                    {
+                        m_discovery.Unadvertise(profile);
+                    }
+                    catch (Exception ex)
+                    {
+                        m_logger.LogDebug(ex, "Multicast unadvertise failed.");
+                    }
+                }
+                m_profiles.Clear();
+            }
+            finally
+            {
+                m_discovery?.Dispose();
+                m_discovery = null;
+
+                m_service?.Stop();
+                m_service?.Dispose();
+                m_service = null;
+                m_started = false;
+            }
+
+            return Task.CompletedTask;
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            if (m_disposed)
+            {
+                return;
+            }
+            m_disposed = true;
+            try
+            {
+                StopAsync().GetAwaiter().GetResult();
+            }
+            catch (Exception ex)
+            {
+                m_logger.LogDebug(ex, "Multicast dispose failed.");
+            }
+        }
+
+        private void OnServiceInstanceDiscovered(object sender, ServiceInstanceDiscoveryEventArgs e)
+        {
+            try
+            {
+                Message msg = e.Message;
+                if (msg == null)
+                {
+                    return;
+                }
+
+                // Extract SRV (host+port), A/AAAA (address), TXT (path/caps).
+                SRVRecord srv = msg.AdditionalRecords.OfType<SRVRecord>().FirstOrDefault()
+                    ?? msg.Answers.OfType<SRVRecord>().FirstOrDefault();
+                if (srv == null)
+                {
+                    return;
+                }
+
+                string instanceName = e.ServiceInstanceName?.ToString() ?? srv.Name?.ToString();
+                if (string.IsNullOrEmpty(instanceName))
+                {
+                    return;
+                }
+
+                IPAddress address = msg.AdditionalRecords.OfType<ARecord>().FirstOrDefault()?.Address
+                    ?? msg.Answers.OfType<ARecord>().FirstOrDefault()?.Address
+                    ?? msg.AdditionalRecords.OfType<AAAARecord>().FirstOrDefault()?.Address
+                    ?? IPAddress.Loopback;
+
+                TXTRecord txt = msg.AdditionalRecords.OfType<TXTRecord>().FirstOrDefault()
+                    ?? msg.Answers.OfType<TXTRecord>().FirstOrDefault();
+
+                string path = "/";
+                List<string> caps = [];
+                if (txt != null)
+                {
+                    foreach (string str in txt.Strings)
+                    {
+                        if (str.StartsWith("path=", StringComparison.Ordinal))
+                        {
+                            path = str.Substring("path=".Length);
+                        }
+                        else if (str.StartsWith("caps=", StringComparison.Ordinal))
+                        {
+                            foreach (string raw in str.Substring("caps=".Length)
+                                .Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries))
+                            {
+                                string trimmed = raw.Trim();
+                                if (trimmed.Length > 0)
+                                {
+                                    caps.Add(trimmed);
+                                }
+                            }
+                        }
+                    }
+                }
+
+                string discoveryUrl = $"opc.tcp://{address}:{srv.Port}{path}";
+
+                m_store.UpsertMulticastRecord(
+                    serverUri: null,
+                    serverName: instanceName,
+                    discoveryUrl: discoveryUrl,
+                    capabilities: caps);
+            }
+            catch (Exception ex)
+            {
+                m_logger.LogDebug(ex, "Failed to process mDNS service instance.");
+            }
+        }
+
+        private ServiceProfile TryBuildProfile(
+            string applicationUri,
+            string discoveryUrl,
+            IList<string> capabilities)
+        {
+            try
+            {
+                Uri parsed = new(discoveryUrl, UriKind.Absolute);
+                if (parsed.Port <= 0)
+                {
+                    return null;
+                }
+
+                IEnumerable<IPAddress> addrs = ResolveLocalAddresses();
+                string instanceName = SanitizeInstanceName(applicationUri);
+
+                var profile = new ServiceProfile(
+                    instanceName,
+                    OpcUaServiceType,
+                    (ushort)parsed.Port,
+                    addrs);
+
+                string path = string.IsNullOrEmpty(parsed.AbsolutePath) ? "/" : parsed.AbsolutePath;
+                profile.AddProperty("path", path);
+                if (capabilities.Count > 0)
+                {
+                    profile.AddProperty("caps", string.Join(",", capabilities));
+                }
+
+                return profile;
+            }
+            catch (Exception ex)
+            {
+                m_logger.LogDebug(ex, "Failed to build mDNS profile for {Url}.", discoveryUrl);
+                return null;
+            }
+        }
+
+        private IEnumerable<IPAddress> ResolveLocalAddresses()
+        {
+            if (m_loopbackOnly)
+            {
+                yield return IPAddress.Loopback;
+                yield break;
+            }
+
+            foreach (NetworkInterface nic in NetworkInterface.GetAllNetworkInterfaces())
+            {
+                if (nic.OperationalStatus != OperationalStatus.Up)
+                {
+                    continue;
+                }
+
+                IPInterfaceProperties ipProps = nic.GetIPProperties();
+                foreach (UnicastIPAddressInformation u in ipProps.UnicastAddresses)
+                {
+                    if (u.Address.AddressFamily == AddressFamily.InterNetwork
+                        || u.Address.AddressFamily == AddressFamily.InterNetworkV6)
+                    {
+                        yield return u.Address;
+                    }
+                }
+            }
+        }
+
+        private static string SanitizeInstanceName(string applicationUri)
+        {
+            if (string.IsNullOrEmpty(applicationUri))
+            {
+                return "OpcUaLds";
+            }
+
+            // mDNS instance names should be friendly UTF-8 strings; strip URI scheme.
+            int schemeIdx = applicationUri.IndexOf("://", StringComparison.Ordinal);
+            string trimmed = schemeIdx >= 0 ? applicationUri.Substring(schemeIdx + 3) : applicationUri;
+            // limit length and replace separators that confuse some browsers.
+            string sanitized = trimmed
+                .Replace('/', '-')
+                .Replace(':', '-')
+                .Replace('?', '-');
+            return sanitized.Length > 63 ? sanitized.Substring(0, 63) : sanitized;
+        }
+    }
+}

--- a/Libraries/Opc.Ua.Lds.Server/Opc.Ua.Lds.Server.csproj
+++ b/Libraries/Opc.Ua.Lds.Server/Opc.Ua.Lds.Server.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>$(LibTargetFrameworks)</TargetFrameworks>
+    <PackageId>$(PackagePrefix).Opc.Ua.Lds.Server</PackageId>
+    <AssemblyName>$(AssemblyPrefix).Lds.Server</AssemblyName>
+    <RootNamespace>Opc.Ua.Lds.Server</RootNamespace>
+    <Description>OPC UA Local Discovery Server (LDS / LDS-ME) Class Library</Description>
+    <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
+    <IsPackable>true</IsPackable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))">true</IsAotCompatible>
+  </PropertyGroup>
+  <ItemGroup>
+    <InternalsVisibleTo Include="Opc.Ua.Lds.Server.Tests" />
+  </ItemGroup>
+  <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
+    <PackageId>$(PackageId).Debug</PackageId>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Stack\Opc.Ua.Core\Opc.Ua.Core.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Makaretu.Dns.Multicast" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+  </ItemGroup>
+  <Target Name="GetPackagingOutputs" />
+</Project>

--- a/Libraries/Opc.Ua.Lds.Server/RegisteredServerStore.cs
+++ b/Libraries/Opc.Ua.Lds.Server/RegisteredServerStore.cs
@@ -1,0 +1,549 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace Opc.Ua.Lds.Server
+{
+    /// <summary>
+    /// Thread-safe in-memory database of servers registered with the LDS plus
+    /// network records advertised via LDS-ME.
+    /// </summary>
+    /// <remarks>
+    /// Per OPC UA Part 12 §6.4.5.1, registered servers should re-register
+    /// periodically; entries are pruned when they have not been refreshed
+    /// within <see cref="RegistrationLifetime"/>. mDNS-observed records
+    /// follow their own TTL via <see cref="MulticastRecordLifetime"/>.
+    /// </remarks>
+    public sealed class RegisteredServerStore : IDisposable
+    {
+        private readonly SemaphoreSlim m_lock = new(1, 1);
+        private readonly Dictionary<string, RegistrationEntry> m_byUri
+            = new(StringComparer.Ordinal);
+        private readonly List<ServerOnNetworkRecord> m_records = [];
+        private readonly ILogger m_logger;
+        private uint m_nextRecordId = 1;
+        private DateTime m_lastCounterResetTime;
+        private Timer m_pruneTimer;
+        private bool m_disposed;
+
+        /// <summary>
+        /// Creates a new in-memory store.
+        /// </summary>
+        public RegisteredServerStore(ILogger logger = null)
+        {
+            m_logger = logger ?? Microsoft.Extensions.Logging.Abstractions.NullLogger.Instance;
+            m_lastCounterResetTime = DateTime.UtcNow;
+        }
+
+        /// <summary>
+        /// Lifetime for explicit RegisterServer registrations. After this period
+        /// without a refresh, the registration is considered stale and removed.
+        /// Default: 10 minutes (informational guidance from Part 12; servers in
+        /// practice re-register every 30 seconds).
+        /// </summary>
+        public TimeSpan RegistrationLifetime { get; set; } = TimeSpan.FromMinutes(10);
+
+        /// <summary>
+        /// TTL for mDNS-observed network records. Defaults to 75 seconds, which
+        /// matches the standard mDNS service-record TTL.
+        /// </summary>
+        public TimeSpan MulticastRecordLifetime { get; set; } = TimeSpan.FromSeconds(75);
+
+        /// <summary>
+        /// Most recent time the network record id counter was reset. Exposed via
+        /// <see cref="ServerOnNetworkRecord"/> queries for client cursor logic.
+        /// </summary>
+        public DateTime LastCounterResetTime
+        {
+            get
+            {
+                m_lock.Wait();
+                try
+                {
+                    return m_lastCounterResetTime;
+                }
+                finally
+                {
+                    m_lock.Release();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Test/diagnostic helper: snapshot of all current registrations.
+        /// </summary>
+        public IReadOnlyList<RegistrationEntry> Snapshot()
+        {
+            m_lock.Wait();
+            try
+            {
+                return m_byUri.Values.Select(Clone).ToList();
+            }
+            finally
+            {
+                m_lock.Release();
+            }
+        }
+
+        /// <summary>
+        /// Test/diagnostic helper: snapshot of all current network records.
+        /// </summary>
+        public IReadOnlyList<ServerOnNetworkRecord> SnapshotNetworkRecords()
+        {
+            m_lock.Wait();
+            try
+            {
+                return m_records.ConvertAll(Clone);
+            }
+            finally
+            {
+                m_lock.Release();
+            }
+        }
+
+        /// <summary>
+        /// Starts the background pruning timer. Tests typically skip this and
+        /// drive prune deterministically via <see cref="Prune(DateTime)"/>.
+        /// </summary>
+        public void StartPruneTimer(TimeSpan? interval = null)
+        {
+            TimeSpan tick = interval ?? TimeSpan.FromSeconds(30);
+            m_pruneTimer?.Dispose();
+            m_pruneTimer = new Timer(_ =>
+            {
+                try
+                {
+                    Prune(DateTime.UtcNow);
+                }
+                catch (Exception ex)
+                {
+                    m_logger.LogWarning(ex, "RegisteredServerStore prune failed.");
+                }
+            }, null, tick, tick);
+        }
+
+        /// <summary>
+        /// Adds, updates, or removes a registration based on
+        /// <paramref name="server"/>'s state. Returns the live registration
+        /// (post-merge) or <c>null</c> if it was removed.
+        /// </summary>
+        public async Task<RegistrationEntry> RegisterAsync(
+            RegisteredServer server,
+            MdnsDiscoveryConfiguration mdnsConfig,
+            CancellationToken cancellationToken = default)
+        {
+            if (server == null)
+            {
+                throw new ArgumentNullException(nameof(server));
+            }
+
+            await m_lock.WaitAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                string uri = server.ServerUri;
+
+                // semaphore file: if path is set but file is missing, drop the registration
+                bool semaphoreValid = string.IsNullOrEmpty(server.SemaphoreFilePath)
+                    || File.Exists(server.SemaphoreFilePath);
+
+                if (!server.IsOnline || !semaphoreValid)
+                {
+                    if (m_byUri.Remove(uri))
+                    {
+                        m_logger.LogInformation(
+                            "LDS: removed registration for {Uri} (IsOnline={Online}, SemaphoreOk={Sem}).",
+                            uri,
+                            server.IsOnline,
+                            semaphoreValid);
+                    }
+                    RemoveNetworkRecordsForUriCore(uri);
+                    return null;
+                }
+
+                if (!m_byUri.TryGetValue(uri, out RegistrationEntry entry))
+                {
+                    entry = new RegistrationEntry { ServerUri = uri };
+                    m_byUri[uri] = entry;
+                }
+
+                entry.ProductUri = server.ProductUri;
+                entry.ServerNames = server.ServerNames.IsNull
+                    ? new List<LocalizedText>()
+                    : server.ServerNames.ToList();
+                entry.ServerType = server.ServerType;
+                entry.GatewayServerUri = server.GatewayServerUri;
+                entry.DiscoveryUrls = server.DiscoveryUrls.IsNull
+                    ? new List<string>()
+                    : server.DiscoveryUrls.ToList();
+                entry.SemaphoreFilePath = server.SemaphoreFilePath;
+                entry.IsOnline = true;
+                entry.LastSeenUtc = DateTime.UtcNow;
+
+                if (mdnsConfig != null)
+                {
+                    entry.MdnsServerName = mdnsConfig.MdnsServerName;
+                    entry.ServerCapabilities = mdnsConfig.ServerCapabilities.IsNull
+                        ? new List<string>()
+                        : mdnsConfig.ServerCapabilities.ToList();
+
+                    UpdateNetworkRecordsCore(entry);
+                }
+                else if (entry.MdnsServerName != null && entry.ServerCapabilities.Count > 0)
+                {
+                    // refresh existing mDNS records' LastSeen
+                    UpdateNetworkRecordsCore(entry);
+                }
+
+                return Clone(entry);
+            }
+            finally
+            {
+                m_lock.Release();
+            }
+        }
+
+        /// <summary>
+        /// Returns translated <see cref="ApplicationDescription"/> entries for
+        /// every active registration whose ServerUri passes <paramref name="serverUriFilter"/>.
+        /// </summary>
+        public IList<ApplicationDescription> Find(
+            ICollection<string> serverUriFilter,
+            ICollection<string> requestedLocaleIds)
+        {
+            m_lock.Wait();
+            try
+            {
+                var result = new List<ApplicationDescription>(m_byUri.Count);
+                foreach (RegistrationEntry e in m_byUri.Values)
+                {
+                    if (serverUriFilter is { Count: > 0 }
+                        && !serverUriFilter.Contains(e.ServerUri))
+                    {
+                        continue;
+                    }
+
+                    LocalizedText name = SelectName(e.ServerNames, requestedLocaleIds);
+
+                    result.Add(new ApplicationDescription
+                    {
+                        ApplicationUri = e.ServerUri,
+                        ProductUri = e.ProductUri,
+                        ApplicationName = name,
+                        ApplicationType = e.ServerType,
+                        GatewayServerUri = e.GatewayServerUri,
+                        DiscoveryUrls = [.. e.DiscoveryUrls]
+                    });
+                }
+                return result;
+            }
+            finally
+            {
+                m_lock.Release();
+            }
+        }
+
+        /// <summary>
+        /// Returns paginated <see cref="ServerOnNetwork"/> records honoring
+        /// <paramref name="startingRecordId"/>, <paramref name="maxRecordsToReturn"/>,
+        /// and <paramref name="serverCapabilityFilter"/>.
+        /// </summary>
+        public (IList<ServerOnNetwork> records, DateTime lastCounterResetTime) ListOnNetwork(
+            uint startingRecordId,
+            uint maxRecordsToReturn,
+            ICollection<string> serverCapabilityFilter)
+        {
+            m_lock.Wait();
+            try
+            {
+                IEnumerable<ServerOnNetworkRecord> source = m_records
+                    .Where(r => r.RecordId >= startingRecordId)
+                    .OrderBy(r => r.RecordId);
+
+                if (serverCapabilityFilter is { Count: > 0 })
+                {
+                    source = source.Where(r =>
+                        serverCapabilityFilter.All(cap => r.ServerCapabilities.Contains(cap)));
+                }
+
+                if (maxRecordsToReturn > 0)
+                {
+                    source = source.Take((int)maxRecordsToReturn);
+                }
+
+                IList<ServerOnNetwork> dto = source
+                    .Select(r => new ServerOnNetwork
+                    {
+                        RecordId = r.RecordId,
+                        ServerName = r.ServerName,
+                        DiscoveryUrl = r.DiscoveryUrl,
+                        ServerCapabilities = [.. r.ServerCapabilities]
+                    })
+                    .ToList();
+
+                return (dto, m_lastCounterResetTime);
+            }
+            finally
+            {
+                m_lock.Release();
+            }
+        }
+
+        /// <summary>
+        /// Adds or refreshes mDNS-observed peer records. Called by
+        /// <see cref="MulticastDiscovery"/> when service discoveries occur.
+        /// </summary>
+        public void UpsertMulticastRecord(
+            string serverUri,
+            string serverName,
+            string discoveryUrl,
+            IEnumerable<string> capabilities)
+        {
+            if (string.IsNullOrEmpty(discoveryUrl))
+            {
+                throw new ArgumentException("DiscoveryUrl must be provided.", nameof(discoveryUrl));
+            }
+
+            m_lock.Wait();
+            try
+            {
+                ServerOnNetworkRecord existing = m_records.FirstOrDefault(r =>
+                    r.ObservedViaMulticast
+                    && string.Equals(r.DiscoveryUrl, discoveryUrl, StringComparison.Ordinal));
+
+                if (existing != null)
+                {
+                    existing.LastSeenUtc = DateTime.UtcNow;
+                    existing.ServerName = serverName;
+                    existing.ServerCapabilities = capabilities?.ToList() ?? [];
+                    return;
+                }
+
+                m_records.Add(new ServerOnNetworkRecord
+                {
+                    RecordId = m_nextRecordId++,
+                    ServerUri = serverUri,
+                    ServerName = serverName,
+                    DiscoveryUrl = discoveryUrl,
+                    ServerCapabilities = capabilities?.ToList() ?? [],
+                    LastSeenUtc = DateTime.UtcNow,
+                    ObservedViaMulticast = true
+                });
+            }
+            finally
+            {
+                m_lock.Release();
+            }
+        }
+
+        /// <summary>
+        /// Removes stale registrations and stale mDNS-observed records.
+        /// </summary>
+        public void Prune(DateTime nowUtc)
+        {
+            m_lock.Wait();
+            try
+            {
+                List<string> staleUris = m_byUri.Values
+                    .Where(e =>
+                        nowUtc - e.LastSeenUtc > RegistrationLifetime
+                        || (!string.IsNullOrEmpty(e.SemaphoreFilePath) && !File.Exists(e.SemaphoreFilePath)))
+                    .Select(e => e.ServerUri)
+                    .ToList();
+
+                foreach (string uri in staleUris)
+                {
+                    m_byUri.Remove(uri);
+                    RemoveNetworkRecordsForUriCore(uri);
+                }
+
+                m_records.RemoveAll(r =>
+                    r.ObservedViaMulticast
+                    && nowUtc - r.LastSeenUtc > MulticastRecordLifetime);
+            }
+            finally
+            {
+                m_lock.Release();
+            }
+        }
+
+        /// <summary>
+        /// Test seam: directly insert a registration without protocol validation.
+        /// Used by the LdsTestFixture to deterministically populate state.
+        /// </summary>
+        internal void SeedRegistration(RegistrationEntry entry)
+        {
+            if (entry == null)
+            {
+                throw new ArgumentNullException(nameof(entry));
+            }
+            if (string.IsNullOrEmpty(entry.ServerUri))
+            {
+                throw new ArgumentException("ServerUri must be set.", nameof(entry));
+            }
+
+            m_lock.Wait();
+            try
+            {
+                m_byUri[entry.ServerUri] = entry;
+                if (!string.IsNullOrEmpty(entry.MdnsServerName)
+                    && entry.ServerCapabilities is { Count: > 0 })
+                {
+                    UpdateNetworkRecordsCore(entry);
+                }
+            }
+            finally
+            {
+                m_lock.Release();
+            }
+        }
+
+        /// <summary>
+        /// Test seam: drop all state and reset counters.
+        /// </summary>
+        internal void Clear()
+        {
+            m_lock.Wait();
+            try
+            {
+                m_byUri.Clear();
+                m_records.Clear();
+                m_nextRecordId = 1;
+                m_lastCounterResetTime = DateTime.UtcNow;
+            }
+            finally
+            {
+                m_lock.Release();
+            }
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            if (m_disposed)
+            {
+                return;
+            }
+            m_disposed = true;
+            m_pruneTimer?.Dispose();
+            m_lock.Dispose();
+        }
+
+        private void UpdateNetworkRecordsCore(RegistrationEntry entry)
+        {
+            // Replace any prior records for this ServerUri originating from
+            // explicit registration (preserve mDNS-observed records).
+            m_records.RemoveAll(r =>
+                !r.ObservedViaMulticast
+                && string.Equals(r.ServerUri, entry.ServerUri, StringComparison.Ordinal));
+
+            foreach (string url in entry.DiscoveryUrls)
+            {
+                LocalizedText firstName = entry.ServerNames.Count > 0
+                    ? entry.ServerNames[0]
+                    : LocalizedText.Null;
+
+                m_records.Add(new ServerOnNetworkRecord
+                {
+                    RecordId = m_nextRecordId++,
+                    ServerUri = entry.ServerUri,
+                    ServerName = entry.MdnsServerName ?? firstName.Text,
+                    DiscoveryUrl = url,
+                    ServerCapabilities = [.. entry.ServerCapabilities],
+                    LastSeenUtc = DateTime.UtcNow,
+                    ObservedViaMulticast = false
+                });
+            }
+        }
+
+        private void RemoveNetworkRecordsForUriCore(string serverUri)
+        {
+            m_records.RemoveAll(r =>
+                !r.ObservedViaMulticast
+                && string.Equals(r.ServerUri, serverUri, StringComparison.Ordinal));
+        }
+
+        private static LocalizedText SelectName(
+            IList<LocalizedText> names,
+            ICollection<string> requestedLocaleIds)
+        {
+            if (names == null || names.Count == 0)
+            {
+                return new LocalizedText(string.Empty);
+            }
+
+            if (requestedLocaleIds is { Count: > 0 })
+            {
+                foreach (string locale in requestedLocaleIds)
+                {
+                    LocalizedText match = names.FirstOrDefault(n =>
+                        string.Equals(n.Locale, locale, StringComparison.OrdinalIgnoreCase));
+                    if (!match.IsNullOrEmpty)
+                    {
+                        return match;
+                    }
+                }
+            }
+
+            return names[0];
+        }
+
+        private static RegistrationEntry Clone(RegistrationEntry e) => new()
+        {
+            ServerUri = e.ServerUri,
+            ProductUri = e.ProductUri,
+            ServerNames = [.. e.ServerNames],
+            ServerType = e.ServerType,
+            GatewayServerUri = e.GatewayServerUri,
+            DiscoveryUrls = [.. e.DiscoveryUrls],
+            SemaphoreFilePath = e.SemaphoreFilePath,
+            IsOnline = e.IsOnline,
+            LastSeenUtc = e.LastSeenUtc,
+            ServerCapabilities = [.. e.ServerCapabilities],
+            MdnsServerName = e.MdnsServerName
+        };
+
+        private static ServerOnNetworkRecord Clone(ServerOnNetworkRecord r) => new()
+        {
+            RecordId = r.RecordId,
+            ServerUri = r.ServerUri,
+            ServerName = r.ServerName,
+            DiscoveryUrl = r.DiscoveryUrl,
+            ServerCapabilities = [.. r.ServerCapabilities],
+            LastSeenUtc = r.LastSeenUtc,
+            ObservedViaMulticast = r.ObservedViaMulticast
+        };
+    }
+}

--- a/Libraries/Opc.Ua.Lds.Server/RegistrationEntry.cs
+++ b/Libraries/Opc.Ua.Lds.Server/RegistrationEntry.cs
@@ -1,0 +1,105 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using System.Collections.Generic;
+
+namespace Opc.Ua.Lds.Server
+{
+    /// <summary>
+    /// In-memory record of a server registered with the LDS via
+    /// <see cref="LdsServer.RegisterServerAsync"/> or
+    /// <see cref="LdsServer.RegisterServer2Async"/>.
+    /// </summary>
+    /// <remarks>
+    /// Registrations are keyed by <see cref="ServerUri"/>. Setting <see cref="IsOnline"/>
+    /// to <c>false</c> in a subsequent register call removes the entry from the store.
+    /// </remarks>
+    public sealed class RegistrationEntry
+    {
+        /// <summary>
+        /// The server's <c>ApplicationUri</c>. Acts as the unique key for the registration.
+        /// </summary>
+        public string ServerUri { get; set; }
+
+        /// <summary>
+        /// The server's product URI.
+        /// </summary>
+        public string ProductUri { get; set; }
+
+        /// <summary>
+        /// The server's localized application names.
+        /// </summary>
+        public IList<LocalizedText> ServerNames { get; set; } = new List<LocalizedText>();
+
+        /// <summary>
+        /// The server's <see cref="ApplicationType"/>. LDS rejects
+        /// <see cref="ApplicationType.Client"/> registrations.
+        /// </summary>
+        public ApplicationType ServerType { get; set; } = ApplicationType.Server;
+
+        /// <summary>
+        /// Optional gateway server URI for non-OPC UA server registrations.
+        /// </summary>
+        public string GatewayServerUri { get; set; }
+
+        /// <summary>
+        /// One or more discovery endpoint URLs.
+        /// </summary>
+        public IList<string> DiscoveryUrls { get; set; } = new List<string>();
+
+        /// <summary>
+        /// Optional file path used to keep the registration alive while the file exists.
+        /// </summary>
+        public string SemaphoreFilePath { get; set; }
+
+        /// <summary>
+        /// Whether the server is currently online and accepting connections.
+        /// </summary>
+        public bool IsOnline { get; set; }
+
+        /// <summary>
+        /// Wall-clock timestamp of the most recent register call.
+        /// </summary>
+        public DateTime LastSeenUtc { get; set; }
+
+        /// <summary>
+        /// The capabilities advertised by the registered server, derived from the most
+        /// recent <c>MdnsDiscoveryConfiguration</c> if any. Empty for plain
+        /// <c>RegisterServer</c> calls.
+        /// </summary>
+        public IList<string> ServerCapabilities { get; set; } = new List<string>();
+
+        /// <summary>
+        /// The mDNS server name advertised by the most recent
+        /// <c>MdnsDiscoveryConfiguration</c>. Null for plain <c>RegisterServer</c> calls.
+        /// </summary>
+        public string MdnsServerName { get; set; }
+    }
+}

--- a/Libraries/Opc.Ua.Lds.Server/ServerOnNetworkRecord.cs
+++ b/Libraries/Opc.Ua.Lds.Server/ServerOnNetworkRecord.cs
@@ -1,0 +1,81 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using System.Collections.Generic;
+
+namespace Opc.Ua.Lds.Server
+{
+    /// <summary>
+    /// Network-level record exposed to clients via
+    /// <see cref="LdsServer.FindServersOnNetworkAsync"/>. Each
+    /// <see cref="MdnsDiscoveryConfiguration"/> attached to a register call
+    /// produces one record; observed mDNS peers also surface as records.
+    /// </summary>
+    public sealed class ServerOnNetworkRecord
+    {
+        /// <summary>
+        /// The monotonic record id assigned by the store.
+        /// </summary>
+        public uint RecordId { get; internal set; }
+
+        /// <summary>
+        /// The server's <c>ApplicationUri</c>. Used to correlate the record back
+        /// to a <see cref="RegistrationEntry"/> when one exists.
+        /// </summary>
+        public string ServerUri { get; set; }
+
+        /// <summary>
+        /// The mDNS server name (display string) for this record.
+        /// </summary>
+        public string ServerName { get; set; }
+
+        /// <summary>
+        /// One discovery URL the client can use to reach the server.
+        /// </summary>
+        public string DiscoveryUrl { get; set; }
+
+        /// <summary>
+        /// The capabilities advertised by the server.
+        /// </summary>
+        public IList<string> ServerCapabilities { get; set; } = new List<string>();
+
+        /// <summary>
+        /// Wall-clock timestamp of the most recent observation. Used for TTL-based
+        /// pruning of mDNS-observed records.
+        /// </summary>
+        public DateTime LastSeenUtc { get; internal set; }
+
+        /// <summary>
+        /// True if the record originated from an mDNS network observation as
+        /// opposed to an explicit RegisterServer2 call.
+        /// </summary>
+        public bool ObservedViaMulticast { get; set; }
+    }
+}

--- a/Libraries/Opc.Ua.Server/FileSystem/DirectoryBrowser.cs
+++ b/Libraries/Opc.Ua.Server/FileSystem/DirectoryBrowser.cs
@@ -1,0 +1,180 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System.Collections.Generic;
+using System.Threading;
+
+namespace Opc.Ua.Server.FileSystem
+{
+    /// <summary>
+    /// Enumerates the immediate children (files + directories) of a
+    /// <see cref="DirectoryObjectState"/> via the underlying
+    /// <see cref="IFileSystemProvider"/>.
+    /// </summary>
+    internal sealed class DirectoryBrowser : NodeBrowser
+    {
+        public DirectoryBrowser(
+            ISystemContext context, ViewDescription? view,
+            NodeId referenceType, bool includeSubtypes, BrowseDirection browseDirection,
+            QualifiedName browseName, IEnumerable<IReference>? additionalReferences,
+            bool internalOnly,
+            FileSystemNodeManager manager,
+            DirectoryObjectState source)
+            : base(context, view, referenceType, includeSubtypes, browseDirection,
+                browseName, additionalReferences, internalOnly)
+        {
+            m_manager = manager;
+            m_source = source;
+            m_stage = Stage.Begin;
+        }
+
+        public override IReference? Next()
+        {
+            lock (DataLock)
+            {
+                IReference? reference = base.Next();
+                if (reference != null)
+                {
+                    return reference;
+                }
+
+                if (InternalOnly || m_manager == null)
+                {
+                    return null;
+                }
+                if (!IsRequired(ReferenceTypeIds.HasComponent, false))
+                {
+                    return null;
+                }
+
+                if (m_stage == Stage.Begin)
+                {
+                    m_pending = LoadEntries();
+                    m_stage = Stage.Children;
+                }
+
+                if (m_stage == Stage.Children)
+                {
+                    reference = NextChild();
+                    if (reference != null)
+                    {
+                        return reference;
+                    }
+                    m_stage = Stage.Done;
+                }
+
+                return null;
+            }
+        }
+
+        private List<FileSystemEntry> LoadEntries()
+        {
+            var list = new List<FileSystemEntry>();
+            try
+            {
+                IAsyncEnumerator<FileSystemEntry> enumerator = m_manager.Provider
+                    .EnumerateAsync(m_source.ProviderPath, CancellationToken.None)
+                    .GetAsyncEnumerator(CancellationToken.None);
+                try
+                {
+                    while (enumerator.MoveNextAsync().AsTask().GetAwaiter().GetResult())
+                    {
+                        list.Add(enumerator.Current);
+                    }
+                }
+                finally
+                {
+                    enumerator.DisposeAsync().AsTask().GetAwaiter().GetResult();
+                }
+            }
+            catch
+            {
+                // Browse continues without children when the provider
+                // can't enumerate (e.g. permission denied).
+            }
+            return list;
+        }
+
+        private NodeStateReference? NextChild()
+        {
+            if (m_pending == null)
+            {
+                return null;
+            }
+
+            // Named child requested — scan once and stop.
+            if (!BrowseName.IsNull)
+            {
+                if (m_source.BrowseName.NamespaceIndex != BrowseName.NamespaceIndex)
+                {
+                    m_pending = null;
+                    return null;
+                }
+                foreach (FileSystemEntry entry in m_pending)
+                {
+                    if (entry.Name == BrowseName.Name)
+                    {
+                        m_pending = null;
+                        return CreateReference(entry);
+                    }
+                }
+                m_pending = null;
+                return null;
+            }
+
+            if (m_pending.Count == 0)
+            {
+                return null;
+            }
+            FileSystemEntry head = m_pending[0];
+            m_pending.RemoveAt(0);
+            return CreateReference(head);
+        }
+
+        private NodeStateReference CreateReference(FileSystemEntry entry)
+        {
+            NodeId targetId = entry.IsDirectory
+                ? FileSystemNodeId.BuildDirectory(entry.Path, m_manager.NamespaceIndex)
+                : FileSystemNodeId.BuildFile(entry.Path, m_manager.NamespaceIndex);
+            return new NodeStateReference(ReferenceTypeIds.HasComponent, false, targetId);
+        }
+
+        private enum Stage
+        {
+            Begin,
+            Children,
+            Done
+        }
+
+        private readonly FileSystemNodeManager m_manager;
+        private readonly DirectoryObjectState m_source;
+        private List<FileSystemEntry>? m_pending;
+        private Stage m_stage;
+    }
+}

--- a/Libraries/Opc.Ua.Server/FileSystem/DirectoryObjectState.cs
+++ b/Libraries/Opc.Ua.Server/FileSystem/DirectoryObjectState.cs
@@ -1,0 +1,367 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+
+namespace Opc.Ua.Server.FileSystem
+{
+    /// <summary>
+    /// Address-space representation of a single directory in an
+    /// <see cref="IFileSystemProvider"/>. Hangs the FileDirectoryType
+    /// methods (CreateFile / CreateDirectory / DeleteFileSystemObject
+    /// / MoveOrCopy) on top of the provider.
+    /// </summary>
+    internal sealed class DirectoryObjectState : FileDirectoryState
+    {
+        public string ProviderPath { get; }
+
+        public bool IsRoot { get; }
+
+        public DirectoryObjectState(
+            ISystemContext context,
+            NodeId nodeId,
+            string providerPath,
+            string displayName,
+            bool isRoot)
+            : base(null)
+        {
+            ProviderPath = providerPath ?? string.Empty;
+            IsRoot = isRoot;
+
+            TypeDefinitionId = ObjectTypeIds.FileDirectoryType;
+            SymbolicName = ProviderPath;
+            NodeId = nodeId;
+            BrowseName = new QualifiedName(displayName);
+            DisplayName = new LocalizedText(displayName);
+            Description = LocalizedText.Null;
+            WriteMask = 0;
+            UserWriteMask = 0;
+            EventNotifier = EventNotifiers.None;
+
+            DeleteFileSystemObject = new DeleteFileMethodState(this)
+            {
+                OnCall = OnDeleteFileSystemObject,
+                Executable = true,
+                UserExecutable = true
+            };
+            DeleteFileSystemObject.Create(context, MethodIds.FileDirectoryType_DeleteFileSystemObject,
+                new QualifiedName(BrowseNames.DeleteFileSystemObject),
+                new LocalizedText(BrowseNames.DeleteFileSystemObject), false);
+
+            CreateFile = new CreateFileMethodState(this)
+            {
+                OnCall = OnCreateFile,
+                Executable = true,
+                UserExecutable = true
+            };
+            CreateFile.Create(context, MethodIds.FileDirectoryType_CreateFile,
+                new QualifiedName(BrowseNames.CreateFile),
+                new LocalizedText(BrowseNames.CreateFile), false);
+
+            CreateDirectory = new CreateDirectoryMethodState(this)
+            {
+                OnCall = OnCreateDirectory,
+                Executable = true,
+                UserExecutable = true
+            };
+            CreateDirectory.Create(context, MethodIds.FileDirectoryType_CreateDirectory,
+                new QualifiedName(BrowseNames.CreateDirectory),
+                new LocalizedText(BrowseNames.CreateDirectory), false);
+
+            MoveOrCopy = new MoveOrCopyMethodState(this)
+            {
+                OnCall = OnMoveOrCopy,
+                Executable = true,
+                UserExecutable = true
+            };
+            MoveOrCopy.Create(context, MethodIds.FileDirectoryType_MoveOrCopy,
+                new QualifiedName(BrowseNames.MoveOrCopy),
+                new LocalizedText(BrowseNames.MoveOrCopy), false);
+        }
+
+        public override INodeBrowser CreateBrowser(
+            ISystemContext context, ViewDescription? view, NodeId referenceType,
+            bool includeSubtypes, BrowseDirection browseDirection,
+            QualifiedName browseName, IEnumerable<IReference>? additionalReferences,
+            bool internalOnly)
+        {
+            FileSystemNodeManager? manager = context?.SystemHandle as FileSystemNodeManager;
+            var browser = new DirectoryBrowser(
+                context!, view, referenceType, includeSubtypes,
+                browseDirection, browseName, additionalReferences,
+                internalOnly, manager!, this);
+            PopulateBrowser(context!, browser);
+            return browser;
+        }
+
+        protected override void PopulateBrowser(ISystemContext context, NodeBrowser browser)
+        {
+            base.PopulateBrowser(context, browser);
+
+            FileSystemNodeManager? manager = context?.SystemHandle as FileSystemNodeManager;
+            if (manager == null)
+            {
+                return;
+            }
+
+            // Inverse reference to the parent: for the mount root we
+            // expose a HasComponent inverse to Server.FileSystem
+            // (i=16314). For nested directories the parent is another
+            // directory inside this provider.
+            if (browser.IsRequired(ReferenceTypeIds.HasComponent, true))
+            {
+                if (IsRoot)
+                {
+                    browser.Add(ReferenceTypeIds.HasComponent, true, ObjectIds.FileSystem);
+                }
+                else
+                {
+                    NodeId parentId = manager.GetParentNodeId(ProviderPath);
+                    if (!parentId.IsNull)
+                    {
+                        browser.Add(ReferenceTypeIds.HasComponent, true, parentId);
+                    }
+                }
+            }
+        }
+
+        private ServiceResult OnCreateDirectory(ISystemContext context, MethodState method,
+            NodeId objectId, string directoryName, ref NodeId directoryNodeId)
+        {
+            FileSystemNodeManager? manager = context?.SystemHandle as FileSystemNodeManager;
+            if (manager == null)
+            {
+                return ServiceResult.Create(StatusCodes.BadInvalidState,
+                    "Node manager unavailable.");
+            }
+            if (string.IsNullOrEmpty(directoryName))
+            {
+                return ServiceResult.Create(StatusCodes.BadInvalidArgument,
+                    "Directory name required.");
+            }
+            string newPath = manager.CombineProviderPath(ProviderPath, directoryName);
+            try
+            {
+                manager.Provider.CreateDirectoryAsync(newPath, CancellationToken.None)
+                    .AsTask().GetAwaiter().GetResult();
+                directoryNodeId = FileSystemNodeId.BuildDirectory(newPath, manager.NamespaceIndex);
+                return ServiceResult.Good;
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                return ServiceResult.Create(ex, StatusCodes.BadUserAccessDenied,
+                    "Failed to create directory.");
+            }
+            catch (IOException ex)
+            {
+                return ServiceResult.Create(ex, StatusCodes.BadBrowseNameDuplicated,
+                    "Directory or file with same name exists.");
+            }
+        }
+
+        private ServiceResult OnCreateFile(ISystemContext context, MethodState method,
+            NodeId objectId, string fileName, bool requestFileOpen,
+            ref NodeId fileNodeId, ref uint fileHandle)
+        {
+            FileSystemNodeManager? manager = context?.SystemHandle as FileSystemNodeManager;
+            if (manager == null)
+            {
+                return ServiceResult.Create(StatusCodes.BadInvalidState,
+                    "Node manager unavailable.");
+            }
+            if (string.IsNullOrEmpty(fileName))
+            {
+                return ServiceResult.Create(StatusCodes.BadInvalidArgument,
+                    "File name required.");
+            }
+            string newPath = manager.CombineProviderPath(ProviderPath, fileName);
+            try
+            {
+                if (!requestFileOpen)
+                {
+                    manager.Provider.CreateFileAsync(newPath, CancellationToken.None)
+                        .AsTask().GetAwaiter().GetResult();
+                    fileNodeId = FileSystemNodeId.BuildFile(newPath, manager.NamespaceIndex);
+                    fileHandle = 0u;
+                    return ServiceResult.Good;
+                }
+
+                fileNodeId = FileSystemNodeId.BuildFile(newPath, manager.NamespaceIndex);
+                FileHandle? handle = manager.GetOrCreateHandle(fileNodeId, newPath);
+                if (handle == null)
+                {
+                    return ServiceResult.Create(StatusCodes.BadInvalidState,
+                        "Failed to obtain file handle.");
+                }
+                // Open with write + erase to mirror the spec's
+                // "create + open for write" semantics.
+                return handle.Open(0x6, out fileHandle);
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                return ServiceResult.Create(ex, StatusCodes.BadUserAccessDenied,
+                    "Failed to create file.");
+            }
+            catch (IOException ex)
+            {
+                return ServiceResult.Create(ex, StatusCodes.BadBrowseNameDuplicated,
+                    "Directory or file with same name exists.");
+            }
+        }
+
+        private ServiceResult OnDeleteFileSystemObject(ISystemContext context, MethodState method,
+            NodeId objectId, NodeId objectToDelete)
+        {
+            FileSystemNodeManager? manager = context?.SystemHandle as FileSystemNodeManager;
+            if (manager == null)
+            {
+                return ServiceResult.Create(StatusCodes.BadInvalidState,
+                    "Node manager unavailable.");
+            }
+            if (!FileSystemNodeId.TryParse(objectToDelete, out FileSystemNodeId parsed))
+            {
+                return ServiceResult.Create(StatusCodes.BadInvalidState,
+                    "Not a file-system object.");
+            }
+            if (parsed.RootType == FileSystemNodeId.Root)
+            {
+                return ServiceResult.Create(StatusCodes.BadUserAccessDenied,
+                    "Cannot delete the file-system root.");
+            }
+            try
+            {
+                manager.Provider.DeleteAsync(parsed.ProviderPath, CancellationToken.None)
+                    .AsTask().GetAwaiter().GetResult();
+                manager.ForgetHandle(objectToDelete);
+                return ServiceResult.Good;
+            }
+            catch (FileNotFoundException ex)
+            {
+                return ServiceResult.Create(ex, StatusCodes.BadNotFound,
+                    "File-system object not found.");
+            }
+            catch (DirectoryNotFoundException ex)
+            {
+                return ServiceResult.Create(ex, StatusCodes.BadNotFound,
+                    "File-system object not found.");
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                return ServiceResult.Create(ex, StatusCodes.BadUserAccessDenied,
+                    "Failed to delete file-system object.");
+            }
+            catch (IOException ex)
+            {
+                return ServiceResult.Create(ex, StatusCodes.BadUserAccessDenied,
+                    "Failed to delete file-system object.");
+            }
+        }
+
+        private ServiceResult OnMoveOrCopy(ISystemContext context, MethodState method,
+            NodeId objectId, NodeId objectToMoveOrCopy, NodeId targetDirectory,
+            bool createCopy, string newName, ref NodeId newNodeId)
+        {
+            FileSystemNodeManager? manager = context?.SystemHandle as FileSystemNodeManager;
+            if (manager == null)
+            {
+                return ServiceResult.Create(StatusCodes.BadInvalidState,
+                    "Node manager unavailable.");
+            }
+            if (!FileSystemNodeId.TryParse(objectToMoveOrCopy, out FileSystemNodeId source)
+                || source.RootType == FileSystemNodeId.Root)
+            {
+                return ServiceResult.Create(StatusCodes.BadInvalidArgument,
+                    "Source is not a directory or file.");
+            }
+            if (!FileSystemNodeId.TryParse(targetDirectory, out FileSystemNodeId target)
+                || target.RootType == FileSystemNodeId.File)
+            {
+                return ServiceResult.Create(StatusCodes.BadInvalidArgument,
+                    "Target is not a directory.");
+            }
+
+            string sourceName = ProviderPathName(source.ProviderPath);
+            string finalName = !string.IsNullOrEmpty(newName) ? newName : sourceName;
+            string targetPath = manager.CombineProviderPath(target.ProviderPath, finalName);
+
+            try
+            {
+                if (createCopy)
+                {
+                    manager.Provider.CopyAsync(source.ProviderPath, targetPath, CancellationToken.None)
+                        .AsTask().GetAwaiter().GetResult();
+                }
+                else
+                {
+                    manager.Provider.MoveAsync(source.ProviderPath, targetPath, CancellationToken.None)
+                        .AsTask().GetAwaiter().GetResult();
+                    manager.ForgetHandle(objectToMoveOrCopy);
+                }
+
+                newNodeId = source.RootType == FileSystemNodeId.File
+                    ? FileSystemNodeId.BuildFile(targetPath, manager.NamespaceIndex)
+                    : FileSystemNodeId.BuildDirectory(targetPath, manager.NamespaceIndex);
+                return ServiceResult.Good;
+            }
+            catch (FileNotFoundException ex)
+            {
+                return ServiceResult.Create(ex, StatusCodes.BadNotFound,
+                    "Source not found.");
+            }
+            catch (DirectoryNotFoundException ex)
+            {
+                return ServiceResult.Create(ex, StatusCodes.BadNotFound,
+                    "Source not found.");
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                return ServiceResult.Create(ex, StatusCodes.BadUserAccessDenied,
+                    "Failed to move or copy.");
+            }
+            catch (IOException ex)
+            {
+                return ServiceResult.Create(ex, StatusCodes.BadBrowseNameDuplicated,
+                    "Failed to move or copy.");
+            }
+        }
+
+        private static string ProviderPathName(string providerPath)
+        {
+            if (string.IsNullOrEmpty(providerPath))
+            {
+                return string.Empty;
+            }
+            int slash = providerPath.LastIndexOf('/');
+            return slash < 0 ? providerPath : providerPath.Substring(slash + 1);
+        }
+    }
+}

--- a/Libraries/Opc.Ua.Server/FileSystem/FileHandle.cs
+++ b/Libraries/Opc.Ua.Server/FileSystem/FileHandle.cs
@@ -1,0 +1,274 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Opc.Ua.Server.FileSystem
+{
+    /// <summary>
+    /// Per-file handle bag. Tracks the streams opened against a single
+    /// file via repeated <c>FileType.Open</c> calls (one writer +
+    /// many readers per the spec) and dispenses the integer
+    /// file-handle values returned to OPC UA clients.
+    /// </summary>
+    internal sealed class FileHandle : IDisposable
+    {
+        public FileHandle(IFileSystemProvider provider, string providerPath)
+        {
+            m_provider = provider;
+            ProviderPath = providerPath;
+        }
+
+        public string ProviderPath { get; }
+
+        public ushort OpenCount
+        {
+            get
+            {
+                lock (m_lock)
+                {
+                    return (ushort)(m_reads.Count + (m_write != null ? 1 : 0));
+                }
+            }
+        }
+
+        public bool IsWriteable
+        {
+            get
+            {
+                lock (m_lock)
+                {
+                    if (!m_provider.IsWritable || m_reads.Count != 0 || m_write != null)
+                    {
+                        return false;
+                    }
+                }
+                // Outside the lock: ask the provider for the latest
+                // writable bit without serialising readers.
+                FileSystemEntry? entry = m_provider.GetEntryAsync(
+                    ProviderPath, CancellationToken.None)
+                    .AsTask().GetAwaiter().GetResult();
+                return entry?.IsWritable ?? false;
+            }
+        }
+
+        public long Length
+        {
+            get
+            {
+                FileSystemEntry? entry = m_provider.GetEntryAsync(
+                    ProviderPath, CancellationToken.None)
+                    .AsTask().GetAwaiter().GetResult();
+                return entry?.Length ?? 0L;
+            }
+        }
+
+        public DateTime LastModifiedTime
+        {
+            get
+            {
+                FileSystemEntry? entry = m_provider.GetEntryAsync(
+                    ProviderPath, CancellationToken.None)
+                    .AsTask().GetAwaiter().GetResult();
+                return entry?.LastModifiedUtc ?? DateTime.MinValue;
+            }
+        }
+
+        public string MimeType
+        {
+            get
+            {
+                FileSystemEntry? entry = m_provider.GetEntryAsync(
+                    ProviderPath, CancellationToken.None)
+                    .AsTask().GetAwaiter().GetResult();
+                return entry?.MimeType ?? string.Empty;
+            }
+        }
+
+        public Stream? GetStream(uint fileHandle)
+        {
+            lock (m_lock)
+            {
+                if (m_write != null && fileHandle == 1)
+                {
+                    return m_write;
+                }
+                if (m_reads.TryGetValue(fileHandle, out Stream? stream))
+                {
+                    return stream;
+                }
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Implements <c>FileType.Open</c>. The mode bits are per
+        /// Part 5 §C: 0x1 = Read, 0x2 = Write, 0x4 = EraseExisting,
+        /// 0x8 = Append.
+        /// </summary>
+        public ServiceResult Open(byte mode, out uint fileHandle)
+        {
+            fileHandle = 0u;
+            bool wantsRead = (mode & 0x1) != 0;
+            bool wantsWrite = (mode & 0x2) != 0;
+
+            if (!wantsRead && !wantsWrite)
+            {
+                return ServiceResult.Create(
+                    StatusCodes.BadInvalidArgument,
+                    "FileType.Open mode must include read or write.");
+            }
+            if (wantsRead && wantsWrite)
+            {
+                return ServiceResult.Create(
+                    StatusCodes.BadInvalidArgument,
+                    "Simultaneous read + write open not supported.");
+            }
+            if (wantsWrite && !m_provider.IsWritable)
+            {
+                return ServiceResult.Create(
+                    StatusCodes.BadUserAccessDenied,
+                    "Provider is read-only.");
+            }
+
+            try
+            {
+                if (wantsRead)
+                {
+                    Stream stream = m_provider
+                        .OpenReadAsync(ProviderPath, CancellationToken.None)
+                        .AsTask().GetAwaiter().GetResult();
+                    lock (m_lock)
+                    {
+                        if (m_write != null)
+                        {
+                            stream.Dispose();
+                            return ServiceResult.Create(
+                                StatusCodes.BadInvalidState,
+                                "File already open for write.");
+                        }
+                        fileHandle = ++m_nextHandle;
+                        m_reads.Add(fileHandle, stream);
+                    }
+                    return ServiceResult.Good;
+                }
+
+                FileWriteMode writeMode;
+                if ((mode & 0x4) != 0)
+                {
+                    writeMode = FileWriteMode.Truncate;
+                }
+                else if ((mode & 0x8) != 0)
+                {
+                    writeMode = FileWriteMode.Append;
+                }
+                else
+                {
+                    writeMode = FileWriteMode.OpenOrCreate;
+                }
+
+                Stream writeStream = m_provider
+                    .OpenWriteAsync(ProviderPath, writeMode, CancellationToken.None)
+                    .AsTask().GetAwaiter().GetResult();
+                lock (m_lock)
+                {
+                    if (m_reads.Count != 0 || m_write != null)
+                    {
+                        writeStream.Dispose();
+                        return ServiceResult.Create(
+                            StatusCodes.BadInvalidState,
+                            "File already open for read or write.");
+                    }
+                    m_write = writeStream;
+                    fileHandle = 1u;
+                }
+                return ServiceResult.Good;
+            }
+            catch (FileNotFoundException ex)
+            {
+                return ServiceResult.Create(ex, StatusCodes.BadNotFound,
+                    "File not found");
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                return ServiceResult.Create(ex, StatusCodes.BadUserAccessDenied,
+                    "Failed to open file");
+            }
+            catch (IOException ex)
+            {
+                return ServiceResult.Create(ex, StatusCodes.BadInvalidState,
+                    "Failed to open file");
+            }
+        }
+
+        public bool Close(uint fileHandle)
+        {
+            lock (m_lock)
+            {
+                if (m_write != null && fileHandle == 1)
+                {
+                    m_write.Dispose();
+                    m_write = null;
+                    return true;
+                }
+                if (m_reads.TryGetValue(fileHandle, out Stream? stream))
+                {
+                    stream.Dispose();
+                    m_reads.Remove(fileHandle);
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        public void Dispose()
+        {
+            lock (m_lock)
+            {
+                m_write?.Dispose();
+                m_write = null;
+                foreach (Stream stream in m_reads.Values)
+                {
+                    stream.Dispose();
+                }
+                m_reads.Clear();
+            }
+        }
+
+        private readonly object m_lock = new();
+        private readonly Dictionary<uint, Stream> m_reads = new();
+        private readonly IFileSystemProvider m_provider;
+        private uint m_nextHandle = 1;
+        private Stream? m_write;
+    }
+}

--- a/Libraries/Opc.Ua.Server/FileSystem/FileObjectState.cs
+++ b/Libraries/Opc.Ua.Server/FileSystem/FileObjectState.cs
@@ -1,0 +1,409 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using System.IO;
+
+namespace Opc.Ua.Server.FileSystem
+{
+    /// <summary>
+    /// Address-space representation of a single file in an
+    /// <see cref="IFileSystemProvider"/>. Hangs the FileType
+    /// metadata properties (Size, Writable, LastModifiedTime, …)
+    /// and the FileType methods (Open / Read / Write / Close /
+    /// SetPosition / GetPosition) on top of an underlying
+    /// <see cref="FileHandle"/> obtained from the owning
+    /// <see cref="FileSystemNodeManager"/>.
+    /// </summary>
+    internal sealed class FileObjectState : FileState
+    {
+        public string ProviderPath { get; }
+
+        public FileObjectState(
+            ISystemContext context,
+            NodeId nodeId,
+            string providerPath,
+            string displayName)
+            : base(null)
+        {
+            ProviderPath = providerPath;
+
+            TypeDefinitionId = ObjectTypeIds.FileType;
+            SymbolicName = providerPath;
+            NodeId = nodeId;
+            BrowseName = new QualifiedName(displayName);
+            DisplayName = new LocalizedText(displayName);
+            Description = LocalizedText.Null;
+            WriteMask = 0;
+            UserWriteMask = 0;
+            EventNotifier = EventNotifiers.None;
+
+            OpenCount = PropertyState<ushort>.With<VariantBuilder>(this);
+            OpenCount.OnReadValue += OnOpenCount;
+            OpenCount.AccessLevel = AccessLevels.CurrentRead;
+            OpenCount.UserAccessLevel = AccessLevels.CurrentRead;
+            OpenCount.Create(context, VariableIds.FileType_OpenCount,
+                new QualifiedName(BrowseNames.OpenCount),
+                new LocalizedText(BrowseNames.OpenCount), true);
+
+            Writable = PropertyState<bool>.With<VariantBuilder>(this);
+            Writable.OnReadValue += OnWritable;
+            Writable.AccessLevel = AccessLevels.CurrentRead;
+            Writable.UserAccessLevel = AccessLevels.CurrentRead;
+            Writable.Create(context, VariableIds.FileType_Writable,
+                new QualifiedName(BrowseNames.Writable),
+                new LocalizedText(BrowseNames.Writable), true);
+
+            UserWritable = PropertyState<bool>.With<VariantBuilder>(this);
+            UserWritable.OnReadValue += OnWritable;
+            UserWritable.AccessLevel = AccessLevels.CurrentRead;
+            UserWritable.UserAccessLevel = AccessLevels.CurrentRead;
+            UserWritable.Create(context, VariableIds.FileType_UserWritable,
+                new QualifiedName(BrowseNames.UserWritable),
+                new LocalizedText(BrowseNames.UserWritable), true);
+
+            Size = PropertyState<ulong>.With<VariantBuilder>(this);
+            Size.OnReadValue += OnSize;
+            Size.AccessLevel = AccessLevels.CurrentRead;
+            Size.UserAccessLevel = AccessLevels.CurrentRead;
+            Size.Create(context, VariableIds.FileType_Size,
+                new QualifiedName(BrowseNames.Size),
+                new LocalizedText(BrowseNames.Size), true);
+
+            MimeType = PropertyState<string>.With<VariantBuilder>(this);
+            MimeType.OnReadValue += OnMimeType;
+            MimeType.AccessLevel = AccessLevels.CurrentRead;
+            MimeType.UserAccessLevel = AccessLevels.CurrentRead;
+            MimeType.Create(context, VariableIds.FileType_MimeType,
+                new QualifiedName(BrowseNames.MimeType),
+                new LocalizedText(BrowseNames.MimeType), true);
+
+            LastModifiedTime = PropertyState<DateTimeUtc>.With<VariantBuilder>(this);
+            LastModifiedTime.OnReadValue += OnLastModifiedTime;
+            LastModifiedTime.AccessLevel = AccessLevels.CurrentRead;
+            LastModifiedTime.UserAccessLevel = AccessLevels.CurrentRead;
+            LastModifiedTime.Create(context, VariableIds.FileType_LastModifiedTime,
+                new QualifiedName(BrowseNames.LastModifiedTime),
+                new LocalizedText(BrowseNames.LastModifiedTime), true);
+
+            Open = new OpenMethodState(this)
+            {
+                OnCall = OnOpen,
+                Executable = true,
+                UserExecutable = true
+            };
+            Open.Create(context, MethodIds.FileType_Open,
+                new QualifiedName(BrowseNames.Open),
+                new LocalizedText(BrowseNames.Open), false);
+
+            Write = new WriteMethodState(this)
+            {
+                OnCall = OnWrite,
+                Executable = true,
+                UserExecutable = true
+            };
+            Write.Create(context, MethodIds.FileType_Write,
+                new QualifiedName(BrowseNames.Write),
+                new LocalizedText(BrowseNames.Write), false);
+
+            Read = new ReadMethodState(this)
+            {
+                OnCall = OnRead,
+                Executable = true,
+                UserExecutable = true
+            };
+            Read.Create(context, MethodIds.FileType_Read,
+                new QualifiedName(BrowseNames.Read),
+                new LocalizedText(BrowseNames.Read), false);
+
+            Close = new CloseMethodState(this)
+            {
+                OnCall = OnClose,
+                Executable = true,
+                UserExecutable = true
+            };
+            Close.Create(context, MethodIds.FileType_Close,
+                new QualifiedName(BrowseNames.Close),
+                new LocalizedText(BrowseNames.Close), false);
+
+            GetPosition = new GetPositionMethodState(this)
+            {
+                OnCall = OnGetPosition,
+                Executable = true,
+                UserExecutable = true
+            };
+            GetPosition.Create(context, MethodIds.FileType_GetPosition,
+                new QualifiedName(BrowseNames.GetPosition),
+                new LocalizedText(BrowseNames.GetPosition), false);
+
+            SetPosition = new SetPositionMethodState(this)
+            {
+                OnCall = OnSetPosition,
+                Executable = true,
+                UserExecutable = true
+            };
+            SetPosition.Create(context, MethodIds.FileType_SetPosition,
+                new QualifiedName(BrowseNames.SetPosition),
+                new LocalizedText(BrowseNames.SetPosition), false);
+        }
+
+        private ServiceResult OnMimeType(ISystemContext context, NodeState node,
+            NumericRange indexRange, QualifiedName dataEncoding, ref Variant value,
+            ref StatusCode statusCode, ref DateTimeUtc timestamp)
+        {
+            if (!TryGetHandle(context, out FileHandle? handle, out ServiceResult result))
+            {
+                return result;
+            }
+            value = new Variant(handle.MimeType);
+            timestamp = DateTimeUtc.Now;
+            statusCode = StatusCodes.Uncertain;
+            return ServiceResult.Good;
+        }
+
+        private ServiceResult OnLastModifiedTime(ISystemContext context, NodeState node,
+            NumericRange indexRange, QualifiedName dataEncoding, ref Variant value,
+            ref StatusCode statusCode, ref DateTimeUtc timestamp)
+        {
+            if (!TryGetHandle(context, out FileHandle? handle, out ServiceResult result))
+            {
+                return result;
+            }
+            value = new Variant((DateTimeUtc)handle.LastModifiedTime);
+            timestamp = DateTimeUtc.Now;
+            statusCode = StatusCodes.Good;
+            return ServiceResult.Good;
+        }
+
+        private ServiceResult OnWritable(ISystemContext context, NodeState node,
+            NumericRange indexRange, QualifiedName dataEncoding, ref Variant value,
+            ref StatusCode statusCode, ref DateTimeUtc timestamp)
+        {
+            if (!TryGetHandle(context, out FileHandle? handle, out ServiceResult result))
+            {
+                return result;
+            }
+            value = new Variant(handle.IsWriteable);
+            timestamp = DateTimeUtc.Now;
+            statusCode = StatusCodes.Good;
+            return ServiceResult.Good;
+        }
+
+        private ServiceResult OnSize(ISystemContext context, NodeState node,
+            NumericRange indexRange, QualifiedName dataEncoding, ref Variant value,
+            ref StatusCode statusCode, ref DateTimeUtc timestamp)
+        {
+            if (!TryGetHandle(context, out FileHandle? handle, out ServiceResult result))
+            {
+                return result;
+            }
+            value = new Variant((ulong)handle.Length);
+            timestamp = DateTimeUtc.Now;
+            statusCode = StatusCodes.Good;
+            return ServiceResult.Good;
+        }
+
+        private ServiceResult OnOpenCount(ISystemContext context, NodeState node,
+            NumericRange indexRange, QualifiedName dataEncoding, ref Variant value,
+            ref StatusCode statusCode, ref DateTimeUtc timestamp)
+        {
+            if (!TryGetHandle(context, out FileHandle? handle, out ServiceResult result))
+            {
+                return result;
+            }
+            value = new Variant(handle.OpenCount);
+            timestamp = DateTimeUtc.Now;
+            statusCode = StatusCodes.Good;
+            return ServiceResult.Good;
+        }
+
+        private ServiceResult OnOpen(ISystemContext context, MethodState method,
+            NodeId objectId, byte mode, ref uint fileHandle)
+        {
+            if (!TryGetHandle(context, out FileHandle? handle, out ServiceResult result))
+            {
+                return result;
+            }
+            return handle.Open(mode, out fileHandle);
+        }
+
+        private ServiceResult OnClose(ISystemContext context, MethodState method,
+            NodeId objectId, uint fileHandle)
+        {
+            if (!TryGetHandle(context, out FileHandle? handle, out ServiceResult result))
+            {
+                return result;
+            }
+            return handle.Close(fileHandle)
+                ? ServiceResult.Good
+                : ServiceResult.Create(StatusCodes.BadInvalidState,
+                    "File handle could not be closed.");
+        }
+
+        private ServiceResult OnSetPosition(ISystemContext context, MethodState method,
+            NodeId objectId, uint fileHandle, ulong position)
+        {
+            if (!TryGetHandle(context, out FileHandle? handle, out ServiceResult result))
+            {
+                return result;
+            }
+            Stream? stream = handle.GetStream(fileHandle);
+            if (stream == null)
+            {
+                return ServiceResult.Create(StatusCodes.BadInvalidState,
+                    "File handle not open.");
+            }
+            stream.Position = (long)position;
+            return ServiceResult.Good;
+        }
+
+        private ServiceResult OnGetPosition(ISystemContext context, MethodState method,
+            NodeId objectId, uint fileHandle, ref ulong position)
+        {
+            if (!TryGetHandle(context, out FileHandle? handle, out ServiceResult result))
+            {
+                return result;
+            }
+            Stream? stream = handle.GetStream(fileHandle);
+            if (stream == null)
+            {
+                return ServiceResult.Create(StatusCodes.BadInvalidState,
+                    "File handle not open.");
+            }
+            position = (ulong)stream.Position;
+            return ServiceResult.Good;
+        }
+
+        private ServiceResult OnRead(ISystemContext context, MethodState method,
+            NodeId objectId, uint fileHandle, int length, ref ByteString data)
+        {
+            if (!TryGetHandle(context, out FileHandle? handle, out ServiceResult result))
+            {
+                return result;
+            }
+            Stream? stream = handle.GetStream(fileHandle);
+            if (stream == null)
+            {
+                return ServiceResult.Create(StatusCodes.BadInvalidState,
+                    "File handle not open.");
+            }
+
+            if (length < 0)
+            {
+                return ServiceResult.Create(StatusCodes.BadInvalidArgument,
+                    "Negative length.");
+            }
+            var buffer = new byte[length];
+            int read = stream.Read(buffer, 0, length);
+            if (read == length)
+            {
+                data = ByteString.From(buffer);
+            }
+            else
+            {
+                var trimmed = new byte[read];
+                Array.Copy(buffer, 0, trimmed, 0, read);
+                data = ByteString.From(trimmed);
+            }
+            return ServiceResult.Good;
+        }
+
+        private ServiceResult OnWrite(ISystemContext context, MethodState method,
+            NodeId objectId, uint fileHandle, ByteString data)
+        {
+            if (!TryGetHandle(context, out FileHandle? handle, out ServiceResult result))
+            {
+                return result;
+            }
+            Stream? stream = handle.GetStream(fileHandle);
+            if (stream == null)
+            {
+                return ServiceResult.Create(StatusCodes.BadInvalidState,
+                    "File handle not open.");
+            }
+            byte[] bytes = data.ToArray();
+            stream.Write(bytes, 0, bytes.Length);
+            return ServiceResult.Good;
+        }
+
+        protected override void PopulateBrowser(ISystemContext context, NodeBrowser browser)
+        {
+            base.PopulateBrowser(context, browser);
+
+            if (!browser.IsRequired(ReferenceTypeIds.HasComponent, true))
+            {
+                return;
+            }
+
+            // Reverse reference to the parent directory.
+            FileSystemNodeManager? manager = ResolveManager(context);
+            if (manager == null)
+            {
+                return;
+            }
+            NodeId parentId = manager.GetParentNodeId(ProviderPath);
+            if (!parentId.IsNull)
+            {
+                browser.Add(ReferenceTypeIds.HasComponent, true, parentId);
+            }
+        }
+
+        private bool TryGetHandle(
+            ISystemContext context,
+            [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out FileHandle? handle,
+            out ServiceResult result)
+        {
+            FileSystemNodeManager? manager = ResolveManager(context);
+            if (manager == null)
+            {
+                handle = null;
+                result = ServiceResult.Create(
+                    StatusCodes.BadInvalidState,
+                    "Node manager unavailable.");
+                return false;
+            }
+
+            handle = manager.GetOrCreateHandle(NodeId, ProviderPath);
+            if (handle == null)
+            {
+                result = ServiceResult.Create(
+                    StatusCodes.BadInvalidState,
+                    "File handle unavailable.");
+                return false;
+            }
+            result = ServiceResult.Good;
+            return true;
+        }
+
+        private static FileSystemNodeManager? ResolveManager(ISystemContext context)
+        {
+            return context?.SystemHandle as FileSystemNodeManager;
+        }
+    }
+}

--- a/Libraries/Opc.Ua.Server/FileSystem/FileSystemEntry.cs
+++ b/Libraries/Opc.Ua.Server/FileSystem/FileSystemEntry.cs
@@ -1,0 +1,75 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+
+namespace Opc.Ua.Server.FileSystem
+{
+    /// <summary>
+    /// Metadata describing a single entry in an
+    /// <see cref="IFileSystemProvider"/>: either a file or a
+    /// directory.
+    /// </summary>
+    /// <param name="Path">
+    /// Provider-relative path (forward-slash separated, never starts with a
+    /// slash, never ends with a slash except for the root which is an
+    /// empty string).
+    /// </param>
+    /// <param name="Name">
+    /// Display / browse name (the last segment of <see cref="Path"/>).
+    /// For the root entry this is the provider's
+    /// <see cref="IFileSystemProvider.MountName"/>.
+    /// </param>
+    /// <param name="IsDirectory">
+    /// <c>true</c> when the entry represents a directory, <c>false</c>
+    /// for a file.
+    /// </param>
+    /// <param name="Length">
+    /// File size in bytes. <c>0</c> for directories.
+    /// </param>
+    /// <param name="IsWritable">
+    /// <c>true</c> when the entry can be written to / modified /
+    /// deleted by the current user.
+    /// </param>
+    /// <param name="LastModifiedUtc">
+    /// Last-write timestamp in UTC.
+    /// </param>
+    /// <param name="MimeType">
+    /// IANA media type (best-effort guess from the file extension is
+    /// acceptable). Empty string for directories or unknown types.
+    /// </param>
+    public readonly record struct FileSystemEntry(
+        string Path,
+        string Name,
+        bool IsDirectory,
+        long Length,
+        bool IsWritable,
+        DateTime LastModifiedUtc,
+        string MimeType);
+}

--- a/Libraries/Opc.Ua.Server/FileSystem/FileSystemNodeId.cs
+++ b/Libraries/Opc.Ua.Server/FileSystem/FileSystemNodeId.cs
@@ -1,0 +1,238 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System.Text;
+
+namespace Opc.Ua.Server.FileSystem
+{
+    /// <summary>
+    /// Encodes / decodes the string-identifier shape used by
+    /// <see cref="FileSystemNodeManager"/> for files, directories,
+    /// and component nodes hung off them.
+    /// </summary>
+    /// <remarks>
+    /// Wire format:
+    /// <c>&lt;rootType&gt;:&lt;providerPath&gt;[?&lt;componentPath&gt;]</c>
+    /// <list type="bullet">
+    /// <item><c>rootType</c> is <c>0</c> for the mount root,
+    /// <c>1</c> for a directory, <c>2</c> for a file.</item>
+    /// <item><c>providerPath</c> is the provider-relative path
+    /// (forward-slash separated). Any literal <c>&amp;</c> or
+    /// <c>?</c> in the path is escaped with a leading <c>&amp;</c>.</item>
+    /// <item><c>componentPath</c> is an optional <c>/</c>-separated
+    /// list of <c>SymbolicName</c> values for a child node hung off
+    /// the root (e.g. <c>"Open"</c>, <c>"Size"</c>).</item>
+    /// </list>
+    /// </remarks>
+    internal readonly struct FileSystemNodeId
+    {
+        /// <summary>Root identifier (mount point).</summary>
+        public const int Root = 0;
+
+        /// <summary>Directory identifier.</summary>
+        public const int Directory = 1;
+
+        /// <summary>File identifier.</summary>
+        public const int File = 2;
+
+        public FileSystemNodeId(
+            int rootType,
+            string providerPath,
+            ushort namespaceIndex,
+            string? componentPath = null)
+        {
+            RootType = rootType;
+            ProviderPath = providerPath ?? string.Empty;
+            NamespaceIndex = namespaceIndex;
+            ComponentPath = componentPath;
+        }
+
+        /// <summary>0 = root, 1 = directory, 2 = file.</summary>
+        public int RootType { get; }
+
+        /// <summary>Provider-relative path (empty for the root).</summary>
+        public string ProviderPath { get; }
+
+        /// <summary>Optional component-name chain.</summary>
+        public string? ComponentPath { get; }
+
+        /// <summary>Namespace index of the encoded NodeId.</summary>
+        public ushort NamespaceIndex { get; }
+
+        public static NodeId BuildRoot(ushort namespaceIndex)
+            => new FileSystemNodeId(Root, string.Empty, namespaceIndex).ToNodeId();
+
+        public static NodeId BuildDirectory(string providerPath, ushort namespaceIndex)
+            => new FileSystemNodeId(Directory, providerPath, namespaceIndex).ToNodeId();
+
+        public static NodeId BuildFile(string providerPath, ushort namespaceIndex)
+            => new FileSystemNodeId(File, providerPath, namespaceIndex).ToNodeId();
+
+        /// <summary>
+        /// Attempts to parse the given <see cref="NodeId"/> into the
+        /// FileSystem wire format.
+        /// </summary>
+        public static bool TryParse(NodeId nodeId, out FileSystemNodeId result)
+        {
+            result = default;
+
+            if (nodeId.IsNull ||
+                !nodeId.TryGetValue(out string? identifier) ||
+                string.IsNullOrEmpty(identifier))
+            {
+                return false;
+            }
+
+            int rootType = 0;
+            int start = -1;
+            for (int ii = 0; ii < identifier.Length; ii++)
+            {
+                if (!char.IsDigit(identifier[ii]))
+                {
+                    start = ii;
+                    break;
+                }
+                rootType = (rootType * 10) + (identifier[ii] - '0');
+            }
+
+            if (start < 0 || start >= identifier.Length || identifier[start] != ':')
+            {
+                return false;
+            }
+
+            // Read provider path with & escapes; an unescaped ?
+            // terminates and starts the component path.
+            var buffer = new StringBuilder();
+            int index = start + 1;
+            int end = identifier.Length;
+            bool escaped = false;
+
+            while (index < end)
+            {
+                char ch = identifier[index++];
+                if (!escaped && ch == '&')
+                {
+                    escaped = true;
+                    continue;
+                }
+                if (!escaped && ch == '?')
+                {
+                    end = index;
+                    break;
+                }
+                buffer.Append(ch);
+                escaped = false;
+            }
+
+            string? componentPath = end < identifier.Length
+                ? identifier.Substring(end)
+                : null;
+
+            result = new FileSystemNodeId(
+                rootType,
+                buffer.ToString(),
+                nodeId.NamespaceIndex,
+                componentPath);
+            return true;
+        }
+
+        /// <summary>
+        /// Returns this struct as a <see cref="NodeId"/> with the
+        /// existing root + component path.
+        /// </summary>
+        public NodeId ToNodeId() => ToNodeId(componentName: null);
+
+        /// <summary>
+        /// Returns this struct as a <see cref="NodeId"/>, optionally
+        /// appending an additional child component name to the
+        /// existing <see cref="ComponentPath"/>.
+        /// </summary>
+        public NodeId ToNodeId(string? componentName)
+        {
+            var buffer = new StringBuilder();
+            buffer.Append(RootType).Append(':');
+
+            for (int ii = 0; ii < ProviderPath.Length; ii++)
+            {
+                char ch = ProviderPath[ii];
+                if (ch is '&' or '?')
+                {
+                    buffer.Append('&');
+                }
+                buffer.Append(ch);
+            }
+
+            if (!string.IsNullOrEmpty(ComponentPath))
+            {
+                buffer.Append('?').Append(ComponentPath);
+            }
+            if (!string.IsNullOrEmpty(componentName))
+            {
+                if (string.IsNullOrEmpty(ComponentPath))
+                {
+                    buffer.Append('?');
+                }
+                else
+                {
+                    buffer.Append('/');
+                }
+                buffer.Append(componentName);
+            }
+
+            return new NodeId(buffer.ToString(), NamespaceIndex);
+        }
+
+        /// <summary>
+        /// Encodes a NodeId for an arbitrary child component of the
+        /// supplied parent node. Mirrors the old
+        /// <c>ModelUtils.ConstructIdForComponent</c> helper.
+        /// </summary>
+        public static NodeId ConstructIdForComponent(
+            NodeState component,
+            ushort namespaceIndex)
+        {
+            if (component == null)
+            {
+                return NodeId.Null;
+            }
+            if (component is not BaseInstanceState instance ||
+                instance.Parent == null ||
+                !instance.Parent.NodeId.TryGetValue(out string? parentId))
+            {
+                return component.NodeId;
+            }
+
+            var buffer = new StringBuilder();
+            buffer.Append(parentId);
+            buffer.Append(parentId.IndexOf('?') < 0 ? '?' : '/');
+            buffer.Append(component.SymbolicName);
+            return new NodeId(buffer.ToString(), namespaceIndex);
+        }
+    }
+}

--- a/Libraries/Opc.Ua.Server/FileSystem/FileSystemNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/FileSystem/FileSystemNodeManager.cs
@@ -1,0 +1,369 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace Opc.Ua.Server.FileSystem
+{
+    /// <summary>
+    /// Exposes an <see cref="IFileSystemProvider"/> in the server's
+    /// address space using the standard OPC UA Part 5 §C / Part 20 §4
+    /// <c>FileType</c> / <c>FileDirectoryType</c> companion model.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The provider is mounted as a single
+    /// <c>FileDirectoryType</c> instance under the standard
+    /// <c>Server.FileSystem</c> object (<c>ObjectIds.FileSystem</c>,
+    /// <c>i=16314</c>) via a <c>HasComponent</c> reference. This is
+    /// what <c>FileSystemClient.OpenServerFileSystem</c> on the
+    /// client side expects to find.
+    /// </para>
+    /// <para>
+    /// To mount several providers side-by-side, register one
+    /// <see cref="FileSystemNodeManager"/> per provider — each owns
+    /// its own namespace and adds its own <c>HasComponent</c> child
+    /// under <c>i=16314</c>.
+    /// </para>
+    /// </remarks>
+    public sealed class FileSystemNodeManager : CustomNodeManager2
+    {
+        /// <summary>
+        /// Base URI used to build the namespace URI of a mounted
+        /// provider. The full URI is
+        /// <c>{NamespaceUriBase}/{MountName}</c>.
+        /// </summary>
+        public const string NamespaceUriBase = "http://opcfoundation.org/UA/Server/FileSystem";
+
+        /// <summary>
+        /// Initialises a new node manager backed by
+        /// <paramref name="provider"/>.
+        /// </summary>
+        public FileSystemNodeManager(
+            IServerInternal server,
+            ApplicationConfiguration configuration,
+            IFileSystemProvider provider)
+            : base(server, configuration, BuildNamespaceUri(provider))
+        {
+            Provider = provider ?? throw new ArgumentNullException(nameof(provider));
+            SystemContext.SystemHandle = this;
+            SystemContext.NodeIdFactory = this;
+
+            var namespaceUris = new List<string> { BuildNamespaceUri(provider) };
+            NamespaceUris = namespaceUris;
+            NamespaceIndex = Server.NamespaceUris.GetIndexOrAppend(namespaceUris[0]);
+        }
+
+        /// <summary>The provider backing this node manager.</summary>
+        public IFileSystemProvider Provider { get; }
+
+        /// <summary>
+        /// Namespace index assigned to this provider's nodes.
+        /// </summary>
+        public new ushort NamespaceIndex { get; }
+
+        /// <inheritdoc/>
+        public override NodeId New(ISystemContext context, NodeState node)
+        {
+            return FileSystemNodeId.ConstructIdForComponent(node, NamespaceIndex);
+        }
+
+        /// <inheritdoc/>
+        public override void CreateAddressSpace(
+            IDictionary<NodeId, IList<IReference>> externalReferences)
+        {
+            lock (Lock)
+            {
+                if (!externalReferences.TryGetValue(ObjectIds.FileSystem,
+                    out IList<IReference>? references))
+                {
+                    externalReferences[ObjectIds.FileSystem] = references = new List<IReference>();
+                }
+                NodeId rootId = FileSystemNodeId.BuildRoot(NamespaceIndex);
+                references.Add(new NodeStateReference(
+                    ReferenceTypeIds.HasComponent, false, rootId));
+            }
+        }
+
+        /// <inheritdoc/>
+        protected override NodeHandle? GetManagerHandle(ServerSystemContext context, NodeId nodeId,
+            IDictionary<NodeId, NodeState>? cache)
+        {
+            lock (Lock)
+            {
+                if (!IsNodeIdInNamespace(nodeId))
+                {
+                    return null;
+                }
+
+                if (nodeId.IdType != IdType.String &&
+                    PredefinedNodes.TryGetValue(nodeId, out NodeState? node))
+                {
+                    return new NodeHandle
+                    {
+                        NodeId = nodeId,
+                        Node = node,
+                        Validated = true
+                    };
+                }
+
+                if (FileSystemNodeId.TryParse(nodeId, out FileSystemNodeId parsed))
+                {
+                    return new NodeHandle
+                    {
+                        NodeId = nodeId,
+                        Validated = false,
+                        ParsedNodeId = new ParsedFileSystemNodeId(parsed)
+                    };
+                }
+
+                return null;
+            }
+        }
+
+        /// <inheritdoc/>
+        public override void DeleteAddressSpace()
+        {
+            lock (Lock)
+            {
+                foreach (FileHandle handle in m_handles.Values)
+                {
+                    handle.Dispose();
+                }
+                m_handles.Clear();
+            }
+        }
+
+        /// <inheritdoc/>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                lock (Lock)
+                {
+                    foreach (FileHandle handle in m_handles.Values)
+                    {
+                        handle.Dispose();
+                    }
+                    m_handles.Clear();
+                }
+            }
+            base.Dispose(disposing);
+        }
+
+        /// <inheritdoc/>
+        protected override NodeState? ValidateNode(ServerSystemContext context, NodeHandle handle,
+            IDictionary<NodeId, NodeState>? cache)
+        {
+            if (handle == null)
+            {
+                return null;
+            }
+            if (handle.Validated)
+            {
+                return handle.Node;
+            }
+
+            NodeState? target = null;
+            if (cache != null && cache.TryGetValue(handle.NodeId, out target))
+            {
+                if (target == null)
+                {
+                    return null;
+                }
+                handle.Node = target;
+                handle.Validated = true;
+                return target;
+            }
+
+            try
+            {
+                if (handle.ParsedNodeId is not ParsedFileSystemNodeId parsed)
+                {
+                    return null;
+                }
+
+                FileSystemEntry? entry = Provider
+                    .GetEntryAsync(parsed.Value.ProviderPath, CancellationToken.None)
+                    .AsTask().GetAwaiter().GetResult();
+                if (parsed.Value.RootType != FileSystemNodeId.Root && entry == null)
+                {
+                    return null;
+                }
+
+                NodeState? root = parsed.Value.RootType switch
+                {
+                    FileSystemNodeId.Root => new DirectoryObjectState(
+                        context,
+                        FileSystemNodeId.BuildRoot(NamespaceIndex),
+                        string.Empty,
+                        Provider.MountName,
+                        isRoot: true),
+                    FileSystemNodeId.Directory => new DirectoryObjectState(
+                        context,
+                        FileSystemNodeId.BuildDirectory(parsed.Value.ProviderPath, NamespaceIndex),
+                        parsed.Value.ProviderPath,
+                        entry!.Value.Name,
+                        isRoot: false),
+                    FileSystemNodeId.File => new FileObjectState(
+                        context,
+                        FileSystemNodeId.BuildFile(parsed.Value.ProviderPath, NamespaceIndex),
+                        parsed.Value.ProviderPath,
+                        entry!.Value.Name),
+                    _ => null
+                };
+                if (root == null)
+                {
+                    return null;
+                }
+
+                if (string.IsNullOrEmpty(parsed.Value.ComponentPath))
+                {
+                    handle.Validated = true;
+                    handle.Node = target = root;
+                    return target;
+                }
+
+                NodeState? component = root.FindChildBySymbolicName(
+                    context, parsed.Value.ComponentPath!);
+                if (component == null)
+                {
+                    return null;
+                }
+                handle.Validated = true;
+                handle.Node = target = component;
+                return target;
+            }
+            finally
+            {
+                cache?.Add(handle.NodeId, target!);
+            }
+        }
+
+        /// <summary>
+        /// Returns the NodeId of the parent directory of the supplied
+        /// provider path, or <see cref="NodeId.Null"/> when the path
+        /// is at the root.
+        /// </summary>
+        internal NodeId GetParentNodeId(string providerPath)
+        {
+            if (string.IsNullOrEmpty(providerPath))
+            {
+                return NodeId.Null;
+            }
+            int slash = providerPath.LastIndexOf('/');
+            string parent = slash < 0 ? string.Empty : providerPath.Substring(0, slash);
+            return string.IsNullOrEmpty(parent)
+                ? FileSystemNodeId.BuildRoot(NamespaceIndex)
+                : FileSystemNodeId.BuildDirectory(parent, NamespaceIndex);
+        }
+
+        /// <summary>
+        /// Combines a parent provider path with a child name, taking
+        /// care of empty parents and trailing slashes.
+        /// </summary>
+        internal string CombineProviderPath(string parent, string name)
+        {
+            if (string.IsNullOrEmpty(parent))
+            {
+                return name;
+            }
+            return parent.TrimEnd('/') + "/" + name;
+        }
+
+        /// <summary>
+        /// Looks up or creates the file handle for the given file
+        /// NodeId. Returns <c>null</c> if the NodeId is not a file
+        /// NodeId in this provider's namespace.
+        /// </summary>
+        internal FileHandle? GetOrCreateHandle(NodeId nodeId, string providerPath)
+        {
+            lock (Lock)
+            {
+                if (m_handles.TryGetValue(nodeId, out FileHandle? handle))
+                {
+                    return handle;
+                }
+                handle = new FileHandle(Provider, providerPath);
+                m_handles.Add(nodeId, handle);
+                return handle;
+            }
+        }
+
+        /// <summary>
+        /// Drops and disposes the file handle associated with
+        /// <paramref name="nodeId"/>. Called after delete / move so
+        /// stale handles don't leak.
+        /// </summary>
+        internal void ForgetHandle(NodeId nodeId)
+        {
+            lock (Lock)
+            {
+                if (m_handles.TryGetValue(nodeId, out FileHandle? handle))
+                {
+                    handle.Dispose();
+                    m_handles.Remove(nodeId);
+                }
+            }
+        }
+
+        private static string BuildNamespaceUri(IFileSystemProvider provider)
+        {
+            if (provider == null)
+            {
+                throw new ArgumentNullException(nameof(provider));
+            }
+            if (string.IsNullOrEmpty(provider.MountName))
+            {
+                throw new ArgumentException(
+                    "Provider MountName must be non-empty.",
+                    nameof(provider));
+            }
+            return NamespaceUriBase + "/" + provider.MountName;
+        }
+
+        private readonly Dictionary<NodeId, FileHandle> m_handles = new();
+
+        /// <summary>
+        /// Boxes a <see cref="FileSystemNodeId"/> for storage in
+        /// <see cref="NodeHandle.ParsedNodeId"/> (which expects a
+        /// reference type).
+        /// </summary>
+        private sealed class ParsedFileSystemNodeId
+        {
+            public ParsedFileSystemNodeId(FileSystemNodeId value)
+            {
+                Value = value;
+            }
+            public FileSystemNodeId Value { get; }
+        }
+    }
+}

--- a/Libraries/Opc.Ua.Server/FileSystem/FileSystemNodeManagerFactory.cs
+++ b/Libraries/Opc.Ua.Server/FileSystem/FileSystemNodeManagerFactory.cs
@@ -1,0 +1,66 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+
+namespace Opc.Ua.Server.FileSystem
+{
+    /// <summary>
+    /// <see cref="INodeManagerFactory"/> that wraps an
+    /// <see cref="IFileSystemProvider"/> so it can be plugged into a
+    /// <c>StandardServer</c> via the standard
+    /// <c>NodeManagerFactories</c> collection.
+    /// </summary>
+    public sealed class FileSystemNodeManagerFactory : INodeManagerFactory
+    {
+        /// <summary>
+        /// Creates a new factory backed by <paramref name="provider"/>.
+        /// </summary>
+        public FileSystemNodeManagerFactory(IFileSystemProvider provider)
+        {
+            m_provider = provider ?? throw new ArgumentNullException(nameof(provider));
+        }
+
+        /// <inheritdoc/>
+        public ArrayOf<string> NamespacesUris =>
+        [
+            FileSystemNodeManager.NamespaceUriBase + "/" + m_provider.MountName
+        ];
+
+        /// <inheritdoc/>
+        public INodeManager Create(
+            IServerInternal server,
+            ApplicationConfiguration configuration)
+        {
+            return new FileSystemNodeManager(server, configuration, m_provider);
+        }
+
+        private readonly IFileSystemProvider m_provider;
+    }
+}

--- a/Libraries/Opc.Ua.Server/FileSystem/FileWriteMode.cs
+++ b/Libraries/Opc.Ua.Server/FileSystem/FileWriteMode.cs
@@ -1,0 +1,61 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+namespace Opc.Ua.Server.FileSystem
+{
+    /// <summary>
+    /// How <see cref="IFileSystemProvider.OpenWriteAsync"/> should open
+    /// the target file. Matches the OPC UA Part 5 §C
+    /// <c>FileType.Open</c> mode bits but without the read flag.
+    /// </summary>
+    public enum FileWriteMode
+    {
+        /// <summary>
+        /// Opens the file for writing; creates it if it doesn't
+        /// exist; preserves existing content (the caller then issues
+        /// <c>SetPosition</c> / <c>Write</c> to put data wherever it
+        /// wants).
+        /// </summary>
+        OpenOrCreate = 0,
+
+        /// <summary>
+        /// Creates the file (truncating any existing content) and
+        /// opens it for writing. Equivalent to the
+        /// <c>FileType.Open</c> "Erase" bit.
+        /// </summary>
+        Truncate = 1,
+
+        /// <summary>
+        /// Opens the file for writing with the position pre-set to
+        /// the end of the file. Equivalent to the
+        /// <c>FileType.Open</c> "Append" bit.
+        /// </summary>
+        Append = 2
+    }
+}

--- a/Libraries/Opc.Ua.Server/FileSystem/IFileSystemProvider.cs
+++ b/Libraries/Opc.Ua.Server/FileSystem/IFileSystemProvider.cs
@@ -1,0 +1,152 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Opc.Ua.Server.FileSystem
+{
+    /// <summary>
+    /// Async storage abstraction used by
+    /// <see cref="FileSystemNodeManager"/> to expose the OPC UA
+    /// Part 5 §C / Part 20 §4 <c>FileType</c> /
+    /// <c>FileDirectoryType</c> companion model over an arbitrary
+    /// backing store.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// All paths are <strong>forward-slash separated, provider-relative</strong>
+    /// strings, with the empty string and <c>"/"</c> both denoting the
+    /// root. Implementations are responsible for translating these
+    /// portable paths to whatever the backing store understands
+    /// (native filesystem paths, blob keys, in-memory tree keys …)
+    /// and for rejecting path-traversal attempts (e.g. <c>".."</c>
+    /// segments that escape the mount root).
+    /// </para>
+    /// <para>
+    /// Implementations should be safe for concurrent calls; the node
+    /// manager does not serialise access on its side. Streams returned
+    /// from <see cref="OpenReadAsync"/> and <see cref="OpenWriteAsync"/>
+    /// are <em>owned by the caller</em> (the node manager closes them
+    /// when the corresponding OPC UA file handle is closed or the
+    /// server shuts down).
+    /// </para>
+    /// </remarks>
+    public interface IFileSystemProvider
+    {
+        /// <summary>
+        /// Display name surfaced as the <c>BrowseName</c> of the root
+        /// mount node in the server's address space. Must be a valid
+        /// OPC UA name (non-null, non-empty, unique among providers
+        /// mounted in the same server).
+        /// </summary>
+        string MountName { get; }
+
+        /// <summary>
+        /// <c>true</c> if the provider permits create / write / delete
+        /// operations. Read-only providers report <c>false</c> here so
+        /// the node manager can decline write requests with
+        /// <see cref="StatusCodes.BadUserAccessDenied"/> without
+        /// round-tripping to the backend.
+        /// </summary>
+        bool IsWritable { get; }
+
+        /// <summary>
+        /// Returns metadata about the file or directory at
+        /// <paramref name="path"/>, or <c>null</c> when the path
+        /// resolves to nothing.
+        /// </summary>
+        ValueTask<FileSystemEntry?> GetEntryAsync(string path, CancellationToken ct);
+
+        /// <summary>
+        /// Enumerates the immediate children (files + directories) of
+        /// the directory at <paramref name="path"/>. Throws
+        /// <see cref="DirectoryNotFoundException"/> when
+        /// <paramref name="path"/> refers to a missing or non-directory
+        /// node.
+        /// </summary>
+        IAsyncEnumerable<FileSystemEntry> EnumerateAsync(string path, CancellationToken ct);
+
+        /// <summary>
+        /// Opens the file at <paramref name="path"/> for reading.
+        /// </summary>
+        /// <exception cref="FileNotFoundException">If the file does not exist.</exception>
+        ValueTask<Stream> OpenReadAsync(string path, CancellationToken ct);
+
+        /// <summary>
+        /// Opens the file at <paramref name="path"/> for writing.
+        /// </summary>
+        /// <param name="path">Provider-relative file path.</param>
+        /// <param name="mode">How the file should be opened / created.</param>
+        /// <param name="ct">Cancellation token.</param>
+        ValueTask<Stream> OpenWriteAsync(string path, FileWriteMode mode, CancellationToken ct);
+
+        /// <summary>
+        /// Creates a directory (and any missing parents) at
+        /// <paramref name="path"/>. No-op when the directory already
+        /// exists. Throws <see cref="IOException"/> when a file
+        /// already occupies the slot.
+        /// </summary>
+        ValueTask CreateDirectoryAsync(string path, CancellationToken ct);
+
+        /// <summary>
+        /// Creates an empty file at <paramref name="path"/>. Throws
+        /// <see cref="IOException"/> when the path already exists
+        /// (either as a file or a directory).
+        /// </summary>
+        ValueTask CreateFileAsync(string path, CancellationToken ct);
+
+        /// <summary>
+        /// Deletes the file or directory at <paramref name="path"/>.
+        /// Directories are deleted recursively. Throws
+        /// <see cref="FileNotFoundException"/> /
+        /// <see cref="DirectoryNotFoundException"/> when the path
+        /// does not exist.
+        /// </summary>
+        ValueTask DeleteAsync(string path, CancellationToken ct);
+
+        /// <summary>
+        /// Moves (renames) <paramref name="source"/> to
+        /// <paramref name="target"/>. Both arguments are
+        /// provider-relative paths. Throws
+        /// <see cref="IOException"/> on collision.
+        /// </summary>
+        ValueTask MoveAsync(string source, string target, CancellationToken ct);
+
+        /// <summary>
+        /// Recursively copies <paramref name="source"/> to
+        /// <paramref name="target"/>. Both arguments are
+        /// provider-relative paths. Throws
+        /// <see cref="IOException"/> on collision.
+        /// </summary>
+        ValueTask CopyAsync(string source, string target, CancellationToken ct);
+    }
+}

--- a/Libraries/Opc.Ua.Server/FileSystem/PhysicalFileSystemProvider.cs
+++ b/Libraries/Opc.Ua.Server/FileSystem/PhysicalFileSystemProvider.cs
@@ -1,0 +1,445 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Opc.Ua.Server.FileSystem
+{
+    /// <summary>
+    /// Default <see cref="IFileSystemProvider"/> implementation that
+    /// maps provider-relative paths onto a single physical directory
+    /// on the host using <see cref="System.IO"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// All operations are sandboxed: any provider-relative path that
+    /// resolves outside the configured root (for example via
+    /// <c>..</c> segments) is rejected with
+    /// <see cref="UnauthorizedAccessException"/>. The check is done
+    /// with <see cref="Path.GetFullPath(string)"/> followed by a
+    /// prefix-match against the canonicalised root.
+    /// </para>
+    /// <para>
+    /// The provider is async-friendly but the underlying
+    /// <see cref="System.IO"/> APIs used here are largely synchronous;
+    /// callers should not rely on these implementations to release the
+    /// calling thread for I/O.
+    /// </para>
+    /// </remarks>
+    public sealed class PhysicalFileSystemProvider : IFileSystemProvider
+    {
+        /// <summary>
+        /// Mounts a single physical directory as the root of an
+        /// <see cref="IFileSystemProvider"/>.
+        /// </summary>
+        /// <param name="rootDirectory">
+        /// Absolute path to the directory to expose. Created if it
+        /// does not already exist.
+        /// </param>
+        /// <param name="mountName">
+        /// BrowseName of the root mount node. Defaults to the
+        /// directory name when <c>null</c> or empty.
+        /// </param>
+        /// <param name="isWritable">
+        /// When <c>false</c>, all write / create / delete / move /
+        /// copy calls fail fast with
+        /// <see cref="StatusCodes.BadUserAccessDenied"/> via
+        /// <see cref="UnauthorizedAccessException"/>.
+        /// </param>
+        public PhysicalFileSystemProvider(
+            string rootDirectory,
+            string? mountName = null,
+            bool isWritable = true)
+        {
+            if (string.IsNullOrEmpty(rootDirectory))
+            {
+                throw new ArgumentException(
+                    "Root directory must not be null or empty.",
+                    nameof(rootDirectory));
+            }
+
+            m_rootDirectory = Path.GetFullPath(rootDirectory);
+            // Normalise the root prefix so subsequent path-traversal
+            // checks have a stable, separator-terminated comparison
+            // anchor that won't accept "/root123" when the actual
+            // root is "/root".
+            m_rootPrefix = m_rootDirectory;
+            if (!m_rootPrefix.EndsWith(
+                    Path.DirectorySeparatorChar.ToString(),
+                    StringComparison.Ordinal))
+            {
+                m_rootPrefix += Path.DirectorySeparatorChar;
+            }
+
+            if (!Directory.Exists(m_rootDirectory))
+            {
+                Directory.CreateDirectory(m_rootDirectory);
+            }
+
+            string resolvedMount = !string.IsNullOrEmpty(mountName)
+                ? mountName!
+                : new DirectoryInfo(m_rootDirectory).Name;
+            MountName = resolvedMount;
+            IsWritable = isWritable;
+        }
+
+        /// <inheritdoc/>
+        public string MountName { get; }
+
+        /// <inheritdoc/>
+        public bool IsWritable { get; }
+
+        /// <inheritdoc/>
+        public ValueTask<FileSystemEntry?> GetEntryAsync(
+            string path,
+            CancellationToken ct)
+        {
+            string full = ResolveAbsolute(path);
+            if (Directory.Exists(full))
+            {
+                return new ValueTask<FileSystemEntry?>(
+                    BuildEntry(path, full, isDirectory: true));
+            }
+            if (File.Exists(full))
+            {
+                return new ValueTask<FileSystemEntry?>(
+                    BuildEntry(path, full, isDirectory: false));
+            }
+            return new ValueTask<FileSystemEntry?>((FileSystemEntry?)null);
+        }
+
+        /// <inheritdoc/>
+        public async IAsyncEnumerable<FileSystemEntry> EnumerateAsync(
+            string path,
+            [EnumeratorCancellation] CancellationToken ct)
+        {
+            string full = ResolveAbsolute(path);
+            if (!Directory.Exists(full))
+            {
+                throw new DirectoryNotFoundException(
+                    $"Directory '{path}' does not exist.");
+            }
+
+            foreach (string entryPath in Directory.EnumerateDirectories(full))
+            {
+                ct.ThrowIfCancellationRequested();
+                yield return BuildEntry(
+                    JoinProviderPath(path, Path.GetFileName(entryPath)),
+                    entryPath,
+                    isDirectory: true);
+            }
+
+            foreach (string entryPath in Directory.EnumerateFiles(full))
+            {
+                ct.ThrowIfCancellationRequested();
+                yield return BuildEntry(
+                    JoinProviderPath(path, Path.GetFileName(entryPath)),
+                    entryPath,
+                    isDirectory: false);
+            }
+
+            await Task.CompletedTask.ConfigureAwait(false);
+        }
+
+        /// <inheritdoc/>
+        public ValueTask<Stream> OpenReadAsync(string path, CancellationToken ct)
+        {
+            string full = ResolveAbsolute(path);
+            if (!File.Exists(full))
+            {
+                throw new FileNotFoundException(
+                    $"File '{path}' does not exist.", full);
+            }
+            return new ValueTask<Stream>(
+                new FileStream(full, FileMode.Open, FileAccess.Read));
+        }
+
+        /// <inheritdoc/>
+        public ValueTask<Stream> OpenWriteAsync(
+            string path,
+            FileWriteMode mode,
+            CancellationToken ct)
+        {
+            EnsureWritable();
+            string full = ResolveAbsolute(path);
+            FileMode fileMode = mode switch
+            {
+                FileWriteMode.Truncate => FileMode.Create,
+                FileWriteMode.Append => FileMode.Append,
+                _ => FileMode.OpenOrCreate
+            };
+            return new ValueTask<Stream>(
+                new FileStream(full, fileMode, FileAccess.Write));
+        }
+
+        /// <inheritdoc/>
+        public ValueTask CreateDirectoryAsync(string path, CancellationToken ct)
+        {
+            EnsureWritable();
+            string full = ResolveAbsolute(path);
+            if (File.Exists(full))
+            {
+                throw new IOException(
+                    $"A file already exists at '{path}'.");
+            }
+            Directory.CreateDirectory(full);
+            return default;
+        }
+
+        /// <inheritdoc/>
+        public ValueTask CreateFileAsync(string path, CancellationToken ct)
+        {
+            EnsureWritable();
+            string full = ResolveAbsolute(path);
+            if (File.Exists(full) || Directory.Exists(full))
+            {
+                throw new IOException(
+                    $"A file or directory already exists at '{path}'.");
+            }
+            using (File.Create(full))
+            {
+                // Just create and close so the entry exists at zero bytes.
+            }
+            return default;
+        }
+
+        /// <inheritdoc/>
+        public ValueTask DeleteAsync(string path, CancellationToken ct)
+        {
+            EnsureWritable();
+            string full = ResolveAbsolute(path);
+            if (Directory.Exists(full))
+            {
+                Directory.Delete(full, recursive: true);
+                return default;
+            }
+            if (File.Exists(full))
+            {
+                File.Delete(full);
+                return default;
+            }
+            throw new FileNotFoundException(
+                $"Nothing to delete at '{path}'.", full);
+        }
+
+        /// <inheritdoc/>
+        public ValueTask MoveAsync(
+            string source,
+            string target,
+            CancellationToken ct)
+        {
+            EnsureWritable();
+            string sourceFull = ResolveAbsolute(source);
+            string targetFull = ResolveAbsolute(target);
+
+            if (File.Exists(targetFull) || Directory.Exists(targetFull))
+            {
+                throw new IOException(
+                    $"Target '{target}' already exists.");
+            }
+            if (File.Exists(sourceFull))
+            {
+                File.Move(sourceFull, targetFull);
+                return default;
+            }
+            if (Directory.Exists(sourceFull))
+            {
+                Directory.Move(sourceFull, targetFull);
+                return default;
+            }
+            throw new FileNotFoundException(
+                $"Nothing to move at '{source}'.", sourceFull);
+        }
+
+        /// <inheritdoc/>
+        public ValueTask CopyAsync(
+            string source,
+            string target,
+            CancellationToken ct)
+        {
+            EnsureWritable();
+            string sourceFull = ResolveAbsolute(source);
+            string targetFull = ResolveAbsolute(target);
+
+            if (File.Exists(targetFull) || Directory.Exists(targetFull))
+            {
+                throw new IOException(
+                    $"Target '{target}' already exists.");
+            }
+            if (File.Exists(sourceFull))
+            {
+                File.Copy(sourceFull, targetFull);
+                return default;
+            }
+            if (Directory.Exists(sourceFull))
+            {
+                CopyDirectoryRecursive(sourceFull, targetFull);
+                return default;
+            }
+            throw new FileNotFoundException(
+                $"Nothing to copy at '{source}'.", sourceFull);
+        }
+
+        private void EnsureWritable()
+        {
+            if (!IsWritable)
+            {
+                throw new UnauthorizedAccessException(
+                    "Provider is read-only.");
+            }
+        }
+
+        /// <summary>
+        /// Translates a provider-relative path to an absolute host
+        /// path while rejecting any attempt to escape the configured
+        /// root via <c>..</c> segments or rooted paths.
+        /// </summary>
+        private string ResolveAbsolute(string path)
+        {
+            string relative = NormaliseRelative(path);
+            string combined = string.IsNullOrEmpty(relative)
+                ? m_rootDirectory
+                : Path.Combine(m_rootDirectory, relative);
+            string full = Path.GetFullPath(combined);
+
+            if (full.Length < m_rootDirectory.Length ||
+                (!string.Equals(full, m_rootDirectory, StringComparison.Ordinal) &&
+                 !full.StartsWith(m_rootPrefix, StringComparison.Ordinal)))
+            {
+                throw new UnauthorizedAccessException(
+                    $"Path '{path}' escapes the provider root.");
+            }
+
+            return full;
+        }
+
+        /// <summary>
+        /// Converts a provider-relative path with <c>/</c> separators
+        /// to a host-relative path with native separators. Strips a
+        /// leading slash and the empty root.
+        /// </summary>
+        private static string NormaliseRelative(string path)
+        {
+            if (string.IsNullOrEmpty(path) || path == "/")
+            {
+                return string.Empty;
+            }
+            string trimmed = path.TrimStart('/');
+            return trimmed.Replace('/', Path.DirectorySeparatorChar);
+        }
+
+        private static string JoinProviderPath(string basePath, string name)
+        {
+            if (string.IsNullOrEmpty(basePath) || basePath == "/")
+            {
+                return name;
+            }
+            return basePath.TrimEnd('/') + "/" + name;
+        }
+
+        private FileSystemEntry BuildEntry(
+            string providerPath,
+            string fullPath,
+            bool isDirectory)
+        {
+            string name = string.IsNullOrEmpty(providerPath)
+                ? MountName
+                : providerPath.Substring(providerPath.LastIndexOf('/') + 1);
+
+            if (isDirectory)
+            {
+                DateTime modified = Directory.GetLastWriteTimeUtc(fullPath);
+                return new FileSystemEntry(
+                    providerPath ?? string.Empty,
+                    name,
+                    IsDirectory: true,
+                    Length: 0,
+                    IsWritable: IsWritable,
+                    LastModifiedUtc: modified,
+                    MimeType: string.Empty);
+            }
+
+            var info = new FileInfo(fullPath);
+            return new FileSystemEntry(
+                providerPath ?? string.Empty,
+                name,
+                IsDirectory: false,
+                Length: info.Length,
+                IsWritable: IsWritable && !info.IsReadOnly,
+                LastModifiedUtc: info.LastWriteTimeUtc,
+                MimeType: GuessMimeType(info.Extension));
+        }
+
+        private static string GuessMimeType(string extension)
+        {
+            if (string.IsNullOrEmpty(extension))
+            {
+                return string.Empty;
+            }
+            return extension.ToLowerInvariant() switch
+            {
+                ".txt" => "text/plain",
+                ".html" or ".htm" => "text/html",
+                ".css" => "text/css",
+                ".js" => "application/javascript",
+                ".json" => "application/json",
+                ".xml" => "application/xml",
+                ".pdf" => "application/pdf",
+                ".png" => "image/png",
+                ".jpg" or ".jpeg" => "image/jpeg",
+                ".gif" => "image/gif",
+                ".zip" => "application/zip",
+                _ => "application/octet-stream"
+            };
+        }
+
+        private static void CopyDirectoryRecursive(string source, string target)
+        {
+            Directory.CreateDirectory(target);
+            foreach (string dir in Directory.GetDirectories(source, "*", SearchOption.AllDirectories))
+            {
+                string sub = dir.Substring(source.Length).TrimStart(Path.DirectorySeparatorChar);
+                Directory.CreateDirectory(Path.Combine(target, sub));
+            }
+            foreach (string file in Directory.GetFiles(source, "*", SearchOption.AllDirectories))
+            {
+                string sub = file.Substring(source.Length).TrimStart(Path.DirectorySeparatorChar);
+                File.Copy(file, Path.Combine(target, sub), overwrite: false);
+            }
+        }
+
+        private readonly string m_rootDirectory;
+        private readonly string m_rootPrefix;
+    }
+}

--- a/Tests/Opc.Ua.Client.Tests/FileSystem/FileSystemClientIntegrationTests.cs
+++ b/Tests/Opc.Ua.Client.Tests/FileSystem/FileSystemClientIntegrationTests.cs
@@ -1,0 +1,413 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Opc.Ua.Client.FileSystem;
+using Opc.Ua.Server.FileSystem;
+using Opc.Ua.Server.Tests;
+using Opc.Ua.Tests;
+using Quickstarts.ReferenceServer;
+
+namespace Opc.Ua.Client.Tests.FileSystem
+{
+    /// <summary>
+    /// End-to-end tests that exercise the client-side
+    /// <see cref="FileSystemClient"/> against a real reference server
+    /// configured with a
+    /// <see cref="PhysicalFileSystemProvider"/> rooted at a per-test
+    /// temp directory.
+    /// </summary>
+    /// <remarks>
+    /// One <c>ServerFixture</c> + <c>ClientFixture</c> + temp-dir
+    /// provider is created per test (via <c>[SetUp]</c>) so each test
+    /// gets a clean slate. Tests are tagged <c>Integration</c> +
+    /// <c>FileSystem</c> for selective filtering.
+    /// </remarks>
+    [TestFixture]
+    [Category("Client")]
+    [Category("FileSystem")]
+    [Category("Integration")]
+    [SetCulture("en-us")]
+    [SetUICulture("en-us")]
+    public class FileSystemClientIntegrationTests
+    {
+        private ServerFixture<ReferenceServer> m_serverFixture;
+        private ClientFixture m_clientFixture;
+        private ReferenceServer m_server;
+        private ISession m_session;
+        private string m_pkiRoot;
+        private string m_providerRoot;
+        private ITelemetryContext m_telemetry;
+
+        [SetUp]
+        public async Task SetUpAsync()
+        {
+            m_telemetry = NUnitTelemetryContext.Create();
+            m_pkiRoot = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            m_providerRoot = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            Directory.CreateDirectory(m_providerRoot);
+
+            m_serverFixture = new ServerFixture<ReferenceServer>(
+                t => new ReferenceServer(t)
+                {
+                    EnableFileSystemNodeManager = true,
+                    FileSystemProvider = new PhysicalFileSystemProvider(
+                        m_providerRoot,
+                        mountName: "TestRoot")
+                })
+            {
+                UriScheme = Utils.UriSchemeOpcTcp,
+                SecurityNone = true,
+                AutoAccept = true,
+                AllNodeManagers = false,
+                OperationLimits = true
+            };
+
+            await m_serverFixture.LoadConfigurationAsync(m_pkiRoot).ConfigureAwait(false);
+            m_server = await m_serverFixture.StartAsync().ConfigureAwait(false);
+
+            m_clientFixture = new ClientFixture(false, false, m_telemetry);
+            await m_clientFixture.LoadClientConfigurationAsync(m_pkiRoot).ConfigureAwait(false);
+
+            string url = $"{Utils.UriSchemeOpcTcp}://localhost:{m_serverFixture.Port}";
+            m_session = await m_clientFixture
+                .ConnectAsync(new Uri(url), SecurityPolicies.None)
+                .ConfigureAwait(false);
+        }
+
+        [TearDown]
+        public async Task TearDownAsync()
+        {
+            try
+            {
+                if (m_session != null)
+                {
+                    await m_session.CloseAsync().ConfigureAwait(false);
+                    m_session.Dispose();
+                }
+            }
+            catch
+            {
+            }
+
+            if (m_serverFixture != null)
+            {
+                await m_serverFixture.StopAsync().ConfigureAwait(false);
+            }
+            m_clientFixture?.Dispose();
+
+            TryDeleteDirectory(m_pkiRoot);
+            TryDeleteDirectory(m_providerRoot);
+        }
+
+        private static void TryDeleteDirectory(string path)
+        {
+            try
+            {
+                if (!string.IsNullOrEmpty(path) && Directory.Exists(path))
+                {
+                    Directory.Delete(path, recursive: true);
+                }
+            }
+            catch
+            {
+            }
+        }
+
+        private FileSystemClient OpenClient()
+        {
+            NodeId mountRoot = ResolveMountRoot();
+            return new FileSystemClient(m_session, mountRoot);
+        }
+
+        private NodeId ResolveMountRoot()
+        {
+            var browseDescriptions = new BrowseDescription[]
+            {
+                new()
+                {
+                    NodeId = ObjectIds.FileSystem,
+                    BrowseDirection = BrowseDirection.Forward,
+                    ReferenceTypeId = ReferenceTypeIds.HasComponent,
+                    IncludeSubtypes = true,
+                    NodeClassMask = (uint)NodeClass.Object,
+                    ResultMask = (uint)BrowseResultMask.All
+                }
+            };
+            BrowseResponse response = m_session
+                .BrowseAsync(default, null, 0, browseDescriptions.ToArrayOf(), default)
+                .AsTask().GetAwaiter().GetResult();
+
+            Assert.That(response.Results.Count, Is.EqualTo(1));
+            foreach (ReferenceDescription reference in response.Results[0].References)
+            {
+                if (reference.BrowseName.Name == "TestRoot")
+                {
+                    return ExpandedNodeId.ToNodeId(reference.NodeId, m_session.NamespaceUris);
+                }
+            }
+            throw new AssertionException(
+                "FileSystem mount 'TestRoot' was not found under Server.FileSystem.");
+        }
+
+        [Test]
+        public async Task RoundTripWriteThenReadFileAsync()
+        {
+            FileSystemClient client = OpenClient();
+
+            UaFileInfo file = await client.Root
+                .CreateFileAsync("hello.txt")
+                .ConfigureAwait(false);
+
+            byte[] payload = Encoding.UTF8.GetBytes("hello world");
+            await file.WriteAllBytesAsync(payload).ConfigureAwait(false);
+
+            byte[] roundTrip = await file.ReadAllBytesAsync().ConfigureAwait(false);
+            Assert.That(roundTrip, Is.EqualTo(payload));
+        }
+
+        [Test]
+        public async Task EnumerateDirectoryListsCreatedEntriesAsync()
+        {
+            FileSystemClient client = OpenClient();
+            await client.Root.CreateFileAsync("a.txt").ConfigureAwait(false);
+            await client.Root.CreateFileAsync("b.txt").ConfigureAwait(false);
+            UaDirectoryInfo sub = await client.Root
+                .CreateSubdirectoryAsync("sub")
+                .ConfigureAwait(false);
+            await sub.CreateFileAsync("c.txt").ConfigureAwait(false);
+
+            var names = new List<string>();
+            await foreach (UaFileSystemInfo info in client.Root.EnumerateAsync())
+            {
+                names.Add(info.Name);
+            }
+            Assert.That(names, Is.EquivalentTo(new[] { "a.txt", "b.txt", "sub" }));
+        }
+
+        [Test]
+        public async Task CreateDirectoryThenSubdirectoryAsync()
+        {
+            FileSystemClient client = OpenClient();
+            UaDirectoryInfo first = await client.Root
+                .CreateSubdirectoryAsync("level1")
+                .ConfigureAwait(false);
+            await first.CreateSubdirectoryAsync("level2").ConfigureAwait(false);
+
+            Assert.That(
+                Directory.Exists(Path.Combine(m_providerRoot, "level1", "level2")),
+                Is.True);
+
+            UaFileSystemInfo found = await client
+                .GetInfoAsync("level1/level2").ConfigureAwait(false);
+            Assert.That(found, Is.InstanceOf<UaDirectoryInfo>());
+        }
+
+        [Test]
+        public async Task DeleteFileRemovesFromEnumerationAsync()
+        {
+            FileSystemClient client = OpenClient();
+            UaFileInfo doomed = await client.Root
+                .CreateFileAsync("doomed.txt")
+                .ConfigureAwait(false);
+            await doomed.DeleteAsync().ConfigureAwait(false);
+
+            bool exists = await client.ExistsAsync("doomed.txt").ConfigureAwait(false);
+            Assert.That(exists, Is.False);
+            Assert.That(File.Exists(Path.Combine(m_providerRoot, "doomed.txt")), Is.False);
+        }
+
+        [Test]
+        public async Task MoveFileChangesNodeIdAsync()
+        {
+            FileSystemClient client = OpenClient();
+            UaFileInfo src = await client.Root
+                .CreateFileAsync("src.txt")
+                .ConfigureAwait(false);
+            NodeId originalNodeId = src.NodeId;
+
+            UaFileSystemInfo moved = await src
+                .MoveToAsync(client.Root, newName: "dest.txt")
+                .ConfigureAwait(false);
+
+            Assert.That(moved.NodeId, Is.Not.EqualTo(originalNodeId));
+            Assert.That(File.Exists(Path.Combine(m_providerRoot, "dest.txt")), Is.True);
+            Assert.That(File.Exists(Path.Combine(m_providerRoot, "src.txt")), Is.False);
+        }
+
+        [Test]
+        public async Task CopyFilePreservesOriginalAsync()
+        {
+            FileSystemClient client = OpenClient();
+            UaFileInfo src = await client.Root
+                .CreateFileAsync("orig.txt")
+                .ConfigureAwait(false);
+            byte[] payload = Encoding.UTF8.GetBytes("payload");
+            await src.WriteAllBytesAsync(payload).ConfigureAwait(false);
+
+            await src.CopyToAsync(client.Root, newName: "copy.txt")
+                .ConfigureAwait(false);
+
+            Assert.That(File.Exists(Path.Combine(m_providerRoot, "orig.txt")), Is.True);
+            Assert.That(File.Exists(Path.Combine(m_providerRoot, "copy.txt")), Is.True);
+            Assert.That(
+                File.ReadAllBytes(Path.Combine(m_providerRoot, "copy.txt")),
+                Is.EqualTo(File.ReadAllBytes(Path.Combine(m_providerRoot, "orig.txt"))));
+        }
+
+        [Test]
+        public async Task LargeFileChunkedReadAsync()
+        {
+            FileSystemClient client = OpenClient();
+            UaFileInfo file = await client.Root
+                .CreateFileAsync("big.bin")
+                .ConfigureAwait(false);
+
+            var rng = new Random(42);
+            byte[] payload = new byte[64 * 1024];
+            rng.NextBytes(payload);
+            await file.WriteAllBytesAsync(payload).ConfigureAwait(false);
+
+            byte[] roundTrip = await file.ReadAllBytesAsync().ConfigureAwait(false);
+            Assert.That(roundTrip, Is.EqualTo(payload));
+        }
+
+        [Test]
+        public async Task MountBrowseNameMatchesProviderAsync()
+        {
+            // FileSystemClient stores a synthetic local "FileSystem"
+            // BrowseName on Root, so verify the actual mount via a
+            // direct Read of the BrowseName attribute.
+            FileSystemClient client = OpenClient();
+            ArrayOf<ReadValueId> nodesToRead = new[]
+            {
+                new ReadValueId
+                {
+                    NodeId = client.Root.NodeId,
+                    AttributeId = Attributes.BrowseName
+                }
+            }.ToArrayOf();
+            ReadResponse response = await m_session.ReadAsync(
+                null,
+                0.0,
+                TimestampsToReturn.Neither,
+                nodesToRead,
+                default).ConfigureAwait(false);
+            QualifiedName actual = response.Results[0].GetValue<QualifiedName>(QualifiedName.Null);
+            Assert.That(actual.Name, Is.EqualTo("TestRoot"));
+        }
+
+        [Test]
+        public async Task GetInfoOnMissingPathReturnsNullAsync()
+        {
+            FileSystemClient client = OpenClient();
+            UaFileSystemInfo info = await client
+                .GetInfoAsync("does-not-exist.txt")
+                .ConfigureAwait(false);
+            Assert.That(info, Is.Null);
+        }
+
+        [Test]
+        public async Task NestedDirectoryEnumerationReturnsCreatedChildrenAsync()
+        {
+            FileSystemClient client = OpenClient();
+            UaDirectoryInfo level1 = await client.Root
+                .CreateSubdirectoryAsync("nest1")
+                .ConfigureAwait(false);
+            UaDirectoryInfo level2 = await level1
+                .CreateSubdirectoryAsync("nest2")
+                .ConfigureAwait(false);
+            await level2.CreateFileAsync("inside.txt").ConfigureAwait(false);
+
+            var names = new List<string>();
+            await foreach (UaFileSystemInfo info in level2.EnumerateAsync())
+            {
+                names.Add(info.Name);
+            }
+            Assert.That(names, Is.EquivalentTo(new[] { "inside.txt" }));
+        }
+
+        [Test]
+        public async Task ReadWrittenTextRoundTripsAsync()
+        {
+            FileSystemClient client = OpenClient();
+            UaFileInfo file = await client.Root
+                .CreateFileAsync("text.txt")
+                .ConfigureAwait(false);
+            const string content = "Hello, OPC UA!";
+            await file.WriteAllTextAsync(content).ConfigureAwait(false);
+
+            string readBack = await file.ReadAllTextAsync().ConfigureAwait(false);
+            Assert.That(readBack, Is.EqualTo(content));
+        }
+
+        [Test]
+        public async Task ReadOnlyProviderRejectsWriteAsync()
+        {
+            // Re-mount the same content under a read-only provider by
+            // restarting the server stack in this single test.
+            await m_session.CloseAsync().ConfigureAwait(false);
+            m_session.Dispose();
+            await m_serverFixture.StopAsync().ConfigureAwait(false);
+
+            m_serverFixture = new ServerFixture<ReferenceServer>(
+                t => new ReferenceServer(t)
+                {
+                    EnableFileSystemNodeManager = true,
+                    FileSystemProvider = new PhysicalFileSystemProvider(
+                        m_providerRoot,
+                        mountName: "TestRoot",
+                        isWritable: false)
+                })
+            {
+                UriScheme = Utils.UriSchemeOpcTcp,
+                SecurityNone = true,
+                AutoAccept = true,
+                AllNodeManagers = false,
+                OperationLimits = true
+            };
+            await m_serverFixture.LoadConfigurationAsync(m_pkiRoot).ConfigureAwait(false);
+            m_server = await m_serverFixture.StartAsync().ConfigureAwait(false);
+
+            string url = $"{Utils.UriSchemeOpcTcp}://localhost:{m_serverFixture.Port}";
+            m_session = await m_clientFixture
+                .ConnectAsync(new Uri(url), SecurityPolicies.None)
+                .ConfigureAwait(false);
+
+            FileSystemClient client = OpenClient();
+            Assert.ThrowsAsync<UnauthorizedAccessException>(async () =>
+                await client.Root.CreateFileAsync("denied.txt").ConfigureAwait(false));
+        }
+    }
+}

--- a/UA.slnx
+++ b/UA.slnx
@@ -1,5 +1,6 @@
 <Solution>
   <Folder Name="/Applications/">
+    <Project Path="Applications/ConsoleLdsServer/ConsoleLdsServer.csproj" />
     <Project Path="Applications/ConsoleReferenceClient/ConsoleReferenceClient.csproj" />
     <Project Path="Applications/ConsoleReferencePublisher/ConsoleReferencePublisher.csproj" />
     <Project Path="Applications/ConsoleReferenceServer/ConsoleReferenceServer.csproj" />
@@ -44,6 +45,7 @@
     <Project Path="Libraries/Opc.Ua.Gds.Client.Common/Opc.Ua.Gds.Client.Common.csproj" />
     <Project Path="Libraries/Opc.Ua.Gds.Common/Opc.Ua.Gds.Common.csproj" />
     <Project Path="Libraries/Opc.Ua.Gds.Server.Common/Opc.Ua.Gds.Server.Common.csproj" />
+    <Project Path="Libraries/Opc.Ua.Lds.Server/Opc.Ua.Lds.Server.csproj" />
     <Project Path="Libraries/Opc.Ua.PubSub/Opc.Ua.PubSub.csproj" />
     <Project Path="Libraries/Opc.Ua.Security.Certificates/Opc.Ua.Security.Certificates.csproj" />
     <Project Path="Libraries/Opc.Ua.Server/Opc.Ua.Server.csproj" />


### PR DESCRIPTION
## Proposed changes

This PR adds two independent new libraries to the .NET Standard stack — split out of PR #3767 so they can be reviewed and merged independently of the rest of the CTT-support framework.

### `Libraries/Opc.Ua.Server/FileSystem` (Part 5 §C / Part 20 §4)

Server-side implementation of the OPC UA `FileType` / `FileDirectoryType` companion model, mirroring the existing `Libraries/Opc.Ua.Client/FileSystem`.

- **`IFileSystemProvider`** — async storage abstraction (`GetEntryAsync` / `EnumerateAsync` / `OpenRead/WriteAsync` / `Create{Directory,File}Async` / `DeleteAsync` / `MoveAsync` / `CopyAsync`). Forward-slash provider-relative paths; the empty string is the root.
- **`FileSystemEntry`** record + **`FileWriteMode`** enum.
- **`PhysicalFileSystemProvider`** — default `System.IO`-based implementation that **mounts a single physical directory** as the FileSystem root. Rejects path-traversal (`..` escapes) via `Path.GetFullPath` + root-prefix check. Optional `isWritable: false` read-only mode.
- **`FileSystemNodeManager`** — drives every Browse / Read / Method call through the configured provider. Anchored as a `FileDirectoryType` instance under the standard `Server.FileSystem` object (`ObjectIds.FileSystem`, `i=16314`) via `HasComponent`, which is what `FileSystemClient.OpenServerFileSystem` finds.
- Companion files (`DirectoryBrowser`, `DirectoryObjectState`, `FileObjectState`, `FileHandle`, `FileSystemNodeId`, `FileSystemNodeManagerFactory`) — all provider-driven.
- Mount multiple providers by registering multiple `FileSystemNodeManager` instances.

#### Client-side fix

`Libraries/Opc.Ua.Client/FileSystem/FileSystemClient.EnumerateChildrenAsync` now stops the BrowseNext loop on `continuation.Length == 0` in addition to `continuation.IsNull`. Without this fix, an empty-but-non-null ByteString continuation returned by the SDK after wire round-trip caused a spurious BrowseNext and failed with `BadContinuationPointInvalid`.

#### Reference-server hook

`Quickstarts.ReferenceServer.ReferenceServer` gains two opt-in properties (defaults off):
- `EnableFileSystemNodeManager` — toggles whether the FileSystem node manager is registered.
- `FileSystemProvider` — caller-supplied `IFileSystemProvider`. When `null` and the flag is on, falls back to a `PhysicalFileSystemProvider` rooted at `%TEMP%/OpcUaReferenceServerFs` (mount name `Temp`).

### `Libraries/Opc.Ua.Lds.Server` (Part 12 §7)

New Local Discovery Server (LDS) library:
- `LdsServer` — main server class.
- `MulticastDiscovery` — DNS-SD / mDNS bootstrap via `Makaretu.Dns.Multicast` (version `0.27.0` added to `Directory.Packages.props`).
- `RegisteredServerStore` — in-memory store with TTL.
- `RegistrationEntry` + `ServerOnNetworkRecord` — value types.

Sample host: `Applications/ConsoleLdsServer`.

### Tests

`Tests/Opc.Ua.Client.Tests/FileSystem/FileSystemClientIntegrationTests.cs` — **12 end-to-end integration tests** over a real `ServerFixture<ReferenceServer>` + `ClientFixture` (opc.tcp, SecurityNone, temp-dir provider):

| Test | Coverage |
|---|---|
| `RoundTripWriteThenReadFileAsync` | Create + write + read |
| `EnumerateDirectoryListsCreatedEntriesAsync` | Browse children |
| `CreateDirectoryThenSubdirectoryAsync` | Nested mkdir + path lookup |
| `DeleteFileRemovesFromEnumerationAsync` | Delete + Exists |
| `MoveFileChangesNodeIdAsync` | MoveTo |
| `CopyFilePreservesOriginalAsync` | CopyTo |
| `LargeFileChunkedReadAsync` | 64 KB chunked read |
| `MountBrowseNameMatchesProviderAsync` | Server-side BrowseName via attribute read |
| `GetInfoOnMissingPathReturnsNullAsync` | Missing path |
| `NestedDirectoryEnumerationReturnsCreatedChildrenAsync` | Multi-level enumeration |
| `ReadWrittenTextRoundTripsAsync` | Text helpers |
| `ReadOnlyProviderRejectsWriteAsync` | Read-only provider via `isWritable: false` |

## Validation

- `dotnet build UA.slnx -c Release` → **0 errors** on all target frameworks (net472, net48, netstandard2.1, net8.0, net9.0, net10.0).
- `Opc.Ua.Server.Tests` → **964 pass / 5 skip / 0 fail**.
- `FileSystemClientIntegrationTests` → **12/12 pass**.

## Relationship to #3767

This PR is a clean split-out of the LDS + FileSystem changes from PR #3767. After this lands, PR #3767 will be rebased to focus solely on the remaining CTT-support framework (RoleManager, Part 17 AliasName, IServiceResponseMutator, etc.).
