### PR TITLE
Relax ExtensionObject equality to match across encoding ids

### DIFF
--- a/Stack/Opc.Ua.Types/BuiltIn/ExtensionObject.cs
+++ b/Stack/Opc.Ua.Types/BuiltIn/ExtensionObject.cs
@@ -198,7 +198,15 @@ namespace Opc.Ua
             {
                 return 0;
             }
-            return HashCode.Combine(TypeId.GetHashCode(), m_body switch
+            // When the body is an IEncodeable, use the encodeable's canonical
+            // TypeId (rather than the wrapper's TypeId) so that two ExtensionObjects
+            // wrapping the same encodeable but tagged with different encoding ids
+            // (TypeId, BinaryEncodingId, XmlEncodingId) produce the same hash —
+            // consistent with the relaxed equality semantics in Equals.
+            int typeIdHash = m_body is IEncodeable encodeable
+                ? encodeable.TypeId.GetHashCode()
+                : TypeId.GetHashCode();
+            return HashCode.Combine(typeIdHash, m_body switch
             {
                 ByteString b => b.GetHashCode(),
                 string s => StringComparer.Ordinal.GetHashCode(s),
@@ -228,7 +236,7 @@ namespace Opc.Ua
             {
                 return isNull1 == isNull2;
             }
-            if (TypeId != value.TypeId)
+            if (!TypeIdsAreEquivalent(this, value))
             {
                 return false;
             }
@@ -249,6 +257,53 @@ namespace Opc.Ua
                 };
             }
             return CoreUtils.IsEqual(m_body!, value.m_body!);
+        }
+
+        /// <summary>
+        /// Tests whether the two ExtensionObjects refer to the same data type.
+        /// </summary>
+        /// <remarks>
+        /// An <see cref="IEncodeable"/> body exposes three node ids that all identify
+        /// the same logical type: <see cref="IEncodeable.TypeId"/>,
+        /// <see cref="IEncodeable.BinaryEncodingId"/>, and
+        /// <see cref="IEncodeable.XmlEncodingId"/>. Depending on how an
+        /// <see cref="ExtensionObject"/> is constructed (binary decode, XML decode,
+        /// JSON decode, or directly from an <see cref="IEncodeable"/>), its
+        /// <see cref="TypeId"/> may carry any one of those ids. Two ExtensionObjects
+        /// wrapping the same encodeable should therefore compare equal regardless of
+        /// which of the three ids each side carries. When neither side has an
+        /// <see cref="IEncodeable"/> body, strict <see cref="TypeId"/> equality is
+        /// required.
+        /// </remarks>
+        private static bool TypeIdsAreEquivalent(ExtensionObject left, ExtensionObject right)
+        {
+            if (left.TypeId == right.TypeId)
+            {
+                return true;
+            }
+            if (right.m_body is IEncodeable rightEncodeable &&
+                TypeIdMatches(left.TypeId, rightEncodeable))
+            {
+                return true;
+            }
+            if (left.m_body is IEncodeable leftEncodeable &&
+                TypeIdMatches(right.TypeId, leftEncodeable))
+            {
+                return true;
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Tests whether the given <paramref name="typeId"/> equals the
+        /// <see cref="IEncodeable.TypeId"/>, <see cref="IEncodeable.BinaryEncodingId"/>,
+        /// or <see cref="IEncodeable.XmlEncodingId"/> of the given encodeable.
+        /// </summary>
+        private static bool TypeIdMatches(ExpandedNodeId typeId, IEncodeable encodeable)
+        {
+            return typeId == encodeable.TypeId
+                || typeId == encodeable.BinaryEncodingId
+                || typeId == encodeable.XmlEncodingId;
         }
 
         /// <inheritdoc/>

--- a/Tests/Opc.Ua.Types.Tests/BuiltIn/ExtensionObjectTests.cs
+++ b/Tests/Opc.Ua.Types.Tests/BuiltIn/ExtensionObjectTests.cs
@@ -108,5 +108,246 @@ namespace Opc.Ua.Types.Tests.BuiltIn
             // default value is null
             Assert.That(TypeInfo.GetDefaultValue(BuiltInType.ExtensionObject), Is.EqualTo(ExtensionObject.Null));
         }
+
+        /// <summary>
+        /// Test helper encodeable exposing three distinct node ids for
+        /// <see cref="IEncodeable.TypeId"/>, <see cref="IEncodeable.BinaryEncodingId"/>,
+        /// and <see cref="IEncodeable.XmlEncodingId"/>.
+        /// </summary>
+        private sealed class TestEncodeable : IEncodeable
+        {
+            public TestEncodeable(int value = 0)
+            {
+                Value = value;
+            }
+
+            public int Value { get; }
+
+            public ExpandedNodeId TypeId => new(200000);
+            public ExpandedNodeId BinaryEncodingId => new(200001);
+            public ExpandedNodeId XmlEncodingId => new(200002);
+
+            public void Encode(IEncoder encoder)
+            {
+            }
+
+            public void Decode(IDecoder decoder)
+            {
+            }
+
+            public bool IsEqual(IEncodeable encodeable)
+            {
+                return encodeable is TestEncodeable other && other.Value == Value;
+            }
+
+            public override int GetHashCode()
+            {
+                return Value;
+            }
+
+            public override bool Equals(object obj)
+            {
+                return obj is TestEncodeable other && other.Value == Value;
+            }
+
+            public object Clone()
+            {
+                return new TestEncodeable(Value);
+            }
+        }
+
+        /// <summary>
+        /// Second test helper encodeable with a different set of three node ids,
+        /// used to verify that unrelated types do not falsely compare equal.
+        /// </summary>
+        private sealed class OtherEncodeable : IEncodeable
+        {
+            public ExpandedNodeId TypeId => new(400000);
+            public ExpandedNodeId BinaryEncodingId => new(400001);
+            public ExpandedNodeId XmlEncodingId => new(400002);
+
+            public void Encode(IEncoder encoder)
+            {
+            }
+
+            public void Decode(IDecoder decoder)
+            {
+            }
+
+            public bool IsEqual(IEncodeable encodeable)
+            {
+                return encodeable is OtherEncodeable;
+            }
+
+            public object Clone()
+            {
+                return new OtherEncodeable();
+            }
+        }
+
+        /// <summary>
+        /// Equals returns true when both sides carry the same encodeable's TypeId.
+        /// </summary>
+        [Test]
+        public void EqualsMatchesWhenTypeIdEqualsBodyTypeId()
+        {
+            var body = new TestEncodeable(42);
+            var left = new ExtensionObject(body);
+            var right = new ExtensionObject(body);
+            Assert.That(left, Is.EqualTo(right));
+            Assert.That(left.GetHashCode(), Is.EqualTo(right.GetHashCode()));
+        }
+
+        /// <summary>
+        /// Equals returns true when one ExtensionObject's TypeId is the encodeable's
+        /// TypeId and the other's TypeId is the encodeable's BinaryEncodingId.
+        /// </summary>
+        [Test]
+        public void EqualsMatchesWhenTypeIdEqualsBodyBinaryEncodingId()
+        {
+            var body = new TestEncodeable(42);
+            var left = new ExtensionObject(body);
+            var right = new ExtensionObject(body.BinaryEncodingId, new TestEncodeable(42));
+            Assert.That(left, Is.EqualTo(right));
+            Assert.That(right, Is.EqualTo(left));
+            Assert.That(left.GetHashCode(), Is.EqualTo(right.GetHashCode()));
+        }
+
+        /// <summary>
+        /// Equals returns true when one ExtensionObject's TypeId is the encodeable's
+        /// TypeId and the other's TypeId is the encodeable's XmlEncodingId.
+        /// </summary>
+        [Test]
+        public void EqualsMatchesWhenTypeIdEqualsBodyXmlEncodingId()
+        {
+            var body = new TestEncodeable(42);
+            var left = new ExtensionObject(body);
+            var right = new ExtensionObject(body.XmlEncodingId, new TestEncodeable(42));
+            Assert.That(left, Is.EqualTo(right));
+            Assert.That(right, Is.EqualTo(left));
+            Assert.That(left.GetHashCode(), Is.EqualTo(right.GetHashCode()));
+        }
+
+        /// <summary>
+        /// Equals returns true when the two ExtensionObjects use different encoding
+        /// ids (Binary vs Xml) for the same encodeable body.
+        /// </summary>
+        [Test]
+        public void EqualsMatchesAcrossEncodingIds()
+        {
+            var body = new TestEncodeable(7);
+            var left = new ExtensionObject(body.BinaryEncodingId, new TestEncodeable(7));
+            var right = new ExtensionObject(body.XmlEncodingId, new TestEncodeable(7));
+            Assert.That(left, Is.EqualTo(right));
+            Assert.That(right, Is.EqualTo(left));
+            Assert.That(left.GetHashCode(), Is.EqualTo(right.GetHashCode()));
+        }
+
+        /// <summary>
+        /// Equals returns false when the TypeId match is satisfied but the body
+        /// payloads differ.
+        /// </summary>
+        [Test]
+        public void EqualsRejectsWhenTypeIdMatchesButBodiesDiffer()
+        {
+            var bodyA = new TestEncodeable(1);
+            var bodyB = new TestEncodeable(2);
+            var left = new ExtensionObject(bodyA);
+            var right = new ExtensionObject(bodyA.BinaryEncodingId, bodyB);
+            Assert.That(left, Is.Not.EqualTo(right));
+            Assert.That(right, Is.Not.EqualTo(left));
+        }
+
+        /// <summary>
+        /// Equals returns false when one side's TypeId is not any of the other
+        /// body's three node ids, and the bodies themselves are of unrelated
+        /// encodeable types.
+        /// </summary>
+        [Test]
+        public void EqualsRejectsWhenTypeIdUnrelated()
+        {
+            var unrelatedTypeId = new ExpandedNodeId(999999);
+            var left = new ExtensionObject(new TestEncodeable(42));
+            var right = new ExtensionObject(unrelatedTypeId, new OtherEncodeable());
+            Assert.That(left, Is.Not.EqualTo(right));
+            Assert.That(right, Is.Not.EqualTo(left));
+        }
+
+        /// <summary>
+        /// Equals returns false when one body is an encodeable and the other side
+        /// wraps a completely different encodeable type, even if the wrapper TypeId
+        /// happens to be unrelated.
+        /// </summary>
+        [Test]
+        public void EqualsRejectsWhenEncodeableTypesDiffer()
+        {
+            var left = new ExtensionObject(new TestEncodeable(1));
+            var right = new ExtensionObject(new OtherEncodeable());
+            Assert.That(left, Is.Not.EqualTo(right));
+            Assert.That(right, Is.Not.EqualTo(left));
+        }
+
+        /// <summary>
+        /// Equals retains strict TypeId equality when the body is not an
+        /// <see cref="IEncodeable"/>; encoding-id relaxation does not apply to
+        /// ByteString, XmlElement, or string bodies.
+        /// </summary>
+        [Test]
+        public void EqualsStrictWhenBodyIsNotEncodeable()
+        {
+            var encodeable = new TestEncodeable(42);
+            ByteString bytes = [1, 2, 3];
+            var binary = new ExtensionObject(encodeable.TypeId, bytes);
+            var binaryDifferentId = new ExtensionObject(encodeable.BinaryEncodingId, bytes);
+            Assert.That(binary, Is.Not.EqualTo(binaryDifferentId));
+
+            string json = "{\"value\":42}";
+            var jsonExt = new ExtensionObject(encodeable.TypeId, json);
+            var jsonDifferentId = new ExtensionObject(encodeable.XmlEncodingId, json);
+            Assert.That(jsonExt, Is.Not.EqualTo(jsonDifferentId));
+        }
+
+        /// <summary>
+        /// GetHashCode produces the same value for any wrapper TypeId in the
+        /// inner encodeable's id set, matching the relaxed Equals semantics.
+        /// </summary>
+        [Test]
+        public void GetHashCodeStableAcrossEncodingIds()
+        {
+            var body = new TestEncodeable(5);
+            var byTypeId = new ExtensionObject(body);
+            var byBinary = new ExtensionObject(body.BinaryEncodingId, new TestEncodeable(5));
+            var byXml = new ExtensionObject(body.XmlEncodingId, new TestEncodeable(5));
+            Assert.That(byBinary.GetHashCode(), Is.EqualTo(byTypeId.GetHashCode()));
+            Assert.That(byXml.GetHashCode(), Is.EqualTo(byTypeId.GetHashCode()));
+        }
+
+        /// <summary>
+        /// The == and != operators honour the relaxed TypeId equality.
+        /// </summary>
+        [Test]
+        public void OperatorEqualsHonoursRelaxedTypeId()
+        {
+            var body = new TestEncodeable(11);
+            var left = new ExtensionObject(body);
+            var right = new ExtensionObject(body.XmlEncodingId, new TestEncodeable(11));
+            Assert.That(left == right, Is.True);
+            Assert.That(left != right, Is.False);
+        }
+
+        /// <summary>
+        /// Equals is symmetric for the relaxed encoding-id cases.
+        /// </summary>
+        [Test]
+        public void EqualsSymmetric()
+        {
+            var body = new TestEncodeable(99);
+            var byTypeId = new ExtensionObject(body);
+            var byBinary = new ExtensionObject(body.BinaryEncodingId, new TestEncodeable(99));
+            var byXml = new ExtensionObject(body.XmlEncodingId, new TestEncodeable(99));
+            Assert.That(byTypeId.Equals(byBinary), Is.EqualTo(byBinary.Equals(byTypeId)));
+            Assert.That(byTypeId.Equals(byXml), Is.EqualTo(byXml.Equals(byTypeId)));
+            Assert.That(byBinary.Equals(byXml), Is.EqualTo(byXml.Equals(byBinary)));
+        }
     }
 }


