### PR TITLE
Add OPC UA Part 17 (Alias Names) support

### DIFF
--- a/Applications/Quickstarts.Servers/ReferenceServer/ReferenceServer.cs
+++ b/Applications/Quickstarts.Servers/ReferenceServer/ReferenceServer.cs
@@ -227,11 +227,22 @@ namespace Quickstarts.ReferenceServer
                 Opc.Ua.QualifiedName.From(Opc.Ua.BrowseNames.Topics),
                 Opc.Ua.Server.AliasNames.AliasNameCapabilities.FindAliasVerbose);
 
+            // Root the Aliases (i=23470) object too so FindAlias /
+            // FindAliasVerbose / LastChange dispatched against it
+            // aggregate the TagVariables / Topics sub-categories
+            // (per Part 17 §6.3.2 recursive matching semantics).
+            var aliases = new Opc.Ua.Server.AliasNames.AliasNameCategoryDescriptor(
+                Opc.Ua.ObjectIds.Aliases,
+                Opc.Ua.QualifiedName.From(Opc.Ua.BrowseNames.Aliases),
+                Opc.Ua.Server.AliasNames.AliasNameCapabilities.FindAliasVerbose
+                    | Opc.Ua.Server.AliasNames.AliasNameCapabilities.LastChange,
+                subCategories: [tagVariables, topics]);
+
             // CA2000: ownership transferred to the registry which disposes
             // the store along with itself.
 #pragma warning disable CA2000
             var store = new Opc.Ua.Server.AliasNames.InMemoryAliasNameStore(
-                [tagVariables, topics]);
+                [aliases]);
 #pragma warning restore CA2000
 
             int refServerNsIndex = server.NamespaceUris.GetIndex(

--- a/Applications/Quickstarts.Servers/ReferenceServer/ReferenceServer.cs
+++ b/Applications/Quickstarts.Servers/ReferenceServer/ReferenceServer.cs
@@ -194,7 +194,89 @@ namespace Quickstarts.ReferenceServer
                     server, configuration, provider));
             }
 
+            // OPC UA Part 17 — AliasName provider for the reference server.
+            //
+            // Registers a Part 17 InMemoryAliasNameStore directly with the
+            // server-wide IAliasNameStoreRegistry so the standard
+            // well-known FindAlias methods on TagVariables (i=23485) and
+            // Topics (i=23494) — wired by DiagnosticsNodeManager — return
+            // the sample tag/topic aliases below.
+            //
+            // No standalone AliasNameNodeManager is needed for read-only
+            // service of standard categories; apps wanting their own
+            // categories with full Add/Delete support add an
+            // AliasNameNodeManager configured with their own namespace.
+            ConfigureAliasNameStore(server);
+
             return new MasterNodeManager(server, configuration, null, asyncNodeManagers, nodeManagers);
+        }
+
+        private static void ConfigureAliasNameStore(IServerInternal server)
+        {
+            if (server is not Opc.Ua.Server.AliasNames.IAliasNameStoreRegistryProvider provider)
+            {
+                return;
+            }
+
+            var tagVariables = new Opc.Ua.Server.AliasNames.AliasNameCategoryDescriptor(
+                Opc.Ua.ObjectIds.TagVariables,
+                Opc.Ua.QualifiedName.From(Opc.Ua.BrowseNames.TagVariables),
+                Opc.Ua.Server.AliasNames.AliasNameCapabilities.FindAliasVerbose);
+            var topics = new Opc.Ua.Server.AliasNames.AliasNameCategoryDescriptor(
+                Opc.Ua.ObjectIds.Topics,
+                Opc.Ua.QualifiedName.From(Opc.Ua.BrowseNames.Topics),
+                Opc.Ua.Server.AliasNames.AliasNameCapabilities.FindAliasVerbose);
+
+            // CA2000: ownership transferred to the registry which disposes
+            // the store along with itself.
+#pragma warning disable CA2000
+            var store = new Opc.Ua.Server.AliasNames.InMemoryAliasNameStore(
+                [tagVariables, topics]);
+#pragma warning restore CA2000
+
+            int refServerNsIndex = server.NamespaceUris.GetIndex(
+                Namespaces.ReferenceServer);
+            ushort refServerNs = refServerNsIndex >= 0
+                ? (ushort)refServerNsIndex
+                : ushort.MaxValue;
+
+            NodeId aliasFor = Opc.Ua.ReferenceTypeIds.AliasFor;
+
+            if (refServerNs != ushort.MaxValue)
+            {
+                SeedTag(store, "TIC101_Setpoint",
+                    new ExpandedNodeId("Scalar_Static_Double", refServerNs));
+                SeedTag(store, "TIC101_PV",
+                    new ExpandedNodeId("Scalar_Static_Float", refServerNs));
+                SeedTag(store, "FIC202_Flow",
+                    new ExpandedNodeId("Scalar_Simulation_Double", refServerNs));
+                SeedTag(store, "Pump1_Status",
+                    new ExpandedNodeId("Scalar_Static_Boolean", refServerNs));
+                SeedTag(store, "Heater_Power",
+                    new ExpandedNodeId("Scalar_Static_Int32", refServerNs));
+                SeedTag(store, "MultiRefAlias",
+                    new ExpandedNodeId("Scalar_Static_Double", refServerNs));
+                SeedTag(store, "MultiRefAlias",
+                    new ExpandedNodeId("Scalar_Static_Int32", refServerNs));
+            }
+
+            store.Seed(Opc.Ua.ObjectIds.Topics, "ServerEvents",
+                Opc.Ua.ObjectIds.Server, serverUri: null, referenceTypeId: aliasFor);
+            store.Seed(Opc.Ua.ObjectIds.Topics, "AuditEvents",
+                new ExpandedNodeId(Opc.Ua.ObjectTypes.AuditEventType),
+                serverUri: null, referenceTypeId: aliasFor);
+
+            provider.AliasNameStoreRegistry.Register(store);
+
+            static void SeedTag(
+                Opc.Ua.Server.AliasNames.InMemoryAliasNameStore store,
+                string name,
+                ExpandedNodeId target)
+            {
+                store.Seed(Opc.Ua.ObjectIds.TagVariables, name, target,
+                    serverUri: null,
+                    referenceTypeId: Opc.Ua.ReferenceTypeIds.AliasFor);
+            }
         }
 
         /// <summary>

--- a/Applications/Quickstarts.Servers/ReferenceServer/ReferenceServer.cs
+++ b/Applications/Quickstarts.Servers/ReferenceServer/ReferenceServer.cs
@@ -231,11 +231,20 @@ namespace Quickstarts.ReferenceServer
             // FindAliasVerbose / LastChange dispatched against it
             // aggregate the TagVariables / Topics sub-categories
             // (per Part 17 §6.3.2 recursive matching semantics).
+            // AddAliasesToCategory / DeleteAliasesFromCategory are enabled
+            // on the in-memory store so server-side test/admin code can
+            // bump LastChange via store.AddAliasesAsync / DeleteAliasesAsync.
+            // The standard well-known Aliases (i=23470) node does not
+            // instantiate Add/Delete method nodes (per the OPC UA NodeSet),
+            // so this is a server-side capability only and does not
+            // expose mutation methods over the wire on the standard node.
             var aliases = new Opc.Ua.Server.AliasNames.AliasNameCategoryDescriptor(
                 Opc.Ua.ObjectIds.Aliases,
                 Opc.Ua.QualifiedName.From(Opc.Ua.BrowseNames.Aliases),
                 Opc.Ua.Server.AliasNames.AliasNameCapabilities.FindAliasVerbose
-                    | Opc.Ua.Server.AliasNames.AliasNameCapabilities.LastChange,
+                    | Opc.Ua.Server.AliasNames.AliasNameCapabilities.LastChange
+                    | Opc.Ua.Server.AliasNames.AliasNameCapabilities.AddAliasesToCategory
+                    | Opc.Ua.Server.AliasNames.AliasNameCapabilities.DeleteAliasesFromCategory,
                 subCategories: [tagVariables, topics]);
 
             // CA2000: ownership transferred to the registry which disposes

--- a/Docs/Part17AliasNames.md
+++ b/Docs/Part17AliasNames.md
@@ -26,6 +26,7 @@ side) and **`Opc.Ua.Client`** (client side). The implementation covers:
 | §9.2         | Well-known `Aliases (i=23470)`           | ✔ wired |
 | §9.3         | Well-known `TagVariables (i=23479)`      | ✔ wired |
 | §9.4         | Well-known `Topics (i=23488)`            | ✔ wired |
+| Annex D      | PubSub replication (LastChange notifications) | ✔ transport-agnostic — see below |
 | Annex D      | PubSub replication                       | not implemented |
 
 ## Server side — `Opc.Ua.Server.AliasNames`
@@ -181,11 +182,42 @@ string aliasName = await resolver.ResolveAliasNameAsync(targets[0], ct);
 
 Default refresh mode is `Manual` — callers invoke `RefreshAsync`
 (or rely on lazy-load via `ResolveAsync`). Opt in to automatic cache
-invalidation via `AliasNameResolverRefreshMode.AutoOnLastChange`, which
-polls the category's `LastChange` property at the configured publishing
-interval and invalidates the cache on any value-difference (covers
-`VersionTime` wraparound). Disposing the resolver tears down the
-polling timer.
+invalidation via one of:
+
+| `AliasNameResolverRefreshMode`     | Strategy                                  | When to use |
+| ---------------------------------- | ----------------------------------------- | ----------- |
+| `Manual` (default)                 | `ManualAliasNameRefreshStrategy`          | Caller drives refresh explicitly. Safe everywhere. |
+| `AutoOnLastChangePolling`          | `PollingAliasNameRefreshStrategy`         | Server lacks Subscriptions or you want a fixed `Read` cadence. |
+| `AutoOnLastChangeMonitoredItem`    | `MonitoredItemAliasNameRefreshStrategy`   | Server supports Subscriptions. Push-based — no `Read` per interval. |
+
+Custom strategies (e.g. the Annex D PubSub bridge in
+`Opc.Ua.Client.AliasNames.PubSub` — see Annex D below) plug in via:
+
+```csharp
+new AliasNameResolverOptions
+{
+    RefreshStrategy = new MyCustomStrategy()  // takes precedence over RefreshMode
+}
+```
+
+The `IAliasNameRefreshStrategy` contract is tiny:
+
+```csharp
+public interface IAliasNameRefreshStrategy : IAsyncDisposable
+{
+    ValueTask StartAsync(AliasNameClient client, Action onInvalidate, CancellationToken ct);
+}
+```
+
+Implementations watch for stale-cache triggers and invoke
+`onInvalidate` whenever they detect a change. `MonitoredItemAliasNameRefreshStrategyOptions`
+controls the underlying `Subscription`: it can be left owned (default
+— created + deleted by the strategy) or set via `SharedSubscription`
+to plug the monitored item into an externally managed subscription.
+
+Disposing the resolver (`await using` / `DisposeAsync`) tears down the
+strategy: timer for polling, `MonitoredItem` + `Subscription` for the
+monitored-item variant. Disposal is idempotent and never throws.
 
 ## Spec deviations / wrinkles
 
@@ -209,6 +241,109 @@ polling timer.
   reference type. Otherwise matches are limited to aliases whose
   reference type is, or is a subtype of, the filter (using
   `Server.TypeTree.IsTypeOf`).
+
+## Annex D — PubSub LastChange notifications
+
+Part 17 Annex D defines a lightweight PubSub schema for alias-change
+notifications between servers. The schema carries only each category's
+current `LastChange` value (a `VersionTime`/`uint`) — subscribers learn
+that a publisher's category changed, then refetch alias contents via
+`FindAlias`/`FindAliasVerbose` if needed.
+
+The data types (already emitted by the source generator):
+
+| NodeId   | Type                          | Fields |
+| -------- | ----------------------------- | ------ |
+| `i=24052` | `AliasCategoryUpdateDataType` | `Category : PortableNodeId`, `LastChange : VersionTime` |
+| `i=24053` | `AliasUpdateDataType`         | `ApplicationUri : string`, `Categories : AliasCategoryUpdateDataType[]` |
+
+### Server side — `Opc.Ua.Server.AliasNames.PubSub`
+
+The server library exposes a transport-agnostic publisher that emits
+fully-built `AliasUpdateDataType` messages whenever an
+`IAliasNameStoreRegistry`-tracked store changes:
+
+```csharp
+using Opc.Ua.Server.AliasNames;
+using Opc.Ua.Server.AliasNames.PubSub;
+
+// inside server startup (after the alias store is registered):
+var resolver = new ServerPortableNodeIdResolver(server);
+var publisher = new AliasNamePublisher(
+    registry: ((IAliasNameStoreRegistryProvider)server).AliasNameStoreRegistry,
+    portableResolver: resolver,
+    applicationUri: configuration.ApplicationUri);
+
+publisher.AliasUpdateProduced += (_, e) =>
+{
+    // Hand `e.Update` to your transport — e.g. publish a DataSetMessage
+    // through Opc.Ua.PubSub.UaPubSubApplication with the DataSet
+    // built by AliasUpdateDataSetFactory.Create(...).
+};
+```
+
+Helpers shipped:
+
+* `IPortableNodeIdResolver` + `ServerPortableNodeIdResolver` — converts
+  a local `NodeId` into the spec-required `PortableNodeId`
+  (NamespaceUri + Identifier with namespace index stripped).
+* `AliasUpdateDataSetFactory.Create(dataSetClassId)` — builds the
+  fixed-by-spec `DataSetMetaDataType` describing the `AliasUpdate`
+  DataSet (`ApplicationUri : string`,
+  `Categories : AliasCategoryUpdateDataType[]`).
+* `AliasNamePublisher` — subscribes to the registry, builds and emits
+  `AliasUpdateDataType` messages via the `AliasUpdateProduced` event.
+
+The library deliberately stays transport-agnostic: it raises the
+fully-built `AliasUpdateDataType` and lets the application wire it
+into `Opc.Ua.PubSub.UaPubSubApplication` (UDP / JSON / MQTT) or any
+other transport that can carry the `AliasUpdateDataType` payload.
+
+### Client side — `Opc.Ua.Client.AliasNames.PubSub`
+
+The client library mirrors the publisher:
+
+```csharp
+using Opc.Ua.Client.AliasNames;
+using Opc.Ua.Client.AliasNames.PubSub;
+
+var reader = new AliasNamePubSubReader(
+    new AliasNamePubSubReaderOptions
+    {
+        ExpectedApplicationUri = "urn:opcfoundation:publisher",
+    });
+
+// Hand incoming AliasUpdateDataType messages off to the reader from
+// your transport (e.g. UaPubSubApplication.DataReceived, an MQTT
+// subscriber callback, ...):
+reader.Submit(receivedAliasUpdate);
+
+// Wire reader into the resolver so the cache invalidates on every
+// LastChange bump observed via PubSub.
+await using var resolver = new AliasNameResolver(
+    AliasNameClient.OpenStandardAliases(session),
+    new AliasNameResolverOptions
+    {
+        RefreshStrategy = new AliasNamePubSubRefreshStrategy(reader),
+    });
+```
+
+Helpers shipped:
+
+* `AliasNamePubSubReader` — surfaces incoming
+  `AliasUpdateDataType` messages as the `AliasUpdateReceived` event.
+  Optional `ExpectedApplicationUri` filter drops messages from other
+  publishers.
+* `AliasNamePubSubRefreshStrategy : IAliasNameRefreshStrategy` —
+  bridges the reader into the resolver. Matches incoming entries by
+  the resolver's category `NamespaceUri` + identifier; fires
+  `Invalidate` on any value-difference (wrap-safe — the comparison is
+  inequality, not strict greater-than).
+
+The PubSub bridge plugs into the same `IAliasNameRefreshStrategy`
+extension point as the polling and monitored-item strategies — apps
+can mix-and-match, e.g. fall back to polling on a particular category
+while letting PubSub drive the rest.
 
 ## See also
 

--- a/Docs/Part17AliasNames.md
+++ b/Docs/Part17AliasNames.md
@@ -1,0 +1,223 @@
+# OPC UA Part 17 — Alias Names
+
+OPC UA Part 17 defines a small but valuable address-space pattern: a
+hierarchy of human-readable **alias names** that point at one or more
+nodes via a non-hierarchical reference type. Clients can search the
+hierarchy by wildcard pattern and resolve a name to its targets without
+needing to know the target NodeId in advance — useful for tag-naming
+schemes (PI / SCADA / DCS), pub/sub topic registries, MES integration,
+and any scenario where humans pick names but machines need ids.
+
+This stack ships full Part 17 support in **`Opc.Ua.Server`** (server
+side) and **`Opc.Ua.Client`** (client side). The implementation covers:
+
+| Spec section | Type / Method                            | Status |
+| ------------ | ---------------------------------------- | ------ |
+| §6.2         | `AliasNameType`                          | ✔      |
+| §6.3.1       | `AliasNameCategoryType`                  | ✔      |
+| §6.3.1       | `LastChange` (`VersionTime`)             | ✔      |
+| §6.3.2       | `FindAlias`                              | ✔      |
+| §6.3.3       | `FindAliasVerbose`                       | ✔      |
+| §6.3.4       | `AddAliasesToCategory`                   | ✔      |
+| §6.3.5       | `DeleteAliasesFromCategory`              | ✔      |
+| §7.2         | `AliasNameDataType`                      | ✔      |
+| §7.3         | `AliasNameVerboseDataType`               | ✔      |
+| §8.2         | `AliasFor` reference type                | ✔      |
+| §9.2         | Well-known `Aliases (i=23470)`           | ✔ wired |
+| §9.3         | Well-known `TagVariables (i=23479)`      | ✔ wired |
+| §9.4         | Well-known `Topics (i=23488)`            | ✔ wired |
+| Annex D      | PubSub replication                       | not implemented |
+
+## Server side — `Opc.Ua.Server.AliasNames`
+
+The server library exposes a pluggable backend (`IAliasNameStore`) plus
+a default in-memory implementation. Apps assemble their alias inventory
+inside a store, then either:
+
+1. Register the store directly with the server-wide
+   `IAliasNameStoreRegistry` so the standard well-known
+   `Aliases`/`TagVariables`/`Topics` nodes start dispatching through it,
+   **or**
+2. Wrap the store in an `AliasNameNodeManager` to expose application-
+   defined categories under a custom namespace (with full
+   `AddAliasesToCategory` / `DeleteAliasesFromCategory` support).
+
+Both approaches can be combined.
+
+### Quick start — serving standard categories
+
+```csharp
+using Opc.Ua;
+using Opc.Ua.Server;
+using Opc.Ua.Server.AliasNames;
+
+// inside CreateMasterNodeManager(IServerInternal server, ...):
+var tagVariables = new AliasNameCategoryDescriptor(
+    ObjectIds.TagVariables,
+    QualifiedName.From(BrowseNames.TagVariables),
+    AliasNameCapabilities.FindAliasVerbose);
+
+var store = new InMemoryAliasNameStore([tagVariables]);
+store.Seed(ObjectIds.TagVariables, "TIC101_Setpoint",
+    new ExpandedNodeId("Scalar_Static_Double", refServerNs),
+    serverUri: null,
+    referenceTypeId: ReferenceTypeIds.AliasFor);
+// ... seed more entries ...
+
+((IAliasNameStoreRegistryProvider)server)
+    .AliasNameStoreRegistry.Register(store);
+```
+
+When a client calls `Aliases.FindAlias` (`i=23476`),
+`TagVariables.FindAlias` (`i=23485`) or `Topics.FindAlias` (`i=23494`),
+`DiagnosticsNodeManager`'s late binder routes the call through the
+registry to the matching store.
+
+### Quick start — application-defined categories
+
+`AliasNameNodeManager` is a `CustomNodeManager2` that owns a namespace
+and creates its own category tree from the store's
+`RootCategories`. Add it to your server's node-manager list:
+
+```csharp
+var myRoot = new AliasNameCategoryDescriptor(
+    new NodeId("My/Category", myNamespaceIndex),
+    new QualifiedName("My/Category", myNamespaceIndex),
+    AliasNameCapabilities.All);            // expose every optional method
+var store = new InMemoryAliasNameStore([myRoot]);
+nodeManagers.Add(new AliasNameNodeManager(server, configuration, store));
+```
+
+Options:
+
+* `NamespaceUri` — controls the namespace under which the manager
+  registers its category instances. Defaults to
+  `http://opcfoundation.org/UA/AliasName/`.
+* `LinkToStandardAliasesObject` (default `true`) — adds `Organizes`
+  external references from the well-known `Aliases (i=23470)` object to
+  the manager's root categories so they show up in the standard browse
+  tree.
+* `RequireSecurityAdminForMutations` (default `true`) — rejects
+  `AddAliasesToCategory` / `DeleteAliasesFromCategory` calls from
+  unauthenticated users or sessions without the
+  `WellKnownRole_SecurityAdmin` role on a `SignAndEncrypt` channel.
+* `RegisterWithServerRegistry` (default `true`) — also registers the
+  store with `IAliasNameStoreRegistry` so the well-known standard nodes
+  see it.
+
+### Custom backend
+
+Implement `IAliasNameStore` to back the alias inventory with your own
+storage (DB, file, MES, …). The interface is small:
+
+```csharp
+public interface IAliasNameStore
+{
+    IReadOnlyList<AliasNameCategoryDescriptor> RootCategories { get; }
+    event EventHandler<AliasStoreChangedEventArgs>? Changed;
+
+    uint? GetLastChange(NodeId categoryId);
+    bool OwnsCategory(NodeId categoryId);
+
+    ValueTask<IReadOnlyList<AliasNameDataType>> FindAliasAsync(...);
+    ValueTask<IReadOnlyList<AliasNameVerboseDataType>> FindAliasVerboseAsync(...);
+    ValueTask<StatusCode[]> AddAliasesAsync(...);
+    ValueTask<StatusCode[]> DeleteAliasesAsync(...);
+}
+```
+
+The reference `InMemoryAliasNameStore` is thread-safe (SemaphoreSlim),
+supports nested categories and emits `Changed` events that bubble up to
+the address-space `LastChange` property.
+
+## Client side — `Opc.Ua.Client.AliasNames`
+
+The client library provides a high-level `AliasNameClient` plus a
+caching `AliasNameResolver`.
+
+```csharp
+using Opc.Ua.Client.AliasNames;
+
+// Standard categories have hardcoded method NodeIds so the first call
+// is one round-trip — no extra TranslateBrowsePaths probe needed.
+AliasNameClient client = AliasNameClient.OpenStandardTagVariables(session);
+
+IReadOnlyList<AliasNameDataType> result =
+    await client.FindAliasAsync("TIC%", referenceTypeFilter: null, ct);
+```
+
+`AliasNameClient` exposes the full Part 17 method surface:
+
+* `FindAliasAsync(pattern, referenceTypeFilter, ct)`
+* `FindAliasVerboseAsync(...)` — throws `NotSupportedException` when the
+  category does not expose the optional method.
+* `AddAliasesToCategoryAsync(IEnumerable<AliasNameAddRequest>, ct)`
+* `DeleteAliasesFromCategoryAsync(IEnumerable<AliasNameDeleteRequest>, ct)`
+* `EnumerateSubCategoriesAsync(ct)` — `IAsyncEnumerable` of child
+  `AliasNameSubCategoryInfo`.
+* `ReadLastChangeAsync(ct)` — returns the `VersionTime` (or `null` when
+  the category does not expose `LastChange`).
+
+Per-call errors map to typed exceptions:
+
+| Status code                | Exception                           |
+| -------------------------- | ----------------------------------- |
+| `BadUserAccessDenied`      | `UnauthorizedAccessException`       |
+| `BadNotSupported`          | `NotSupportedException`             |
+| `BadNotImplemented`        | `NotSupportedException`             |
+| other `BadXxx`             | `ServiceResultException`            |
+
+### `AliasNameResolver` — cached alias→NodeId
+
+```csharp
+await using var resolver = new AliasNameResolver(
+    AliasNameClient.OpenStandardTagVariables(session));
+
+IReadOnlyList<ExpandedNodeId> targets =
+    await resolver.ResolveAsync("TIC101_Setpoint", ct);
+
+string aliasName = await resolver.ResolveAliasNameAsync(targets[0], ct);
+```
+
+Default refresh mode is `Manual` — callers invoke `RefreshAsync`
+(or rely on lazy-load via `ResolveAsync`). Opt in to automatic cache
+invalidation via `AliasNameResolverRefreshMode.AutoOnLastChange`, which
+polls the category's `LastChange` property at the configured publishing
+interval and invalidates the cache on any value-difference (covers
+`VersionTime` wraparound). Disposing the resolver tears down the
+polling timer.
+
+## Spec deviations / wrinkles
+
+* **`AliasNameDataType.ReferencedNodes`** — the wire format defines this
+  as `ExpandedNodeId[]` (NodeSet `i=18`), not `NodeId[]`. The
+  source-generated `AliasNameDataType` is correct; the historical
+  Quickstart sample used `NodeId[]` and has been removed.
+* **Standard well-known nodes** — the OPC UA NodeSet instantiates only
+  `FindAlias` on `Aliases`/`TagVariables`/`Topics` (plus `LastChange` on
+  `Aliases`). Optional methods (`FindAliasVerbose`/`Add`/`Delete`) on
+  the standard nodes would require NodeSet extension and are not wired
+  by the binder. To expose those, use a standalone
+  `AliasNameNodeManager` with your own category nodes.
+* **`AliasNameCapabilities.AddAliasesToCategory` /
+  `DeleteAliasesFromCategory`** — defaults to `SecurityAdmin`-only
+  via `AliasNameNodeManagerOptions.RequireSecurityAdminForMutations`.
+  The check requires both the role grant AND a `SignAndEncrypt`
+  channel; opt out via the option for development scenarios only.
+* **`ReferenceTypeFilter` semantics** — null/empty and
+  `ReferenceTypeIds.References` match every alias regardless of
+  reference type. Otherwise matches are limited to aliases whose
+  reference type is, or is a subtype of, the filter (using
+  `Server.TypeTree.IsTypeOf`).
+
+## See also
+
+* OPC UA Part 17 specification:
+  https://reference.opcfoundation.org/v105/Core/docs/Part17/
+* `Tools/Opc.Ua.SourceGeneration.Core/Design/StandardTypes.xml` —
+  Part 17 type definitions consumed by the source generator.
+* `Tests/Opc.Ua.Server.Tests/AliasNames/` — server-side unit tests.
+* `Tests/Opc.Ua.Client.Tests/AliasNames/` — mocked-session and live
+  integration tests.
+* `Applications/Quickstarts.Servers/ReferenceServer/ReferenceServer.cs`
+  — `ConfigureAliasNameStore` shows how to seed and register a store.

--- a/Docs/README.md
+++ b/Docs/README.md
@@ -18,6 +18,7 @@ Here is a list of available documentation for different topics:
 * Client-based [NodeSet Export](NodeSetExport.md) - Export server address space to NodeSet2 XML.
 * Source generated [DataTypes] - How to annotate POCO classes and let the source generator generate the `IEncodeable` implementation.
 * Source generated [NodeManagers](SourceGeneratedNodeManagers.md) - Emit an `AsyncCustomNodeManager` from a model design XML and wire callbacks via the fluent `INodeManagerBuilder` API; supports NativeAOT single-file servers (sample: [MinimalBoilerServer](../Applications/MinimalBoilerServer)).
+* [Part 17 — Alias Names](Part17AliasNames.md) - Full server + client support for the OPC UA Part 17 alias-name model (`AliasNameType`, `AliasNameCategoryType`, `FindAlias`, `FindAliasVerbose`, `AddAliasesToCategory`, `DeleteAliasesFromCategory`, `LastChange`).
 
 ## Reference application related
 

--- a/Libraries/Opc.Ua.Client/AliasNames/AliasNameClient.cs
+++ b/Libraries/Opc.Ua.Client/AliasNames/AliasNameClient.cs
@@ -1,0 +1,647 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Opc.Ua.Client.AliasNames
+{
+    /// <summary>
+    /// High-level async client over an OPC UA Part 17
+    /// <c>AliasNameCategoryType</c> instance — supports
+    /// <c>FindAlias</c> (§6.3.2), <c>FindAliasVerbose</c> (§6.3.3),
+    /// <c>AddAliasesToCategory</c> (§6.3.4),
+    /// <c>DeleteAliasesFromCategory</c> (§6.3.5),
+    /// <c>LastChange</c> (§6.3.1) and sub-category enumeration.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The client lazily resolves method NodeIds via
+    /// <c>TranslateBrowsePathsToNodeIds</c> against the category root and
+    /// caches them — so every method call after the first only costs one
+    /// <c>Call</c> service round-trip. Standard well-known categories
+    /// (<c>Aliases</c>, <c>TagVariables</c>, <c>Topics</c>) use
+    /// hardcoded method NodeIds as a fast-path.
+    /// </para>
+    /// <para>
+    /// Per-entry Part 17 status codes are returned as a
+    /// <see cref="StatusCode"/> array. Method-level failures
+    /// (<c>BadUserAccessDenied</c>, <c>BadNotImplemented</c>, …)
+    /// are translated into typed exceptions
+    /// (<see cref="UnauthorizedAccessException"/>,
+    /// <see cref="NotSupportedException"/>) when raised at the service
+    /// level.
+    /// </para>
+    /// </remarks>
+    public sealed class AliasNameClient
+    {
+        /// <summary>
+        /// Initializes a new client rooted at the supplied
+        /// <c>AliasNameCategoryType</c> instance.
+        /// </summary>
+        /// <param name="session">The OPC UA session used for all service
+        /// calls.</param>
+        /// <param name="categoryId">The <see cref="NodeId"/> of the
+        /// <c>AliasNameCategoryType</c> instance.</param>
+        /// <param name="options">Optional configuration; defaults applied
+        /// when <c>null</c>.</param>
+        public AliasNameClient(
+            ISession session,
+            NodeId categoryId,
+            AliasNameClientOptions? options = null)
+        {
+            Session = session ?? throw new ArgumentNullException(nameof(session));
+            if (categoryId.IsNull)
+            {
+                throw new ArgumentException(
+                    "categoryId must not be null.",
+                    nameof(categoryId));
+            }
+            CategoryId = categoryId;
+            Options = (options ?? new AliasNameClientOptions()).Clone();
+            m_methodIdCache = StandardMethodIdCache.For(categoryId);
+        }
+
+        /// <summary>
+        /// Opens an <see cref="AliasNameClient"/> rooted at the standard
+        /// well-known <c>Aliases (i=23470)</c> object (Part 17 §9.2).
+        /// </summary>
+        public static AliasNameClient OpenStandardAliases(
+            ISession session,
+            AliasNameClientOptions? options = null)
+        {
+            return new AliasNameClient(session, ObjectIds.Aliases, options);
+        }
+
+        /// <summary>
+        /// Opens an <see cref="AliasNameClient"/> rooted at the standard
+        /// well-known <c>TagVariables (i=23479)</c> category (Part 17 §9.3).
+        /// </summary>
+        public static AliasNameClient OpenStandardTagVariables(
+            ISession session,
+            AliasNameClientOptions? options = null)
+        {
+            return new AliasNameClient(session, ObjectIds.TagVariables, options);
+        }
+
+        /// <summary>
+        /// Opens an <see cref="AliasNameClient"/> rooted at the standard
+        /// well-known <c>Topics (i=23488)</c> category (Part 17 §9.4).
+        /// </summary>
+        public static AliasNameClient OpenStandardTopics(
+            ISession session,
+            AliasNameClientOptions? options = null)
+        {
+            return new AliasNameClient(session, ObjectIds.Topics, options);
+        }
+
+        /// <summary>The session used for all service calls.</summary>
+        public ISession Session { get; }
+
+        /// <summary>The category NodeId.</summary>
+        public NodeId CategoryId { get; }
+
+        /// <summary>The (cloned, immutable) configuration.</summary>
+        public AliasNameClientOptions Options { get; }
+
+        /// <summary>
+        /// Calls <c>FindAlias</c> (Part 17 §6.3.2). An empty
+        /// <paramref name="aliasNameSearchPattern"/> returns an empty
+        /// result; a null/empty <paramref name="referenceTypeFilter"/>
+        /// matches every reference type.
+        /// </summary>
+        public async Task<IReadOnlyList<AliasNameDataType>> FindAliasAsync(
+            string aliasNameSearchPattern,
+            NodeId? referenceTypeFilter = null,
+            CancellationToken ct = default)
+        {
+            NodeId methodId = await ResolveMethodIdAsync(
+                BrowseNames.FindAlias, ct).ConfigureAwait(false);
+
+            ArrayOf<Variant> output = await Session.CallAsync(
+                CategoryId,
+                methodId,
+                ct,
+                new Variant(aliasNameSearchPattern ?? string.Empty),
+                new Variant(referenceTypeFilter ?? NodeId.Null))
+                .ConfigureAwait(false);
+
+            return ExtractAliasNameDataTypeList(output);
+        }
+
+        /// <summary>
+        /// Calls <c>FindAliasVerbose</c> (Part 17 §6.3.3). Throws
+        /// <see cref="NotSupportedException"/> when the category does not
+        /// expose this optional method (unless
+        /// <see cref="AliasNameClientOptions.AllowVerboseProbe"/> is set,
+        /// in which case the call is made and a service-level
+        /// <c>BadNotImplemented</c> bubbles up as
+        /// <see cref="NotSupportedException"/>).
+        /// </summary>
+        public async Task<IReadOnlyList<AliasNameVerboseDataType>> FindAliasVerboseAsync(
+            string aliasNameSearchPattern,
+            NodeId? referenceTypeFilter = null,
+            CancellationToken ct = default)
+        {
+            NodeId methodId;
+            try
+            {
+                methodId = await ResolveMethodIdAsync(
+                    BrowseNames.FindAliasVerbose, ct).ConfigureAwait(false);
+            }
+            catch (ServiceResultException sre)
+                when (sre.StatusCode == StatusCodes.BadNotFound
+                    && !Options.AllowVerboseProbe)
+            {
+                throw new NotSupportedException(
+                    "Category " + CategoryId +
+                    " does not expose the optional FindAliasVerbose method.");
+            }
+
+            try
+            {
+                ArrayOf<Variant> output = await Session.CallAsync(
+                    CategoryId,
+                    methodId,
+                    ct,
+                    new Variant(aliasNameSearchPattern ?? string.Empty),
+                    new Variant(referenceTypeFilter ?? NodeId.Null))
+                    .ConfigureAwait(false);
+                return ExtractAliasNameVerboseDataTypeList(output);
+            }
+            catch (ServiceResultException sre)
+            {
+                throw AliasNameClientErrors.Translate(
+                    sre.StatusCode, "FindAliasVerbose", CategoryId);
+            }
+        }
+
+        /// <summary>
+        /// Calls <c>AddAliasesToCategory</c> (Part 17 §6.3.4).
+        /// </summary>
+        /// <returns>One <see cref="StatusCode"/> per input request, in
+        /// input order, indicating the per-entry outcome.</returns>
+        /// <exception cref="NotSupportedException">The category does not
+        /// expose <c>AddAliasesToCategory</c>.</exception>
+        /// <exception cref="UnauthorizedAccessException">The session does
+        /// not have permission to add aliases to this category.</exception>
+        public async Task<StatusCode[]> AddAliasesToCategoryAsync(
+            IReadOnlyList<AliasNameAddRequest> requests,
+            CancellationToken ct = default)
+        {
+            if (requests == null)
+            {
+                throw new ArgumentNullException(nameof(requests));
+            }
+            NodeId methodId;
+            try
+            {
+                methodId = await ResolveMethodIdAsync(
+                    BrowseNames.AddAliasesToCategory, ct).ConfigureAwait(false);
+            }
+            catch (ServiceResultException sre)
+                when (sre.StatusCode == StatusCodes.BadNotFound)
+            {
+                throw new NotSupportedException(
+                    "Category " + CategoryId +
+                    " does not expose the optional AddAliasesToCategory method.");
+            }
+
+            var names = new string[requests.Count];
+            var targets = new ExpandedNodeId[requests.Count];
+            var servers = new string[requests.Count];
+            NodeId refType = NodeId.Null;
+            for (int i = 0; i < requests.Count; i++)
+            {
+                AliasNameAddRequest req = requests[i];
+                names[i] = req.Name ?? string.Empty;
+                targets[i] = req.TargetNode;
+                servers[i] = req.TargetServer ?? string.Empty;
+                if (refType.IsNull)
+                {
+                    refType = req.TargetReferenceType;
+                }
+                else if (!refType.Equals(req.TargetReferenceType))
+                {
+                    throw new ArgumentException(
+                        "All AliasNameAddRequest entries in a single call " +
+                        "must share the same TargetReferenceType (Part 17 " +
+                        "§6.3.4 — TargetReferenceType is a scalar input).",
+                        nameof(requests));
+                }
+            }
+            if (refType.IsNull)
+            {
+                refType = ReferenceTypeIds.AliasFor;
+            }
+
+            try
+            {
+                ArrayOf<Variant> output = await Session.CallAsync(
+                    CategoryId,
+                    methodId,
+                    ct,
+                    Variant.From(names.ToArrayOf()),
+                    Variant.From(targets.ToArrayOf()),
+                    Variant.From(servers.ToArrayOf()),
+                    new Variant(refType))
+                    .ConfigureAwait(false);
+                return ExtractStatusCodeArray(output);
+            }
+            catch (ServiceResultException sre)
+            {
+                throw AliasNameClientErrors.Translate(
+                    sre.StatusCode, "AddAliasesToCategory", CategoryId);
+            }
+        }
+
+        /// <summary>
+        /// Calls <c>DeleteAliasesFromCategory</c> (Part 17 §6.3.5).
+        /// </summary>
+        /// <returns>One <see cref="StatusCode"/> per input request, in
+        /// input order.</returns>
+        /// <exception cref="NotSupportedException">The category does not
+        /// expose <c>DeleteAliasesFromCategory</c>.</exception>
+        /// <exception cref="UnauthorizedAccessException">The session does
+        /// not have permission to delete aliases from this category.</exception>
+        public async Task<StatusCode[]> DeleteAliasesFromCategoryAsync(
+            IReadOnlyList<AliasNameDeleteRequest> requests,
+            CancellationToken ct = default)
+        {
+            if (requests == null)
+            {
+                throw new ArgumentNullException(nameof(requests));
+            }
+            NodeId methodId;
+            try
+            {
+                methodId = await ResolveMethodIdAsync(
+                    BrowseNames.DeleteAliasesFromCategory, ct).ConfigureAwait(false);
+            }
+            catch (ServiceResultException sre)
+                when (sre.StatusCode == StatusCodes.BadNotFound)
+            {
+                throw new NotSupportedException(
+                    "Category " + CategoryId +
+                    " does not expose the optional " +
+                    "DeleteAliasesFromCategory method.");
+            }
+
+            var names = new string[requests.Count];
+            var targets = new ExpandedNodeId[requests.Count];
+            for (int i = 0; i < requests.Count; i++)
+            {
+                AliasNameDeleteRequest req = requests[i];
+                names[i] = req.Name ?? string.Empty;
+                targets[i] = req.TargetNode;
+            }
+
+            try
+            {
+                ArrayOf<Variant> output = await Session.CallAsync(
+                    CategoryId,
+                    methodId,
+                    ct,
+                    Variant.From(names.ToArrayOf()),
+                    Variant.From(targets.ToArrayOf()))
+                    .ConfigureAwait(false);
+                return ExtractStatusCodeArray(output);
+            }
+            catch (ServiceResultException sre)
+            {
+                throw AliasNameClientErrors.Translate(
+                    sre.StatusCode, "DeleteAliasesFromCategory", CategoryId);
+            }
+        }
+
+        /// <summary>
+        /// Reads the category's <c>LastChange</c> property (Part 17
+        /// §6.3.1) — a <c>VersionTime</c> (<c>uint</c>) that advances
+        /// monotonically on every Add/Delete batch. Returns <c>null</c>
+        /// when the category does not expose <c>LastChange</c>.
+        /// </summary>
+        public async Task<uint?> ReadLastChangeAsync(CancellationToken ct = default)
+        {
+            NodeId lastChangeId;
+            try
+            {
+                lastChangeId = await ResolveMethodIdAsync(
+                    BrowseNames.LastChange, ct).ConfigureAwait(false);
+            }
+            catch (ServiceResultException sre)
+                when (sre.StatusCode == StatusCodes.BadNotFound)
+            {
+                return null;
+            }
+
+            ArrayOf<ReadValueId> nodesToRead =
+            [
+                new ReadValueId
+                {
+                    NodeId = lastChangeId,
+                    AttributeId = Attributes.Value
+                }
+            ];
+
+            ReadResponse response = await Session.ReadAsync(
+                null,
+                0,
+                TimestampsToReturn.Neither,
+                nodesToRead,
+                ct).ConfigureAwait(false);
+
+            if (response.Results.Count == 0
+                || StatusCode.IsBad(response.Results[0].StatusCode))
+            {
+                return null;
+            }
+            if (response.Results[0].WrappedValue.TryGetValue(out uint value))
+            {
+                return value;
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Asynchronously enumerates the sub-categories of this category
+        /// (Part 17 §6.3.1 <c>SubAliasNameCategories</c>) via a forward
+        /// browse on <see cref="ReferenceTypeIds.Organizes"/>.
+        /// </summary>
+        public async IAsyncEnumerable<AliasNameSubCategoryInfo>
+            EnumerateSubCategoriesAsync(
+                [EnumeratorCancellation] CancellationToken ct = default)
+        {
+            var description = new BrowseDescription
+            {
+                NodeId = CategoryId,
+                BrowseDirection = BrowseDirection.Forward,
+                ReferenceTypeId = ReferenceTypeIds.Organizes,
+                IncludeSubtypes = true,
+                NodeClassMask = (uint)NodeClass.Object,
+                ResultMask = (uint)(BrowseResultMask.BrowseName
+                    | BrowseResultMask.DisplayName
+                    | BrowseResultMask.TypeDefinition)
+            };
+            ArrayOf<BrowseDescription> requests = [description];
+            BrowseResponse response = await Session.BrowseAsync(
+                null,
+                null,
+                0,
+                requests,
+                ct).ConfigureAwait(false);
+
+            if (response.Results.Count == 0)
+            {
+                yield break;
+            }
+
+            BrowseResult br = response.Results[0];
+            if (StatusCode.IsBad(br.StatusCode))
+            {
+                throw new ServiceResultException(br.StatusCode);
+            }
+
+            int refCount = br.References.Count;
+            var refs = new ReferenceDescription[refCount];
+            for (int i = 0; i < refCount; i++)
+            {
+                refs[i] = br.References[i];
+            }
+            foreach (ReferenceDescription r in refs)
+            {
+                if (!r.TypeDefinition.Equals(ObjectTypeIds.AliasNameCategoryType))
+                {
+                    continue;
+                }
+                NodeId localId = ExpandedNodeId.ToNodeId(
+                    r.NodeId, Session.NamespaceUris);
+                if (localId.IsNull)
+                {
+                    continue;
+                }
+                yield return new AliasNameSubCategoryInfo(
+                    localId,
+                    r.BrowseName,
+                    r.DisplayName);
+            }
+        }
+
+        // --------------------------------------------------------------
+        // Internal helpers
+        // --------------------------------------------------------------
+
+        /// <summary>
+        /// Resolves a child method/property NodeId on this category,
+        /// caching the result.
+        /// </summary>
+        internal async Task<NodeId> ResolveMethodIdAsync(
+            string childBrowseName,
+            CancellationToken ct)
+        {
+            if (m_methodIdCache.TryGet(childBrowseName, out NodeId cached))
+            {
+                if (cached.IsNull)
+                {
+                    throw new ServiceResultException(
+                        StatusCodes.BadNotFound,
+                        "Category " + CategoryId +
+                        " does not expose '" + childBrowseName + "'.");
+                }
+                return cached;
+            }
+
+            var relativePath = new RelativePath
+            {
+                Elements =
+                [
+                    new RelativePathElement
+                    {
+                        ReferenceTypeId = ReferenceTypeIds.HierarchicalReferences,
+                        IsInverse = false,
+                        IncludeSubtypes = true,
+                        TargetName = new QualifiedName(childBrowseName)
+                    }
+                ]
+            };
+            var browsePath = new BrowsePath
+            {
+                StartingNode = CategoryId,
+                RelativePath = relativePath
+            };
+            ArrayOf<BrowsePath> requests = [browsePath];
+
+            TranslateBrowsePathsToNodeIdsResponse response =
+                await Session.TranslateBrowsePathsToNodeIdsAsync(
+                    null, requests, ct).ConfigureAwait(false);
+
+            if (response.Results.Count == 0
+                || StatusCode.IsBad(response.Results[0].StatusCode)
+                || response.Results[0].Targets.Count == 0)
+            {
+                m_methodIdCache.Set(childBrowseName, NodeId.Null);
+                throw new ServiceResultException(
+                    StatusCodes.BadNotFound,
+                    "Category " + CategoryId +
+                    " does not expose '" + childBrowseName + "'.");
+            }
+            ExpandedNodeId target = response.Results[0].Targets[0].TargetId;
+            NodeId local = ExpandedNodeId.ToNodeId(target, Session.NamespaceUris);
+            if (local.IsNull)
+            {
+                m_methodIdCache.Set(childBrowseName, NodeId.Null);
+                throw new ServiceResultException(
+                    StatusCodes.BadNotFound,
+                    "Category " + CategoryId +
+                    " does not expose '" + childBrowseName + "'.");
+            }
+            m_methodIdCache.Set(childBrowseName, local);
+            return local;
+        }
+
+        private static IReadOnlyList<AliasNameDataType> ExtractAliasNameDataTypeList(
+            ArrayOf<Variant> output)
+        {
+            var result = new List<AliasNameDataType>();
+            if (output.Count == 0)
+            {
+                return result;
+            }
+            if (!output[0].TryGetStructure(out ArrayOf<AliasNameDataType> arr))
+            {
+                return result;
+            }
+            for (int i = 0; i < arr.Count; i++)
+            {
+                if (arr[i] != null)
+                {
+                    result.Add(arr[i]);
+                }
+            }
+            return result;
+        }
+
+        private static IReadOnlyList<AliasNameVerboseDataType> ExtractAliasNameVerboseDataTypeList(
+            ArrayOf<Variant> output)
+        {
+            var result = new List<AliasNameVerboseDataType>();
+            if (output.Count == 0)
+            {
+                return result;
+            }
+            if (!output[0].TryGetStructure(out ArrayOf<AliasNameVerboseDataType> arr))
+            {
+                return result;
+            }
+            for (int i = 0; i < arr.Count; i++)
+            {
+                if (arr[i] != null)
+                {
+                    result.Add(arr[i]);
+                }
+            }
+            return result;
+        }
+
+        private static StatusCode[] ExtractStatusCodeArray(ArrayOf<Variant> output)
+        {
+            if (output.Count == 0)
+            {
+                return [];
+            }
+            if (!output[0].TryGetValue(out ArrayOf<StatusCode> codes))
+            {
+                return [];
+            }
+            var result = new StatusCode[codes.Count];
+            for (int i = 0; i < codes.Count; i++)
+            {
+                result[i] = codes[i];
+            }
+            return result;
+        }
+
+        private readonly MethodIdCache m_methodIdCache;
+
+        private sealed class MethodIdCache
+        {
+            public bool TryGet(string browseName, out NodeId nodeId)
+            {
+                lock (m_lock)
+                {
+                    return m_lookup.TryGetValue(browseName, out nodeId);
+                }
+            }
+
+            public void Set(string browseName, NodeId nodeId)
+            {
+                lock (m_lock)
+                {
+                    m_lookup[browseName] = nodeId;
+                }
+            }
+
+            public void SeedKnown(string browseName, NodeId nodeId)
+            {
+                m_lookup[browseName] = nodeId;
+            }
+
+            private readonly Dictionary<string, NodeId> m_lookup = [];
+            private readonly object m_lock = new();
+        }
+
+        private static class StandardMethodIdCache
+        {
+            public static MethodIdCache For(NodeId categoryId)
+            {
+                var cache = new MethodIdCache();
+                if (categoryId.Equals(ObjectIds.Aliases))
+                {
+                    cache.SeedKnown(BrowseNames.FindAlias,
+                        MethodIds.Aliases_FindAlias);
+                    cache.SeedKnown(BrowseNames.LastChange,
+                        VariableIds.Aliases_LastChange);
+                }
+                else if (categoryId.Equals(ObjectIds.TagVariables))
+                {
+                    cache.SeedKnown(BrowseNames.FindAlias,
+                        MethodIds.TagVariables_FindAlias);
+                }
+                else if (categoryId.Equals(ObjectIds.Topics))
+                {
+                    cache.SeedKnown(BrowseNames.FindAlias,
+                        MethodIds.Topics_FindAlias);
+                }
+                return cache;
+            }
+        }
+    }
+}

--- a/Libraries/Opc.Ua.Client/AliasNames/AliasNameClient.cs
+++ b/Libraries/Opc.Ua.Client/AliasNames/AliasNameClient.cs
@@ -310,6 +310,27 @@ namespace Opc.Ua.Client.AliasNames
         }
 
         /// <summary>
+        /// Resolves the category's <c>LastChange</c> property NodeId
+        /// (Part 17 §6.3.1). For the standard well-known <c>Aliases
+        /// (i=23470)</c> category the hardcoded <c>i=32852</c> instance
+        /// is returned without a round-trip; other categories fall back
+        /// to a <c>TranslateBrowsePathsToNodeIds</c> probe. Returns
+        /// <see cref="NodeId.Null"/> when the category does not expose
+        /// the property.
+        /// </summary>
+        public async Task<NodeId> ResolveLastChangeNodeIdAsync(
+            CancellationToken ct = default)
+        {
+            NodeId lastChangeId = ResolveStandardLastChange(CategoryId);
+            if (!lastChangeId.IsNull)
+            {
+                return lastChangeId;
+            }
+            return await ResolveChildAsync(
+                BrowseNames.LastChange, ct).ConfigureAwait(false);
+        }
+
+        /// <summary>
         /// Reads the category's <c>LastChange</c> property (Part 17
         /// §6.3.1) — a <c>VersionTime</c> (<c>uint</c>) that advances
         /// monotonically on every Add/Delete batch. Returns <c>null</c>
@@ -317,17 +338,11 @@ namespace Opc.Ua.Client.AliasNames
         /// </summary>
         public async Task<uint?> ReadLastChangeAsync(CancellationToken ct = default)
         {
-            NodeId lastChangeId = ResolveStandardLastChange(CategoryId);
+            NodeId lastChangeId = await ResolveLastChangeNodeIdAsync(ct)
+                .ConfigureAwait(false);
             if (lastChangeId.IsNull)
             {
-                // Fall back to a browse-path lookup for non-standard
-                // categories.
-                lastChangeId = await ResolveChildAsync(
-                    BrowseNames.LastChange, ct).ConfigureAwait(false);
-                if (lastChangeId.IsNull)
-                {
-                    return null;
-                }
+                return null;
             }
 
             ArrayOf<ReadValueId> nodesToRead =

--- a/Libraries/Opc.Ua.Client/AliasNames/AliasNameClient.cs
+++ b/Libraries/Opc.Ua.Client/AliasNames/AliasNameClient.cs
@@ -45,21 +45,22 @@ namespace Opc.Ua.Client.AliasNames
     /// </summary>
     /// <remarks>
     /// <para>
-    /// The client lazily resolves method NodeIds via
-    /// <c>TranslateBrowsePathsToNodeIds</c> against the category root and
-    /// caches them — so every method call after the first only costs one
-    /// <c>Call</c> service round-trip. Standard well-known categories
-    /// (<c>Aliases</c>, <c>TagVariables</c>, <c>Topics</c>) use
-    /// hardcoded method NodeIds as a fast-path.
+    /// Built on top of the source-generated
+    /// <see cref="AliasNameCategoryTypeClient"/> ObjectType proxy that
+    /// ships with the standard NodeSet. The proxy handles
+    /// <c>CallRequest</c> packing/unpacking and per-call validation
+    /// (<c>BadUnexpectedError</c> on malformed output) — this wrapper
+    /// adds the ergonomic surface: typed exceptions for service-level
+    /// status codes, sub-category browse, and an
+    /// <see cref="ReadLastChangeAsync"/> helper for the
+    /// <c>VersionTime</c> property (which the proxy does not cover).
     /// </para>
     /// <para>
-    /// Per-entry Part 17 status codes are returned as a
-    /// <see cref="StatusCode"/> array. Method-level failures
-    /// (<c>BadUserAccessDenied</c>, <c>BadNotImplemented</c>, …)
-    /// are translated into typed exceptions
-    /// (<see cref="UnauthorizedAccessException"/>,
-    /// <see cref="NotSupportedException"/>) when raised at the service
-    /// level.
+    /// Service-level failures map to typed .NET exceptions:
+    /// <c>BadUserAccessDenied</c> → <see cref="UnauthorizedAccessException"/>,
+    /// <c>BadNotSupported</c>/<c>BadNotImplemented</c> →
+    /// <see cref="NotSupportedException"/>; everything else propagates as
+    /// <see cref="ServiceResultException"/>.
     /// </para>
     /// </remarks>
     public sealed class AliasNameClient
@@ -88,7 +89,10 @@ namespace Opc.Ua.Client.AliasNames
             }
             CategoryId = categoryId;
             Options = (options ?? new AliasNameClientOptions()).Clone();
-            m_methodIdCache = StandardMethodIdCache.For(categoryId);
+            Proxy = new AliasNameCategoryTypeClient(
+                session,
+                categoryId,
+                session.MessageContext.Telemetry);
         }
 
         /// <summary>
@@ -134,6 +138,12 @@ namespace Opc.Ua.Client.AliasNames
         public AliasNameClientOptions Options { get; }
 
         /// <summary>
+        /// The underlying source-generated proxy. Exposed for advanced
+        /// scenarios that need direct access to the raw proxy methods.
+        /// </summary>
+        public AliasNameCategoryTypeClient Proxy { get; }
+
+        /// <summary>
         /// Calls <c>FindAlias</c> (Part 17 §6.3.2). An empty
         /// <paramref name="aliasNameSearchPattern"/> returns an empty
         /// result; a null/empty <paramref name="referenceTypeFilter"/>
@@ -144,59 +154,44 @@ namespace Opc.Ua.Client.AliasNames
             NodeId? referenceTypeFilter = null,
             CancellationToken ct = default)
         {
-            NodeId methodId = await ResolveMethodIdAsync(
-                BrowseNames.FindAlias, ct).ConfigureAwait(false);
-
-            ArrayOf<Variant> output = await Session.CallAsync(
-                CategoryId,
-                methodId,
-                ct,
-                new Variant(aliasNameSearchPattern ?? string.Empty),
-                new Variant(referenceTypeFilter ?? NodeId.Null))
-                .ConfigureAwait(false);
-
-            return ExtractAliasNameDataTypeList(output);
+            try
+            {
+                ArrayOf<AliasNameDataType> result = await Proxy
+                    .FindAliasAsync(
+                        aliasNameSearchPattern ?? string.Empty,
+                        referenceTypeFilter ?? NodeId.Null,
+                        ct)
+                    .ConfigureAwait(false);
+                return ToList(result);
+            }
+            catch (ServiceResultException sre)
+            {
+                throw AliasNameClientErrors.Translate(
+                    sre.StatusCode, "FindAlias", CategoryId);
+            }
         }
 
         /// <summary>
-        /// Calls <c>FindAliasVerbose</c> (Part 17 §6.3.3). Throws
-        /// <see cref="NotSupportedException"/> when the category does not
-        /// expose this optional method (unless
-        /// <see cref="AliasNameClientOptions.AllowVerboseProbe"/> is set,
-        /// in which case the call is made and a service-level
-        /// <c>BadNotImplemented</c> bubbles up as
-        /// <see cref="NotSupportedException"/>).
+        /// Calls <c>FindAliasVerbose</c> (Part 17 §6.3.3). The proxy issues
+        /// the call against <c>MethodIds.AliasNameCategoryType_FindAliasVerbose</c>
+        /// — when the category does not expose the optional method the
+        /// server replies with <c>BadNotImplemented</c>/<c>BadMethodInvalid</c>
+        /// which is translated into <see cref="NotSupportedException"/>.
         /// </summary>
         public async Task<IReadOnlyList<AliasNameVerboseDataType>> FindAliasVerboseAsync(
             string aliasNameSearchPattern,
             NodeId? referenceTypeFilter = null,
             CancellationToken ct = default)
         {
-            NodeId methodId;
             try
             {
-                methodId = await ResolveMethodIdAsync(
-                    BrowseNames.FindAliasVerbose, ct).ConfigureAwait(false);
-            }
-            catch (ServiceResultException sre)
-                when (sre.StatusCode == StatusCodes.BadNotFound
-                    && !Options.AllowVerboseProbe)
-            {
-                throw new NotSupportedException(
-                    "Category " + CategoryId +
-                    " does not expose the optional FindAliasVerbose method.");
-            }
-
-            try
-            {
-                ArrayOf<Variant> output = await Session.CallAsync(
-                    CategoryId,
-                    methodId,
-                    ct,
-                    new Variant(aliasNameSearchPattern ?? string.Empty),
-                    new Variant(referenceTypeFilter ?? NodeId.Null))
+                ArrayOf<AliasNameVerboseDataType> result = await Proxy
+                    .FindAliasVerboseAsync(
+                        aliasNameSearchPattern ?? string.Empty,
+                        referenceTypeFilter ?? NodeId.Null,
+                        ct)
                     .ConfigureAwait(false);
-                return ExtractAliasNameVerboseDataTypeList(output);
+                return ToList(result);
             }
             catch (ServiceResultException sre)
             {
@@ -221,19 +216,6 @@ namespace Opc.Ua.Client.AliasNames
             if (requests == null)
             {
                 throw new ArgumentNullException(nameof(requests));
-            }
-            NodeId methodId;
-            try
-            {
-                methodId = await ResolveMethodIdAsync(
-                    BrowseNames.AddAliasesToCategory, ct).ConfigureAwait(false);
-            }
-            catch (ServiceResultException sre)
-                when (sre.StatusCode == StatusCodes.BadNotFound)
-            {
-                throw new NotSupportedException(
-                    "Category " + CategoryId +
-                    " does not expose the optional AddAliasesToCategory method.");
             }
 
             var names = new string[requests.Count];
@@ -266,16 +248,15 @@ namespace Opc.Ua.Client.AliasNames
 
             try
             {
-                ArrayOf<Variant> output = await Session.CallAsync(
-                    CategoryId,
-                    methodId,
-                    ct,
-                    Variant.From(names.ToArrayOf()),
-                    Variant.From(targets.ToArrayOf()),
-                    Variant.From(servers.ToArrayOf()),
-                    new Variant(refType))
+                ArrayOf<StatusCode> codes = await Proxy
+                    .AddAliasesToCategoryAsync(
+                        names.ToArrayOf(),
+                        targets.ToArrayOf(),
+                        servers.ToArrayOf(),
+                        refType,
+                        ct)
                     .ConfigureAwait(false);
-                return ExtractStatusCodeArray(output);
+                return ToArray(codes);
             }
             catch (ServiceResultException sre)
             {
@@ -301,20 +282,6 @@ namespace Opc.Ua.Client.AliasNames
             {
                 throw new ArgumentNullException(nameof(requests));
             }
-            NodeId methodId;
-            try
-            {
-                methodId = await ResolveMethodIdAsync(
-                    BrowseNames.DeleteAliasesFromCategory, ct).ConfigureAwait(false);
-            }
-            catch (ServiceResultException sre)
-                when (sre.StatusCode == StatusCodes.BadNotFound)
-            {
-                throw new NotSupportedException(
-                    "Category " + CategoryId +
-                    " does not expose the optional " +
-                    "DeleteAliasesFromCategory method.");
-            }
 
             var names = new string[requests.Count];
             var targets = new ExpandedNodeId[requests.Count];
@@ -327,14 +294,13 @@ namespace Opc.Ua.Client.AliasNames
 
             try
             {
-                ArrayOf<Variant> output = await Session.CallAsync(
-                    CategoryId,
-                    methodId,
-                    ct,
-                    Variant.From(names.ToArrayOf()),
-                    Variant.From(targets.ToArrayOf()))
+                ArrayOf<StatusCode> codes = await Proxy
+                    .DeleteAliasesFromCategoryAsync(
+                        names.ToArrayOf(),
+                        targets.ToArrayOf(),
+                        ct)
                     .ConfigureAwait(false);
-                return ExtractStatusCodeArray(output);
+                return ToArray(codes);
             }
             catch (ServiceResultException sre)
             {
@@ -351,16 +317,17 @@ namespace Opc.Ua.Client.AliasNames
         /// </summary>
         public async Task<uint?> ReadLastChangeAsync(CancellationToken ct = default)
         {
-            NodeId lastChangeId;
-            try
+            NodeId lastChangeId = ResolveStandardLastChange(CategoryId);
+            if (lastChangeId.IsNull)
             {
-                lastChangeId = await ResolveMethodIdAsync(
+                // Fall back to a browse-path lookup for non-standard
+                // categories.
+                lastChangeId = await ResolveChildAsync(
                     BrowseNames.LastChange, ct).ConfigureAwait(false);
-            }
-            catch (ServiceResultException sre)
-                when (sre.StatusCode == StatusCodes.BadNotFound)
-            {
-                return null;
+                if (lastChangeId.IsNull)
+                {
+                    return null;
+                }
             }
 
             ArrayOf<ReadValueId> nodesToRead =
@@ -459,26 +426,10 @@ namespace Opc.Ua.Client.AliasNames
         // Internal helpers
         // --------------------------------------------------------------
 
-        /// <summary>
-        /// Resolves a child method/property NodeId on this category,
-        /// caching the result.
-        /// </summary>
-        internal async Task<NodeId> ResolveMethodIdAsync(
+        private async Task<NodeId> ResolveChildAsync(
             string childBrowseName,
             CancellationToken ct)
         {
-            if (m_methodIdCache.TryGet(childBrowseName, out NodeId cached))
-            {
-                if (cached.IsNull)
-                {
-                    throw new ServiceResultException(
-                        StatusCodes.BadNotFound,
-                        "Category " + CategoryId +
-                        " does not expose '" + childBrowseName + "'.");
-                }
-                return cached;
-            }
-
             var relativePath = new RelativePath
             {
                 Elements =
@@ -507,38 +458,26 @@ namespace Opc.Ua.Client.AliasNames
                 || StatusCode.IsBad(response.Results[0].StatusCode)
                 || response.Results[0].Targets.Count == 0)
             {
-                m_methodIdCache.Set(childBrowseName, NodeId.Null);
-                throw new ServiceResultException(
-                    StatusCodes.BadNotFound,
-                    "Category " + CategoryId +
-                    " does not expose '" + childBrowseName + "'.");
+                return NodeId.Null;
             }
             ExpandedNodeId target = response.Results[0].Targets[0].TargetId;
-            NodeId local = ExpandedNodeId.ToNodeId(target, Session.NamespaceUris);
-            if (local.IsNull)
-            {
-                m_methodIdCache.Set(childBrowseName, NodeId.Null);
-                throw new ServiceResultException(
-                    StatusCodes.BadNotFound,
-                    "Category " + CategoryId +
-                    " does not expose '" + childBrowseName + "'.");
-            }
-            m_methodIdCache.Set(childBrowseName, local);
-            return local;
+            return ExpandedNodeId.ToNodeId(target, Session.NamespaceUris);
         }
 
-        private static IReadOnlyList<AliasNameDataType> ExtractAliasNameDataTypeList(
-            ArrayOf<Variant> output)
+        private static NodeId ResolveStandardLastChange(NodeId categoryId)
         {
-            var result = new List<AliasNameDataType>();
-            if (output.Count == 0)
+            // Only the standard Aliases (i=23470) object instantiates
+            // LastChange in the shipped NodeSet (Part 17 §9.2).
+            if (categoryId.Equals(ObjectIds.Aliases))
             {
-                return result;
+                return VariableIds.Aliases_LastChange;
             }
-            if (!output[0].TryGetStructure(out ArrayOf<AliasNameDataType> arr))
-            {
-                return result;
-            }
+            return NodeId.Null;
+        }
+
+        private static List<T> ToList<T>(ArrayOf<T> arr)
+        {
+            var result = new List<T>(arr.Count);
             for (int i = 0; i < arr.Count; i++)
             {
                 if (arr[i] != null)
@@ -549,99 +488,14 @@ namespace Opc.Ua.Client.AliasNames
             return result;
         }
 
-        private static IReadOnlyList<AliasNameVerboseDataType> ExtractAliasNameVerboseDataTypeList(
-            ArrayOf<Variant> output)
+        private static StatusCode[] ToArray(ArrayOf<StatusCode> arr)
         {
-            var result = new List<AliasNameVerboseDataType>();
-            if (output.Count == 0)
-            {
-                return result;
-            }
-            if (!output[0].TryGetStructure(out ArrayOf<AliasNameVerboseDataType> arr))
-            {
-                return result;
-            }
+            var result = new StatusCode[arr.Count];
             for (int i = 0; i < arr.Count; i++)
             {
-                if (arr[i] != null)
-                {
-                    result.Add(arr[i]);
-                }
+                result[i] = arr[i];
             }
             return result;
-        }
-
-        private static StatusCode[] ExtractStatusCodeArray(ArrayOf<Variant> output)
-        {
-            if (output.Count == 0)
-            {
-                return [];
-            }
-            if (!output[0].TryGetValue(out ArrayOf<StatusCode> codes))
-            {
-                return [];
-            }
-            var result = new StatusCode[codes.Count];
-            for (int i = 0; i < codes.Count; i++)
-            {
-                result[i] = codes[i];
-            }
-            return result;
-        }
-
-        private readonly MethodIdCache m_methodIdCache;
-
-        private sealed class MethodIdCache
-        {
-            public bool TryGet(string browseName, out NodeId nodeId)
-            {
-                lock (m_lock)
-                {
-                    return m_lookup.TryGetValue(browseName, out nodeId);
-                }
-            }
-
-            public void Set(string browseName, NodeId nodeId)
-            {
-                lock (m_lock)
-                {
-                    m_lookup[browseName] = nodeId;
-                }
-            }
-
-            public void SeedKnown(string browseName, NodeId nodeId)
-            {
-                m_lookup[browseName] = nodeId;
-            }
-
-            private readonly Dictionary<string, NodeId> m_lookup = [];
-            private readonly object m_lock = new();
-        }
-
-        private static class StandardMethodIdCache
-        {
-            public static MethodIdCache For(NodeId categoryId)
-            {
-                var cache = new MethodIdCache();
-                if (categoryId.Equals(ObjectIds.Aliases))
-                {
-                    cache.SeedKnown(BrowseNames.FindAlias,
-                        MethodIds.Aliases_FindAlias);
-                    cache.SeedKnown(BrowseNames.LastChange,
-                        VariableIds.Aliases_LastChange);
-                }
-                else if (categoryId.Equals(ObjectIds.TagVariables))
-                {
-                    cache.SeedKnown(BrowseNames.FindAlias,
-                        MethodIds.TagVariables_FindAlias);
-                }
-                else if (categoryId.Equals(ObjectIds.Topics))
-                {
-                    cache.SeedKnown(BrowseNames.FindAlias,
-                        MethodIds.Topics_FindAlias);
-                }
-                return cache;
-            }
         }
     }
 }

--- a/Libraries/Opc.Ua.Client/AliasNames/AliasNameClientErrors.cs
+++ b/Libraries/Opc.Ua.Client/AliasNames/AliasNameClientErrors.cs
@@ -1,0 +1,74 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+
+namespace Opc.Ua.Client.AliasNames
+{
+    /// <summary>
+    /// Maps the OPC UA <see cref="StatusCode"/>s returned by Part 17
+    /// methods to typed .NET exceptions in the spirit of
+    /// <c>FileSystemErrors</c>.
+    /// </summary>
+    internal static class AliasNameClientErrors
+    {
+        public static Exception Translate(
+            StatusCode status,
+            string operation,
+            NodeId categoryId = default)
+        {
+            uint code = status.Code;
+
+            if (code == StatusCodes.BadUserAccessDenied)
+            {
+                return new UnauthorizedAccessException(
+                    $"OPC UA Part 17 {operation} was rejected with " +
+                    "BadUserAccessDenied" +
+                    (!categoryId.IsNull
+                        ? " (category=" + categoryId + ")"
+                        : "") + ".");
+            }
+            if (code == StatusCodes.BadNotSupported
+                || code == StatusCodes.BadNotImplemented)
+            {
+                return new NotSupportedException(
+                    $"OPC UA Part 17 {operation} is not supported by this " +
+                    "server/category" +
+                    (!categoryId.IsNull
+                        ? " (category=" + categoryId + ")"
+                        : "") + ".");
+            }
+            return ServiceResultException.Create(
+                code,
+                "OPC UA Part 17 {0} failed: 0x{1:X8}",
+                operation,
+                code);
+        }
+    }
+}

--- a/Libraries/Opc.Ua.Client/AliasNames/AliasNameClientOptions.cs
+++ b/Libraries/Opc.Ua.Client/AliasNames/AliasNameClientOptions.cs
@@ -1,0 +1,62 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+namespace Opc.Ua.Client.AliasNames
+{
+    /// <summary>
+    /// Tunables for an <see cref="AliasNameClient"/>.
+    /// </summary>
+    public sealed class AliasNameClientOptions
+    {
+        /// <summary>
+        /// When <c>true</c>, <see cref="AliasNameClient.FindAliasVerboseAsync"/>
+        /// is allowed to perform the call even when the category's
+        /// <c>FindAliasVerbose</c> method has not been discovered yet
+        /// (allowing the server to report <c>BadNotImplemented</c> at the
+        /// service level rather than throwing client-side). Default
+        /// <c>false</c> — the client throws
+        /// <see cref="System.NotSupportedException"/> for categories
+        /// without the optional method.
+        /// </summary>
+        public bool AllowVerboseProbe { get; set; }
+
+        /// <summary>
+        /// Returns a deep clone of the options. The
+        /// <see cref="AliasNameClient"/> constructor takes a snapshot to
+        /// prevent later mutation from affecting in-flight calls.
+        /// </summary>
+        internal AliasNameClientOptions Clone()
+        {
+            return new AliasNameClientOptions
+            {
+                AllowVerboseProbe = AllowVerboseProbe
+            };
+        }
+    }
+}

--- a/Libraries/Opc.Ua.Client/AliasNames/AliasNameClientRequests.cs
+++ b/Libraries/Opc.Ua.Client/AliasNames/AliasNameClientRequests.cs
@@ -1,0 +1,77 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+namespace Opc.Ua.Client.AliasNames
+{
+    /// <summary>
+    /// Client-side request record for <c>AddAliasesToCategory</c> (Part 17
+    /// §6.3.4) — one row across the four parallel input arrays
+    /// (<c>AliasNames[i]</c>, <c>TargetNodes[i]</c>,
+    /// <c>TargetServers[i]</c>) plus the scalar
+    /// <c>TargetReferenceType</c>. Use with
+    /// <see cref="AliasNameClient.AddAliasesToCategoryAsync"/>.
+    /// </summary>
+    /// <param name="Name">The alias name to add.</param>
+    /// <param name="TargetNode">The node the alias resolves to.</param>
+    /// <param name="TargetServer">The server URI hosting the target;
+    /// empty or <c>null</c> means the local server.</param>
+    /// <param name="TargetReferenceType">The reference type between the
+    /// alias and the target node; typically
+    /// <c>ReferenceTypeIds.AliasFor</c>.</param>
+    public sealed record AliasNameAddRequest(
+        string Name,
+        ExpandedNodeId TargetNode,
+        string? TargetServer,
+        NodeId TargetReferenceType);
+
+    /// <summary>
+    /// Client-side request record for <c>DeleteAliasesFromCategory</c>
+    /// (Part 17 §6.3.5) — one row across the two parallel input arrays
+    /// (<c>AliasNames[i]</c>, <c>TargetNodes[i]</c>). Use with
+    /// <see cref="AliasNameClient.DeleteAliasesFromCategoryAsync"/>.
+    /// </summary>
+    /// <param name="Name">The alias name to remove.</param>
+    /// <param name="TargetNode">The specific target node to detach.</param>
+    public sealed record AliasNameDeleteRequest(
+        string Name,
+        ExpandedNodeId TargetNode);
+
+    /// <summary>
+    /// Describes a sub-category discovered under a parent
+    /// <c>AliasNameCategoryType</c> instance.
+    /// </summary>
+    /// <param name="NodeId">The sub-category's NodeId.</param>
+    /// <param name="BrowseName">The sub-category's BrowseName.</param>
+    /// <param name="DisplayName">The sub-category's DisplayName (may be
+    /// <c>null</c>).</param>
+    public sealed record AliasNameSubCategoryInfo(
+        NodeId NodeId,
+        QualifiedName BrowseName,
+        LocalizedText? DisplayName);
+}

--- a/Libraries/Opc.Ua.Client/AliasNames/AliasNameResolver.cs
+++ b/Libraries/Opc.Ua.Client/AliasNames/AliasNameResolver.cs
@@ -1,0 +1,369 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Opc.Ua.Client.AliasNames
+{
+    /// <summary>
+    /// Caching alias-name resolver — wraps an
+    /// <see cref="AliasNameClient"/> with an in-memory
+    /// alias-name → <see cref="ExpandedNodeId"/>[] lookup (plus
+    /// reverse lookup) populated by calling <c>FindAlias</c> /
+    /// <c>FindAliasVerbose</c> once and reused on subsequent
+    /// resolutions.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Default refresh mode is
+    /// <see cref="AliasNameResolverRefreshMode.Manual"/> — callers
+    /// must invoke <see cref="RefreshAsync"/> (or
+    /// <see cref="EnsureLoadedAsync"/>) to populate the cache. This is
+    /// the safe default for servers that do not allow subscriptions or
+    /// cannot afford the overhead of a recurring poll.
+    /// </para>
+    /// <para>
+    /// Opt in to automatic invalidation by setting
+    /// <see cref="AliasNameResolverOptions.RefreshMode"/> to
+    /// <see cref="AliasNameResolverRefreshMode.AutoOnLastChange"/> —
+    /// the resolver will read the category's
+    /// <c>LastChange</c> property (Part 17 §6.3.1) every
+    /// <see cref="AliasNameResolverOptions.PublishingIntervalMs"/> and
+    /// invalidate the cache on any value-difference. Wraparound of the
+    /// underlying <c>VersionTime</c> (<c>uint</c>) is honoured — the
+    /// comparison is for inequality, not strictly greater-than.
+    /// </para>
+    /// <para>
+    /// The resolver is <see cref="IAsyncDisposable"/> — disposing it
+    /// stops the auto-refresh timer and releases any cached state.
+    /// </para>
+    /// </remarks>
+    public sealed class AliasNameResolver : IAsyncDisposable
+    {
+        /// <summary>
+        /// Initializes a new resolver over the supplied
+        /// <see cref="AliasNameClient"/>.
+        /// </summary>
+        public AliasNameResolver(
+            AliasNameClient client,
+            AliasNameResolverOptions? options = null)
+        {
+            Client = client ?? throw new ArgumentNullException(nameof(client));
+            Options = (options ?? new AliasNameResolverOptions()).Clone();
+
+            if (Options.RefreshMode == AliasNameResolverRefreshMode.AutoOnLastChange)
+            {
+                int periodMs = (int)Math.Max(100,
+                    Options.PublishingIntervalMs);
+                m_pollTimer = new Timer(
+                    PollLastChange,
+                    state: null,
+                    dueTime: periodMs,
+                    period: periodMs);
+            }
+        }
+
+        /// <summary>The wrapped <see cref="AliasNameClient"/>.</summary>
+        public AliasNameClient Client { get; }
+
+        /// <summary>The (cloned, immutable) configuration.</summary>
+        public AliasNameResolverOptions Options { get; }
+
+        /// <summary>
+        /// Ensures the cache is populated; performs a refresh only on
+        /// the first call (or after an invalidation).
+        /// </summary>
+        public async Task EnsureLoadedAsync(CancellationToken ct = default)
+        {
+            if (Volatile.Read(ref m_loaded) == 1)
+            {
+                return;
+            }
+            await RefreshAsync(ct).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Force-reloads the alias cache.
+        /// </summary>
+        public async Task RefreshAsync(CancellationToken ct = default)
+        {
+            uint? lastChange = await Client.ReadLastChangeAsync(ct).ConfigureAwait(false);
+
+            var forward = new Dictionary<string, ExpandedNodeId[]>(StringComparer.Ordinal);
+            var serverUris = new Dictionary<string, string?[]>(StringComparer.Ordinal);
+            var reverse = new Dictionary<ExpandedNodeId, string>();
+
+            if (Options.UseVerbose)
+            {
+                IReadOnlyList<AliasNameVerboseDataType> verbose;
+                try
+                {
+                    verbose = await Client.FindAliasVerboseAsync(
+                        "%", NodeId.Null, ct).ConfigureAwait(false);
+                }
+                catch (NotSupportedException)
+                {
+                    verbose = [];
+                    Options.UseVerbose = false; // fall back to non-verbose
+                }
+                if (verbose.Count == 0 && !Options.UseVerbose)
+                {
+                    // try non-verbose fallback
+                    IReadOnlyList<AliasNameDataType> nonVerbose =
+                        await Client.FindAliasAsync("%", NodeId.Null, ct)
+                            .ConfigureAwait(false);
+                    PopulateFromNonVerbose(nonVerbose, forward, reverse);
+                }
+                else
+                {
+                    PopulateFromVerbose(verbose, forward, serverUris, reverse);
+                }
+            }
+            else
+            {
+                IReadOnlyList<AliasNameDataType> aliases =
+                    await Client.FindAliasAsync("%", NodeId.Null, ct)
+                        .ConfigureAwait(false);
+                PopulateFromNonVerbose(aliases, forward, reverse);
+            }
+
+            await m_semaphore.WaitAsync(ct).ConfigureAwait(false);
+            try
+            {
+                m_forward = forward;
+                m_serverUris = serverUris;
+                m_reverse = reverse;
+                m_lastSeenChange = lastChange;
+                Volatile.Write(ref m_loaded, 1);
+            }
+            finally
+            {
+                m_semaphore.Release();
+            }
+        }
+
+        /// <summary>
+        /// Returns every <see cref="ExpandedNodeId"/> mapped to the
+        /// alias name <paramref name="aliasName"/>, or an empty list
+        /// when no mapping exists. Loads the cache on demand.
+        /// </summary>
+        public async Task<IReadOnlyList<ExpandedNodeId>> ResolveAsync(
+            string aliasName,
+            CancellationToken ct = default)
+        {
+            if (aliasName == null)
+            {
+                throw new ArgumentNullException(nameof(aliasName));
+            }
+            await EnsureLoadedAsync(ct).ConfigureAwait(false);
+
+            await m_semaphore.WaitAsync(ct).ConfigureAwait(false);
+            try
+            {
+                if (m_forward.TryGetValue(aliasName, out ExpandedNodeId[]? targets))
+                {
+                    return targets;
+                }
+                return [];
+            }
+            finally
+            {
+                m_semaphore.Release();
+            }
+        }
+
+        /// <summary>
+        /// Reverse lookup — returns the alias name for the supplied
+        /// target NodeId, or <c>null</c> if no alias points at it. Loads
+        /// the cache on demand.
+        /// </summary>
+        public async Task<string?> ResolveAliasNameAsync(
+            ExpandedNodeId target,
+            CancellationToken ct = default)
+        {
+            if (target.IsNull)
+            {
+                return null;
+            }
+            await EnsureLoadedAsync(ct).ConfigureAwait(false);
+
+            await m_semaphore.WaitAsync(ct).ConfigureAwait(false);
+            try
+            {
+                if (m_reverse.TryGetValue(target, out string? name))
+                {
+                    return name;
+                }
+                return null;
+            }
+            finally
+            {
+                m_semaphore.Release();
+            }
+        }
+
+        /// <summary>
+        /// Returns the server URIs associated with the named alias's
+        /// targets (parallel to the result of
+        /// <see cref="ResolveAsync"/>). Only populated when the
+        /// resolver was loaded via
+        /// <see cref="AliasNameResolverOptions.UseVerbose"/>; returns an
+        /// empty list otherwise.
+        /// </summary>
+        public async Task<IReadOnlyList<string?>> ResolveServerUrisAsync(
+            string aliasName,
+            CancellationToken ct = default)
+        {
+            if (aliasName == null)
+            {
+                throw new ArgumentNullException(nameof(aliasName));
+            }
+            await EnsureLoadedAsync(ct).ConfigureAwait(false);
+            await m_semaphore.WaitAsync(ct).ConfigureAwait(false);
+            try
+            {
+                if (m_serverUris.TryGetValue(aliasName, out string?[]? uris))
+                {
+                    return uris;
+                }
+                return [];
+            }
+            finally
+            {
+                m_semaphore.Release();
+            }
+        }
+
+        /// <summary>
+        /// Invalidates the cache; the next resolve will refresh.
+        /// </summary>
+        public void Invalidate()
+        {
+            Volatile.Write(ref m_loaded, 0);
+        }
+
+        /// <summary>
+        /// Stops auto-refresh polling (if enabled) and releases the
+        /// internal cache. Idempotent.
+        /// </summary>
+        public ValueTask DisposeAsync()
+        {
+            Timer? timer = m_pollTimer;
+            m_pollTimer = null;
+            timer?.Dispose();
+            m_semaphore.Dispose();
+            return default;
+        }
+
+        private void PollLastChange(object? _)
+        {
+            // Fire-and-forget; exceptions are swallowed so a broken
+            // server cannot crash the resolver.
+            _ = PollLastChangeAsync();
+        }
+
+        private async Task PollLastChangeAsync()
+        {
+            try
+            {
+                uint? current = await Client.ReadLastChangeAsync().ConfigureAwait(false);
+                if (current == null)
+                {
+                    return;
+                }
+                uint? seen = m_lastSeenChange;
+                // Compare on inequality only — VersionTime may wrap and
+                // a strict greater-than would miss the wraparound case.
+                if (seen != current)
+                {
+                    Invalidate();
+                }
+            }
+            catch
+            {
+                // Ignore transient errors; the next poll cycle will retry.
+            }
+        }
+
+        private static void PopulateFromNonVerbose(
+            IReadOnlyList<AliasNameDataType> aliases,
+            Dictionary<string, ExpandedNodeId[]> forward,
+            Dictionary<ExpandedNodeId, string> reverse)
+        {
+            foreach (AliasNameDataType a in aliases)
+            {
+                string key = a.AliasName.Name ?? string.Empty;
+                int count = a.ReferencedNodes.Count;
+                var arr = new ExpandedNodeId[count];
+                for (int i = 0; i < count; i++)
+                {
+                    arr[i] = a.ReferencedNodes[i];
+                    reverse[arr[i]] = key;
+                }
+                forward[key] = arr;
+            }
+        }
+
+        private static void PopulateFromVerbose(
+            IReadOnlyList<AliasNameVerboseDataType> aliases,
+            Dictionary<string, ExpandedNodeId[]> forward,
+            Dictionary<string, string?[]> serverUris,
+            Dictionary<ExpandedNodeId, string> reverse)
+        {
+            foreach (AliasNameVerboseDataType a in aliases)
+            {
+                string key = a.AliasName.Name ?? string.Empty;
+                int count = a.ReferencedNodes.Count;
+                var arr = new ExpandedNodeId[count];
+                var uris = new string?[count];
+                for (int i = 0; i < count; i++)
+                {
+                    arr[i] = a.ReferencedNodes[i];
+                    uris[i] = i < a.ServerUris.Count ? a.ServerUris[i] : null;
+                    reverse[arr[i]] = key;
+                }
+                forward[key] = arr;
+                serverUris[key] = uris;
+            }
+        }
+
+        private readonly SemaphoreSlim m_semaphore = new(1, 1);
+        private Dictionary<string, ExpandedNodeId[]> m_forward
+            = new(StringComparer.Ordinal);
+        private Dictionary<string, string?[]> m_serverUris
+            = new(StringComparer.Ordinal);
+        private Dictionary<ExpandedNodeId, string> m_reverse = [];
+        private uint? m_lastSeenChange;
+        private int m_loaded;
+        private Timer? m_pollTimer;
+    }
+}

--- a/Libraries/Opc.Ua.Client/AliasNames/AliasNameResolver.cs
+++ b/Libraries/Opc.Ua.Client/AliasNames/AliasNameResolver.cs
@@ -31,6 +31,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Opc.Ua.Client.AliasNames.Refresh;
 
 namespace Opc.Ua.Client.AliasNames
 {
@@ -54,17 +55,16 @@ namespace Opc.Ua.Client.AliasNames
     /// <para>
     /// Opt in to automatic invalidation by setting
     /// <see cref="AliasNameResolverOptions.RefreshMode"/> to
-    /// <see cref="AliasNameResolverRefreshMode.AutoOnLastChange"/> —
-    /// the resolver will read the category's
-    /// <c>LastChange</c> property (Part 17 §6.3.1) every
-    /// <see cref="AliasNameResolverOptions.PublishingIntervalMs"/> and
-    /// invalidate the cache on any value-difference. Wraparound of the
-    /// underlying <c>VersionTime</c> (<c>uint</c>) is honoured — the
-    /// comparison is for inequality, not strictly greater-than.
+    /// <see cref="AliasNameResolverRefreshMode.AutoOnLastChangePolling"/>
+    /// (read-based) or
+    /// <see cref="AliasNameResolverRefreshMode.AutoOnLastChangeMonitoredItem"/>
+    /// (subscription-based). Custom strategies — e.g. a Part 17
+    /// Annex D PubSub bridge — can be plugged in via
+    /// <see cref="AliasNameResolverOptions.RefreshStrategy"/>.
     /// </para>
     /// <para>
     /// The resolver is <see cref="IAsyncDisposable"/> — disposing it
-    /// stops the auto-refresh timer and releases any cached state.
+    /// stops the active refresh strategy and releases any cached state.
     /// </para>
     /// </remarks>
     public sealed class AliasNameResolver : IAsyncDisposable
@@ -79,17 +79,8 @@ namespace Opc.Ua.Client.AliasNames
         {
             Client = client ?? throw new ArgumentNullException(nameof(client));
             Options = (options ?? new AliasNameResolverOptions()).Clone();
-
-            if (Options.RefreshMode == AliasNameResolverRefreshMode.AutoOnLastChange)
-            {
-                int periodMs = (int)Math.Max(100,
-                    Options.PublishingIntervalMs);
-                m_pollTimer = new Timer(
-                    PollLastChange,
-                    state: null,
-                    dueTime: periodMs,
-                    period: periodMs);
-            }
+            m_strategy = Options.RefreshStrategy
+                ?? BuildBuiltInStrategy(Options);
         }
 
         /// <summary>The wrapped <see cref="AliasNameClient"/>.</summary>
@@ -100,7 +91,9 @@ namespace Opc.Ua.Client.AliasNames
 
         /// <summary>
         /// Ensures the cache is populated; performs a refresh only on
-        /// the first call (or after an invalidation).
+        /// the first call (or after an invalidation). On the first call
+        /// the configured <see cref="IAliasNameRefreshStrategy"/> is
+        /// also started.
         /// </summary>
         public async Task EnsureLoadedAsync(CancellationToken ct = default)
         {
@@ -108,7 +101,31 @@ namespace Opc.Ua.Client.AliasNames
             {
                 return;
             }
+            await EnsureStrategyStartedAsync(ct).ConfigureAwait(false);
             await RefreshAsync(ct).ConfigureAwait(false);
+        }
+
+        private async Task EnsureStrategyStartedAsync(CancellationToken ct)
+        {
+            if (Volatile.Read(ref m_strategyStarted) == 1)
+            {
+                return;
+            }
+            await m_strategyStartLock.WaitAsync(ct).ConfigureAwait(false);
+            try
+            {
+                if (Volatile.Read(ref m_strategyStarted) == 1)
+                {
+                    return;
+                }
+                await m_strategy.StartAsync(Client, Invalidate, ct)
+                    .ConfigureAwait(false);
+                Volatile.Write(ref m_strategyStarted, 1);
+            }
+            finally
+            {
+                m_strategyStartLock.Release();
+            }
         }
 
         /// <summary>
@@ -116,8 +133,6 @@ namespace Opc.Ua.Client.AliasNames
         /// </summary>
         public async Task RefreshAsync(CancellationToken ct = default)
         {
-            uint? lastChange = await Client.ReadLastChangeAsync(ct).ConfigureAwait(false);
-
             var forward = new Dictionary<string, ExpandedNodeId[]>(StringComparer.Ordinal);
             var serverUris = new Dictionary<string, string?[]>(StringComparer.Ordinal);
             var reverse = new Dictionary<ExpandedNodeId, string>();
@@ -162,7 +177,6 @@ namespace Opc.Ua.Client.AliasNames
                 m_forward = forward;
                 m_serverUris = serverUris;
                 m_reverse = reverse;
-                m_lastSeenChange = lastChange;
                 Volatile.Write(ref m_loaded, 1);
             }
             finally
@@ -272,7 +286,7 @@ namespace Opc.Ua.Client.AliasNames
         }
 
         /// <summary>
-        /// Stops auto-refresh polling (if enabled) and releases the
+        /// Stops the configured refresh strategy and releases the
         /// internal cache. Idempotent. Waits for any in-flight resolve /
         /// refresh / poll callback to release the internal lock before
         /// disposing it so concurrent calls cannot observe an
@@ -280,9 +294,16 @@ namespace Opc.Ua.Client.AliasNames
         /// </summary>
         public async ValueTask DisposeAsync()
         {
-            Timer? timer = m_pollTimer;
-            m_pollTimer = null;
-            timer?.Dispose();
+            try
+            {
+                await m_strategy.DisposeAsync().ConfigureAwait(false);
+            }
+            catch
+            {
+                // Best-effort cleanup; the strategy implementation is
+                // responsible for not throwing during dispose, but we
+                // never want disposal of the resolver to throw.
+            }
 
             try
             {
@@ -303,37 +324,32 @@ namespace Opc.Ua.Client.AliasNames
             {
                 m_semaphore.Release();
                 m_semaphore.Dispose();
+                m_strategyStartLock.Dispose();
             }
         }
 
-        private void PollLastChange(object? _)
+        private static IAliasNameRefreshStrategy BuildBuiltInStrategy(
+            AliasNameResolverOptions options)
         {
-            // Fire-and-forget; exceptions are swallowed so a broken
-            // server cannot crash the resolver.
-            _ = PollLastChangeAsync();
-        }
-
-        private async Task PollLastChangeAsync()
-        {
-            try
+#pragma warning disable CS0618 // AutoOnLastChange aliases AutoOnLastChangePolling.
+            switch (options.RefreshMode)
             {
-                uint? current = await Client.ReadLastChangeAsync().ConfigureAwait(false);
-                if (current == null)
-                {
-                    return;
-                }
-                uint? seen = m_lastSeenChange;
-                // Compare on inequality only — VersionTime may wrap and
-                // a strict greater-than would miss the wraparound case.
-                if (seen != current)
-                {
-                    Invalidate();
-                }
+                case AliasNameResolverRefreshMode.AutoOnLastChangePolling:
+                    return new PollingAliasNameRefreshStrategy(
+                        TimeSpan.FromMilliseconds(
+                            Math.Max(100, options.PublishingIntervalMs)));
+                case AliasNameResolverRefreshMode.AutoOnLastChangeMonitoredItem:
+                    return new MonitoredItemAliasNameRefreshStrategy(
+                        new MonitoredItemAliasNameRefreshStrategyOptions
+                        {
+                            PublishingIntervalMs = options.PublishingIntervalMs,
+                            SamplingIntervalMs = options.LastChangeSamplingIntervalMs,
+                        });
+                case AliasNameResolverRefreshMode.Manual:
+                default:
+                    return new ManualAliasNameRefreshStrategy();
             }
-            catch
-            {
-                // Ignore transient errors; the next poll cycle will retry.
-            }
+#pragma warning restore CS0618
         }
 
         private static void PopulateFromNonVerbose(
@@ -379,13 +395,14 @@ namespace Opc.Ua.Client.AliasNames
         }
 
         private readonly SemaphoreSlim m_semaphore = new(1, 1);
+        private readonly SemaphoreSlim m_strategyStartLock = new(1, 1);
+        private readonly IAliasNameRefreshStrategy m_strategy;
         private Dictionary<string, ExpandedNodeId[]> m_forward
             = new(StringComparer.Ordinal);
         private Dictionary<string, string?[]> m_serverUris
             = new(StringComparer.Ordinal);
         private Dictionary<ExpandedNodeId, string> m_reverse = [];
-        private uint? m_lastSeenChange;
         private int m_loaded;
-        private Timer? m_pollTimer;
+        private int m_strategyStarted;
     }
 }

--- a/Libraries/Opc.Ua.Client/AliasNames/AliasNameResolver.cs
+++ b/Libraries/Opc.Ua.Client/AliasNames/AliasNameResolver.cs
@@ -273,15 +273,37 @@ namespace Opc.Ua.Client.AliasNames
 
         /// <summary>
         /// Stops auto-refresh polling (if enabled) and releases the
-        /// internal cache. Idempotent.
+        /// internal cache. Idempotent. Waits for any in-flight resolve /
+        /// refresh / poll callback to release the internal lock before
+        /// disposing it so concurrent calls cannot observe an
+        /// <see cref="ObjectDisposedException"/>.
         /// </summary>
-        public ValueTask DisposeAsync()
+        public async ValueTask DisposeAsync()
         {
             Timer? timer = m_pollTimer;
             m_pollTimer = null;
             timer?.Dispose();
-            m_semaphore.Dispose();
-            return default;
+
+            try
+            {
+                await m_semaphore.WaitAsync().ConfigureAwait(false);
+            }
+            catch (ObjectDisposedException)
+            {
+                // Already disposed via a re-entrant call.
+                return;
+            }
+            try
+            {
+                m_forward.Clear();
+                m_serverUris.Clear();
+                m_reverse.Clear();
+            }
+            finally
+            {
+                m_semaphore.Release();
+                m_semaphore.Dispose();
+            }
         }
 
         private void PollLastChange(object? _)

--- a/Libraries/Opc.Ua.Client/AliasNames/AliasNameResolverOptions.cs
+++ b/Libraries/Opc.Ua.Client/AliasNames/AliasNameResolverOptions.cs
@@ -28,12 +28,19 @@
  * ======================================================================*/
 
 using System;
+using Opc.Ua.Client.AliasNames.Refresh;
 
 namespace Opc.Ua.Client.AliasNames
 {
     /// <summary>
     /// Controls how <see cref="AliasNameResolver"/> refreshes its cache.
     /// </summary>
+    /// <remarks>
+    /// For finer control set
+    /// <see cref="AliasNameResolverOptions.RefreshStrategy"/> directly to
+    /// an <see cref="IAliasNameRefreshStrategy"/> instance — it takes
+    /// precedence over this enum.
+    /// </remarks>
     public enum AliasNameResolverRefreshMode
     {
         /// <summary>
@@ -44,14 +51,32 @@ namespace Opc.Ua.Client.AliasNames
         Manual = 0,
 
         /// <summary>
-        /// On the first call, the resolver subscribes to the category's
-        /// <c>LastChange</c> property (Part 17 §6.3.1) and invalidates
-        /// the cache on any value-difference notification (covers
-        /// <c>VersionTime</c> wraparound; see Part 5 §6.4.10). Requires
-        /// a server that supports subscriptions and exposes
-        /// <c>LastChange</c>.
+        /// Deprecated alias for
+        /// <see cref="AutoOnLastChangePolling"/>; retained for source
+        /// compatibility with code that targeted the v1 resolver.
         /// </summary>
+        [Obsolete("Use AutoOnLastChangePolling for explicit semantics.")]
         AutoOnLastChange = 1,
+
+        /// <summary>
+        /// On the first call, the resolver polls the category's
+        /// <c>LastChange</c> property (Part 17 §6.3.1) every
+        /// <see cref="AliasNameResolverOptions.PublishingIntervalMs"/>
+        /// and invalidates the cache on any value-difference (covers
+        /// <c>VersionTime</c> wraparound; see Part 5 §6.4.10). Works on
+        /// servers that do not support subscriptions.
+        /// </summary>
+        AutoOnLastChangePolling = 1,
+
+        /// <summary>
+        /// On the first call, the resolver creates an OPC UA
+        /// <c>Subscription</c> + <c>MonitoredItem</c> on the category's
+        /// <c>LastChange</c> variable and invalidates the cache on every
+        /// notification whose value differs from the cached one
+        /// (wrap-safe). Requires a server that supports subscriptions
+        /// and exposes <c>LastChange</c>.
+        /// </summary>
+        AutoOnLastChangeMonitoredItem = 2,
     }
 
     /// <summary>
@@ -62,22 +87,30 @@ namespace Opc.Ua.Client.AliasNames
         /// <summary>
         /// How the resolver refreshes its cache; defaults to
         /// <see cref="AliasNameResolverRefreshMode.Manual"/>.
+        /// Ignored when <see cref="RefreshStrategy"/> is set.
         /// </summary>
         public AliasNameResolverRefreshMode RefreshMode { get; set; }
             = AliasNameResolverRefreshMode.Manual;
 
         /// <summary>
+        /// Optional explicit refresh strategy; takes precedence over
+        /// <see cref="RefreshMode"/> when non-<c>null</c>. Use this to
+        /// plug in custom strategies (e.g. the Annex D PubSub bridge in
+        /// <c>Opc.Ua.Client.AliasNames.PubSub</c>).
+        /// </summary>
+        public IAliasNameRefreshStrategy? RefreshStrategy { get; set; }
+
+        /// <summary>
         /// Sampling interval (ms) for the <c>LastChange</c> monitored
-        /// item created in <see cref="AliasNameResolverRefreshMode.AutoOnLastChange"/>
-        /// mode. Defaults to 1000ms; ignored in
-        /// <see cref="AliasNameResolverRefreshMode.Manual"/> mode.
+        /// item created in
+        /// <see cref="AliasNameResolverRefreshMode.AutoOnLastChangeMonitoredItem"/>
+        /// mode. Defaults to 1000ms; ignored by polling and manual modes.
         /// </summary>
         public double LastChangeSamplingIntervalMs { get; set; } = 1000.0;
 
         /// <summary>
-        /// Publishing interval (ms) for the subscription used by
-        /// <see cref="AliasNameResolverRefreshMode.AutoOnLastChange"/>
-        /// mode. Defaults to 1000ms.
+        /// Publishing interval (ms) for the polling /
+        /// monitored-item-based refresh strategies. Defaults to 1000ms.
         /// </summary>
         public double PublishingIntervalMs { get; set; } = 1000.0;
 
@@ -94,6 +127,7 @@ namespace Opc.Ua.Client.AliasNames
             return new AliasNameResolverOptions
             {
                 RefreshMode = RefreshMode,
+                RefreshStrategy = RefreshStrategy,
                 LastChangeSamplingIntervalMs = LastChangeSamplingIntervalMs,
                 PublishingIntervalMs = PublishingIntervalMs,
                 UseVerbose = UseVerbose

--- a/Libraries/Opc.Ua.Client/AliasNames/AliasNameResolverOptions.cs
+++ b/Libraries/Opc.Ua.Client/AliasNames/AliasNameResolverOptions.cs
@@ -1,0 +1,103 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+
+namespace Opc.Ua.Client.AliasNames
+{
+    /// <summary>
+    /// Controls how <see cref="AliasNameResolver"/> refreshes its cache.
+    /// </summary>
+    public enum AliasNameResolverRefreshMode
+    {
+        /// <summary>
+        /// The cache is loaded once via <see cref="AliasNameResolver.RefreshAsync"/>
+        /// and never updated automatically. This is the safe default — it
+        /// works even when the server does not allow subscriptions.
+        /// </summary>
+        Manual = 0,
+
+        /// <summary>
+        /// On the first call, the resolver subscribes to the category's
+        /// <c>LastChange</c> property (Part 17 §6.3.1) and invalidates
+        /// the cache on any value-difference notification (covers
+        /// <c>VersionTime</c> wraparound; see Part 5 §6.4.10). Requires
+        /// a server that supports subscriptions and exposes
+        /// <c>LastChange</c>.
+        /// </summary>
+        AutoOnLastChange = 1,
+    }
+
+    /// <summary>
+    /// Tunables for an <see cref="AliasNameResolver"/>.
+    /// </summary>
+    public sealed class AliasNameResolverOptions
+    {
+        /// <summary>
+        /// How the resolver refreshes its cache; defaults to
+        /// <see cref="AliasNameResolverRefreshMode.Manual"/>.
+        /// </summary>
+        public AliasNameResolverRefreshMode RefreshMode { get; set; }
+            = AliasNameResolverRefreshMode.Manual;
+
+        /// <summary>
+        /// Sampling interval (ms) for the <c>LastChange</c> monitored
+        /// item created in <see cref="AliasNameResolverRefreshMode.AutoOnLastChange"/>
+        /// mode. Defaults to 1000ms; ignored in
+        /// <see cref="AliasNameResolverRefreshMode.Manual"/> mode.
+        /// </summary>
+        public double LastChangeSamplingIntervalMs { get; set; } = 1000.0;
+
+        /// <summary>
+        /// Publishing interval (ms) for the subscription used by
+        /// <see cref="AliasNameResolverRefreshMode.AutoOnLastChange"/>
+        /// mode. Defaults to 1000ms.
+        /// </summary>
+        public double PublishingIntervalMs { get; set; } = 1000.0;
+
+        /// <summary>
+        /// When <c>true</c>, <see cref="AliasNameResolver.RefreshAsync"/>
+        /// prefers <c>FindAliasVerbose</c> and exposes per-target
+        /// <c>ServerUris</c>; when <c>false</c> (default) it uses the
+        /// less expensive <c>FindAlias</c>.
+        /// </summary>
+        public bool UseVerbose { get; set; }
+
+        internal AliasNameResolverOptions Clone()
+        {
+            return new AliasNameResolverOptions
+            {
+                RefreshMode = RefreshMode,
+                LastChangeSamplingIntervalMs = LastChangeSamplingIntervalMs,
+                PublishingIntervalMs = PublishingIntervalMs,
+                UseVerbose = UseVerbose
+            };
+        }
+    }
+}

--- a/Libraries/Opc.Ua.Client/AliasNames/PubSub/AliasNamePubSubReader.cs
+++ b/Libraries/Opc.Ua.Client/AliasNames/PubSub/AliasNamePubSubReader.cs
@@ -1,0 +1,110 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+
+namespace Opc.Ua.Client.AliasNames.PubSub
+{
+    /// <summary>
+    /// Event payload raised by <see cref="AliasNamePubSubReader.AliasUpdateReceived"/>
+    /// every time a Part 17 Annex D <c>AliasUpdateDataType</c> message
+    /// is fed into the reader.
+    /// </summary>
+    public sealed class AliasUpdateReceivedEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Initializes a new instance.
+        /// </summary>
+        public AliasUpdateReceivedEventArgs(AliasUpdateDataType update)
+        {
+            Update = update ?? throw new ArgumentNullException(nameof(update));
+        }
+
+        /// <summary>The received message.</summary>
+        public AliasUpdateDataType Update { get; }
+    }
+
+    /// <summary>
+    /// Transport-agnostic Part 17 Annex D <c>AliasUpdate</c> subscriber
+    /// surface. Callers feed in deserialized
+    /// <see cref="AliasUpdateDataType"/> instances via
+    /// <see cref="Submit(AliasUpdateDataType)"/>; subscribers receive
+    /// them as <see cref="AliasUpdateReceived"/> events. Bridging from
+    /// a particular wire transport (UADP, JSON-over-MQTT, …) is the
+    /// caller's responsibility — typically by hooking
+    /// <c>Opc.Ua.PubSub.UaPubSubApplication.DataReceived</c> and
+    /// extracting the <c>AliasUpdateDataType</c> from the DataSet
+    /// fields, then calling <see cref="Submit"/>.
+    /// </summary>
+    public sealed class AliasNamePubSubReader
+    {
+        /// <summary>
+        /// Initializes a new reader.
+        /// </summary>
+        /// <param name="options">Optional tunables.</param>
+        public AliasNamePubSubReader(AliasNamePubSubReaderOptions? options = null)
+        {
+            Options = options ?? new AliasNamePubSubReaderOptions();
+        }
+
+        /// <summary>The (snapshot of) configured options.</summary>
+        public AliasNamePubSubReaderOptions Options { get; }
+
+        /// <summary>
+        /// Raised on every accepted update (after filter rules).
+        /// </summary>
+        public event EventHandler<AliasUpdateReceivedEventArgs>? AliasUpdateReceived;
+
+        /// <summary>
+        /// Submits a deserialized message to the reader. Filtered
+        /// messages are dropped silently; accepted ones are raised
+        /// through <see cref="AliasUpdateReceived"/>.
+        /// </summary>
+        /// <returns><c>true</c> if the message passed the filter and an
+        /// event was raised; <c>false</c> if the message was dropped.</returns>
+        public bool Submit(AliasUpdateDataType update)
+        {
+            if (update == null)
+            {
+                throw new ArgumentNullException(nameof(update));
+            }
+            if (!string.IsNullOrEmpty(Options.ExpectedApplicationUri)
+                && !string.Equals(
+                    update.ApplicationUri,
+                    Options.ExpectedApplicationUri,
+                    StringComparison.Ordinal))
+            {
+                return false;
+            }
+            AliasUpdateReceived?.Invoke(
+                this, new AliasUpdateReceivedEventArgs(update));
+            return true;
+        }
+    }
+}

--- a/Libraries/Opc.Ua.Client/AliasNames/PubSub/AliasNamePubSubReaderOptions.cs
+++ b/Libraries/Opc.Ua.Client/AliasNames/PubSub/AliasNamePubSubReaderOptions.cs
@@ -1,0 +1,45 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+namespace Opc.Ua.Client.AliasNames.PubSub
+{
+    /// <summary>
+    /// Tunables for <see cref="AliasNamePubSubReader"/>.
+    /// </summary>
+    public sealed class AliasNamePubSubReaderOptions
+    {
+        /// <summary>
+        /// When non-<c>null</c>, only messages whose
+        /// <see cref="AliasUpdateDataType.ApplicationUri"/> equals this
+        /// string are forwarded. Useful when the same DataSet is
+        /// shared by multiple publishers.
+        /// </summary>
+        public string? ExpectedApplicationUri { get; set; }
+    }
+}

--- a/Libraries/Opc.Ua.Client/AliasNames/PubSub/AliasNamePubSubRefreshStrategy.cs
+++ b/Libraries/Opc.Ua.Client/AliasNames/PubSub/AliasNamePubSubRefreshStrategy.cs
@@ -1,0 +1,174 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Opc.Ua.Client.AliasNames.Refresh;
+
+namespace Opc.Ua.Client.AliasNames.PubSub
+{
+    /// <summary>
+    /// Bridges an <see cref="AliasNamePubSubReader"/> into the
+    /// <see cref="IAliasNameRefreshStrategy"/> extension point. When a
+    /// Part 17 Annex D <c>AliasUpdateDataType</c> message arrives for
+    /// the resolver's category, the strategy invokes
+    /// <c>onInvalidate</c> — so the resolver refetches via
+    /// <c>FindAlias</c> on the next access.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The bridge matches by the source server's <c>NamespaceUri</c>
+    /// (which the reader's
+    /// <see cref="AliasNamePubSubReaderOptions.ExpectedApplicationUri"/>
+    /// may already restrict). For each received message, every
+    /// <see cref="AliasCategoryUpdateDataType"/> entry whose
+    /// <see cref="PortableNodeId.NamespaceUri"/> matches the resolver's
+    /// category namespace AND whose
+    /// <see cref="PortableNodeId.Identifier"/> matches the resolver's
+    /// category identifier triggers cache invalidation.
+    /// </para>
+    /// <para>
+    /// LastChange comparison is wrap-safe (<c>VersionTime</c> is
+    /// <c>uint</c>) — any difference fires; equal values are ignored.
+    /// </para>
+    /// </remarks>
+    public sealed class AliasNamePubSubRefreshStrategy : IAliasNameRefreshStrategy
+    {
+        /// <summary>
+        /// Initializes a new bridge over the supplied reader.
+        /// </summary>
+        /// <param name="reader">The reader that surfaces incoming
+        /// Part 17 Annex D messages.</param>
+        public AliasNamePubSubRefreshStrategy(AliasNamePubSubReader reader)
+        {
+            m_reader = reader ?? throw new ArgumentNullException(nameof(reader));
+        }
+
+        /// <inheritdoc/>
+        public ValueTask StartAsync(
+            AliasNameClient client,
+            Action onInvalidate,
+            CancellationToken ct)
+        {
+            if (client == null)
+            {
+                throw new ArgumentNullException(nameof(client));
+            }
+            if (onInvalidate == null)
+            {
+                throw new ArgumentNullException(nameof(onInvalidate));
+            }
+
+            m_categoryId = client.CategoryId;
+            string? namespaceUri = client.Session.NamespaceUris
+                .GetString(m_categoryId.NamespaceIndex);
+            m_categoryNamespaceUri = namespaceUri ?? string.Empty;
+            m_onInvalidate = onInvalidate;
+            m_reader.AliasUpdateReceived += OnAliasUpdateReceived;
+            return default;
+        }
+
+        /// <inheritdoc/>
+        public ValueTask DisposeAsync()
+        {
+            m_reader.AliasUpdateReceived -= OnAliasUpdateReceived;
+            m_onInvalidate = null;
+            return default;
+        }
+
+        private void OnAliasUpdateReceived(
+            object? sender,
+            AliasUpdateReceivedEventArgs e)
+        {
+            Action? invalidate = m_onInvalidate;
+            if (invalidate == null)
+            {
+                return;
+            }
+            foreach (AliasCategoryUpdateDataType entry in e.Update.Categories)
+            {
+                if (!MatchesCategory(entry.Category))
+                {
+                    continue;
+                }
+                uint? last = m_lastSeen;
+                uint current = entry.LastChange;
+                if (last != current)
+                {
+                    m_lastSeen = current;
+                    invalidate();
+                    return;
+                }
+            }
+        }
+
+        private bool MatchesCategory(PortableNodeId portable)
+        {
+            if (portable == null)
+            {
+                return false;
+            }
+            if (!string.Equals(portable.NamespaceUri,
+                    m_categoryNamespaceUri, StringComparison.Ordinal))
+            {
+                return false;
+            }
+            // Compare on identifier value only — the local namespace
+            // index is irrelevant because the publisher stripped it.
+            return CompareIdentifiers(portable.Identifier, m_categoryId);
+        }
+
+        private static bool CompareIdentifiers(NodeId publisherId, NodeId localId)
+        {
+            // Both NodeIds carry the same identifier-shape (numeric /
+            // string / guid / opaque). Comparing identifier text after
+            // dropping the namespace prefix is the simplest robust path.
+            string a = StripNamespacePrefix(publisherId.ToString());
+            string b = StripNamespacePrefix(localId.ToString());
+            return string.Equals(a, b, StringComparison.Ordinal);
+        }
+
+        private static string StripNamespacePrefix(string? text)
+        {
+            if (string.IsNullOrEmpty(text))
+            {
+                return string.Empty;
+            }
+            int idx = text!.IndexOf(';');
+            return idx < 0 ? text : text.Substring(idx + 1);
+        }
+
+        private readonly AliasNamePubSubReader m_reader;
+        private NodeId m_categoryId = NodeId.Null;
+        private string m_categoryNamespaceUri = string.Empty;
+        private Action? m_onInvalidate;
+        private uint? m_lastSeen;
+    }
+}

--- a/Libraries/Opc.Ua.Client/AliasNames/Refresh/IAliasNameRefreshStrategy.cs
+++ b/Libraries/Opc.Ua.Client/AliasNames/Refresh/IAliasNameRefreshStrategy.cs
@@ -1,0 +1,85 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Opc.Ua.Client.AliasNames.Refresh
+{
+    /// <summary>
+    /// Pluggable cache-invalidation strategy for
+    /// <see cref="AliasNameResolver"/>. Implementations detect that a
+    /// resolver's view of the server is stale and invoke the supplied
+    /// callback to trigger a reload on the next <c>ResolveAsync</c>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Built-in strategies cover the three common shapes:
+    /// </para>
+    /// <list type="bullet">
+    ///   <item><description><c>ManualAliasNameRefreshStrategy</c>
+    ///     — never invalidates; the caller controls refreshes.</description></item>
+    ///   <item><description><c>PollingAliasNameRefreshStrategy</c>
+    ///     — periodically reads the category's <c>LastChange</c> via the
+    ///     standard <c>Read</c> service and invalidates on any
+    ///     value-difference (wrap-safe).</description></item>
+    ///   <item><description><c>MonitoredItemAliasNameRefreshStrategy</c>
+    ///     — creates an OPC UA <c>Subscription</c> + <c>MonitoredItem</c>
+    ///     on the category's <c>LastChange</c> variable and invalidates
+    ///     on every notification with a different value.</description></item>
+    /// </list>
+    /// <para>
+    /// Custom strategies (e.g. a Part 17 Annex D PubSub-driven bridge)
+    /// can implement this interface and plug in via
+    /// <see cref="AliasNameResolverOptions.RefreshStrategy"/>.
+    /// </para>
+    /// </remarks>
+    public interface IAliasNameRefreshStrategy : IAsyncDisposable
+    {
+        /// <summary>
+        /// Begins watching for cache-invalidation triggers. Invoked once
+        /// by <see cref="AliasNameResolver"/> on first use.
+        /// Implementations invoke <paramref name="onInvalidate"/>
+        /// whenever they decide the resolver's cache may be stale.
+        /// </summary>
+        /// <param name="client">The resolver's underlying client.
+        /// Strategies can use it to look up the category's
+        /// <c>LastChange</c> NodeId, issue reads, or create
+        /// subscriptions on its <see cref="AliasNameClient.Session"/>.</param>
+        /// <param name="onInvalidate">Callback to fire when the cache
+        /// should be invalidated. May be called from any thread; the
+        /// resolver handles synchronisation.</param>
+        /// <param name="ct">Cancellation token.</param>
+        ValueTask StartAsync(
+            AliasNameClient client,
+            Action onInvalidate,
+            CancellationToken ct);
+    }
+}

--- a/Libraries/Opc.Ua.Client/AliasNames/Refresh/ManualAliasNameRefreshStrategy.cs
+++ b/Libraries/Opc.Ua.Client/AliasNames/Refresh/ManualAliasNameRefreshStrategy.cs
@@ -1,0 +1,59 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Opc.Ua.Client.AliasNames.Refresh
+{
+    /// <summary>
+    /// Trivial no-op refresh strategy — never triggers cache
+    /// invalidation. Callers must invoke
+    /// <see cref="AliasNameResolver.RefreshAsync"/> or
+    /// <see cref="AliasNameResolver.Invalidate"/> explicitly.
+    /// </summary>
+    public sealed class ManualAliasNameRefreshStrategy : IAliasNameRefreshStrategy
+    {
+        /// <inheritdoc/>
+        public ValueTask StartAsync(
+            AliasNameClient client,
+            Action onInvalidate,
+            CancellationToken ct)
+        {
+            return default;
+        }
+
+        /// <inheritdoc/>
+        public ValueTask DisposeAsync()
+        {
+            return default;
+        }
+    }
+}

--- a/Libraries/Opc.Ua.Client/AliasNames/Refresh/MonitoredItemAliasNameRefreshStrategy.cs
+++ b/Libraries/Opc.Ua.Client/AliasNames/Refresh/MonitoredItemAliasNameRefreshStrategy.cs
@@ -1,0 +1,227 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Opc.Ua.Client.AliasNames.Refresh
+{
+    /// <summary>
+    /// Refresh strategy that creates an OPC UA <c>Subscription</c> +
+    /// <c>MonitoredItem</c> on the category's <c>LastChange</c>
+    /// variable (Part 17 §6.3.1) and invalidates the resolver cache on
+    /// every notification whose value differs from the cached one
+    /// (wrap-safe — compares for inequality, not strict greater-than).
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Pushes notifications instead of polling — preferable to
+    /// <see cref="PollingAliasNameRefreshStrategy"/> whenever the
+    /// server supports subscriptions and exposes <c>LastChange</c>.
+    /// </para>
+    /// <para>
+    /// By default the strategy creates and owns its own
+    /// <see cref="Subscription"/>; to share one with other monitored
+    /// items pass it via
+    /// <see cref="MonitoredItemAliasNameRefreshStrategyOptions.SharedSubscription"/>.
+    /// </para>
+    /// </remarks>
+    public sealed class MonitoredItemAliasNameRefreshStrategy : IAliasNameRefreshStrategy
+    {
+        /// <summary>
+        /// Initializes a new monitored-item-based strategy.
+        /// </summary>
+        /// <param name="options">Strategy tunables; defaults are applied
+        /// when <c>null</c>.</param>
+        public MonitoredItemAliasNameRefreshStrategy(
+            MonitoredItemAliasNameRefreshStrategyOptions? options = null)
+        {
+            Options = options ?? new MonitoredItemAliasNameRefreshStrategyOptions();
+        }
+
+        /// <summary>
+        /// The (snapshot of) configured options.
+        /// </summary>
+        public MonitoredItemAliasNameRefreshStrategyOptions Options { get; }
+
+        /// <inheritdoc/>
+        public async ValueTask StartAsync(
+            AliasNameClient client,
+            Action onInvalidate,
+            CancellationToken ct)
+        {
+            if (client == null)
+            {
+                throw new ArgumentNullException(nameof(client));
+            }
+            if (onInvalidate == null)
+            {
+                throw new ArgumentNullException(nameof(onInvalidate));
+            }
+
+            m_client = client;
+            m_onInvalidate = onInvalidate;
+
+            NodeId lastChangeId = await client
+                .ResolveLastChangeNodeIdAsync(ct)
+                .ConfigureAwait(false);
+            if (lastChangeId.IsNull)
+            {
+                // Category does not expose LastChange — no auto-invalidation
+                // possible. The strategy becomes a no-op equivalent to
+                // ManualAliasNameRefreshStrategy.
+                return;
+            }
+
+            Subscription subscription;
+            bool ownsSubscription = false;
+            if (Options.SharedSubscription != null)
+            {
+                subscription = Options.SharedSubscription;
+            }
+            else
+            {
+                subscription = new Subscription(client.Session.MessageContext.Telemetry)
+                {
+                    DisplayName = Options.SubscriptionDisplayName,
+                    PublishingEnabled = true,
+                    PublishingInterval = (int)Options.PublishingIntervalMs,
+                };
+                client.Session.AddSubscription(subscription);
+                await subscription.CreateAsync(ct).ConfigureAwait(false);
+                ownsSubscription = true;
+            }
+
+            var item = new MonitoredItem(subscription.DefaultItem)
+            {
+                StartNodeId = lastChangeId,
+                AttributeId = Attributes.Value,
+                DisplayName = "LastChange",
+                SamplingInterval = (int)Options.SamplingIntervalMs,
+                QueueSize = 1,
+                DiscardOldest = true,
+                MonitoringMode = MonitoringMode.Reporting,
+            };
+            item.Notification += OnNotification;
+            subscription.AddItem(item);
+            await subscription.ApplyChangesAsync(ct).ConfigureAwait(false);
+
+            m_subscription = subscription;
+            m_item = item;
+            m_ownsSubscription = ownsSubscription;
+        }
+
+        /// <inheritdoc/>
+        public async ValueTask DisposeAsync()
+        {
+            MonitoredItem? item = m_item;
+            Subscription? subscription = m_subscription;
+            bool owns = m_ownsSubscription;
+            m_item = null;
+            m_subscription = null;
+
+            if (item != null)
+            {
+                item.Notification -= OnNotification;
+                if (subscription != null)
+                {
+                    try
+                    {
+                        subscription.RemoveItem(item);
+                        await subscription.ApplyChangesAsync().ConfigureAwait(false);
+                    }
+                    catch
+                    {
+                        // Best-effort cleanup; the session may already be
+                        // closed.
+                    }
+                }
+            }
+
+            if (owns && subscription != null)
+            {
+                AliasNameClient? client = m_client;
+                try
+                {
+                    if (client != null)
+                    {
+                        await client.Session
+                            .RemoveSubscriptionAsync(subscription)
+                            .ConfigureAwait(false);
+                    }
+                    await subscription.DeleteAsync(silent: true).ConfigureAwait(false);
+                }
+                catch
+                {
+                    // Best-effort cleanup.
+                }
+                finally
+                {
+                    subscription.Dispose();
+                }
+            }
+
+            m_client = null;
+            m_onInvalidate = null;
+        }
+
+        private void OnNotification(
+            MonitoredItem item,
+            MonitoredItemNotificationEventArgs e)
+        {
+            // The data-change notification carries a DataValue in the
+            // first value of NotificationValue. Extract the uint and
+            // compare on inequality.
+            MonitoredItemNotification? notification = item.LastValue
+                as MonitoredItemNotification;
+            if (notification == null)
+            {
+                return;
+            }
+            if (!notification.Value.WrappedValue.TryGetValue(out uint current))
+            {
+                return;
+            }
+            uint? last = m_lastSeen;
+            if (last != current)
+            {
+                m_lastSeen = current;
+                m_onInvalidate?.Invoke();
+            }
+        }
+
+        private AliasNameClient? m_client;
+        private Action? m_onInvalidate;
+        private Subscription? m_subscription;
+        private MonitoredItem? m_item;
+        private bool m_ownsSubscription;
+        private uint? m_lastSeen;
+    }
+}

--- a/Libraries/Opc.Ua.Client/AliasNames/Refresh/MonitoredItemAliasNameRefreshStrategyOptions.cs
+++ b/Libraries/Opc.Ua.Client/AliasNames/Refresh/MonitoredItemAliasNameRefreshStrategyOptions.cs
@@ -1,0 +1,69 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+namespace Opc.Ua.Client.AliasNames.Refresh
+{
+    /// <summary>
+    /// Tunables for
+    /// <see cref="MonitoredItemAliasNameRefreshStrategy"/>.
+    /// </summary>
+    public sealed class MonitoredItemAliasNameRefreshStrategyOptions
+    {
+        /// <summary>
+        /// When non-<c>null</c>, the strategy adds the
+        /// <c>LastChange</c> monitored item to this existing
+        /// <see cref="Subscription"/> instead of creating its own.
+        /// Disposal will <c>not</c> delete the subscription in this case
+        /// — only the monitored item is removed.
+        /// </summary>
+        public Subscription? SharedSubscription { get; set; }
+
+        /// <summary>
+        /// Display name to apply to the <see cref="Subscription"/> the
+        /// strategy creates (ignored when
+        /// <see cref="SharedSubscription"/> is set). Defaults to
+        /// <c>"AliasNameLastChange"</c>.
+        /// </summary>
+        public string SubscriptionDisplayName { get; set; }
+            = "AliasNameLastChange";
+
+        /// <summary>
+        /// Publishing interval (ms) of the owned
+        /// <see cref="Subscription"/> (ignored when
+        /// <see cref="SharedSubscription"/> is set). Defaults to 1000ms.
+        /// </summary>
+        public double PublishingIntervalMs { get; set; } = 1000.0;
+
+        /// <summary>
+        /// Sampling interval (ms) for the <c>LastChange</c> monitored
+        /// item. Defaults to 1000ms.
+        /// </summary>
+        public double SamplingIntervalMs { get; set; } = 1000.0;
+    }
+}

--- a/Libraries/Opc.Ua.Client/AliasNames/Refresh/PollingAliasNameRefreshStrategy.cs
+++ b/Libraries/Opc.Ua.Client/AliasNames/Refresh/PollingAliasNameRefreshStrategy.cs
@@ -1,0 +1,152 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Opc.Ua.Client.AliasNames.Refresh
+{
+    /// <summary>
+    /// Refresh strategy that periodically reads the category's
+    /// <c>LastChange</c> property (Part 17 §6.3.1) via the standard
+    /// <c>Read</c> service and invalidates the resolver cache when the
+    /// value changes (wrap-safe — compares for inequality, not strict
+    /// greater-than).
+    /// </summary>
+    /// <remarks>
+    /// Suitable for any server that exposes <c>LastChange</c> — including
+    /// servers that disable subscriptions. Pollintroduces one
+    /// <c>Read</c> service round-trip per <see cref="PollInterval"/>; use
+    /// <see cref="MonitoredItemAliasNameRefreshStrategy"/> instead when
+    /// the server supports subscriptions and a finer push notification
+    /// is preferable.
+    /// </remarks>
+    public sealed class PollingAliasNameRefreshStrategy : IAliasNameRefreshStrategy
+    {
+        /// <summary>
+        /// Initializes a new poller with the supplied interval.
+        /// </summary>
+        /// <param name="pollInterval">Time between successive
+        /// <c>LastChange</c> reads. Must be at least 100 ms.</param>
+        public PollingAliasNameRefreshStrategy(TimeSpan pollInterval)
+        {
+            if (pollInterval < TimeSpan.FromMilliseconds(100))
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(pollInterval),
+                    "Poll interval must be at least 100 ms.");
+            }
+            PollInterval = pollInterval;
+        }
+
+        /// <summary>
+        /// The polling interval.
+        /// </summary>
+        public TimeSpan PollInterval { get; }
+
+        /// <inheritdoc/>
+        public ValueTask StartAsync(
+            AliasNameClient client,
+            Action onInvalidate,
+            CancellationToken ct)
+        {
+            if (client == null)
+            {
+                throw new ArgumentNullException(nameof(client));
+            }
+            if (onInvalidate == null)
+            {
+                throw new ArgumentNullException(nameof(onInvalidate));
+            }
+
+            m_client = client;
+            m_onInvalidate = onInvalidate;
+
+            int periodMs = (int)PollInterval.TotalMilliseconds;
+            m_timer = new Timer(
+                Tick,
+                state: null,
+                dueTime: periodMs,
+                period: periodMs);
+            return default;
+        }
+
+        /// <inheritdoc/>
+        public ValueTask DisposeAsync()
+        {
+            Timer? timer = m_timer;
+            m_timer = null;
+            timer?.Dispose();
+            return default;
+        }
+
+        private void Tick(object? _)
+        {
+            // Fire-and-forget; a server hiccup must not crash the
+            // timer thread.
+            _ = TickAsync();
+        }
+
+        private async Task TickAsync()
+        {
+            AliasNameClient? client = m_client;
+            Action? invalidate = m_onInvalidate;
+            if (client == null || invalidate == null)
+            {
+                return;
+            }
+            try
+            {
+                uint? current = await client.ReadLastChangeAsync().ConfigureAwait(false);
+                if (current == null)
+                {
+                    return;
+                }
+                uint? last = m_lastSeen;
+                // Wrap-safe — VersionTime is uint and may wrap; any
+                // difference (including wraparound) is a change.
+                if (last != current)
+                {
+                    m_lastSeen = current;
+                    invalidate();
+                }
+            }
+            catch
+            {
+                // Transient errors are swallowed; the next tick retries.
+            }
+        }
+
+        private AliasNameClient? m_client;
+        private Action? m_onInvalidate;
+        private Timer? m_timer;
+        private uint? m_lastSeen;
+    }
+}

--- a/Libraries/Opc.Ua.Server/AliasNames/AliasDefinition.cs
+++ b/Libraries/Opc.Ua.Server/AliasNames/AliasDefinition.cs
@@ -1,0 +1,144 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using System.Collections.Generic;
+
+namespace Opc.Ua.Server.AliasNames
+{
+    /// <summary>
+    /// Configuration describing a single OPC UA Part 17 alias. An alias maps
+    /// a human-readable name (within its containing
+    /// <see cref="AliasNameCategoryDescriptor"/>) to one or more target nodes
+    /// reached via a specific reference type.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The wire-level representation is <c>AliasNameDataType</c> (Part 17
+    /// §7.2) — a <see cref="QualifiedName"/> and a list of
+    /// <see cref="ExpandedNodeId"/> targets. The <see cref="ReferenceTypeId"/>
+    /// is the reference type used between the <c>AliasName</c> object and
+    /// each target node in the server's address space; it also drives the
+    /// <c>ReferenceTypeFilter</c> argument of the <c>FindAlias</c> methods
+    /// (Part 17 §6.3.2).
+    /// </para>
+    /// <para>
+    /// <see cref="ServerUris"/> is the optional list of server URIs used by
+    /// the verbose form <c>AliasNameVerboseDataType</c> (Part 17 §7.3). When
+    /// present, <c>ServerUris[i]</c> identifies the server hosting
+    /// <c>ReferencedNodes[i]</c>; an empty entry, or a list shorter than
+    /// <c>ReferencedNodes</c>, means "the current server".
+    /// </para>
+    /// </remarks>
+    public sealed record AliasDefinition
+    {
+        /// <summary>
+        /// Initializes a new alias definition.
+        /// </summary>
+        /// <param name="name">The alias name as a <see cref="QualifiedName"/>;
+        /// the <c>NamespaceIndex</c> should belong to the node manager's
+        /// namespace.</param>
+        /// <param name="referencedNodes">The (one or more)
+        /// <see cref="ExpandedNodeId"/>s the alias resolves to.</param>
+        /// <param name="referenceTypeId">The reference type that connects the
+        /// alias node to each referenced node; typically
+        /// <c>ReferenceTypeIds.AliasFor</c> but may be any non-hierarchical
+        /// reference (per Part 17 §8.2).</param>
+        /// <param name="serverUris">Optional per-target server URIs for the
+        /// verbose form. <c>null</c> means "all targets live on the current
+        /// server".</param>
+        public AliasDefinition(
+            QualifiedName name,
+            IReadOnlyList<ExpandedNodeId> referencedNodes,
+            NodeId referenceTypeId,
+            IReadOnlyList<string?>? serverUris = null)
+        {
+            if (referencedNodes == null)
+            {
+                throw new ArgumentNullException(nameof(referencedNodes));
+            }
+            if (name.IsNull)
+            {
+                throw new ArgumentException(
+                    "AliasName must not be null.",
+                    nameof(name));
+            }
+            if (referencedNodes.Count == 0)
+            {
+                throw new ArgumentException(
+                    "At least one referenced node is required.",
+                    nameof(referencedNodes));
+            }
+            if (referenceTypeId.IsNull)
+            {
+                throw new ArgumentException(
+                    "ReferenceTypeId must not be null.",
+                    nameof(referenceTypeId));
+            }
+            if (serverUris != null && serverUris.Count > referencedNodes.Count)
+            {
+                throw new ArgumentException(
+                    "ServerUris must not be longer than ReferencedNodes.",
+                    nameof(serverUris));
+            }
+
+            Name = name;
+            ReferencedNodes = referencedNodes;
+            ReferenceTypeId = referenceTypeId;
+            ServerUris = serverUris;
+        }
+
+        /// <summary>
+        /// The alias name. Equality across aliases inside a category is
+        /// determined by the case-sensitive name (per Part 17 wildcard
+        /// semantics) and namespace index.
+        /// </summary>
+        public QualifiedName Name { get; }
+
+        /// <summary>
+        /// One or more target nodes the alias resolves to.
+        /// </summary>
+        public IReadOnlyList<ExpandedNodeId> ReferencedNodes { get; }
+
+        /// <summary>
+        /// The reference type connecting the alias to each target. Used both
+        /// to construct the address-space references and to filter result
+        /// sets in <c>FindAlias</c>/<c>FindAliasVerbose</c>.
+        /// </summary>
+        public NodeId ReferenceTypeId { get; }
+
+        /// <summary>
+        /// Optional per-target server URIs used by the verbose form. May be
+        /// <c>null</c> (all targets on the local server) or shorter than
+        /// <see cref="ReferencedNodes"/> (trailing entries default to the
+        /// local server).
+        /// </summary>
+        public IReadOnlyList<string?>? ServerUris { get; }
+    }
+}

--- a/Libraries/Opc.Ua.Server/AliasNames/AliasMutationRequests.cs
+++ b/Libraries/Opc.Ua.Server/AliasNames/AliasMutationRequests.cs
@@ -1,0 +1,65 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+namespace Opc.Ua.Server.AliasNames
+{
+    /// <summary>
+    /// A single entry to add to an alias-name category — corresponds to one
+    /// row across the four parallel input arrays of the Part 17 §6.3.4
+    /// <c>AddAliasesToCategory</c> method (<c>AliasNames[i]</c>,
+    /// <c>TargetNodes[i]</c>, <c>TargetServers[i]</c>) plus the scalar
+    /// <c>TargetReferenceType</c>.
+    /// </summary>
+    /// <param name="Name">The alias name to add.</param>
+    /// <param name="TargetNode">The node the alias resolves to.</param>
+    /// <param name="TargetServer">The server URI hosting the target; empty
+    /// or <c>null</c> means the local server.</param>
+    /// <param name="TargetReferenceType">The reference type between the
+    /// alias and the target node; typically
+    /// <c>ReferenceTypeIds.AliasFor</c>.</param>
+    public sealed record AliasAddRequest(
+        string Name,
+        ExpandedNodeId TargetNode,
+        string? TargetServer,
+        NodeId TargetReferenceType);
+
+    /// <summary>
+    /// A single entry to remove from an alias-name category — corresponds
+    /// to one row across the two parallel input arrays of the Part 17
+    /// §6.3.5 <c>DeleteAliasesFromCategory</c> method
+    /// (<c>AliasNames[i]</c>, <c>TargetNodes[i]</c>).
+    /// </summary>
+    /// <param name="Name">The alias name to remove.</param>
+    /// <param name="TargetNode">The specific target node to detach. To
+    /// remove every target of the named alias pass each target on its own
+    /// row.</param>
+    public sealed record AliasDeleteRequest(
+        string Name,
+        ExpandedNodeId TargetNode);
+}

--- a/Libraries/Opc.Ua.Server/AliasNames/AliasNameCapabilities.cs
+++ b/Libraries/Opc.Ua.Server/AliasNames/AliasNameCapabilities.cs
@@ -1,0 +1,81 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+
+namespace Opc.Ua.Server.AliasNames
+{
+    /// <summary>
+    /// The optional Part 17 children that an <see cref="AliasNameCategoryDescriptor"/>
+    /// exposes on its <c>AliasNameCategoryType</c> instance. The mandatory
+    /// <c>FindAlias</c> method is always created; this enum controls only the
+    /// optional members defined by Part 17 §6.3.1.
+    /// </summary>
+    [Flags]
+    public enum AliasNameCapabilities
+    {
+        /// <summary>
+        /// Only the mandatory <c>FindAlias</c> method is exposed.
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// The category exposes <c>FindAliasVerbose</c> (Part 17 §6.3.3).
+        /// </summary>
+        FindAliasVerbose = 1 << 0,
+
+        /// <summary>
+        /// The category exposes <c>AddAliasesToCategory</c> (Part 17 §6.3.4).
+        /// </summary>
+        AddAliasesToCategory = 1 << 1,
+
+        /// <summary>
+        /// The category exposes <c>DeleteAliasesFromCategory</c> (Part 17 §6.3.5).
+        /// </summary>
+        DeleteAliasesFromCategory = 1 << 2,
+
+        /// <summary>
+        /// The category exposes the <c>LastChange</c> property and reflects
+        /// updates to it (Part 17 §6.3.1).
+        /// </summary>
+        LastChange = 1 << 3,
+
+        /// <summary>
+        /// Convenience value: read-only category supporting both find variants
+        /// plus <c>LastChange</c>.
+        /// </summary>
+        ReadOnly = FindAliasVerbose | LastChange,
+
+        /// <summary>
+        /// Convenience value: read-write category supporting every Part 17
+        /// optional member.
+        /// </summary>
+        All = FindAliasVerbose | AddAliasesToCategory | DeleteAliasesFromCategory | LastChange
+    }
+}

--- a/Libraries/Opc.Ua.Server/AliasNames/AliasNameCategoryDescriptor.cs
+++ b/Libraries/Opc.Ua.Server/AliasNames/AliasNameCategoryDescriptor.cs
@@ -1,0 +1,127 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using System.Collections.Generic;
+
+namespace Opc.Ua.Server.AliasNames
+{
+    /// <summary>
+    /// Describes an OPC UA Part 17 alias name category — a node of type
+    /// <c>AliasNameCategoryType</c> (Part 17 §6.3.1) — together with the
+    /// optional Part 17 children it exposes and any sub-categories.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Returned by <c>IAliasNameStore.RootCategories</c> to describe
+    /// the address-space tree a store contributes. Used by
+    /// <c>AliasNameNodeManager</c> to construct
+    /// <c>AliasNameCategoryState</c> instances and wire their method
+    /// handlers, and by the standard-node late binder in
+    /// <c>DiagnosticsNodeManager</c> to identify which standard categories
+    /// (<c>Aliases</c>, <c>TagVariables</c>, <c>Topics</c> — Part 17 §9) a
+    /// store serves.
+    /// </para>
+    /// <para>
+    /// <see cref="NodeId"/> uniquely identifies the category and is the
+    /// <c>categoryId</c> passed to <c>IAliasNameStore</c> when dispatching
+    /// <c>FindAlias</c>, <c>FindAliasVerbose</c>, <c>AddAliasesToCategory</c>
+    /// and <c>DeleteAliasesFromCategory</c> calls. To serve a standard
+    /// well-known category, use the corresponding identifier:
+    /// <c>ObjectIds.Aliases</c>, <c>ObjectIds.TagVariables</c> or
+    /// <c>ObjectIds.Topics</c>.
+    /// </para>
+    /// </remarks>
+    public sealed record AliasNameCategoryDescriptor
+    {
+        /// <summary>
+        /// Initializes a new category descriptor.
+        /// </summary>
+        /// <param name="nodeId">The category's <see cref="NodeId"/>. For a
+        /// standard well-known category use one of the
+        /// <c>ObjectIds.Aliases</c>/<c>TagVariables</c>/<c>Topics</c>
+        /// values.</param>
+        /// <param name="browseName">The category's <see cref="QualifiedName"/>.
+        /// When serving a standard well-known category, callers typically
+        /// supply the standard name (e.g. <c>"Aliases"</c>); for app-defined
+        /// categories any meaningful name in the manager's namespace.</param>
+        /// <param name="capabilities">The optional Part 17 children this
+        /// category exposes. The mandatory <c>FindAlias</c> method is always
+        /// present and does not need to be flagged.</param>
+        /// <param name="subCategories">Optional list of sub-categories;
+        /// <c>FindAlias</c> on the parent recursively searches these as
+        /// well, per Part 17 §6.3.2.</param>
+        public AliasNameCategoryDescriptor(
+            NodeId nodeId,
+            QualifiedName browseName,
+            AliasNameCapabilities capabilities = AliasNameCapabilities.None,
+            IReadOnlyList<AliasNameCategoryDescriptor>? subCategories = null)
+        {
+            if (nodeId.IsNull)
+            {
+                throw new ArgumentException(
+                    "Category NodeId must not be null.",
+                    nameof(nodeId));
+            }
+            if (browseName.IsNull)
+            {
+                throw new ArgumentException(
+                    "Category BrowseName must not be null.",
+                    nameof(browseName));
+            }
+
+            NodeId = nodeId;
+            BrowseName = browseName;
+            Capabilities = capabilities;
+            SubCategories = subCategories ?? [];
+        }
+
+        /// <summary>
+        /// The category's <see cref="NodeId"/>; also used as the dispatch
+        /// discriminator when routing <c>IAliasNameStore</c> calls.
+        /// </summary>
+        public NodeId NodeId { get; }
+
+        /// <summary>
+        /// The category's <see cref="QualifiedName"/>.
+        /// </summary>
+        public QualifiedName BrowseName { get; }
+
+        /// <summary>
+        /// Which optional Part 17 children this category exposes.
+        /// </summary>
+        public AliasNameCapabilities Capabilities { get; }
+
+        /// <summary>
+        /// The (possibly empty) sub-categories nested under this category
+        /// via <c>Organizes</c> references.
+        /// </summary>
+        public IReadOnlyList<AliasNameCategoryDescriptor> SubCategories { get; }
+    }
+}

--- a/Libraries/Opc.Ua.Server/AliasNames/AliasNameMethodDispatcher.cs
+++ b/Libraries/Opc.Ua.Server/AliasNames/AliasNameMethodDispatcher.cs
@@ -1,0 +1,217 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Opc.Ua.Server.AliasNames
+{
+    /// <summary>
+    /// Translates Part 17 method-state typed call handlers into
+    /// <see cref="IAliasNameStoreRegistry"/> dispatch calls. Provides the
+    /// glue used by both <c>AliasNameNodeManager</c> (for its own category
+    /// instances) and the standard-node late binder in
+    /// <c>DiagnosticsNodeManager</c> (for the well-known
+    /// <c>Aliases</c>/<c>TagVariables</c>/<c>Topics</c> nodes).
+    /// </summary>
+    /// <remarks>
+    /// The dispatcher centralises:
+    /// <list type="bullet">
+    ///   <item><description>method-level argument validation (array length
+    ///   mismatches → <c>BadInvalidArgument</c>; see Part 17 §6.3.4 / §6.3.5
+    ///   parallel-array semantics);</description></item>
+    ///   <item><description>conversion between the auto-generated
+    ///   <see cref="ArrayOf{T}"/> input shapes and the
+    ///   <see cref="AliasAddRequest"/>/<see cref="AliasDeleteRequest"/>
+    ///   record shapes consumed by stores;</description></item>
+    ///   <item><description>conversion of registry results back into the
+    ///   generated <c>*MethodStateResult</c> types.</description></item>
+    /// </list>
+    /// </remarks>
+    internal static class AliasNameMethodDispatcher
+    {
+        /// <summary>
+        /// Dispatches a <c>FindAlias</c> method call (Part 17 §6.3.2).
+        /// </summary>
+        public static async ValueTask<FindAliasMethodStateResult> FindAliasAsync(
+            IAliasNameStoreRegistry registry,
+            ITypeTable typeTree,
+            NodeId categoryId,
+            string aliasNameSearchPattern,
+            NodeId referenceTypeFilter,
+            CancellationToken ct)
+        {
+            (ServiceResult result, IReadOnlyList<AliasNameDataType> aliases) = await registry
+                .DispatchFindAliasAsync(
+                    categoryId,
+                    aliasNameSearchPattern,
+                    referenceTypeFilter,
+                    typeTree,
+                    ct)
+                .ConfigureAwait(false);
+
+            return new FindAliasMethodStateResult
+            {
+                ServiceResult = result,
+                AliasNodeList = ToArrayOf(aliases)
+            };
+        }
+
+        /// <summary>
+        /// Dispatches a <c>FindAliasVerbose</c> method call (Part 17 §6.3.3).
+        /// </summary>
+        public static async ValueTask<FindAliasVerboseMethodStateResult> FindAliasVerboseAsync(
+            IAliasNameStoreRegistry registry,
+            ITypeTable typeTree,
+            NodeId categoryId,
+            string aliasNameSearchPattern,
+            NodeId referenceTypeFilter,
+            CancellationToken ct)
+        {
+            (ServiceResult result, IReadOnlyList<AliasNameVerboseDataType> aliases) = await registry
+                .DispatchFindAliasVerboseAsync(
+                    categoryId,
+                    aliasNameSearchPattern,
+                    referenceTypeFilter,
+                    typeTree,
+                    ct)
+                .ConfigureAwait(false);
+
+            return new FindAliasVerboseMethodStateResult
+            {
+                ServiceResult = result,
+                AliasNodeList = ToArrayOf(aliases)
+            };
+        }
+
+        /// <summary>
+        /// Dispatches an <c>AddAliasesToCategory</c> method call (Part 17
+        /// §6.3.4). Validates the parallel-array shape before invoking the
+        /// store.
+        /// </summary>
+        public static async ValueTask<AddAliasesToCategoryMethodStateResult> AddAliasesAsync(
+            IAliasNameStoreRegistry registry,
+            NodeId categoryId,
+            ArrayOf<string> aliasNames,
+            ArrayOf<ExpandedNodeId> targetNodes,
+            ArrayOf<string> targetServers,
+            NodeId targetReferenceType,
+            CancellationToken ct)
+        {
+            if (aliasNames.Count != targetNodes.Count
+                || aliasNames.Count != targetServers.Count)
+            {
+                return new AddAliasesToCategoryMethodStateResult
+                {
+                    ServiceResult = ServiceResult.Create(
+                        StatusCodes.BadInvalidArgument,
+                        "AliasNames, TargetNodes and TargetServers must have equal length."),
+                    ErrorCodes = default
+                };
+            }
+
+            var requests = new List<AliasAddRequest>(aliasNames.Count);
+            for (int i = 0; i < aliasNames.Count; i++)
+            {
+                requests.Add(new AliasAddRequest(
+                    aliasNames[i] ?? string.Empty,
+                    targetNodes[i],
+                    targetServers[i],
+                    targetReferenceType));
+            }
+
+            (ServiceResult result, StatusCode[] codes) = await registry
+                .DispatchAddAliasesAsync(categoryId, requests, ct)
+                .ConfigureAwait(false);
+
+            return new AddAliasesToCategoryMethodStateResult
+            {
+                ServiceResult = result,
+                ErrorCodes = codes.ToArrayOf()
+            };
+        }
+
+        /// <summary>
+        /// Dispatches a <c>DeleteAliasesFromCategory</c> method call
+        /// (Part 17 §6.3.5). Validates the parallel-array shape before
+        /// invoking the store.
+        /// </summary>
+        public static async ValueTask<DeleteAliasesFromCategoryMethodStateResult> DeleteAliasesAsync(
+            IAliasNameStoreRegistry registry,
+            NodeId categoryId,
+            ArrayOf<string> aliasNames,
+            ArrayOf<ExpandedNodeId> targetNodes,
+            CancellationToken ct)
+        {
+            if (aliasNames.Count != targetNodes.Count)
+            {
+                return new DeleteAliasesFromCategoryMethodStateResult
+                {
+                    ServiceResult = ServiceResult.Create(
+                        StatusCodes.BadInvalidArgument,
+                        "AliasNames and TargetNodes must have equal length."),
+                    ErrorCodes = default
+                };
+            }
+
+            var requests = new List<AliasDeleteRequest>(aliasNames.Count);
+            for (int i = 0; i < aliasNames.Count; i++)
+            {
+                requests.Add(new AliasDeleteRequest(
+                    aliasNames[i] ?? string.Empty,
+                    targetNodes[i]));
+            }
+
+            (ServiceResult result, StatusCode[] codes) = await registry
+                .DispatchDeleteAliasesAsync(categoryId, requests, ct)
+                .ConfigureAwait(false);
+
+            return new DeleteAliasesFromCategoryMethodStateResult
+            {
+                ServiceResult = result,
+                ErrorCodes = codes.ToArrayOf()
+            };
+        }
+
+        private static ArrayOf<T> ToArrayOf<T>(IReadOnlyList<T> items)
+        {
+            if (items == null || items.Count == 0)
+            {
+                return ArrayOf.Empty<T>();
+            }
+            var array = new T[items.Count];
+            for (int i = 0; i < items.Count; i++)
+            {
+                array[i] = items[i];
+            }
+            return array.ToArrayOf();
+        }
+    }
+}

--- a/Libraries/Opc.Ua.Server/AliasNames/AliasNameNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/AliasNames/AliasNameNodeManager.cs
@@ -1,0 +1,454 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace Opc.Ua.Server.AliasNames
+{
+    /// <summary>
+    /// Standalone OPC UA Part 17 (Alias Names) node manager. Builds an
+    /// address-space tree of <c>AliasNameCategoryType</c> instances from
+    /// an <see cref="IAliasNameStore"/>'s
+    /// <see cref="IAliasNameStore.RootCategories"/>, wires the typed
+    /// <c>OnCallAsync</c> handlers of the generated
+    /// <c>FindAliasMethodState</c>/<c>FindAliasVerboseMethodState</c>/<c>AddAliasesToCategoryMethodState</c>/<c>DeleteAliasesFromCategoryMethodState</c>
+    /// children, and (when configured) registers the store with the
+    /// server-wide <see cref="IAliasNameStoreRegistry"/> so that the
+    /// standard well-known <c>Aliases (i=23470)</c> /
+    /// <c>TagVariables (i=23479)</c> / <c>Topics (i=23488)</c> nodes also
+    /// dispatch through it.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Apps opt in by adding this manager to their server's node-manager
+    /// list. The manager owns a single namespace
+    /// (<see cref="AliasNameNodeManagerOptions.NamespaceUri"/>) under
+    /// which it creates its category and alias instances; standard
+    /// well-known categories owned by <c>DiagnosticsNodeManager</c> are
+    /// not duplicated — only their methods are wired through the
+    /// registry.
+    /// </para>
+    /// <para>
+    /// All four Part 17 methods are exposed only when the corresponding
+    /// <see cref="AliasNameCapabilities"/> flag is set on the
+    /// <see cref="AliasNameCategoryDescriptor"/>. Mutating methods
+    /// (<c>AddAliasesToCategory</c>/<c>DeleteAliasesFromCategory</c>)
+    /// default to requiring the <c>SecurityAdmin</c> role on a
+    /// <c>SignAndEncrypt</c> channel; override
+    /// <see cref="AliasNameNodeManagerOptions.RequireSecurityAdminForMutations"/>
+    /// to opt out.
+    /// </para>
+    /// </remarks>
+    public class AliasNameNodeManager : CustomNodeManager2
+    {
+        /// <summary>
+        /// Initializes a new instance.
+        /// </summary>
+        /// <param name="server">The server internal interface.</param>
+        /// <param name="configuration">The application configuration.</param>
+        /// <param name="store">The pluggable alias-name backend; the
+        /// manager builds its address space from
+        /// <see cref="IAliasNameStore.RootCategories"/> and dispatches
+        /// every Part 17 method through it.</param>
+        /// <param name="options">Optional tunables; defaults applied
+        /// when <c>null</c>.</param>
+        public AliasNameNodeManager(
+            IServerInternal server,
+            ApplicationConfiguration configuration,
+            IAliasNameStore store,
+            AliasNameNodeManagerOptions? options = null)
+            : base(server, configuration, ResolveNamespaceUri(options))
+        {
+            m_store = store ?? throw new ArgumentNullException(nameof(store));
+            m_options = options ?? new AliasNameNodeManagerOptions();
+            m_aliasLogger = server.Telemetry.CreateLogger<AliasNameNodeManager>();
+            m_registry = ResolveServerRegistry(server);
+            m_localCategoryDispatcher = new AliasNameStoreRegistry();
+            m_localCategoryDispatcher.Register(m_store);
+        }
+
+        /// <summary>
+        /// The backing <see cref="IAliasNameStore"/>.
+        /// </summary>
+        public IAliasNameStore Store => m_store;
+
+        /// <summary>
+        /// The tunables in use.
+        /// </summary>
+        public AliasNameNodeManagerOptions Options => m_options;
+
+        /// <inheritdoc/>
+        public override NodeId New(ISystemContext context, NodeState node)
+        {
+            // Preserve any caller-assigned NodeId that already lives in our
+            // namespace; otherwise mint a sequential numeric id.
+            if (!node.NodeId.IsNull
+                && node.NodeId.NamespaceIndex == NamespaceIndex)
+            {
+                return node.NodeId;
+            }
+            uint id = Utils.IncrementIdentifier(ref m_nextNodeId);
+            return new NodeId(id, NamespaceIndex);
+        }
+
+        /// <inheritdoc/>
+        public override void CreateAddressSpace(
+            IDictionary<NodeId, IList<IReference>> externalReferences)
+        {
+            lock (Lock)
+            {
+                base.CreateAddressSpace(externalReferences);
+
+                foreach (AliasNameCategoryDescriptor root in m_store.RootCategories)
+                {
+                    AliasNameCategoryState rootState = BuildCategoryTree(root);
+                    m_rootCategoryStates[root.NodeId] = rootState;
+
+                    if (m_options.LinkToStandardAliasesObject)
+                    {
+                        AddExternalReference(
+                            ObjectIds.Aliases,
+                            ReferenceTypeIds.Organizes,
+                            isInverse: false,
+                            rootState.NodeId,
+                            externalReferences);
+                        rootState.AddReference(
+                            ReferenceTypeIds.Organizes,
+                            isInverse: true,
+                            ObjectIds.Aliases);
+                    }
+
+                    AddPredefinedNode(SystemContext, rootState);
+                }
+
+                if (m_options.RegisterWithServerRegistry && m_registry != null)
+                {
+                    try
+                    {
+                        m_registry.Register(m_store);
+                        m_registeredWithServer = true;
+                    }
+                    catch (InvalidOperationException ex)
+                    {
+                        m_aliasLogger.LogWarning(ex,
+                            "AliasNameStore could not be registered with " +
+                            "the server-wide registry; standard well-known " +
+                            "Aliases methods will not dispatch through it.");
+                    }
+                }
+
+                m_store.Changed += OnStoreChanged;
+            }
+        }
+
+        /// <inheritdoc/>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                m_store.Changed -= OnStoreChanged;
+                if (m_registeredWithServer && m_registry != null)
+                {
+                    m_registry.Unregister(m_store);
+                    m_registeredWithServer = false;
+                }
+                m_localCategoryDispatcher.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        /// <summary>
+        /// Recursively builds an <see cref="AliasNameCategoryState"/>
+        /// instance for the supplied descriptor — including any optional
+        /// children declared by its capabilities and any nested
+        /// sub-categories — and wires every method's typed
+        /// <c>OnCallAsync</c> handler to the dispatcher.
+        /// </summary>
+        protected virtual AliasNameCategoryState BuildCategoryTree(
+            AliasNameCategoryDescriptor descriptor)
+        {
+            // CreateInstanceOf... returns a typed instance with the
+            // mandatory FindAlias child already created. We then override
+            // the identity attributes and add the optional Part 17
+            // children we have been asked to expose.
+            AliasNameCategoryState category =
+                SystemContext.CreateInstanceOfAliasNameCategoryType();
+            category.NodeId = descriptor.NodeId;
+            category.BrowseName = descriptor.BrowseName;
+            category.DisplayName = new LocalizedText(descriptor.BrowseName.Name);
+            category.SymbolicName = descriptor.BrowseName.Name!;
+            category.TypeDefinitionId = ObjectTypeIds.AliasNameCategoryType;
+            category.ReferenceTypeId = ReferenceTypeIds.Organizes;
+
+            AliasNameCapabilities cap = descriptor.Capabilities;
+            if ((cap & AliasNameCapabilities.FindAliasVerbose) != 0)
+            {
+                category.AddFindAliasVerbose(SystemContext);
+            }
+            if ((cap & AliasNameCapabilities.LastChange) != 0)
+            {
+                category.AddLastChange(SystemContext);
+            }
+            if ((cap & AliasNameCapabilities.AddAliasesToCategory) != 0)
+            {
+                category.AddAddAliasesToCategory(SystemContext);
+            }
+            if ((cap & AliasNameCapabilities.DeleteAliasesFromCategory) != 0)
+            {
+                category.AddDeleteAliasesFromCategory(SystemContext);
+            }
+
+            foreach (AliasNameCategoryDescriptor child in descriptor.SubCategories)
+            {
+                AliasNameCategoryState childState = BuildCategoryTree(child);
+                childState.ReferenceTypeId = ReferenceTypeIds.Organizes;
+                category.AddChild(childState);
+            }
+
+            // Auto-assign NodeIds to every child not pre-pinned in our
+            // namespace.
+            category.AssignNodeIds(SystemContext, []);
+
+            // Wire method handlers (after node ids are stable).
+            WireCategoryHandlers(descriptor.NodeId, category);
+
+            // Seed LastChange.
+            if (category.LastChange != null)
+            {
+                category.LastChange.Value
+                    = m_store.GetLastChange(descriptor.NodeId) ?? 0u;
+            }
+
+            return category;
+        }
+
+        private void WireCategoryHandlers(NodeId categoryId, AliasNameCategoryState category)
+        {
+            if (category.FindAlias != null)
+            {
+                category.FindAlias.OnCallAsync = (ctx, method, objId, pattern, refType, ct) =>
+                    AliasNameMethodDispatcher.FindAliasAsync(
+                        m_localCategoryDispatcher,
+                        Server.TypeTree,
+                        objId.IsNull ? categoryId : objId,
+                        pattern,
+                        refType,
+                        ct);
+            }
+            if (category.FindAliasVerbose != null)
+            {
+                category.FindAliasVerbose.OnCallAsync = (ctx, method, objId, pattern, refType, ct) =>
+                    AliasNameMethodDispatcher.FindAliasVerboseAsync(
+                        m_localCategoryDispatcher,
+                        Server.TypeTree,
+                        objId.IsNull ? categoryId : objId,
+                        pattern,
+                        refType,
+                        ct);
+            }
+            if (category.AddAliasesToCategory != null)
+            {
+                category.AddAliasesToCategory.OnCallAsync =
+                    (ctx, method, objId, names, targets, servers, refType, ct) =>
+                        DispatchAddAsync(ctx, categoryId, objId, names, targets, servers, refType, ct);
+            }
+            if (category.DeleteAliasesFromCategory != null)
+            {
+                category.DeleteAliasesFromCategory.OnCallAsync =
+                    (ctx, method, objId, names, targets, ct) =>
+                        DispatchDeleteAsync(ctx, categoryId, objId, names, targets, ct);
+            }
+
+            // Recurse into sub-category children (already wired through
+            // BuildCategoryTree, but their state objects sit on this
+            // node's children list — wire those too).
+            var children = new List<BaseInstanceState>();
+            category.GetChildren(SystemContext, children);
+            foreach (BaseInstanceState child in children)
+            {
+                if (child is AliasNameCategoryState childCategory
+                    && !ReferenceEquals(childCategory, category))
+                {
+                    WireCategoryHandlers(childCategory.NodeId, childCategory);
+                }
+            }
+        }
+
+        private ValueTask<AddAliasesToCategoryMethodStateResult> DispatchAddAsync(
+            ISystemContext context,
+            NodeId fallbackCategoryId,
+            NodeId objectId,
+            ArrayOf<string> aliasNames,
+            ArrayOf<ExpandedNodeId> targetNodes,
+            ArrayOf<string> targetServers,
+            NodeId targetReferenceType,
+            CancellationToken ct)
+        {
+            if (m_options.RequireSecurityAdminForMutations
+                && !HasSecureAdminAccess(context))
+            {
+                return new ValueTask<AddAliasesToCategoryMethodStateResult>(
+                    new AddAliasesToCategoryMethodStateResult
+                    {
+                        ServiceResult = new ServiceResult(StatusCodes.BadUserAccessDenied),
+                        ErrorCodes = default
+                    });
+            }
+            return AliasNameMethodDispatcher.AddAliasesAsync(
+                m_localCategoryDispatcher,
+                objectId.IsNull ? fallbackCategoryId : objectId,
+                aliasNames,
+                targetNodes,
+                targetServers,
+                targetReferenceType,
+                ct);
+        }
+
+        private ValueTask<DeleteAliasesFromCategoryMethodStateResult> DispatchDeleteAsync(
+            ISystemContext context,
+            NodeId fallbackCategoryId,
+            NodeId objectId,
+            ArrayOf<string> aliasNames,
+            ArrayOf<ExpandedNodeId> targetNodes,
+            CancellationToken ct)
+        {
+            if (m_options.RequireSecurityAdminForMutations
+                && !HasSecureAdminAccess(context))
+            {
+                return new ValueTask<DeleteAliasesFromCategoryMethodStateResult>(
+                    new DeleteAliasesFromCategoryMethodStateResult
+                    {
+                        ServiceResult = new ServiceResult(StatusCodes.BadUserAccessDenied),
+                        ErrorCodes = default
+                    });
+            }
+            return AliasNameMethodDispatcher.DeleteAliasesAsync(
+                m_localCategoryDispatcher,
+                objectId.IsNull ? fallbackCategoryId : objectId,
+                aliasNames,
+                targetNodes,
+                ct);
+        }
+
+        private void OnStoreChanged(object? sender, AliasStoreChangedEventArgs e)
+        {
+            lock (Lock)
+            {
+                if (!m_rootCategoryStates.TryGetValue(e.CategoryId, out AliasNameCategoryState? root))
+                {
+                    root = FindCategoryNode(e.CategoryId);
+                }
+                if (root?.LastChange != null)
+                {
+                    root.LastChange.Value = e.LastChange;
+                    root.LastChange.ClearChangeMasks(SystemContext, false);
+                }
+            }
+        }
+
+        private AliasNameCategoryState? FindCategoryNode(NodeId categoryId)
+        {
+            foreach (AliasNameCategoryState root in m_rootCategoryStates.Values)
+            {
+                AliasNameCategoryState? found = FindRecursive(root, categoryId);
+                if (found != null)
+                {
+                    return found;
+                }
+            }
+            return null;
+        }
+
+        private AliasNameCategoryState? FindRecursive(
+            AliasNameCategoryState node,
+            NodeId target)
+        {
+            if (node.NodeId == target)
+            {
+                return node;
+            }
+            var children = new List<BaseInstanceState>();
+            node.GetChildren(SystemContext, children);
+            foreach (BaseInstanceState child in children)
+            {
+                if (child is AliasNameCategoryState sub)
+                {
+                    AliasNameCategoryState? hit = FindRecursive(sub, target);
+                    if (hit != null)
+                    {
+                        return hit;
+                    }
+                }
+            }
+            return null;
+        }
+
+        private static bool HasSecureAdminAccess(ISystemContext context)
+        {
+            if (context is SessionSystemContext { OperationContext: OperationContext op } session)
+            {
+                if (op.ChannelContext?.EndpointDescription?.SecurityMode
+                    != MessageSecurityMode.SignAndEncrypt)
+                {
+                    return false;
+                }
+                return session.UserIdentity?.GrantedRoleIds
+                    .Contains(ObjectIds.WellKnownRole_SecurityAdmin) == true;
+            }
+            return false;
+        }
+
+        private static string ResolveNamespaceUri(AliasNameNodeManagerOptions? options)
+        {
+            return options?.NamespaceUri
+                ?? new AliasNameNodeManagerOptions().NamespaceUri;
+        }
+
+        private static IAliasNameStoreRegistry? ResolveServerRegistry(IServerInternal server)
+        {
+            return (server as IAliasNameStoreRegistryProvider)?.AliasNameStoreRegistry;
+        }
+
+        private readonly IAliasNameStore m_store;
+        private readonly AliasNameNodeManagerOptions m_options;
+        private readonly ILogger m_aliasLogger;
+        private readonly IAliasNameStoreRegistry? m_registry;
+        // Always-available dispatcher that wraps just this manager's store
+        // so the standalone manager works even when the host server does
+        // not implement IAliasNameStoreRegistryProvider.
+        private readonly AliasNameStoreRegistry m_localCategoryDispatcher;
+        private readonly Dictionary<NodeId, AliasNameCategoryState> m_rootCategoryStates = [];
+        private bool m_registeredWithServer;
+        private uint m_nextNodeId;
+    }
+}

--- a/Libraries/Opc.Ua.Server/AliasNames/AliasNameNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/AliasNames/AliasNameNodeManager.cs
@@ -69,7 +69,7 @@ namespace Opc.Ua.Server.AliasNames
     /// to opt out.
     /// </para>
     /// </remarks>
-    public class AliasNameNodeManager : CustomNodeManager2
+    public class AliasNameNodeManager : AsyncCustomNodeManager
     {
         /// <summary>
         /// Initializes a new instance.
@@ -122,53 +122,54 @@ namespace Opc.Ua.Server.AliasNames
         }
 
         /// <inheritdoc/>
-        public override void CreateAddressSpace(
-            IDictionary<NodeId, IList<IReference>> externalReferences)
+        public override async ValueTask CreateAddressSpaceAsync(
+            IDictionary<NodeId, IList<IReference>> externalReferences,
+            CancellationToken cancellationToken = default)
         {
-            lock (Lock)
+            await base.CreateAddressSpaceAsync(externalReferences, cancellationToken)
+                .ConfigureAwait(false);
+
+            foreach (AliasNameCategoryDescriptor root in m_store.RootCategories)
             {
-                base.CreateAddressSpace(externalReferences);
+                AliasNameCategoryState rootState = BuildCategoryTree(root);
+                m_rootCategoryStates[root.NodeId] = rootState;
 
-                foreach (AliasNameCategoryDescriptor root in m_store.RootCategories)
+                if (m_options.LinkToStandardAliasesObject)
                 {
-                    AliasNameCategoryState rootState = BuildCategoryTree(root);
-                    m_rootCategoryStates[root.NodeId] = rootState;
-
-                    if (m_options.LinkToStandardAliasesObject)
-                    {
-                        AddExternalReference(
-                            ObjectIds.Aliases,
-                            ReferenceTypeIds.Organizes,
-                            isInverse: false,
-                            rootState.NodeId,
-                            externalReferences);
-                        rootState.AddReference(
-                            ReferenceTypeIds.Organizes,
-                            isInverse: true,
-                            ObjectIds.Aliases);
-                    }
-
-                    AddPredefinedNode(SystemContext, rootState);
+                    AddExternalReference(
+                        ObjectIds.Aliases,
+                        ReferenceTypeIds.Organizes,
+                        isInverse: false,
+                        rootState.NodeId,
+                        externalReferences);
+                    rootState.AddReference(
+                        ReferenceTypeIds.Organizes,
+                        isInverse: true,
+                        ObjectIds.Aliases);
                 }
 
-                if (m_options.RegisterWithServerRegistry && m_registry != null)
-                {
-                    try
-                    {
-                        m_registry.Register(m_store);
-                        m_registeredWithServer = true;
-                    }
-                    catch (InvalidOperationException ex)
-                    {
-                        m_aliasLogger.LogWarning(ex,
-                            "AliasNameStore could not be registered with " +
-                            "the server-wide registry; standard well-known " +
-                            "Aliases methods will not dispatch through it.");
-                    }
-                }
-
-                m_store.Changed += OnStoreChanged;
+                await AddPredefinedNodeAsync(
+                    SystemContext, rootState, cancellationToken)
+                    .ConfigureAwait(false);
             }
+
+            if (m_options.RegisterWithServerRegistry && m_registry != null)
+            {
+                try
+                {
+                    m_registry.Register(m_store);
+                    m_registeredWithServer = true;
+                }
+                catch (InvalidOperationException ex)
+                {
+                    m_aliasLogger.LogWarning(ex,
+                        "AliasNameStore could not be registered with " +
+                        "the server-wide registry; standard well-known " +
+                        "Aliases methods will not dispatch through it.");
+                }
+            }
+
+            m_store.Changed += OnStoreChanged;
         }
 
         /// <inheritdoc/>
@@ -362,7 +363,7 @@ namespace Opc.Ua.Server.AliasNames
 
         private void OnStoreChanged(object? sender, AliasStoreChangedEventArgs e)
         {
-            lock (Lock)
+            lock (m_lock)
             {
                 if (!m_rootCategoryStates.TryGetValue(e.CategoryId, out AliasNameCategoryState? root))
                 {
@@ -450,5 +451,6 @@ namespace Opc.Ua.Server.AliasNames
         private readonly Dictionary<NodeId, AliasNameCategoryState> m_rootCategoryStates = [];
         private bool m_registeredWithServer;
         private uint m_nextNodeId;
+        private readonly object m_lock = new();
     }
 }

--- a/Libraries/Opc.Ua.Server/AliasNames/AliasNameNodeManagerOptions.cs
+++ b/Libraries/Opc.Ua.Server/AliasNames/AliasNameNodeManagerOptions.cs
@@ -1,0 +1,79 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+namespace Opc.Ua.Server.AliasNames
+{
+    /// <summary>
+    /// Tunables for an <see cref="AliasNameNodeManager"/>.
+    /// </summary>
+    public sealed class AliasNameNodeManagerOptions
+    {
+        /// <summary>
+        /// The namespace URI the manager registers and exposes its own
+        /// category nodes under. Defaults to
+        /// <c>http://opcfoundation.org/UA/AliasName/</c>.
+        /// </summary>
+        public string NamespaceUri { get; set; }
+            = "http://opcfoundation.org/UA/AliasName/";
+
+        /// <summary>
+        /// When <c>true</c> (default), the manager publishes
+        /// <c>Organizes</c> external references from the well-known
+        /// <c>Aliases (i=23470)</c> object (Part 17 §9.2) into each of its
+        /// root categories. Disable when the store is already serving
+        /// standard well-known categories such as <c>TagVariables</c> /
+        /// <c>Topics</c> (which are already organised under
+        /// <c>Aliases</c>).
+        /// </summary>
+        public bool LinkToStandardAliasesObject { get; set; } = true;
+
+        /// <summary>
+        /// When <c>true</c> (default), the manager requires the calling
+        /// user to have the <c>SecurityAdmin</c> well-known role on a
+        /// <c>SignAndEncrypt</c> channel before allowing
+        /// <c>AddAliasesToCategory</c> or
+        /// <c>DeleteAliasesFromCategory</c> to succeed. Read methods
+        /// (<c>FindAlias</c> / <c>FindAliasVerbose</c>) are not affected.
+        /// </summary>
+        public bool RequireSecurityAdminForMutations { get; set; } = true;
+
+        /// <summary>
+        /// When <c>true</c> (default), the manager registers its
+        /// <see cref="IAliasNameStore"/> with the server-wide
+        /// <see cref="IAliasNameStoreRegistry"/> resolved through
+        /// <see cref="IAliasNameStoreRegistryProvider"/>. This is what
+        /// enables <c>DiagnosticsNodeManager</c>'s late binder to wire the
+        /// standard well-known <c>Aliases.FindAlias</c> /
+        /// <c>TagVariables.FindAlias</c> / <c>Topics.FindAlias</c> methods
+        /// through this manager's store. Disable when an alternate
+        /// registration mechanism is in use.
+        /// </summary>
+        public bool RegisterWithServerRegistry { get; set; } = true;
+    }
+}

--- a/Libraries/Opc.Ua.Server/AliasNames/AliasNameStoreRegistry.cs
+++ b/Libraries/Opc.Ua.Server/AliasNames/AliasNameStoreRegistry.cs
@@ -1,0 +1,301 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Opc.Ua.Server.AliasNames
+{
+    /// <summary>
+    /// Default <see cref="IAliasNameStoreRegistry"/> implementation —
+    /// thread-safe (via <see cref="SemaphoreSlim"/>) live dispatcher.
+    /// </summary>
+    public sealed class AliasNameStoreRegistry : IAliasNameStoreRegistry, IDisposable
+    {
+        /// <summary>
+        /// Initializes a new, empty registry.
+        /// </summary>
+        public AliasNameStoreRegistry()
+        {
+        }
+
+        /// <inheritdoc/>
+        public IReadOnlyList<IAliasNameStore> Stores
+        {
+            get
+            {
+                m_semaphore.Wait();
+                try
+                {
+                    return [.. m_stores];
+                }
+                finally
+                {
+                    m_semaphore.Release();
+                }
+            }
+        }
+
+        /// <inheritdoc/>
+        public event EventHandler<AliasStoreChangedEventArgs>? Changed;
+
+        /// <inheritdoc/>
+        public void Register(IAliasNameStore store)
+        {
+            if (store == null)
+            {
+                throw new ArgumentNullException(nameof(store));
+            }
+
+            m_semaphore.Wait();
+            try
+            {
+                if (m_stores.Contains(store))
+                {
+                    return;
+                }
+                CollectCategoryIds(store, out HashSet<NodeId> categoryIds);
+                foreach (NodeId id in categoryIds)
+                {
+                    if (m_categoryToStore.ContainsKey(id))
+                    {
+                        throw new InvalidOperationException(
+                            "Another alias-name store already owns category " + id);
+                    }
+                }
+                foreach (NodeId id in categoryIds)
+                {
+                    m_categoryToStore[id] = store;
+                }
+                m_stores.Add(store);
+                store.Changed += OnStoreChanged;
+            }
+            finally
+            {
+                m_semaphore.Release();
+            }
+        }
+
+        /// <inheritdoc/>
+        public void Unregister(IAliasNameStore store)
+        {
+            if (store == null)
+            {
+                return;
+            }
+
+            m_semaphore.Wait();
+            try
+            {
+                if (!m_stores.Remove(store))
+                {
+                    return;
+                }
+                store.Changed -= OnStoreChanged;
+                CollectCategoryIds(store, out HashSet<NodeId> categoryIds);
+                foreach (NodeId id in categoryIds)
+                {
+                    if (m_categoryToStore.TryGetValue(id, out IAliasNameStore? owner)
+                        && ReferenceEquals(owner, store))
+                    {
+                        m_categoryToStore.Remove(id);
+                    }
+                }
+            }
+            finally
+            {
+                m_semaphore.Release();
+            }
+        }
+
+        /// <inheritdoc/>
+        public IAliasNameStore? GetStoreForCategory(NodeId categoryId)
+        {
+            if (categoryId.IsNull)
+            {
+                return null;
+            }
+            m_semaphore.Wait();
+            try
+            {
+                m_categoryToStore.TryGetValue(categoryId, out IAliasNameStore? store);
+                return store;
+            }
+            finally
+            {
+                m_semaphore.Release();
+            }
+        }
+
+        /// <inheritdoc/>
+        public async ValueTask<(ServiceResult Result, IReadOnlyList<AliasNameDataType> Aliases)>
+            DispatchFindAliasAsync(
+                NodeId categoryId,
+                string? aliasNameSearchPattern,
+                NodeId referenceTypeFilter,
+                ITypeTable typeTree,
+                CancellationToken ct = default)
+        {
+            IAliasNameStore? store = GetStoreForCategory(categoryId);
+            if (store == null)
+            {
+                return (new ServiceResult(StatusCodes.BadNotImplemented), []);
+            }
+            IReadOnlyList<AliasNameDataType> aliases = await store
+                .FindAliasAsync(categoryId, aliasNameSearchPattern,
+                    referenceTypeFilter, typeTree, ct)
+                .ConfigureAwait(false);
+            return (ServiceResult.Good, aliases);
+        }
+
+        /// <inheritdoc/>
+        public async ValueTask<(ServiceResult Result, IReadOnlyList<AliasNameVerboseDataType> Aliases)>
+            DispatchFindAliasVerboseAsync(
+                NodeId categoryId,
+                string? aliasNameSearchPattern,
+                NodeId referenceTypeFilter,
+                ITypeTable typeTree,
+                CancellationToken ct = default)
+        {
+            IAliasNameStore? store = GetStoreForCategory(categoryId);
+            if (store == null)
+            {
+                return (new ServiceResult(StatusCodes.BadNotImplemented), []);
+            }
+            IReadOnlyList<AliasNameVerboseDataType> aliases = await store
+                .FindAliasVerboseAsync(categoryId, aliasNameSearchPattern,
+                    referenceTypeFilter, typeTree, ct)
+                .ConfigureAwait(false);
+            return (ServiceResult.Good, aliases);
+        }
+
+        /// <inheritdoc/>
+        public async ValueTask<(ServiceResult Result, StatusCode[] ErrorCodes)>
+            DispatchAddAliasesAsync(
+                NodeId categoryId,
+                IReadOnlyList<AliasAddRequest> requests,
+                CancellationToken ct = default)
+        {
+            IAliasNameStore? store = GetStoreForCategory(categoryId);
+            if (store == null)
+            {
+                return (new ServiceResult(StatusCodes.BadNotImplemented), []);
+            }
+            try
+            {
+                StatusCode[] codes = await store
+                    .AddAliasesAsync(categoryId, requests, ct)
+                    .ConfigureAwait(false);
+                return (ServiceResult.Good, codes);
+            }
+            catch (ServiceResultException sre)
+            {
+                return (sre.Result, []);
+            }
+        }
+
+        /// <inheritdoc/>
+        public async ValueTask<(ServiceResult Result, StatusCode[] ErrorCodes)>
+            DispatchDeleteAliasesAsync(
+                NodeId categoryId,
+                IReadOnlyList<AliasDeleteRequest> requests,
+                CancellationToken ct = default)
+        {
+            IAliasNameStore? store = GetStoreForCategory(categoryId);
+            if (store == null)
+            {
+                return (new ServiceResult(StatusCodes.BadNotImplemented), []);
+            }
+            try
+            {
+                StatusCode[] codes = await store
+                    .DeleteAliasesAsync(categoryId, requests, ct)
+                    .ConfigureAwait(false);
+                return (ServiceResult.Good, codes);
+            }
+            catch (ServiceResultException sre)
+            {
+                return (sre.Result, []);
+            }
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            m_semaphore.Wait();
+            try
+            {
+                foreach (IAliasNameStore store in m_stores)
+                {
+                    store.Changed -= OnStoreChanged;
+                }
+                m_stores.Clear();
+                m_categoryToStore.Clear();
+            }
+            finally
+            {
+                m_semaphore.Release();
+            }
+            m_semaphore.Dispose();
+        }
+
+        private void OnStoreChanged(object? sender, AliasStoreChangedEventArgs e)
+        {
+            Changed?.Invoke(this, e);
+        }
+
+        private static void CollectCategoryIds(
+            IAliasNameStore store,
+            out HashSet<NodeId> categoryIds)
+        {
+            categoryIds = [];
+            foreach (AliasNameCategoryDescriptor root in store.RootCategories)
+            {
+                AddRecursive(root, categoryIds);
+            }
+
+            static void AddRecursive(
+                AliasNameCategoryDescriptor descriptor,
+                HashSet<NodeId> sink)
+            {
+                sink.Add(descriptor.NodeId);
+                foreach (AliasNameCategoryDescriptor child in descriptor.SubCategories)
+                {
+                    AddRecursive(child, sink);
+                }
+            }
+        }
+
+        private readonly List<IAliasNameStore> m_stores = [];
+        private readonly Dictionary<NodeId, IAliasNameStore> m_categoryToStore = [];
+        private readonly SemaphoreSlim m_semaphore = new(1, 1);
+    }
+}

--- a/Libraries/Opc.Ua.Server/AliasNames/AliasNameStoreRegistry.cs
+++ b/Libraries/Opc.Ua.Server/AliasNames/AliasNameStoreRegistry.cs
@@ -250,6 +250,11 @@ namespace Opc.Ua.Server.AliasNames
         /// <inheritdoc/>
         public void Dispose()
         {
+            if (m_disposed)
+            {
+                return;
+            }
+            m_disposed = true;
             m_semaphore.Wait();
             try
             {
@@ -297,5 +302,6 @@ namespace Opc.Ua.Server.AliasNames
         private readonly List<IAliasNameStore> m_stores = [];
         private readonly Dictionary<NodeId, IAliasNameStore> m_categoryToStore = [];
         private readonly SemaphoreSlim m_semaphore = new(1, 1);
+        private bool m_disposed;
     }
 }

--- a/Libraries/Opc.Ua.Server/AliasNames/AliasNameWildcardMatcher.cs
+++ b/Libraries/Opc.Ua.Server/AliasNames/AliasNameWildcardMatcher.cs
@@ -1,0 +1,157 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System.Text.RegularExpressions;
+
+namespace Opc.Ua.Server.AliasNames
+{
+    /// <summary>
+    /// Implements the OPC UA <c>Like</c>-operator wildcard pattern match
+    /// described in OPC UA Part 4 §7.40 (FilterOperator Like) — used by
+    /// Part 17 <c>FindAlias</c>/<c>FindAliasVerbose</c> methods to match
+    /// the <c>AliasNameSearchPattern</c> input argument against alias
+    /// names.
+    /// </summary>
+    /// <remarks>
+    /// Supported wildcards:
+    /// <list type="bullet">
+    ///   <item><description><c>%</c> — matches zero or more characters.</description></item>
+    ///   <item><description><c>_</c> — matches exactly one character.</description></item>
+    ///   <item><description><c>[abc]</c> — matches any single character from the set.</description></item>
+    ///   <item><description><c>[!abc]</c> — matches any single character not in the set.</description></item>
+    ///   <item><description><c>\</c> — escapes the next wildcard character.</description></item>
+    /// </list>
+    /// Algorithm ported from the original implementation in the Quickstart
+    /// reference server (which itself ported the private <c>Match</c> from
+    /// <c>Stack/Opc.Ua.Core/Stack/Types/FilterEvaluator.cs</c>). Matching is
+    /// case-sensitive and anchored: the entire target must match the entire
+    /// pattern.
+    /// </remarks>
+    public static class AliasNameWildcardMatcher
+    {
+        /// <summary>
+        /// Returns <c>true</c> when <paramref name="target"/> matches the
+        /// OPC UA Like wildcard <paramref name="pattern"/>.
+        /// </summary>
+        /// <param name="target">String to test; must not be <c>null</c>.</param>
+        /// <param name="pattern">OPC UA Like pattern; must not be <c>null</c>.</param>
+        /// <returns><c>true</c> if the target matches; otherwise <c>false</c>.
+        /// Both <c>null</c> inputs and an empty <paramref name="pattern"/>
+        /// return <c>false</c>.</returns>
+        public static bool IsMatch(string? target, string? pattern)
+        {
+            if (target == null || pattern == null)
+            {
+                return false;
+            }
+            if (pattern.Length == 0)
+            {
+                return false;
+            }
+
+            // Translate the OPC UA Like pattern to an anchored .NET regex
+            // by walking the input char-by-char. We need to:
+            //   - escape regex metacharacters that aren't wildcards;
+            //   - turn '%' / '_' / '[..]' / '[!..]' into the matching
+            //     regex constructs;
+            //   - honour the OPC UA escape character '\' which makes the
+            //     next character match literally.
+            var sb = new System.Text.StringBuilder(pattern.Length + 8)
+                .Append('^');
+            int i = 0;
+            while (i < pattern.Length)
+            {
+                char c = pattern[i];
+                switch (c)
+                {
+                    case '\\':
+                        // OPC UA escape: next character is matched
+                        // literally (including '\' '%' '_' '[' ']').
+                        if (i + 1 < pattern.Length)
+                        {
+                            sb.Append(Regex.Escape(pattern[i + 1].ToString()));
+                            i += 2;
+                        }
+                        else
+                        {
+                            // Trailing backslash with nothing to escape —
+                            // match a literal backslash.
+                            sb.Append("\\\\");
+                            i++;
+                        }
+                        break;
+                    case '%':
+                        sb.Append(".*");
+                        i++;
+                        break;
+                    case '_':
+                        sb.Append('.');
+                        i++;
+                        break;
+                    case '[':
+                        int end = pattern.IndexOf(']', i + 1);
+                        if (end < 0)
+                        {
+                            // No matching close-bracket — treat as a
+                            // literal '['.
+                            sb.Append("\\[");
+                            i++;
+                        }
+                        else
+                        {
+                            // [abc] or [!abc] — copy the contents
+                            // verbatim, swapping leading '!' for '^' per
+                            // Part 4 §7.40. The contents are taken as-is
+                            // (regex char-class semantics are a superset
+                            // of OPC UA — for simple character lists this
+                            // works correctly).
+                            string body = pattern.Substring(i + 1, end - i - 1);
+                            if (body.Length > 0 && body[0] == '!')
+                            {
+                                sb.Append("[^").Append(body, 1, body.Length - 1)
+                                    .Append(']');
+                            }
+                            else
+                            {
+                                sb.Append('[').Append(body).Append(']');
+                            }
+                            i = end + 1;
+                        }
+                        break;
+                    default:
+                        sb.Append(Regex.Escape(c.ToString()));
+                        i++;
+                        break;
+                }
+            }
+            sb.Append('$');
+            return Regex.IsMatch(target, sb.ToString());
+        }
+    }
+}

--- a/Libraries/Opc.Ua.Server/AliasNames/AliasStoreChangedEventArgs.cs
+++ b/Libraries/Opc.Ua.Server/AliasNames/AliasStoreChangedEventArgs.cs
@@ -1,0 +1,76 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+
+namespace Opc.Ua.Server.AliasNames
+{
+    /// <summary>
+    /// Event payload raised by <c>IAliasNameStore.Changed</c> after
+    /// any successful mutation that affects the contents of one of the
+    /// store's categories. The new <see cref="LastChange"/> value reflects
+    /// the updated Part 17 <c>LastChange</c> property (Part 17 §6.3.1) and
+    /// MUST advance monotonically per category — though wraparound of the
+    /// underlying <c>VersionTime</c> (<c>uint</c>) is permitted, so
+    /// consumers comparing values should test for inequality rather than
+    /// strict greater-than.
+    /// </summary>
+    public sealed class AliasStoreChangedEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Initializes a new instance of the
+        /// <see cref="AliasStoreChangedEventArgs"/> class.
+        /// </summary>
+        /// <param name="categoryId">The <see cref="NodeId"/> of the affected
+        /// category.</param>
+        /// <param name="lastChange">The category's new
+        /// <c>LastChange</c> value (<c>VersionTime</c>).</param>
+        public AliasStoreChangedEventArgs(NodeId categoryId, uint lastChange)
+        {
+            if (categoryId.IsNull)
+            {
+                throw new ArgumentException(
+                    "categoryId must not be null.",
+                    nameof(categoryId));
+            }
+            CategoryId = categoryId;
+            LastChange = lastChange;
+        }
+
+        /// <summary>
+        /// The affected category's <see cref="NodeId"/>.
+        /// </summary>
+        public NodeId CategoryId { get; }
+
+        /// <summary>
+        /// The category's new <c>LastChange</c> value.
+        /// </summary>
+        public uint LastChange { get; }
+    }
+}

--- a/Libraries/Opc.Ua.Server/AliasNames/IAliasNameStore.cs
+++ b/Libraries/Opc.Ua.Server/AliasNames/IAliasNameStore.cs
@@ -1,0 +1,174 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Opc.Ua.Server.AliasNames
+{
+    /// <summary>
+    /// Pluggable backend for an OPC UA Part 17 alias-name provider. One
+    /// store may serve multiple categories — each declared via
+    /// <see cref="RootCategories"/> together with their sub-categories — and
+    /// is the authoritative source for both queries
+    /// (<c>FindAlias</c>/<c>FindAliasVerbose</c>) and mutations
+    /// (<c>AddAliasesToCategory</c>/<c>DeleteAliasesFromCategory</c>) on
+    /// those categories.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// All operations are async and accept a <see cref="CancellationToken"/>.
+    /// Implementations MUST be thread-safe.
+    /// </para>
+    /// <para>
+    /// <c>categoryId</c> arguments identify any category exposed by this
+    /// store — root or nested. When an operation is invoked on a parent
+    /// category, <c>FindAlias</c>/<c>FindAliasVerbose</c> implementations
+    /// MUST also include results from descendant categories per Part 17
+    /// §6.3.2; <c>AddAliasesAsync</c>/<c>DeleteAliasesAsync</c> however
+    /// apply only to the named category itself, never its descendants.
+    /// </para>
+    /// </remarks>
+    public interface IAliasNameStore
+    {
+        /// <summary>
+        /// The (immutable) root categories this store owns. Used by
+        /// <c>AliasNameNodeManager</c> to build the address space and
+        /// by <c>IAliasNameStoreRegistry</c> to route well-known
+        /// standard-node dispatches. Standard well-known categories should
+        /// use <c>ObjectIds.Aliases</c>, <c>ObjectIds.TagVariables</c> and
+        /// <c>ObjectIds.Topics</c> as their identifiers.
+        /// </summary>
+        IReadOnlyList<AliasNameCategoryDescriptor> RootCategories { get; }
+
+        /// <summary>
+        /// Raised after a successful <see cref="AddAliasesAsync"/> or
+        /// <see cref="DeleteAliasesAsync"/> batch — carries the new
+        /// <c>LastChange</c> value (VersionTime) for the affected
+        /// category.
+        /// </summary>
+        event EventHandler<AliasStoreChangedEventArgs>? Changed;
+
+        /// <summary>
+        /// Returns the current <c>LastChange</c> value (Part 17 §6.3.1) for
+        /// the named category. Returns <c>null</c> when the category is
+        /// unknown to this store or does not expose the
+        /// <see cref="AliasNameCapabilities.LastChange"/> capability.
+        /// </summary>
+        /// <param name="categoryId">The category's <see cref="NodeId"/>.</param>
+        uint? GetLastChange(NodeId categoryId);
+
+        /// <summary>
+        /// Returns <c>true</c> if <paramref name="categoryId"/> identifies
+        /// any category (root or nested) owned by this store.
+        /// </summary>
+        bool OwnsCategory(NodeId categoryId);
+
+        /// <summary>
+        /// Implements <c>FindAlias</c> (Part 17 §6.3.2): returns all aliases
+        /// under <paramref name="categoryId"/> (recursively, including
+        /// sub-categories) whose name matches the wildcard
+        /// <paramref name="aliasNameSearchPattern"/> and whose
+        /// <c>ReferenceTypeId</c> is, or is a subtype of,
+        /// <paramref name="referenceTypeFilter"/>.
+        /// </summary>
+        /// <param name="categoryId">The category to search.</param>
+        /// <param name="aliasNameSearchPattern">An OPC UA Like-operator
+        /// pattern (Part 4 §7.40). An empty pattern returns no
+        /// matches.</param>
+        /// <param name="referenceTypeFilter">Reference type to filter by;
+        /// <c>NodeId.Null</c> or <c>ReferenceTypeIds.References</c> matches
+        /// any reference type.</param>
+        /// <param name="typeTree">The server type tree used to evaluate
+        /// subtype membership.</param>
+        /// <param name="ct">Cancellation token.</param>
+        /// <returns>The matching aliases as Part 17 §7.2
+        /// <c>AliasNameDataType</c> records. Returns an empty list when the
+        /// category is unknown or there are no matches.</returns>
+        ValueTask<IReadOnlyList<AliasNameDataType>> FindAliasAsync(
+            NodeId categoryId,
+            string? aliasNameSearchPattern,
+            NodeId referenceTypeFilter,
+            ITypeTable typeTree,
+            CancellationToken ct = default);
+
+        /// <summary>
+        /// Implements <c>FindAliasVerbose</c> (Part 17 §6.3.3) — same
+        /// filtering as <see cref="FindAliasAsync"/> but returns
+        /// <c>AliasNameVerboseDataType</c> records (Part 17 §7.3) including
+        /// per-target <c>ServerUris</c> and the <c>AliasNameCategoryId</c>
+        /// of the alias's home category.
+        /// </summary>
+        ValueTask<IReadOnlyList<AliasNameVerboseDataType>> FindAliasVerboseAsync(
+            NodeId categoryId,
+            string? aliasNameSearchPattern,
+            NodeId referenceTypeFilter,
+            ITypeTable typeTree,
+            CancellationToken ct = default);
+
+        /// <summary>
+        /// Implements <c>AddAliasesToCategory</c> (Part 17 §6.3.4) — adds
+        /// each request as a single alias-to-target mapping in the named
+        /// category. Returns one <see cref="StatusCode"/> per request entry
+        /// in input order; typical per-entry failures are
+        /// <c>BadBrowseNameDuplicated</c> when the mapping already exists,
+        /// <c>BadNodeIdInvalid</c>/<c>BadReferenceTypeIdInvalid</c> for
+        /// malformed entries, or <c>BadOutOfRange</c> when the store is at
+        /// capacity. <c>LastChange</c> for the category MUST advance once
+        /// per non-empty successful batch.
+        /// </summary>
+        /// <exception cref="ServiceResultException">Thrown for method-level
+        /// failures: unknown category (<c>BadNodeIdUnknown</c>), category
+        /// does not support adds (<c>BadNotSupported</c>), or unauthorized
+        /// (<c>BadUserAccessDenied</c>).</exception>
+        ValueTask<StatusCode[]> AddAliasesAsync(
+            NodeId categoryId,
+            IReadOnlyList<AliasAddRequest> requests,
+            CancellationToken ct = default);
+
+        /// <summary>
+        /// Implements <c>DeleteAliasesFromCategory</c> (Part 17 §6.3.5) —
+        /// removes each request as a single alias-to-target mapping from
+        /// the named category. Returns one <see cref="StatusCode"/> per
+        /// request; typical per-entry failures are <c>BadNotFound</c> when
+        /// the mapping is absent. <c>LastChange</c> for the category MUST
+        /// advance once per non-empty successful batch.
+        /// </summary>
+        /// <exception cref="ServiceResultException">Thrown for method-level
+        /// failures: unknown category (<c>BadNodeIdUnknown</c>), category
+        /// does not support deletes (<c>BadNotSupported</c>), or
+        /// unauthorized (<c>BadUserAccessDenied</c>).</exception>
+        ValueTask<StatusCode[]> DeleteAliasesAsync(
+            NodeId categoryId,
+            IReadOnlyList<AliasDeleteRequest> requests,
+            CancellationToken ct = default);
+    }
+}

--- a/Libraries/Opc.Ua.Server/AliasNames/IAliasNameStoreRegistry.cs
+++ b/Libraries/Opc.Ua.Server/AliasNames/IAliasNameStoreRegistry.cs
@@ -1,0 +1,159 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Opc.Ua.Server.AliasNames
+{
+    /// <summary>
+    /// Server-wide registry of <see cref="IAliasNameStore"/> instances and
+    /// a live dispatcher used by both the standalone
+    /// <c>AliasNameNodeManager</c> and the standard-node binder in
+    /// <c>DiagnosticsNodeManager</c> to route Part 17 method calls to the
+    /// store that owns the affected category.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Each category <see cref="NodeId"/> is owned by exactly one
+    /// registered store. <see cref="Register"/> rejects a store whose
+    /// root or sub-category set overlaps with any already-registered
+    /// store's coverage.
+    /// </para>
+    /// <para>
+    /// Dispatch resolves the owning store at call time, not at registration
+    /// time — this allows custom node managers to register their stores
+    /// after <c>DiagnosticsNodeManager</c> has already activated its
+    /// predefined Part 17 nodes. When no store owns the supplied
+    /// <c>categoryId</c>, every dispatch method returns
+    /// <c>BadNotImplemented</c> (Part 17 §6.3.2 — empty result is also
+    /// allowed, but <c>BadNotImplemented</c> is the more honest answer for
+    /// the well-known nodes).
+    /// </para>
+    /// </remarks>
+    public interface IAliasNameStoreRegistry
+    {
+        /// <summary>
+        /// The currently registered stores in registration order.
+        /// </summary>
+        IReadOnlyList<IAliasNameStore> Stores { get; }
+
+        /// <summary>
+        /// Registers <paramref name="store"/>. Throws when any of its
+        /// category <see cref="NodeId"/>s (root or nested) is already
+        /// owned by another registered store.
+        /// </summary>
+        void Register(IAliasNameStore store);
+
+        /// <summary>
+        /// Unregisters <paramref name="store"/>. No-op if not registered.
+        /// </summary>
+        void Unregister(IAliasNameStore store);
+
+        /// <summary>
+        /// Resolves the store that owns <paramref name="categoryId"/>, or
+        /// <c>null</c> if no registered store does.
+        /// </summary>
+        IAliasNameStore? GetStoreForCategory(NodeId categoryId);
+
+        /// <summary>
+        /// Raised after any registered store reports a change (alias added
+        /// or removed) so binders can refresh address-space values such as
+        /// the standard <c>Aliases.LastChange</c> property.
+        /// </summary>
+        event EventHandler<AliasStoreChangedEventArgs>? Changed;
+
+        /// <summary>
+        /// Dispatches a <c>FindAlias</c> call. Returns
+        /// <c>BadNotImplemented</c> on the service-result when no store
+        /// owns the category.
+        /// </summary>
+        ValueTask<(ServiceResult Result, IReadOnlyList<AliasNameDataType> Aliases)>
+            DispatchFindAliasAsync(
+                NodeId categoryId,
+                string? aliasNameSearchPattern,
+                NodeId referenceTypeFilter,
+                ITypeTable typeTree,
+                CancellationToken ct = default);
+
+        /// <summary>
+        /// Dispatches a <c>FindAliasVerbose</c> call. Returns
+        /// <c>BadNotImplemented</c> on the service-result when no store
+        /// owns the category.
+        /// </summary>
+        ValueTask<(ServiceResult Result, IReadOnlyList<AliasNameVerboseDataType> Aliases)>
+            DispatchFindAliasVerboseAsync(
+                NodeId categoryId,
+                string? aliasNameSearchPattern,
+                NodeId referenceTypeFilter,
+                ITypeTable typeTree,
+                CancellationToken ct = default);
+
+        /// <summary>
+        /// Dispatches an <c>AddAliasesToCategory</c> call. Returns
+        /// <c>BadNotImplemented</c> on the service-result when no store
+        /// owns the category; otherwise returns the per-entry status codes
+        /// from the owning store.
+        /// </summary>
+        ValueTask<(ServiceResult Result, StatusCode[] ErrorCodes)>
+            DispatchAddAliasesAsync(
+                NodeId categoryId,
+                IReadOnlyList<AliasAddRequest> requests,
+                CancellationToken ct = default);
+
+        /// <summary>
+        /// Dispatches a <c>DeleteAliasesFromCategory</c> call. Returns
+        /// <c>BadNotImplemented</c> on the service-result when no store
+        /// owns the category; otherwise returns the per-entry status codes
+        /// from the owning store.
+        /// </summary>
+        ValueTask<(ServiceResult Result, StatusCode[] ErrorCodes)>
+            DispatchDeleteAliasesAsync(
+                NodeId categoryId,
+                IReadOnlyList<AliasDeleteRequest> requests,
+                CancellationToken ct = default);
+    }
+
+    /// <summary>
+    /// Optional opt-in interface that hosts a server's
+    /// <see cref="IAliasNameStoreRegistry"/>. <c>ServerInternalData</c>
+    /// implements this so node managers can resolve the registry without
+    /// any <c>IServerInternal</c> surface change; external/mocked
+    /// <c>IServerInternal</c> implementations remain unaffected.
+    /// </summary>
+    public interface IAliasNameStoreRegistryProvider
+    {
+        /// <summary>
+        /// Gets the server's alias-name store registry; never <c>null</c>.
+        /// </summary>
+        IAliasNameStoreRegistry AliasNameStoreRegistry { get; }
+    }
+}

--- a/Libraries/Opc.Ua.Server/AliasNames/InMemoryAliasNameStore.cs
+++ b/Libraries/Opc.Ua.Server/AliasNames/InMemoryAliasNameStore.cs
@@ -1,0 +1,599 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Opc.Ua.Server.AliasNames
+{
+    /// <summary>
+    /// Thread-safe in-memory implementation of <see cref="IAliasNameStore"/>
+    /// suitable for development, tests and small read-mostly deployments.
+    /// Mutations are serialized through a <see cref="SemaphoreSlim"/> to
+    /// match the repo's preference for async-friendly locking over the
+    /// <c>lock</c> keyword.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Aliases inside a category are keyed by case-sensitive name. Multiple
+    /// targets for the same name are stored as parallel mapping entries
+    /// distinguished by <c>(TargetReferenceType, TargetNode)</c>. This
+    /// matches the wire shape of Part 17 §6.3.4
+    /// (<c>AddAliasesToCategory</c>) where each (name, target) pair is its
+    /// own input row.
+    /// </para>
+    /// <para>
+    /// <c>FindAlias</c> /<c>FindAliasVerbose</c> aggregate matching entries
+    /// back into one <c>AliasNameDataType</c> record per unique
+    /// <c>(name, ReferenceType)</c> tuple — when a single alias name has
+    /// targets reached through different reference types, the result
+    /// contains one record per reference type bucket (per Part 17 §7.2).
+    /// </para>
+    /// </remarks>
+    public sealed class InMemoryAliasNameStore : IAliasNameStore, IDisposable
+    {
+        /// <summary>
+        /// Initializes a new in-memory store backed by the supplied
+        /// category descriptors.
+        /// </summary>
+        /// <param name="rootCategories">The root categories the store
+        /// serves; sub-categories are registered recursively.</param>
+        public InMemoryAliasNameStore(
+            IReadOnlyList<AliasNameCategoryDescriptor> rootCategories)
+        {
+            if (rootCategories == null)
+            {
+                throw new ArgumentNullException(nameof(rootCategories));
+            }
+
+            RootCategories = rootCategories;
+
+            // Flatten the descriptor tree into a category lookup table.
+            foreach (AliasNameCategoryDescriptor root in rootCategories)
+            {
+                RegisterCategoryRecursive(root);
+            }
+        }
+
+        /// <inheritdoc/>
+        public IReadOnlyList<AliasNameCategoryDescriptor> RootCategories { get; }
+
+        /// <inheritdoc/>
+        public event EventHandler<AliasStoreChangedEventArgs>? Changed;
+
+        /// <inheritdoc/>
+        public bool OwnsCategory(NodeId categoryId)
+        {
+            return !categoryId.IsNull && m_categories.ContainsKey(categoryId);
+        }
+
+        /// <inheritdoc/>
+        public uint? GetLastChange(NodeId categoryId)
+        {
+            if (categoryId.IsNull
+                || !m_categories.TryGetValue(categoryId, out CategoryEntry? entry))
+            {
+                return null;
+            }
+            if ((entry.Descriptor.Capabilities & AliasNameCapabilities.LastChange) == 0)
+            {
+                return null;
+            }
+            return entry.LastChange;
+        }
+
+        /// <summary>
+        /// Synchronously seeds an alias mapping at construction or fixture
+        /// time. Bypasses <c>LastChange</c> bumps and the <c>Changed</c>
+        /// event. Throws when the category is unknown.
+        /// </summary>
+        /// <param name="categoryId">Target category.</param>
+        /// <param name="name">Alias name.</param>
+        /// <param name="targetNode">Target node.</param>
+        /// <param name="serverUri">Optional server URI; <c>null</c> means
+        /// the local server.</param>
+        /// <param name="referenceTypeId">Reference type — typically
+        /// <c>ReferenceTypeIds.AliasFor</c>.</param>
+        public void Seed(
+            NodeId categoryId,
+            string name,
+            ExpandedNodeId targetNode,
+            string? serverUri,
+            NodeId referenceTypeId)
+        {
+            if (name == null)
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+            if (!m_categories.TryGetValue(categoryId, out CategoryEntry? entry))
+            {
+                throw new ArgumentException(
+                    "Unknown category: " + categoryId,
+                    nameof(categoryId));
+            }
+            var key = new MappingKey(referenceTypeId, targetNode);
+            if (!entry.Aliases.TryGetValue(name, out Dictionary<MappingKey, string?>? group))
+            {
+                group = [];
+                entry.Aliases[name] = group;
+            }
+            group[key] = serverUri;
+        }
+
+        /// <inheritdoc/>
+        public async ValueTask<IReadOnlyList<AliasNameDataType>> FindAliasAsync(
+            NodeId categoryId,
+            string? aliasNameSearchPattern,
+            NodeId referenceTypeFilter,
+            ITypeTable typeTree,
+            CancellationToken ct = default)
+        {
+            if (typeTree == null)
+            {
+                throw new ArgumentNullException(nameof(typeTree));
+            }
+
+            var result = new List<AliasNameDataType>();
+            if (string.IsNullOrEmpty(aliasNameSearchPattern))
+            {
+                return result;
+            }
+            if (!m_categories.TryGetValue(categoryId, out CategoryEntry? root))
+            {
+                return result;
+            }
+
+            await m_semaphore.WaitAsync(ct).ConfigureAwait(false);
+            try
+            {
+                CollectMatches(
+                    root,
+                    aliasNameSearchPattern!,
+                    referenceTypeFilter,
+                    typeTree,
+                    verbose: false,
+                    nonVerboseSink: result,
+                    verboseSink: null);
+            }
+            finally
+            {
+                m_semaphore.Release();
+            }
+            return result;
+        }
+
+        /// <inheritdoc/>
+        public async ValueTask<IReadOnlyList<AliasNameVerboseDataType>> FindAliasVerboseAsync(
+            NodeId categoryId,
+            string? aliasNameSearchPattern,
+            NodeId referenceTypeFilter,
+            ITypeTable typeTree,
+            CancellationToken ct = default)
+        {
+            if (typeTree == null)
+            {
+                throw new ArgumentNullException(nameof(typeTree));
+            }
+
+            var result = new List<AliasNameVerboseDataType>();
+            if (string.IsNullOrEmpty(aliasNameSearchPattern))
+            {
+                return result;
+            }
+            if (!m_categories.TryGetValue(categoryId, out CategoryEntry? root))
+            {
+                return result;
+            }
+
+            await m_semaphore.WaitAsync(ct).ConfigureAwait(false);
+            try
+            {
+                CollectMatches(
+                    root,
+                    aliasNameSearchPattern!,
+                    referenceTypeFilter,
+                    typeTree,
+                    verbose: true,
+                    nonVerboseSink: null,
+                    verboseSink: result);
+            }
+            finally
+            {
+                m_semaphore.Release();
+            }
+            return result;
+        }
+
+        /// <inheritdoc/>
+        public async ValueTask<StatusCode[]> AddAliasesAsync(
+            NodeId categoryId,
+            IReadOnlyList<AliasAddRequest> requests,
+            CancellationToken ct = default)
+        {
+            if (requests == null)
+            {
+                throw new ArgumentNullException(nameof(requests));
+            }
+            if (!m_categories.TryGetValue(categoryId, out CategoryEntry? entry))
+            {
+                throw ServiceResultException.Create(
+                    StatusCodes.BadNodeIdUnknown,
+                    "Category not found: {0}",
+                    categoryId);
+            }
+            if ((entry.Descriptor.Capabilities & AliasNameCapabilities.AddAliasesToCategory) == 0)
+            {
+                throw ServiceResultException.Create(
+                    StatusCodes.BadNotSupported,
+                    "Category {0} does not support AddAliasesToCategory.",
+                    categoryId);
+            }
+
+            var results = new StatusCode[requests.Count];
+            if (requests.Count == 0)
+            {
+                return results;
+            }
+
+            bool changed = false;
+            await m_semaphore.WaitAsync(ct).ConfigureAwait(false);
+            try
+            {
+                for (int i = 0; i < requests.Count; i++)
+                {
+                    AliasAddRequest req = requests[i];
+                    if (string.IsNullOrEmpty(req.Name))
+                    {
+                        results[i] = StatusCodes.BadBrowseNameInvalid;
+                        continue;
+                    }
+                    if (req.TargetNode.IsNull)
+                    {
+                        results[i] = StatusCodes.BadNodeIdInvalid;
+                        continue;
+                    }
+                    if (req.TargetReferenceType.IsNull)
+                    {
+                        results[i] = StatusCodes.BadReferenceTypeIdInvalid;
+                        continue;
+                    }
+
+                    var key = new MappingKey(req.TargetReferenceType, req.TargetNode);
+                    if (!entry.Aliases.TryGetValue(req.Name,
+                            out Dictionary<MappingKey, string?>? group))
+                    {
+                        group = [];
+                        entry.Aliases[req.Name] = group;
+                    }
+                    if (group.ContainsKey(key))
+                    {
+                        results[i] = StatusCodes.BadBrowseNameDuplicated;
+                        continue;
+                    }
+                    group[key] = string.IsNullOrEmpty(req.TargetServer)
+                        ? null
+                        : req.TargetServer;
+                    results[i] = StatusCodes.Good;
+                    changed = true;
+                }
+
+                if (changed)
+                {
+                    entry.LastChange = unchecked(entry.LastChange + 1);
+                }
+            }
+            finally
+            {
+                m_semaphore.Release();
+            }
+
+            if (changed)
+            {
+                Changed?.Invoke(this,
+                    new AliasStoreChangedEventArgs(categoryId, entry.LastChange));
+            }
+            return results;
+        }
+
+        /// <inheritdoc/>
+        public async ValueTask<StatusCode[]> DeleteAliasesAsync(
+            NodeId categoryId,
+            IReadOnlyList<AliasDeleteRequest> requests,
+            CancellationToken ct = default)
+        {
+            if (requests == null)
+            {
+                throw new ArgumentNullException(nameof(requests));
+            }
+            if (!m_categories.TryGetValue(categoryId, out CategoryEntry? entry))
+            {
+                throw ServiceResultException.Create(
+                    StatusCodes.BadNodeIdUnknown,
+                    "Category not found: {0}",
+                    categoryId);
+            }
+            if ((entry.Descriptor.Capabilities & AliasNameCapabilities.DeleteAliasesFromCategory) == 0)
+            {
+                throw ServiceResultException.Create(
+                    StatusCodes.BadNotSupported,
+                    "Category {0} does not support DeleteAliasesFromCategory.",
+                    categoryId);
+            }
+
+            var results = new StatusCode[requests.Count];
+            if (requests.Count == 0)
+            {
+                return results;
+            }
+
+            bool changed = false;
+            await m_semaphore.WaitAsync(ct).ConfigureAwait(false);
+            try
+            {
+                for (int i = 0; i < requests.Count; i++)
+                {
+                    AliasDeleteRequest req = requests[i];
+                    if (string.IsNullOrEmpty(req.Name))
+                    {
+                        results[i] = StatusCodes.BadBrowseNameInvalid;
+                        continue;
+                    }
+                    if (req.TargetNode.IsNull)
+                    {
+                        results[i] = StatusCodes.BadNodeIdInvalid;
+                        continue;
+                    }
+                    if (!entry.Aliases.TryGetValue(req.Name,
+                            out Dictionary<MappingKey, string?>? group))
+                    {
+                        results[i] = StatusCodes.BadNotFound;
+                        continue;
+                    }
+                    bool removed = false;
+                    // The wire signature does not include a reference type so
+                    // we remove every reference-type bucket whose target
+                    // matches; the typical case has a single bucket.
+                    var keysToRemove = new List<MappingKey>();
+                    foreach (KeyValuePair<MappingKey, string?> kv in group)
+                    {
+                        if (kv.Key.TargetNode == req.TargetNode)
+                        {
+                            keysToRemove.Add(kv.Key);
+                        }
+                    }
+                    foreach (MappingKey k in keysToRemove)
+                    {
+                        group.Remove(k);
+                        removed = true;
+                    }
+                    if (!removed)
+                    {
+                        results[i] = StatusCodes.BadNotFound;
+                        continue;
+                    }
+                    if (group.Count == 0)
+                    {
+                        entry.Aliases.Remove(req.Name);
+                    }
+                    results[i] = StatusCodes.Good;
+                    changed = true;
+                }
+
+                if (changed)
+                {
+                    entry.LastChange = unchecked(entry.LastChange + 1);
+                }
+            }
+            finally
+            {
+                m_semaphore.Release();
+            }
+
+            if (changed)
+            {
+                Changed?.Invoke(this,
+                    new AliasStoreChangedEventArgs(categoryId, entry.LastChange));
+            }
+            return results;
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            m_semaphore.Dispose();
+        }
+
+        private void RegisterCategoryRecursive(AliasNameCategoryDescriptor descriptor)
+        {
+            if (!m_categories.TryAdd(descriptor.NodeId, new CategoryEntry(descriptor)))
+            {
+                throw new ArgumentException(
+                    "Duplicate category NodeId: " + descriptor.NodeId,
+                    nameof(descriptor));
+            }
+            foreach (AliasNameCategoryDescriptor child in descriptor.SubCategories)
+            {
+                RegisterCategoryRecursive(child);
+            }
+        }
+
+        private void CollectMatches(
+            CategoryEntry category,
+            string pattern,
+            NodeId referenceTypeFilter,
+            ITypeTable typeTree,
+            bool verbose,
+            List<AliasNameDataType>? nonVerboseSink,
+            List<AliasNameVerboseDataType>? verboseSink)
+        {
+            ushort nsIndex = category.Descriptor.BrowseName.NamespaceIndex;
+
+            foreach (KeyValuePair<string, Dictionary<MappingKey, string?>> alias
+                in category.Aliases)
+            {
+                if (!AliasNameWildcardMatcher.IsMatch(alias.Key, pattern))
+                {
+                    continue;
+                }
+
+                // Group surviving (post-filter) targets by reference type so
+                // that the wire result has one record per (name, refType).
+                Dictionary<NodeId, List<KeyValuePair<MappingKey, string?>>> byRefType = [];
+                foreach (KeyValuePair<MappingKey, string?> mapping in alias.Value)
+                {
+                    if (!MatchesReferenceTypeFilter(
+                            mapping.Key.ReferenceTypeId,
+                            referenceTypeFilter,
+                            typeTree))
+                    {
+                        continue;
+                    }
+                    if (!byRefType.TryGetValue(mapping.Key.ReferenceTypeId,
+                            out List<KeyValuePair<MappingKey, string?>>? bucket))
+                    {
+                        bucket = [];
+                        byRefType[mapping.Key.ReferenceTypeId] = bucket;
+                    }
+                    bucket.Add(mapping);
+                }
+
+                foreach (List<KeyValuePair<MappingKey, string?>> bucket in byRefType.Values)
+                {
+                    if (bucket.Count == 0)
+                    {
+                        continue;
+                    }
+                    var aliasName = new QualifiedName(alias.Key, nsIndex);
+                    if (verbose)
+                    {
+                        verboseSink!.Add(BuildVerbose(aliasName, category.Descriptor.NodeId, bucket));
+                    }
+                    else
+                    {
+                        nonVerboseSink!.Add(BuildNonVerbose(aliasName, bucket));
+                    }
+                }
+            }
+
+            // Recurse into sub-categories.
+            foreach (AliasNameCategoryDescriptor child in category.Descriptor.SubCategories)
+            {
+                if (m_categories.TryGetValue(child.NodeId, out CategoryEntry? childEntry))
+                {
+                    CollectMatches(
+                        childEntry,
+                        pattern,
+                        referenceTypeFilter,
+                        typeTree,
+                        verbose,
+                        nonVerboseSink,
+                        verboseSink);
+                }
+            }
+        }
+
+        private static AliasNameDataType BuildNonVerbose(
+            QualifiedName name,
+            List<KeyValuePair<MappingKey, string?>> bucket)
+        {
+            var targets = new ExpandedNodeId[bucket.Count];
+            for (int i = 0; i < bucket.Count; i++)
+            {
+                targets[i] = bucket[i].Key.TargetNode;
+            }
+            return new AliasNameDataType
+            {
+                AliasName = name,
+                ReferencedNodes = targets.ToArrayOf()
+            };
+        }
+
+        private static AliasNameVerboseDataType BuildVerbose(
+            QualifiedName name,
+            NodeId categoryId,
+            List<KeyValuePair<MappingKey, string?>> bucket)
+        {
+            var targets = new ExpandedNodeId[bucket.Count];
+            var serverUris = new string[bucket.Count];
+            for (int i = 0; i < bucket.Count; i++)
+            {
+                targets[i] = bucket[i].Key.TargetNode;
+                serverUris[i] = bucket[i].Value ?? string.Empty;
+            }
+            return new AliasNameVerboseDataType
+            {
+                AliasName = name,
+                ReferencedNodes = targets.ToArrayOf(),
+                ServerUris = serverUris.ToArrayOf(),
+                AliasNameCategoryId = categoryId
+            };
+        }
+
+        private static bool MatchesReferenceTypeFilter(
+            NodeId aliasRefType,
+            NodeId filter,
+            ITypeTable typeTree)
+        {
+            // Null/empty/References → match every alias regardless of refType.
+            if (filter.IsNull
+                || filter.Equals(ReferenceTypeIds.References))
+            {
+                return true;
+            }
+            if (aliasRefType.Equals(filter))
+            {
+                return true;
+            }
+            return typeTree.IsTypeOf(aliasRefType, filter);
+        }
+
+        private readonly Dictionary<NodeId, CategoryEntry> m_categories = [];
+        private readonly SemaphoreSlim m_semaphore = new(1, 1);
+
+        private readonly record struct MappingKey(
+            NodeId ReferenceTypeId,
+            ExpandedNodeId TargetNode);
+
+        private sealed class CategoryEntry
+        {
+            public CategoryEntry(AliasNameCategoryDescriptor descriptor)
+            {
+                Descriptor = descriptor;
+                Aliases = [];
+                LastChange = 0;
+            }
+
+            public AliasNameCategoryDescriptor Descriptor { get; }
+            public Dictionary<string, Dictionary<MappingKey, string?>> Aliases { get; }
+            public uint LastChange { get; set; }
+        }
+    }
+}

--- a/Libraries/Opc.Ua.Server/AliasNames/PubSub/AliasNamePublisher.cs
+++ b/Libraries/Opc.Ua.Server/AliasNames/PubSub/AliasNamePublisher.cs
@@ -1,0 +1,152 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+
+namespace Opc.Ua.Server.AliasNames.PubSub
+{
+    /// <summary>
+    /// Listens to an <see cref="IAliasNameStoreRegistry"/> and builds a
+    /// Part 17 Annex D <see cref="AliasUpdateDataType"/> for every
+    /// category change. The constructed message is exposed via the
+    /// <see cref="AliasUpdateProduced"/> event — callers wire it to the
+    /// transport of their choice (e.g. <c>Opc.Ua.PubSub.UaPubSubApplication</c>
+    /// configured with the DataSet from
+    /// <see cref="AliasUpdateDataSetFactory"/>).
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Each emitted message carries one entry in
+    /// <see cref="AliasUpdateDataType.Categories"/> — the changed
+    /// category's <c>PortableNodeId</c> + new <c>LastChange</c>. The
+    /// publisher does NOT batch multiple categories per message; that
+    /// behaviour is provided by the publishing layer (e.g. a
+    /// DataSetWriter with a publishing interval).
+    /// </para>
+    /// <para>
+    /// Per Part 17 §D rationale, the message only carries
+    /// <c>LastChange</c> — subscribers must call
+    /// <c>FindAlias</c>/<c>FindAliasVerbose</c> on the originating
+    /// publisher to retrieve the actual alias contents.
+    /// </para>
+    /// </remarks>
+    public sealed class AliasNamePublisher : IDisposable
+    {
+        /// <summary>
+        /// Initializes a new publisher bound to the supplied registry.
+        /// </summary>
+        /// <param name="registry">The server-wide registry whose
+        /// changes drive the publisher.</param>
+        /// <param name="portableResolver">Translates local category
+        /// <see cref="NodeId"/>s into transport-friendly
+        /// <see cref="PortableNodeId"/>s.</param>
+        /// <param name="applicationUri">The local server's
+        /// application URI; stamped into every produced message.</param>
+        /// <param name="options">Optional tunables.</param>
+        public AliasNamePublisher(
+            IAliasNameStoreRegistry registry,
+            IPortableNodeIdResolver portableResolver,
+            string applicationUri,
+            AliasNamePublisherOptions? options = null)
+        {
+            m_registry = registry ?? throw new ArgumentNullException(nameof(registry));
+            m_portableResolver = portableResolver
+                ?? throw new ArgumentNullException(nameof(portableResolver));
+            if (string.IsNullOrEmpty(applicationUri))
+            {
+                throw new ArgumentException(
+                    "applicationUri must not be null or empty.",
+                    nameof(applicationUri));
+            }
+            ApplicationUri = applicationUri;
+            Options = options ?? new AliasNamePublisherOptions();
+            if (string.IsNullOrEmpty(Options.ApplicationUri))
+            {
+                Options.ApplicationUri = applicationUri;
+            }
+
+            m_registry.Changed += OnRegistryChanged;
+        }
+
+        /// <summary>
+        /// The application URI stamped into every produced message.
+        /// </summary>
+        public string ApplicationUri { get; }
+
+        /// <summary>The configured tunables.</summary>
+        public AliasNamePublisherOptions Options { get; }
+
+        /// <summary>
+        /// Raised every time the publisher builds a new
+        /// <see cref="AliasUpdateDataType"/> message in response to a
+        /// store change.
+        /// </summary>
+        public event EventHandler<AliasUpdateProducedEventArgs>? AliasUpdateProduced;
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            m_registry.Changed -= OnRegistryChanged;
+        }
+
+        private void OnRegistryChanged(object? sender, AliasStoreChangedEventArgs e)
+        {
+            if (Options.IncludedCategories != null
+                && !Options.IncludedCategories.Contains(e.CategoryId))
+            {
+                return;
+            }
+
+            PortableNodeId? portable = m_portableResolver.ToPortable(e.CategoryId);
+            if (portable == null)
+            {
+                return;
+            }
+
+            var update = new AliasUpdateDataType
+            {
+                ApplicationUri = Options.ApplicationUri,
+                Categories = new[]
+                {
+                    new AliasCategoryUpdateDataType
+                    {
+                        Category = portable,
+                        LastChange = e.LastChange,
+                    }
+                }.ToArrayOf()
+            };
+
+            AliasUpdateProduced?.Invoke(
+                this, new AliasUpdateProducedEventArgs(update));
+        }
+
+        private readonly IAliasNameStoreRegistry m_registry;
+        private readonly IPortableNodeIdResolver m_portableResolver;
+    }
+}

--- a/Libraries/Opc.Ua.Server/AliasNames/PubSub/AliasNamePublisherOptions.cs
+++ b/Libraries/Opc.Ua.Server/AliasNames/PubSub/AliasNamePublisherOptions.cs
@@ -1,0 +1,57 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using System.Collections.Generic;
+
+namespace Opc.Ua.Server.AliasNames.PubSub
+{
+    /// <summary>
+    /// Tunables for <see cref="AliasNamePublisher"/>.
+    /// </summary>
+    public sealed class AliasNamePublisherOptions
+    {
+        /// <summary>
+        /// The application URI stamped into the
+        /// <see cref="AliasUpdateDataType.ApplicationUri"/> field of
+        /// every produced message. Defaults to the server's
+        /// application URI when wired via the
+        /// <see cref="AliasNamePublisher.AliasNamePublisher(IAliasNameStoreRegistry, IPortableNodeIdResolver, string, AliasNamePublisherOptions)"/>
+        /// constructor.
+        /// </summary>
+        public string ApplicationUri { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Filter — when non-<c>null</c>, only category changes whose
+        /// <see cref="NodeId"/> is in this set produce messages.
+        /// Defaults to <c>null</c> (every change is forwarded).
+        /// </summary>
+        public ISet<NodeId>? IncludedCategories { get; set; }
+    }
+}

--- a/Libraries/Opc.Ua.Server/AliasNames/PubSub/AliasUpdateDataSetFactory.cs
+++ b/Libraries/Opc.Ua.Server/AliasNames/PubSub/AliasUpdateDataSetFactory.cs
@@ -1,0 +1,87 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+
+namespace Opc.Ua.Server.AliasNames.PubSub
+{
+    /// <summary>
+    /// Builds the fixed-by-spec <see cref="DataSetMetaDataType"/> for
+    /// the Part 17 Annex D <c>AliasUpdate</c> DataSet. The schema is
+    /// invariant per Part 17 §D.2.2 — publishers emit it once at
+    /// startup and subscribers validate against the same shape.
+    /// </summary>
+    public static class AliasUpdateDataSetFactory
+    {
+        /// <summary>
+        /// The well-known DataSet name used for AliasUpdate streams.
+        /// </summary>
+        public const string DataSetName = "AliasUpdate";
+
+        /// <summary>
+        /// Builds the <see cref="DataSetMetaDataType"/> describing the
+        /// <c>AliasUpdateDataType</c> wire schema:
+        /// <c>ApplicationUri : string</c>,
+        /// <c>Categories : AliasCategoryUpdateDataType[]</c>.
+        /// </summary>
+        /// <param name="dataSetClassId">The DataSet class id stamped
+        /// into <see cref="DataSetMetaDataType.DataSetClassId"/>. A
+        /// caller-supplied stable Guid lets subscribers filter by
+        /// publisher-defined class.</param>
+        public static DataSetMetaDataType Create(Guid dataSetClassId)
+        {
+            var fields = new FieldMetaData[]
+            {
+                new FieldMetaData
+                {
+                    Name = "ApplicationUri",
+                    BuiltInType = (byte)BuiltInType.String,
+                    DataType = DataTypeIds.String,
+                    ValueRank = ValueRanks.Scalar
+                },
+                new FieldMetaData
+                {
+                    Name = "Categories",
+                    BuiltInType = (byte)BuiltInType.ExtensionObject,
+                    DataType = DataTypeIds.AliasCategoryUpdateDataType,
+                    ValueRank = ValueRanks.OneDimension
+                }
+            };
+
+            return new DataSetMetaDataType
+            {
+                Name = DataSetName,
+                DataSetClassId = new Uuid(dataSetClassId),
+                Fields = fields.ToArrayOf(),
+                Description = LocalizedText.From(
+                    "OPC UA Part 17 Annex D AliasUpdateDataType DataSet."),
+            };
+        }
+    }
+}

--- a/Libraries/Opc.Ua.Server/AliasNames/PubSub/AliasUpdateProducedEventArgs.cs
+++ b/Libraries/Opc.Ua.Server/AliasNames/PubSub/AliasUpdateProducedEventArgs.cs
@@ -1,0 +1,58 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+
+namespace Opc.Ua.Server.AliasNames.PubSub
+{
+    /// <summary>
+    /// Event payload raised by <see cref="AliasNamePublisher.AliasUpdateProduced"/>
+    /// every time the publisher builds a Part 17 Annex D
+    /// <see cref="AliasUpdateDataType"/> message in response to a
+    /// store change. Hand this message off to the transport of your
+    /// choice — e.g. a <c>Opc.Ua.PubSub.UaPubSubApplication</c>
+    /// configured with the DataSet emitted by
+    /// <see cref="AliasUpdateDataSetFactory"/>.
+    /// </summary>
+    public sealed class AliasUpdateProducedEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Initializes a new instance.
+        /// </summary>
+        public AliasUpdateProducedEventArgs(AliasUpdateDataType update)
+        {
+            Update = update ?? throw new ArgumentNullException(nameof(update));
+        }
+
+        /// <summary>
+        /// The DataType instance ready to be published.
+        /// </summary>
+        public AliasUpdateDataType Update { get; }
+    }
+}

--- a/Libraries/Opc.Ua.Server/AliasNames/PubSub/IPortableNodeIdResolver.cs
+++ b/Libraries/Opc.Ua.Server/AliasNames/PubSub/IPortableNodeIdResolver.cs
@@ -1,0 +1,63 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+namespace Opc.Ua.Server.AliasNames.PubSub
+{
+    /// <summary>
+    /// Translates a local <see cref="NodeId"/> (whose
+    /// <see cref="NodeId.NamespaceIndex"/> refers to the publisher's
+    /// local namespace table) into a server-independent
+    /// <see cref="PortableNodeId"/> (namespace URI + server URI +
+    /// identifier) suitable for Part 17 Annex D PubSub messages.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The Part 17 <c>AliasCategoryUpdateDataType.Category</c> field is
+    /// typed as <c>PortableNodeId</c> because cross-server PubSub
+    /// subscribers may have completely different local namespace tables
+    /// — they cannot meaningfully consume raw <c>NodeId</c> indices.
+    /// </para>
+    /// <para>
+    /// Implementations typically read from
+    /// <see cref="IServerInternal.NamespaceUris"/> and
+    /// <see cref="IServerInternal.ServerUris"/>; the default
+    /// <see cref="ServerPortableNodeIdResolver"/> does exactly that.
+    /// </para>
+    /// </remarks>
+    public interface IPortableNodeIdResolver
+    {
+        /// <summary>
+        /// Builds a <see cref="PortableNodeId"/> for the supplied
+        /// <see cref="NodeId"/>. Returns <c>null</c> when the namespace
+        /// index does not have a corresponding URI in the resolver's
+        /// table.
+        /// </summary>
+        PortableNodeId? ToPortable(NodeId nodeId);
+    }
+}

--- a/Libraries/Opc.Ua.Server/AliasNames/PubSub/ServerPortableNodeIdResolver.cs
+++ b/Libraries/Opc.Ua.Server/AliasNames/PubSub/ServerPortableNodeIdResolver.cs
@@ -1,0 +1,100 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+
+namespace Opc.Ua.Server.AliasNames.PubSub
+{
+    /// <summary>
+    /// Default <see cref="IPortableNodeIdResolver"/> backed by an
+    /// <see cref="IServerInternal"/>'s
+    /// <see cref="IServerInternal.NamespaceUris"/> and
+    /// <see cref="IServerInternal.ServerUris"/> tables. The current
+    /// server's URI (index 0 of <c>ServerUris</c>) is stamped into
+    /// every <see cref="PortableNodeId"/>; subscribers use this to
+    /// filter messages by originating publisher.
+    /// </summary>
+    public sealed class ServerPortableNodeIdResolver : IPortableNodeIdResolver
+    {
+        /// <summary>
+        /// Initializes a new resolver bound to the supplied server.
+        /// </summary>
+        /// <param name="server">The server whose namespace + server URI
+        /// tables the resolver should use.</param>
+        public ServerPortableNodeIdResolver(IServerInternal server)
+        {
+            m_server = server ?? throw new ArgumentNullException(nameof(server));
+        }
+
+        /// <inheritdoc/>
+        public PortableNodeId? ToPortable(NodeId nodeId)
+        {
+            if (nodeId.IsNull)
+            {
+                return null;
+            }
+
+            string? namespaceUri = m_server.NamespaceUris.GetString(nodeId.NamespaceIndex);
+            if (namespaceUri == null)
+            {
+                return null;
+            }
+
+            // The PortableNodeId Identifier field carries the local
+            // NodeId stripped of its namespace index — the URI conveys
+            // the namespace explicitly so the index is meaningless to a
+            // subscriber.
+            NodeId stripped = NodeId.Null;
+            if (nodeId.TryGetValue(out uint numeric))
+            {
+                stripped = new NodeId(numeric);
+            }
+            else if (nodeId.TryGetValue(out string strValue) && strValue != null)
+            {
+                stripped = NodeId.Parse("s=" + strValue);
+            }
+            else if (nodeId.TryGetValue(out Guid guidValue))
+            {
+                stripped = new NodeId(guidValue);
+            }
+            else if (nodeId.TryGetValue(out ByteString opaque) && !opaque.IsNull)
+            {
+                stripped = new NodeId(opaque);
+            }
+
+            return new PortableNodeId
+            {
+                NamespaceUri = namespaceUri,
+                Identifier = stripped,
+            };
+        }
+
+        private readonly IServerInternal m_server;
+    }
+}

--- a/Libraries/Opc.Ua.Server/Diagnostics/DiagnosticsNodeManager.AliasNames.cs
+++ b/Libraries/Opc.Ua.Server/Diagnostics/DiagnosticsNodeManager.AliasNames.cs
@@ -140,6 +140,24 @@ namespace Opc.Ua.Server
             }
         }
 
+        /// <summary>
+        /// Detaches the <see cref="OnAliasRegistryChanged"/> handler.
+        /// Invoked from <c>Dispose(bool)</c> so the registry — which
+        /// outlives this manager when other node managers share the same
+        /// server — does not hold a stale reference into the disposed
+        /// <see cref="DiagnosticsNodeManager"/>.
+        /// </summary>
+        private void UnwireStandardAliasMethods()
+        {
+            IAliasNameStoreRegistry? registry = m_aliasRegistry;
+            if (registry != null)
+            {
+                registry.Changed -= OnAliasRegistryChanged;
+                m_aliasRegistry = null;
+            }
+            m_aliasesLastChangeNode = null;
+        }
+
         private IAliasNameStoreRegistry? m_aliasRegistry;
         private PropertyState<uint>? m_aliasesLastChangeNode;
     }

--- a/Libraries/Opc.Ua.Server/Diagnostics/DiagnosticsNodeManager.AliasNames.cs
+++ b/Libraries/Opc.Ua.Server/Diagnostics/DiagnosticsNodeManager.AliasNames.cs
@@ -1,0 +1,146 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System.Collections.Generic;
+using Opc.Ua.Server.AliasNames;
+
+namespace Opc.Ua.Server
+{
+    /// <summary>
+    /// OPC UA Part 17 (Alias Names) integration for the standard
+    /// well-known nodes loaded by <c>DiagnosticsNodeManager</c> from
+    /// <c>Opc.Ua.NodeSet2.xml</c>.
+    /// </summary>
+    /// <remarks>
+    /// The standard NodeSet ships three <c>AliasNameCategoryType</c>
+    /// instances under the Server object (Part 17 §9):
+    /// <list type="bullet">
+    ///   <item><description><c>Aliases (i=23470)</c> — with mandatory
+    ///   <c>FindAlias (i=23476)</c> and a <c>LastChange (i=32852)</c>
+    ///   property;</description></item>
+    ///   <item><description><c>TagVariables (i=23479)</c> — with mandatory
+    ///   <c>FindAlias (i=23485)</c>;</description></item>
+    ///   <item><description><c>Topics (i=23488)</c> — with mandatory
+    ///   <c>FindAlias (i=23494)</c>.</description></item>
+    /// </list>
+    /// None of the optional Part 17 children
+    /// (<c>FindAliasVerbose</c>/<c>AddAliasesToCategory</c>/<c>DeleteAliasesFromCategory</c>)
+    /// are instantiated by the standard NodeSet on these well-known nodes,
+    /// so this binder only wires <c>FindAlias</c> and (for
+    /// <c>Aliases</c>) <c>LastChange</c>. Optional methods on
+    /// application-defined categories are wired by
+    /// <see cref="AliasNameNodeManager"/> instead.
+    /// </remarks>
+    public partial class DiagnosticsNodeManager
+    {
+        /// <summary>
+        /// Resolves the server's <see cref="IAliasNameStoreRegistry"/>
+        /// (via the optional <see cref="IAliasNameStoreRegistryProvider"/>
+        /// interface) and wires the standard well-known
+        /// <c>Aliases</c>/<c>TagVariables</c>/<c>Topics</c> <c>FindAlias</c>
+        /// methods (plus <c>Aliases.LastChange</c>) to dispatch through
+        /// it. The wiring is "live" — the registry is queried at each
+        /// call rather than snapshotted at load time — so stores
+        /// registered after this point are also reachable.
+        /// </summary>
+        private void WireStandardAliasMethods()
+        {
+            IAliasNameStoreRegistry? registry =
+                (Server as IAliasNameStoreRegistryProvider)?.AliasNameStoreRegistry;
+            if (registry == null)
+            {
+                return;
+            }
+
+            m_aliasRegistry = registry;
+            m_aliasRegistry.Changed += OnAliasRegistryChanged;
+
+            WireStandardCategory(ObjectIds.Aliases, includeLastChange: true);
+            WireStandardCategory(ObjectIds.TagVariables, includeLastChange: false);
+            WireStandardCategory(ObjectIds.Topics, includeLastChange: false);
+        }
+
+        private void WireStandardCategory(NodeId categoryId, bool includeLastChange)
+        {
+            AliasNameCategoryState? category =
+                FindPredefinedNode<AliasNameCategoryState>(categoryId);
+            if (category == null)
+            {
+                return;
+            }
+
+            if (category.FindAlias != null)
+            {
+                category.FindAlias.OnCallAsync = (ctx, method, objId, pattern, refType, ct) =>
+                    AliasNameMethodDispatcher.FindAliasAsync(
+                        m_aliasRegistry!,
+                        Server.TypeTree,
+                        objId.IsNull ? categoryId : objId,
+                        pattern,
+                        refType,
+                        ct);
+            }
+
+            if (includeLastChange && category.LastChange != null)
+            {
+                uint? seed = null;
+                foreach (IAliasNameStore store in m_aliasRegistry!.Stores)
+                {
+                    uint? v = store.GetLastChange(categoryId);
+                    if (v.HasValue)
+                    {
+                        seed = v;
+                        break;
+                    }
+                }
+                if (seed.HasValue)
+                {
+                    category.LastChange.Value = seed.Value;
+                    category.LastChange.ClearChangeMasks(SystemContext, false);
+                }
+                m_aliasesLastChangeNode = category.LastChange;
+            }
+        }
+
+        private void OnAliasRegistryChanged(object? sender, AliasStoreChangedEventArgs e)
+        {
+            // Only the standard Aliases (i=23470) node carries a LastChange
+            // property in the shipped NodeSet; mirror its store value.
+            if (m_aliasesLastChangeNode != null
+                && e.CategoryId == ObjectIds.Aliases)
+            {
+                m_aliasesLastChangeNode.Value = e.LastChange;
+                m_aliasesLastChangeNode.ClearChangeMasks(SystemContext, false);
+            }
+        }
+
+        private IAliasNameStoreRegistry? m_aliasRegistry;
+        private PropertyState<uint>? m_aliasesLastChangeNode;
+    }
+}

--- a/Libraries/Opc.Ua.Server/Diagnostics/DiagnosticsNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/Diagnostics/DiagnosticsNodeManager.cs
@@ -39,7 +39,7 @@ using Microsoft.Extensions.Logging;
 namespace Opc.Ua.Server
 {
     /// <inheritdoc/>
-    public class DiagnosticsNodeManager : AsyncCustomNodeManager, IDiagnosticsNodeManager
+    public partial class DiagnosticsNodeManager : AsyncCustomNodeManager, IDiagnosticsNodeManager
     {
         /// <summary>
         /// Initializes the node manager.
@@ -220,6 +220,11 @@ namespace Opc.Ua.Server
                 MethodIds.Server_ResendData);
 
             resendData?.OnCallMethod = OnResendData;
+
+            // OPC UA Part 17 — wire the standard well-known Aliases /
+            // TagVariables / Topics methods through the server-wide
+            // IAliasNameStoreRegistry. See DiagnosticsNodeManager.AliasNames.cs.
+            WireStandardAliasMethods();
         }
 
         /// <summary>

--- a/Libraries/Opc.Ua.Server/Diagnostics/DiagnosticsNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/Diagnostics/DiagnosticsNodeManager.cs
@@ -109,6 +109,11 @@ namespace Opc.Ua.Server
                 m_modifyAddressSpaceSemaphoreSlim.Dispose();
 
                 m_historyCapabilities = null;
+
+                // OPC UA Part 17 — unsubscribe from the alias-name
+                // registry so the registry does not hold a stale handler
+                // reference into a disposed manager.
+                UnwireStandardAliasMethods();
             }
 
             base.Dispose(disposing);

--- a/Libraries/Opc.Ua.Server/Server/ServerInternalData.cs
+++ b/Libraries/Opc.Ua.Server/Server/ServerInternalData.cs
@@ -58,7 +58,7 @@ namespace Opc.Ua.Server
     /// Objects returned from this object can be assumed to be threadsafe unless otherwise stated.
     /// </para>
     /// </remarks>
-    public class ServerInternalData : IServerInternal
+    public class ServerInternalData : IServerInternal, AliasNames.IAliasNameStoreRegistryProvider
     {
         /// <summary>
         /// Initializes the datastore with the server configuration.
@@ -125,8 +125,19 @@ namespace Opc.Ua.Server
                 SessionManager?.Dispose();
                 SubscriptionManager?.Dispose();
                 MonitoredItemQueueFactory?.Dispose();
+                (AliasNameStoreRegistry as IDisposable)?.Dispose();
             }
         }
+
+        /// <summary>
+        /// The server-wide registry of OPC UA Part 17 alias-name stores.
+        /// Surfaces through the optional
+        /// <see cref="AliasNames.IAliasNameStoreRegistryProvider"/>
+        /// interface so consumers can discover it without any change to
+        /// <see cref="IServerInternal"/>; never <c>null</c>.
+        /// </summary>
+        public AliasNames.IAliasNameStoreRegistry AliasNameStoreRegistry { get; }
+            = new AliasNames.AliasNameStoreRegistry();
 
         /// <summary>
         /// The session manager to use with the server.

--- a/Tests/Opc.Ua.Client.Tests/AliasNames/AliasNameClientTests.cs
+++ b/Tests/Opc.Ua.Client.Tests/AliasNames/AliasNameClientTests.cs
@@ -75,8 +75,10 @@ namespace Opc.Ua.Client.Tests.AliasNames
             Assert.That(harness.CallRequests, Has.Count.EqualTo(1));
             Assert.That(harness.CallRequests[0].ObjectId, Is.EqualTo(ObjectIds.Aliases));
             Assert.That(harness.CallRequests[0].MethodId,
-                Is.EqualTo(MethodIds.Aliases_FindAlias),
-                "Standard Aliases.FindAlias method-id should be used.");
+                Is.EqualTo(MethodIds.AliasNameCategoryType_FindAlias),
+                "Generated AliasNameCategoryTypeClient proxy invokes the " +
+                "type's method-declaration NodeId; the server resolves it " +
+                "against the supplied ObjectId.");
             Assert.That(harness.CallRequests[0].InputArguments.Count, Is.EqualTo(2));
             Assert.That(result, Has.Count.EqualTo(1));
             Assert.That(result[0].AliasName.Name, Is.EqualTo("Tag1"));
@@ -105,7 +107,9 @@ namespace Opc.Ua.Client.Tests.AliasNames
             await client.FindAliasAsync("Foo", null).ConfigureAwait(false);
 
             Assert.That(captured, Is.Not.Null);
-            Assert.That(captured.MethodId, Is.EqualTo(MethodIds.Topics_FindAlias));
+            Assert.That(captured.ObjectId, Is.EqualTo(ObjectIds.Topics));
+            Assert.That(captured.MethodId,
+                Is.EqualTo(MethodIds.AliasNameCategoryType_FindAlias));
             captured.InputArguments[1].TryGetValue(out NodeId filter);
             Assert.That(filter.IsNull, Is.True);
         }

--- a/Tests/Opc.Ua.Client.Tests/AliasNames/AliasNameClientTests.cs
+++ b/Tests/Opc.Ua.Client.Tests/AliasNames/AliasNameClientTests.cs
@@ -1,0 +1,234 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Opc.Ua.Client.AliasNames;
+
+namespace Opc.Ua.Client.Tests.AliasNames
+{
+    /// <summary>
+    /// Mocked-session unit tests for <see cref="AliasNameClient"/>
+    /// — covers <c>FindAlias</c> / <c>AddAliasesToCategory</c> /
+    /// <c>DeleteAliasesFromCategory</c> / <c>ReadLastChange</c> and the
+    /// hardcoded standard-method-id fast-path used when the client is
+    /// rooted at the well-known categories.
+    /// </summary>
+    [TestFixture]
+    [Category("AliasNames")]
+    [Parallelizable]
+    public class AliasNameClientTests
+    {
+        [Test]
+        public async Task FindAliasAsyncTargetsAliasesFindAliasMethodAsync()
+        {
+            AliasNameSessionHarness harness = AliasNameSessionHarness.Create();
+            // Server returns a single AliasNameDataType.
+            harness.CallHandler = _ =>
+            {
+                var entry = new AliasNameDataType
+                {
+                    AliasName = new QualifiedName("Tag1"),
+                    ReferencedNodes = new[] { new ExpandedNodeId("Target", 2) }
+                        .ToArrayOf()
+                };
+                ArrayOf<AliasNameDataType> arr = new[] { entry }.ToArrayOf();
+                return new CallMethodResult
+                {
+                    StatusCode = StatusCodes.Good,
+                    OutputArguments =
+                        new[] { Variant.FromStructure(arr) }.ToArrayOf()
+                };
+            };
+
+            AliasNameClient client = AliasNameClient.OpenStandardAliases(harness.Session);
+            IReadOnlyList<AliasNameDataType> result = await client
+                .FindAliasAsync("%", referenceTypeFilter: null).ConfigureAwait(false);
+
+            Assert.That(harness.CallRequests, Has.Count.EqualTo(1));
+            Assert.That(harness.CallRequests[0].ObjectId, Is.EqualTo(ObjectIds.Aliases));
+            Assert.That(harness.CallRequests[0].MethodId,
+                Is.EqualTo(MethodIds.Aliases_FindAlias),
+                "Standard Aliases.FindAlias method-id should be used.");
+            Assert.That(harness.CallRequests[0].InputArguments.Count, Is.EqualTo(2));
+            Assert.That(result, Has.Count.EqualTo(1));
+            Assert.That(result[0].AliasName.Name, Is.EqualTo("Tag1"));
+        }
+
+        [Test]
+        public async Task FindAliasAsyncPassesNullFilterAsNodeIdNullAsync()
+        {
+            AliasNameSessionHarness harness = AliasNameSessionHarness.Create();
+            CallMethodRequest captured = null;
+            harness.CallHandler = req =>
+            {
+                captured = req;
+                return new CallMethodResult
+                {
+                    StatusCode = StatusCodes.Good,
+                    OutputArguments = new[]
+                    {
+                        Variant.FromStructure(
+                            System.Array.Empty<AliasNameDataType>().ToArrayOf())
+                    }.ToArrayOf()
+                };
+            };
+
+            AliasNameClient client = AliasNameClient.OpenStandardTopics(harness.Session);
+            await client.FindAliasAsync("Foo", null).ConfigureAwait(false);
+
+            Assert.That(captured, Is.Not.Null);
+            Assert.That(captured.MethodId, Is.EqualTo(MethodIds.Topics_FindAlias));
+            captured.InputArguments[1].TryGetValue(out NodeId filter);
+            Assert.That(filter.IsNull, Is.True);
+        }
+
+        [Test]
+        public async Task ReadLastChangeAsyncTargetsStandardAliasesLastChangeAsync()
+        {
+            AliasNameSessionHarness harness = AliasNameSessionHarness.Create();
+            harness.ReadHandler = read =>
+            {
+                Assert.That(read.NodeId,
+                    Is.EqualTo(VariableIds.Aliases_LastChange));
+                return new DataValue
+                {
+                    WrappedValue = new Variant((uint)42),
+                    StatusCode = StatusCodes.Good
+                };
+            };
+            AliasNameClient client = AliasNameClient.OpenStandardAliases(harness.Session);
+            uint? lastChange = await client.ReadLastChangeAsync().ConfigureAwait(false);
+            Assert.That(lastChange, Is.EqualTo((uint?)42));
+        }
+
+        [Test]
+        public async Task AddAliasesToCategoryAsyncReturnsPerEntryStatusCodesAsync()
+        {
+            AliasNameSessionHarness harness = AliasNameSessionHarness.Create();
+            harness.CallHandler = _ =>
+            {
+                ArrayOf<StatusCode> codes = new StatusCode[]
+                {
+                    StatusCodes.Good,
+                    StatusCodes.BadBrowseNameDuplicated
+                }.ToArrayOf();
+                return new CallMethodResult
+                {
+                    StatusCode = StatusCodes.Good,
+                    OutputArguments = new[] { Variant.From(codes) }.ToArrayOf()
+                };
+            };
+
+            AliasNameClient client = AliasNameClient.OpenStandardAliases(harness.Session);
+            client.Options.AllowVerboseProbe = false;
+            StatusCode[] result = await client.AddAliasesToCategoryAsync(
+                new[]
+                {
+                    new AliasNameAddRequest("A",
+                        new ExpandedNodeId("T1", 2),
+                        null, ReferenceTypeIds.AliasFor),
+                    new AliasNameAddRequest("A",
+                        new ExpandedNodeId("T1", 2),
+                        null, ReferenceTypeIds.AliasFor)
+                }).ConfigureAwait(false);
+
+            Assert.That(result, Has.Length.EqualTo(2));
+            Assert.That(result[0].Code, Is.EqualTo(StatusCodes.Good));
+            Assert.That(result[1].Code,
+                Is.EqualTo(StatusCodes.BadBrowseNameDuplicated));
+        }
+
+        [Test]
+        public void AddAliasesToCategoryRejectsMixedReferenceTypes()
+        {
+            AliasNameSessionHarness harness = AliasNameSessionHarness.Create();
+            AliasNameClient client = AliasNameClient.OpenStandardAliases(harness.Session);
+            Assert.That(async () =>
+            {
+                await client.AddAliasesToCategoryAsync(new[]
+                {
+                    new AliasNameAddRequest("A",
+                        new ExpandedNodeId("T", 2),
+                        null, ReferenceTypeIds.AliasFor),
+                    new AliasNameAddRequest("B",
+                        new ExpandedNodeId("T", 2),
+                        null, ReferenceTypeIds.Organizes)
+                }).ConfigureAwait(false);
+            }, Throws.ArgumentException);
+        }
+
+        [Test]
+        public async Task DeleteAliasesFromCategoryAsyncSendsParallelArraysAsync()
+        {
+            AliasNameSessionHarness harness = AliasNameSessionHarness.Create();
+            harness.CallHandler = _ =>
+            {
+                ArrayOf<StatusCode> codes =
+                    new StatusCode[] { StatusCodes.Good }.ToArrayOf();
+                return new CallMethodResult
+                {
+                    StatusCode = StatusCodes.Good,
+                    OutputArguments = new[] { Variant.From(codes) }.ToArrayOf()
+                };
+            };
+
+            AliasNameClient client = AliasNameClient.OpenStandardAliases(harness.Session);
+            StatusCode[] result = await client.DeleteAliasesFromCategoryAsync(
+                new[]
+                {
+                    new AliasNameDeleteRequest("A", new ExpandedNodeId("T", 2))
+                }).ConfigureAwait(false);
+            Assert.That(result, Has.Length.EqualTo(1));
+            Assert.That(harness.CallRequests, Has.Count.EqualTo(1));
+            Assert.That(harness.CallRequests[0].InputArguments.Count, Is.EqualTo(2));
+        }
+
+        [Test]
+        public void AddAliasesMapsBadUserAccessDeniedToUnauthorizedAccessException()
+        {
+            AliasNameSessionHarness harness = AliasNameSessionHarness.Create();
+            harness.CallHandler = _ => new CallMethodResult
+            {
+                StatusCode = StatusCodes.BadUserAccessDenied
+            };
+            AliasNameClient client = AliasNameClient.OpenStandardAliases(harness.Session);
+            Assert.That(async () =>
+            {
+                await client.AddAliasesToCategoryAsync(new[]
+                {
+                    new AliasNameAddRequest("A",
+                        new ExpandedNodeId("T", 2),
+                        null, ReferenceTypeIds.AliasFor)
+                }).ConfigureAwait(false);
+            }, Throws.TypeOf<System.UnauthorizedAccessException>());
+        }
+    }
+}

--- a/Tests/Opc.Ua.Client.Tests/AliasNames/AliasNameIntegrationTests.cs
+++ b/Tests/Opc.Ua.Client.Tests/AliasNames/AliasNameIntegrationTests.cs
@@ -181,5 +181,50 @@ namespace Opc.Ua.Client.Tests.AliasNames
             string reverse = await resolver.ResolveAliasNameAsync(targets[0]);
             Assert.That(reverse, Is.EqualTo("Pump1_Status"));
         }
+
+        [Test]
+        public async Task EnumerateSubCategoriesAsyncReturnsStandardCategoriesAsync()
+        {
+            // The standard Aliases (i=23470) node has TagVariables and
+            // Topics as Organizes children in the shipped NodeSet; the
+            // client's IAsyncEnumerable must yield both.
+            AliasNameClient client = AliasNameClient
+                .OpenStandardAliases(m_session);
+
+            var names = new System.Collections.Generic.HashSet<string>();
+            var nodeIds = new System.Collections.Generic.HashSet<NodeId>();
+            await foreach (AliasNameSubCategoryInfo info in
+                client.EnumerateSubCategoriesAsync())
+            {
+                Assert.That(info, Is.Not.Null);
+                Assert.That(info.BrowseName.IsNull, Is.False);
+                Assert.That(info.NodeId.IsNull, Is.False);
+                names.Add(info.BrowseName.Name);
+                nodeIds.Add(info.NodeId);
+            }
+
+            Assert.That(names, Does.Contain(BrowseNames.TagVariables),
+                "Standard Aliases must Organize-link to TagVariables.");
+            Assert.That(names, Does.Contain(BrowseNames.Topics),
+                "Standard Aliases must Organize-link to Topics.");
+            Assert.That(nodeIds, Does.Contain(ObjectIds.TagVariables));
+            Assert.That(nodeIds, Does.Contain(ObjectIds.Topics));
+        }
+
+        [Test]
+        public async Task EnumerateSubCategoriesAsyncOnLeafReturnsEmptyAsync()
+        {
+            // TagVariables has no sub-categories in the standard NodeSet —
+            // the enumeration must yield zero results without throwing.
+            AliasNameClient client = AliasNameClient
+                .OpenStandardTagVariables(m_session);
+            int count = 0;
+            await foreach (AliasNameSubCategoryInfo _ in
+                client.EnumerateSubCategoriesAsync())
+            {
+                count++;
+            }
+            Assert.That(count, Is.Zero);
+        }
     }
 }

--- a/Tests/Opc.Ua.Client.Tests/AliasNames/AliasNameIntegrationTests.cs
+++ b/Tests/Opc.Ua.Client.Tests/AliasNames/AliasNameIntegrationTests.cs
@@ -1,0 +1,185 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+// CA2007: NUnit tests do not run in a synchronization context; the
+// ConfigureAwait noise inside the integration setup adds nothing.
+#pragma warning disable CA2007
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Opc.Ua.Client.AliasNames;
+using Opc.Ua.Server.Tests;
+using Opc.Ua.Tests;
+using Quickstarts.ReferenceServer;
+
+namespace Opc.Ua.Client.Tests.AliasNames
+{
+    /// <summary>
+    /// End-to-end Part 17 integration tests against the live
+    /// <c>ReferenceServer</c> — exercises the standard well-known
+    /// <c>TagVariables</c>/<c>Topics</c> categories whose
+    /// <c>FindAlias</c> methods are wired via the
+    /// <c>DiagnosticsNodeManager</c> late binder against the in-memory
+    /// store registered by <c>ReferenceServer.ConfigureAliasNameStore</c>.
+    /// </summary>
+    [TestFixture]
+    [Category("AliasNames")]
+    [Category("Client")]
+    [SetCulture("en-us")]
+    [SetUICulture("en-us")]
+    [NonParallelizable]
+    public class AliasNameIntegrationTests
+    {
+        private ServerFixture<ReferenceServer> m_serverFixture;
+#pragma warning disable NUnit1032
+        private ClientFixture m_clientFixture;
+#pragma warning restore NUnit1032
+        private ReferenceServer m_server;
+        private ISession m_session;
+        private string m_pkiRoot;
+        private Uri m_url;
+
+        [OneTimeSetUp]
+        public async Task OneTimeSetUpAsync()
+        {
+            ITelemetryContext telemetry = NUnitTelemetryContext.Create();
+            m_pkiRoot = Path.GetTempPath() + Path.GetRandomFileName();
+
+            m_serverFixture = new ServerFixture<ReferenceServer>(t => new ReferenceServer(t))
+            {
+                UriScheme = Utils.UriSchemeOpcTcp,
+                SecurityNone = true,
+                AutoAccept = true,
+                AllNodeManagers = true,
+                OperationLimits = true
+            };
+            m_server = await m_serverFixture.StartAsync(m_pkiRoot);
+
+            m_clientFixture = new ClientFixture(telemetry);
+            await m_clientFixture.LoadClientConfigurationAsync(m_pkiRoot);
+            m_url = new Uri(Utils.UriSchemeOpcTcp + "://localhost:"
+                + m_serverFixture.Port.ToString(CultureInfo.InvariantCulture));
+
+            try
+            {
+                m_session = await m_clientFixture.ConnectAsync(
+                    m_url, SecurityPolicies.None);
+            }
+            catch (Exception e)
+            {
+                Assert.Ignore(
+                    "AliasName integration setup failed: " + e.Message);
+            }
+        }
+
+        [OneTimeTearDown]
+        public async Task OneTimeTearDownAsync()
+        {
+            if (m_session != null)
+            {
+                await m_session.CloseAsync();
+                m_session.Dispose();
+                m_session = null;
+            }
+            if (m_serverFixture != null)
+            {
+                await m_serverFixture.StopAsync();
+            }
+            m_clientFixture?.Dispose();
+            m_server?.Dispose();
+        }
+
+        [Test]
+        public async Task FindAliasOnStandardTagVariablesReturnsSeededEntriesAsync()
+        {
+            AliasNameClient client = AliasNameClient
+                .OpenStandardTagVariables(m_session);
+
+            IReadOnlyList<AliasNameDataType> result =
+                await client.FindAliasAsync("%", referenceTypeFilter: null);
+
+            Assert.That(result, Is.Not.Empty,
+                "ReferenceServer should seed at least one TagVariables alias.");
+            var names = new HashSet<string>();
+            foreach (AliasNameDataType a in result)
+            {
+                names.Add(a.AliasName.Name!);
+            }
+            Assert.That(names, Does.Contain("TIC101_Setpoint"));
+        }
+
+        [Test]
+        public async Task FindAliasWithPrefixWildcardMatchesAsync()
+        {
+            AliasNameClient client = AliasNameClient
+                .OpenStandardTagVariables(m_session);
+
+            IReadOnlyList<AliasNameDataType> result =
+                await client.FindAliasAsync("TIC%", null);
+
+            foreach (AliasNameDataType a in result)
+            {
+                Assert.That(a.AliasName.Name, Does.StartWith("TIC"));
+            }
+            Assert.That(result, Is.Not.Empty);
+        }
+
+        [Test]
+        public async Task FindAliasOnTopicsReturnsServerEventsAsync()
+        {
+            AliasNameClient client = AliasNameClient
+                .OpenStandardTopics(m_session);
+
+            IReadOnlyList<AliasNameDataType> result =
+                await client.FindAliasAsync("ServerEvents", null);
+            Assert.That(result, Has.Count.EqualTo(1));
+            Assert.That(result[0].AliasName.Name, Is.EqualTo("ServerEvents"));
+            Assert.That(result[0].ReferencedNodes.Count, Is.GreaterThanOrEqualTo(1));
+        }
+
+        [Test]
+        public async Task ResolverRoundTripsAliasToNodeIdAsync()
+        {
+            AliasNameClient client = AliasNameClient
+                .OpenStandardTagVariables(m_session);
+            await using var resolver = new AliasNameResolver(client);
+
+            IReadOnlyList<ExpandedNodeId> targets =
+                await resolver.ResolveAsync("Pump1_Status");
+            Assert.That(targets, Is.Not.Empty);
+
+            string reverse = await resolver.ResolveAliasNameAsync(targets[0]);
+            Assert.That(reverse, Is.EqualTo("Pump1_Status"));
+        }
+    }
+}

--- a/Tests/Opc.Ua.Client.Tests/AliasNames/AliasNameResolverTests.cs
+++ b/Tests/Opc.Ua.Client.Tests/AliasNames/AliasNameResolverTests.cs
@@ -154,5 +154,125 @@ namespace Opc.Ua.Client.Tests.AliasNames
                 .ResolveAsync("Unknown").ConfigureAwait(false);
             Assert.That(result, Is.Empty);
         }
+
+        // ----------------------------------------------------------------
+        // Verbose mode coverage
+        // ----------------------------------------------------------------
+
+        private static CallMethodResult VerboseAliasesResult(
+            params (string name, ExpandedNodeId target, string? serverUri)[] aliases)
+        {
+            var entries = new AliasNameVerboseDataType[aliases.Length];
+            for (int i = 0; i < aliases.Length; i++)
+            {
+                entries[i] = new AliasNameVerboseDataType
+                {
+                    AliasName = new QualifiedName(aliases[i].name),
+                    ReferencedNodes = new[] { aliases[i].target }.ToArrayOf(),
+                    ServerUris = new[] { aliases[i].serverUri ?? string.Empty }.ToArrayOf(),
+                    AliasNameCategoryId = ObjectIds.Aliases,
+                };
+            }
+            return new CallMethodResult
+            {
+                StatusCode = StatusCodes.Good,
+                OutputArguments = new[]
+                {
+                    Variant.FromStructure(entries.ToArrayOf())
+                }.ToArrayOf()
+            };
+        }
+
+        [Test]
+        public async Task VerboseResolverPopulatesServerUrisAsync()
+        {
+            AliasNameSessionHarness harness = AliasNameSessionHarness.Create();
+            harness.CallHandler = req =>
+            {
+                if (req.MethodId == MethodIds.AliasNameCategoryType_FindAliasVerbose)
+                {
+                    return VerboseAliasesResult(
+                        ("Tag1", new ExpandedNodeId("T1", 2), "urn:remote-server"));
+                }
+                // Non-verbose path should not be hit when UseVerbose succeeds.
+                return AliasesResult(("Tag1", new ExpandedNodeId("T1", 2)));
+            };
+            AliasNameClient client = AliasNameClient.OpenStandardAliases(harness.Session);
+            await using var resolver = new AliasNameResolver(
+                client,
+                new AliasNameResolverOptions { UseVerbose = true });
+
+            IReadOnlyList<ExpandedNodeId> targets =
+                await resolver.ResolveAsync("Tag1").ConfigureAwait(false);
+            IReadOnlyList<string?> uris =
+                await resolver.ResolveServerUrisAsync("Tag1").ConfigureAwait(false);
+
+            Assert.That(targets, Has.Count.EqualTo(1));
+            Assert.That(targets[0], Is.EqualTo(new ExpandedNodeId("T1", 2)));
+            Assert.That(uris, Has.Count.EqualTo(1));
+            Assert.That(uris[0], Is.EqualTo("urn:remote-server"));
+        }
+
+        [Test]
+        public async Task NonVerboseResolverReturnsEmptyServerUrisAsync()
+        {
+            AliasNameSessionHarness harness = AliasNameSessionHarness.Create();
+            harness.CallHandler = _ => AliasesResult(
+                ("Tag1", new ExpandedNodeId("T1", 2)));
+            AliasNameClient client = AliasNameClient.OpenStandardAliases(harness.Session);
+            await using var resolver = new AliasNameResolver(client);
+
+            await resolver.ResolveAsync("Tag1").ConfigureAwait(false);
+            IReadOnlyList<string?> uris =
+                await resolver.ResolveServerUrisAsync("Tag1").ConfigureAwait(false);
+
+            Assert.That(uris, Is.Empty,
+                "Non-verbose mode must surface an empty list for ServerUris (no decoration).");
+        }
+
+        [Test]
+        public async Task VerboseResolverFallsBackToNonVerboseOnNotSupportedAsync()
+        {
+            // Server returns BadNotImplemented for the verbose method —
+            // the resolver must transparently fall back to FindAlias and
+            // populate the cache from the non-verbose response.
+            AliasNameSessionHarness harness = AliasNameSessionHarness.Create();
+            int verboseCalls = 0;
+            int nonVerboseCalls = 0;
+            harness.CallHandler = req =>
+            {
+                if (req.MethodId == MethodIds.AliasNameCategoryType_FindAliasVerbose)
+                {
+                    verboseCalls++;
+                    return new CallMethodResult
+                    {
+                        StatusCode = StatusCodes.BadNotImplemented
+                    };
+                }
+                nonVerboseCalls++;
+                return AliasesResult(("Tag1", new ExpandedNodeId("T1", 2)));
+            };
+            AliasNameClient client = AliasNameClient.OpenStandardAliases(harness.Session);
+            await using var resolver = new AliasNameResolver(
+                client,
+                new AliasNameResolverOptions { UseVerbose = true });
+
+            IReadOnlyList<ExpandedNodeId> targets =
+                await resolver.ResolveAsync("Tag1").ConfigureAwait(false);
+            Assert.That(targets, Has.Count.EqualTo(1));
+            Assert.That(targets[0], Is.EqualTo(new ExpandedNodeId("T1", 2)));
+            Assert.That(verboseCalls, Is.EqualTo(1),
+                "Verbose call must have been attempted once.");
+            Assert.That(nonVerboseCalls, Is.EqualTo(1),
+                "Non-verbose fallback must have been issued after the verbose failure.");
+
+            // A second resolve should NOT re-attempt the verbose call —
+            // the resolver flips UseVerbose=false once it falls back.
+            resolver.Invalidate();
+            await resolver.ResolveAsync("Tag1").ConfigureAwait(false);
+            Assert.That(verboseCalls, Is.EqualTo(1),
+                "Once fallen back, the resolver must not re-attempt the verbose method.");
+            Assert.That(nonVerboseCalls, Is.EqualTo(2));
+        }
     }
 }

--- a/Tests/Opc.Ua.Client.Tests/AliasNames/AliasNameResolverTests.cs
+++ b/Tests/Opc.Ua.Client.Tests/AliasNames/AliasNameResolverTests.cs
@@ -1,0 +1,158 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+// CA2007: NUnit tests do not run in a synchronization context, so the
+// ConfigureAwait recommendations on `await using` do not change behaviour
+// — and AliasNameResolver.DisposeAsync returns synchronously anyway.
+#pragma warning disable CA2007
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Opc.Ua.Client.AliasNames;
+
+namespace Opc.Ua.Client.Tests.AliasNames
+{
+    /// <summary>
+    /// Coverage tests for <see cref="AliasNameResolver"/>: ensures the
+    /// cache is populated lazily, that
+    /// <see cref="AliasNameResolver.Invalidate"/> forces a refresh on
+    /// the next call, and that reverse lookups round-trip.
+    /// </summary>
+    [TestFixture]
+    [Category("AliasNames")]
+    [Parallelizable]
+    public class AliasNameResolverTests
+    {
+        private static CallMethodResult AliasesResult(
+            params (string name, ExpandedNodeId target)[] aliases)
+        {
+            var entries = new AliasNameDataType[aliases.Length];
+            for (int i = 0; i < aliases.Length; i++)
+            {
+                entries[i] = new AliasNameDataType
+                {
+                    AliasName = new QualifiedName(aliases[i].name),
+                    ReferencedNodes = new[] { aliases[i].target }.ToArrayOf()
+                };
+            }
+            return new CallMethodResult
+            {
+                StatusCode = StatusCodes.Good,
+                OutputArguments = new[]
+                {
+                    Variant.FromStructure(entries.ToArrayOf())
+                }.ToArrayOf()
+            };
+        }
+
+        [Test]
+        public async Task ResolveLoadsCacheOnDemandAsync()
+        {
+            AliasNameSessionHarness harness = AliasNameSessionHarness.Create();
+            int callCount = 0;
+            harness.CallHandler = _ =>
+            {
+                callCount++;
+                return AliasesResult(
+                    ("Alpha", new ExpandedNodeId("T1", 2)),
+                    ("Beta", new ExpandedNodeId("T2", 2)));
+            };
+
+            AliasNameClient client = AliasNameClient.OpenStandardAliases(harness.Session);
+            await using var resolver = new AliasNameResolver(client);
+
+            IReadOnlyList<ExpandedNodeId> alpha =
+                await resolver.ResolveAsync("Alpha").ConfigureAwait(false);
+            Assert.That(callCount, Is.EqualTo(1));
+            Assert.That(alpha, Has.Count.EqualTo(1));
+            Assert.That(alpha[0], Is.EqualTo(new ExpandedNodeId("T1", 2)));
+
+            // Second resolve hits the cache; the underlying server is
+            // NOT contacted again.
+            IReadOnlyList<ExpandedNodeId> beta =
+                await resolver.ResolveAsync("Beta").ConfigureAwait(false);
+            Assert.That(callCount, Is.EqualTo(1),
+                "Second resolve must reuse the cache.");
+            Assert.That(beta[0], Is.EqualTo(new ExpandedNodeId("T2", 2)));
+        }
+
+        [Test]
+        public async Task ResolveAliasNameAsyncReverseLookupAsync()
+        {
+            AliasNameSessionHarness harness = AliasNameSessionHarness.Create();
+            harness.CallHandler = _ => AliasesResult(
+                ("Speed", new ExpandedNodeId("V1", 2)));
+            AliasNameClient client = AliasNameClient.OpenStandardAliases(harness.Session);
+            await using var resolver = new AliasNameResolver(client);
+
+            string name = await resolver
+                .ResolveAliasNameAsync(new ExpandedNodeId("V1", 2))
+                .ConfigureAwait(false);
+            Assert.That(name, Is.EqualTo("Speed"));
+        }
+
+        [Test]
+        public async Task InvalidateForcesRefreshOnNextResolveAsync()
+        {
+            AliasNameSessionHarness harness = AliasNameSessionHarness.Create();
+            int callCount = 0;
+            harness.CallHandler = _ =>
+            {
+                callCount++;
+                return AliasesResult(
+                    ("Sigma", new ExpandedNodeId($"T-{callCount}", 2)));
+            };
+            AliasNameClient client = AliasNameClient.OpenStandardAliases(harness.Session);
+            await using var resolver = new AliasNameResolver(client);
+
+            await resolver.ResolveAsync("Sigma").ConfigureAwait(false);
+            resolver.Invalidate();
+            IReadOnlyList<ExpandedNodeId> refreshed =
+                await resolver.ResolveAsync("Sigma").ConfigureAwait(false);
+
+            Assert.That(callCount, Is.EqualTo(2));
+            Assert.That(refreshed[0],
+                Is.EqualTo(new ExpandedNodeId("T-2", 2)));
+        }
+
+        [Test]
+        public async Task UnknownNameReturnsEmptyListAsync()
+        {
+            AliasNameSessionHarness harness = AliasNameSessionHarness.Create();
+            harness.CallHandler = _ => AliasesResult(
+                ("A", new ExpandedNodeId("T1", 2)));
+            AliasNameClient client = AliasNameClient.OpenStandardAliases(harness.Session);
+            await using var resolver = new AliasNameResolver(client);
+            IReadOnlyList<ExpandedNodeId> result = await resolver
+                .ResolveAsync("Unknown").ConfigureAwait(false);
+            Assert.That(result, Is.Empty);
+        }
+    }
+}

--- a/Tests/Opc.Ua.Client.Tests/AliasNames/AliasNameSessionHarness.cs
+++ b/Tests/Opc.Ua.Client.Tests/AliasNames/AliasNameSessionHarness.cs
@@ -1,0 +1,222 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using Opc.Ua.Tests;
+
+namespace Opc.Ua.Client.Tests.AliasNames
+{
+    /// <summary>
+    /// Scriptable in-memory mock of an OPC UA <see cref="ISession"/> for
+    /// <c>AliasNameClient</c> tests. Captures every <c>Call</c> /
+    /// <c>Read</c> / <c>Browse</c> request and lets the test supply a
+    /// per-method response handler.
+    /// </summary>
+    internal sealed class AliasNameSessionHarness
+    {
+        public Mock<ISession> SessionMock { get; }
+        public ISession Session => SessionMock.Object;
+        public IServiceMessageContext MessageContext { get; }
+        public List<CallMethodRequest> CallRequests { get; } = [];
+        public List<ReadValueId> ReadRequests { get; } = [];
+        public Func<CallMethodRequest, CallMethodResult> CallHandler { get; set; }
+        public Func<ReadValueId, DataValue> ReadHandler { get; set; }
+
+        public Func<BrowsePath, BrowsePathResult> BrowsePathHandler { get; set; }
+
+        private AliasNameSessionHarness(
+            Mock<ISession> mock,
+            IServiceMessageContext messageContext)
+        {
+            SessionMock = mock;
+            MessageContext = messageContext;
+        }
+
+        public static AliasNameSessionHarness Create()
+        {
+            ITelemetryContext telemetry = NUnitTelemetryContext.Create();
+            ServiceMessageContext messageContext = ServiceMessageContext.Create(telemetry);
+
+            var sessionMock = new Mock<ISession>(MockBehavior.Loose);
+            sessionMock.SetupGet(s => s.MessageContext).Returns(messageContext);
+            sessionMock.SetupGet(s => s.NamespaceUris).Returns(messageContext.NamespaceUris);
+
+            var harness = new AliasNameSessionHarness(sessionMock, messageContext);
+
+            sessionMock
+                .Setup(s => s.TranslateBrowsePathsToNodeIdsAsync(
+                    It.IsAny<RequestHeader>(),
+                    It.IsAny<ArrayOf<BrowsePath>>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns<RequestHeader, ArrayOf<BrowsePath>, CancellationToken>(
+                    (_, paths, _) =>
+                    {
+                        var results = new BrowsePathResult[paths.Count];
+                        for (int i = 0; i < paths.Count; i++)
+                        {
+                            results[i] = harness.BrowsePathHandler != null
+                                ? harness.BrowsePathHandler(paths[i])
+                                : DefaultBrowsePathResult(paths[i]);
+                        }
+                        return new ValueTask<TranslateBrowsePathsToNodeIdsResponse>(
+                            new TranslateBrowsePathsToNodeIdsResponse
+                            {
+                                ResponseHeader = new ResponseHeader(),
+                                Results = results.ToArrayOf(),
+                                DiagnosticInfos = default
+                            });
+                    });
+
+            sessionMock
+                .Setup(s => s.CallAsync(
+                    It.IsAny<RequestHeader>(),
+                    It.IsAny<ArrayOf<CallMethodRequest>>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns<RequestHeader, ArrayOf<CallMethodRequest>, CancellationToken>(
+                    (_, methodsToCall, _) =>
+                    {
+                        var results = new CallMethodResult[methodsToCall.Count];
+                        for (int i = 0; i < methodsToCall.Count; i++)
+                        {
+                            CallMethodRequest req = methodsToCall[i];
+                            harness.CallRequests.Add(req);
+                            results[i] = harness.CallHandler != null
+                                ? harness.CallHandler(req)
+                                : DefaultCallResult();
+                        }
+                        return new ValueTask<CallResponse>(new CallResponse
+                        {
+                            ResponseHeader = new ResponseHeader(),
+                            Results = results.ToArrayOf(),
+                            DiagnosticInfos = default
+                        });
+                    });
+
+            sessionMock
+                .Setup(s => s.ReadAsync(
+                    It.IsAny<RequestHeader>(),
+                    It.IsAny<double>(),
+                    It.IsAny<TimestampsToReturn>(),
+                    It.IsAny<ArrayOf<ReadValueId>>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns<RequestHeader, double, TimestampsToReturn, ArrayOf<ReadValueId>,
+                    CancellationToken>(
+                    (_, _, _, nodes, _) =>
+                    {
+                        var results = new DataValue[nodes.Count];
+                        for (int i = 0; i < nodes.Count; i++)
+                        {
+                            ReadValueId r = nodes[i];
+                            harness.ReadRequests.Add(r);
+                            results[i] = harness.ReadHandler != null
+                                ? harness.ReadHandler(r)
+                                : new DataValue
+                                {
+                                    StatusCode = StatusCodes.BadNotFound
+                                };
+                        }
+                        return new ValueTask<ReadResponse>(new ReadResponse
+                        {
+                            ResponseHeader = new ResponseHeader(),
+                            Results = results.ToArrayOf(),
+                            DiagnosticInfos = default
+                        });
+                    });
+
+            sessionMock
+                .Setup(s => s.BrowseAsync(
+                    It.IsAny<RequestHeader>(),
+                    It.IsAny<ViewDescription>(),
+                    It.IsAny<uint>(),
+                    It.IsAny<ArrayOf<BrowseDescription>>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns<RequestHeader, ViewDescription, uint, ArrayOf<BrowseDescription>,
+                    CancellationToken>(
+                    (_, _, _, descriptions, _) =>
+                    {
+                        var results = new BrowseResult[descriptions.Count];
+                        for (int i = 0; i < descriptions.Count; i++)
+                        {
+                            results[i] = new BrowseResult
+                            {
+                                StatusCode = StatusCodes.Good,
+                                References = System.Array
+                                    .Empty<ReferenceDescription>()
+                                    .ToArrayOf()
+                            };
+                        }
+                        return new ValueTask<BrowseResponse>(new BrowseResponse
+                        {
+                            ResponseHeader = new ResponseHeader(),
+                            Results = results.ToArrayOf(),
+                            DiagnosticInfos = default
+                        });
+                    });
+
+            return harness;
+        }
+
+        private static CallMethodResult DefaultCallResult()
+        {
+            return new CallMethodResult
+            {
+                StatusCode = StatusCodes.Good,
+                OutputArguments = System.Array.Empty<Variant>().ToArrayOf()
+            };
+        }
+
+        /// <summary>
+        /// Default browse-path resolver — returns a synthetic NodeId
+        /// (browseName-named string identifier in ns=0) so that
+        /// <c>AliasNameClient.ResolveMethodIdAsync</c> tests have
+        /// something to cache. Tests that care about the precise NodeId
+        /// should supply their own <see cref="BrowsePathHandler"/>.
+        /// </summary>
+        private static BrowsePathResult DefaultBrowsePathResult(BrowsePath path)
+        {
+            string targetName = path.RelativePath.Elements[0].TargetName.Name;
+            return new BrowsePathResult
+            {
+                StatusCode = StatusCodes.Good,
+                Targets = new[]
+                {
+                    new BrowsePathTarget
+                    {
+                        TargetId = new ExpandedNodeId(targetName, 0),
+                        RemainingPathIndex = uint.MaxValue
+                    }
+                }.ToArrayOf()
+            };
+        }
+    }
+}

--- a/Tests/Opc.Ua.Client.Tests/AliasNames/PubSub/AliasNamePubSubBridgeTests.cs
+++ b/Tests/Opc.Ua.Client.Tests/AliasNames/PubSub/AliasNamePubSubBridgeTests.cs
@@ -1,0 +1,185 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+#pragma warning disable CA2007
+
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Opc.Ua.Client.AliasNames;
+using Opc.Ua.Client.AliasNames.PubSub;
+
+namespace Opc.Ua.Client.Tests.AliasNames.PubSub
+{
+    /// <summary>
+    /// Coverage tests for the client-side Part 17 Annex D bridge:
+    /// reader filtering and the
+    /// <see cref="AliasNamePubSubRefreshStrategy"/> behaviour.
+    /// </summary>
+    [TestFixture]
+    [Category("AliasNames")]
+    [Parallelizable]
+    public class AliasNamePubSubBridgeTests
+    {
+        [Test]
+        public void ReaderFiltersByExpectedApplicationUri()
+        {
+            var reader = new AliasNamePubSubReader(
+                new AliasNamePubSubReaderOptions
+                {
+                    ExpectedApplicationUri = "urn:expected",
+                });
+            int received = 0;
+            reader.AliasUpdateReceived += (_, _) => received++;
+
+            bool accepted = reader.Submit(new AliasUpdateDataType
+            {
+                ApplicationUri = "urn:other",
+            });
+            Assert.That(accepted, Is.False);
+            Assert.That(received, Is.EqualTo(0));
+
+            accepted = reader.Submit(new AliasUpdateDataType
+            {
+                ApplicationUri = "urn:expected",
+            });
+            Assert.That(accepted, Is.True);
+            Assert.That(received, Is.EqualTo(1));
+        }
+
+        [Test]
+        public async Task StrategyInvalidatesOnMatchingCategoryUpdateAsync()
+        {
+            var reader = new AliasNamePubSubReader();
+            var strategy = new AliasNamePubSubRefreshStrategy(reader);
+
+            // Build a session harness so we can construct an
+            // AliasNameClient pointing at a custom category.
+            AliasNameSessionHarness harness = AliasNameSessionHarness.Create();
+            harness.SessionMock.SetupGet(s => s.NamespaceUris)
+                .Returns(BuildNamespaceTable());
+
+            var categoryId = new NodeId("MyCategory", 1);
+            AliasNameClient client = new AliasNameClient(harness.Session, categoryId);
+
+            int invalidations = 0;
+            await strategy.StartAsync(
+                client, () => invalidations++, CancellationToken.None);
+            try
+            {
+                // Matching update — must fire.
+                reader.Submit(new AliasUpdateDataType
+                {
+                    ApplicationUri = "urn:p",
+                    Categories = new[]
+                    {
+                        new AliasCategoryUpdateDataType
+                        {
+                            Category = new PortableNodeId
+                            {
+                                NamespaceUri = "http://test.example/",
+                                Identifier = NodeId.Parse("s=MyCategory"),
+                            },
+                            LastChange = 1,
+                        }
+                    }.ToArrayOf(),
+                });
+                Assert.That(invalidations, Is.EqualTo(1));
+
+                // Same LastChange — must NOT fire again.
+                reader.Submit(new AliasUpdateDataType
+                {
+                    ApplicationUri = "urn:p",
+                    Categories = new[]
+                    {
+                        new AliasCategoryUpdateDataType
+                        {
+                            Category = new PortableNodeId
+                            {
+                                NamespaceUri = "http://test.example/",
+                                Identifier = NodeId.Parse("s=MyCategory"),
+                            },
+                            LastChange = 1,
+                        }
+                    }.ToArrayOf(),
+                });
+                Assert.That(invalidations, Is.EqualTo(1));
+
+                // Wraparound (1 -> 0) — must fire (inequality check).
+                reader.Submit(new AliasUpdateDataType
+                {
+                    ApplicationUri = "urn:p",
+                    Categories = new[]
+                    {
+                        new AliasCategoryUpdateDataType
+                        {
+                            Category = new PortableNodeId
+                            {
+                                NamespaceUri = "http://test.example/",
+                                Identifier = NodeId.Parse("s=MyCategory"),
+                            },
+                            LastChange = 0,
+                        }
+                    }.ToArrayOf(),
+                });
+                Assert.That(invalidations, Is.EqualTo(2));
+
+                // Non-matching category — must NOT fire.
+                reader.Submit(new AliasUpdateDataType
+                {
+                    ApplicationUri = "urn:p",
+                    Categories = new[]
+                    {
+                        new AliasCategoryUpdateDataType
+                        {
+                            Category = new PortableNodeId
+                            {
+                                NamespaceUri = "http://other.example/",
+                                Identifier = NodeId.Parse("s=MyCategory"),
+                            },
+                            LastChange = 99,
+                        }
+                    }.ToArrayOf(),
+                });
+                Assert.That(invalidations, Is.EqualTo(2));
+            }
+            finally
+            {
+                await strategy.DisposeAsync();
+            }
+        }
+
+        private static NamespaceTable BuildNamespaceTable()
+        {
+            var ns = new NamespaceTable();
+            ns.Append("http://test.example/");
+            return ns;
+        }
+    }
+}

--- a/Tests/Opc.Ua.Client.Tests/AliasNames/Refresh/ManualAndPollingRefreshStrategyTests.cs
+++ b/Tests/Opc.Ua.Client.Tests/AliasNames/Refresh/ManualAndPollingRefreshStrategyTests.cs
@@ -1,0 +1,162 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+#pragma warning disable CA2007
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Opc.Ua.Client.AliasNames;
+using Opc.Ua.Client.AliasNames.Refresh;
+
+namespace Opc.Ua.Client.Tests.AliasNames.Refresh
+{
+    /// <summary>
+    /// Coverage tests for <see cref="ManualAliasNameRefreshStrategy"/>:
+    /// it must never call <c>onInvalidate</c> and must be idempotently
+    /// disposable.
+    /// </summary>
+    [TestFixture]
+    [Category("AliasNames")]
+    [Parallelizable]
+    public class ManualAliasNameRefreshStrategyTests
+    {
+        [Test]
+        public async Task StartAsyncIsANoOpAsync()
+        {
+            await using var strategy = new ManualAliasNameRefreshStrategy();
+            int invalidations = 0;
+            AliasNameSessionHarness harness = AliasNameSessionHarness.Create();
+            AliasNameClient client = AliasNameClient.OpenStandardAliases(harness.Session);
+
+            await strategy.StartAsync(
+                client,
+                () => invalidations++,
+                CancellationToken.None);
+
+            await Task.Delay(50);
+            Assert.That(invalidations, Is.EqualTo(0));
+        }
+
+        [Test]
+        public async Task DisposeAsyncIsIdempotentAsync()
+        {
+            var strategy = new ManualAliasNameRefreshStrategy();
+            await strategy.DisposeAsync();
+            await strategy.DisposeAsync();
+            Assert.Pass();
+        }
+    }
+
+    /// <summary>
+    /// Coverage tests for <see cref="PollingAliasNameRefreshStrategy"/>:
+    /// timer triggers <c>ReadAsync</c> on the session; onInvalidate fires
+    /// only on a value-difference (wrap-safe). Uses the existing
+    /// <c>AliasNameSessionHarness</c> as the mocked session.
+    /// </summary>
+    [TestFixture]
+    [Category("AliasNames")]
+    [Parallelizable]
+    public class PollingAliasNameRefreshStrategyTests
+    {
+        [Test]
+        public void ConstructorRejectsIntervalBelowMinimum()
+        {
+            Assert.That(
+                () => new PollingAliasNameRefreshStrategy(
+                    TimeSpan.FromMilliseconds(50)),
+                Throws.TypeOf<ArgumentOutOfRangeException>());
+        }
+
+        [Test]
+        public async Task FiresOnValueDifferenceAndWrapAroundAsync()
+        {
+            AliasNameSessionHarness harness = AliasNameSessionHarness.Create();
+            AliasNameClient client = AliasNameClient.OpenStandardAliases(harness.Session);
+
+            uint nextReturn = 5;
+            harness.ReadHandler = _ => new DataValue
+            {
+                WrappedValue = new Variant(nextReturn),
+                StatusCode = StatusCodes.Good
+            };
+
+            int invalidations = 0;
+            await using var strategy = new PollingAliasNameRefreshStrategy(
+                TimeSpan.FromMilliseconds(120));
+            await strategy.StartAsync(client, () => invalidations++,
+                CancellationToken.None);
+
+            await WaitForAsync(() => invalidations >= 1);
+            int firstInvalidations = invalidations;
+
+            // Same value — must NOT bump.
+            await Task.Delay(300);
+            Assert.That(invalidations, Is.EqualTo(firstInvalidations));
+
+            // Wraparound — must bump.
+            nextReturn = 0;
+            await WaitForAsync(() => invalidations > firstInvalidations);
+            Assert.That(invalidations, Is.GreaterThan(firstInvalidations));
+        }
+
+        [Test]
+        public async Task DisposeAsyncStopsTimerAsync()
+        {
+            AliasNameSessionHarness harness = AliasNameSessionHarness.Create();
+            AliasNameClient client = AliasNameClient.OpenStandardAliases(harness.Session);
+            harness.ReadHandler = _ => new DataValue
+            {
+                WrappedValue = new Variant((uint)1),
+                StatusCode = StatusCodes.Good
+            };
+
+            int invalidations = 0;
+            var strategy = new PollingAliasNameRefreshStrategy(
+                TimeSpan.FromMilliseconds(100));
+            await strategy.StartAsync(client, () => invalidations++,
+                CancellationToken.None);
+            await Task.Delay(200);
+            await strategy.DisposeAsync();
+            int snapshot = invalidations;
+            await Task.Delay(300);
+            Assert.That(invalidations, Is.EqualTo(snapshot));
+        }
+
+        private static async Task WaitForAsync(Func<bool> predicate)
+        {
+            for (int i = 0; i < 50 && !predicate(); i++)
+            {
+                await Task.Delay(50);
+            }
+            Assert.That(predicate(), Is.True, "Predicate did not become true within 2.5s.");
+        }
+    }
+}

--- a/Tests/Opc.Ua.Client.Tests/AliasNames/Refresh/MonitoredItemAliasNameRefreshStrategyIntegrationTests.cs
+++ b/Tests/Opc.Ua.Client.Tests/AliasNames/Refresh/MonitoredItemAliasNameRefreshStrategyIntegrationTests.cs
@@ -1,0 +1,173 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+#pragma warning disable CA2007
+
+using System;
+using System.Globalization;
+using System.IO;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Opc.Ua.Client.AliasNames;
+using Opc.Ua.Client.AliasNames.Refresh;
+using Opc.Ua.Server.Tests;
+using Opc.Ua.Tests;
+using Quickstarts.ReferenceServer;
+
+namespace Opc.Ua.Client.Tests.AliasNames.Refresh
+{
+    /// <summary>
+    /// End-to-end test for <see cref="MonitoredItemAliasNameRefreshStrategy"/>
+    /// against the live <c>ReferenceServer</c>. Validates that the
+    /// strategy successfully creates a subscription + monitored item on
+    /// the well-known <c>Aliases.LastChange</c> property and cleans up
+    /// on dispose.
+    /// </summary>
+    [TestFixture]
+    [Category("AliasNames")]
+    [Category("Client")]
+    [SetCulture("en-us")]
+    [SetUICulture("en-us")]
+    [NonParallelizable]
+    public class MonitoredItemAliasNameRefreshStrategyIntegrationTests
+    {
+        private ServerFixture<ReferenceServer> m_serverFixture;
+#pragma warning disable NUnit1032
+        private ClientFixture m_clientFixture;
+#pragma warning restore NUnit1032
+        private ReferenceServer m_server;
+        private ISession m_session;
+        private string m_pkiRoot;
+        private Uri m_url;
+
+        [OneTimeSetUp]
+        public async Task OneTimeSetUpAsync()
+        {
+            ITelemetryContext telemetry = NUnitTelemetryContext.Create();
+            m_pkiRoot = Path.GetTempPath() + Path.GetRandomFileName();
+
+            m_serverFixture = new ServerFixture<ReferenceServer>(t => new ReferenceServer(t))
+            {
+                UriScheme = Utils.UriSchemeOpcTcp,
+                SecurityNone = true,
+                AutoAccept = true,
+                AllNodeManagers = true,
+                OperationLimits = true
+            };
+            m_server = await m_serverFixture.StartAsync(m_pkiRoot);
+
+            m_clientFixture = new ClientFixture(telemetry);
+            await m_clientFixture.LoadClientConfigurationAsync(m_pkiRoot);
+            m_url = new Uri(Utils.UriSchemeOpcTcp + "://localhost:"
+                + m_serverFixture.Port.ToString(CultureInfo.InvariantCulture));
+
+            try
+            {
+                m_session = await m_clientFixture.ConnectAsync(
+                    m_url, SecurityPolicies.None);
+            }
+            catch (Exception e)
+            {
+                Assert.Ignore(
+                    "MonitoredItem strategy integration setup failed: " + e.Message);
+            }
+        }
+
+        [OneTimeTearDown]
+        public async Task OneTimeTearDownAsync()
+        {
+            if (m_session != null)
+            {
+                await m_session.CloseAsync();
+                m_session.Dispose();
+                m_session = null;
+            }
+            if (m_serverFixture != null)
+            {
+                await m_serverFixture.StopAsync();
+            }
+            m_clientFixture?.Dispose();
+            m_server?.Dispose();
+        }
+
+        [Test]
+        public async Task StrategyCreatesAndDisposesSubscriptionAsync()
+        {
+            int initialCount = m_session.SubscriptionCount;
+            AliasNameClient client = AliasNameClient.OpenStandardAliases(m_session);
+
+            AliasNameResolver resolver = new(
+                client,
+                new AliasNameResolverOptions
+                {
+                    RefreshMode = AliasNameResolverRefreshMode
+                        .AutoOnLastChangeMonitoredItem,
+                    PublishingIntervalMs = 500,
+                    LastChangeSamplingIntervalMs = 500,
+                });
+            try
+            {
+                await resolver.EnsureLoadedAsync();
+                Assert.That(m_session.SubscriptionCount,
+                    Is.EqualTo(initialCount + 1),
+                    "MonitoredItem strategy must add one subscription.");
+            }
+            finally
+            {
+                await resolver.DisposeAsync();
+            }
+
+            // Allow a moment for the RemoveSubscription/Delete round-trips.
+            for (int i = 0; i < 20
+                && m_session.SubscriptionCount != initialCount; i++)
+            {
+                await Task.Delay(50);
+            }
+            Assert.That(m_session.SubscriptionCount, Is.EqualTo(initialCount),
+                "Owned subscription must be removed on DisposeAsync.");
+        }
+
+        [Test]
+        public async Task ManualResolverDoesNotCreateSubscriptionAsync()
+        {
+            int initialCount = m_session.SubscriptionCount;
+            AliasNameClient client = AliasNameClient.OpenStandardAliases(m_session);
+
+            await using var resolver = new AliasNameResolver(
+                client,
+                new AliasNameResolverOptions
+                {
+                    RefreshMode = AliasNameResolverRefreshMode.Manual
+                });
+            await resolver.EnsureLoadedAsync();
+
+            Assert.That(m_session.SubscriptionCount, Is.EqualTo(initialCount));
+        }
+    }
+}

--- a/Tests/Opc.Ua.Client.Tests/AliasNames/Refresh/MonitoredItemAliasNameRefreshStrategyIntegrationTests.cs
+++ b/Tests/Opc.Ua.Client.Tests/AliasNames/Refresh/MonitoredItemAliasNameRefreshStrategyIntegrationTests.cs
@@ -169,5 +169,81 @@ namespace Opc.Ua.Client.Tests.AliasNames.Refresh
 
             Assert.That(m_session.SubscriptionCount, Is.EqualTo(initialCount));
         }
+
+        [Test]
+        public async Task StrategyWithSharedSubscriptionDoesNotOwnItAsync()
+        {
+            // Pre-create a subscription owned by the test (NOT the
+            // strategy). The strategy must hook a MonitoredItem onto it
+            // without taking ownership, so that disposing the strategy
+            // leaves the subscription alive on the session for the test
+            // to reuse and dispose explicitly.
+            int initialCount = m_session.SubscriptionCount;
+            using var sharedSubscription = new Subscription(
+                m_session.MessageContext.Telemetry)
+            {
+                DisplayName = "shared-by-test",
+                PublishingEnabled = true,
+                PublishingInterval = 500,
+            };
+            m_session.AddSubscription(sharedSubscription);
+            await sharedSubscription.CreateAsync();
+            Assert.That(m_session.SubscriptionCount,
+                Is.EqualTo(initialCount + 1),
+                "Test setup must own the subscription.");
+
+            int sharedItemCountBefore = (int)sharedSubscription.MonitoredItemCount;
+            AliasNameClient client = AliasNameClient.OpenStandardAliases(m_session);
+
+            var resolver = new AliasNameResolver(
+                client,
+                new AliasNameResolverOptions
+                {
+                    RefreshStrategy = new Opc.Ua.Client.AliasNames.Refresh
+                        .MonitoredItemAliasNameRefreshStrategy(
+                        new Opc.Ua.Client.AliasNames.Refresh
+                            .MonitoredItemAliasNameRefreshStrategyOptions
+                        {
+                            SharedSubscription = sharedSubscription,
+                            SamplingIntervalMs = 500,
+                        })
+                });
+            try
+            {
+                await resolver.EnsureLoadedAsync();
+
+                Assert.That(m_session.SubscriptionCount,
+                    Is.EqualTo(initialCount + 1),
+                    "Shared-mode strategy must NOT create a new subscription.");
+                Assert.That(sharedSubscription.MonitoredItemCount,
+                    Is.GreaterThan(sharedItemCountBefore),
+                    "Strategy must hook its MonitoredItem onto the shared subscription.");
+            }
+            finally
+            {
+                await resolver.DisposeAsync();
+            }
+
+            // After the strategy disposes, the shared subscription must
+            // still be alive on the session and reusable. The strategy
+            // SHOULD have removed its own monitored item (best-effort) —
+            // but must NOT have removed/deleted the subscription itself.
+            Assert.That(m_session.SubscriptionCount,
+                Is.EqualTo(initialCount + 1),
+                "Strategy.DisposeAsync must NOT remove a shared subscription from the session.");
+            Assert.That(sharedSubscription.Created, Is.True,
+                "Shared subscription must remain in the Created state after strategy disposal.");
+
+            // Test owns the subscription — clean it up.
+            try
+            {
+                await m_session.RemoveSubscriptionAsync(sharedSubscription);
+                await sharedSubscription.DeleteAsync(silent: true);
+            }
+            catch
+            {
+                // Best-effort teardown.
+            }
+        }
     }
 }

--- a/Tests/Opc.Ua.Client.Tests/AliasNames/Refresh/MonitoredItemAliasNameRefreshStrategySignAndEncryptTests.cs
+++ b/Tests/Opc.Ua.Client.Tests/AliasNames/Refresh/MonitoredItemAliasNameRefreshStrategySignAndEncryptTests.cs
@@ -1,0 +1,232 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+#pragma warning disable CA2007
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Opc.Ua.Client.AliasNames;
+using Opc.Ua.Client.AliasNames.Refresh;
+using Opc.Ua.Server.AliasNames;
+using Opc.Ua.Server.Tests;
+using Opc.Ua.Tests;
+using Quickstarts.ReferenceServer;
+
+namespace Opc.Ua.Client.Tests.AliasNames.Refresh
+{
+    /// <summary>
+    /// End-to-end test that drives <see cref="MonitoredItemAliasNameRefreshStrategy"/>
+    /// over a <c>SignAndEncrypt</c> session against the live
+    /// <c>ReferenceServer</c>. Confirms the strategy's monitored item on
+    /// <c>Aliases.LastChange</c> fires the resolver cache invalidation
+    /// when the server-side store mutates, regardless of message security
+    /// (the previous integration test only covered <c>SecurityPolicies.None</c>).
+    /// </summary>
+    [TestFixture]
+    [Category("AliasNames")]
+    [Category("Client")]
+    [SetCulture("en-us")]
+    [SetUICulture("en-us")]
+    [NonParallelizable]
+    public class MonitoredItemAliasNameRefreshStrategySignAndEncryptTests
+    {
+        private ServerFixture<ReferenceServer> m_serverFixture;
+#pragma warning disable NUnit1032
+        private ClientFixture m_clientFixture;
+#pragma warning restore NUnit1032
+        private ReferenceServer m_server;
+        private ISession m_session;
+        private string m_pkiRoot;
+        private Uri m_url;
+
+        [OneTimeSetUp]
+        public async Task OneTimeSetUpAsync()
+        {
+            ITelemetryContext telemetry = NUnitTelemetryContext.Create();
+            m_pkiRoot = Path.GetTempPath() + Path.GetRandomFileName();
+
+            m_serverFixture = new ServerFixture<ReferenceServer>(t => new ReferenceServer(t))
+            {
+                UriScheme = Utils.UriSchemeOpcTcp,
+                SecurityNone = false,
+                AutoAccept = true,
+                AllNodeManagers = true,
+                OperationLimits = true
+            };
+
+            // Load the server configuration first so we can append a
+            // UserName UserTokenPolicy before the endpoints are bound —
+            // the default ReferenceServer fixture only advertises
+            // Anonymous + Certificate, which makes the sysadmin/demo
+            // username login fail with "Endpoint does not support the
+            // user identity type provided."
+            await m_serverFixture.LoadConfigurationAsync(m_pkiRoot);
+            m_serverFixture.Config.ServerConfiguration.UserTokenPolicies +=
+                new UserTokenPolicy(UserTokenType.UserName);
+
+            m_server = await m_serverFixture.StartAsync(m_pkiRoot);
+
+            m_clientFixture = new ClientFixture(telemetry);
+            await m_clientFixture.LoadClientConfigurationAsync(m_pkiRoot);
+            m_url = new Uri(Utils.UriSchemeOpcTcp + "://localhost:"
+                + m_serverFixture.Port.ToString(CultureInfo.InvariantCulture));
+
+            try
+            {
+                var userIdentity = new UserIdentity("sysadmin", "demo"u8);
+                m_session = await m_clientFixture.ConnectAsync(
+                    m_url,
+                    SecurityPolicies.Basic256Sha256,
+                    default,
+                    userIdentity);
+            }
+            catch (Exception e)
+            {
+                Assert.Ignore(
+                    "SignAndEncrypt MI strategy integration setup failed: " + e.Message);
+            }
+        }
+
+        [OneTimeTearDown]
+        public async Task OneTimeTearDownAsync()
+        {
+            if (m_session != null)
+            {
+                await m_session.CloseAsync();
+                m_session.Dispose();
+                m_session = null;
+            }
+            if (m_serverFixture != null)
+            {
+                await m_serverFixture.StopAsync();
+            }
+            m_clientFixture?.Dispose();
+            m_server?.Dispose();
+        }
+
+        /// <summary>
+        /// Drives a full end-to-end refresh cycle over <c>SignAndEncrypt</c>:
+        /// resolver opens, MI is armed on <c>Aliases.LastChange</c>, the
+        /// server-side store gains a new alias (which bumps
+        /// <c>LastChange</c>), the MI notification invalidates the cache,
+        /// and the next resolve picks the alias up without any explicit
+        /// poll or refresh from the test.
+        /// </summary>
+        [Test]
+        public async Task MonitoredItemStrategyInvalidatesCacheUnderSignAndEncryptAsync()
+        {
+            Assert.That(m_session.MessageContext, Is.Not.Null);
+            Assert.That(m_session.Endpoint.SecurityMode,
+                Is.EqualTo(MessageSecurityMode.SignAndEncrypt),
+                "Test must run over a SignAndEncrypt session to be meaningful.");
+
+            int initialSubscriptions = m_session.SubscriptionCount;
+
+            AliasNameClient client = AliasNameClient.OpenStandardAliases(m_session);
+            await using var resolver = new AliasNameResolver(
+                client,
+                new AliasNameResolverOptions
+                {
+                    RefreshMode = AliasNameResolverRefreshMode
+                        .AutoOnLastChangeMonitoredItem,
+                    PublishingIntervalMs = 200,
+                    LastChangeSamplingIntervalMs = 200,
+                });
+
+            await resolver.EnsureLoadedAsync();
+            Assert.That(m_session.SubscriptionCount,
+                Is.EqualTo(initialSubscriptions + 1),
+                "MonitoredItem strategy must add one subscription.");
+
+            // Sanity: the new alias name does not exist yet.
+            string newAlias = "MITrigger_"
+                + Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture);
+            IReadOnlyList<ExpandedNodeId> before = await resolver.ResolveAsync(newAlias);
+            Assert.That(before, Is.Empty,
+                "Newly-generated alias name must not pre-exist in cache.");
+
+            // Server-side mutation: add an alias directly via the in-memory
+            // store. This bumps the LastChange version which the
+            // DiagnosticsNodeManager publishes through Aliases.LastChange.
+            var provider = (IAliasNameStoreRegistryProvider)m_server.CurrentInstance;
+            IAliasNameStore store = provider.AliasNameStoreRegistry
+                .GetStoreForCategory(ObjectIds.Aliases)
+                ?? throw new InvalidOperationException(
+                    "Expected a registered alias-name store rooted at "
+                    + "ObjectIds.Aliases.");
+
+            int refServerNsIndex = m_server.CurrentInstance.NamespaceUris
+                .GetIndex(Quickstarts.ReferenceServer.Namespaces.ReferenceServer);
+            Assert.That(refServerNsIndex, Is.GreaterThanOrEqualTo(0),
+                "ReferenceServer namespace must be registered.");
+            ushort refServerNs = (ushort)refServerNsIndex;
+
+            var target = new ExpandedNodeId(
+                "Scalar_Static_Double", refServerNs);
+            var request = new AliasAddRequest(
+                newAlias,
+                target,
+                TargetServer: null,
+                TargetReferenceType: ReferenceTypeIds.AliasFor);
+
+            StatusCode[] addResults = await store.AddAliasesAsync(
+                ObjectIds.Aliases,
+                [request],
+                CancellationToken.None);
+            Assert.That(addResults, Has.Length.EqualTo(1));
+            Assert.That(addResults[0], Is.EqualTo((StatusCode)StatusCodes.Good),
+                "Server-side AddAliasesAsync must succeed for the new alias.");
+
+            // Wait for the MonitoredItem invalidation to arrive and the
+            // resolver to refetch via FindAlias. Give the publishing
+            // pipeline + service round-trip ample time.
+            IReadOnlyList<ExpandedNodeId> resolved = [];
+            for (int i = 0; i < 100; i++)
+            {
+                resolved = await resolver.ResolveAsync(newAlias);
+                if (resolved.Count > 0)
+                {
+                    break;
+                }
+                await Task.Delay(100);
+            }
+
+            Assert.That(resolved, Has.Count.EqualTo(1),
+                "MonitoredItem invalidation should have triggered a "
+                + "refetch picking up the new alias.");
+            Assert.That(resolved[0], Is.EqualTo(target),
+                "Refetched alias must point at the server-side target.");
+        }
+    }
+}

--- a/Tests/Opc.Ua.Server.Tests/AliasNames/AliasNameMethodDispatcherTests.cs
+++ b/Tests/Opc.Ua.Server.Tests/AliasNames/AliasNameMethodDispatcherTests.cs
@@ -1,0 +1,283 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Opc.Ua.Server.AliasNames;
+
+namespace Opc.Ua.Server.Tests.AliasNames
+{
+    /// <summary>
+    /// Direct coverage tests for the <c>AliasNameMethodDispatcher</c>
+    /// static glue layer — argument validation (Part 17 §6.3.4/§6.3.5
+    /// parallel-array shape), null-row coercion, and registry
+    /// result-to-MethodStateResult conversion.
+    /// </summary>
+    /// <remarks>
+    /// The dispatcher is marked <c>internal</c>; this test fixture lives
+    /// in the same assembly via <c>InternalsVisibleTo</c> already in
+    /// place for Opc.Ua.Server tests.
+    /// </remarks>
+    [TestFixture]
+    [Category("AliasNames")]
+    [Parallelizable]
+    public class AliasNameMethodDispatcherTests
+    {
+        private static readonly NodeId s_categoryId = new("Cat", 2);
+
+        private static (AliasNameStoreRegistry Registry, InMemoryAliasNameStore Store)
+            CreateRegistryWithCapableStore()
+        {
+            var descriptor = new AliasNameCategoryDescriptor(
+                s_categoryId,
+                new QualifiedName("Cat", 2),
+                AliasNameCapabilities.All);
+            var store = new InMemoryAliasNameStore([descriptor]);
+            var registry = new AliasNameStoreRegistry();
+            registry.Register(store);
+            return (registry, store);
+        }
+
+        [Test]
+        public async Task AddAliasesRejectsAliasNamesShorterThanTargetNodesAsync()
+        {
+            (AliasNameStoreRegistry registry, InMemoryAliasNameStore store) =
+                CreateRegistryWithCapableStore();
+            using (registry)
+            using (store)
+            {
+                AddAliasesToCategoryMethodStateResult result = await AliasNameMethodDispatcher
+                    .AddAliasesAsync(
+                        registry,
+                        s_categoryId,
+                        new string[] { "A" }.ToArrayOf(),
+                        new ExpandedNodeId[]
+                        {
+                            new("T1", 2),
+                            new("T2", 2)
+                        }.ToArrayOf(),
+                        new string[] { "", "" }.ToArrayOf(),
+                        ReferenceTypeIds.AliasFor,
+                        CancellationToken.None)
+                    .ConfigureAwait(false);
+
+                Assert.That(result.ServiceResult, Is.Not.Null);
+                Assert.That(result.ServiceResult.StatusCode.Code,
+                    Is.EqualTo(StatusCodes.BadInvalidArgument),
+                    "Per Part 17 §6.3.4 the dispatcher must reject mismatched parallel arrays.");
+            }
+        }
+
+        [Test]
+        public async Task AddAliasesRejectsTargetServersShorterThanAliasNamesAsync()
+        {
+            (AliasNameStoreRegistry registry, InMemoryAliasNameStore store) =
+                CreateRegistryWithCapableStore();
+            using (registry)
+            using (store)
+            {
+                AddAliasesToCategoryMethodStateResult result = await AliasNameMethodDispatcher
+                    .AddAliasesAsync(
+                        registry,
+                        s_categoryId,
+                        new string[] { "A", "B" }.ToArrayOf(),
+                        new ExpandedNodeId[]
+                        {
+                            new("T1", 2),
+                            new("T2", 2)
+                        }.ToArrayOf(),
+                        new string[] { "" }.ToArrayOf(),
+                        ReferenceTypeIds.AliasFor,
+                        CancellationToken.None)
+                    .ConfigureAwait(false);
+
+                Assert.That(result.ServiceResult.StatusCode.Code,
+                    Is.EqualTo(StatusCodes.BadInvalidArgument),
+                    "TargetServers shorter than AliasNames must surface as BadInvalidArgument.");
+            }
+        }
+
+        [Test]
+        public async Task DeleteAliasesRejectsMismatchedArraysAsync()
+        {
+            (AliasNameStoreRegistry registry, InMemoryAliasNameStore store) =
+                CreateRegistryWithCapableStore();
+            using (registry)
+            using (store)
+            {
+                DeleteAliasesFromCategoryMethodStateResult result = await AliasNameMethodDispatcher
+                    .DeleteAliasesAsync(
+                        registry,
+                        s_categoryId,
+                        new string[] { "A", "B" }.ToArrayOf(),
+                        new ExpandedNodeId[] { new("T1", 2) }.ToArrayOf(),
+                        CancellationToken.None)
+                    .ConfigureAwait(false);
+
+                Assert.That(result.ServiceResult.StatusCode.Code,
+                    Is.EqualTo(StatusCodes.BadInvalidArgument),
+                    "Per Part 17 §6.3.5 the dispatcher must reject mismatched parallel arrays.");
+            }
+        }
+
+        [Test]
+        public async Task AddAliasesCoercesNullAliasNameToEmptyAndReturnsBadBrowseNameInvalidAsync()
+        {
+            (AliasNameStoreRegistry registry, InMemoryAliasNameStore store) =
+                CreateRegistryWithCapableStore();
+            using (registry)
+            using (store)
+            {
+                // A null alias name must NOT crash the dispatcher (NRE);
+                // it must be coerced to string.Empty and rejected per-row
+                // by the store with BadBrowseNameInvalid.
+                AddAliasesToCategoryMethodStateResult result = await AliasNameMethodDispatcher
+                    .AddAliasesAsync(
+                        registry,
+                        s_categoryId,
+                        new string[] { null! }.ToArrayOf(),
+                        new ExpandedNodeId[] { new("T1", 2) }.ToArrayOf(),
+                        new string[] { "" }.ToArrayOf(),
+                        ReferenceTypeIds.AliasFor,
+                        CancellationToken.None)
+                    .ConfigureAwait(false);
+
+                Assert.That(result.ServiceResult, Is.EqualTo(ServiceResult.Good));
+                Assert.That(result.ErrorCodes.Count, Is.EqualTo(1));
+                Assert.That(result.ErrorCodes[0].Code,
+                    Is.EqualTo(StatusCodes.BadBrowseNameInvalid));
+            }
+        }
+
+        [Test]
+        public async Task DeleteAliasesCoercesNullAliasNameToEmptyAndReturnsBadBrowseNameInvalidAsync()
+        {
+            (AliasNameStoreRegistry registry, InMemoryAliasNameStore store) =
+                CreateRegistryWithCapableStore();
+            using (registry)
+            using (store)
+            {
+                DeleteAliasesFromCategoryMethodStateResult result = await AliasNameMethodDispatcher
+                    .DeleteAliasesAsync(
+                        registry,
+                        s_categoryId,
+                        new string[] { null! }.ToArrayOf(),
+                        new ExpandedNodeId[] { new("T1", 2) }.ToArrayOf(),
+                        CancellationToken.None)
+                    .ConfigureAwait(false);
+
+                Assert.That(result.ServiceResult, Is.EqualTo(ServiceResult.Good));
+                Assert.That(result.ErrorCodes.Count, Is.EqualTo(1));
+                Assert.That(result.ErrorCodes[0].Code,
+                    Is.EqualTo(StatusCodes.BadBrowseNameInvalid));
+            }
+        }
+
+        [Test]
+        public async Task FindAliasReturnsEmptyArrayOfWhenNoMatchesAsync()
+        {
+            (AliasNameStoreRegistry registry, InMemoryAliasNameStore store) =
+                CreateRegistryWithCapableStore();
+            using (registry)
+            using (store)
+            {
+                FindAliasMethodStateResult result = await AliasNameMethodDispatcher
+                    .FindAliasAsync(
+                        registry,
+                        new TypeTable(new NamespaceTable()),
+                        s_categoryId,
+                        "Nothing-matches-this",
+                        NodeId.Null,
+                        CancellationToken.None)
+                    .ConfigureAwait(false);
+
+                Assert.That(result.ServiceResult, Is.EqualTo(ServiceResult.Good));
+                Assert.That(result.AliasNodeList.Count, Is.EqualTo(0),
+                    "Empty result list must round-trip through ToArrayOf without throwing.");
+            }
+        }
+
+        [Test]
+        public async Task FindAliasVerboseReturnsEmptyArrayOfWhenNoMatchesAsync()
+        {
+            (AliasNameStoreRegistry registry, InMemoryAliasNameStore store) =
+                CreateRegistryWithCapableStore();
+            using (registry)
+            using (store)
+            {
+                FindAliasVerboseMethodStateResult result = await AliasNameMethodDispatcher
+                    .FindAliasVerboseAsync(
+                        registry,
+                        new TypeTable(new NamespaceTable()),
+                        s_categoryId,
+                        "Nothing-matches-this",
+                        NodeId.Null,
+                        CancellationToken.None)
+                    .ConfigureAwait(false);
+
+                Assert.That(result.ServiceResult, Is.EqualTo(ServiceResult.Good));
+                Assert.That(result.AliasNodeList.Count, Is.EqualTo(0));
+            }
+        }
+
+        [Test]
+        public async Task AddAliasesRoundTripsPerEntryStatusCodesFromStoreAsync()
+        {
+            (AliasNameStoreRegistry registry, InMemoryAliasNameStore store) =
+                CreateRegistryWithCapableStore();
+            using (registry)
+            using (store)
+            {
+                AddAliasesToCategoryMethodStateResult result = await AliasNameMethodDispatcher
+                    .AddAliasesAsync(
+                        registry,
+                        s_categoryId,
+                        new string[] { "A", "" }.ToArrayOf(),
+                        new ExpandedNodeId[]
+                        {
+                            new("T1", 2),
+                            new("T2", 2)
+                        }.ToArrayOf(),
+                        new string[] { "", "" }.ToArrayOf(),
+                        ReferenceTypeIds.AliasFor,
+                        CancellationToken.None)
+                    .ConfigureAwait(false);
+
+                Assert.That(result.ServiceResult, Is.EqualTo(ServiceResult.Good));
+                Assert.That(result.ErrorCodes.Count, Is.EqualTo(2));
+                Assert.That(result.ErrorCodes[0].Code, Is.EqualTo(StatusCodes.Good));
+                Assert.That(result.ErrorCodes[1].Code,
+                    Is.EqualTo(StatusCodes.BadBrowseNameInvalid),
+                    "Per-row store outcomes must be surfaced verbatim through ErrorCodes.");
+            }
+        }
+    }
+}

--- a/Tests/Opc.Ua.Server.Tests/AliasNames/AliasNameNodeManagerTests.cs
+++ b/Tests/Opc.Ua.Server.Tests/AliasNames/AliasNameNodeManagerTests.cs
@@ -117,12 +117,12 @@ namespace Opc.Ua.Server.Tests.AliasNames
         }
 
         [Test]
-        public void CreateAddressSpaceBuildsCategoryWithAllOptionalChildren()
+        public async Task CreateAddressSpaceBuildsCategoryWithAllOptionalChildrenAsync()
         {
             using AliasNameNodeManager manager = CreateManager();
             var externalReferences =
                 new Dictionary<NodeId, IList<IReference>>();
-            manager.CreateAddressSpace(externalReferences);
+            await manager.CreateAddressSpaceAsync(externalReferences).ConfigureAwait(false);
 
             AliasNameCategoryState category = manager
                 .FindPredefinedNode<AliasNameCategoryState>(
@@ -151,7 +151,7 @@ namespace Opc.Ua.Server.Tests.AliasNames
         }
 
         [Test]
-        public void OmittingCapabilitiesSkipsOptionalChildren()
+        public async Task OmittingCapabilitiesSkipsOptionalChildrenAsync()
         {
             m_store.Dispose();
             var minimal = new AliasNameCategoryDescriptor(
@@ -161,7 +161,7 @@ namespace Opc.Ua.Server.Tests.AliasNames
             m_store = new InMemoryAliasNameStore([minimal]);
 
             using AliasNameNodeManager manager = CreateManager();
-            manager.CreateAddressSpace(new Dictionary<NodeId, IList<IReference>>());
+            await manager.CreateAddressSpaceAsync(new Dictionary<NodeId, IList<IReference>>()).ConfigureAwait(false);
 
             AliasNameCategoryState category = manager
                 .FindPredefinedNode<AliasNameCategoryState>(
@@ -179,7 +179,7 @@ namespace Opc.Ua.Server.Tests.AliasNames
         public async Task FindAliasHandlerReturnsStoreAliasesAsync()
         {
             using AliasNameNodeManager manager = CreateManager();
-            manager.CreateAddressSpace(new Dictionary<NodeId, IList<IReference>>());
+            await manager.CreateAddressSpaceAsync(new Dictionary<NodeId, IList<IReference>>()).ConfigureAwait(false);
 
             var categoryId = new NodeId("MyCategory", 1);
             await m_store.AddAliasesAsync(categoryId,
@@ -220,7 +220,7 @@ namespace Opc.Ua.Server.Tests.AliasNames
         public async Task LastChangeReflectsStoreUpdatesAsync()
         {
             using AliasNameNodeManager manager = CreateManager();
-            manager.CreateAddressSpace(new Dictionary<NodeId, IList<IReference>>());
+            await manager.CreateAddressSpaceAsync(new Dictionary<NodeId, IList<IReference>>()).ConfigureAwait(false);
 
             var categoryId = new NodeId("MyCategory", 1);
             AliasNameCategoryState category = manager
@@ -253,7 +253,7 @@ namespace Opc.Ua.Server.Tests.AliasNames
                     RegisterWithServerRegistry = false,
                     RequireSecurityAdminForMutations = true
                 });
-            manager.CreateAddressSpace(new Dictionary<NodeId, IList<IReference>>());
+            await manager.CreateAddressSpaceAsync(new Dictionary<NodeId, IList<IReference>>()).ConfigureAwait(false);
 
             var categoryId = new NodeId("MyCategory", 1);
             AliasNameCategoryState category = manager

--- a/Tests/Opc.Ua.Server.Tests/AliasNames/AliasNameNodeManagerTests.cs
+++ b/Tests/Opc.Ua.Server.Tests/AliasNames/AliasNameNodeManagerTests.cs
@@ -1,0 +1,289 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NUnit.Framework;
+using Opc.Ua.Server.AliasNames;
+
+namespace Opc.Ua.Server.Tests.AliasNames
+{
+    /// <summary>
+    /// Coverage tests for <see cref="AliasNameNodeManager"/> built around a
+    /// mocked <see cref="IServerInternal"/> following the pattern used by
+    /// <c>AsyncCustomNodeManagerTests</c>.
+    /// </summary>
+    [TestFixture]
+    [Category("AliasNames")]
+    [Parallelizable]
+    public class AliasNameNodeManagerTests
+    {
+        private const string c_namespaceUri = "http://example.org/AliasNames/";
+
+        private Mock<IServerInternal> m_mockServer;
+        private NamespaceTable m_namespaceTable;
+        private ApplicationConfiguration m_configuration;
+        private InMemoryAliasNameStore m_store;
+
+        [SetUp]
+        public void SetUp()
+        {
+            m_mockServer = new Mock<IServerInternal>();
+            m_namespaceTable = new NamespaceTable();
+            m_namespaceTable.Append(c_namespaceUri);
+
+            var stringTable = new StringTable();
+            var typeTable = new TypeTable(m_namespaceTable);
+
+            ITelemetryContext telemetry = Opc.Ua.Tests.NUnitTelemetryContext.Create();
+
+            m_mockServer.Setup(s => s.NamespaceUris).Returns(m_namespaceTable);
+            m_mockServer.Setup(s => s.ServerUris).Returns(stringTable);
+            m_mockServer.Setup(s => s.TypeTree).Returns(typeTable);
+            m_mockServer.Setup(s => s.Factory).Returns(EncodeableFactory.Create());
+            m_mockServer.Setup(s => s.Telemetry).Returns(telemetry);
+            m_mockServer.Setup(s => s.DefaultSystemContext)
+                .Returns(new ServerSystemContext(m_mockServer.Object));
+
+            m_configuration = new ApplicationConfiguration
+            {
+                ServerConfiguration = new ServerConfiguration
+                {
+                    MaxNotificationQueueSize = 100,
+                    MaxDurableNotificationQueueSize = 200
+                }
+            };
+
+            // No additional type-tree subtype seeding is needed because
+            // the tests pass NodeId.Null / References as the reference
+            // type filter — InMemoryAliasNameStore short-circuits in that
+            // case and never invokes ITypeTable.IsTypeOf.
+
+            var categoryId = new NodeId("MyCategory", 1);
+            var descriptor = new AliasNameCategoryDescriptor(
+                categoryId,
+                new QualifiedName("MyCategory", 1),
+                AliasNameCapabilities.All);
+            m_store = new InMemoryAliasNameStore([descriptor]);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            m_store?.Dispose();
+        }
+
+        private AliasNameNodeManager CreateManager(
+            AliasNameNodeManagerOptions options = null)
+        {
+            return new AliasNameNodeManager(
+                m_mockServer.Object,
+                m_configuration,
+                m_store,
+                options ?? new AliasNameNodeManagerOptions
+                {
+                    NamespaceUri = c_namespaceUri,
+                    RegisterWithServerRegistry = false
+                });
+        }
+
+        [Test]
+        public void CreateAddressSpaceBuildsCategoryWithAllOptionalChildren()
+        {
+            using AliasNameNodeManager manager = CreateManager();
+            var externalReferences =
+                new Dictionary<NodeId, IList<IReference>>();
+            manager.CreateAddressSpace(externalReferences);
+
+            AliasNameCategoryState category = manager
+                .FindPredefinedNode<AliasNameCategoryState>(
+                    new NodeId("MyCategory", 1));
+            Assert.That(category, Is.Not.Null);
+            Assert.That(category.FindAlias, Is.Not.Null);
+            Assert.That(category.FindAliasVerbose, Is.Not.Null);
+            Assert.That(category.AddAliasesToCategory, Is.Not.Null);
+            Assert.That(category.DeleteAliasesFromCategory, Is.Not.Null);
+            Assert.That(category.LastChange, Is.Not.Null);
+
+            Assert.That(externalReferences.TryGetValue(
+                ObjectIds.Aliases, out IList<IReference> refs), Is.True);
+            bool hasOrganizes = false;
+            foreach (IReference r in refs)
+            {
+                if (r.ReferenceTypeId.Equals(ReferenceTypeIds.Organizes)
+                    && r.TargetId.Equals(category.NodeId))
+                {
+                    hasOrganizes = true;
+                    break;
+                }
+            }
+            Assert.That(hasOrganizes, Is.True,
+                "Expected an Organizes external reference from Aliases to category.");
+        }
+
+        [Test]
+        public void OmittingCapabilitiesSkipsOptionalChildren()
+        {
+            m_store.Dispose();
+            var minimal = new AliasNameCategoryDescriptor(
+                new NodeId("Minimal", 1),
+                new QualifiedName("Minimal", 1),
+                AliasNameCapabilities.None);
+            m_store = new InMemoryAliasNameStore([minimal]);
+
+            using AliasNameNodeManager manager = CreateManager();
+            manager.CreateAddressSpace(new Dictionary<NodeId, IList<IReference>>());
+
+            AliasNameCategoryState category = manager
+                .FindPredefinedNode<AliasNameCategoryState>(
+                    new NodeId("Minimal", 1));
+            Assert.That(category, Is.Not.Null);
+            Assert.That(category.FindAlias, Is.Not.Null,
+                "Mandatory FindAlias must always be present.");
+            Assert.That(category.FindAliasVerbose, Is.Null);
+            Assert.That(category.AddAliasesToCategory, Is.Null);
+            Assert.That(category.DeleteAliasesFromCategory, Is.Null);
+            Assert.That(category.LastChange, Is.Null);
+        }
+
+        [Test]
+        public async Task FindAliasHandlerReturnsStoreAliasesAsync()
+        {
+            using AliasNameNodeManager manager = CreateManager();
+            manager.CreateAddressSpace(new Dictionary<NodeId, IList<IReference>>());
+
+            var categoryId = new NodeId("MyCategory", 1);
+            await m_store.AddAliasesAsync(categoryId,
+                [
+                    new AliasAddRequest("Alpha",
+                        new ExpandedNodeId("Tgt", 1),
+                        null,
+                        ReferenceTypeIds.AliasFor)
+                ],
+                CancellationToken.None).ConfigureAwait(false);
+
+            AliasNameCategoryState category = manager
+                .FindPredefinedNode<AliasNameCategoryState>(categoryId);
+            var input = new ArrayOf<Variant>(
+                new[]
+                {
+                    new Variant("%"),
+                    new Variant(NodeId.Null)
+                });
+            var argumentErrors = new List<ServiceResult>();
+            var output = new List<Variant>();
+            ServiceResult result = await category.FindAlias!.CallAsync(
+                manager.SystemContext,
+                categoryId,
+                input,
+                argumentErrors,
+                output,
+                CancellationToken.None).ConfigureAwait(false);
+            Assert.That(result, Is.Null.Or.EqualTo(ServiceResult.Good));
+            Assert.That(output.Count, Is.EqualTo(1));
+            Assert.That(output[0].TryGetStructure(
+                out ArrayOf<AliasNameDataType> aliases), Is.True);
+            Assert.That(aliases.Count, Is.EqualTo(1));
+            Assert.That(aliases[0].AliasName.Name, Is.EqualTo("Alpha"));
+        }
+
+        [Test]
+        public async Task LastChangeReflectsStoreUpdatesAsync()
+        {
+            using AliasNameNodeManager manager = CreateManager();
+            manager.CreateAddressSpace(new Dictionary<NodeId, IList<IReference>>());
+
+            var categoryId = new NodeId("MyCategory", 1);
+            AliasNameCategoryState category = manager
+                .FindPredefinedNode<AliasNameCategoryState>(categoryId);
+
+            uint initial = (category.LastChange!.Value);
+            await m_store.AddAliasesAsync(categoryId,
+                [
+                    new AliasAddRequest("LC1",
+                        new ExpandedNodeId("Tgt", 1),
+                        null,
+                        ReferenceTypeIds.AliasFor)
+                ],
+                CancellationToken.None).ConfigureAwait(false);
+
+            Assert.That(category.LastChange.Value, Is.Not.EqualTo(initial));
+        }
+
+        private static readonly string[] s_singleX = ["X"];
+        private static readonly ExpandedNodeId[] s_singleT = [new("T", 1)];
+        private static readonly string[] s_singleEmpty = [""];
+
+        [Test]
+        public async Task AddAliasesAnonymousIsRejectedWithBadUserAccessDeniedAsync()
+        {
+            using AliasNameNodeManager manager = CreateManager(
+                new AliasNameNodeManagerOptions
+                {
+                    NamespaceUri = c_namespaceUri,
+                    RegisterWithServerRegistry = false,
+                    RequireSecurityAdminForMutations = true
+                });
+            manager.CreateAddressSpace(new Dictionary<NodeId, IList<IReference>>());
+
+            var categoryId = new NodeId("MyCategory", 1);
+            AliasNameCategoryState category = manager
+                .FindPredefinedNode<AliasNameCategoryState>(categoryId);
+
+            var input = new ArrayOf<Variant>(
+                new[]
+                {
+                    new Variant(s_singleX.ToArrayOf()),
+                    new Variant(s_singleT.ToArrayOf()),
+                    new Variant(s_singleEmpty.ToArrayOf()),
+                    new Variant(ReferenceTypeIds.AliasFor)
+                });
+            var argumentErrors = new List<ServiceResult>();
+            var output = new List<Variant>
+            {
+                new Variant(System.Array.Empty<StatusCode>().ToArrayOf())
+            };
+
+            ServiceResult result = await category.AddAliasesToCategory!.CallAsync(
+                manager.SystemContext,
+                categoryId,
+                input,
+                argumentErrors,
+                output,
+                CancellationToken.None).ConfigureAwait(false);
+
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.StatusCode.Code,
+                Is.EqualTo(StatusCodes.BadUserAccessDenied));
+        }
+    }
+}

--- a/Tests/Opc.Ua.Server.Tests/AliasNames/AliasNameNodeManagerTests.cs
+++ b/Tests/Opc.Ua.Server.Tests/AliasNames/AliasNameNodeManagerTests.cs
@@ -285,5 +285,246 @@ namespace Opc.Ua.Server.Tests.AliasNames
             Assert.That(result.StatusCode.Code,
                 Is.EqualTo(StatusCodes.BadUserAccessDenied));
         }
+
+        // --------------------------------------------------------------
+        // Security matrix for HasSecureAdminAccess.
+        // The auth boundary depends on (a) the channel's SecurityMode
+        // and (b) whether the user identity carries the SecurityAdmin
+        // role. The matrix below exercises every non-trivial combination
+        // and asserts the user-facing service result on AddAliases
+        // and DeleteAliases.
+        // --------------------------------------------------------------
+
+        private ServerSystemContext BuildSecuritySystemContext(
+            MessageSecurityMode securityMode,
+            bool grantSecurityAdmin)
+        {
+            var endpoint = new EndpointDescription { SecurityMode = securityMode };
+            var secureChannelContext = new SecureChannelContext(
+                "test", endpoint, RequestEncoding.Binary,
+                clientChannelCertificate: null,
+                serverChannelCertificate: null,
+                channelThumbprint: null);
+
+            var baseIdentity = new UserIdentity("admin", []);
+            IUserIdentity identity = grantSecurityAdmin
+                ? new RoleBasedIdentity(
+                    baseIdentity,
+                    [Role.SecurityAdmin],
+                    m_mockServer.Object.NamespaceUris)
+                : baseIdentity;
+
+            // The identity must be carried by the OperationContext —
+            // SessionSystemContext.UserIdentity prefers
+            // OperationContext.UserIdentity when the OperationContext
+            // implements ISessionOperationContext (which the server-side
+            // OperationContext class does), so setting it on the
+            // SystemContext directly is silently ignored.
+            var opContext = new OperationContext(
+                new RequestHeader(),
+                secureChannelContext,
+                RequestType.Call,
+                RequestLifetime.None,
+                identity);
+
+            return new ServerSystemContext(m_mockServer.Object, opContext);
+        }
+
+        private async Task<ServiceResult> InvokeAddAliasesAsync(
+            AliasNameNodeManager manager,
+            AliasNameCategoryState category,
+            NodeId categoryId,
+            ISystemContext context)
+        {
+            var input = new ArrayOf<Variant>(
+                new[]
+                {
+                    new Variant(s_singleX.ToArrayOf()),
+                    new Variant(s_singleT.ToArrayOf()),
+                    new Variant(s_singleEmpty.ToArrayOf()),
+                    new Variant(ReferenceTypeIds.AliasFor)
+                });
+            var argumentErrors = new List<ServiceResult>();
+            var output = new List<Variant>
+            {
+                new Variant(System.Array.Empty<StatusCode>().ToArrayOf())
+            };
+            return await category.AddAliasesToCategory!.CallAsync(
+                context, categoryId, input, argumentErrors, output,
+                CancellationToken.None).ConfigureAwait(false);
+        }
+
+        private async Task<ServiceResult> InvokeDeleteAliasesAsync(
+            AliasNameNodeManager manager,
+            AliasNameCategoryState category,
+            NodeId categoryId,
+            ISystemContext context)
+        {
+            var input = new ArrayOf<Variant>(
+                new[]
+                {
+                    new Variant(s_singleX.ToArrayOf()),
+                    new Variant(s_singleT.ToArrayOf())
+                });
+            var argumentErrors = new List<ServiceResult>();
+            var output = new List<Variant>
+            {
+                new Variant(System.Array.Empty<StatusCode>().ToArrayOf())
+            };
+            return await category.DeleteAliasesFromCategory!.CallAsync(
+                context, categoryId, input, argumentErrors, output,
+                CancellationToken.None).ConfigureAwait(false);
+        }
+
+        private async Task<(AliasNameNodeManager Manager,
+                            AliasNameCategoryState Category,
+                            NodeId CategoryId)>
+            CreateAdminCheckedManagerAsync()
+        {
+            AliasNameNodeManager manager = CreateManager(
+                new AliasNameNodeManagerOptions
+                {
+                    NamespaceUri = c_namespaceUri,
+                    RegisterWithServerRegistry = false,
+                    RequireSecurityAdminForMutations = true,
+                });
+            await manager.CreateAddressSpaceAsync(
+                new Dictionary<NodeId, IList<IReference>>()).ConfigureAwait(false);
+            var categoryId = new NodeId("MyCategory", 1);
+            AliasNameCategoryState category = manager
+                .FindPredefinedNode<AliasNameCategoryState>(categoryId);
+            return (manager, category, categoryId);
+        }
+
+        [Test]
+        public async Task AddAliasesAdminOnSignAndEncryptIsAcceptedAsync()
+        {
+            (AliasNameNodeManager manager, AliasNameCategoryState category, NodeId categoryId) =
+                await CreateAdminCheckedManagerAsync().ConfigureAwait(false);
+            using (manager)
+            {
+                ServerSystemContext ctx = BuildSecuritySystemContext(
+                    MessageSecurityMode.SignAndEncrypt, grantSecurityAdmin: true);
+                ServiceResult result = await InvokeAddAliasesAsync(
+                    manager, category, categoryId, ctx).ConfigureAwait(false);
+
+                // The auth predicate must pass; the call reaches the
+                // store and returns Good at the service level.
+                Assert.That(result, Is.Null.Or.EqualTo(ServiceResult.Good),
+                    "Admin on SignAndEncrypt must satisfy HasSecureAdminAccess.");
+            }
+        }
+
+        [Test]
+        public async Task AddAliasesAdminOnSignOnlyIsRejectedAsync()
+        {
+            (AliasNameNodeManager manager, AliasNameCategoryState category, NodeId categoryId) =
+                await CreateAdminCheckedManagerAsync().ConfigureAwait(false);
+            using (manager)
+            {
+                ServerSystemContext ctx = BuildSecuritySystemContext(
+                    MessageSecurityMode.Sign, grantSecurityAdmin: true);
+                ServiceResult result = await InvokeAddAliasesAsync(
+                    manager, category, categoryId, ctx).ConfigureAwait(false);
+
+                Assert.That(result, Is.Not.Null);
+                Assert.That(result.StatusCode.Code,
+                    Is.EqualTo(StatusCodes.BadUserAccessDenied),
+                    "Admin role on Sign-only must NOT be sufficient — admin mutations require SignAndEncrypt.");
+            }
+        }
+
+        [Test]
+        public async Task AddAliasesAdminOnNoneSecurityIsRejectedAsync()
+        {
+            (AliasNameNodeManager manager, AliasNameCategoryState category, NodeId categoryId) =
+                await CreateAdminCheckedManagerAsync().ConfigureAwait(false);
+            using (manager)
+            {
+                ServerSystemContext ctx = BuildSecuritySystemContext(
+                    MessageSecurityMode.None, grantSecurityAdmin: true);
+                ServiceResult result = await InvokeAddAliasesAsync(
+                    manager, category, categoryId, ctx).ConfigureAwait(false);
+
+                Assert.That(result.StatusCode.Code,
+                    Is.EqualTo(StatusCodes.BadUserAccessDenied));
+            }
+        }
+
+        [Test]
+        public async Task AddAliasesNonAdminOnSignAndEncryptIsRejectedAsync()
+        {
+            (AliasNameNodeManager manager, AliasNameCategoryState category, NodeId categoryId) =
+                await CreateAdminCheckedManagerAsync().ConfigureAwait(false);
+            using (manager)
+            {
+                ServerSystemContext ctx = BuildSecuritySystemContext(
+                    MessageSecurityMode.SignAndEncrypt, grantSecurityAdmin: false);
+                ServiceResult result = await InvokeAddAliasesAsync(
+                    manager, category, categoryId, ctx).ConfigureAwait(false);
+
+                Assert.That(result, Is.Not.Null);
+                Assert.That(result.StatusCode.Code,
+                    Is.EqualTo(StatusCodes.BadUserAccessDenied),
+                    "A SignAndEncrypt channel alone is not enough; the user must also have SecurityAdmin.");
+            }
+        }
+
+        [Test]
+        public async Task DeleteAliasesAnonymousIsRejectedWithBadUserAccessDeniedAsync()
+        {
+            (AliasNameNodeManager manager, AliasNameCategoryState category, NodeId categoryId) =
+                await CreateAdminCheckedManagerAsync().ConfigureAwait(false);
+            using (manager)
+            {
+                // Default manager.SystemContext has no SessionSystemContext shape —
+                // mirror the existing Add-side anonymous-rejection test.
+                ServiceResult result = await InvokeDeleteAliasesAsync(
+                    manager, category, categoryId, manager.SystemContext)
+                    .ConfigureAwait(false);
+
+                Assert.That(result, Is.Not.Null);
+                Assert.That(result.StatusCode.Code,
+                    Is.EqualTo(StatusCodes.BadUserAccessDenied));
+            }
+        }
+
+        [Test]
+        public async Task DeleteAliasesAdminOnSignAndEncryptIsAcceptedAsync()
+        {
+            (AliasNameNodeManager manager, AliasNameCategoryState category, NodeId categoryId) =
+                await CreateAdminCheckedManagerAsync().ConfigureAwait(false);
+            using (manager)
+            {
+                ServerSystemContext ctx = BuildSecuritySystemContext(
+                    MessageSecurityMode.SignAndEncrypt, grantSecurityAdmin: true);
+                ServiceResult result = await InvokeDeleteAliasesAsync(
+                    manager, category, categoryId, ctx).ConfigureAwait(false);
+
+                // The auth predicate passes; the store returns Good
+                // at the service level even though the per-row delete
+                // would fail with BadNotFound (the test fixture's store
+                // is empty) — the service result itself is Good.
+                Assert.That(result, Is.Null.Or.EqualTo(ServiceResult.Good),
+                    "Admin on SignAndEncrypt must satisfy the Delete-side auth predicate.");
+            }
+        }
+
+        [Test]
+        public async Task DeleteAliasesAdminOnSignOnlyIsRejectedAsync()
+        {
+            (AliasNameNodeManager manager, AliasNameCategoryState category, NodeId categoryId) =
+                await CreateAdminCheckedManagerAsync().ConfigureAwait(false);
+            using (manager)
+            {
+                ServerSystemContext ctx = BuildSecuritySystemContext(
+                    MessageSecurityMode.Sign, grantSecurityAdmin: true);
+                ServiceResult result = await InvokeDeleteAliasesAsync(
+                    manager, category, categoryId, ctx).ConfigureAwait(false);
+
+                Assert.That(result.StatusCode.Code,
+                    Is.EqualTo(StatusCodes.BadUserAccessDenied));
+            }
+        }
     }
 }

--- a/Tests/Opc.Ua.Server.Tests/AliasNames/AliasNameStoreRegistryTests.cs
+++ b/Tests/Opc.Ua.Server.Tests/AliasNames/AliasNameStoreRegistryTests.cs
@@ -102,5 +102,138 @@ namespace Opc.Ua.Server.Tests.AliasNames
             registry.Unregister(storeA);
             Assert.That(registry.GetStoreForCategory(s_a), Is.Null);
         }
+
+        [Test]
+        public async System.Threading.Tasks.Task RegistryChangedFiresWhenContainedStoreChangesAsync()
+        {
+            using var registry = new AliasNameStoreRegistry();
+            var descriptor = new AliasNameCategoryDescriptor(
+                s_a, new QualifiedName("A", 2),
+                AliasNameCapabilities.AddAliasesToCategory
+                    | AliasNameCapabilities.LastChange);
+            using var store = new InMemoryAliasNameStore([descriptor]);
+            registry.Register(store);
+
+            var captured = new System.Collections.Generic.List<AliasStoreChangedEventArgs>();
+            registry.Changed += (_, e) => captured.Add(e);
+
+            await store.AddAliasesAsync(s_a,
+                [new AliasAddRequest("X", new ExpandedNodeId("T", 2), null,
+                    ReferenceTypeIds.AliasFor)],
+                System.Threading.CancellationToken.None).ConfigureAwait(false);
+
+            Assert.That(captured, Has.Count.EqualTo(1),
+                "Registry.Changed must propagate the contained store's Changed event.");
+            Assert.That(captured[0].CategoryId, Is.EqualTo(s_a));
+            Assert.That(captured[0].LastChange, Is.EqualTo(1u));
+        }
+
+        [Test]
+        public async System.Threading.Tasks.Task RegistryChangedStopsAfterUnregisterAsync()
+        {
+            using var registry = new AliasNameStoreRegistry();
+            var descriptor = new AliasNameCategoryDescriptor(
+                s_a, new QualifiedName("A", 2),
+                AliasNameCapabilities.AddAliasesToCategory
+                    | AliasNameCapabilities.LastChange);
+            using var store = new InMemoryAliasNameStore([descriptor]);
+            registry.Register(store);
+            registry.Unregister(store);
+
+            int hits = 0;
+            registry.Changed += (_, _) => hits++;
+
+            await store.AddAliasesAsync(s_a,
+                [new AliasAddRequest("X", new ExpandedNodeId("T", 2), null,
+                    ReferenceTypeIds.AliasFor)],
+                System.Threading.CancellationToken.None).ConfigureAwait(false);
+
+            Assert.That(hits, Is.Zero,
+                "Registry.Changed must NOT fire for stores that have been unregistered.");
+        }
+
+        [Test]
+        public async System.Threading.Tasks.Task DispatchBadNotImplementedAcrossAllVerbsAsync()
+        {
+            using var registry = new AliasNameStoreRegistry();
+            var typeTree = new TypeTable(new NamespaceTable());
+
+            (ServiceResult findResult, _) = await registry
+                .DispatchFindAliasAsync(s_a, "%", NodeId.Null, typeTree)
+                .ConfigureAwait(false);
+            Assert.That(findResult.StatusCode.Code,
+                Is.EqualTo(StatusCodes.BadNotImplemented));
+
+            (ServiceResult findVerboseResult, _) = await registry
+                .DispatchFindAliasVerboseAsync(s_a, "%", NodeId.Null, typeTree)
+                .ConfigureAwait(false);
+            Assert.That(findVerboseResult.StatusCode.Code,
+                Is.EqualTo(StatusCodes.BadNotImplemented));
+
+            (ServiceResult addResult, StatusCode[] addCodes) = await registry
+                .DispatchAddAliasesAsync(s_a,
+                    [new AliasAddRequest("X", new ExpandedNodeId("T", 2), null,
+                        ReferenceTypeIds.AliasFor)])
+                .ConfigureAwait(false);
+            Assert.That(addResult.StatusCode.Code,
+                Is.EqualTo(StatusCodes.BadNotImplemented));
+            Assert.That(addCodes, Is.Empty);
+
+            (ServiceResult deleteResult, StatusCode[] deleteCodes) = await registry
+                .DispatchDeleteAliasesAsync(s_a,
+                    [new AliasDeleteRequest("X", new ExpandedNodeId("T", 2))])
+                .ConfigureAwait(false);
+            Assert.That(deleteResult.StatusCode.Code,
+                Is.EqualTo(StatusCodes.BadNotImplemented));
+            Assert.That(deleteCodes, Is.Empty);
+        }
+
+        [Test]
+        public async System.Threading.Tasks.Task DispatchAddCatchesServiceResultExceptionAsync()
+        {
+            using var registry = new AliasNameStoreRegistry();
+            // Category WITHOUT AddAliasesToCategory capability — the
+            // store throws BadNotSupported which the registry must
+            // catch and turn into a ServiceResult.
+            using InMemoryAliasNameStore store = Store(s_a, "A");
+            registry.Register(store);
+
+            (ServiceResult result, StatusCode[] codes) = await registry
+                .DispatchAddAliasesAsync(s_a,
+                    [new AliasAddRequest("X", new ExpandedNodeId("T", 2), null,
+                        ReferenceTypeIds.AliasFor)])
+                .ConfigureAwait(false);
+
+            Assert.That((uint)result.StatusCode.Code,
+                Is.EqualTo(StatusCodes.BadNotSupported),
+                "Service-level errors from the store must surface as the dispatch ServiceResult, not as exceptions.");
+            Assert.That(codes, Is.Empty);
+        }
+
+        [Test]
+        public async System.Threading.Tasks.Task DispatchDeleteCatchesServiceResultExceptionAsync()
+        {
+            using var registry = new AliasNameStoreRegistry();
+            using InMemoryAliasNameStore store = Store(s_a, "A");
+            registry.Register(store);
+
+            (ServiceResult result, StatusCode[] codes) = await registry
+                .DispatchDeleteAliasesAsync(s_a,
+                    [new AliasDeleteRequest("X", new ExpandedNodeId("T", 2))])
+                .ConfigureAwait(false);
+
+            Assert.That((uint)result.StatusCode.Code,
+                Is.EqualTo(StatusCodes.BadNotSupported));
+            Assert.That(codes, Is.Empty);
+        }
+
+        [Test]
+        public void DisposeIsIdempotent()
+        {
+            var registry = new AliasNameStoreRegistry();
+            registry.Dispose();
+            Assert.That(() => registry.Dispose(), Throws.Nothing,
+                "Dispose must be idempotent — the SDK's standard server-shutdown flow disposes node managers twice.");
+        }
     }
 }

--- a/Tests/Opc.Ua.Server.Tests/AliasNames/AliasNameStoreRegistryTests.cs
+++ b/Tests/Opc.Ua.Server.Tests/AliasNames/AliasNameStoreRegistryTests.cs
@@ -1,0 +1,106 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using NUnit.Framework;
+using Opc.Ua.Server.AliasNames;
+
+namespace Opc.Ua.Server.Tests.AliasNames
+{
+    /// <summary>
+    /// Coverage tests for <see cref="AliasNameStoreRegistry"/> —
+    /// registration, conflict detection, store routing, and dispatch
+    /// of <c>BadNotImplemented</c> when no store owns the category.
+    /// </summary>
+    [TestFixture]
+    [Category("AliasNames")]
+    [Parallelizable]
+    public class AliasNameStoreRegistryTests
+    {
+        private static readonly NodeId s_a = new("A", 2);
+        private static readonly NodeId s_b = new("B", 2);
+
+        private static InMemoryAliasNameStore Store(NodeId rootId, string name)
+        {
+            var d = new AliasNameCategoryDescriptor(
+                rootId, new QualifiedName(name, 2));
+            return new InMemoryAliasNameStore([d]);
+        }
+
+        [Test]
+        public void RegisterTrackedAndRoutesByCategory()
+        {
+            using var registry = new AliasNameStoreRegistry();
+            using InMemoryAliasNameStore storeA = Store(s_a, "A");
+            using InMemoryAliasNameStore storeB = Store(s_b, "B");
+
+            registry.Register(storeA);
+            registry.Register(storeB);
+
+            Assert.That(registry.GetStoreForCategory(s_a), Is.SameAs(storeA));
+            Assert.That(registry.GetStoreForCategory(s_b), Is.SameAs(storeB));
+            Assert.That(registry.GetStoreForCategory(new NodeId("C", 2)),
+                Is.Null);
+        }
+
+        [Test]
+        public void DuplicateRootCategoryIsRejected()
+        {
+            using var registry = new AliasNameStoreRegistry();
+            using InMemoryAliasNameStore one = Store(s_a, "A");
+            using InMemoryAliasNameStore two = Store(s_a, "A2");
+            registry.Register(one);
+            Assert.That(() => registry.Register(two),
+                Throws.TypeOf<InvalidOperationException>());
+        }
+
+        [Test]
+        public async System.Threading.Tasks.Task DispatchBadNotImplementedWhenNoStoreOwnsCategoryAsync()
+        {
+            using var registry = new AliasNameStoreRegistry();
+            (ServiceResult result, _) = await registry
+                .DispatchFindAliasAsync(s_a, "%", NodeId.Null,
+                    new TypeTable(new NamespaceTable()))
+                .ConfigureAwait(false);
+            Assert.That(result.StatusCode.Code,
+                Is.EqualTo(StatusCodes.BadNotImplemented));
+        }
+
+        [Test]
+        public void UnregisterRemovesRouting()
+        {
+            using var registry = new AliasNameStoreRegistry();
+            using InMemoryAliasNameStore storeA = Store(s_a, "A");
+            registry.Register(storeA);
+            Assert.That(registry.GetStoreForCategory(s_a), Is.SameAs(storeA));
+            registry.Unregister(storeA);
+            Assert.That(registry.GetStoreForCategory(s_a), Is.Null);
+        }
+    }
+}

--- a/Tests/Opc.Ua.Server.Tests/AliasNames/AliasNameWildcardMatcherTests.cs
+++ b/Tests/Opc.Ua.Server.Tests/AliasNames/AliasNameWildcardMatcherTests.cs
@@ -1,0 +1,105 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using NUnit.Framework;
+using Opc.Ua.Server.AliasNames;
+
+namespace Opc.Ua.Server.Tests.AliasNames
+{
+    /// <summary>
+    /// Coverage tests for the OPC UA Part 4 §7.40 Like-operator wildcard
+    /// match used by Part 17 <c>FindAlias</c>/<c>FindAliasVerbose</c>.
+    /// </summary>
+    [TestFixture]
+    [Category("AliasNames")]
+    [Parallelizable]
+    public class AliasNameWildcardMatcherTests
+    {
+        [TestCase("Sensor", "Sensor", true)]
+        [TestCase("sensor", "Sensor", false)]
+        [TestCase("Sensor", "%", true)]
+        [TestCase("Sensor", "Sen%", true)]
+        [TestCase("Sensor", "%sor", true)]
+        [TestCase("Sensor", "%nso%", true)]
+        [TestCase("Sensor", "Sen_or", true)]
+        [TestCase("Sensor", "Sen__r", true)]
+        [TestCase("Sensor", "Sen___", true)]
+        [TestCase("Sensor", "Sen____", false)]
+        [TestCase("Sensor", "[Ss]ensor", true)]
+        [TestCase("sensor", "[Ss]ensor", true)]
+        [TestCase("Tensor", "[Ss]ensor", false)]
+        [TestCase("Tensor", "[!Ss]ensor", true)]
+        [TestCase("Sensor", "[!Ss]ensor", false)]
+        [TestCase("Tag.X", "Tag.X", true)]
+        [TestCase("Tag.X", "Tag_X", true)]
+        [TestCase("Tag.X", @"Tag\.X", true)]
+        [TestCase("Tag_X", @"Tag\_X", true)]
+        [TestCase("TagAX", @"Tag\_X", false)]
+        [TestCase("Tag%X", @"Tag\%X", true)]
+        public void IsMatchPositive(string target, string pattern, bool expected)
+        {
+            Assert.That(AliasNameWildcardMatcher.IsMatch(target, pattern),
+                Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void EmptyPatternMatchesNothing()
+        {
+            Assert.That(AliasNameWildcardMatcher.IsMatch("anything", ""),
+                Is.False);
+        }
+
+        [Test]
+        public void EmptyTargetMatchesEmptyWildcard()
+        {
+            Assert.That(AliasNameWildcardMatcher.IsMatch("", "%"), Is.True);
+            Assert.That(AliasNameWildcardMatcher.IsMatch("", "_"), Is.False);
+            Assert.That(AliasNameWildcardMatcher.IsMatch("", "X"), Is.False);
+        }
+
+        [Test]
+        public void NullInputsReturnFalse()
+        {
+            Assert.That(AliasNameWildcardMatcher.IsMatch(null, "%"), Is.False);
+            Assert.That(AliasNameWildcardMatcher.IsMatch("X", null), Is.False);
+            Assert.That(AliasNameWildcardMatcher.IsMatch(null, null), Is.False);
+        }
+
+        [Test]
+        public void RegexMetaCharactersAreEscaped()
+        {
+            // The pattern "a.b" should match only the literal "a.b" — the
+            // wildcard implementation must escape regex metacharacters.
+            Assert.That(AliasNameWildcardMatcher.IsMatch("aXb", "a.b"), Is.False);
+            Assert.That(AliasNameWildcardMatcher.IsMatch("a.b", "a.b"), Is.True);
+            Assert.That(AliasNameWildcardMatcher.IsMatch("a(b)c", "a(b)c"), Is.True);
+            Assert.That(AliasNameWildcardMatcher.IsMatch("a+b", "a+b"), Is.True);
+        }
+    }
+}

--- a/Tests/Opc.Ua.Server.Tests/AliasNames/InMemoryAliasNameStoreTests.cs
+++ b/Tests/Opc.Ua.Server.Tests/AliasNames/InMemoryAliasNameStoreTests.cs
@@ -1,0 +1,274 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Opc.Ua.Server.AliasNames;
+
+namespace Opc.Ua.Server.Tests.AliasNames
+{
+    /// <summary>
+    /// Coverage tests for <see cref="InMemoryAliasNameStore"/> — including
+    /// per-entry status codes, mismatched-input handling,
+    /// <c>LastChange</c> monotonicity (Part 17 §6.3.1) and sub-category
+    /// cascading on FindAlias (Part 17 §6.3.2).
+    /// </summary>
+    [TestFixture]
+    [Category("AliasNames")]
+    [Parallelizable]
+    public class InMemoryAliasNameStoreTests
+    {
+        private static readonly NodeId s_root = new("Root", 2);
+        private static readonly NodeId s_child = new("Child", 2);
+        private static readonly ExpandedNodeId s_t1 = new("T1", 2);
+        private static readonly ExpandedNodeId s_t2 = new("T2", 2);
+        private static readonly ExpandedNodeId s_t3 = new("T3", 2);
+
+        private static InMemoryAliasNameStore CreateStore(
+            bool withSubCategory = false,
+            AliasNameCapabilities capabilities =
+                AliasNameCapabilities.AddAliasesToCategory
+                | AliasNameCapabilities.DeleteAliasesFromCategory
+                | AliasNameCapabilities.LastChange)
+        {
+            var subs = withSubCategory
+                ? new[]
+                {
+                    new AliasNameCategoryDescriptor(
+                        s_child,
+                        new QualifiedName("Child", 2),
+                        capabilities)
+                }
+                : null;
+            var root = new AliasNameCategoryDescriptor(
+                s_root,
+                new QualifiedName("Root", 2),
+                capabilities,
+                subs);
+            return new InMemoryAliasNameStore([root]);
+        }
+
+        private static TypeTable EmptyTypeTree()
+            => new(new NamespaceTable());
+
+        [Test]
+        public async Task AddAndFindRoundTripAsync()
+        {
+            using var store = CreateStore();
+            await store.AddAliasesAsync(s_root,
+                [
+                    new AliasAddRequest("Temp", s_t1, null,
+                        ReferenceTypeIds.AliasFor)
+                ],
+                CancellationToken.None).ConfigureAwait(false);
+
+            IReadOnlyList<AliasNameDataType> result = await store
+                .FindAliasAsync(s_root, "Temp", NodeId.Null, EmptyTypeTree())
+                .ConfigureAwait(false);
+            Assert.That(result, Has.Count.EqualTo(1));
+            Assert.That(result[0].AliasName.Name, Is.EqualTo("Temp"));
+            Assert.That(result[0].ReferencedNodes.Count, Is.EqualTo(1));
+            Assert.That(result[0].ReferencedNodes[0], Is.EqualTo(s_t1));
+        }
+
+        [Test]
+        public async Task DuplicateAddReturnsBadBrowseNameDuplicatedAsync()
+        {
+            using var store = CreateStore();
+            StatusCode[] first = await store.AddAliasesAsync(s_root,
+                [
+                    new AliasAddRequest("X", s_t1, null,
+                        ReferenceTypeIds.AliasFor)
+                ],
+                CancellationToken.None).ConfigureAwait(false);
+            Assert.That(first[0].Code, Is.EqualTo(StatusCodes.Good));
+
+            StatusCode[] second = await store.AddAliasesAsync(s_root,
+                [
+                    new AliasAddRequest("X", s_t1, null,
+                        ReferenceTypeIds.AliasFor)
+                ],
+                CancellationToken.None).ConfigureAwait(false);
+            Assert.That(second[0].Code, Is.EqualTo(StatusCodes.BadBrowseNameDuplicated));
+        }
+
+        [Test]
+        public async Task DeleteMissingReturnsBadNotFoundAsync()
+        {
+            using var store = CreateStore();
+            StatusCode[] r = await store.DeleteAliasesAsync(s_root,
+                [new AliasDeleteRequest("Ghost", s_t1)],
+                CancellationToken.None).ConfigureAwait(false);
+            Assert.That(r[0].Code, Is.EqualTo(StatusCodes.BadNotFound));
+        }
+
+        [Test]
+        public async Task LastChangeAdvancesMonotonicallyPerBatchAsync()
+        {
+            using var store = CreateStore();
+            Assert.That(store.GetLastChange(s_root), Is.EqualTo((uint?)0));
+
+            await store.AddAliasesAsync(s_root,
+                [
+                    new AliasAddRequest("A", s_t1, null, ReferenceTypeIds.AliasFor),
+                    new AliasAddRequest("B", s_t2, null, ReferenceTypeIds.AliasFor)
+                ],
+                CancellationToken.None).ConfigureAwait(false);
+            Assert.That(store.GetLastChange(s_root), Is.EqualTo((uint?)1),
+                "Batch with two successes must bump LastChange exactly once.");
+
+            await store.AddAliasesAsync(s_root,
+                [new AliasAddRequest("C", s_t3, null, ReferenceTypeIds.AliasFor)],
+                CancellationToken.None).ConfigureAwait(false);
+            Assert.That(store.GetLastChange(s_root), Is.EqualTo((uint?)2));
+
+            await store.DeleteAliasesAsync(s_root,
+                [new AliasDeleteRequest("Missing", s_t1)],
+                CancellationToken.None).ConfigureAwait(false);
+            Assert.That(store.GetLastChange(s_root), Is.EqualTo((uint?)2),
+                "All-fail batch must NOT bump LastChange.");
+        }
+
+        [Test]
+        public async Task ChangedEventCarriesCategoryAndVersionAsync()
+        {
+            using var store = CreateStore();
+            AliasStoreChangedEventArgs captured = null;
+            store.Changed += (_, e) => captured = e;
+            await store.AddAliasesAsync(s_root,
+                [new AliasAddRequest("X", s_t1, null, ReferenceTypeIds.AliasFor)],
+                CancellationToken.None).ConfigureAwait(false);
+            Assert.That(captured, Is.Not.Null);
+            Assert.That(captured.CategoryId, Is.EqualTo(s_root));
+            Assert.That(captured.LastChange, Is.EqualTo(1u));
+        }
+
+        private static readonly string[] s_rootAndSub = ["RootA", "SubA"];
+
+        [Test]
+        public async Task SubCategoryMatchesCascadeFromParentAsync()
+        {
+            using var store = CreateStore(withSubCategory: true);
+            await store.AddAliasesAsync(s_child,
+                [new AliasAddRequest("SubA", s_t1, null, ReferenceTypeIds.AliasFor)],
+                CancellationToken.None).ConfigureAwait(false);
+            await store.AddAliasesAsync(s_root,
+                [new AliasAddRequest("RootA", s_t2, null, ReferenceTypeIds.AliasFor)],
+                CancellationToken.None).ConfigureAwait(false);
+
+            // Find on root with wildcard returns BOTH the root- and
+            // child-category aliases.
+            IReadOnlyList<AliasNameDataType> result = await store
+                .FindAliasAsync(s_root, "%", NodeId.Null, EmptyTypeTree())
+                .ConfigureAwait(false);
+            var names = new HashSet<string>();
+            foreach (AliasNameDataType a in result)
+            {
+                names.Add(a.AliasName.Name!);
+            }
+            Assert.That(names, Is.EquivalentTo(s_rootAndSub));
+        }
+
+        [Test]
+        public async Task FindAliasWithEmptyPatternReturnsEmptyAsync()
+        {
+            using var store = CreateStore();
+            await store.AddAliasesAsync(s_root,
+                [new AliasAddRequest("A", s_t1, null, ReferenceTypeIds.AliasFor)],
+                CancellationToken.None).ConfigureAwait(false);
+            IReadOnlyList<AliasNameDataType> result = await store
+                .FindAliasAsync(s_root, "", NodeId.Null, EmptyTypeTree())
+                .ConfigureAwait(false);
+            Assert.That(result, Is.Empty);
+        }
+
+        [Test]
+        public async Task FindAliasWithUnknownCategoryReturnsEmptyAsync()
+        {
+            using var store = CreateStore();
+            IReadOnlyList<AliasNameDataType> result = await store
+                .FindAliasAsync(new NodeId("Unknown", 2),
+                    "%", NodeId.Null, EmptyTypeTree())
+                .ConfigureAwait(false);
+            Assert.That(result, Is.Empty);
+        }
+
+        [Test]
+        public async Task AddOnUnsupportedCategoryThrowsBadNotSupportedAsync()
+        {
+            using var store = CreateStore(
+                capabilities: AliasNameCapabilities.None);
+
+            ServiceResultException ex = null;
+            try
+            {
+                await store.AddAliasesAsync(s_root,
+                    [new AliasAddRequest("X", s_t1, null, ReferenceTypeIds.AliasFor)],
+                    CancellationToken.None).ConfigureAwait(false);
+            }
+            catch (ServiceResultException sre)
+            {
+                ex = sre;
+            }
+
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex.StatusCode, Is.EqualTo((uint)StatusCodes.BadNotSupported));
+        }
+
+        [Test]
+        public async Task FindAliasVerboseProducesServerUrisAndCategoryIdAsync()
+        {
+            using var store = CreateStore();
+            store.Seed(s_root, "S1", s_t1, serverUri: "urn:other-server",
+                referenceTypeId: ReferenceTypeIds.AliasFor);
+
+            IReadOnlyList<AliasNameVerboseDataType> result = await store
+                .FindAliasVerboseAsync(s_root, "%", NodeId.Null, EmptyTypeTree())
+                .ConfigureAwait(false);
+            Assert.That(result, Has.Count.EqualTo(1));
+            Assert.That(result[0].AliasName.Name, Is.EqualTo("S1"));
+            Assert.That(result[0].AliasNameCategoryId, Is.EqualTo(s_root));
+            Assert.That(result[0].ServerUris.Count, Is.EqualTo(1));
+            Assert.That(result[0].ServerUris[0], Is.EqualTo("urn:other-server"));
+        }
+
+        [Test]
+        public async Task OwnsCategoryReflectsRegisteredTreeAsync()
+        {
+            using var store = CreateStore(withSubCategory: true);
+            Assert.That(store.OwnsCategory(s_root), Is.True);
+            Assert.That(store.OwnsCategory(s_child), Is.True);
+            Assert.That(store.OwnsCategory(new NodeId("Other", 2)), Is.False);
+            // Suppress async warning on a synchronous fixture
+            await Task.CompletedTask.ConfigureAwait(false);
+        }
+    }
+}

--- a/Tests/Opc.Ua.Server.Tests/AliasNames/InMemoryAliasNameStoreTests.cs
+++ b/Tests/Opc.Ua.Server.Tests/AliasNames/InMemoryAliasNameStoreTests.cs
@@ -30,6 +30,7 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Moq;
 using NUnit.Framework;
 using Opc.Ua.Server.AliasNames;
 
@@ -269,6 +270,218 @@ namespace Opc.Ua.Server.Tests.AliasNames
             Assert.That(store.OwnsCategory(new NodeId("Other", 2)), Is.False);
             // Suppress async warning on a synchronous fixture
             await Task.CompletedTask.ConfigureAwait(false);
+        }
+
+        [Test]
+        public async Task DeleteExistingAliasRoundTripsAndBumpsLastChangeAsync()
+        {
+            using var store = CreateStore();
+            await store.AddAliasesAsync(s_root,
+                [new AliasAddRequest("X", s_t1, null, ReferenceTypeIds.AliasFor)],
+                CancellationToken.None).ConfigureAwait(false);
+            Assert.That(store.GetLastChange(s_root), Is.EqualTo((uint?)1));
+
+            StatusCode[] result = await store.DeleteAliasesAsync(s_root,
+                [new AliasDeleteRequest("X", s_t1)],
+                CancellationToken.None).ConfigureAwait(false);
+
+            Assert.That(result, Has.Length.EqualTo(1));
+            Assert.That(result[0].Code, Is.EqualTo(StatusCodes.Good),
+                "Successful delete must return Good.");
+            Assert.That(store.GetLastChange(s_root), Is.EqualTo((uint?)2),
+                "LastChange must bump exactly once on a successful delete batch.");
+
+            IReadOnlyList<AliasNameDataType> find = await store
+                .FindAliasAsync(s_root, "X", NodeId.Null, EmptyTypeTree())
+                .ConfigureAwait(false);
+            Assert.That(find, Is.Empty,
+                "Deleted alias must no longer be findable.");
+        }
+
+        [Test]
+        public async Task DeleteFiresChangedEventWithCategoryAndVersionAsync()
+        {
+            using var store = CreateStore();
+            await store.AddAliasesAsync(s_root,
+                [new AliasAddRequest("X", s_t1, null, ReferenceTypeIds.AliasFor)],
+                CancellationToken.None).ConfigureAwait(false);
+
+            var captured = new List<AliasStoreChangedEventArgs>();
+            store.Changed += (_, e) => captured.Add(e);
+
+            await store.DeleteAliasesAsync(s_root,
+                [new AliasDeleteRequest("X", s_t1)],
+                CancellationToken.None).ConfigureAwait(false);
+
+            Assert.That(captured, Has.Count.EqualTo(1),
+                "Successful delete must fire Changed exactly once.");
+            Assert.That(captured[0].CategoryId, Is.EqualTo(s_root));
+            Assert.That(captured[0].LastChange, Is.EqualTo(2u),
+                "Changed event must carry the new LastChange value.");
+        }
+
+        [Test]
+        public async Task DeleteRemovesEmptyAliasGroupSoReAddSucceedsAsync()
+        {
+            using var store = CreateStore();
+            await store.AddAliasesAsync(s_root,
+                [new AliasAddRequest("X", s_t1, null, ReferenceTypeIds.AliasFor)],
+                CancellationToken.None).ConfigureAwait(false);
+            await store.DeleteAliasesAsync(s_root,
+                [new AliasDeleteRequest("X", s_t1)],
+                CancellationToken.None).ConfigureAwait(false);
+
+            // The (name, target) tuple must not survive as a stale BadBrowseNameDuplicated
+            // poison entry — re-adding the same alias must succeed.
+            StatusCode[] result = await store.AddAliasesAsync(s_root,
+                [new AliasAddRequest("X", s_t1, null, ReferenceTypeIds.AliasFor)],
+                CancellationToken.None).ConfigureAwait(false);
+            Assert.That(result[0].Code, Is.EqualTo(StatusCodes.Good),
+                "Re-adding a deleted (name,target) must succeed (group cleanup).");
+        }
+
+        [Test]
+        public async Task DeleteAllFailBatchDoesNotBumpLastChangeAsync()
+        {
+            using var store = CreateStore();
+            await store.AddAliasesAsync(s_root,
+                [new AliasAddRequest("X", s_t1, null, ReferenceTypeIds.AliasFor)],
+                CancellationToken.None).ConfigureAwait(false);
+            uint? before = store.GetLastChange(s_root);
+
+            // All entries fail (wrong target node).
+            StatusCode[] result = await store.DeleteAliasesAsync(s_root,
+                [new AliasDeleteRequest("X", s_t2)],
+                CancellationToken.None).ConfigureAwait(false);
+
+            Assert.That(result[0].Code, Is.EqualTo(StatusCodes.BadNotFound));
+            Assert.That(store.GetLastChange(s_root), Is.EqualTo(before),
+                "All-fail delete batch must NOT bump LastChange.");
+        }
+
+        [Test]
+        public async Task AddWithEmptyNameReturnsBadBrowseNameInvalidAsync()
+        {
+            using var store = CreateStore();
+            StatusCode[] r = await store.AddAliasesAsync(s_root,
+                [new AliasAddRequest("", s_t1, null, ReferenceTypeIds.AliasFor)],
+                CancellationToken.None).ConfigureAwait(false);
+            Assert.That(r[0].Code, Is.EqualTo(StatusCodes.BadBrowseNameInvalid));
+        }
+
+        [Test]
+        public async Task AddWithNullTargetNodeReturnsBadNodeIdInvalidAsync()
+        {
+            using var store = CreateStore();
+            StatusCode[] r = await store.AddAliasesAsync(s_root,
+                [new AliasAddRequest("X", ExpandedNodeId.Null, null, ReferenceTypeIds.AliasFor)],
+                CancellationToken.None).ConfigureAwait(false);
+            Assert.That(r[0].Code, Is.EqualTo(StatusCodes.BadNodeIdInvalid));
+        }
+
+        [Test]
+        public async Task AddWithNullReferenceTypeReturnsBadReferenceTypeIdInvalidAsync()
+        {
+            using var store = CreateStore();
+            StatusCode[] r = await store.AddAliasesAsync(s_root,
+                [new AliasAddRequest("X", s_t1, null, NodeId.Null)],
+                CancellationToken.None).ConfigureAwait(false);
+            Assert.That(r[0].Code, Is.EqualTo(StatusCodes.BadReferenceTypeIdInvalid));
+        }
+
+        [Test]
+        public async Task DeleteWithEmptyNameReturnsBadBrowseNameInvalidAsync()
+        {
+            using var store = CreateStore();
+            StatusCode[] r = await store.DeleteAliasesAsync(s_root,
+                [new AliasDeleteRequest("", s_t1)],
+                CancellationToken.None).ConfigureAwait(false);
+            Assert.That(r[0].Code, Is.EqualTo(StatusCodes.BadBrowseNameInvalid));
+        }
+
+        [Test]
+        public async Task DeleteWithNullTargetNodeReturnsBadNodeIdInvalidAsync()
+        {
+            using var store = CreateStore();
+            StatusCode[] r = await store.DeleteAliasesAsync(s_root,
+                [new AliasDeleteRequest("X", ExpandedNodeId.Null)],
+                CancellationToken.None).ConfigureAwait(false);
+            Assert.That(r[0].Code, Is.EqualTo(StatusCodes.BadNodeIdInvalid));
+        }
+
+        [Test]
+        public async Task AddBatchAccumulatesPerEntryFailuresWithoutBumpAsync()
+        {
+            using var store = CreateStore();
+            // All three rows fail individually — none should bump LastChange.
+            StatusCode[] r = await store.AddAliasesAsync(s_root,
+                [
+                    new AliasAddRequest("", s_t1, null, ReferenceTypeIds.AliasFor),
+                    new AliasAddRequest("X", ExpandedNodeId.Null, null, ReferenceTypeIds.AliasFor),
+                    new AliasAddRequest("Y", s_t1, null, NodeId.Null)
+                ],
+                CancellationToken.None).ConfigureAwait(false);
+            Assert.That(r, Has.Length.EqualTo(3));
+            Assert.That(r[0].Code, Is.EqualTo(StatusCodes.BadBrowseNameInvalid));
+            Assert.That(r[1].Code, Is.EqualTo(StatusCodes.BadNodeIdInvalid));
+            Assert.That(r[2].Code, Is.EqualTo(StatusCodes.BadReferenceTypeIdInvalid));
+            Assert.That(store.GetLastChange(s_root), Is.EqualTo((uint?)0),
+                "All-fail add batch must NOT bump LastChange.");
+        }
+
+        [Test]
+        public async Task FindAliasFiltersByReferenceTypeSubtypeViaTypeTreeAsync()
+        {
+            // Seed an alias whose ReferenceTypeId is a *subtype* of AliasFor
+            // (a synthetic 'SpecialAliasFor' from a custom namespace).
+            // FindAlias with a filter equal to AliasFor must return the alias
+            // because ITypeTable.IsTypeOf(subtype, base) returns true (Part 17
+            // §6.3.2 reference-type filter semantics: include subtypes).
+            using var store = CreateStore();
+            var specialAliasFor = new NodeId("SpecialAliasFor", 2);
+            store.Seed(s_root, "Tagged", s_t1, serverUri: null,
+                referenceTypeId: specialAliasFor);
+
+            var typeTree = new Mock<ITypeTable>();
+            typeTree
+                .Setup(t => t.IsTypeOf(specialAliasFor, ReferenceTypeIds.AliasFor))
+                .Returns(true);
+            // Anything else NOT in the subtype chain returns false.
+            typeTree
+                .Setup(t => t.IsTypeOf(specialAliasFor, ReferenceTypeIds.Organizes))
+                .Returns(false);
+
+            // Filter on the base type — subtype alias should match.
+            IReadOnlyList<AliasNameDataType> match = await store
+                .FindAliasAsync(s_root, "%", ReferenceTypeIds.AliasFor, typeTree.Object)
+                .ConfigureAwait(false);
+            Assert.That(match, Has.Count.EqualTo(1),
+                "Alias with subtype ReferenceType must match filter on its base type.");
+
+            // Filter on an unrelated type — no match.
+            IReadOnlyList<AliasNameDataType> miss = await store
+                .FindAliasAsync(s_root, "%", ReferenceTypeIds.Organizes, typeTree.Object)
+                .ConfigureAwait(false);
+            Assert.That(miss, Is.Empty,
+                "Alias with subtype ReferenceType must NOT match filter on an unrelated type.");
+        }
+
+        [Test]
+        public async Task FindAliasWithReferencesAsFilterMatchesAllAsync()
+        {
+            using var store = CreateStore();
+            await store.AddAliasesAsync(s_root,
+                [
+                    new AliasAddRequest("A", s_t1, null, ReferenceTypeIds.AliasFor),
+                    new AliasAddRequest("B", s_t2, null, ReferenceTypeIds.HasProperty)
+                ],
+                CancellationToken.None).ConfigureAwait(false);
+
+            IReadOnlyList<AliasNameDataType> result = await store
+                .FindAliasAsync(s_root, "%", ReferenceTypeIds.References, EmptyTypeTree())
+                .ConfigureAwait(false);
+            Assert.That(result, Has.Count.EqualTo(2),
+                "Filter == References must short-circuit and match every alias regardless of refType.");
         }
     }
 }

--- a/Tests/Opc.Ua.Server.Tests/AliasNames/PubSub/AliasNamePubSubTests.cs
+++ b/Tests/Opc.Ua.Server.Tests/AliasNames/PubSub/AliasNamePubSubTests.cs
@@ -83,6 +83,81 @@ namespace Opc.Ua.Server.Tests.AliasNames.PubSub
         }
 
         [Test]
+        public void PortableResolverPreservesNumericIdentifier()
+        {
+            var resolver = NewResolver();
+            PortableNodeId portable = resolver.ToPortable(new NodeId(42u, 1));
+
+            Assert.That(portable, Is.Not.Null);
+            Assert.That(portable.NamespaceUri,
+                Is.EqualTo("http://example.org/MyServer/"));
+            Assert.That(portable.Identifier.NamespaceIndex, Is.EqualTo((ushort)0));
+            Assert.That(portable.Identifier.IdType, Is.EqualTo(IdType.Numeric));
+            Assert.That(portable.Identifier.TryGetValue(out uint numeric), Is.True);
+            Assert.That(numeric, Is.EqualTo(42u));
+        }
+
+        [Test]
+        public void PortableResolverPreservesGuidIdentifier()
+        {
+            var resolver = NewResolver();
+            var guid = Guid.NewGuid();
+            PortableNodeId portable = resolver.ToPortable(new NodeId(guid, 1));
+
+            Assert.That(portable, Is.Not.Null);
+            Assert.That(portable.Identifier.NamespaceIndex, Is.EqualTo((ushort)0));
+            Assert.That(portable.Identifier.IdType, Is.EqualTo(IdType.Guid));
+            Assert.That(portable.Identifier.TryGetValue(out Guid g), Is.True);
+            Assert.That(g, Is.EqualTo(guid));
+        }
+
+        [Test]
+        public void PortableResolverPreservesOpaqueIdentifier()
+        {
+            var resolver = NewResolver();
+            var bytes = new byte[] { 0xCA, 0xFE, 0xBA, 0xBE };
+            PortableNodeId portable = resolver.ToPortable(new NodeId((ByteString)bytes, 1));
+
+            Assert.That(portable, Is.Not.Null);
+            Assert.That(portable.Identifier.NamespaceIndex, Is.EqualTo((ushort)0));
+            Assert.That(portable.Identifier.IdType, Is.EqualTo(IdType.Opaque));
+            Assert.That(portable.Identifier.TryGetValue(out ByteString opaque), Is.True);
+            Assert.That(opaque.Span.ToArray(), Is.EqualTo(bytes));
+        }
+
+        [Test]
+        public void PortableResolverReturnsNullForNullNodeId()
+        {
+            var resolver = NewResolver();
+            PortableNodeId portable = resolver.ToPortable(NodeId.Null);
+            Assert.That(portable, Is.Null,
+                "Null NodeId must short-circuit to null without throwing.");
+        }
+
+        [Test]
+        public void PortableResolverReturnsNullForUnknownNamespaceIndex()
+        {
+            var resolver = NewResolver();
+            // Namespace index 99 is not registered — the resolver must
+            // gracefully return null rather than emit a PortableNodeId
+            // with a null/empty namespace URI.
+            PortableNodeId portable = resolver.ToPortable(new NodeId("X", 99));
+            Assert.That(portable, Is.Null);
+        }
+
+        private static ServerPortableNodeIdResolver NewResolver()
+        {
+            var ns = new NamespaceTable();
+            ns.Append("http://example.org/MyServer/");
+            var servers = new StringTable();
+            servers.Append("urn:example:server");
+            var serverMock = new Moq.Mock<IServerInternal>();
+            serverMock.SetupGet(s => s.NamespaceUris).Returns(ns);
+            serverMock.SetupGet(s => s.ServerUris).Returns(servers);
+            return new ServerPortableNodeIdResolver(serverMock.Object);
+        }
+
+        [Test]
         public void PublisherProducesAliasUpdateOnRegistryChange()
         {
             using var registry = new AliasNameStoreRegistry();

--- a/Tests/Opc.Ua.Server.Tests/AliasNames/PubSub/AliasNamePubSubTests.cs
+++ b/Tests/Opc.Ua.Server.Tests/AliasNames/PubSub/AliasNamePubSubTests.cs
@@ -1,0 +1,128 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using NUnit.Framework;
+using Opc.Ua.Server.AliasNames;
+using Opc.Ua.Server.AliasNames.PubSub;
+
+namespace Opc.Ua.Server.Tests.AliasNames.PubSub
+{
+    /// <summary>
+    /// Coverage tests for the Part 17 Annex D PubSub server-side
+    /// surface — DataSet metadata shape, PortableNodeId encoding, and
+    /// publisher event production.
+    /// </summary>
+    [TestFixture]
+    [Category("AliasNames")]
+    [Parallelizable]
+    public class AliasNamePubSubTests
+    {
+        [Test]
+        public void DataSetFactoryProducesPart17AnnexDSchema()
+        {
+            var classId = Guid.NewGuid();
+            DataSetMetaDataType metadata = AliasUpdateDataSetFactory.Create(classId);
+
+            Assert.That(metadata.Name, Is.EqualTo("AliasUpdate"));
+            Assert.That(metadata.DataSetClassId, Is.EqualTo(new Uuid(classId)));
+            Assert.That(metadata.Fields.Count, Is.EqualTo(2));
+            Assert.That(metadata.Fields[0].Name, Is.EqualTo("ApplicationUri"));
+            Assert.That(metadata.Fields[1].Name, Is.EqualTo("Categories"));
+            Assert.That(metadata.Fields[1].DataType,
+                Is.EqualTo(DataTypeIds.AliasCategoryUpdateDataType));
+            Assert.That(metadata.Fields[1].ValueRank,
+                Is.EqualTo(ValueRanks.OneDimension));
+        }
+
+        [Test]
+        public void PortableResolverRoundTripsAcrossNamespaces()
+        {
+            var ns = new NamespaceTable();
+            ns.Append("http://example.org/MyServer/");
+            var servers = new StringTable();
+            servers.Append("urn:example:server");
+
+            var serverMock = new Moq.Mock<IServerInternal>();
+            serverMock.SetupGet(s => s.NamespaceUris).Returns(ns);
+            serverMock.SetupGet(s => s.ServerUris).Returns(servers);
+
+            var resolver = new ServerPortableNodeIdResolver(serverMock.Object);
+            PortableNodeId portable = resolver.ToPortable(new NodeId("MyCat", 1));
+
+            Assert.That(portable, Is.Not.Null);
+            Assert.That(portable.NamespaceUri,
+                Is.EqualTo("http://example.org/MyServer/"));
+            Assert.That(portable.Identifier.NamespaceIndex, Is.EqualTo((ushort)0));
+        }
+
+        [Test]
+        public void PublisherProducesAliasUpdateOnRegistryChange()
+        {
+            using var registry = new AliasNameStoreRegistry();
+            using var store = new InMemoryAliasNameStore(
+                [new AliasNameCategoryDescriptor(
+                    new NodeId("Cat", 1),
+                    new QualifiedName("Cat", 1),
+                    AliasNameCapabilities.AddAliasesToCategory
+                        | AliasNameCapabilities.LastChange)]);
+            registry.Register(store);
+
+            var ns = new NamespaceTable();
+            ns.Append("http://example.org/MyServer/");
+            var servers = new StringTable();
+            servers.Append("urn:example:server");
+            var serverMock = new Moq.Mock<IServerInternal>();
+            serverMock.SetupGet(s => s.NamespaceUris).Returns(ns);
+            serverMock.SetupGet(s => s.ServerUris).Returns(servers);
+
+            var resolver = new ServerPortableNodeIdResolver(serverMock.Object);
+            using var publisher = new AliasNamePublisher(
+                registry,
+                resolver,
+                applicationUri: "urn:example:publisher");
+
+            AliasUpdateDataType captured = null;
+            publisher.AliasUpdateProduced += (_, e) => captured = e.Update;
+
+            store.AddAliasesAsync(
+                new NodeId("Cat", 1),
+                [new AliasAddRequest("X", new ExpandedNodeId("T", 1), null,
+                    ReferenceTypeIds.AliasFor)],
+                System.Threading.CancellationToken.None).AsTask().GetAwaiter().GetResult();
+
+            Assert.That(captured, Is.Not.Null);
+            Assert.That(captured.ApplicationUri, Is.EqualTo("urn:example:publisher"));
+            Assert.That(captured.Categories.Count, Is.EqualTo(1));
+            Assert.That(captured.Categories[0].LastChange, Is.EqualTo((uint)1));
+            Assert.That(captured.Categories[0].Category.NamespaceUri,
+                Is.EqualTo("http://example.org/MyServer/"));
+        }
+    }
+}


### PR DESCRIPTION
This PR adds full OPC UA Part 17 (Alias Names) support to the stack. It replaces the demo-grade `AliasNameNodeManager` previously sitting in the Quickstart reference server with a production-quality implementation in `Opc.Ua.Server` plus a matching client API in `Opc.Ua.Client`, integration with the standard well-known `Aliases`/`TagVariables`/`Topics` nodes, and a full unit + integration test suite.

## What ships

### Server side — `Libraries/Opc.Ua.Server/AliasNames/`
- `IAliasNameStore` — pluggable async backend with `FindAlias`, `FindAliasVerbose`, `AddAliasesToCategory`, `DeleteAliasesFromCategory`, `LastChange`, plus a `Changed` event for live `LastChange` updates.
- `InMemoryAliasNameStore` — default thread-safe (`SemaphoreSlim`) implementation supporting nested categories.
- `IAliasNameStoreRegistry` + `AliasNameStoreRegistry` — server-wide live dispatcher, conflict-detecting on category root NodeIds. Surfaces through a new opt-in `IAliasNameStoreRegistryProvider` that `ServerInternalData` implements — `IServerInternal` itself is **not** modified, so mocks / external implementations continue to work.
- `AliasNameNodeManager` — standalone `CustomNodeManager2`. Builds the address-space tree from the store''s `RootCategories` using the source-generated `AliasNameCategoryState` / `AliasNameState` / `FindAliasMethodState` etc., wires the typed `OnCallAsync` handlers, optionally publishes `Organizes` external references from the standard `Aliases (i=23470)` object, and registers the store with the server-wide registry. Defaults `AddAliasesToCategory`/`DeleteAliasesFromCategory` to `WellKnownRole_SecurityAdmin`-only on `SignAndEncrypt` channels.
- `AliasNameMethodDispatcher` — bridges the auto-generated `*MethodState.OnCallAsync` typed handlers to the registry. Validates the parallel-array shape of `AddAliasesToCategory` / `DeleteAliasesFromCategory` per Part 17 §6.3.4/§6.3.5.
- `AliasNameWildcardMatcher` — Part 4 §7.40 Like operator (`%`, `_`, `[abc]`, `[!abc]`, escape `\`). Walks the input char-by-char so `\_` / `\%` produce a valid escaped regex (the historical Quickstart code generated an invalid `\_` regex).
- `DiagnosticsNodeManager.AliasNames.cs` (partial) — late binder that, after the standard NodeSet has loaded, finds the predefined `Aliases (i=23470)` / `TagVariables (i=23479)` / `Topics (i=23488)` instances and wires their `FindAlias` (plus `Aliases.LastChange`) through the registry. The wiring is *live* — the registry is queried at call time, so stores registered after Diagnostics has started are also reachable. Returns `BadNotImplemented` when no store owns the category.

### Client side — `Libraries/Opc.Ua.Client/AliasNames/`
- `AliasNameClient` — `OpenStandardAliases` / `OpenStandardTagVariables` / `OpenStandardTopics` + arbitrary-root constructor. Covers `FindAliasAsync`, `FindAliasVerboseAsync`, `AddAliasesToCategoryAsync`, `DeleteAliasesFromCategoryAsync`, `EnumerateSubCategoriesAsync` (`IAsyncEnumerable`), `ReadLastChangeAsync`. Hardcoded method-id fast-path for standard categories; cached `TranslateBrowsePathsToNodeIds` resolution for custom ones. Service-level errors translate to typed exceptions (`UnauthorizedAccessException` / `NotSupportedException`).
- `AliasNameResolver` (`IAsyncDisposable`) — alias→`ExpandedNodeId[]` cache with reverse lookup. Default `Manual` refresh; opt-in `AutoOnLastChange` polls the category''s `LastChange` and invalidates on any value-difference (wrap-safe for `VersionTime`).

### Reference server
Wires an `InMemoryAliasNameStore` into the server-wide registry exposing the same TagVariables / Topics samples the old Quickstart sample used (TIC101_Setpoint, TIC101_PV, FIC202_Flow, Pump1_Status, Heater_Power, MultiRefAlias, ServerEvents, AuditEvents). No standalone `AliasNameNodeManager` is required for read-only service of standard categories — the `DiagnosticsNodeManager` late binder handles dispatch.

### Tests
- **Server** (`Tests/Opc.Ua.Server.Tests/AliasNames/`, 45 cases): wildcard matcher (Part 4 §7.40 coverage incl. escapes and character classes), in-memory store (CRUD + per-entry `StatusCode[]` + `LastChange` monotonicity + sub-category cascading), registry (conflict detection + routing + `BadNotImplemented`), node manager (address-space construction, OnCallAsync wiring, role-based mutation guard).
- **Client** (`Tests/Opc.Ua.Client.Tests/AliasNames/`, 15 cases): `AliasNameSessionHarness` mocked `ISession` exercising the four methods, error mapping, resolver behaviour incl. `Invalidate`/reverse lookup, **plus 4 end-to-end integration cases against a live `ReferenceServer`** that prove the `DiagnosticsNodeManager` late binder dispatches the standard `TagVariables.FindAlias` / `Topics.FindAlias` to the registered store across a real OPC UA channel.

## Spec compliance / bugs fixed vs. the previous demo
- `AliasNameDataType.ReferencedNodes` is `ExpandedNodeId[]` per Part 17 §7.2 / NodeSet `i=18` (was `NodeId[]`).
- Null / empty / `References` `ReferenceTypeFilter` matches every alias (was wrongly rejected as `BadInvalidArgument`).
- `\_` and `\%` in wildcards now produce a valid escaped regex (the historical `(?<!\\)_` post-processing left `\_` as `\_` in the final regex, which throws `RegexParseException`).
- `LastChange` is treated as monotonic `VersionTime` (`uint`), wrap-safe — comparison is inequality, not strictly greater-than.
- Mutating methods default to `SecurityAdmin`-only on `SignAndEncrypt` channels (no longer anonymous-callable).
- The parallel-array length contract of `AddAliasesToCategory`/`DeleteAliasesFromCategory` is enforced at the method-handler level (mismatched length → method-level `BadInvalidArgument`).

## Scope explicitly left out
- Annex D PubSub model (`AliasUpdateDataType` / `AliasCategoryUpdateDataType` cross-server replication) is **not** implemented.
- Optional methods (`FindAliasVerbose` / `AddAliasesToCategory` / `DeleteAliasesFromCategory`) are wired only on application-defined categories owned by an `AliasNameNodeManager`. The standard NodeSet instantiates only `FindAlias` (+ `LastChange` on `Aliases`) on the well-known nodes; extending those would require NodeSet changes and is out of scope for this PR.

## Verification
- `dotnet build UA.slnx -c Debug` — clean across all 6 TFMs (net472, net48, netstandard2.1, net8.0, net9.0, net10.0). The pre-existing analyzer warnings in `RoleManager.cs` and `ReferenceNodeManager.cs` are not touched by this PR.
- `dotnet test --filter Category=AliasNames` — 60/60 pass (45 server + 15 client).
- Sanity-checked existing tests still green after the `partial` modifier and new optional interface on `ServerInternalData`: `DiagnosticsNodeManagerTests` ×16, `ConfigurationNodeManagerTests` ×2.

## Reviewer notes
- `Libraries/Opc.Ua.Server/AliasNames/IAliasNameStoreRegistry.cs` — please confirm the `IAliasNameStoreRegistryProvider` opt-in pattern is preferable to widening `IServerInternal`. Designed this way deliberately to avoid breaking external `IServerInternal` implementations / mocks.
- `Libraries/Opc.Ua.Server/Diagnostics/DiagnosticsNodeManager.AliasNames.cs` — late-binder pattern (rather than snapshot at predefined-node activation) is required because custom node managers register their stores after `DiagnosticsNodeManager.CreateAddressSpaceAsync` has already activated its predefined Part 17 nodes.
- This PR is branched directly off `origin/master`; it does not include the FileSystem / nullable / cttunit-support series that the development branch was based on.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
