### PR TITLE
GC reduction via IPooledEncodeable activator pooling

### DIFF
--- a/Docs/MigrationGuide.md
+++ b/Docs/MigrationGuide.md
@@ -1209,6 +1209,48 @@ The `SubscriptionOptions` and `MonitoredItemOptions` records used by this API li
 
 The classic `ManagedSession.Subscriptions` collection (V1 `Subscription` objects) remains supported. Mixing classic subscriptions with the V2 manager on the same session is allowed for the time being, but this will change in future releases; classic subscriptions still receive notifications via the internal `SubscriptionBridge` when the V2 engine is active.
 
+**Opt-in V2 notification pooling (`WithPoolNotifications`):**
+
+The V2 subscription engine supports activator-level pooling of decoded
+notification payload instances (`DataChangeNotification`,
+`MonitoredItemNotification`, `EventNotificationList`, `EventFieldList`) to
+reduce GC pressure on high-throughput publish loops. Pooling is **opt-in**
+and disabled by default. Enable it on the builder, in
+`ManagedSessionOptions`, or directly on the V2 manager:
+
+```csharp
+ManagedSession session = await new ManagedSessionBuilder(configuration, telemetry)
+    .UseEndpoint(endpoint)
+    .WithPoolNotifications()        // opt in
+    .ConnectAsync(ct);
+```
+
+When pooling is enabled, the V2 dispatcher walks each decoded notification
+after the handler `await` completes and calls
+`IPooledEncodeable.Reuse()` on every payload item, returning instances to
+their static activator pools. The recorded benchmarks show ~315× fewer
+allocations per `MonitoredItemNotification` and a corresponding drop in
+gen-0 GC pressure
+(see [`Docs/perf/PooledNotificationBenchmarks.md`](perf/PooledNotificationBenchmarks.md)).
+
+**Handler contract change (only when `WithPoolNotifications` is enabled):**
+Handlers must **not** retain references to notification objects past the
+`await` of the dispatch call. The pool may re-rent those instances to the
+next publish immediately after `Reuse()` runs. Handlers that need to keep
+values must **copy** them out of the dispatched struct before returning.
+The `DataValueChange` / `EventNotification` projection structs are
+designed not to surface pooled instances directly — copy-by-value of the
+struct itself is safe and is the recommended pattern. See
+[`Docs/Sessions.md`](Sessions.md#v2-notification-pooling-opt-in) for full
+detail and a code example.
+
+This affects only the V2 engine; the classic subscription engine is
+unaffected. There is no breaking change to `IEncodeable`,
+`IDecoder`, `IServiceMessageContext`, or
+`ISubscriptionNotificationHandler` — pooling is opt-in via the new
+`IPooledEncodeable` sub-interface, which only the source-generated
+publish-payload types implement today.
+
 **Dependency Injection:**
 
 `AddOpcUaClient` registers a `ManagedSession` factory delegate that lazily connects on first use:

--- a/Docs/Sessions.md
+++ b/Docs/Sessions.md
@@ -410,6 +410,29 @@ The dispatcher is the only framework-initiated `Reuse()` caller.
 Handler code that follows the retain-by-copy rule never reaches
 the unsafe pattern.
 
+### Server-side request/response pooling
+
+On the server side, decoded `IServiceRequest` and `IServiceResponse`
+objects are automatically returned to their activator pools after the
+service handler completes and the response is encoded to the wire.
+This is **unconditional** — no opt-in flag is required — because the
+server framework owns the full lifecycle of both objects:
+
+- The request is decoded by the channel, consumed by the service
+  handler, and never exposed to application code by reference.
+- The response is constructed by the handler, encoded by the channel's
+  `WriteSymmetricMessage` / `BinaryEncoder.EncodeMessage` path, and
+  then has no further consumers.
+
+The reuse calls are placed in `finally` blocks in
+`TcpTransportListener.OnRequestReceivedAsync` (UA-TCP transport) and
+`EndpointBase.InvokeServiceAsync` (HTTPS transport), ensuring both
+objects are released regardless of success or failure.
+
+Server-side node managers and service handlers do not need any code
+changes to benefit from this pooling — it is transparent at the
+channel/transport layer.
+
 ### Choosing an engine
 
 | Scenario | Engine |

--- a/Docs/Sessions.md
+++ b/Docs/Sessions.md
@@ -321,6 +321,95 @@ subscription.TryAddMonitoredItem(
     out IMonitoredItem _);
 ```
 
+### V2 notification pooling (opt-in)
+
+The V2 subscription engine supports activator-level pooling of
+notification payload instances to reduce GC pressure on
+high-throughput publish loops. Pooling is **opt-in** and disabled by
+default. Enable it via `ManagedSessionBuilder.WithPoolNotifications()`,
+the `ManagedSessionOptions.PoolNotifications` init property, or by
+setting `ISubscriptionManager.PoolNotifications = true` directly on
+the V2 manager:
+
+```csharp
+ManagedSession session = await new ManagedSessionBuilder(configuration, telemetry)
+    .UseEndpoint(endpoint)
+    .WithPoolNotifications()        // opt in
+    .ConnectAsync(ct);
+```
+
+How it works:
+
+- Types that opt in to pooling implement `IPooledEncodeable`
+  (a subinterface of `IEncodeable`) and provide a `Reuse()` method
+  that resets fields and returns the instance to its activator's
+  pool. The activator derives from `PooledEncodeableType<T>` instead
+  of `EncodeableType<T>` and owns a bounded, lock-free pool.
+- When `PoolNotifications` is `true`, the V2 subscription
+  dispatcher walks each `DataChangeNotification` /
+  `EventNotificationList` in a `finally` block after the handler
+  await completes, calling `Reuse()` on every payload item that
+  implements `IPooledEncodeable`. Types that do not implement the
+  interface are skipped silently — the walk is universally safe.
+- The walk runs on the subscription's single-reader
+  `ProcessMessageAsync` loop, so it never races the channel decode
+  that produced the payload.
+
+#### Handler contract — retain by copy
+
+When `PoolNotifications` is enabled, handlers **must not** retain a
+reference to a `DataChangeNotification` / `EventNotificationList` /
+`MonitoredItemNotification` / `EventFieldList` past the await of
+the dispatch call. The pool may re-rent those instances to the next
+publish immediately after `Reuse()` runs. Handlers that need to
+keep values must **copy** them out before returning:
+
+```csharp
+public ValueTask OnDataChangeNotificationAsync(
+    ISubscription subscription, uint sequenceNumber,
+    DateTime publishTime,
+    ReadOnlyMemory<DataValueChange> notification,
+    PublishState publishStateMask, IReadOnlyList<string> stringTable)
+{
+    foreach (DataValueChange change in notification.Span)
+    {
+        // OK: DataValueChange is a struct, captured by value.
+        // Value (DataValue) and DiagnosticInfo are not themselves
+        // pooled in this design, so storing them past the call is
+        // safe.
+        m_history.Add(new MyHistoryEntry(
+            change.MonitoredItem?.NodeId,
+            change.Value,           // safe to retain
+            change.DiagnosticInfo));
+    }
+
+    return default;
+}
+```
+
+The `DataValueChange` and `EventNotification` projection structs
+are designed not to surface a reference to a pooled instance —
+they project the inner `DataValue` / `ArrayOf<Variant>` directly,
+which are not themselves pooled. Handlers can safely copy
+`DataValueChange` / `EventNotification` by value and continue to
+use them after the await.
+
+What is **not** safe under pooled mode:
+
+- Retaining the outer `DataChangeNotification` /
+  `EventNotificationList` reference past the await.
+- Retaining individual `MonitoredItemNotification` /
+  `EventFieldList` references past the await.
+- Calling `Reuse()` on a retained reference after the framework
+  has already done so — `Reuse()` is idempotent against accidental
+  double-call (it uses a per-instance sentinel), but the pool may
+  have already re-rented the instance, in which case the late
+  `Reuse()` steals it from its current consumer.
+
+The dispatcher is the only framework-initiated `Reuse()` caller.
+Handler code that follows the retain-by-copy rule never reaches
+the unsafe pattern.
+
 ### Choosing an engine
 
 | Scenario | Engine |

--- a/Docs/perf/PooledNotificationBenchmarks.md
+++ b/Docs/perf/PooledNotificationBenchmarks.md
@@ -1,0 +1,104 @@
+# V2 Subscription Notification Pooling — Benchmark Results
+
+Microbenchmark results for the `IPooledEncodeable` + `PooledEncodeableType<T>`
+activator pooling feature added in support of `ManagedSessionBuilder.WithPoolNotifications()`.
+
+## Source
+
+`Tests/Opc.Ua.Client.Tests/Subscription/PooledNotificationBenchmarks.cs`
+
+## Methodology
+
+- BenchmarkDotNet v0.15.8, `[MemoryDiagnoser]`, `InProcessEmitToolchain` (avoids
+  the cold-rebuild timeout that the default toolchain hits on the test
+  assembly's transitive reference graph).
+- `ShortRun` job: 3 warmup iterations, 3 measured iterations, single launch.
+- Inner loop is `Iterations = 1000` allocate/use cycles per benchmark
+  invocation — measured values are aggregate over the inner loop.
+- Pre-warm in `[GlobalSetup]` populates all four type pools to steady-state
+  before the first measured iteration so the pool-hit fast path is exercised
+  rather than the cold-pool `new T()` fallback.
+
+## Environment
+
+| Item | Value |
+|---|---|
+| OS | Windows 11 (10.0.26200.8390 / 25H2) |
+| CPU | Intel Xeon W-2235 @ 3.80 GHz, 6 physical / 12 logical cores |
+| SDK | .NET SDK 10.0.300 |
+| Host runtime | .NET 10.0.8 (RyuJIT, x86-64-v4) |
+| Config | Release, `c Release -f net10.0` |
+
+## Results
+
+| Method | Mean | Allocated/op | Allocation ratio | Gen0/1000 ops |
+|---|---:|---:|---:|---:|
+| `new MonitoredItemNotification()` *(baseline)* | 33.890 µs | 128,408 B | 1.000 | 29.75 |
+| `MonitoredItemNotificationActivator + Reuse` | **22.134 µs** | **408 B** | **0.003** | **0.092** |
+| `new DataChangeNotification()` | 58.490 µs | 232,344 B | 1.809 | 53.83 |
+| `DataChangeNotificationActivator + Reuse` | **56.175 µs** | **32,344 B** | **0.252** | **7.45** |
+| `new EventFieldList()` | 9.407 µs | 48,408 B | 0.377 | 11.22 |
+| `EventFieldListActivator + Reuse` | **22.537 µs** | **408 B** | **0.003** | **0.092** |
+
+Notes:
+- `MonitoredItemNotification` baseline allocates ~125 KB / 1000 ops; pooled
+  reduces that to **0.3% of baseline** (408 B per 1000 ops — only the
+  `int sum` capture).
+- `DataChangeNotification` baseline includes the inner `MonitoredItemNotification`
+  + the `MonitoredItemNotification[]` backing array. Pooling both the container
+  and the item brings allocation down to **25% of baseline** — the residual is
+  the `MonitoredItemNotification[]` itself (array pooling is explicitly out of
+  scope for this phase; see `Docs/Sessions.md` and Section 9 of the design plan).
+- `EventFieldList` is a degenerate case: the baseline `new` path is already
+  cheap (10 µs) because the struct's empty `EventFields` `ArrayOf<Variant>` does
+  not allocate; the pooled path adds the `Interlocked.CompareExchange` + pool
+  round-trip and ends up slightly slower (22 µs) for this microbench shape.
+  Under the realistic dispatch scenario where each `EventFieldList` carries a
+  non-empty `EventFields`, the allocation savings dominate (similar shape to
+  `MonitoredItemNotification`).
+- `Gen0/1000 ops` drops by orders of magnitude in every pooled case — this is
+  the direct GC-reduction headline.
+
+## Interpretation
+
+For the dominant publish-payload allocator (`MonitoredItemNotification`,
+which arrives in arrays of arbitrary length on every data-change publish):
+
+- Mean time per item drops from ~34 µs/1000 to ~22 µs/1000 (a 35% throughput
+  improvement on the synthetic benchmark, with the gap widening as the inner
+  loop cache-warms).
+- Allocations per 1000 ops drop from 128 KB to 408 B — **~315× reduction**.
+- Gen-0 collections per 1000 ops drop from 29.75 to 0.09 — **~320× reduction**.
+
+The realistic V2 publish workload (1k–10k monitored-item updates per second
+sustained) translates these numbers directly to fewer GC pauses and reduced
+managed-heap churn.
+
+## Reproducing
+
+```pwsh
+# Build release
+dotnet build Tests/Opc.Ua.Client.Tests -c Release -f net10.0
+
+# Run BDN harness
+cd Tests/Opc.Ua.Client.Tests/bin/Release/net10.0
+dotnet Opc.Ua.Client.Tests.dll --filter "*PooledNotificationBenchmarks*"
+```
+
+Artifacts (markdown, csv, html) are written to
+`Tests/Opc.Ua.Client.Tests/bin/Release/net10.0/BenchmarkDotNet.Artifacts/results/`.
+
+## Out of scope
+
+The following payloads are not pooled in this phase (per the design plan,
+`plans/24-subscription-v2-gc-reduction.md` Section 9 "Out of scope") and
+remain attributable to the residual baseline-shaped allocation in the pooled
+`DataChangeNotification` numbers above:
+
+- `DataValue` (built-in, not `IEncodeable`)
+- `Variant` value payload
+- Dispatch backing arrays (`DataValueChange[]`, `EventNotification[]`,
+  `MonitoredItemNotification[]`)
+
+Revisit if a measurement of a full publish loop against the reference server
+shows these as remaining hot spots after the current pooling work lands.

--- a/Libraries/Opc.Ua.Client/Fluent/ManagedSessionBuilder.cs
+++ b/Libraries/Opc.Ua.Client/Fluent/ManagedSessionBuilder.cs
@@ -270,6 +270,32 @@ namespace Opc.Ua.Client
         }
 
         /// <summary>
+        /// Enable activator-level pooling of V2 subscription
+        /// notification payload instances. When enabled, the V2
+        /// subscription dispatcher calls
+        /// <see cref="IPooledEncodeable.Reuse"/> on notification
+        /// payload objects (such as <c>MonitoredItemNotification</c>)
+        /// after each handler dispatch, releasing them back to their
+        /// activator's pool for reuse on the next publish. Handlers
+        /// that retain values past the dispatch call must copy them.
+        /// Disabled by default.
+        /// </summary>
+        /// <remarks>
+        /// Has no effect when the classic subscription engine is in
+        /// use; this option only applies to the V2
+        /// <see cref="Subscriptions.ISubscriptionManager"/>.
+        /// </remarks>
+        public ManagedSessionBuilder WithPoolNotifications(
+            bool poolNotifications = true)
+        {
+            m_options = m_options with
+            {
+                PoolNotifications = poolNotifications
+            };
+            return this;
+        }
+
+        /// <summary>
         /// Use a specific session factory. By default, the builder
         /// creates a new <see cref="DefaultSessionFactory"/> configured with
         /// the V2 subscription engine.
@@ -346,6 +372,7 @@ namespace Opc.Ua.Client
                 opts.CheckDomain,
                 engineFactory,
                 opts.TransferSubscriptionsOnRecreate,
+                opts.PoolNotifications,
                 ct);
         }
     }

--- a/Libraries/Opc.Ua.Client/Fluent/ServiceCollectionExtensions.cs
+++ b/Libraries/Opc.Ua.Client/Fluent/ServiceCollectionExtensions.cs
@@ -187,6 +187,10 @@ namespace Opc.Ua.Client
                 {
                     builder.WithTransferSubscriptionsOnRecreate();
                 }
+                if (options.Session.PoolNotifications)
+                {
+                    builder.WithPoolNotifications();
+                }
 
                 return builder.ConnectAsync(ct);
             }

--- a/Libraries/Opc.Ua.Client/Session/ManagedSession.cs
+++ b/Libraries/Opc.Ua.Client/Session/ManagedSession.cs
@@ -74,7 +74,8 @@ namespace Opc.Ua.Client
             string sessionName,
             uint sessionTimeout,
             bool checkDomain,
-            bool transferSubscriptionsOnRecreate)
+            bool transferSubscriptionsOnRecreate,
+            bool poolNotifications)
         {
             m_configuration = configuration
                 ?? throw new ArgumentNullException(nameof(configuration));
@@ -93,6 +94,7 @@ namespace Opc.Ua.Client
             m_sessionTimeout = sessionTimeout;
             m_checkDomain = checkDomain;
             m_transferSubscriptionsOnRecreate = transferSubscriptionsOnRecreate;
+            m_poolNotifications = poolNotifications;
 
             StateMachine = new ConnectionStateMachine(
                 reconnectPolicy, logger);
@@ -134,6 +136,12 @@ namespace Opc.Ua.Client
         /// subscriptions before falling back to per-subscription
         /// recreate. Default <c>false</c> — recreate is the universal
         /// fallback; transfer requires server support.</param>
+        /// <param name="poolNotifications">When <c>true</c>, the V2
+        /// subscription manager calls <see cref="IPooledEncodeable.Reuse"/>
+        /// on notification payload instances after handler dispatch to
+        /// release them back to their activator pools. Default
+        /// <c>false</c>. See <c>ManagedSessionOptions.PoolNotifications</c>
+        /// for the retain-by-copy contract.</param>
         /// <param name="ct">Cancellation token.</param>
         /// <returns>A connected <see cref="ManagedSession"/>.</returns>
         public static async Task<ManagedSession> CreateAsync(
@@ -150,6 +158,7 @@ namespace Opc.Ua.Client
             bool checkDomain = false,
             ISubscriptionEngineFactory? engineFactory = null,
             bool transferSubscriptionsOnRecreate = false,
+            bool poolNotifications = false,
             CancellationToken ct = default)
         {
             telemetry ??= sessionFactory.Telemetry;
@@ -183,7 +192,8 @@ namespace Opc.Ua.Client
                 sessionName,
                 sessionTimeout,
                 checkDomain,
-                transferSubscriptionsOnRecreate);
+                transferSubscriptionsOnRecreate,
+                poolNotifications);
 
             managed.StateMachine.Start();
             managed.StateMachine.RequestConnect();
@@ -853,13 +863,20 @@ namespace Opc.Ua.Client
                 // setting persists for the entire session lifetime
                 // once applied here. No-op when the classic engine is
                 // in use.
-                if (m_transferSubscriptionsOnRecreate &&
+                if ((m_transferSubscriptionsOnRecreate || m_poolNotifications) &&
                     session.SubscriptionEngine
                         is DefaultSubscriptionEngine v2 &&
                     v2.SubscriptionManager
                         is Subscriptions.SubscriptionManager v2Manager)
                 {
-                    v2Manager.TransferSubscriptionsOnRecreate = true;
+                    if (m_transferSubscriptionsOnRecreate)
+                    {
+                        v2Manager.TransferSubscriptionsOnRecreate = true;
+                    }
+                    if (m_poolNotifications)
+                    {
+                        v2Manager.PoolNotifications = true;
+                    }
                 }
 
                 if (m_redundancyHandler != null)
@@ -1191,6 +1208,7 @@ namespace Opc.Ua.Client
         private readonly uint m_sessionTimeout;
         private readonly bool m_checkDomain;
         private readonly bool m_transferSubscriptionsOnRecreate;
+        private readonly bool m_poolNotifications;
         private ServerRedundancyInfo? m_redundancyInfo;
         private int m_disposed;
     }

--- a/Libraries/Opc.Ua.Client/Session/ManagedSessionOptions.cs
+++ b/Libraries/Opc.Ua.Client/Session/ManagedSessionOptions.cs
@@ -109,5 +109,29 @@ namespace Opc.Ua.Client
         /// V2 manager.
         /// </remarks>
         public bool TransferSubscriptionsOnRecreate { get; init; }
+
+        /// <summary>
+        /// <para>
+        /// When <c>true</c>, opt the V2 subscription engine into
+        /// activator-level pooling of notification payload instances.
+        /// After each publish dispatch the subscription calls
+        /// <see cref="IPooledEncodeable.Reuse"/> on notification objects
+        /// (such as <c>MonitoredItemNotification</c>), releasing them
+        /// back to their activator's pool for reuse on the next decode.
+        /// </para>
+        /// <para>
+        /// Handlers that retain references to notification values past
+        /// the dispatch call must copy the retained values before
+        /// returning from the handler — the pool may re-rent those
+        /// instances to other consumers immediately after the handler
+        /// returns. Default: <c>false</c> (opt-in).
+        /// </para>
+        /// <para>
+        /// Has no effect when the classic subscription engine is in
+        /// use; this option only applies to the V2
+        /// <see cref="Subscriptions.ISubscriptionManager"/>.
+        /// </para>
+        /// </summary>
+        public bool PoolNotifications { get; init; }
     }
 }

--- a/Libraries/Opc.Ua.Client/Subscription/IMessageAckQueue.cs
+++ b/Libraries/Opc.Ua.Client/Subscription/IMessageAckQueue.cs
@@ -62,5 +62,15 @@ namespace Opc.Ua.Client.Subscriptions
         /// should re-evaluate worker counts and resume publishing.
         /// </summary>
         void Update();
+
+        /// <summary>
+        /// Whether the V2 subscription dispatcher should call
+        /// <see cref="IPooledEncodeable.Reuse"/> on notification payload
+        /// instances after the handler returns. The value reflects the
+        /// current <see cref="ISubscriptionManager.PoolNotifications"/>
+        /// setting; toggling it on the manager takes effect on the next
+        /// dispatch.
+        /// </summary>
+        bool PoolNotifications { get; }
     }
 }

--- a/Libraries/Opc.Ua.Client/Subscription/ISubscriptionManager.cs
+++ b/Libraries/Opc.Ua.Client/Subscription/ISubscriptionManager.cs
@@ -89,6 +89,27 @@ namespace Opc.Ua.Client.Subscriptions
         int Count { get; }
 
         /// <summary>
+        /// <para>
+        /// When <c>true</c>, the V2 subscription dispatcher calls
+        /// <see cref="IPooledEncodeable.Reuse"/> on notification payload
+        /// instances (such as <c>MonitoredItemNotification</c>) after
+        /// the handler returns, releasing them back to their
+        /// activator-level pools for reuse.
+        /// </para>
+        /// <para>
+        /// When <c>false</c> (default), instances are simply released
+        /// to the GC as before.
+        /// </para>
+        /// <para>
+        /// Setting this property takes effect on the next publish
+        /// dispatch. Handlers that retain notification values past the
+        /// dispatch call must not enable this option, or must copy the
+        /// retained values before returning from the handler.
+        /// </para>
+        /// </summary>
+        bool PoolNotifications { get; set; }
+
+        /// <summary>
         /// Subscriptions
         /// </summary>
         IEnumerable<ISubscription> Items { get; }

--- a/Libraries/Opc.Ua.Client/Subscription/ISubscriptionNotificationHandler.cs
+++ b/Libraries/Opc.Ua.Client/Subscription/ISubscriptionNotificationHandler.cs
@@ -35,7 +35,24 @@ using Opc.Ua.Client.Subscriptions.MonitoredItems;
 namespace Opc.Ua.Client.Subscriptions
 {
     /// <summary>
-    /// Data Value change notification
+    /// <para>
+    /// Data value change observed on a monitored item during the V2
+    /// publish dispatch.
+    /// </para>
+    /// <para>
+    /// Lifetime note (pooled notifications): when the V2 subscription
+    /// manager has <see cref="ISubscriptionManager.PoolNotifications"/>
+    /// enabled, the underlying <c>MonitoredItemNotification</c> that
+    /// supplied this struct's fields is recycled back to its
+    /// activator pool after the handler returns. This struct's
+    /// references (<see cref="Value"/>, <see cref="DiagnosticInfo"/>)
+    /// project the inner <c>DataValue</c> / <c>DiagnosticInfo</c>
+    /// instances directly — those are not themselves pooled (out of
+    /// scope), so a handler may safely copy this struct by value and
+    /// continue using <see cref="Value"/> after the call. Pool-aware
+    /// projection audit: confirmed safe — no reference to a pooled
+    /// instance is surfaced.
+    /// </para>
     /// </summary>
     /// <param name="MonitoredItem"></param>
     /// <param name="Value"></param>
@@ -44,7 +61,21 @@ namespace Opc.Ua.Client.Subscriptions
         DataValue Value, DiagnosticInfo? DiagnosticInfo);
 
     /// <summary>
-    /// Event notification
+    /// <para>
+    /// Event notification observed during the V2 publish dispatch.
+    /// </para>
+    /// <para>
+    /// Lifetime note (pooled notifications): when the V2 subscription
+    /// manager has <see cref="ISubscriptionManager.PoolNotifications"/>
+    /// enabled, the underlying <c>EventFieldList</c> is recycled back
+    /// to its activator pool after the handler returns. The
+    /// <see cref="Fields"/> property is captured by value as an
+    /// <see cref="ArrayOf{T}"/> wrapping the original event-fields
+    /// array. Arrays are not pooled in this design (out of scope), so
+    /// the captured backing array survives the recycle. Pool-aware
+    /// projection audit: confirmed safe — no reference to a pooled
+    /// instance is surfaced.
+    /// </para>
     /// </summary>
     /// <param name="MonitoredItem"></param>
     /// <param name="Fields"></param>

--- a/Libraries/Opc.Ua.Client/Subscription/MessageProcessor.cs
+++ b/Libraries/Opc.Ua.Client/Subscription/MessageProcessor.cs
@@ -65,6 +65,16 @@ namespace Opc.Ua.Client.Subscriptions
         protected ITelemetryContext Observability { get; }
 
         /// <summary>
+        /// Whether the message processor should release pooled notification
+        /// payload instances back to their activator pools after the handler
+        /// dispatch completes. Reflects the current
+        /// <see cref="IMessageAckQueue.PoolNotifications"/> setting on the
+        /// subscription manager; toggling the manager-level setting takes
+        /// effect on the next dispatch.
+        /// </summary>
+        protected bool PoolNotifications => m_completion.PoolNotifications;
+
+        /// <summary>
         /// Create subscription
         /// </summary>
         /// <param name="services"></param>

--- a/Libraries/Opc.Ua.Client/Subscription/Subscription.cs
+++ b/Libraries/Opc.Ua.Client/Subscription/Subscription.cs
@@ -306,23 +306,88 @@ namespace Opc.Ua.Client.Subscriptions
         }
 
         /// <inheritdoc/>
-        protected override ValueTask OnDataChangeNotificationAsync(uint sequenceNumber,
+        protected override async ValueTask OnDataChangeNotificationAsync(uint sequenceNumber,
             DateTime publishTime, DataChangeNotification notification,
             PublishState publishStateMask, IReadOnlyList<string> stringTable)
         {
-            return m_handler.OnDataChangeNotificationAsync(this, sequenceNumber,
-                publishTime, m_monitoredItems.CreateNotification(notification),
-                publishStateMask, stringTable);
+            try
+            {
+                await m_handler.OnDataChangeNotificationAsync(this, sequenceNumber,
+                    publishTime, m_monitoredItems.CreateNotification(notification),
+                    publishStateMask, stringTable).ConfigureAwait(false);
+            }
+            finally
+            {
+                if (PoolNotifications)
+                {
+                    ReuseDataChangeNotification(notification);
+                }
+            }
         }
 
         /// <inheritdoc/>
-        protected override ValueTask OnEventDataNotificationAsync(uint sequenceNumber,
+        protected override async ValueTask OnEventDataNotificationAsync(uint sequenceNumber,
             DateTime publishTime, EventNotificationList notification,
             PublishState publishStateMask, IReadOnlyList<string> stringTable)
         {
-            return m_handler.OnEventDataNotificationAsync(this, sequenceNumber,
-                publishTime, m_monitoredItems.CreateNotification(notification),
-                publishStateMask, stringTable);
+            try
+            {
+                await m_handler.OnEventDataNotificationAsync(this, sequenceNumber,
+                    publishTime, m_monitoredItems.CreateNotification(notification),
+                    publishStateMask, stringTable).ConfigureAwait(false);
+            }
+            finally
+            {
+                if (PoolNotifications)
+                {
+                    ReuseEventNotificationList(notification);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Walk a dispatched <see cref="DataChangeNotification"/> after the
+        /// handler returns and release pooled payload instances back to
+        /// their activators. Items that do not implement
+        /// <see cref="IPooledEncodeable"/> are skipped silently — this
+        /// allows the walk to be safe before source-gen learns to emit
+        /// the interface for tagged types, and serves as the universal
+        /// dispatch path for any future pooled payload variant.
+        /// </summary>
+        private static void ReuseDataChangeNotification(DataChangeNotification notification)
+        {
+            ReadOnlySpan<MonitoredItemNotification> items =
+                notification.MonitoredItems.Span;
+            for (int i = 0; i < items.Length; i++)
+            {
+                if (items[i] is IPooledEncodeable item)
+                {
+                    item.Reuse();
+                }
+            }
+            if (notification is IPooledEncodeable container)
+            {
+                container.Reuse();
+            }
+        }
+
+        /// <summary>
+        /// Event-side companion to <see cref="ReuseDataChangeNotification"/>.
+        /// </summary>
+        private static void ReuseEventNotificationList(EventNotificationList notification)
+        {
+            ReadOnlySpan<EventFieldList> events = notification.Events.Span;
+            for (int i = 0; i < events.Length; i++)
+            {
+                if (events[i] is IPooledEncodeable evt)
+                {
+                    evt.Reuse();
+                }
+            }
+            if (notification is IPooledEncodeable container)
+            {
+                container.Reuse();
+            }
         }
 
         /// <inheritdoc/>

--- a/Libraries/Opc.Ua.Client/Subscription/SubscriptionManager.cs
+++ b/Libraries/Opc.Ua.Client/Subscription/SubscriptionManager.cs
@@ -89,6 +89,9 @@ namespace Opc.Ua.Client.Subscriptions
         public bool TransferSubscriptionsOnRecreate { get; set; }
 
         /// <inheritdoc/>
+        public bool PoolNotifications { get; set; }
+
+        /// <inheritdoc/>
         public DiagnosticsMasks ReturnDiagnostics { get; set; }
 
         /// <inheritdoc/>

--- a/Libraries/Opc.Ua.Server/Subscription/MonitoredItem/MonitoredItem.cs
+++ b/Libraries/Opc.Ua.Server/Subscription/MonitoredItem/MonitoredItem.cs
@@ -1002,12 +1002,11 @@ namespace Opc.Ua.Server
                     eventFieldValues.Add(Variant.Null);
                 }
             }
-            return new EventFieldList
-            {
-                ClientHandle = ClientHandle,
-                Handle = instance,
-                EventFields = eventFieldValues
-            };
+            var result = (EventFieldList)EventFieldListActivator.Instance.CreateInstance();
+            result.ClientHandle = ClientHandle;
+            result.Handle = instance;
+            result.EventFields = eventFieldValues;
+            return result;
         }
 
         /// <summary>
@@ -1474,7 +1473,9 @@ namespace Opc.Ua.Server
             }
 
             // copy data value.
-            var item = new MonitoredItemNotification { ClientHandle = ClientHandle, Value = value! };
+            var item = (MonitoredItemNotification)MonitoredItemNotificationActivator.Instance.CreateInstance();
+            item.ClientHandle = ClientHandle;
+            item.Value = value!;
 
             // apply timestamp filter.
             if (m_timestampsToReturn is not TimestampsToReturn.Server and not TimestampsToReturn.Both)

--- a/Libraries/Opc.Ua.Server/Subscription/Subscription.cs
+++ b/Libraries/Opc.Ua.Server/Subscription/Subscription.cs
@@ -258,6 +258,10 @@ namespace Opc.Ua.Server
                     }
 
                     m_monitoredItems.Clear();
+                    for (int ii = 0; ii < m_sentMessages.Count; ii++)
+                    {
+                        ReuseNotificationPayloads(m_sentMessages[ii]);
+                    }
                     m_sentMessages.Clear();
                     m_itemsToCheck.Clear();
                     m_itemsToPublish.Clear();
@@ -717,7 +721,9 @@ namespace Opc.Ua.Server
                             m_lastSentMessage--;
                         }
 
+                        NotificationMessage removed = m_sentMessages[ii];
                         m_sentMessages.RemoveAt(ii);
+                        ReuseNotificationPayloads(removed);
                         return null;
                     }
                 }
@@ -1069,6 +1075,10 @@ namespace Opc.Ua.Server
                     overflowCount,
                     Id,
                     m_maxMessageCount);
+                for (int ii = 0; ii < overflowCount; ii++)
+                {
+                    ReuseNotificationPayloads(messages[ii]);
+                }
                 messages.RemoveRange(0, overflowCount);
             }
 
@@ -1082,10 +1092,18 @@ namespace Opc.Ua.Server
 
                 if (m_maxMessageCount <= messages.Count)
                 {
+                    for (int ii = 0; ii < m_sentMessages.Count; ii++)
+                    {
+                        ReuseNotificationPayloads(m_sentMessages[ii]);
+                    }
                     m_sentMessages.Clear();
                 }
                 else
                 {
+                    for (int ii = 0; ii < messages.Count; ii++)
+                    {
+                        ReuseNotificationPayloads(m_sentMessages[ii]);
+                    }
                     m_sentMessages.RemoveRange(0, messages.Count);
                 }
             }
@@ -2766,5 +2784,39 @@ namespace Opc.Ua.Server
         private readonly Dictionary<uint, List<ITriggeredMonitoredItem>> m_itemsToTrigger;
         private readonly bool m_supportsDurable;
         private readonly ILogger m_logger;
+
+        /// <summary>
+        /// Walk a <see cref="NotificationMessage"/> that is being
+        /// discarded (acknowledged or evicted from the retransmission
+        /// queue) and return every pooled notification payload to its
+        /// activator's pool via <see cref="IPooledEncodeable.Reuse"/>.
+        /// </summary>
+        private static void ReuseNotificationPayloads(NotificationMessage message)
+        {
+            ReadOnlySpan<ExtensionObject> data = message.NotificationData.Span;
+            for (int i = 0; i < data.Length; i++)
+            {
+                if (data[i].TryGetValue(out DataChangeNotification? dcn))
+                {
+                    ReadOnlySpan<MonitoredItemNotification> items =
+                        dcn.MonitoredItems.Span;
+                    for (int j = 0; j < items.Length; j++)
+                    {
+                        (items[j] as IPooledEncodeable)?.Reuse();
+                    }
+                    (dcn as IPooledEncodeable)?.Reuse();
+                }
+                else if (data[i].TryGetValue(out EventNotificationList? enl))
+                {
+                    ReadOnlySpan<EventFieldList> events = enl.Events.Span;
+                    for (int j = 0; j < events.Length; j++)
+                    {
+                        (events[j] as IPooledEncodeable)?.Reuse();
+                    }
+                    (enl as IPooledEncodeable)?.Reuse();
+                }
+            }
+            (message as IPooledEncodeable)?.Reuse();
+        }
     }
 }

--- a/Libraries/Opc.Ua.Server/Subscription/Subscription.cs
+++ b/Libraries/Opc.Ua.Server/Subscription/Subscription.cs
@@ -812,11 +812,9 @@ namespace Opc.Ua.Server
             {
                 m_expired = true;
 
-                message = new NotificationMessage
-                {
-                    SequenceNumber = m_sequenceNumber,
-                    PublishTime = DateTimeUtc.Now
-                };
+                message = (NotificationMessage)NotificationMessageActivator.Instance.CreateInstance();
+                message.SequenceNumber = m_sequenceNumber;
+                message.PublishTime = DateTimeUtc.Now;
 
                 Utils.IncrementIdentifier(ref m_sequenceNumber);
 
@@ -825,10 +823,8 @@ namespace Opc.Ua.Server
                     Diagnostics.NextSequenceNumber = m_sequenceNumber;
                 }
 
-                var notification = new StatusChangeNotification
-                {
-                    Status = StatusCodes.BadTimeout
-                };
+                var notification = (StatusChangeNotification)StatusChangeNotificationActivator.Instance.CreateInstance();
+                notification.Status = StatusCodes.BadTimeout;
                 message.NotificationData = message.NotificationData.AddItem(
                     new ExtensionObject(notification));
             }
@@ -845,11 +841,9 @@ namespace Opc.Ua.Server
 
             lock (m_lock)
             {
-                message = new NotificationMessage
-                {
-                    SequenceNumber = m_sequenceNumber,
-                    PublishTime = DateTimeUtc.Now
-                };
+                message = (NotificationMessage)NotificationMessageActivator.Instance.CreateInstance();
+                message.SequenceNumber = m_sequenceNumber;
+                message.PublishTime = DateTimeUtc.Now;
 
                 Utils.IncrementIdentifier(ref m_sequenceNumber);
 
@@ -858,10 +852,8 @@ namespace Opc.Ua.Server
                     Diagnostics.NextSequenceNumber = m_sequenceNumber;
                 }
 
-                var notification = new StatusChangeNotification
-                {
-                    Status = StatusCodes.GoodSubscriptionTransferred
-                };
+                var notification = (StatusChangeNotification)StatusChangeNotificationActivator.Instance.CreateInstance();
+                notification.Status = StatusCodes.GoodSubscriptionTransferred;
                 message.NotificationData =
                     message.NotificationData.AddItem(new ExtensionObject(notification));
             }
@@ -1048,12 +1040,9 @@ namespace Opc.Ua.Server
             if (messages.Count == 0)
             {
                 // create a keep alive message.
-                var message = new NotificationMessage
-                {
-                    // use the sequence number for the next message.
-                    SequenceNumber = m_sequenceNumber,
-                    PublishTime = DateTimeUtc.Now
-                };
+                var message = (NotificationMessage)NotificationMessageActivator.Instance.CreateInstance();
+                message.SequenceNumber = m_sequenceNumber;
+                message.PublishTime = DateTimeUtc.Now;
 
                 // return the available sequence numbers.
                 for (int ii = 0; ii <= m_lastSentMessage && ii < m_sentMessages.Count; ii++)
@@ -1154,11 +1143,9 @@ namespace Opc.Ua.Server
         {
             notificationCount = 0;
 
-            var message = new NotificationMessage
-            {
-                SequenceNumber = m_sequenceNumber,
-                PublishTime = DateTimeUtc.Now
-            };
+            var message = (NotificationMessage)NotificationMessageActivator.Instance.CreateInstance();
+            message.SequenceNumber = m_sequenceNumber;
+            message.PublishTime = DateTimeUtc.Now;
 
             Utils.IncrementIdentifier(ref m_sequenceNumber);
 
@@ -1176,10 +1163,8 @@ namespace Opc.Ua.Server
                     eventList.Add(events.Dequeue());
                     notificationCount++;
                 }
-                var notification = new EventNotificationList
-                {
-                    Events = eventList
-                };
+                var notification = (EventNotificationList)EventNotificationListActivator.Instance.CreateInstance();
+                notification.Events = eventList;
                 message.NotificationData =
                     message.NotificationData.AddItem(new ExtensionObject(notification));
             }
@@ -1207,11 +1192,9 @@ namespace Opc.Ua.Server
                     notificationCount++;
                 }
 
-                var notification = new DataChangeNotification
-                {
-                    MonitoredItems = dataChangeList,
-                    DiagnosticInfos = diagnosticsExist ? diagnosticInfos : default!
-                };
+                var notification = (DataChangeNotification)DataChangeNotificationActivator.Instance.CreateInstance();
+                notification.MonitoredItems = dataChangeList;
+                notification.DiagnosticInfos = diagnosticsExist ? diagnosticInfos : default!;
 
                 message.NotificationData =
                     message.NotificationData.AddItem(new ExtensionObject(notification));

--- a/Stack/Opc.Ua.Core/Stack/Server/EndpointBase.cs
+++ b/Stack/Opc.Ua.Core/Stack/Server/EndpointBase.cs
@@ -259,6 +259,8 @@ namespace Opc.Ua
             SecureChannelContext secureChannelContext,
             CancellationToken cancellationToken)
         {
+            IServiceRequest? serviceRequest = null;
+            IServiceResponse? response = null;
             try
             {
                 // check for bad data.
@@ -276,12 +278,12 @@ namespace Opc.Ua
                     throw new ServiceResultException(StatusCodes.BadInvalidArgument);
                 }
 
-                IServiceRequest serviceRequest = BinaryDecoder.DecodeMessage<IServiceRequest>(
+                serviceRequest = BinaryDecoder.DecodeMessage<IServiceRequest>(
                     request.InvokeServiceRequest,
                     MessageContext);
 
                 // process the request.
-                IServiceResponse response = await ProcessRequestAsync(
+                response = await ProcessRequestAsync(
                     secureChannelContext,
                     serviceRequest,
                     cancellationToken).ConfigureAwait(false);
@@ -302,6 +304,15 @@ namespace Opc.Ua
                 {
                     InvokeServiceResponse = BinaryEncoder.EncodeMessage(fault, MessageContext)
                 };
+            }
+            finally
+            {
+                // Return decoded request and response to their activator
+                // pools for reuse. Both have been fully consumed: the
+                // request by the service handler and the response by the
+                // binary encoder.
+                (serviceRequest as IPooledEncodeable)?.Reuse();
+                (response as IPooledEncodeable)?.Reuse();
             }
         }
 

--- a/Stack/Opc.Ua.Core/Stack/Tcp/TcpTransportListener.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/TcpTransportListener.cs
@@ -1066,6 +1066,7 @@ namespace Opc.Ua.Bindings
             uint requestId,
             IServiceRequest request)
         {
+            IServiceResponse? response = null;
             try
             {
                 if (m_callback != null)
@@ -1078,7 +1079,7 @@ namespace Opc.Ua.Bindings
                         channel.ServerCertificate?.RawData,
                         channel.ChannelThumbprint);
 
-                    IServiceResponse response = await m_callback.ProcessRequestAsync(
+                    response = await m_callback.ProcessRequestAsync(
                         context,
                         request).ConfigureAwait(false);
 
@@ -1128,6 +1129,15 @@ namespace Opc.Ua.Bindings
                         faultEx,
                         "TCPLISTENER - Failed to send fault response to client.");
                 }
+            }
+            finally
+            {
+                // Return decoded request and response to their activator
+                // pools for reuse. Both have been fully consumed at this
+                // point: the request by the service handler and the
+                // response by the channel's wire-encode path.
+                (request as IPooledEncodeable)?.Reuse();
+                (response as IPooledEncodeable)?.Reuse();
             }
         }
 

--- a/Stack/Opc.Ua.Types/Encoders/BoundedObjectPool.cs
+++ b/Stack/Opc.Ua.Types/Encoders/BoundedObjectPool.cs
@@ -1,0 +1,146 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using System.Threading;
+
+namespace Opc.Ua
+{
+    /// <summary>
+    /// <para>
+    /// Bounded lock-free object pool with a single "first item" fast
+    /// slot and a shared array of additional slots reclaimed via
+    /// <see cref="Interlocked.CompareExchange{T}(ref T, T, T)"/>. Modeled
+    /// on the design of <c>Microsoft.Extensions.ObjectPool.DefaultObjectPool</c>
+    /// but hand-rolled here to avoid taking a new public package reference
+    /// on the OPC UA core types assembly.
+    /// </para>
+    /// <para>
+    /// The pool never blocks. A <see cref="Get"/> miss falls through to
+    /// <c>new T()</c>. A <see cref="Return"/> beyond the configured
+    /// maximum drops the instance to the GC. Callers are responsible for
+    /// resetting instance state before returning.
+    /// </para>
+    /// </summary>
+    /// <typeparam name="T">The pooled type. Must be a class with a
+    /// public parameterless constructor.</typeparam>
+    internal sealed class BoundedObjectPool<T> where T : class, new()
+    {
+        private T? m_firstItem;
+        private readonly T?[] m_items;
+        private readonly int m_maximumRetained;
+
+        /// <summary>
+        /// Create a new pool that retains up to <paramref name="maximumRetained"/>
+        /// instances. One slot is reserved as a fast first-item slot
+        /// accessed via <see cref="Interlocked.CompareExchange{T}(ref T, T, T)"/>;
+        /// the remainder live on a shared slot array. Get and Return
+        /// hit the fast slot first.
+        /// </summary>
+        /// <param name="maximumRetained">Upper bound on instances held by
+        /// the pool. Must be positive.</param>
+        public BoundedObjectPool(int maximumRetained)
+        {
+            if (maximumRetained <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(maximumRetained));
+            }
+            m_maximumRetained = maximumRetained;
+            // Subtract one for the first-item slot. If the cap is 1 we
+            // keep an empty shared array and rely on the fast slot alone.
+            m_items = new T?[maximumRetained - 1];
+        }
+
+        /// <summary>
+        /// Maximum number of instances retained by the pool, including
+        /// the fast first-item slot.
+        /// </summary>
+        public int MaximumRetained => m_maximumRetained;
+
+        /// <summary>
+        /// Rent an instance from the pool. Returns a recycled instance
+        /// on a hit; otherwise constructs a fresh instance via
+        /// <c>new T()</c>.
+        /// </summary>
+        public T Get()
+        {
+            T? item = m_firstItem;
+            if (item is not null &&
+                Interlocked.CompareExchange(ref m_firstItem, null, item) == item)
+            {
+                return item;
+            }
+
+            T?[] items = m_items;
+            for (int i = 0; i < items.Length; i++)
+            {
+                item = items[i];
+                if (item is not null &&
+                    Interlocked.CompareExchange(ref items[i], null, item) == item)
+                {
+                    return item;
+                }
+            }
+
+            return new T();
+        }
+
+        /// <summary>
+        /// Return an instance to the pool. The pool may discard the
+        /// instance if it is full. The caller is responsible for
+        /// resetting any mutable state on the instance before calling
+        /// this method.
+        /// </summary>
+        public void Return(T instance)
+        {
+            if (instance is null)
+            {
+                return;
+            }
+
+            if (m_firstItem is null &&
+                Interlocked.CompareExchange(ref m_firstItem, instance, null) is null)
+            {
+                return;
+            }
+
+            T?[] items = m_items;
+            for (int i = 0; i < items.Length; i++)
+            {
+                if (items[i] is null &&
+                    Interlocked.CompareExchange(ref items[i], instance, null) is null)
+                {
+                    return;
+                }
+            }
+
+            // Pool is full; let the instance be collected.
+        }
+    }
+}

--- a/Stack/Opc.Ua.Types/Encoders/IPooledEncodeable.cs
+++ b/Stack/Opc.Ua.Types/Encoders/IPooledEncodeable.cs
@@ -1,0 +1,76 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+namespace Opc.Ua
+{
+    /// <summary>
+    /// <para>
+    /// Opt-in marker for encodeable types that participate in
+    /// activator-level pooling. Implementing this interface is the
+    /// single signal the framework uses to decide whether an instance
+    /// should be returned to its activator's pool after the framework
+    /// is done with it. Plain <see cref="IEncodeable"/> implementations
+    /// are unaffected.
+    /// </para>
+    /// <para>
+    /// The framework calls <see cref="Reuse"/> after the handler
+    /// dispatch completes for instances it created via a pooled
+    /// activator (see <see cref="PooledEncodeableType{T}"/>). Callers
+    /// must not retain a reference to the instance past their own
+    /// <see cref="Reuse"/> call: the pool may re-rent the instance to
+    /// an unrelated consumer at any time after <see cref="Reuse"/>
+    /// returns.
+    /// </para>
+    /// </summary>
+    public interface IPooledEncodeable : IEncodeable
+    {
+        /// <summary>
+        /// <para>
+        /// Reset every mutable field on the instance to its default
+        /// value and return the instance to its activator's pool for
+        /// reuse.
+        /// </para>
+        /// <para>
+        /// Implementations must be idempotent against accidental
+        /// double invocation: the first call resets state and pools
+        /// the instance; subsequent calls on the same reference are
+        /// no-ops. The field reset must complete before the pool
+        /// return so a future rent observes a fully cleared instance.
+        /// </para>
+        /// <para>
+        /// Implementations must not assume the calling thread. The
+        /// framework's only Reuse caller is the V2 subscription
+        /// dispatcher, which runs on the subscription's single-reader
+        /// message loop, but third-party callers may invoke Reuse on
+        /// other threads.
+        /// </para>
+        /// </summary>
+        void Reuse();
+    }
+}

--- a/Stack/Opc.Ua.Types/Encoders/PooledEncodeableType.cs
+++ b/Stack/Opc.Ua.Types/Encoders/PooledEncodeableType.cs
@@ -1,0 +1,131 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System.Xml;
+
+namespace Opc.Ua
+{
+    /// <summary>
+    /// <para>
+    /// Encodeable activator base for types that opt into pooling via
+    /// <see cref="IPooledEncodeable"/>. Maintains a per-activator,
+    /// process-global bounded pool of instances. <see cref="CreateInstance"/>
+    /// rents from the pool (or constructs a new instance on miss) and
+    /// then calls <see cref="InitializeRent"/> so the derived activator
+    /// can clear any per-rent state on the instance (typically a pooled
+    /// sentinel field used by the type's <see cref="IPooledEncodeable.Reuse"/>
+    /// implementation).
+    /// </para>
+    /// <para>
+    /// <see cref="Return"/> is called by the type's
+    /// <see cref="IPooledEncodeable.Reuse"/> body after the instance has
+    /// reset its fields. The pool may drop the instance to the GC when
+    /// the bound is exceeded.
+    /// </para>
+    /// </summary>
+    /// <typeparam name="T">The pooled encodeable type.</typeparam>
+    public abstract class PooledEncodeableType<T> : EncodeableType<T>
+        where T : class, IPooledEncodeable, new()
+    {
+        /// <summary>
+        /// Default upper bound on pooled instances per activator.
+        /// </summary>
+        public const int DefaultMaximumRetained = 1024;
+
+        private readonly BoundedObjectPool<T> m_pool;
+
+        /// <summary>
+        /// Construct a pooled activator with the default
+        /// <see cref="DefaultMaximumRetained"/> bound.
+        /// </summary>
+        protected PooledEncodeableType()
+            : this(DefaultMaximumRetained)
+        {
+        }
+
+        /// <summary>
+        /// Construct a pooled activator with the given upper bound on
+        /// retained instances.
+        /// </summary>
+        /// <param name="maximumRetained">Upper bound on instances held
+        /// by the pool. Must be positive.</param>
+        protected PooledEncodeableType(int maximumRetained)
+        {
+            m_pool = new BoundedObjectPool<T>(maximumRetained);
+        }
+
+        /// <inheritdoc/>
+        public abstract override XmlQualifiedName XmlName { get; }
+
+        /// <summary>
+        /// Maximum number of instances this activator's pool retains.
+        /// </summary>
+        public int MaximumRetained => m_pool.MaximumRetained;
+
+        /// <summary>
+        /// Rent an instance of <typeparamref name="T"/> from the pool,
+        /// or construct a fresh one on a pool miss. After rent the
+        /// <see cref="InitializeRent"/> hook is invoked so the derived
+        /// activator can perform any per-rent reset (e.g. clearing the
+        /// instance's pooled sentinel back to the live state).
+        /// </summary>
+        public sealed override IEncodeable CreateInstance()
+        {
+            T instance = m_pool.Get();
+            InitializeRent(instance);
+            return instance;
+        }
+
+        /// <summary>
+        /// Return <paramref name="instance"/> to the activator's pool
+        /// for reuse. Intended to be called from the type's
+        /// <see cref="IPooledEncodeable.Reuse"/> implementation after
+        /// the instance has reset its fields. Not intended for direct
+        /// caller use.
+        /// </summary>
+        public void Return(T instance)
+        {
+            m_pool.Return(instance);
+        }
+
+        /// <summary>
+        /// Hook invoked on every rent, immediately after the instance
+        /// is obtained from the pool (or newly constructed) and before
+        /// it is returned to the caller of <see cref="CreateInstance"/>.
+        /// Derived activators override this to clear the instance's
+        /// pooled sentinel field. The default implementation is a no-op
+        /// for types whose <see cref="IPooledEncodeable.Reuse"/>
+        /// implementation does not require a separate per-rent reset.
+        /// </summary>
+        /// <param name="instance">The freshly rented instance.</param>
+        protected virtual void InitializeRent(T instance)
+        {
+        }
+    }
+}

--- a/Tests/Opc.Ua.Client.Tests/Session/ManagedSessionComplianceTests.cs
+++ b/Tests/Opc.Ua.Client.Tests/Session/ManagedSessionComplianceTests.cs
@@ -618,6 +618,7 @@ namespace Opc.Ua.Client.Tests.ManagedSession
                         typeof(string),
                         typeof(uint),
                         typeof(bool),
+                        typeof(bool),
                         typeof(bool)
                     ],
                     null);
@@ -635,6 +636,7 @@ namespace Opc.Ua.Client.Tests.ManagedSession
                     default(ArrayOf<string>),
                     "TestManagedSession",
                     60000u,
+                    false,
                     false,
                     false
                 ]);

--- a/Tests/Opc.Ua.Client.Tests/Subscription/Fakes/FakeMessageAckQueue.cs
+++ b/Tests/Opc.Ua.Client.Tests/Subscription/Fakes/FakeMessageAckQueue.cs
@@ -77,5 +77,13 @@ namespace Opc.Ua.Client.Subscriptions.Fakes
         {
             UpdateCalls++;
         }
+
+        /// <summary>
+        /// Test-controlled value for the
+        /// <see cref="IMessageAckQueue.PoolNotifications"/> setter the
+        /// subscription dispatcher reads to decide whether to perform the
+        /// pooled-notification reuse walk.
+        /// </summary>
+        public bool PoolNotifications { get; set; }
     }
 }

--- a/Tests/Opc.Ua.Client.Tests/Subscription/PooledNotificationBenchmarks.cs
+++ b/Tests/Opc.Ua.Client.Tests/Subscription/PooledNotificationBenchmarks.cs
@@ -1,0 +1,211 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+#nullable enable
+
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Engines;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Toolchains.InProcess.Emit;
+using NUnit.Framework;
+
+namespace Opc.Ua.Client.Subscriptions
+{
+    /// <summary>
+    /// Microbenchmark for V2 subscription notification pooling.
+    /// Compares the unpooled <c>new</c> path against the pooled
+    /// <c>CreateInstance() + Reuse()</c> path for each publish-payload
+    /// type tagged <c>Poolable="true"</c> in the design XML
+    /// (<see cref="MonitoredItemNotification"/>,
+    /// <see cref="DataChangeNotification"/>,
+    /// <see cref="EventFieldList"/>,
+    /// <see cref="EventNotificationList"/>).
+    /// </summary>
+    /// <remarks>
+    /// To run interactively:
+    /// <code>
+    /// dotnet test Tests/Opc.Ua.Client.Tests --filter "FullyQualifiedName~PooledNotificationBenchmarks"
+    /// </code>
+    /// To run as a BenchmarkDotNet harness, invoke the test fixture's
+    /// <c>[GlobalSetup]</c>/<c>[Benchmark]</c> via the standard BDN
+    /// runner. The <c>[Test]</c> attributes also let the suite double
+    /// as a smoke test under the unit-test runner.
+    /// </remarks>
+    [TestFixture]
+    [MemoryDiagnoser]
+    [Category("PooledNotificationBenchmarks")]
+    [NonParallelizable]
+    [Config(typeof(InProcessConfig))]
+    public class PooledNotificationBenchmarks
+    {
+        /// <summary>
+        /// In-process toolchain config — skips BDN's auto-generated
+        /// project rebuild (which times out for a test assembly that
+        /// transitively pulls hundreds of references).
+        /// </summary>
+        private sealed class InProcessConfig : ManualConfig
+        {
+            public InProcessConfig()
+            {
+                AddJob(Job.ShortRun
+                    .WithToolchain(InProcessEmitToolchain.Instance)
+                    .WithStrategy(RunStrategy.Throughput));
+            }
+        }
+
+        private const int Iterations = 1000;
+
+        [GlobalSetup]
+        [OneTimeSetUp]
+        public void Setup()
+        {
+            // Pre-warm the pools so the first benchmark iteration
+            // doesn't pay the cost of populating them.
+            for (int i = 0; i < Iterations; i++)
+            {
+                var m = (MonitoredItemNotification)
+                    MonitoredItemNotificationActivator.Instance.CreateInstance();
+                m.Reuse();
+                var d = (DataChangeNotification)
+                    DataChangeNotificationActivator.Instance.CreateInstance();
+                d.Reuse();
+                var e = (EventFieldList)
+                    EventFieldListActivator.Instance.CreateInstance();
+                e.Reuse();
+                var en = (EventNotificationList)
+                    EventNotificationListActivator.Instance.CreateInstance();
+                en.Reuse();
+            }
+        }
+
+        [Benchmark(Baseline = true, Description = "new MonitoredItemNotification()")]
+        [Test]
+        public void UnpooledMonitoredItemNotification()
+        {
+            int sum = 0;
+            for (int i = 0; i < Iterations; i++)
+            {
+                var item = new MonitoredItemNotification
+                {
+                    ClientHandle = (uint)i
+                };
+                sum += (int)item.ClientHandle;
+            }
+            Assert.That(sum, Is.GreaterThanOrEqualTo(0));
+        }
+
+        [Benchmark(Description = "MonitoredItemNotificationActivator + Reuse")]
+        [Test]
+        public void PooledMonitoredItemNotification()
+        {
+            int sum = 0;
+            for (int i = 0; i < Iterations; i++)
+            {
+                var item = (MonitoredItemNotification)
+                    MonitoredItemNotificationActivator.Instance.CreateInstance();
+                item.ClientHandle = (uint)i;
+                sum += (int)item.ClientHandle;
+                item.Reuse();
+            }
+            Assert.That(sum, Is.GreaterThanOrEqualTo(0));
+        }
+
+        [Benchmark(Description = "new DataChangeNotification()")]
+        [Test]
+        public void UnpooledDataChangeNotification()
+        {
+            int count = 0;
+            for (int i = 0; i < Iterations; i++)
+            {
+                var notification = new DataChangeNotification
+                {
+                    MonitoredItems = new MonitoredItemNotification[]
+                    {
+                        new() { ClientHandle = (uint)i }
+                    }
+                };
+                count += notification.MonitoredItems.Count;
+            }
+            Assert.That(count, Is.EqualTo(Iterations));
+        }
+
+        [Benchmark(Description = "DataChangeNotificationActivator + Reuse")]
+        [Test]
+        public void PooledDataChangeNotification()
+        {
+            int count = 0;
+            for (int i = 0; i < Iterations; i++)
+            {
+                var notification = (DataChangeNotification)
+                    DataChangeNotificationActivator.Instance.CreateInstance();
+                var item = (MonitoredItemNotification)
+                    MonitoredItemNotificationActivator.Instance.CreateInstance();
+                item.ClientHandle = (uint)i;
+                notification.MonitoredItems = new MonitoredItemNotification[] { item };
+                count += notification.MonitoredItems.Count;
+                item.Reuse();
+                notification.Reuse();
+            }
+            Assert.That(count, Is.EqualTo(Iterations));
+        }
+
+        [Benchmark(Description = "new EventFieldList()")]
+        [Test]
+        public void UnpooledEventFieldList()
+        {
+            int sum = 0;
+            for (int i = 0; i < Iterations; i++)
+            {
+                var item = new EventFieldList
+                {
+                    ClientHandle = (uint)i
+                };
+                sum += (int)item.ClientHandle;
+            }
+            Assert.That(sum, Is.GreaterThanOrEqualTo(0));
+        }
+
+        [Benchmark(Description = "EventFieldListActivator + Reuse")]
+        [Test]
+        public void PooledEventFieldList()
+        {
+            int sum = 0;
+            for (int i = 0; i < Iterations; i++)
+            {
+                var item = (EventFieldList)
+                    EventFieldListActivator.Instance.CreateInstance();
+                item.ClientHandle = (uint)i;
+                sum += (int)item.ClientHandle;
+                item.Reuse();
+            }
+            Assert.That(sum, Is.GreaterThanOrEqualTo(0));
+        }
+    }
+}

--- a/Tests/Opc.Ua.Client.Tests/Subscription/PooledNotificationDispatchTests.cs
+++ b/Tests/Opc.Ua.Client.Tests/Subscription/PooledNotificationDispatchTests.cs
@@ -1,0 +1,398 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using NUnit.Framework;
+using Opc.Ua.Client.Subscriptions.Fakes;
+using Opc.Ua.Tests;
+
+namespace Opc.Ua.Client.Subscriptions
+{
+    /// <summary>
+    /// Integration tests for V2 publish-dispatch pooled notification
+    /// recycling. Validates that <see cref="IPooledEncodeable.Reuse"/>
+    /// on a source-generated publish-payload type behaves correctly
+    /// end-to-end: it resets fields, returns the instance to its
+    /// activator's static pool, and a subsequent
+    /// <c>CreateInstance()</c> hands the same recycled instance back
+    /// with the sentinel cleared.
+    /// </summary>
+    [TestFixture]
+    [Category("PooledNotificationDispatch")]
+    [NonParallelizable]
+    public sealed class PooledNotificationDispatchTests
+    {
+        [SetUp]
+        public void SetUp()
+        {
+            m_completion = new FakeMessageAckQueue { PoolNotifications = true };
+            m_telemetry = NUnitTelemetryContext.Create();
+            m_mockServices = new Mock<ISubscriptionServiceSetClientMethods>();
+            // Drain process-global pools so per-test instance identity
+            // checks are stable. The pools are static on the closed
+            // generic activator types, so prior tests in the run can
+            // leave instances around; we evict everything we can see.
+            DrainPool(MonitoredItemNotificationActivator.Instance);
+            DrainPool(DataChangeNotificationActivator.Instance);
+            DrainPool(EventFieldListActivator.Instance);
+            DrainPool(EventNotificationListActivator.Instance);
+        }
+
+        [Test]
+        public void GeneratedMonitoredItemNotificationImplementsPooledEncodeable()
+        {
+            var instance = new MonitoredItemNotification();
+            Assert.That(instance, Is.InstanceOf<IPooledEncodeable>());
+        }
+
+        [Test]
+        public void ReuseOnMonitoredItemNotificationResetsFieldsAndReturnsToPool()
+        {
+            // Rent via the activator so the sentinel starts at 0.
+            var rented = (MonitoredItemNotification)
+                MonitoredItemNotificationActivator.Instance.CreateInstance();
+            rented.ClientHandle = 42;
+            rented.Value = new DataValue
+            {
+                StatusCode = StatusCodes.Good,
+                SourceTimestamp = DateTimeUtc.Now
+            };
+
+            rented.Reuse();
+
+            // Fields reset to default.
+            Assert.That(rented.ClientHandle, Is.EqualTo(0u),
+                "Reuse should reset ClientHandle to default(uint)");
+            Assert.That(rented.Value, Is.Null,
+                "Reuse should reset Value to default (null)");
+
+            // Pool should now hand the same reference back.
+            var reRented = (MonitoredItemNotification)
+                MonitoredItemNotificationActivator.Instance.CreateInstance();
+            Assert.That(reRented, Is.SameAs(rented),
+                "Activator should re-rent the instance returned by Reuse");
+        }
+
+        [Test]
+        public void DoubleReuseOnGeneratedTypeIsIdempotent()
+        {
+            var rented = (MonitoredItemNotification)
+                MonitoredItemNotificationActivator.Instance.CreateInstance();
+            rented.Reuse();
+            // Second Reuse must be a no-op: it must not re-add the
+            // instance to the pool. We verify by renting twice — the
+            // first rent gets the original; the second must be a
+            // fresh new instance because the pool only ever held one
+            // entry.
+            rented.Reuse();
+            var first = (MonitoredItemNotification)
+                MonitoredItemNotificationActivator.Instance.CreateInstance();
+            var second = (MonitoredItemNotification)
+                MonitoredItemNotificationActivator.Instance.CreateInstance();
+            Assert.That(first, Is.SameAs(rented));
+            Assert.That(second, Is.Not.SameAs(rented));
+        }
+
+        [Test]
+        public void RentAfterReuseClearsSentinelSoSubsequentReuseStillWorks()
+        {
+            var rented = (MonitoredItemNotification)
+                MonitoredItemNotificationActivator.Instance.CreateInstance();
+            rented.ClientHandle = 7;
+            rented.Reuse();
+            var rerented = (MonitoredItemNotification)
+                MonitoredItemNotificationActivator.Instance.CreateInstance();
+            Assert.That(rerented, Is.SameAs(rented));
+            // After rent, sentinel should be clear; touching and reusing
+            // again should reset the fields and re-pool.
+            rerented.ClientHandle = 99;
+            rerented.Reuse();
+            Assert.That(rerented.ClientHandle, Is.EqualTo(0u));
+            var third = (MonitoredItemNotification)
+                MonitoredItemNotificationActivator.Instance.CreateInstance();
+            Assert.That(third, Is.SameAs(rented),
+                "Sentinel should clear on rent so subsequent Reuse can " +
+                "re-pool the same instance");
+        }
+
+        [Test]
+        public void ReuseOnDataChangeNotificationResetsMonitoredItemsAndPools()
+        {
+            var rented = (DataChangeNotification)
+                DataChangeNotificationActivator.Instance.CreateInstance();
+            rented.MonitoredItems = new MonitoredItemNotification[]
+            {
+                new() { ClientHandle = 1 },
+                new() { ClientHandle = 2 }
+            };
+            Assert.That(rented.MonitoredItems.Count, Is.EqualTo(2));
+            rented.Reuse();
+            Assert.That(rented.MonitoredItems.Count, Is.EqualTo(0),
+                "Reuse should drop the MonitoredItems backing reference");
+            var reRented = (DataChangeNotification)
+                DataChangeNotificationActivator.Instance.CreateInstance();
+            Assert.That(reRented, Is.SameAs(rented));
+        }
+
+        [Test]
+        public void ReuseOnEventFieldListResetsAndPools()
+        {
+            var rented = (EventFieldList)
+                EventFieldListActivator.Instance.CreateInstance();
+            rented.ClientHandle = 12;
+            rented.EventFields = new Variant[] { new(42), new("text") };
+            Assert.That(rented.EventFields.Count, Is.EqualTo(2));
+            rented.Reuse();
+            Assert.That(rented.ClientHandle, Is.EqualTo(0u));
+            Assert.That(rented.EventFields.Count, Is.EqualTo(0));
+            var reRented = (EventFieldList)
+                EventFieldListActivator.Instance.CreateInstance();
+            Assert.That(reRented, Is.SameAs(rented));
+        }
+
+        [Test]
+        public void ReuseOnEventNotificationListResetsAndPools()
+        {
+            var rented = (EventNotificationList)
+                EventNotificationListActivator.Instance.CreateInstance();
+            rented.Events = new EventFieldList[]
+            {
+                new() { ClientHandle = 5 }
+            };
+            Assert.That(rented.Events.Count, Is.EqualTo(1));
+            rented.Reuse();
+            Assert.That(rented.Events.Count, Is.EqualTo(0));
+            var reRented = (EventNotificationList)
+                EventNotificationListActivator.Instance.CreateInstance();
+            Assert.That(reRented, Is.SameAs(rented));
+        }
+
+        [Test]
+        public async Task DispatcherCallsReuseOnPayloadWhenPoolNotificationsEnabledAsync()
+        {
+            // Wire a TestMessageProcessor that mirrors the V2
+            // Subscription dispatch contract: on data change, walk the
+            // notification and call Reuse() on each pooled item
+            // (matching the production code in Subscription.cs).
+            DrainPool(MonitoredItemNotificationActivator.Instance);
+            DrainPool(DataChangeNotificationActivator.Instance);
+
+            // Rent payload items from the activators so we have known
+            // instance identities to assert pool re-entry against.
+            var monitoredItem = (MonitoredItemNotification)
+                MonitoredItemNotificationActivator.Instance.CreateInstance();
+            monitoredItem.ClientHandle = 17;
+            var dataChange = (DataChangeNotification)
+                DataChangeNotificationActivator.Instance.CreateInstance();
+            dataChange.MonitoredItems = new[] { monitoredItem };
+
+            var stringTable = new List<string>();
+            var availableSeq = new List<uint>();
+            var sut = new TestMessageProcessor(m_mockServices.Object,
+                m_completion, m_telemetry)
+            {
+                Id = 1
+            };
+            await using (sut.ConfigureAwait(false))
+            {
+                await sut.OnPublishReceivedAsync(new NotificationMessage
+                {
+                    SequenceNumber = 1,
+                    NotificationData =
+                    [
+                        new ExtensionObject(dataChange)
+                    ]
+                }, availableSeq, stringTable).ConfigureAwait(false);
+
+                await sut.DataChangeNotificationReceived
+                    .WaitAsync()
+                    .WaitAsync(TimeSpan.FromSeconds(5))
+                    .ConfigureAwait(false);
+            }
+
+            // After the dispatcher finally runs the reuse walk, the
+            // activator's pool should contain our items. Rent and check
+            // identity to verify pooling actually happened.
+            var rentedItem = (MonitoredItemNotification)
+                MonitoredItemNotificationActivator.Instance.CreateInstance();
+            var rentedContainer = (DataChangeNotification)
+                DataChangeNotificationActivator.Instance.CreateInstance();
+            Assert.That(rentedItem, Is.SameAs(monitoredItem),
+                "Pool should hand back the MonitoredItemNotification that " +
+                "was reused after dispatch");
+            Assert.That(rentedContainer, Is.SameAs(dataChange),
+                "Pool should hand back the DataChangeNotification that was " +
+                "reused after dispatch");
+            Assert.That(rentedItem.ClientHandle, Is.EqualTo(0u),
+                "Reused MonitoredItemNotification should have been reset");
+        }
+
+        [Test]
+        public async Task DispatcherSkipsReuseWalkWhenPoolNotificationsDisabledAsync()
+        {
+            DrainPool(MonitoredItemNotificationActivator.Instance);
+            m_completion.PoolNotifications = false;
+
+            var monitoredItem = new MonitoredItemNotification { ClientHandle = 99 };
+            var dataChange = new DataChangeNotification
+            {
+                MonitoredItems = new[] { monitoredItem }
+            };
+
+            var stringTable = new List<string>();
+            var availableSeq = new List<uint>();
+            var sut = new TestMessageProcessor(m_mockServices.Object,
+                m_completion, m_telemetry)
+            {
+                Id = 1
+            };
+            await using (sut.ConfigureAwait(false))
+            {
+                await sut.OnPublishReceivedAsync(new NotificationMessage
+                {
+                    SequenceNumber = 1,
+                    NotificationData =
+                    [
+                        new ExtensionObject(dataChange)
+                    ]
+                }, availableSeq, stringTable).ConfigureAwait(false);
+
+                await sut.DataChangeNotificationReceived
+                    .WaitAsync()
+                    .WaitAsync(TimeSpan.FromSeconds(5))
+                    .ConfigureAwait(false);
+            }
+
+            // Pool is empty: nothing was returned because the dispatcher
+            // skipped the reuse walk. CreateInstance allocates a fresh.
+            var fresh = (MonitoredItemNotification)
+                MonitoredItemNotificationActivator.Instance.CreateInstance();
+            Assert.That(fresh, Is.Not.SameAs(monitoredItem),
+                "PoolNotifications=false must not return instances to pool");
+            // The original item's fields must NOT have been reset by the
+            // dispatcher (since the reuse walk was skipped).
+            Assert.That(monitoredItem.ClientHandle, Is.EqualTo(99u),
+                "PoolNotifications=false must leave the payload untouched");
+        }
+
+        /// <summary>
+        /// Rent and discard up to <paramref name="limit"/> instances from
+        /// the activator to drain its pool to empty (or near-empty) before
+        /// a test runs. The static pools are process-global so prior
+        /// tests in the same run can leave entries that confuse identity
+        /// assertions.
+        /// </summary>
+        private static void DrainPool<T>(PooledEncodeableType<T> activator,
+            int limit = 64)
+            where T : class, IPooledEncodeable, new()
+        {
+            // CreateInstance always returns an instance; we can't tell
+            // pool hit from miss from outside. Rent up to `limit` items;
+            // dropped references will be collected eventually.
+            for (int i = 0; i < limit; i++)
+            {
+                _ = activator.CreateInstance();
+            }
+        }
+
+        private sealed class TestMessageProcessor : MessageProcessor
+        {
+            public TestMessageProcessor(ISubscriptionServiceSetClientMethods session,
+                IMessageAckQueue completion, ITelemetryContext telemetry)
+                : base(session, completion, telemetry)
+            {
+            }
+
+            public AsyncManualResetEvent DataChangeNotificationReceived { get; } = new();
+            public AsyncManualResetEvent EventNotificationReceived { get; } = new();
+            public AsyncManualResetEvent KeepAliveNotificationReceived { get; } = new();
+            public AsyncManualResetEvent StatusChangeNotificationReceived { get; } = new();
+
+            protected override ValueTask OnDataChangeNotificationAsync(uint sequenceNumber,
+                DateTime publishTime, DataChangeNotification notification,
+                PublishState publishStateMask, IReadOnlyList<string> stringTable)
+            {
+                DataChangeNotificationReceived.Set();
+                if (PoolNotifications)
+                {
+                    // Mirror the production reuse walk from
+                    // Subscription.cs. Tested here in isolation so we
+                    // don't drag in the full Subscription stack.
+                    ReadOnlySpan<MonitoredItemNotification> items =
+                        notification.MonitoredItems.Span;
+                    for (int i = 0; i < items.Length; i++)
+                    {
+                        if (items[i] is IPooledEncodeable p)
+                        {
+                            p.Reuse();
+                        }
+                    }
+                    if (notification is IPooledEncodeable container)
+                    {
+                        container.Reuse();
+                    }
+                }
+                return default;
+            }
+
+            protected override ValueTask OnEventDataNotificationAsync(uint sequenceNumber,
+                DateTime publishTime, EventNotificationList notification,
+                PublishState publishStateMask, IReadOnlyList<string> stringTable)
+            {
+                EventNotificationReceived.Set();
+                return default;
+            }
+
+            protected override ValueTask OnKeepAliveNotificationAsync(uint sequenceNumber,
+                DateTime publishTime, PublishState publishStateMask)
+            {
+                KeepAliveNotificationReceived.Set();
+                return default;
+            }
+
+            protected override ValueTask OnStatusChangeNotificationAsync(uint sequenceNumber,
+                DateTime publishTime, StatusChangeNotification notification,
+                PublishState publishStateMask, IReadOnlyList<string> stringTable)
+            {
+                StatusChangeNotificationReceived.Set();
+                return default;
+            }
+        }
+
+        private FakeMessageAckQueue m_completion = null!;
+        private ITelemetryContext m_telemetry = null!;
+        private Mock<ISubscriptionServiceSetClientMethods> m_mockServices = null!;
+    }
+}

--- a/Tests/Opc.Ua.Types.Tests/Encoders/PooledEncodeableTypeTests.cs
+++ b/Tests/Opc.Ua.Types.Tests/Encoders/PooledEncodeableTypeTests.cs
@@ -1,0 +1,253 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Xml;
+using NUnit.Framework;
+
+#nullable enable
+
+namespace Opc.Ua.Types.Tests.Encoders
+{
+    /// <summary>
+    /// Tests for <see cref="PooledEncodeableType{T}"/> and the
+    /// <see cref="IPooledEncodeable"/> reuse contract.
+    /// </summary>
+    [TestFixture]
+    [Category("PooledEncodeableType")]
+    [SetCulture("en-us")]
+    [SetUICulture("en-us")]
+    [Parallelizable(ParallelScope.Fixtures)]
+    public sealed class PooledEncodeableTypeTests
+    {
+        [Test]
+        public void RentReturnRentReusesTheSameInstance()
+        {
+            var activator = new TestPooledActivator();
+            var rentedFirst = (TestPooled)activator.CreateInstance();
+            rentedFirst.Reuse();
+            var rentedSecond = (TestPooled)activator.CreateInstance();
+            Assert.That(rentedSecond, Is.SameAs(rentedFirst));
+        }
+
+        [Test]
+        public void DoubleReuseIsIdempotentAndDoesNotDoubleReturn()
+        {
+            var activator = new TestPooledActivator();
+            var rented = (TestPooled)activator.CreateInstance();
+            rented.Reuse();
+            rented.Reuse();
+            // After two reuses the pool should contain exactly one instance.
+            var nextRent = (TestPooled)activator.CreateInstance();
+            Assert.That(nextRent, Is.SameAs(rented));
+            // The second rent in succession should be a fresh instance because
+            // the pool already handed `rented` back out.
+            var freshAfterPool = (TestPooled)activator.CreateInstance();
+            Assert.That(freshAfterPool, Is.Not.SameAs(rented));
+        }
+
+        [Test]
+        public void RentClearsTheSentinelSoSubsequentReuseDoesRealWork()
+        {
+            var activator = new TestPooledActivator();
+            var rented = (TestPooled)activator.CreateInstance();
+            rented.Touch();
+            rented.Reuse();
+            // Re-rent should clear the sentinel; touch again so we can verify
+            // that the next Reuse runs (resets and returns).
+            var rerented = (TestPooled)activator.CreateInstance();
+            Assert.That(rerented, Is.SameAs(rented));
+            rerented.Touch();
+            Assert.That(rerented.IsTouched, Is.True);
+            rerented.Reuse();
+            // After Reuse, fields must be reset.
+            Assert.That(rerented.IsTouched, Is.False);
+        }
+
+        [Test]
+        public void ReturnsBeyondMaximumRetainedAreDroppedToGc()
+        {
+            const int cap = 4;
+            var activator = new TestPooledActivator(cap);
+            var rented = new TestPooled[cap + 4];
+            for (int i = 0; i < rented.Length; i++)
+            {
+                rented[i] = (TestPooled)activator.CreateInstance();
+            }
+            for (int i = 0; i < rented.Length; i++)
+            {
+                rented[i].Reuse();
+            }
+            // The pool keeps exactly `cap` instances (one fast slot plus
+            // cap-1 shared). Renting `cap` times should produce pool-stored
+            // originals; the (cap+1)th rent falls through to `new T()`.
+            int matched = 0;
+            for (int i = 0; i < cap + 1; i++)
+            {
+                var instance = (TestPooled)activator.CreateInstance();
+                for (int j = 0; j < rented.Length; j++)
+                {
+                    if (ReferenceEquals(instance, rented[j]))
+                    {
+                        matched++;
+                        break;
+                    }
+                }
+            }
+            Assert.That(matched, Is.EqualTo(cap),
+                "exactly `cap` instances should have been retained and re-rented");
+        }
+
+        [Test]
+        public void ConcurrentRentReturnIsSafe()
+        {
+            var activator = new TestPooledActivator(maximumRetained: 64);
+            const int iterations = 5000;
+            const int threads = 8;
+            var seen = new ConcurrentBag<TestPooled>();
+
+            Parallel.For(0, threads, _ =>
+            {
+                for (int i = 0; i < iterations; i++)
+                {
+                    var instance = (TestPooled)activator.CreateInstance();
+                    seen.Add(instance);
+                    instance.Touch();
+                    instance.Reuse();
+                }
+            });
+
+            // Every observed instance must be in a clean state after Reuse.
+            // Concurrent rent/return must not have left any instance in a
+            // partially-reset state, and must not throw.
+            foreach (TestPooled instance in seen)
+            {
+                Assert.That(instance.IsTouched, Is.False,
+                    "Reuse() must reset the touch flag");
+            }
+        }
+
+        [Test]
+        public void CreateInstanceReturnsFreshInstanceWhenPoolIsEmpty()
+        {
+            var activator = new TestPooledActivator();
+            var a = (TestPooled)activator.CreateInstance();
+            var b = (TestPooled)activator.CreateInstance();
+            Assert.That(a, Is.Not.SameAs(b));
+        }
+
+        [Test]
+        public void ReuseResetsFieldsBeforeReturningToPool()
+        {
+            var activator = new TestPooledActivator();
+            var rented = (TestPooled)activator.CreateInstance();
+            rented.Touch();
+            Assert.That(rented.IsTouched, Is.True);
+            rented.Reuse();
+            Assert.That(rented.IsTouched, Is.False);
+        }
+
+        [Test]
+        public void MaximumRetainedReportsConfiguredValue()
+        {
+            var activator = new TestPooledActivator(maximumRetained: 7);
+            Assert.That(activator.MaximumRetained, Is.EqualTo(7));
+        }
+
+        [Test]
+        public void PooledActivatorConstructorRejectsNonPositiveBound()
+        {
+            Assert.That(() => new TestPooledActivator(maximumRetained: 0),
+                Throws.TypeOf<ArgumentOutOfRangeException>());
+            Assert.That(() => new TestPooledActivator(maximumRetained: -1),
+                Throws.TypeOf<ArgumentOutOfRangeException>());
+        }
+
+        [SuppressMessage("Performance", "CA1812:Avoid uninstantiated internal classes",
+            Justification = "Instantiated via PooledEncodeableType<T>.CreateInstance through the `new()` constraint.")]
+        private sealed class TestPooled : IPooledEncodeable
+        {
+            private int m_pooledSentinel;
+            private bool m_touched;
+            private TestPooledActivator? m_activator;
+
+            public ExpandedNodeId TypeId => ExpandedNodeId.Null;
+            public ExpandedNodeId BinaryEncodingId => ExpandedNodeId.Null;
+            public ExpandedNodeId XmlEncodingId => ExpandedNodeId.Null;
+
+            public bool IsTouched => m_touched;
+            public void Touch() => m_touched = true;
+
+            public void Encode(IEncoder encoder) { }
+            public void Decode(IDecoder decoder) { }
+            public bool IsEqual(IEncodeable? encodeable) => ReferenceEquals(this, encodeable);
+            public object Clone() => MemberwiseClone();
+
+            public void Reuse()
+            {
+                if (Interlocked.CompareExchange(ref m_pooledSentinel, 1, 0) != 0)
+                {
+                    return;
+                }
+                m_touched = false;
+                m_activator?.Return(this);
+            }
+
+            internal void OnRent(TestPooledActivator activator)
+            {
+                m_activator = activator;
+                Volatile.Write(ref m_pooledSentinel, 0);
+            }
+        }
+
+        private sealed class TestPooledActivator : PooledEncodeableType<TestPooled>
+        {
+            public TestPooledActivator() : base()
+            {
+            }
+
+            public TestPooledActivator(int maximumRetained)
+                : base(maximumRetained)
+            {
+            }
+
+            public override XmlQualifiedName XmlName { get; }
+                = new XmlQualifiedName("TestPooled", "urn:test");
+
+            protected override void InitializeRent(TestPooled instance)
+            {
+                instance.OnRent(this);
+            }
+        }
+    }
+}

--- a/Tools/Opc.Ua.SourceGeneration.Core/Generators/DataTypeGenerator.cs
+++ b/Tools/Opc.Ua.SourceGeneration.Core/Generators/DataTypeGenerator.cs
@@ -82,6 +82,11 @@ namespace Opc.Ua.SourceGeneration
                 LoadTemplate_ListOfTypes,
                 WriteTemplate_ListOfTypes);
             template.AddReplacement(
+                Tokens.ListOfPooledExtensions,
+                datatypes,
+                LoadTemplate_ListOfPooledExtensions,
+                WriteTemplate_ListOfTypes);
+            template.AddReplacement(
                 Tokens.ListOfDataTypeDefinitions,
                 datatypes,
                 LoadTemplate_ListOfDataTypeDefinitions,
@@ -117,7 +122,14 @@ namespace Opc.Ua.SourceGeneration
                 datatype.IsStructure &&
                 !datatype.IsAbstract)
             {
-                return DataTypeTemplates.StructureActivatorClass;
+                // Types that live in the Opc.Ua.Types library don't get
+                // the IPooledEncodeable partial emitted (they're not
+                // generated in this assembly) so they can't satisfy the
+                // PooledEncodeableType<T> constraint. Use the plain
+                // EncodeableType<T> for them.
+                return datatype.IsPartOfOpcUaTypesLibrary()
+                    ? DataTypeTemplates.StructureActivatorClass
+                    : DataTypeTemplates.PooledStructureActivatorClass;
             }
             if (datatype.BasicDataType == BasicDataType.Enumeration &&
                 datatype.IsEnumeration)
@@ -125,6 +137,64 @@ namespace Opc.Ua.SourceGeneration
                 return DataTypeTemplates.EnumerationActivatorClass;
             }
             return null;
+        }
+
+        /// <summary>
+        /// Selector for the supplemental <c>partial class</c> body that
+        /// implements <see cref="IPooledEncodeable"/> on concrete
+        /// structure types. All concrete non-abstract structures are
+        /// poolable — this includes service request/response types and
+        /// notification payload types.
+        /// </summary>
+        private TemplateString LoadTemplate_ListOfPooledExtensions(ILoadContext context)
+        {
+            if (context.Target is not DataTypeDesign datatype ||
+                datatype.IsPartOfOpcUaTypesLibrary())
+            {
+                return null;
+            }
+            if (datatype.BasicDataType == BasicDataType.UserDefined &&
+                datatype.IsStructure &&
+                !datatype.IsAbstract)
+            {
+                return HasPoolableBase(datatype)
+                    ? DataTypeTemplates.DerivedPooledExtensionClass
+                    : DataTypeTemplates.PooledExtensionClass;
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Returns true when the data type derives from another
+        /// concrete structure type that will itself receive a pooled
+        /// extension in this compilation — meaning the sentinel field,
+        /// <c>Reuse()</c> and <c>ClearPooledSentinel()</c> are
+        /// inherited from that base and the derived type must use
+        /// <c>new</c> to hide them. Walks up the inheritance chain
+        /// to find the first non-abstract ancestor that is a
+        /// generated structure (not in the Opc.Ua.Types library).
+        /// </summary>
+        private static bool HasPoolableBase(DataTypeDesign datatype)
+        {
+            DataTypeDesign current = datatype.BaseTypeNode as DataTypeDesign;
+            while (current is not null)
+            {
+                if (current.BasicDataType == BasicDataType.Structure)
+                {
+                    return false;
+                }
+
+                if (current.BasicDataType == BasicDataType.UserDefined &&
+                    current.IsStructure &&
+                    !current.IsAbstract &&
+                    !current.IsPartOfOpcUaTypesLibrary())
+                {
+                    return true;
+                }
+
+                current = current.BaseTypeNode as DataTypeDesign;
+            }
+            return false;
         }
 
         private TemplateString LoadTemplate_ListOfActivatorRegistrations(ILoadContext context)
@@ -635,6 +705,11 @@ namespace Opc.Ua.SourceGeneration
                 Tokens.ListOfFieldInitializers,
                 fields,
                 LoadTemplate_ListOfFieldInitializers);
+
+            context.Template.AddReplacement(
+                Tokens.ListOfFieldResets,
+                fields,
+                LoadTemplate_ListOfFieldResets);
 
             context.Template.AddReplacement(
                 Tokens.ListOfFields,
@@ -1153,6 +1228,26 @@ namespace Opc.Ua.SourceGeneration
                     field.DefaultValue));
 
             context.Out.WriteLine("{0} = {1};", field.GetChildFieldName(), value);
+            return null;
+        }
+
+        /// <summary>
+        /// Emits one assignment per declared field in the form
+        /// <c>m_field = default;</c>. Used by the
+        /// <c>PooledExtensionClass</c> template to reset all fields
+        /// before returning the instance to its activator's pool.
+        /// <c>default</c> covers reference types (assigns <c>null</c>),
+        /// value types (zero), and <see cref="ArrayOf{T}"/> /
+        /// <c>ReadOnlyMemory&lt;T&gt;</c>-backed structs (drops the
+        /// backing reference).
+        /// </summary>
+        private TemplateString LoadTemplate_ListOfFieldResets(ILoadContext context)
+        {
+            if (context.Target is not Parameter field)
+            {
+                return null;
+            }
+            context.Out.WriteLine("{0} = default;", field.GetChildFieldName());
             return null;
         }
 

--- a/Tools/Opc.Ua.SourceGeneration.Core/Generators/DataTypeTemplates.cs
+++ b/Tools/Opc.Ua.SourceGeneration.Core/Generators/DataTypeTemplates.cs
@@ -47,6 +47,8 @@ namespace Opc.Ua.SourceGeneration
             {
                 {{Tokens.ListOfTypes}}
 
+                {{Tokens.ListOfPooledExtensions}}
+
                 {{Tokens.ListOfTypeActivators}}
 
                 /// <summary>
@@ -182,6 +184,112 @@ namespace Opc.Ua.SourceGeneration
                 public override global::Opc.Ua.IEncodeable CreateInstance()
                 {
                     return new {{Tokens.ClassName}}();
+                }
+            }
+            """);
+
+        /// <summary>
+        /// Pooled-encodeable activator. Emitted in place of
+        /// <see cref="StructureActivatorClass"/> when the design XML
+        /// marks the complex type with <c>Poolable="true"</c>. Derives
+        /// from <c>PooledEncodeableType&lt;T&gt;</c> so the activator
+        /// itself owns a bounded per-type pool. The
+        /// <c>InitializeRent</c> override clears the per-instance
+        /// pooled sentinel each time an instance is handed out so the
+        /// next <c>Reuse()</c> call does real work instead of being
+        /// no-op'd by the idempotency guard.
+        /// </summary>
+        public static readonly TemplateString PooledStructureActivatorClass = TemplateString.Parse(
+            $$"""
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("{{Tokens.Tool}}", "{{Tokens.Version}}")]
+            [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute()]
+            public sealed class {{Tokens.ClassName}}Activator : global::Opc.Ua.PooledEncodeableType<{{Tokens.ClassName}}>
+            {
+                /// <summary>
+                /// The singleton instance of the activator.
+                /// </summary>
+                public static readonly {{Tokens.ClassName}}Activator Instance
+                    = new {{Tokens.ClassName}}Activator();
+
+                /// <inheritdoc/>
+                public override global::System.Xml.XmlQualifiedName XmlName { get; } =
+                    new global::System.Xml.XmlQualifiedName("{{Tokens.ClassName}}", {{Tokens.XmlNamespaceUri}});
+
+                /// <inheritdoc/>
+                protected override void InitializeRent({{Tokens.ClassName}} instance)
+                {
+                    instance.ClearPooledSentinel();
+                }
+            }
+            """);
+
+        /// <summary>
+        /// Supplemental partial-class body emitted for complex types
+        /// tagged <c>Poolable="true"</c>. Adds
+        /// <see cref="IPooledEncodeable"/> to the type's base list,
+        /// declares the per-instance pooled sentinel, and implements
+        /// <c>Reuse()</c> as a CAS-guarded idempotent field reset
+        /// that returns the instance to its activator's pool. The
+        /// existing <see cref="Class"/> / <see cref="DerivedClass"/>
+        /// / <see cref="ClassWithOptionalFields"/> /
+        /// <see cref="DerivedClassWithOptionalFields"/> body is
+        /// emitted unchanged; this template is appended after it.
+        /// </summary>
+        public static readonly TemplateString PooledExtensionClass = TemplateString.Parse(
+            $$"""
+            public partial class {{Tokens.ClassName}} : global::Opc.Ua.IPooledEncodeable
+            {
+                private int m_pooledSentinel;
+
+                /// <inheritdoc/>
+                public void Reuse()
+                {
+                    if (global::System.Threading.Interlocked.CompareExchange(
+                        ref m_pooledSentinel, 1, 0) != 0)
+                    {
+                        return;
+                    }
+                    {{Tokens.ListOfFieldResets}}
+                    {{Tokens.ClassName}}Activator.Instance.Return(this);
+                }
+
+                internal void ClearPooledSentinel()
+                {
+                    global::System.Threading.Volatile.Write(ref m_pooledSentinel, 0);
+                }
+            }
+            """);
+
+        /// <summary>
+        /// Variant of <see cref="PooledExtensionClass"/> for derived
+        /// types whose base class already declares Reuse and
+        /// ClearPooledSentinel. Uses <c>new</c> on the public/internal
+        /// methods to hide the inherited versions so each concrete type
+        /// routes through its own activator's pool. The sentinel field
+        /// is always <c>private</c> (not inherited) so no <c>new</c>
+        /// is needed on it.
+        /// </summary>
+        public static readonly TemplateString DerivedPooledExtensionClass = TemplateString.Parse(
+            $$"""
+            public partial class {{Tokens.ClassName}} : global::Opc.Ua.IPooledEncodeable
+            {
+                private int m_pooledSentinel;
+
+                /// <inheritdoc/>
+                public new void Reuse()
+                {
+                    if (global::System.Threading.Interlocked.CompareExchange(
+                        ref m_pooledSentinel, 1, 0) != 0)
+                    {
+                        return;
+                    }
+                    {{Tokens.ListOfFieldResets}}
+                    {{Tokens.ClassName}}Activator.Instance.Return(this);
+                }
+
+                internal new void ClearPooledSentinel()
+                {
+                    global::System.Threading.Volatile.Write(ref m_pooledSentinel, 0);
                 }
             }
             """);

--- a/Tools/Opc.Ua.SourceGeneration.Core/Templating/Tokens.cs
+++ b/Tools/Opc.Ua.SourceGeneration.Core/Templating/Tokens.cs
@@ -223,5 +223,7 @@ namespace Opc.Ua.SourceGeneration
         public static string AccessLevelValue => nameof(AccessLevelValue);
         public static string UserAccessLevelValue => nameof(UserAccessLevelValue);
         public static string ListOfInitOnlyBackingFields => nameof(ListOfInitOnlyBackingFields);
+        public static string ListOfPooledExtensions => nameof(ListOfPooledExtensions);
+        public static string ListOfFieldResets => nameof(ListOfFieldResets);
     }
 }


### PR DESCRIPTION
## Proposed changes

Add opt-in activator-level pooling for `IEncodeable` instances decoded during V2 subscription publish dispatch, significantly reducing GC pressure on high-throughput publish loops.

### Design

This design pushes pooling into the **encodeable activator** (`PooledEncodeableType<T> : EncodeableType<T>`):

- A new `IPooledEncodeable : IEncodeable` opt-in marker interface adds a single `Reuse()` method
- `PooledEncodeableType<T>` owns a bounded lock-free per-type pool (`BoundedObjectPool<T>`, hand-rolled to avoid a new package dependency)
- The source generator emits `PooledEncodeableType<T>` activators and `IPooledEncodeable.Reuse()` bodies for **all concrete non-abstract structure types** (including service request/response types)
- The V2 `Subscription` dispatcher walks the response in a `finally` block after handler dispatch and calls `Reuse()` on each pooled payload item, gated by `PoolNotifications`
- No changes to `IEncodeable`, `IDecoder`, `IServiceMessageContext`, or `ISubscriptionNotificationHandler`

### Benchmark results (MonitoredItemNotification, 1000 ops)

| Metric | Baseline (`new`) | Pooled (`Reuse`) | Improvement |
|---|---|---|---|
| Allocated/op | 128,408 B | 408 B | **315x** |
| Gen0/1000 ops | 29.75 | 0.09 | **320x** |
| Mean time | 33.9 us | 22.1 us | **35%** faster |

Full benchmark results in `Docs/perf/PooledNotificationBenchmarks.md`.

### New public API surface

- `IPooledEncodeable : IEncodeable` -- opt-in marker with `void Reuse()`
- `PooledEncodeableType<T> : EncodeableType<T>` -- activator base with bounded pool
- `ISubscriptionManager.PoolNotifications { get; set; }`
- `ManagedSessionOptions.PoolNotifications { get; init; }`
- `ManagedSessionBuilder.WithPoolNotifications(bool)`

### Handler contract (when pooling enabled)

Handlers must not retain references to notification payload objects past the dispatch `await`. The `DataValueChange` / `EventNotification` projection structs are safe to copy by value (they do not surface pooled instance references). Full documentation in `Docs/Sessions.md`.

## Related Issues

- Related to the V2 subscription engine (PR #3730)

## Types of changes

- [x] Enhancement (non-breaking change which adds functionality)
- [x] Test enhancement (non-breaking change to increase test coverage)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [x] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines.
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [x] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [x] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

### Files changed (24 files, ~1,893 lines)

**Runtime foundation** (`Stack/Opc.Ua.Types/Encoders/`):
- `IPooledEncodeable.cs` -- new interface
- `BoundedObjectPool.cs` -- lock-free bounded pool (Microsoft DefaultObjectPool pattern, no package dependency)
- `PooledEncodeableType.cs` -- activator base

**Client plumbing** (`Libraries/Opc.Ua.Client/`):
- `ISubscriptionManager.cs`, `IMessageAckQueue.cs`, `SubscriptionManager.cs` -- `PoolNotifications` property
- `ManagedSessionOptions.cs`, `ManagedSessionBuilder.cs`, `ManagedSession.cs`, `ServiceCollectionExtensions.cs` -- options/builder/DI wiring
- `MessageProcessor.cs` -- `PoolNotifications` protected helper
- `Subscription.cs` -- reuse-walk in dispatch `finally` blocks
- `ISubscriptionNotificationHandler.cs` -- lifetime documentation on projection structs

**Source generator** (`Tools/Opc.Ua.SourceGeneration.Core/`):
- `DataTypeTemplates.cs` -- `PooledStructureActivatorClass`, `PooledExtensionClass`, `DerivedPooledExtensionClass` templates
- `DataTypeGenerator.cs` -- template selection logic, `HasPoolableBase` chain-walk, `LoadTemplate_ListOfFieldResets`
- `Tokens.cs` -- `ListOfPooledExtensions`, `ListOfFieldResets`

**Tests**:
- `PooledEncodeableTypeTests.cs` -- 9 unit tests
- `PooledNotificationDispatchTests.cs` -- 9 integration tests
- `PooledNotificationBenchmarks.cs` -- 6 BDN benchmarks

**Documentation**:
- `Docs/Sessions.md` -- V2 notification pooling section
- `Docs/MigrationGuide.md` -- WithPoolNotifications entry
- `Docs/perf/PooledNotificationBenchmarks.md` -- benchmark results

### Design decisions

1. **No external XML changes** -- poolable selection is hardcoded in the generator (all concrete structures). The design XML files (`UA Core Services.xml`) come from outside and are not modified.
2. **`Reuse()` is idempotent** -- `Interlocked.CompareExchange` sentinel prevents double-return. Each derived type gets its own private sentinel field and `new` methods so it routes through its own activator.
3. **No `IEncodeable` change** -- `IPooledEncodeable` is a sub-interface; existing `IEncodeable` implementations are unaffected.
4. **Hand-rolled pool** -- avoids taking `Microsoft.Extensions.ObjectPool` as a new dependency on `Opc.Ua.Types`.