### PR DESCRIPTION
## Proposed changes

Relax `ExtensionObject.Equals(ExtensionObject)` so that two wrappers around the same `IEncodeable` compare equal even when their `TypeId`s are different forms of the same logical type id.

An `IEncodeable` exposes three node ids that all identify the same data type:

- `IEncodeable.TypeId` — the DataType node id
- `IEncodeable.BinaryEncodingId` — `ObjectIds.<Type>_Encoding_DefaultBinary`
- `IEncodeable.XmlEncodingId` — `ObjectIds.<Type>_Encoding_DefaultXml`

Depending on which encoder produced an `ExtensionObject` (binary, XML, JSON, or direct construction from an `IEncodeable`), the wrapper's `TypeId` may carry any one of those three ids. Today the equality check is a strict `TypeId != value.TypeId` early-return, so two `ExtensionObject`s wrapping the same encodeable value compare as unequal whenever they carry different encoding ids.

This PR changes the equality test so the incoming `TypeId` on either side may match any of the inner `IEncodeable`'s three node ids ("any combination"). Strict `TypeId` equality is still required when neither side has an `IEncodeable` body (e.g. `ByteString`, `XmlElement`, or `string` bodies are unaffected). `GetHashCode` is aligned: when the body is an `IEncodeable`, the canonical `IEncodeable.TypeId` is used for the hash so equal values continue to share a hash code.

The change is backward-compatible: every pair that was equal before is still equal afterwards; only previously-unequal pairs wrapping the same encodeable with different encoding-id `TypeId`s become equal.

### Implementation

- `Stack/Opc.Ua.Types/BuiltIn/ExtensionObject.cs`
  - New private helpers `TypeIdsAreEquivalent(left, right)` and `TypeIdMatches(typeId, encodeable)`.
  - `Equals(ExtensionObject)` replaces the strict early-return with the symmetric relaxed check.
  - `GetHashCode` uses `body.TypeId` when body is `IEncodeable`.

### Tests

- `Tests/Opc.Ua.Types.Tests/BuiltIn/ExtensionObjectTests.cs`
  - Two private test helpers (`TestEncodeable` with three distinct ids and value-based equality/hash; `OtherEncodeable` for unrelated-type cases).
  - 11 new tests:
    - Match against body `TypeId`, `BinaryEncodingId`, `XmlEncodingId`
    - Cross-encoding-id match (Binary ↔ Xml)
    - Reject when bodies differ even with matching id
    - Reject when both wrapper `TypeId` and body are unrelated
    - Reject when wrapped encodeable types differ
    - Strict equality preserved for non-`IEncodeable` bodies (`ByteString`, `string`)
    - Hash stability across encoding ids
    - `==` / `!=` operator coverage
    - Symmetry verification

### Validation

Locally on `net10.0`:

- `dotnet test Tests/Opc.Ua.Types.Tests` — **7530 passed, 0 failed**
- `dotnet test Tests/Opc.Ua.Core.Tests` — **6643 passed, 0 failed** (86 skipped, pre-existing)

## Related Issues

- Fixes #

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- [x] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [x] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines.
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [x] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [x] I have added necessary documentation (if appropriate).
- [x] Any dependent changes have been merged and published in downstream modules.

## Further comments

The relaxed semantics make `ExtensionObject` equality reflect logical data-type identity rather than the particular encoding id a producer happened to attach. This matters anywhere `ExtensionObject`s round-trip through different encoders (binary vs XML vs JSON) and are then compared — for example test assertions, dedup/caching by value, and equality-based diffing.
