### PR TITLE
Adopt System.TimeProvider across the stack (fixes #2458)

### DIFF
--- a/Applications/ConsoleReferencePublisher/PublishedValuesWrites.cs
+++ b/Applications/ConsoleReferencePublisher/PublishedValuesWrites.cs
@@ -60,7 +60,8 @@ namespace Quickstarts.ConsoleReferencePublisher
         private readonly ILogger m_logger;
         private readonly ArrayOf<PublishedDataSetDataType> m_publishedDataSets;
         private readonly IUaPubSubDataStore m_dataStore;
-        private Timer m_updateValuesTimer = null!;
+        private readonly TimeProvider m_timeProvider;
+        private ITimer m_updateValuesTimer = null!;
 
         private readonly string[] m_aviationAlphabet =
         [
@@ -99,12 +100,20 @@ namespace Quickstarts.ConsoleReferencePublisher
         /// Constructor
         /// </summary>
         /// <param name="uaPubSubApplication"></param>
-        public PublishedValuesWrites(UaPubSubApplication uaPubSubApplication, ITelemetryContext telemetry)
+        /// <param name="telemetry"></param>
+        /// <param name="timeProvider">
+        /// Optional time provider. Defaults to <see cref="TimeProvider.System"/>.
+        /// </param>
+        public PublishedValuesWrites(
+            UaPubSubApplication uaPubSubApplication,
+            ITelemetryContext telemetry,
+            TimeProvider? timeProvider = null)
         {
             m_logger = telemetry.CreateLogger<PublishedValuesWrites>();
             m_publishedDataSets = uaPubSubApplication.UaPubSubConfigurator.PubSubConfiguration
                 .PublishedDataSets;
             m_dataStore = uaPubSubApplication.DataStore;
+            m_timeProvider = timeProvider ??= TimeProvider.System;
         }
 
         public void Dispose()
@@ -149,7 +158,11 @@ namespace Quickstarts.ConsoleReferencePublisher
                     "SamplePublisher.DataStoreValuesGenerator.LoadInitialData wrong field");
             }
 
-            m_updateValuesTimer = new Timer(UpdateValues, null, 1000, 1000);
+            m_updateValuesTimer = m_timeProvider.CreateTimer(
+                UpdateValues,
+                null,
+                TimeSpan.FromSeconds(1),
+                TimeSpan.FromSeconds(1));
         }
 
         /// <summary>

--- a/Applications/ConsoleReferencePublisher/PublishedValuesWrites.cs
+++ b/Applications/ConsoleReferencePublisher/PublishedValuesWrites.cs
@@ -113,7 +113,7 @@ namespace Quickstarts.ConsoleReferencePublisher
             m_publishedDataSets = uaPubSubApplication.UaPubSubConfigurator.PubSubConfiguration
                 .PublishedDataSets;
             m_dataStore = uaPubSubApplication.DataStore;
-            m_timeProvider = timeProvider ??= TimeProvider.System;
+            m_timeProvider = timeProvider ?? TimeProvider.System;
         }
 
         public void Dispose()

--- a/Applications/Quickstarts.Servers/Alarms/AlarmNodeManager.cs
+++ b/Applications/Quickstarts.Servers/Alarms/AlarmNodeManager.cs
@@ -1190,12 +1190,14 @@ namespace Alarms
         {
             m_logger.LogInformation("Alarms: Starting simulation");
 
+            TimeProvider timeProvider = (Server as ITimeProviderProvider)?.TimeProvider
+                ?? TimeProvider.System;
             m_simulationTimer?.Dispose();
-            m_simulationTimer = new Timer(
+            m_simulationTimer = timeProvider.CreateTimer(
                 DoSimulation,
                 null,
-                kSimulationInterval,
-                kSimulationInterval);
+                TimeSpan.FromMilliseconds(kSimulationInterval),
+                TimeSpan.FromMilliseconds(kSimulationInterval));
         }
 
         /// <summary>
@@ -1234,7 +1236,7 @@ namespace Alarms
         ];
 
         private const ushort kSimulationInterval = 100;
-        private Timer? m_simulationTimer;
+        private ITimer? m_simulationTimer;
         private AlarmGroup? m_analogGroup;
         private BaseDataVariableState? m_maintenanceMode;
         private AlarmSuppressionEngine? m_suppressionEngine;

--- a/Applications/Quickstarts.Servers/Boiler/BoilerState.cs
+++ b/Applications/Quickstarts.Servers/Boiler/BoilerState.cs
@@ -32,6 +32,7 @@ using System.Collections.Generic;
 using System.Threading;
 using Microsoft.Extensions.Logging;
 using Opc.Ua;
+using Opc.Ua.Server;
 
 namespace Boiler
 {
@@ -88,11 +89,13 @@ namespace Boiler
                     }
 
                     m_simulationContext = context;
-                    m_simulationTimer = new Timer(
+                    TimeProvider timeProvider = ((context as ServerSystemContext)?.Server
+                        as ITimeProviderProvider)?.TimeProvider ?? TimeProvider.System;
+                    m_simulationTimer = timeProvider.CreateTimer(
                         DoSimulation,
                         null,
-                        (int)updateRate,
-                        (int)updateRate);
+                        TimeSpan.FromMilliseconds(updateRate),
+                        TimeSpan.FromMilliseconds(updateRate));
                     break;
                 case Opc.Ua.Methods.ProgramStateMachineType_Halt:
                 case Opc.Ua.Methods.ProgramStateMachineType_Suspend:
@@ -296,6 +299,6 @@ namespace Boiler
 
         private ILogger m_logger = null!;
         private ISystemContext m_simulationContext = null!;
-        private Timer? m_simulationTimer;
+        private ITimer? m_simulationTimer;
     }
 }

--- a/Applications/Quickstarts.Servers/MemoryBuffer/MemoryBufferState.cs
+++ b/Applications/Quickstarts.Servers/MemoryBuffer/MemoryBufferState.cs
@@ -494,8 +494,14 @@ namespace MemoryBuffer
             if (m_monitoringTable == null)
             {
                 m_monitoringTable = new MemoryBufferMonitoredItem[elementCount][];
+                TimeProvider timeProvider = (Server as ITimeProviderProvider)?.TimeProvider
+                    ?? TimeProvider.System;
                 m_scanTimer?.Dispose();
-                m_scanTimer = new Timer(DoScan, null, 100, 100);
+                m_scanTimer = timeProvider.CreateTimer(
+                    DoScan,
+                    null,
+                    TimeSpan.FromMilliseconds(100),
+                    TimeSpan.FromMilliseconds(100));
             }
 
             int elementOffet = (int)(tag.Offset / ElementSize);
@@ -688,7 +694,7 @@ namespace MemoryBuffer
         private int m_elementSize;
         private DateTimeUtc m_lastScanTime;
         private byte[] m_buffer = null!;
-        private Timer? m_scanTimer;
+        private ITimer? m_scanTimer;
         private int m_updateCount;
         private int m_itemCount;
     }

--- a/Applications/Quickstarts.Servers/ReferenceServer/ReferenceNodeManager.cs
+++ b/Applications/Quickstarts.Servers/ReferenceServer/ReferenceNodeManager.cs
@@ -3911,8 +3911,14 @@ namespace Quickstarts.ReferenceServer
                     // reset random generator and generate boundary values
                     ResetRandomGenerator(100, 1);
 
+                    TimeProvider timeProvider = (Server as ITimeProviderProvider)?.TimeProvider
+                        ?? TimeProvider.System;
                     m_simulationTimer?.Dispose();
-                    m_simulationTimer = new Timer(DoSimulation, null, m_simulationInterval, m_simulationInterval);
+                    m_simulationTimer = timeProvider.CreateTimer(
+                        DoSimulation,
+                        null,
+                        TimeSpan.FromMilliseconds(m_simulationInterval),
+                        TimeSpan.FromMilliseconds(m_simulationInterval));
                 }
             }
             finally
@@ -3932,7 +3938,9 @@ namespace Quickstarts.ReferenceServer
 
                 if (m_simulationEnabled)
                 {
-                    m_simulationTimer!.Change(100, m_simulationInterval);
+                    m_simulationTimer!.Change(
+                        TimeSpan.FromMilliseconds(100),
+                        TimeSpan.FromMilliseconds(m_simulationInterval));
                 }
 
                 return ServiceResult.Good;
@@ -3955,11 +3963,15 @@ namespace Quickstarts.ReferenceServer
 
                 if (m_simulationEnabled)
                 {
-                    m_simulationTimer!.Change(100, m_simulationInterval);
+                    m_simulationTimer!.Change(
+                        TimeSpan.FromMilliseconds(100),
+                        TimeSpan.FromMilliseconds(m_simulationInterval));
                 }
                 else
                 {
-                    m_simulationTimer!.Change(100, 0);
+                    m_simulationTimer!.Change(
+                        TimeSpan.FromMilliseconds(100),
+                        TimeSpan.Zero);
                 }
 
                 return ServiceResult.Good;
@@ -5460,7 +5472,7 @@ namespace Quickstarts.ReferenceServer
         private readonly SemaphoreSlim m_semaphore = new(1, 1);
         private RandomSource m_randomSource = null!;
         private DataGenerator m_generator = null!;
-        private Timer? m_simulationTimer;
+        private ITimer? m_simulationTimer;
         private ushort m_simulationInterval = 1000;
         private bool m_simulationEnabled = true;
         private int m_simulationsRunning;

--- a/Applications/Quickstarts.Servers/SampleNodeManager/SampleNodeManager.cs
+++ b/Applications/Quickstarts.Servers/SampleNodeManager/SampleNodeManager.cs
@@ -2773,11 +2773,13 @@ namespace Opc.Ua.Sample
         {
             m_sampledItems.Add(monitoredItem);
 
-            m_samplingTimer ??= new Timer(
+            TimeProvider timeProvider = (Server as ITimeProviderProvider)?.TimeProvider
+                ?? TimeProvider.System;
+            m_samplingTimer ??= timeProvider.CreateTimer(
                 DoSample,
                 null,
-                (int)m_minimumSamplingInterval,
-                (int)m_minimumSamplingInterval);
+                TimeSpan.FromMilliseconds(m_minimumSamplingInterval),
+                TimeSpan.FromMilliseconds(m_minimumSamplingInterval));
         }
 
         /// <summary>
@@ -3238,7 +3240,7 @@ namespace Opc.Ua.Sample
 
         private IList<string> m_namespaceUris = null!;
         private ushort[] m_namespaceIndexes = null!;
-        private Timer? m_samplingTimer;
+        private ITimer? m_samplingTimer;
         private readonly ILogger m_logger;
         private readonly List<DataChangeMonitoredItem> m_sampledItems = [];
         private readonly double m_minimumSamplingInterval;

--- a/Applications/Quickstarts.Servers/TestData/TestDataNodeManager.cs
+++ b/Applications/Quickstarts.Servers/TestData/TestDataNodeManager.cs
@@ -88,7 +88,12 @@ namespace TestData
             m_lastUsedId = m_configuration.NextUnusedId - 1;
 
             // create the object used to access the test system.
-            m_system = new TestDataSystem(this, server.NamespaceUris, server.ServerUris, server.Telemetry);
+            m_system = new TestDataSystem(
+                this,
+                server.NamespaceUris,
+                server.ServerUris,
+                server.Telemetry,
+                (server as ITimeProviderProvider)?.TimeProvider);
 
             // update the default context.
             SystemContext.SystemHandle = m_system;

--- a/Applications/Quickstarts.Servers/TestData/TestDataSystem.cs
+++ b/Applications/Quickstarts.Servers/TestData/TestDataSystem.cs
@@ -65,13 +65,15 @@ namespace TestData
             ITestDataSystemCallback callback,
             NamespaceTable namespaceUris,
             StringTable serverUris,
-            ITelemetryContext telemetry)
+            ITelemetryContext telemetry,
+            TimeProvider? timeProvider = null)
         {
             m_callback = callback;
             m_logger = telemetry.CreateLogger<TestDataSystem>();
             m_minimumSamplingInterval = int.MaxValue;
             m_monitoredNodes = [];
             m_samplingNodes = null;
+            m_timeProvider = timeProvider ??= TimeProvider.System;
             Generator = new Opc.Ua.Test.DataGenerator(null, telemetry)
             {
                 NamespaceUris = namespaceUris,
@@ -824,11 +826,11 @@ namespace TestData
                     m_timer?.Dispose();
                     m_timer = null;
 
-                    m_timer = new Timer(
+                    m_timer = m_timeProvider.CreateTimer(
                         DoSample,
                         null,
-                        m_minimumSamplingInterval,
-                        m_minimumSamplingInterval);
+                        TimeSpan.FromMilliseconds(m_minimumSamplingInterval),
+                        TimeSpan.FromMilliseconds(m_minimumSamplingInterval));
                 }
             }
         }
@@ -837,7 +839,7 @@ namespace TestData
         {
             m_logger.LogTrace(
                 "DoSample HiRes={HiRes:ss.ffff} Now={CurrentTime:ss.ffff}",
-                HiResClock.UtcNow,
+                m_timeProvider.GetUtcNow().UtcDateTime,
                 DateTime.UtcNow);
 
             var samples = new Queue<Sample>();
@@ -934,7 +936,8 @@ namespace TestData
         private int m_minimumSamplingInterval;
         private Dictionary<uint, BaseVariableState>? m_monitoredNodes;
         private IList<BaseVariableState>? m_samplingNodes;
-        private Timer? m_timer;
+        private ITimer? m_timer;
+        private readonly TimeProvider m_timeProvider;
         private StatusCode m_systemStatus;
     }
 }

--- a/Applications/Quickstarts.Servers/TestData/TestDataSystem.cs
+++ b/Applications/Quickstarts.Servers/TestData/TestDataSystem.cs
@@ -73,7 +73,7 @@ namespace TestData
             m_minimumSamplingInterval = int.MaxValue;
             m_monitoredNodes = [];
             m_samplingNodes = null;
-            m_timeProvider = timeProvider ??= TimeProvider.System;
+            m_timeProvider = timeProvider ?? TimeProvider.System;
             Generator = new Opc.Ua.Test.DataGenerator(null, telemetry)
             {
                 NamespaceUris = namespaceUris,

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -33,6 +33,7 @@
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.6.0" />
     <PackageVersion Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
     <PackageVersion Include="ModelContextProtocol" Version="1.3.0" />
     <PackageVersion Include="ModelContextProtocol.AspNetCore" Version="1.3.0" />

--- a/Docs/MigrationGuide.md
+++ b/Docs/MigrationGuide.md
@@ -1895,6 +1895,44 @@ The `Timer` field type changes from `System.Threading.Timer` to `ITimer` — bot
 implement `IDisposable` and the same `Change` / `Dispose` semantics; only the
 parameter types on `Change` differ (`TimeSpan` instead of `int`/`uint`/`long`).
 
+#### Monotonic timestamps for duration calculations
+
+`TimeProvider.GetTimestamp()` returns a `long` monotonic timestamp that does not
+suffer from the 32-bit wraparound of `Environment.TickCount` / `HiResClock.TickCount`
+nor the system-clock drift of `DateTime.UtcNow`. All internal duration math in the
+stack now uses `GetTimestamp()` + `GetElapsedTime(start)` instead of `int`-tick
+subtraction. Several public read-only properties were added or marked `[Obsolete]`
+as part of the migration:
+
+| Old (`[Obsolete]`)                                                       | New                                                                                  |
+| ------------------------------------------------------------------------ | ------------------------------------------------------------------------------------ |
+| `ISession.LastKeepAliveTickCount: int` (wraps every ~49.7 days)          | `ISession.LastKeepAliveTimestamp: long` + `timeProvider.GetElapsedTime(timestamp)`   |
+| `ChannelToken.Expired`, `ChannelToken.ActivationRequired` (read HiResClock) | `ChannelToken.IsExpired(TimeProvider)`, `ChannelToken.IsActivationRequired(TimeProvider)` |
+| `ChannelToken.CreatedAtTickCount: int`                                   | New internal `ChannelToken.CreatedAtTimestamp: long` (set automatically; new behaviour) |
+| `UaSCUaBinaryChannel.LastActiveTickCount: int` (protected)               | `UaSCUaBinaryChannel.GetElapsedSinceLastActive(): TimeSpan` (internal)               |
+
+Pattern for new code computing an internal duration:
+
+```csharp
+// before:
+int startTicks = m_timeProvider.GetTickCount();
+// ... do work ...
+int elapsedMs = m_timeProvider.GetTickCount() - startTicks;
+
+// after:
+long startTimestamp = m_timeProvider.GetTimestamp();
+// ... do work ...
+TimeSpan elapsed = m_timeProvider.GetElapsedTime(startTimestamp);
+```
+
+`SessionReconnectHandler` and the classic `Subscription` republish-window logic
+were both migrated. Consumers who previously read
+`current.LastKeepAliveTickCount` from a reactivation-timeout estimate should
+switch to `m_timeProvider.GetElapsedTime(current.LastKeepAliveTimestamp)`.
+The `Obsolete` int property remains in place for back-compat and is still
+populated by the stack — but new code should not depend on its non-wrapping
+behaviour.
+
 ### Subscriptions and Transports
 
 #### Durable subscriptions and reshaped Subscription tree

--- a/Docs/MigrationGuide.md
+++ b/Docs/MigrationGuide.md
@@ -1833,7 +1833,7 @@ public sealed class Foo
     public Foo(/* existing args */, TimeProvider? timeProvider = null)
     {
         // existing initialisation…
-        m_timeProvider = timeProvider ??= TimeProvider.System;
+        m_timeProvider = timeProvider ?? TimeProvider.System;
     }
 }
 ```

--- a/Docs/MigrationGuide.md
+++ b/Docs/MigrationGuide.md
@@ -1901,15 +1901,13 @@ parameter types on `Change` differ (`TimeSpan` instead of `int`/`uint`/`long`).
 suffer from the 32-bit wraparound of `Environment.TickCount` / `HiResClock.TickCount`
 nor the system-clock drift of `DateTime.UtcNow`. All internal duration math in the
 stack now uses `GetTimestamp()` + `GetElapsedTime(start)` instead of `int`-tick
-subtraction. Several public read-only properties were added or marked `[Obsolete]`
-as part of the migration:
+subtraction. The following public surface changes were made:
 
-| Old (`[Obsolete]`)                                                       | New                                                                                  |
-| ------------------------------------------------------------------------ | ------------------------------------------------------------------------------------ |
-| `ISession.LastKeepAliveTickCount: int` (wraps every ~49.7 days)          | `ISession.LastKeepAliveTimestamp: long` + `timeProvider.GetElapsedTime(timestamp)`   |
-| `ChannelToken.Expired`, `ChannelToken.ActivationRequired` (read HiResClock) | `ChannelToken.IsExpired(TimeProvider)`, `ChannelToken.IsActivationRequired(TimeProvider)` |
-| `ChannelToken.CreatedAtTickCount: int`                                   | New internal `ChannelToken.CreatedAtTimestamp: long` (set automatically; new behaviour) |
-| `UaSCUaBinaryChannel.LastActiveTickCount: int` (protected)               | `UaSCUaBinaryChannel.GetElapsedSinceLastActive(): TimeSpan` (internal)               |
+| Old (removed or `[Obsolete]`)                                            | New                                                                                                  |
+| ------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------- |
+| `ISession.LastKeepAliveTickCount: int` (was on the interface)            | `ISession.LastKeepAliveTimestamp: long` + `timeProvider.GetElapsedTime(timestamp)` (legacy int now an `[Obsolete]` extension property in `SessionObsolete`) |
+| `ChannelToken.Expired`, `ChannelToken.ActivationRequired`, `ChannelToken.CreatedAtTickCount` | Removed. Use `ChannelToken.IsExpired(TimeProvider)` / `ChannelToken.IsActivationRequired(TimeProvider)` (internal). |
+| `UaSCUaBinaryChannel.LastActiveTickCount: int` (protected)               | Removed. Use `UaSCUaBinaryChannel.GetElapsedSinceLastActive(): TimeSpan` (internal).                 |
 
 Pattern for new code computing an internal duration:
 
@@ -1924,14 +1922,6 @@ long startTimestamp = m_timeProvider.GetTimestamp();
 // ... do work ...
 TimeSpan elapsed = m_timeProvider.GetElapsedTime(startTimestamp);
 ```
-
-`SessionReconnectHandler` and the classic `Subscription` republish-window logic
-were both migrated. Consumers who previously read
-`current.LastKeepAliveTickCount` from a reactivation-timeout estimate should
-switch to `m_timeProvider.GetElapsedTime(current.LastKeepAliveTimestamp)`.
-The `Obsolete` int property remains in place for back-compat and is still
-populated by the stack — but new code should not depend on its non-wrapping
-behaviour.
 
 ### Subscriptions and Transports
 

--- a/Docs/MigrationGuide.md
+++ b/Docs/MigrationGuide.md
@@ -68,6 +68,7 @@
       - [Auto-emit `GeneralModelChangeEvent` from `CustomNodeManager`](#auto-emit-generalmodelchangeevent-from-customnodemanager)
     - [Address-space model change tracking](#address-space-model-change-tracking)
       - [New `INodeCache.InvalidateNode` member](#new-inodecacheinvalidatenode-member)
+    - [Time and Timer abstraction (`TimeProvider`)](#time-and-timer-abstraction-timeprovider)
     - [Subscriptions and Transports](#subscriptions-and-transports)
       - [Durable subscriptions and reshaped Subscription tree](#durable-subscriptions-and-reshaped-subscription-tree)
       - [PubSub](#pubsub)
@@ -1794,6 +1795,105 @@ public sealed class MyNodeCache : INodeCache
 Implementations that can perform per-node eviction should do so —
 the tracker is most efficient when targeted invalidation is
 available.
+
+### Time and Timer abstraction (`TimeProvider`)
+
+**Not source-breaking.** The stack now uses
+[`System.TimeProvider`](https://learn.microsoft.com/dotnet/api/system.timeprovider) as
+its canonical clock and scheduler so that timeouts, intervals, keep-alive loops,
+reconnect back-off, publishing pacing, certificate-lifetime checks, and similar
+duration-sensitive code paths are mockable in tests and immune to wall-clock changes.
+
+`HiResClock` is still in place but **every public member is now marked
+`[Obsolete]`**. The class itself is not obsolete so that existing field references
+(`HiResClock.Disabled`) keep round-tripping through configuration; only the static
+clock-reading members raise CS0618. The recommended replacements are:
+
+| Legacy API                              | Replacement                                                                          |
+| --------------------------------------- | ------------------------------------------------------------------------------------ |
+| `HiResClock.UtcNow`                     | `timeProvider.GetUtcNow().UtcDateTime`                                               |
+| `HiResClock.TickCount64` / `.Ticks`     | `timeProvider.GetTimestamp()`                                                        |
+| `HiResClock.TickCount` (int wraparound) | `timeProvider.GetTickCount()` (internal extension in `Opc.Ua`)                       |
+| `HiResClock.UtcTickCount(offsetMs)`     | `timeProvider.GetTimestampMilliseconds() + offsetMs`                                 |
+| elapsed-time math via `TickCount`       | `long start = timeProvider.GetTimestamp(); … TimeSpan elapsed = timeProvider.GetElapsedTime(start);` |
+| `new Stopwatch()` / `Stopwatch.StartNew()` for duration | `long start = timeProvider.GetTimestamp(); … timeProvider.GetElapsedTime(start);` |
+| `new System.Threading.Timer(…)`         | `ITimer timer = timeProvider.CreateTimer(callback, state, dueTime, period);`         |
+| `Task.Delay(delay, ct)` in production timing loops | `Task.Delay(delay, timeProvider, ct)`                                       |
+| `new CancellationTokenSource(timeout)`  | `new CancellationTokenSource(timeout, timeProvider)`                                 |
+
+**Constructor pattern.** Components that need a clock now take a nullable
+`TimeProvider` as the **last** constructor parameter with a default value of `null`.
+If `null` is passed, `TimeProvider.System` is used. Example:
+
+```csharp
+public sealed class Foo
+{
+    private readonly TimeProvider m_timeProvider;
+
+    public Foo(/* existing args */, TimeProvider? timeProvider = null)
+    {
+        // existing initialisation…
+        m_timeProvider = timeProvider ??= TimeProvider.System;
+    }
+}
+```
+
+For published public types whose existing constructors must remain
+binary-compatible, the original constructor signature is preserved and a new
+overload that ends with `TimeProvider?` is added. The legacy constructor delegates
+to the new one passing `timeProvider: null`. No existing constructor is marked
+`[Obsolete]` in this release.
+
+**Dependency injection.** `AddOpcUaServerBuilder` / `AddOpcUaClientBuilder` register
+`TimeProvider.System` via `TryAddSingleton<TimeProvider>` and wire the resolved
+provider into every component they construct. To run a server or client against a
+fake clock in tests, register a `Microsoft.Extensions.Time.Testing.FakeTimeProvider`
+in the service collection before the OPC UA builders.
+
+```csharp
+services.AddSingleton<TimeProvider>(new FakeTimeProvider());
+services.AddOpcUaServerBuilder(/* … */);
+```
+
+Outside DI, pass the `TimeProvider` directly to the type's constructor as the last
+argument.
+
+**Migrating off `HiResClock`.** Replace the call with the table above. If the
+migration cannot happen immediately, wrap the affected scope with
+`#pragma warning disable CS0618` / `#pragma warning restore CS0618`.
+
+```csharp
+// before:
+long start = HiResClock.TickCount64;
+DoWork();
+TimeSpan elapsed = TimeSpan.FromTicks(HiResClock.TickCount64 - start);
+
+// after:
+long start = m_timeProvider.GetTimestamp();
+DoWork();
+TimeSpan elapsed = m_timeProvider.GetElapsedTime(start);
+```
+
+```csharp
+// before:
+DateTime utcNow = HiResClock.UtcNow;
+
+// after — when a wall-clock value is required (e.g. for an OPC UA SourceTimestamp):
+DateTime utcNow = m_timeProvider.GetUtcNow().UtcDateTime;
+```
+
+```csharp
+// before:
+m_timer = new Timer(OnTick, state: null, dueTime: 1_000, period: Timeout.Infinite);
+
+// after:
+m_timer = m_timeProvider.CreateTimer(OnTick, state: null,
+    dueTime: TimeSpan.FromMilliseconds(1_000), period: Timeout.InfiniteTimeSpan);
+```
+
+The `Timer` field type changes from `System.Threading.Timer` to `ITimer` — both
+implement `IDisposable` and the same `Change` / `Dispose` semantics; only the
+parameter types on `Change` differ (`TimeSpan` instead of `int`/`uint`/`long`).
 
 ### Subscriptions and Transports
 

--- a/Libraries/Opc.Ua.Client/AliasNames/Refresh/PollingAliasNameRefreshStrategy.cs
+++ b/Libraries/Opc.Ua.Client/AliasNames/Refresh/PollingAliasNameRefreshStrategy.cs
@@ -58,7 +58,8 @@ namespace Opc.Ua.Client.AliasNames.Refresh
         /// <param name="timeProvider">Optional <see cref="TimeProvider"/>
         /// used to create the poll timer. Defaults to
         /// <see cref="TimeProvider.System"/> when <c>null</c>.</param>
-        public PollingAliasNameRefreshStrategy(TimeSpan pollInterval,
+        public PollingAliasNameRefreshStrategy(
+            TimeSpan pollInterval,
             TimeProvider? timeProvider = null)
         {
             if (pollInterval < TimeSpan.FromMilliseconds(100))
@@ -67,7 +68,7 @@ namespace Opc.Ua.Client.AliasNames.Refresh
                     nameof(pollInterval),
                     "Poll interval must be at least 100 ms.");
             }
-            m_timeProvider = timeProvider ??= TimeProvider.System;
+            m_timeProvider = timeProvider ?? TimeProvider.System;
             PollInterval = pollInterval;
         }
 

--- a/Libraries/Opc.Ua.Client/AliasNames/Refresh/PollingAliasNameRefreshStrategy.cs
+++ b/Libraries/Opc.Ua.Client/AliasNames/Refresh/PollingAliasNameRefreshStrategy.cs
@@ -55,7 +55,11 @@ namespace Opc.Ua.Client.AliasNames.Refresh
         /// </summary>
         /// <param name="pollInterval">Time between successive
         /// <c>LastChange</c> reads. Must be at least 100 ms.</param>
-        public PollingAliasNameRefreshStrategy(TimeSpan pollInterval)
+        /// <param name="timeProvider">Optional <see cref="TimeProvider"/>
+        /// used to create the poll timer. Defaults to
+        /// <see cref="TimeProvider.System"/> when <c>null</c>.</param>
+        public PollingAliasNameRefreshStrategy(TimeSpan pollInterval,
+            TimeProvider? timeProvider = null)
         {
             if (pollInterval < TimeSpan.FromMilliseconds(100))
             {
@@ -63,6 +67,7 @@ namespace Opc.Ua.Client.AliasNames.Refresh
                     nameof(pollInterval),
                     "Poll interval must be at least 100 ms.");
             }
+            m_timeProvider = timeProvider ??= TimeProvider.System;
             PollInterval = pollInterval;
         }
 
@@ -80,19 +85,18 @@ namespace Opc.Ua.Client.AliasNames.Refresh
             m_client = client ?? throw new ArgumentNullException(nameof(client));
             m_onInvalidate = onInvalidate ?? throw new ArgumentNullException(nameof(onInvalidate));
 
-            int periodMs = (int)PollInterval.TotalMilliseconds;
-            m_timer = new Timer(
+            m_timer = m_timeProvider.CreateTimer(
                 Tick,
                 state: null,
-                dueTime: periodMs,
-                period: periodMs);
+                dueTime: PollInterval,
+                period: PollInterval);
             return default;
         }
 
         /// <inheritdoc/>
         public ValueTask DisposeAsync()
         {
-            Timer? timer = m_timer;
+            ITimer? timer = m_timer;
             m_timer = null;
             timer?.Dispose();
             return default;
@@ -137,7 +141,8 @@ namespace Opc.Ua.Client.AliasNames.Refresh
 
         private AliasNameClient? m_client;
         private Action? m_onInvalidate;
-        private Timer? m_timer;
+        private ITimer? m_timer;
         private uint? m_lastSeen;
+        private readonly TimeProvider m_timeProvider;
     }
 }

--- a/Libraries/Opc.Ua.Client/ComplexTypes/NodeCacheResolver.cs
+++ b/Libraries/Opc.Ua.Client/ComplexTypes/NodeCacheResolver.cs
@@ -91,8 +91,10 @@ namespace Opc.Ua.Client.ComplexTypes
         public NodeCacheResolver(
             ISession session,
             INodeCache nodeCache,
-            ITelemetryContext telemetry)
+            ITelemetryContext telemetry,
+            TimeProvider? timeProvider = null)
         {
+            m_timeProvider = timeProvider ??= TimeProvider.System;
             m_session = session;
             m_nodeCache = nodeCache;
             m_logger = telemetry.CreateLogger<NodeCacheResolver>();
@@ -380,8 +382,7 @@ namespace Opc.Ua.Client.ComplexTypes
             var result = new List<INode>();
             var nodesToBrowse = new List<ExpandedNodeId> { dataType };
 #if DEBUG
-            var stopwatch = new Stopwatch();
-            stopwatch.Start();
+            long startTimestamp = m_timeProvider.GetTimestamp();
 #endif
             if (addRootNode)
             {
@@ -422,11 +423,10 @@ namespace Opc.Ua.Client.ComplexTypes
                 nodesToBrowse = nextNodesToBrowse;
             }
 #if DEBUG
-            stopwatch.Stop();
             m_logger.LogInformation(
                 "LoadDataTypes returns {Count} nodes in {Duration}ms",
                 result.Count,
-                stopwatch.ElapsedMilliseconds);
+                (long)m_timeProvider.GetElapsedTime(startTimestamp).TotalMilliseconds);
 #endif
             return result;
         }
@@ -812,5 +812,6 @@ namespace Opc.Ua.Client.ComplexTypes
         private readonly INodeCache m_nodeCache;
         private readonly ISession m_session;
         private readonly ILogger m_logger;
+        private readonly TimeProvider m_timeProvider;
     }
 }

--- a/Libraries/Opc.Ua.Client/ComplexTypes/NodeCacheResolver.cs
+++ b/Libraries/Opc.Ua.Client/ComplexTypes/NodeCacheResolver.cs
@@ -94,7 +94,7 @@ namespace Opc.Ua.Client.ComplexTypes
             ITelemetryContext telemetry,
             TimeProvider? timeProvider = null)
         {
-            m_timeProvider = timeProvider ??= TimeProvider.System;
+            m_timeProvider = timeProvider ?? TimeProvider.System;
             m_session = session;
             m_nodeCache = nodeCache;
             m_logger = telemetry.CreateLogger<NodeCacheResolver>();

--- a/Libraries/Opc.Ua.Client/Fluent/ManagedSessionBuilder.cs
+++ b/Libraries/Opc.Ua.Client/Fluent/ManagedSessionBuilder.cs
@@ -379,12 +379,15 @@ namespace Opc.Ua.Client
             }
 
             ISubscriptionEngineFactory engineFactory =
-                opts.SubscriptionEngineFactory ?? DefaultSubscriptionEngineFactory.Instance;
+                opts.SubscriptionEngineFactory ?? (opts.TimeProvider == null
+                    ? DefaultSubscriptionEngineFactory.Instance
+                    : new DefaultSubscriptionEngineFactory(opts.TimeProvider));
 
             ISessionFactory sessionFactory = m_sessionFactory ??
                 new DefaultSessionFactory(m_telemetry)
                 {
-                    SubscriptionEngineFactory = engineFactory
+                    SubscriptionEngineFactory = engineFactory,
+                    TimeProvider = opts.TimeProvider
                 };
 
             IReconnectPolicy reconnect =

--- a/Libraries/Opc.Ua.Client/Fluent/OpcUaClientBuilderExtensions.cs
+++ b/Libraries/Opc.Ua.Client/Fluent/OpcUaClientBuilderExtensions.cs
@@ -572,11 +572,13 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 ITelemetryContext telemetry = sp.GetRequiredService<ITelemetryContext>();
                 OpcUaClientOptions options = sp.GetRequiredService<OpcUaClientOptions>();
+                TimeProvider timeProvider = sp.GetRequiredService<TimeProvider>();
                 return new DefaultSessionFactory(telemetry)
                 {
                     SubscriptionEngineFactory =
                         options.Session.SubscriptionEngineFactory
-                        ?? DefaultSubscriptionEngineFactory.Instance
+                        ?? new DefaultSubscriptionEngineFactory(timeProvider),
+                    TimeProvider = timeProvider
                 };
             });
 

--- a/Libraries/Opc.Ua.Client/Fluent/OpcUaClientBuilderExtensions.cs
+++ b/Libraries/Opc.Ua.Client/Fluent/OpcUaClientBuilderExtensions.cs
@@ -566,13 +566,11 @@ namespace Microsoft.Extensions.DependencyInjection
             services.TryAddSingleton<ITelemetryContext>(
                 sp => new ServiceProviderTelemetryContext(sp));
 
-            services.TryAddSingleton(TimeProvider.System);
-
             services.TryAddSingleton<ISessionFactory>(sp =>
             {
                 ITelemetryContext telemetry = sp.GetRequiredService<ITelemetryContext>();
                 OpcUaClientOptions options = sp.GetRequiredService<OpcUaClientOptions>();
-                TimeProvider timeProvider = sp.GetRequiredService<TimeProvider>();
+                TimeProvider? timeProvider = sp.GetService<TimeProvider>();
                 return new DefaultSessionFactory(telemetry)
                 {
                     SubscriptionEngineFactory =
@@ -723,9 +721,12 @@ namespace Microsoft.Extensions.DependencyInjection
                 }
 #pragma warning restore CS0618
 
-                TimeProvider timeProvider =
-                    options.Session.TimeProvider ?? m_sp.GetRequiredService<TimeProvider>();
-                builder.WithTimeProvider(timeProvider);
+                TimeProvider? timeProvider =
+                    options.Session.TimeProvider ?? m_sp.GetService<TimeProvider>();
+                if (timeProvider != null)
+                {
+                    builder.WithTimeProvider(timeProvider);
+                }
 
                 if (options.Session.PreferredLocales is { Count: > 0 } locales)
                 {

--- a/Libraries/Opc.Ua.Client/Identity/GdsKeyCredentialAccessTokenProvider.cs
+++ b/Libraries/Opc.Ua.Client/Identity/GdsKeyCredentialAccessTokenProvider.cs
@@ -58,6 +58,7 @@ namespace Opc.Ua.Client
         private static readonly TimeSpan s_defaultCacheLifetime = TimeSpan.FromMinutes(5);
         private static readonly TimeSpan s_refreshSkew = TimeSpan.FromSeconds(30);
         private readonly Func<CancellationToken, ValueTask<GdsIssuedKeyCredential>> m_acquireCredential;
+        private readonly TimeProvider m_timeProvider;
         private readonly SemaphoreSlim m_lock = new(1, 1);
         private GdsIssuedKeyCredential? m_cachedCredential;
         private bool m_disposed;
@@ -72,7 +73,8 @@ namespace Opc.Ua.Client
             ByteString publicKey = default,
             string? securityPolicyUri = null,
             ArrayOf<NodeId>? requestedRoles = null,
-            TimeSpan? cacheLifetime = null)
+            TimeSpan? cacheLifetime = null,
+            TimeProvider? timeProvider = null)
             : this(
                 new ReflectionKeyCredentialClient(
                     keyCredentialServiceClient,
@@ -81,7 +83,8 @@ namespace Opc.Ua.Client
                     securityPolicyUri,
                     requestedRoles ?? []).AcquireAsync,
                 authorityUri,
-                cacheLifetime)
+                cacheLifetime,
+                timeProvider)
         {
         }
 
@@ -91,11 +94,13 @@ namespace Opc.Ua.Client
         public GdsKeyCredentialAccessTokenProvider(
             Func<CancellationToken, ValueTask<GdsIssuedKeyCredential>> acquireCredential,
             string authorityUri,
-            TimeSpan? cacheLifetime = null)
+            TimeSpan? cacheLifetime = null,
+            TimeProvider? timeProvider = null)
         {
             m_acquireCredential = acquireCredential ?? throw new ArgumentNullException(nameof(acquireCredential));
             AuthorityUri = authorityUri ?? throw new ArgumentNullException(nameof(authorityUri));
             CacheLifetime = cacheLifetime ?? s_defaultCacheLifetime;
+            m_timeProvider = timeProvider ??= TimeProvider.System;
         }
 
         /// <inheritdoc/>
@@ -114,7 +119,7 @@ namespace Opc.Ua.Client
             ThrowIfDisposed();
             GdsIssuedKeyCredential credential = await GetCredentialAsync(ct).ConfigureAwait(false);
             string nonce = CreateNonce();
-            DateTime issuedAt = DateTime.UtcNow;
+            DateTime issuedAt = m_timeProvider.GetUtcNow().UtcDateTime;
             long issuedAtSeconds = new DateTimeOffset(issuedAt).ToUnixTimeSeconds();
             string proof = CreateProof(
                 credential.CredentialSecret,
@@ -162,7 +167,7 @@ namespace Opc.Ua.Client
             {
                 ThrowIfDisposed();
                 if (m_cachedCredential != null &&
-                    m_cachedCredential.ExpiresAt - s_refreshSkew > DateTime.UtcNow)
+                    m_cachedCredential.ExpiresAt - s_refreshSkew > m_timeProvider.GetUtcNow().UtcDateTime)
                 {
                     return m_cachedCredential.Copy();
                 }
@@ -171,7 +176,7 @@ namespace Opc.Ua.Client
                 GdsIssuedKeyCredential issued = await m_acquireCredential(ct).ConfigureAwait(false);
                 if (issued.ExpiresAt == DateTime.MinValue || issued.ExpiresAt == default)
                 {
-                    issued = issued with { ExpiresAt = DateTime.UtcNow.Add(CacheLifetime) };
+                    issued = issued with { ExpiresAt = m_timeProvider.GetUtcNow().UtcDateTime.Add(CacheLifetime) };
                 }
                 m_cachedCredential = issued.Copy();
                 return issued;

--- a/Libraries/Opc.Ua.Client/Identity/GdsKeyCredentialAccessTokenProvider.cs
+++ b/Libraries/Opc.Ua.Client/Identity/GdsKeyCredentialAccessTokenProvider.cs
@@ -100,7 +100,7 @@ namespace Opc.Ua.Client
             m_acquireCredential = acquireCredential ?? throw new ArgumentNullException(nameof(acquireCredential));
             AuthorityUri = authorityUri ?? throw new ArgumentNullException(nameof(authorityUri));
             CacheLifetime = cacheLifetime ?? s_defaultCacheLifetime;
-            m_timeProvider = timeProvider ??= TimeProvider.System;
+            m_timeProvider = timeProvider ?? TimeProvider.System;
         }
 
         /// <inheritdoc/>

--- a/Libraries/Opc.Ua.Client/ReverseConnectManager.cs
+++ b/Libraries/Opc.Ua.Client/ReverseConnectManager.cs
@@ -712,8 +712,8 @@ namespace Opc.Ua.Client
         /// </summary>
         private async Task OnConnectionWaitingAsync(object sender, ConnectionWaitingEventArgs e)
         {
-            int startTime = m_timeProvider.GetTickCount();
-            int endTime = startTime + (m_configuration?.HoldTime ?? 15000);
+            long startTimestamp = m_timeProvider.GetTimestamp();
+            TimeSpan holdTime = TimeSpan.FromMilliseconds(m_configuration?.HoldTime ?? 15000);
 
             bool matched = MatchRegistration(sender, e);
             while (!matched)
@@ -724,10 +724,10 @@ namespace Opc.Ua.Client
                 {
                     ct = m_cts.Token;
                 }
-                int delay = endTime - m_timeProvider.GetTickCount();
-                if (delay > 0)
+                TimeSpan delay = holdTime - m_timeProvider.GetElapsedTime(startTimestamp);
+                if (delay > TimeSpan.Zero)
                 {
-                    await m_timeProvider.Delay(TimeSpan.FromMilliseconds(delay), ct)
+                    await m_timeProvider.Delay(delay, ct)
                         .ContinueWith(tsk =>
                         {
                             if (tsk.IsCanceled)
@@ -739,7 +739,7 @@ namespace Opc.Ua.Client
                                         "Matched reverse connection {ServerUri} {EndpointUrl} after {Duration}ms",
                                         e.ServerUri,
                                         e.EndpointUrl,
-                                        m_timeProvider.GetTickCount() - startTime);
+                                        (long)m_timeProvider.GetElapsedTime(startTimestamp).TotalMilliseconds);
                                 }
                             }
                         },
@@ -756,7 +756,7 @@ namespace Opc.Ua.Client
                 e.Accepted ? "Accepted" : "Rejected",
                 e.ServerUri,
                 e.EndpointUrl,
-                m_timeProvider.GetTickCount() - startTime);
+                (long)m_timeProvider.GetElapsedTime(startTimestamp).TotalMilliseconds);
         }
 
         /// <summary>

--- a/Libraries/Opc.Ua.Client/ReverseConnectManager.cs
+++ b/Libraries/Opc.Ua.Client/ReverseConnectManager.cs
@@ -215,7 +215,7 @@ namespace Opc.Ua.Client
         /// async timeouts. Defaults to <see cref="TimeProvider.System"/>.</param>
         public ReverseConnectManager(ITelemetryContext telemetry, TimeProvider? timeProvider)
         {
-            m_timeProvider = timeProvider ??= TimeProvider.System;
+            m_timeProvider = timeProvider ?? TimeProvider.System;
             m_telemetry = telemetry;
             m_logger = telemetry.CreateLogger<ReverseConnectManager>();
             m_state = ReverseConnectManagerState.New;

--- a/Libraries/Opc.Ua.Client/ReverseConnectManager.cs
+++ b/Libraries/Opc.Ua.Client/ReverseConnectManager.cs
@@ -203,7 +203,19 @@ namespace Opc.Ua.Client
         /// Initializes the object with default values.
         /// </summary>
         public ReverseConnectManager(ITelemetryContext telemetry)
+            : this(telemetry, timeProvider: null)
         {
+        }
+
+        /// <summary>
+        /// Initializes the object with default values.
+        /// </summary>
+        /// <param name="telemetry">The telemetry context to use to create obvservability instruments.</param>
+        /// <param name="timeProvider">Optional time provider used for elapsed-time calculations and
+        /// async timeouts. Defaults to <see cref="TimeProvider.System"/>.</param>
+        public ReverseConnectManager(ITelemetryContext telemetry, TimeProvider? timeProvider)
+        {
+            m_timeProvider = timeProvider ??= TimeProvider.System;
             m_telemetry = telemetry;
             m_logger = telemetry.CreateLogger<ReverseConnectManager>();
             m_state = ReverseConnectManagerState.New;
@@ -700,7 +712,7 @@ namespace Opc.Ua.Client
         /// </summary>
         private async Task OnConnectionWaitingAsync(object sender, ConnectionWaitingEventArgs e)
         {
-            int startTime = HiResClock.TickCount;
+            int startTime = m_timeProvider.GetTickCount();
             int endTime = startTime + (m_configuration?.HoldTime ?? 15000);
 
             bool matched = MatchRegistration(sender, e);
@@ -712,10 +724,10 @@ namespace Opc.Ua.Client
                 {
                     ct = m_cts.Token;
                 }
-                int delay = endTime - HiResClock.TickCount;
+                int delay = endTime - m_timeProvider.GetTickCount();
                 if (delay > 0)
                 {
-                    await Task.Delay(delay, ct)
+                    await m_timeProvider.Delay(TimeSpan.FromMilliseconds(delay), ct)
                         .ContinueWith(tsk =>
                         {
                             if (tsk.IsCanceled)
@@ -727,7 +739,7 @@ namespace Opc.Ua.Client
                                         "Matched reverse connection {ServerUri} {EndpointUrl} after {Duration}ms",
                                         e.ServerUri,
                                         e.EndpointUrl,
-                                        HiResClock.TickCount - startTime);
+                                        m_timeProvider.GetTickCount() - startTime);
                                 }
                             }
                         },
@@ -744,7 +756,7 @@ namespace Opc.Ua.Client
                 e.Accepted ? "Accepted" : "Rejected",
                 e.ServerUri,
                 e.EndpointUrl,
-                HiResClock.TickCount - startTime);
+                m_timeProvider.GetTickCount() - startTime);
         }
 
         /// <summary>
@@ -841,6 +853,7 @@ namespace Opc.Ua.Client
         private Type? m_configType;
 
         private readonly Lock m_lock = new();
+        private readonly TimeProvider m_timeProvider;
         private readonly ILogger m_logger;
         private readonly ITelemetryContext m_telemetry;
         private ConfigurationWatcher? m_configurationWatcher;

--- a/Libraries/Opc.Ua.Client/Session/ClassicSubscriptionEngine.cs
+++ b/Libraries/Opc.Ua.Client/Session/ClassicSubscriptionEngine.cs
@@ -62,7 +62,7 @@ namespace Opc.Ua.Client
                 .CreateLogger<ClassicSubscriptionEngine>();
             m_minPublishRequestCount = kDefaultPublishRequestCount;
             m_maxPublishRequestCount = kMaxPublishRequestCountMax;
-            m_timeProvider = timeProvider ??= TimeProvider.System;
+            m_timeProvider = timeProvider ?? TimeProvider.System;
         }
 
         /// <inheritdoc/>

--- a/Libraries/Opc.Ua.Client/Session/ClassicSubscriptionEngine.cs
+++ b/Libraries/Opc.Ua.Client/Session/ClassicSubscriptionEngine.cs
@@ -49,7 +49,12 @@ namespace Opc.Ua.Client
         /// </summary>
         /// <param name="context">The session context that provides
         /// access to session state and services.</param>
-        public ClassicSubscriptionEngine(ISubscriptionEngineContext context)
+        /// <param name="timeProvider">Optional <see cref="TimeProvider"/>
+        /// used for throttling and back-off delays. Defaults to
+        /// <see cref="TimeProvider.System"/> when <c>null</c>.</param>
+        public ClassicSubscriptionEngine(
+            ISubscriptionEngineContext context,
+            TimeProvider? timeProvider = null)
         {
             m_context = context
                 ?? throw new ArgumentNullException(nameof(context));
@@ -57,6 +62,7 @@ namespace Opc.Ua.Client
                 .CreateLogger<ClassicSubscriptionEngine>();
             m_minPublishRequestCount = kDefaultPublishRequestCount;
             m_maxPublishRequestCount = kMaxPublishRequestCountMax;
+            m_timeProvider = timeProvider ??= TimeProvider.System;
         }
 
         /// <inheritdoc/>
@@ -586,7 +592,7 @@ namespace Opc.Ua.Client
                     // server load
                     _ = Task.Run(async () =>
                     {
-                        await Task.Delay(100)
+                        await m_timeProvider.Delay(TimeSpan.FromMilliseconds(100))
                             .ConfigureAwait(false);
                         QueueBeginPublish();
                     });
@@ -1032,6 +1038,7 @@ namespace Opc.Ua.Client
         private const int kPublishRequestSequenceNumberOutdatedThreshold = 100;
         private readonly ISubscriptionEngineContext m_context;
         private readonly ILogger m_logger;
+        private readonly TimeProvider m_timeProvider;
         private readonly object m_acknowledgementsToSendLock = new();
         private List<SubscriptionAcknowledgement> m_acknowledgementsToSend = [];
         internal uint PublishCounter;

--- a/Libraries/Opc.Ua.Client/Session/ClassicSubscriptionEngineFactory.cs
+++ b/Libraries/Opc.Ua.Client/Session/ClassicSubscriptionEngineFactory.cs
@@ -29,6 +29,8 @@
 
 namespace Opc.Ua.Client
 {
+    using System;
+
     /// <summary>
     /// Factory that creates <see cref="ClassicSubscriptionEngine"/>
     /// instances. This is the default factory used when no custom
@@ -42,10 +44,34 @@ namespace Opc.Ua.Client
         /// </summary>
         public static ClassicSubscriptionEngineFactory Instance { get; } = new();
 
+        /// <summary>
+        /// Initializes a new instance of the
+        /// <see cref="ClassicSubscriptionEngineFactory"/> class bound to
+        /// <see cref="TimeProvider.System"/>.
+        /// </summary>
+        public ClassicSubscriptionEngineFactory()
+            : this(null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the
+        /// <see cref="ClassicSubscriptionEngineFactory"/> class.
+        /// </summary>
+        /// <param name="timeProvider">Optional <see cref="TimeProvider"/>
+        /// forwarded to the engines created by this factory. Defaults to
+        /// <see cref="TimeProvider.System"/> when <c>null</c>.</param>
+        public ClassicSubscriptionEngineFactory(TimeProvider? timeProvider = null)
+        {
+            m_timeProvider = timeProvider ??= TimeProvider.System;
+        }
+
         /// <inheritdoc/>
         public ISubscriptionEngine Create(ISubscriptionEngineContext context)
         {
-            return new ClassicSubscriptionEngine(context);
+            return new ClassicSubscriptionEngine(context, m_timeProvider);
         }
+
+        private readonly TimeProvider m_timeProvider;
     }
 }

--- a/Libraries/Opc.Ua.Client/Session/ClassicSubscriptionEngineFactory.cs
+++ b/Libraries/Opc.Ua.Client/Session/ClassicSubscriptionEngineFactory.cs
@@ -27,10 +27,10 @@
  * http://opcfoundation.org/License/MIT/1.00/
  * ======================================================================*/
 
+using System;
+
 namespace Opc.Ua.Client
 {
-    using System;
-
     /// <summary>
     /// Factory that creates <see cref="ClassicSubscriptionEngine"/>
     /// instances. This is the default factory used when no custom
@@ -63,7 +63,7 @@ namespace Opc.Ua.Client
         /// <see cref="TimeProvider.System"/> when <c>null</c>.</param>
         public ClassicSubscriptionEngineFactory(TimeProvider? timeProvider = null)
         {
-            m_timeProvider = timeProvider ??= TimeProvider.System;
+            m_timeProvider = timeProvider ?? TimeProvider.System;
         }
 
         /// <inheritdoc/>

--- a/Libraries/Opc.Ua.Client/Session/ConnectionStateMachine.cs
+++ b/Libraries/Opc.Ua.Client/Session/ConnectionStateMachine.cs
@@ -104,7 +104,7 @@ namespace Opc.Ua.Client
                 ?? throw new ArgumentNullException(nameof(reconnectPolicy));
             m_logger = logger
                 ?? throw new ArgumentNullException(nameof(logger));
-            m_timeProvider = timeProvider ??= TimeProvider.System;
+            m_timeProvider = timeProvider ?? TimeProvider.System;
         }
 
         /// <summary>Current connection state.</summary>

--- a/Libraries/Opc.Ua.Client/Session/ConnectionStateMachine.cs
+++ b/Libraries/Opc.Ua.Client/Session/ConnectionStateMachine.cs
@@ -44,6 +44,7 @@ namespace Opc.Ua.Client
         private volatile ConnectionState m_state = ConnectionState.Disconnected;
         private readonly IReconnectPolicy m_reconnectPolicy;
         private readonly ILogger m_logger;
+        private readonly TimeProvider m_timeProvider;
         private readonly CancellationTokenSource m_cts = new();
         private readonly AsyncAutoResetEvent m_trigger = new(false);
         private readonly AsyncManualResetEvent m_connected = new(false);
@@ -91,14 +92,19 @@ namespace Opc.Ua.Client
         /// <param name="reconnectPolicy">The reconnect policy that
         /// controls backoff and retry limits.</param>
         /// <param name="logger">Logger instance.</param>
+        /// <param name="timeProvider">Optional <see cref="System.TimeProvider"/>
+        /// used for reconnect delay timing. Defaults to
+        /// <see cref="TimeProvider.System"/> when <c>null</c>.</param>
         public ConnectionStateMachine(
             IReconnectPolicy reconnectPolicy,
-            ILogger logger)
+            ILogger logger,
+            TimeProvider? timeProvider = null)
         {
             m_reconnectPolicy = reconnectPolicy
                 ?? throw new ArgumentNullException(nameof(reconnectPolicy));
             m_logger = logger
                 ?? throw new ArgumentNullException(nameof(logger));
+            m_timeProvider = timeProvider ??= TimeProvider.System;
         }
 
         /// <summary>Current connection state.</summary>
@@ -384,7 +390,7 @@ namespace Opc.Ua.Client
                     "ConnectionStateMachine:Reconnect attempt {Attempt}, delay {DelayMs} ms.",
                     attempt, (int)delay.Value.TotalMilliseconds);
 
-                await Task.Delay(delay.Value, ct)
+                await m_timeProvider.Delay(delay.Value, ct)
                     .ConfigureAwait(false);
 
                 ServiceResult result = await InvokeReconnectAsync(ct)

--- a/Libraries/Opc.Ua.Client/Session/DefaultSessionFactory.cs
+++ b/Libraries/Opc.Ua.Client/Session/DefaultSessionFactory.cs
@@ -67,6 +67,14 @@ namespace Opc.Ua.Client
         public ISubscriptionEngineFactory? SubscriptionEngineFactory { get; init; }
 
         /// <summary>
+        /// Optional <see cref="TimeProvider"/> forwarded to every
+        /// <see cref="Session"/> created by this factory. When
+        /// <see langword="null"/>, the session uses
+        /// <see cref="TimeProvider.System"/>.
+        /// </summary>
+        public TimeProvider? TimeProvider { get; init; }
+
+        /// <summary>
         /// Obsolete default constructor
         /// </summary>
         [Obsolete("Use DefaultSessionFactory(ITelemetryContext) instead.")]
@@ -398,7 +406,8 @@ namespace Opc.Ua.Client
                 clientCertificateChain,
                 availableEndpoints,
                 discoveryProfileUris,
-                SubscriptionEngineFactory)
+                SubscriptionEngineFactory,
+                TimeProvider)
             {
                 ReturnDiagnostics = ReturnDiagnostics
             };

--- a/Libraries/Opc.Ua.Client/Session/DefaultSubscriptionEngine.cs
+++ b/Libraries/Opc.Ua.Client/Session/DefaultSubscriptionEngine.cs
@@ -77,7 +77,7 @@ namespace Opc.Ua.Client
             {
                 throw new ArgumentNullException(nameof(context));
             }
-            m_timeProvider = timeProvider ??= TimeProvider.System;
+            m_timeProvider = timeProvider ?? TimeProvider.System;
             m_manager = new SubscriptionManager(
                 new EngineContextAdapter(context, m_timeProvider),
                 context.Telemetry.LoggerFactory,

--- a/Libraries/Opc.Ua.Client/Session/DefaultSubscriptionEngine.cs
+++ b/Libraries/Opc.Ua.Client/Session/DefaultSubscriptionEngine.cs
@@ -55,15 +55,34 @@ namespace Opc.Ua.Client
         /// access to session state and services.</param>
         public DefaultSubscriptionEngine(
             ISubscriptionEngineContext context)
+            : this(context, null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the
+        /// <see cref="DefaultSubscriptionEngine"/> class.
+        /// </summary>
+        /// <param name="context">The session context that provides
+        /// access to session state and services.</param>
+        /// <param name="timeProvider">An optional <see cref="TimeProvider"/>
+        /// used by the publish/subscribe pipeline for timer scheduling and
+        /// duration calculations. When <see langword="null"/>,
+        /// <see cref="TimeProvider.System"/> is used.</param>
+        public DefaultSubscriptionEngine(
+            ISubscriptionEngineContext context,
+            TimeProvider? timeProvider = null)
         {
             if (context == null)
             {
                 throw new ArgumentNullException(nameof(context));
             }
+            m_timeProvider = timeProvider ??= TimeProvider.System;
             m_manager = new SubscriptionManager(
-                new EngineContextAdapter(context),
+                new EngineContextAdapter(context, m_timeProvider),
                 context.Telemetry.LoggerFactory,
-                context.ReturnDiagnostics);
+                context.ReturnDiagnostics,
+                m_timeProvider);
 
             // The V2 SubscriptionManager starts paused. Resume it so
             // publish workers begin processing as soon as a
@@ -189,9 +208,12 @@ namespace Opc.Ua.Client
         /// </summary>
         private sealed class EngineContextAdapter : ISubscriptionManagerContext
         {
-            public EngineContextAdapter(ISubscriptionEngineContext context)
+            public EngineContextAdapter(
+                ISubscriptionEngineContext context,
+                TimeProvider timeProvider)
             {
                 m_context = context;
+                m_timeProvider = timeProvider;
             }
 
             /// <inheritdoc/>
@@ -204,7 +226,7 @@ namespace Opc.Ua.Client
                     new SubscriptionContextAdapter(m_context);
                 return new DefaultSubscription(
                     subscriptionContext, handler, queue,
-                    options, m_context.Telemetry);
+                    options, m_context.Telemetry, m_timeProvider);
             }
 
             /// <inheritdoc/>
@@ -241,6 +263,7 @@ namespace Opc.Ua.Client
             }
 
             private readonly ISubscriptionEngineContext m_context;
+            private readonly TimeProvider m_timeProvider;
         }
 
         /// <summary>
@@ -515,9 +538,10 @@ namespace Opc.Ua.Client
                 ISubscriptionNotificationHandler handler,
                 IMessageAckQueue completion,
                 IOptionsMonitor<Subscriptions.SubscriptionOptions> options,
-                ITelemetryContext telemetry)
+                ITelemetryContext telemetry,
+                TimeProvider? timeProvider = null)
                 : base(context, handler, completion,
-                       options, telemetry)
+                       options, telemetry, timeProvider)
             {
             }
 
@@ -556,6 +580,7 @@ namespace Opc.Ua.Client
         }
 
         private readonly SubscriptionManager m_manager;
+        private readonly TimeProvider m_timeProvider;
         private bool m_disposed;
     }
 }

--- a/Libraries/Opc.Ua.Client/Session/DefaultSubscriptionEngineFactory.cs
+++ b/Libraries/Opc.Ua.Client/Session/DefaultSubscriptionEngineFactory.cs
@@ -27,10 +27,10 @@
  * http://opcfoundation.org/License/MIT/1.00/
  * ======================================================================*/
 
+using System;
+
 namespace Opc.Ua.Client
 {
-    using System;
-
     /// <summary>
     /// Factory that creates <see cref="DefaultSubscriptionEngine"/>
     /// instances backed by the V2 channel-based publish pipeline.
@@ -63,7 +63,7 @@ namespace Opc.Ua.Client
         /// used.</param>
         public DefaultSubscriptionEngineFactory(TimeProvider? timeProvider = null)
         {
-            m_timeProvider = timeProvider ??= TimeProvider.System;
+            m_timeProvider = timeProvider ?? TimeProvider.System;
         }
 
         /// <inheritdoc/>

--- a/Libraries/Opc.Ua.Client/Session/DefaultSubscriptionEngineFactory.cs
+++ b/Libraries/Opc.Ua.Client/Session/DefaultSubscriptionEngineFactory.cs
@@ -29,6 +29,8 @@
 
 namespace Opc.Ua.Client
 {
+    using System;
+
     /// <summary>
     /// Factory that creates <see cref="DefaultSubscriptionEngine"/>
     /// instances backed by the V2 channel-based publish pipeline.
@@ -37,14 +39,39 @@ namespace Opc.Ua.Client
         : ISubscriptionEngineFactory
     {
         /// <summary>
-        /// Shared singleton instance.
+        /// Shared singleton instance bound to <see cref="TimeProvider.System"/>.
         /// </summary>
         public static DefaultSubscriptionEngineFactory Instance { get; } = new();
+
+        /// <summary>
+        /// Initializes a new instance of the
+        /// <see cref="DefaultSubscriptionEngineFactory"/> class bound to
+        /// <see cref="TimeProvider.System"/>.
+        /// </summary>
+        public DefaultSubscriptionEngineFactory()
+            : this(null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the
+        /// <see cref="DefaultSubscriptionEngineFactory"/> class.
+        /// </summary>
+        /// <param name="timeProvider">An optional <see cref="TimeProvider"/>
+        /// forwarded to every created <see cref="DefaultSubscriptionEngine"/>.
+        /// When <see langword="null"/>, <see cref="TimeProvider.System"/> is
+        /// used.</param>
+        public DefaultSubscriptionEngineFactory(TimeProvider? timeProvider = null)
+        {
+            m_timeProvider = timeProvider ??= TimeProvider.System;
+        }
 
         /// <inheritdoc/>
         public ISubscriptionEngine Create(ISubscriptionEngineContext context)
         {
-            return new DefaultSubscriptionEngine(context);
+            return new DefaultSubscriptionEngine(context, m_timeProvider);
         }
+
+        private readonly TimeProvider m_timeProvider;
     }
 }

--- a/Libraries/Opc.Ua.Client/Session/ISession.cs
+++ b/Libraries/Opc.Ua.Client/Session/ISession.cs
@@ -267,7 +267,17 @@ namespace Opc.Ua.Client
         /// <summary>
         /// Gets the TickCount in ms of the last keep alive based on <see cref="TimeProvider"/>.
         /// </summary>
+        [Obsolete("Use LastKeepAliveTimestamp + TimeProvider.GetElapsedTime. " +
+            "LastKeepAliveTickCount is a 32-bit value that wraps every ~49.7 days.")]
         int LastKeepAliveTickCount { get; }
+
+        /// <summary>
+        /// Gets the monotonic timestamp (from <see cref="TimeProvider.GetTimestamp"/>) of the
+        /// last keep alive. Use together with <see cref="TimeProvider.GetElapsedTime(long)"/>
+        /// to compute the elapsed time since the last keep alive without DateTime drift or
+        /// 32-bit tick wrap.
+        /// </summary>
+        long LastKeepAliveTimestamp { get; }
 
         /// <summary>
         /// Gets the number of outstanding publish or keep alive requests.

--- a/Libraries/Opc.Ua.Client/Session/ISession.cs
+++ b/Libraries/Opc.Ua.Client/Session/ISession.cs
@@ -265,13 +265,6 @@ namespace Opc.Ua.Client
         DateTime LastKeepAliveTime { get; }
 
         /// <summary>
-        /// Gets the TickCount in ms of the last keep alive based on <see cref="TimeProvider"/>.
-        /// </summary>
-        [Obsolete("Use LastKeepAliveTimestamp + TimeProvider.GetElapsedTime. " +
-            "LastKeepAliveTickCount is a 32-bit value that wraps every ~49.7 days.")]
-        int LastKeepAliveTickCount { get; }
-
-        /// <summary>
         /// Gets the monotonic timestamp (from <see cref="TimeProvider.GetTimestamp"/>) of the
         /// last keep alive. Use together with <see cref="TimeProvider.GetElapsedTime(long)"/>
         /// to compute the elapsed time since the last keep alive without DateTime drift or

--- a/Libraries/Opc.Ua.Client/Session/ISession.cs
+++ b/Libraries/Opc.Ua.Client/Session/ISession.cs
@@ -265,7 +265,7 @@ namespace Opc.Ua.Client
         DateTime LastKeepAliveTime { get; }
 
         /// <summary>
-        /// Gets the TickCount in ms of the last keep alive based on <see cref="HiResClock.TickCount"/>.
+        /// Gets the TickCount in ms of the last keep alive based on <see cref="TimeProvider"/>.
         /// </summary>
         int LastKeepAliveTickCount { get; }
 

--- a/Libraries/Opc.Ua.Client/Session/ManagedSession.cs
+++ b/Libraries/Opc.Ua.Client/Session/ManagedSession.cs
@@ -392,8 +392,16 @@ namespace Opc.Ua.Client
             => m_session?.LastKeepAliveTime ?? DateTime.MinValue;
 
         /// <inheritdoc/>
+        [Obsolete("Use LastKeepAliveTimestamp + TimeProvider.GetElapsedTime. " +
+            "LastKeepAliveTickCount is a 32-bit value that wraps every ~49.7 days.")]
         public int LastKeepAliveTickCount
+#pragma warning disable CS0618 // Back-compat surface.
             => m_session?.LastKeepAliveTickCount ?? 0;
+#pragma warning restore CS0618
+
+        /// <inheritdoc/>
+        public long LastKeepAliveTimestamp
+            => m_session?.LastKeepAliveTimestamp ?? 0L;
 
         /// <inheritdoc/>
         public int OutstandingRequestCount

--- a/Libraries/Opc.Ua.Client/Session/ManagedSession.cs
+++ b/Libraries/Opc.Ua.Client/Session/ManagedSession.cs
@@ -392,14 +392,6 @@ namespace Opc.Ua.Client
             => m_session?.LastKeepAliveTime ?? DateTime.MinValue;
 
         /// <inheritdoc/>
-        [Obsolete("Use LastKeepAliveTimestamp + TimeProvider.GetElapsedTime. " +
-            "LastKeepAliveTickCount is a 32-bit value that wraps every ~49.7 days.")]
-        public int LastKeepAliveTickCount
-#pragma warning disable CS0618 // Back-compat surface.
-            => m_session?.LastKeepAliveTickCount ?? 0;
-#pragma warning restore CS0618
-
-        /// <inheritdoc/>
         public long LastKeepAliveTimestamp
             => m_session?.LastKeepAliveTimestamp ?? 0L;
 

--- a/Libraries/Opc.Ua.Client/Session/ManagedSession.cs
+++ b/Libraries/Opc.Ua.Client/Session/ManagedSession.cs
@@ -178,14 +178,17 @@ namespace Opc.Ua.Client
             // factory is a DefaultSessionFactory and no engine factory is
             // already configured on it, propagate this choice so the inner
             // Session is constructed with the V2 engine.
-            engineFactory ??= DefaultSubscriptionEngineFactory.Instance;
+            engineFactory ??= timeProvider == null
+                ? DefaultSubscriptionEngineFactory.Instance
+                : new DefaultSubscriptionEngineFactory(timeProvider);
             if (sessionFactory is DefaultSessionFactory dsf &&
                 dsf.SubscriptionEngineFactory is null)
             {
                 sessionFactory = new DefaultSessionFactory(dsf.Telemetry)
                 {
                     ReturnDiagnostics = dsf.ReturnDiagnostics,
-                    SubscriptionEngineFactory = engineFactory
+                    SubscriptionEngineFactory = engineFactory,
+                    TimeProvider = timeProvider ?? dsf.TimeProvider
                 };
             }
 

--- a/Libraries/Opc.Ua.Client/Session/ManagedSession.cs
+++ b/Libraries/Opc.Ua.Client/Session/ManagedSession.cs
@@ -102,7 +102,7 @@ namespace Opc.Ua.Client
             m_poolNotifications = poolNotifications;
 
             StateMachine = new ConnectionStateMachine(
-                reconnectPolicy, logger);
+                reconnectPolicy, logger, m_timeProvider);
 
             WireStateMachineCallbacks();
         }

--- a/Libraries/Opc.Ua.Client/Session/Session.cs
+++ b/Libraries/Opc.Ua.Client/Session/Session.cs
@@ -187,7 +187,11 @@ namespace Opc.Ua.Client
             m_keepAliveInterval = template.KeepAliveInterval;
 
             // Create timer for keep alive event triggering but in off state
-            m_keepAliveTimer = m_timeProvider.CreateTimer(_ => m_keepAliveEvent.Set(), this, Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+            m_keepAliveTimer = m_timeProvider.CreateTimer(
+                _ => m_keepAliveEvent.Set(),
+                this,
+                Timeout.InfiniteTimeSpan,
+                Timeout.InfiniteTimeSpan);
 
             m_checkDomain = template.m_checkDomain;
             ContinuationPointPolicy = template.ContinuationPointPolicy;
@@ -236,7 +240,7 @@ namespace Opc.Ua.Client
                 throw new ArgumentNullException(nameof(messageContext));
             }
 
-            m_timeProvider = timeProvider ??= TimeProvider.System;
+            m_timeProvider = timeProvider ?? TimeProvider.System;
             m_telemetry = messageContext.Telemetry;
             m_logger = m_telemetry.CreateLogger<Session>();
 
@@ -291,7 +295,11 @@ namespace Opc.Ua.Client
             m_nodeCache = new NodeCache(new NodeCacheContext(this), m_telemetry);
 
             // Create timer for keep alive event triggering but in off state
-            m_keepAliveTimer = m_timeProvider.CreateTimer(_ => m_keepAliveEvent.Set(), this, Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+            m_keepAliveTimer = m_timeProvider.CreateTimer(
+                _ => m_keepAliveEvent.Set(),
+                this,
+                Timeout.InfiniteTimeSpan,
+                Timeout.InfiniteTimeSpan);
 
             // Create the subscription engine. Session defaults to the
             // classic engine (legacy applications + classic Subscription
@@ -820,11 +828,12 @@ namespace Opc.Ua.Client
                 if (StatusCode.IsGood(lastKeepAliveErrorStatusCode) ||
                     lastKeepAliveErrorStatusCode == StatusCodes.BadNoCommunication)
                 {
-                    int delta = m_timeProvider.GetTickCount() - LastKeepAliveTickCount;
+                    TimeSpan elapsed = m_timeProvider.GetElapsedTime(m_lastKeepAliveTimestamp);
 
                     // add a guard band to allow for network lag.
-                    return ((m_keepAliveInterval * m_keepAliveIntervalFactor) +
-                        m_keepAliveGuardBand) <= delta;
+                    return TimeSpan.FromMilliseconds(
+                        (m_keepAliveInterval * m_keepAliveIntervalFactor) +
+                        m_keepAliveGuardBand) <= elapsed;
                 }
 
                 // another error was reported which caused keep alive to stop.
@@ -3032,8 +3041,10 @@ namespace Opc.Ua.Client
 
                 header.TimeoutHint = kReconnectTimeout;
 
-                using var timeout = CancellationTokenSource.CreateLinkedTokenSource(ct);
-                timeout.CancelAfter(TimeSpan.FromMilliseconds(kReconnectTimeout / 2));
+                using CancellationTokenSource timeoutCts = m_timeProvider
+                    .CreateCancellationTokenSource(TimeSpan.FromMilliseconds(kReconnectTimeout / 2));
+                using var timeout = CancellationTokenSource.CreateLinkedTokenSource(
+                    ct, timeoutCts.Token);
                 try
                 {
                     // reactivate session.
@@ -3296,6 +3307,7 @@ namespace Opc.Ua.Client
             Interlocked.Exchange(
                 ref m_lastKeepAliveTime,
                 m_timeProvider.GetUtcNow().UtcDateTime.Ticks);
+            m_lastKeepAliveTimestamp = m_timeProvider.GetTimestamp();
             LastKeepAliveTickCount = m_timeProvider.GetTickCount();
 
             m_serverState = ServerState.Unknown;
@@ -3777,6 +3789,7 @@ namespace Opc.Ua.Client
                 Interlocked.Exchange(
                     ref m_lastKeepAliveTime,
                     m_timeProvider.GetUtcNow().UtcDateTime.Ticks);
+                m_lastKeepAliveTimestamp = m_timeProvider.GetTimestamp();
                 LastKeepAliveTickCount = m_timeProvider.GetTickCount();
 
                 lock (m_outstandingRequests)
@@ -3800,6 +3813,7 @@ namespace Opc.Ua.Client
                 Interlocked.Exchange(
                     ref m_lastKeepAliveTime,
                     m_timeProvider.GetUtcNow().UtcDateTime.Ticks);
+                m_lastKeepAliveTimestamp = m_timeProvider.GetTimestamp();
                 LastKeepAliveTickCount = m_timeProvider.GetTickCount();
             }
 
@@ -3830,10 +3844,10 @@ namespace Opc.Ua.Client
             if (result.StatusCode == StatusCodes.BadNoCommunication)
             {
                 //keep alive read timed out
-                int delta = m_timeProvider.GetTickCount() - LastKeepAliveTickCount;
+                TimeSpan elapsed = m_timeProvider.GetElapsedTime(m_lastKeepAliveTimestamp);
                 m_logger.LogInformation(
                     "KEEP ALIVE LATE: {Duration}ms, EndpointUrl={EndpointUrl}, RequestCount={Good}/{Outstanding}",
-                    delta,
+                    elapsed.TotalMilliseconds,
                     Endpoint?.EndpointUrl,
                     GoodPublishRequestCount,
                     OutstandingRequestCount);
@@ -4868,6 +4882,7 @@ namespace Opc.Ua.Client
         private Certificate? m_serverCertificate;
 #pragma warning restore CA2213
         private long m_lastKeepAliveTime;
+        private long m_lastKeepAliveTimestamp;
         private StatusCode m_lastKeepAliveErrorStatusCode;
         private ServerState m_serverState;
         private int m_keepAliveInterval;

--- a/Libraries/Opc.Ua.Client/Session/Session.cs
+++ b/Libraries/Opc.Ua.Client/Session/Session.cs
@@ -854,14 +854,6 @@ namespace Opc.Ua.Client
         }
 
         /// <summary>
-        /// Gets the TickCount in ms of the last keep alive based on <see cref="TimeProvider"/>.
-        /// Independent of system time changes.
-        /// </summary>
-        [Obsolete("Use LastKeepAliveTimestamp + TimeProvider.GetElapsedTime. " +
-            "LastKeepAliveTickCount is a 32-bit value that wraps every ~49.7 days.")]
-        public int LastKeepAliveTickCount { get; private set; }
-
-        /// <summary>
         /// Gets the monotonic timestamp (from <see cref="TimeProvider.GetTimestamp"/>) of the
         /// last keep alive. Use together with <see cref="TimeProvider.GetElapsedTime(long)"/>
         /// to compute the elapsed time since the last keep alive without DateTime drift or
@@ -3318,9 +3310,6 @@ namespace Opc.Ua.Client
                 ref m_lastKeepAliveTime,
                 m_timeProvider.GetUtcNow().UtcDateTime.Ticks);
             m_lastKeepAliveTimestamp = m_timeProvider.GetTimestamp();
-#pragma warning disable CS0618 // Back-compat: keep populating LastKeepAliveTickCount.
-            LastKeepAliveTickCount = m_timeProvider.GetTickCount();
-#pragma warning restore CS0618
 
             m_serverState = ServerState.Unknown;
 
@@ -3804,9 +3793,6 @@ namespace Opc.Ua.Client
                     ref m_lastKeepAliveTime,
                     m_timeProvider.GetUtcNow().UtcDateTime.Ticks);
                 m_lastKeepAliveTimestamp = m_timeProvider.GetTimestamp();
-#pragma warning disable CS0618 // Back-compat: keep populating LastKeepAliveTickCount.
-                LastKeepAliveTickCount = m_timeProvider.GetTickCount();
-#pragma warning restore CS0618
 
                 lock (m_outstandingRequests)
                 {
@@ -3830,9 +3816,6 @@ namespace Opc.Ua.Client
                     ref m_lastKeepAliveTime,
                     m_timeProvider.GetUtcNow().UtcDateTime.Ticks);
                 m_lastKeepAliveTimestamp = m_timeProvider.GetTimestamp();
-#pragma warning disable CS0618 // Back-compat: keep populating LastKeepAliveTickCount.
-                LastKeepAliveTickCount = m_timeProvider.GetTickCount();
-#pragma warning restore CS0618
             }
 
             // save server state.

--- a/Libraries/Opc.Ua.Client/Session/Session.cs
+++ b/Libraries/Opc.Ua.Client/Session/Session.cs
@@ -112,6 +112,9 @@ namespace Opc.Ua.Client
         /// <param name="engineFactory">Optional subscription engine factory. When
         /// <c>null</c> the session uses <see cref="ClassicSubscriptionEngineFactory"/>
         /// by default.</param>
+        /// <param name="timeProvider">Optional <see cref="TimeProvider"/> used by the
+        /// session for keep-alive timers and elapsed-time calculations. When
+        /// <see langword="null"/>, <see cref="TimeProvider.System"/> is used.</param>
         /// <remarks>
         /// The application configuration is used to look up the certificate if none
         /// is provided. The clientCertificate must have the private key. This will
@@ -129,13 +132,15 @@ namespace Opc.Ua.Client
             CertificateCollection? clientCertificateChain = null,
             ArrayOf<EndpointDescription> availableEndpoints = default,
             ArrayOf<string> discoveryProfileUris = default,
-            ISubscriptionEngineFactory? engineFactory = null)
+            ISubscriptionEngineFactory? engineFactory = null,
+            TimeProvider? timeProvider = null)
             : this(
                   channel,
                   configuration,
                   endpoint,
                   channel.MessageContext ?? configuration.CreateMessageContext(),
-                  engineFactory)
+                  engineFactory,
+                  timeProvider)
         {
             m_instanceCertificate = clientCertificate;
             m_instanceCertificateChain = clientCertificateChain;
@@ -155,7 +160,8 @@ namespace Opc.Ua.Client
                   template.m_configuration,
                   template.ConfiguredEndpoint,
                   channel.MessageContext ?? template.m_configuration.CreateMessageContext(),
-                  template.SubscriptionEngineFactory)
+                  template.SubscriptionEngineFactory,
+                  template.m_timeProvider)
         {
             // AddRef so the clone has its own reference; the template
             // retains its existing one. Both Sessions independently
@@ -179,7 +185,7 @@ namespace Opc.Ua.Client
             m_keepAliveInterval = template.KeepAliveInterval;
 
             // Create timer for keep alive event triggering but in off state
-            m_keepAliveTimer = new Timer(_ => m_keepAliveEvent.Set(), this, Timeout.Infinite, Timeout.Infinite);
+            m_keepAliveTimer = m_timeProvider.CreateTimer(_ => m_keepAliveEvent.Set(), this, Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
 
             m_checkDomain = template.m_checkDomain;
             ContinuationPointPolicy = template.ContinuationPointPolicy;
@@ -219,7 +225,8 @@ namespace Opc.Ua.Client
             ApplicationConfiguration configuration,
             ConfiguredEndpoint endpoint,
             IServiceMessageContext messageContext,
-            ISubscriptionEngineFactory? engineFactory = null)
+            ISubscriptionEngineFactory? engineFactory = null,
+            TimeProvider? timeProvider = null)
             : base(channel, messageContext.Telemetry)
         {
             if (messageContext == null)
@@ -227,6 +234,7 @@ namespace Opc.Ua.Client
                 throw new ArgumentNullException(nameof(messageContext));
             }
 
+            m_timeProvider = timeProvider ??= TimeProvider.System;
             m_telemetry = messageContext.Telemetry;
             m_logger = m_telemetry.CreateLogger<Session>();
 
@@ -281,7 +289,7 @@ namespace Opc.Ua.Client
             m_nodeCache = new NodeCache(new NodeCacheContext(this), m_telemetry);
 
             // Create timer for keep alive event triggering but in off state
-            m_keepAliveTimer = new Timer(_ => m_keepAliveEvent.Set(), this, Timeout.Infinite, Timeout.Infinite);
+            m_keepAliveTimer = m_timeProvider.CreateTimer(_ => m_keepAliveEvent.Set(), this, Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
 
             // Create the subscription engine.
             SubscriptionEngineFactory = engineFactory
@@ -805,7 +813,7 @@ namespace Opc.Ua.Client
                 if (StatusCode.IsGood(lastKeepAliveErrorStatusCode) ||
                     lastKeepAliveErrorStatusCode == StatusCodes.BadNoCommunication)
                 {
-                    int delta = HiResClock.TickCount - LastKeepAliveTickCount;
+                    int delta = m_timeProvider.GetTickCount() - LastKeepAliveTickCount;
 
                     // add a guard band to allow for network lag.
                     return ((m_keepAliveInterval * m_keepAliveIntervalFactor) +
@@ -830,7 +838,7 @@ namespace Opc.Ua.Client
         }
 
         /// <summary>
-        /// Gets the TickCount in ms of the last keep alive based on <see cref="HiResClock.TickCount"/>.
+        /// Gets the TickCount in ms of the last keep alive based on <see cref="TimeProvider"/>.
         /// Independent of system time changes.
         /// </summary>
         public int LastKeepAliveTickCount { get; private set; }
@@ -3278,8 +3286,10 @@ namespace Opc.Ua.Client
             int keepAliveInterval = m_keepAliveInterval;
 
             m_lastKeepAliveErrorStatusCode = StatusCodes.Good;
-            Interlocked.Exchange(ref m_lastKeepAliveTime, DateTime.UtcNow.Ticks);
-            LastKeepAliveTickCount = HiResClock.TickCount;
+            Interlocked.Exchange(
+                ref m_lastKeepAliveTime,
+                m_timeProvider.GetUtcNow().UtcDateTime.Ticks);
+            LastKeepAliveTickCount = m_timeProvider.GetTickCount();
 
             m_serverState = ServerState.Unknown;
 
@@ -3314,7 +3324,7 @@ namespace Opc.Ua.Client
                 }
 
                 // send initial keep alive.
-                m_keepAliveTimer.Change(0, m_keepAliveInterval);
+                m_keepAliveTimer.Change(TimeSpan.Zero, TimeSpan.FromMilliseconds(m_keepAliveInterval));
             }
         }
 
@@ -3344,7 +3354,8 @@ namespace Opc.Ua.Client
             {
                 if (m_keepAliveWorker != null)
                 {
-                    m_keepAliveTimer.Change(m_keepAliveInterval, m_keepAliveInterval);
+                    m_keepAliveTimer.Change(TimeSpan.FromMilliseconds(m_keepAliveInterval),
+                        TimeSpan.FromMilliseconds(m_keepAliveInterval));
                 }
             }
         }
@@ -3367,7 +3378,7 @@ namespace Opc.Ua.Client
                 m_keepAliveWorker = null;
                 m_keepAliveCancellation = null;
 
-                m_keepAliveTimer.Change(Timeout.Infinite, Timeout.Infinite);
+                m_keepAliveTimer.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
             }
 
             if (keepAliveWorker == null)
@@ -3433,7 +3444,7 @@ namespace Opc.Ua.Client
                     ? int.MaxValue
                     : PublishRequestCancelDelayOnCloseSession;
 
-                int startTime = HiResClock.TickCount;
+                int startTime = m_timeProvider.GetTickCount();
                 while (true)
                 {
                     // Check if all publish requests completed
@@ -3456,7 +3467,7 @@ namespace Opc.Ua.Client
                     }
 
                     // Check timeout
-                    int elapsed = HiResClock.TickCount - startTime;
+                    int elapsed = m_timeProvider.GetTickCount() - startTime;
                     if (elapsed >= waitTimeout)
                     {
                         m_logger.LogWarning(
@@ -3574,7 +3585,7 @@ namespace Opc.Ua.Client
                         RequestId = requestId,
                         RequestTypeId = typeId,
                         Result = result,
-                        TickCount = HiResClock.TickCount
+                        TickCount = m_timeProvider.GetTickCount()
                     };
 
                     m_outstandingRequests.AddLast(state);
@@ -3624,7 +3635,7 @@ namespace Opc.Ua.Client
                         RequestId = requestId,
                         RequestTypeId = typeId,
                         Result = result,
-                        TickCount = HiResClock.TickCount,
+                        TickCount = m_timeProvider.GetTickCount(),
                         Activity = null
                     };
 
@@ -3756,8 +3767,10 @@ namespace Opc.Ua.Client
                 }
 
                 m_lastKeepAliveErrorStatusCode = StatusCodes.Good;
-                Interlocked.Exchange(ref m_lastKeepAliveTime, DateTime.UtcNow.Ticks);
-                LastKeepAliveTickCount = HiResClock.TickCount;
+                Interlocked.Exchange(
+                    ref m_lastKeepAliveTime,
+                    m_timeProvider.GetUtcNow().UtcDateTime.Ticks);
+                LastKeepAliveTickCount = m_timeProvider.GetTickCount();
 
                 lock (m_outstandingRequests)
                 {
@@ -3777,8 +3790,10 @@ namespace Opc.Ua.Client
             else
             {
                 m_lastKeepAliveErrorStatusCode = StatusCodes.Good;
-                Interlocked.Exchange(ref m_lastKeepAliveTime, DateTime.UtcNow.Ticks);
-                LastKeepAliveTickCount = HiResClock.TickCount;
+                Interlocked.Exchange(
+                    ref m_lastKeepAliveTime,
+                    m_timeProvider.GetUtcNow().UtcDateTime.Ticks);
+                LastKeepAliveTickCount = m_timeProvider.GetTickCount();
             }
 
             // save server state.
@@ -3808,7 +3823,7 @@ namespace Opc.Ua.Client
             if (result.StatusCode == StatusCodes.BadNoCommunication)
             {
                 //keep alive read timed out
-                int delta = HiResClock.TickCount - LastKeepAliveTickCount;
+                int delta = m_timeProvider.GetTickCount() - LastKeepAliveTickCount;
                 m_logger.LogInformation(
                     "KEEP ALIVE LATE: {Duration}ms, EndpointUrl={EndpointUrl}, RequestCount={Good}/{Outstanding}",
                     delta,
@@ -3824,7 +3839,10 @@ namespace Opc.Ua.Client
                 try
                 {
                     m_inKeepAliveCallback = true;
-                    var args = new KeepAliveEventArgs(result, ServerState.Unknown, DateTime.UtcNow);
+                    var args = new KeepAliveEventArgs(
+                        result,
+                        ServerState.Unknown,
+                        m_timeProvider.GetUtcNow().UtcDateTime);
                     callback(this, args);
                     m_inKeepAliveCallback = false;
                     return !args.CancelKeepAlive;
@@ -4847,7 +4865,7 @@ namespace Opc.Ua.Client
         private ServerState m_serverState;
         private int m_keepAliveInterval;
 #pragma warning disable CA2213 // Disposed in DisposeAsyncCore/Dispose
-        private readonly Timer m_keepAliveTimer;
+        private readonly ITimer m_keepAliveTimer;
 #pragma warning restore CA2213
         private readonly AsyncAutoResetEvent m_keepAliveEvent = new();
         private uint m_keepAliveCounter;
@@ -4867,6 +4885,7 @@ namespace Opc.Ua.Client
         private readonly ArrayOf<EndpointDescription> m_discoveryServerEndpoints;
         private readonly ArrayOf<string> m_discoveryProfileUris;
         private new readonly ILogger m_logger;
+        private readonly TimeProvider m_timeProvider;
 #pragma warning disable CA2213 // Disposed in DisposeAsyncCore/Dispose
         private readonly ISubscriptionEngine m_engine;
 #pragma warning restore CA2213

--- a/Libraries/Opc.Ua.Client/Session/Session.cs
+++ b/Libraries/Opc.Ua.Client/Session/Session.cs
@@ -857,7 +857,17 @@ namespace Opc.Ua.Client
         /// Gets the TickCount in ms of the last keep alive based on <see cref="TimeProvider"/>.
         /// Independent of system time changes.
         /// </summary>
+        [Obsolete("Use LastKeepAliveTimestamp + TimeProvider.GetElapsedTime. " +
+            "LastKeepAliveTickCount is a 32-bit value that wraps every ~49.7 days.")]
         public int LastKeepAliveTickCount { get; private set; }
+
+        /// <summary>
+        /// Gets the monotonic timestamp (from <see cref="TimeProvider.GetTimestamp"/>) of the
+        /// last keep alive. Use together with <see cref="TimeProvider.GetElapsedTime(long)"/>
+        /// to compute the elapsed time since the last keep alive without DateTime drift or
+        /// 32-bit tick wrap.
+        /// </summary>
+        public long LastKeepAliveTimestamp => m_lastKeepAliveTimestamp;
 
         /// <summary>
         /// Gets the number of outstanding publish or keep alive requests.
@@ -3308,7 +3318,9 @@ namespace Opc.Ua.Client
                 ref m_lastKeepAliveTime,
                 m_timeProvider.GetUtcNow().UtcDateTime.Ticks);
             m_lastKeepAliveTimestamp = m_timeProvider.GetTimestamp();
+#pragma warning disable CS0618 // Back-compat: keep populating LastKeepAliveTickCount.
             LastKeepAliveTickCount = m_timeProvider.GetTickCount();
+#pragma warning restore CS0618
 
             m_serverState = ServerState.Unknown;
 
@@ -3463,7 +3475,7 @@ namespace Opc.Ua.Client
                     ? int.MaxValue
                     : PublishRequestCancelDelayOnCloseSession;
 
-                int startTime = m_timeProvider.GetTickCount();
+                long startTimestamp = m_timeProvider.GetTimestamp();
                 while (true)
                 {
                     // Check if all publish requests completed
@@ -3486,7 +3498,7 @@ namespace Opc.Ua.Client
                     }
 
                     // Check timeout
-                    int elapsed = m_timeProvider.GetTickCount() - startTime;
+                    int elapsed = (int)m_timeProvider.GetElapsedTime(startTimestamp).TotalMilliseconds;
                     if (elapsed >= waitTimeout)
                     {
                         m_logger.LogWarning(
@@ -3604,7 +3616,7 @@ namespace Opc.Ua.Client
                         RequestId = requestId,
                         RequestTypeId = typeId,
                         Result = result,
-                        TickCount = m_timeProvider.GetTickCount()
+                        Timestamp = m_timeProvider.GetTimestamp()
                     };
 
                     m_outstandingRequests.AddLast(state);
@@ -3629,14 +3641,16 @@ namespace Opc.Ua.Client
                 if (state != null)
                 {
                     // mark any old requests as defunct (i.e. the should have returned before this request).
-                    const int maxAge = 1000;
+                    TimeSpan maxAge = TimeSpan.FromMilliseconds(1000);
 
                     for (LinkedListNode<AsyncRequestState>? ii = m_outstandingRequests.First;
                         ii != null;
                         ii = ii.Next)
                     {
                         if (ii.Value.RequestTypeId == typeId &&
-                            (state.TickCount - ii.Value.TickCount) > maxAge)
+                            m_timeProvider.GetElapsedTime(
+                                ii.Value.Timestamp,
+                                state.Timestamp) > maxAge)
                         {
                             ii.Value.Defunct = true;
                         }
@@ -3654,7 +3668,7 @@ namespace Opc.Ua.Client
                         RequestId = requestId,
                         RequestTypeId = typeId,
                         Result = result,
-                        TickCount = m_timeProvider.GetTickCount(),
+                        Timestamp = m_timeProvider.GetTimestamp(),
                         Activity = null
                     };
 
@@ -3790,7 +3804,9 @@ namespace Opc.Ua.Client
                     ref m_lastKeepAliveTime,
                     m_timeProvider.GetUtcNow().UtcDateTime.Ticks);
                 m_lastKeepAliveTimestamp = m_timeProvider.GetTimestamp();
+#pragma warning disable CS0618 // Back-compat: keep populating LastKeepAliveTickCount.
                 LastKeepAliveTickCount = m_timeProvider.GetTickCount();
+#pragma warning restore CS0618
 
                 lock (m_outstandingRequests)
                 {
@@ -3814,7 +3830,9 @@ namespace Opc.Ua.Client
                     ref m_lastKeepAliveTime,
                     m_timeProvider.GetUtcNow().UtcDateTime.Ticks);
                 m_lastKeepAliveTimestamp = m_timeProvider.GetTimestamp();
+#pragma warning disable CS0618 // Back-compat: keep populating LastKeepAliveTickCount.
                 LastKeepAliveTickCount = m_timeProvider.GetTickCount();
+#pragma warning restore CS0618
             }
 
             // save server state.
@@ -4916,7 +4934,7 @@ namespace Opc.Ua.Client
         {
             public uint RequestTypeId { get; init; }
             public uint RequestId { get; init; }
-            public int TickCount { get; init; }
+            public long Timestamp { get; init; }
             public required Task Result { get; set; }
             public bool Defunct { get; set; }
             public required Activity? Activity { get; init; }

--- a/Libraries/Opc.Ua.Client/Session/Session.cs
+++ b/Libraries/Opc.Ua.Client/Session/Session.cs
@@ -293,7 +293,9 @@ namespace Opc.Ua.Client
 
             // Create the subscription engine.
             SubscriptionEngineFactory = engineFactory
-                ?? ClassicSubscriptionEngineFactory.Instance;
+                ?? (ReferenceEquals(m_timeProvider, TimeProvider.System)
+                    ? ClassicSubscriptionEngineFactory.Instance
+                    : new ClassicSubscriptionEngineFactory(m_timeProvider));
             m_engine = SubscriptionEngineFactory.Create(new SessionEngineContext(this));
 
             // set the default preferred locales.
@@ -1631,7 +1633,7 @@ namespace Opc.Ua.Client
                 }
 
                 m_reconnectLock.Release();
-                await Task.Delay(100, ct).ConfigureAwait(false);
+                await m_timeProvider.Delay(TimeSpan.FromMilliseconds(100), ct).ConfigureAwait(false);
             }
         }
 
@@ -3486,7 +3488,7 @@ namespace Opc.Ua.Client
                     // Wait a bit before checking again
                     try
                     {
-                        await Task.Delay(100, ct).ConfigureAwait(false);
+                        await m_timeProvider.Delay(TimeSpan.FromMilliseconds(100), ct).ConfigureAwait(false);
                     }
                     catch (OperationCanceledException)
                     {

--- a/Libraries/Opc.Ua.Client/Session/SessionObsolete.cs
+++ b/Libraries/Opc.Ua.Client/Session/SessionObsolete.cs
@@ -42,6 +42,19 @@ namespace Opc.Ua.Client
     /// </summary>
     public static class SessionObsolete
     {
+        extension(ISession session)
+        {
+            /// <summary>
+            /// Gets the TickCount in ms of the last keep alive based on
+            /// <see cref="ISession.LastKeepAliveTimestamp"/>.
+            /// </summary>
+            [Obsolete("Use LastKeepAliveTimestamp + TimeProvider.GetElapsedTime. " +
+                "LastKeepAliveTickCount is a 32-bit value that wraps every ~49.7 days.")]
+            public int LastKeepAliveTickCount
+                => unchecked((int)(session.LastKeepAliveTimestamp *
+                    1000L / TimeProvider.System.TimestampFrequency));
+        }
+
         /// <summary>
         /// Reconnects to the server after a network failure.
         /// </summary>

--- a/Libraries/Opc.Ua.Client/Session/SessionReconnectHandler.cs
+++ b/Libraries/Opc.Ua.Client/Session/SessionReconnectHandler.cs
@@ -390,7 +390,7 @@ namespace Opc.Ua.Client
         /// </summary>
         private async void OnReconnectAsync(object? state)
         {
-            int reconnectStart = m_timeProvider.GetTickCount();
+            long reconnectStartTimestamp = m_timeProvider.GetTimestamp();
             try
             {
                 // check for exit.
@@ -459,7 +459,8 @@ namespace Opc.Ua.Client
                     }
                     else
                     {
-                        int elapsed = m_timeProvider.GetTickCount() - reconnectStart;
+                        int elapsed = (int)m_timeProvider
+                            .GetElapsedTime(reconnectStartTimestamp).TotalMilliseconds;
                         m_logger.LogInformation(
                             "Reconnect period is {ReconnectPeriod} ms, {Elapsed} ms elapsed in reconnect.",
                             m_reconnectPeriod,
@@ -534,7 +535,8 @@ namespace Opc.Ua.Client
                             // check if reactivating is still an option.
                             int timeout =
                                 Convert.ToInt32(current.SessionTimeout) -
-                                (m_timeProvider.GetTickCount() - current.LastKeepAliveTickCount);
+                                (int)m_timeProvider.GetElapsedTime(
+                                    current.LastKeepAliveTimestamp).TotalMilliseconds;
                             if (timeout > 0)
                             {
                                 m_logger.LogInformation(

--- a/Libraries/Opc.Ua.Client/Session/SessionReconnectHandler.cs
+++ b/Libraries/Opc.Ua.Client/Session/SessionReconnectHandler.cs
@@ -132,15 +132,36 @@ namespace Opc.Ua.Client
             ITelemetryContext telemetry,
             bool reconnectAbort = false,
             int maxReconnectPeriod = -1)
+            : this(telemetry, reconnectAbort, maxReconnectPeriod, timeProvider: null)
         {
+        }
+
+        /// <summary>
+        /// Create a reconnect handler.
+        /// </summary>
+        /// <param name="telemetry">The telemetry context to use to create obvservability instruments</param>
+        /// <param name="reconnectAbort">Set to <c>true</c> to allow reconnect abort if keep alive recovered.</param>
+        /// <param name="maxReconnectPeriod">
+        ///     The upper limit for the reconnect period after exponential backoff.
+        ///     -1 (default) indicates that no exponential backoff should be used.
+        /// </param>
+        /// <param name="timeProvider">Optional time provider used for timers and elapsed-time
+        /// calculations. Defaults to <see cref="TimeProvider.System"/>.</param>
+        public SessionReconnectHandler(
+            ITelemetryContext telemetry,
+            bool reconnectAbort,
+            int maxReconnectPeriod,
+            TimeProvider? timeProvider)
+        {
+            m_timeProvider = timeProvider ??= TimeProvider.System;
             m_telemetry = telemetry;
             m_logger = telemetry.CreateLogger<SessionReconnectHandler>();
             m_reconnectAbort = reconnectAbort;
-            m_reconnectTimer = new Timer(
+            m_reconnectTimer = m_timeProvider.CreateTimer(
                 OnReconnectAsync,
                 this,
-                Timeout.Infinite,
-                Timeout.Infinite);
+                Timeout.InfiniteTimeSpan,
+                Timeout.InfiniteTimeSpan);
             m_state = ReconnectState.Ready;
             m_cancelReconnect = false;
             m_updateFromServer = false;
@@ -307,8 +328,8 @@ namespace Opc.Ua.Client
                     m_callback = callback;
                     m_reverseConnectManager = reverseConnectManager;
                     m_reconnectTimer.Change(
-                        JitteredReconnectPeriod(reconnectPeriod),
-                        Timeout.Infinite);
+                        TimeSpan.FromMilliseconds(JitteredReconnectPeriod(reconnectPeriod)),
+                        Timeout.InfiniteTimeSpan);
                     m_reconnectPeriod = CheckedReconnectPeriod(reconnectPeriod, true);
                     m_state = ReconnectState.Triggered;
                     return m_state;
@@ -319,8 +340,8 @@ namespace Opc.Ua.Client
                 {
                     m_baseReconnectPeriod = reconnectPeriod;
                     m_reconnectTimer.Change(
-                        JitteredReconnectPeriod(reconnectPeriod),
-                        Timeout.Infinite);
+                        TimeSpan.FromMilliseconds(JitteredReconnectPeriod(reconnectPeriod)),
+                        Timeout.InfiniteTimeSpan);
                     m_reconnectPeriod = CheckedReconnectPeriod(reconnectPeriod, true);
                 }
 
@@ -369,7 +390,7 @@ namespace Opc.Ua.Client
         /// </summary>
         private async void OnReconnectAsync(object? state)
         {
-            int reconnectStart = HiResClock.TickCount;
+            int reconnectStart = m_timeProvider.GetTickCount();
             try
             {
                 // check for exit.
@@ -438,7 +459,7 @@ namespace Opc.Ua.Client
                     }
                     else
                     {
-                        int elapsed = HiResClock.TickCount - reconnectStart;
+                        int elapsed = m_timeProvider.GetTickCount() - reconnectStart;
                         m_logger.LogInformation(
                             "Reconnect period is {ReconnectPeriod} ms, {Elapsed} ms elapsed in reconnect.",
                             m_reconnectPeriod,
@@ -446,7 +467,7 @@ namespace Opc.Ua.Client
                         int adjustedReconnectPeriod = CheckedReconnectPeriod(
                             m_reconnectPeriod - elapsed);
                         adjustedReconnectPeriod = JitteredReconnectPeriod(adjustedReconnectPeriod);
-                        m_reconnectTimer?.Change(adjustedReconnectPeriod, Timeout.Infinite);
+                        m_reconnectTimer?.Change(TimeSpan.FromMilliseconds(adjustedReconnectPeriod), Timeout.InfiniteTimeSpan);
                         m_logger.LogInformation(
                             "Next adjusted reconnect scheduled in {ReconnectPeriod} ms.",
                             adjustedReconnectPeriod);
@@ -513,7 +534,7 @@ namespace Opc.Ua.Client
                             // check if reactivating is still an option.
                             int timeout =
                                 Convert.ToInt32(current.SessionTimeout) -
-                                (HiResClock.TickCount - current.LastKeepAliveTickCount);
+                                (m_timeProvider.GetTickCount() - current.LastKeepAliveTickCount);
                             if (timeout > 0)
                             {
                                 m_logger.LogInformation(
@@ -719,7 +740,7 @@ namespace Opc.Ua.Client
         /// </summary>
         private void EnterReadyState()
         {
-            m_reconnectTimer?.Change(Timeout.Infinite, Timeout.Infinite);
+            m_reconnectTimer?.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
             m_state = ReconnectState.Ready;
             m_cancelReconnect = false;
             m_updateFromServer = false;
@@ -736,7 +757,8 @@ namespace Opc.Ua.Client
         private int m_reconnectPeriod;
         private int m_baseReconnectPeriod;
         private readonly int m_maxReconnectPeriod;
-        private Timer? m_reconnectTimer;
+        private ITimer? m_reconnectTimer;
+        private readonly TimeProvider m_timeProvider;
         private EventHandler? m_callback;
         private ReverseConnectManager? m_reverseConnectManager;
     }

--- a/Libraries/Opc.Ua.Client/Session/SessionReconnectHandler.cs
+++ b/Libraries/Opc.Ua.Client/Session/SessionReconnectHandler.cs
@@ -125,8 +125,8 @@ namespace Opc.Ua.Client
         /// <param name="telemetry">The telemetry context to use to create obvservability instruments</param>
         /// <param name="reconnectAbort">Set to <c>true</c> to allow reconnect abort if keep alive recovered.</param>
         /// <param name="maxReconnectPeriod">
-        ///     The upper limit for the reconnect period after exponential backoff.
-        ///     -1 (default) indicates that no exponential backoff should be used.
+        /// The upper limit for the reconnect period after exponential backoff.
+        /// -1 (default) indicates that no exponential backoff should be used.
         /// </param>
         public SessionReconnectHandler(
             ITelemetryContext telemetry,
@@ -142,8 +142,8 @@ namespace Opc.Ua.Client
         /// <param name="telemetry">The telemetry context to use to create obvservability instruments</param>
         /// <param name="reconnectAbort">Set to <c>true</c> to allow reconnect abort if keep alive recovered.</param>
         /// <param name="maxReconnectPeriod">
-        ///     The upper limit for the reconnect period after exponential backoff.
-        ///     -1 (default) indicates that no exponential backoff should be used.
+        /// The upper limit for the reconnect period after exponential backoff.
+        /// -1 (default) indicates that no exponential backoff should be used.
         /// </param>
         /// <param name="timeProvider">Optional time provider used for timers and elapsed-time
         /// calculations. Defaults to <see cref="TimeProvider.System"/>.</param>
@@ -153,7 +153,7 @@ namespace Opc.Ua.Client
             int maxReconnectPeriod,
             TimeProvider? timeProvider)
         {
-            m_timeProvider = timeProvider ??= TimeProvider.System;
+            m_timeProvider = timeProvider ?? TimeProvider.System;
             m_telemetry = telemetry;
             m_logger = telemetry.CreateLogger<SessionReconnectHandler>();
             m_reconnectAbort = reconnectAbort;

--- a/Libraries/Opc.Ua.Client/StateMachines/FiniteStateMachineTypeClientExtensions.cs
+++ b/Libraries/Opc.Ua.Client/StateMachines/FiniteStateMachineTypeClientExtensions.cs
@@ -219,11 +219,21 @@ namespace Opc.Ua.Client.StateMachines
         /// <see cref="ObserveFiniteTransitionsAsync"/> with timeout
         /// and cancellation.
         /// </summary>
+        /// <param name="client">The proxy client.</param>
+        /// <param name="streaming">The streaming subscription used to observe transitions.</param>
+        /// <param name="targetStateId">The state NodeId to wait for.</param>
+        /// <param name="timeout">Optional timeout; <c>null</c> waits indefinitely.</param>
+        /// <param name="timeProvider">
+        /// Optional <see cref="TimeProvider"/> used for the timeout
+        /// scheduler; defaults to <see cref="TimeProvider.System"/>.
+        /// </param>
+        /// <param name="ct">Cancellation token.</param>
         public static async ValueTask<FiniteStateSnapshot> WaitForStateAsync(
             this FiniteStateMachineTypeClient client,
             IStreamingSubscription streaming,
             NodeId targetStateId,
             TimeSpan? timeout = null,
+            TimeProvider? timeProvider = null,
             CancellationToken ct = default)
         {
             if (client == null)
@@ -247,11 +257,14 @@ namespace Opc.Ua.Client.StateMachines
                 return current;
             }
 
+            TimeProvider tp = timeProvider ?? TimeProvider.System;
             using CancellationTokenSource? timeoutCts = timeout.HasValue
-                ? CancellationTokenSource.CreateLinkedTokenSource(ct)
+                ? tp.CreateCancellationTokenSource(timeout.Value)
                 : null;
-            timeoutCts?.CancelAfter(timeout!.Value);
-            CancellationToken effective = timeoutCts?.Token ?? ct;
+            using CancellationTokenSource? linkedCts = timeoutCts != null
+                ? CancellationTokenSource.CreateLinkedTokenSource(ct, timeoutCts.Token)
+                : null;
+            CancellationToken effective = linkedCts?.Token ?? ct;
 
             await foreach (FiniteStateSnapshot snap in client
                 .ObserveFiniteTransitionsAsync(streaming, options: null, effective)

--- a/Libraries/Opc.Ua.Client/StateMachines/StateMachineTypeClientExtensions.cs
+++ b/Libraries/Opc.Ua.Client/StateMachines/StateMachineTypeClientExtensions.cs
@@ -154,11 +154,21 @@ namespace Opc.Ua.Client.StateMachines
         /// (matched by localized name) or the timeout/cancellation
         /// fires.
         /// </summary>
+        /// <param name="client">The proxy client.</param>
+        /// <param name="streaming">The streaming subscription used to observe transitions.</param>
+        /// <param name="targetState">The state to wait for.</param>
+        /// <param name="timeout">Optional timeout; <c>null</c> waits indefinitely.</param>
+        /// <param name="timeProvider">
+        /// Optional <see cref="TimeProvider"/> used for the timeout
+        /// scheduler; defaults to <see cref="TimeProvider.System"/>.
+        /// </param>
+        /// <param name="ct">Cancellation token.</param>
         public static async ValueTask WaitForStateAsync(
             this StateMachineTypeClient client,
             IStreamingSubscription streaming,
             LocalizedText targetState,
             TimeSpan? timeout = null,
+            TimeProvider? timeProvider = null,
             CancellationToken ct = default)
         {
             if (client == null)
@@ -177,11 +187,14 @@ namespace Opc.Ua.Client.StateMachines
                 return;
             }
 
+            TimeProvider tp = timeProvider ?? TimeProvider.System;
             using CancellationTokenSource? timeoutCts = timeout.HasValue
-                ? CancellationTokenSource.CreateLinkedTokenSource(ct)
+                ? tp.CreateCancellationTokenSource(timeout.Value)
                 : null;
-            timeoutCts?.CancelAfter(timeout!.Value);
-            CancellationToken effective = timeoutCts?.Token ?? ct;
+            using CancellationTokenSource? linkedCts = timeoutCts != null
+                ? CancellationTokenSource.CreateLinkedTokenSource(ct, timeoutCts.Token)
+                : null;
+            CancellationToken effective = linkedCts?.Token ?? ct;
 
             await foreach (StateMachineSnapshot snap in client
                 .ObserveStateChangesAsync(streaming, options: null, effective)

--- a/Libraries/Opc.Ua.Client/Subscription/Classic/Subscription.cs
+++ b/Libraries/Opc.Ua.Client/Subscription/Classic/Subscription.cs
@@ -62,7 +62,7 @@ namespace Opc.Ua.Client
         /// </summary>
         [Obsolete("Use Subscription(TelemetryContext) instead")]
         public Subscription()
-            : this(null!, null)
+            : this(null!, null, null)
         {
         }
 
@@ -70,12 +70,21 @@ namespace Opc.Ua.Client
         /// Creates a empty object.
         /// </summary>
         public Subscription(ITelemetryContext telemetry, SubscriptionOptions? options = null)
+            : this(telemetry, options, null)
         {
+        }
+
+        /// <summary>
+        /// Creates a empty object.
+        /// </summary>
+        public Subscription(ITelemetryContext telemetry, SubscriptionOptions? options,
+            TimeProvider? timeProvider)
+        {
+            m_timeProvider = timeProvider ??= TimeProvider.System;
             Telemetry = telemetry ?? AmbientMessageContext.Telemetry;
             m_logger = Telemetry.CreateLogger<Subscription>();
             State = options ?? new SubscriptionOptions();
             DefaultItem = CreateMonitoredItem();
-            m_timeProvider = TimeProvider.System;
         }
 
         /// <summary>
@@ -776,7 +785,7 @@ namespace Opc.Ua.Client
         {
             get
             {
-                int timeSinceLastNotification = HiResClock.TickCount - m_lastNotificationTickCount;
+                int timeSinceLastNotification = m_timeProvider.GetTickCount() - m_lastNotificationTickCount;
                 return timeSinceLastNotification > m_keepAliveInterval + kKeepAliveTimerMargin;
             }
         }
@@ -1597,10 +1606,10 @@ namespace Opc.Ua.Client
                     TraceState("PUBLISHING RECOVERED");
                 }
 
-                DateTime now = DateTime.UtcNow;
+                DateTime now = m_timeProvider.GetUtcNow().UtcDateTime;
                 Interlocked.Exchange(ref m_lastNotificationTime, now.Ticks);
 
-                int tickCount = HiResClock.TickCount;
+                int tickCount = m_timeProvider.GetTickCount();
                 m_lastNotificationTickCount = tickCount;
 
                 // create queue for the first time.
@@ -1987,8 +1996,8 @@ namespace Opc.Ua.Client
                     // only republish consecutive sequence numbers
                     // triggers the republish mechanism immediately,
                     // if event is in the past
-                    DateTime now = DateTime.UtcNow.AddMilliseconds(-RepublishMessageTimeout * 2);
-                    int tickCount = HiResClock.TickCount - (RepublishMessageTimeout * 2);
+                    DateTime now = m_timeProvider.GetUtcNow().UtcDateTime.AddMilliseconds(-RepublishMessageTimeout * 2);
+                    int tickCount = m_timeProvider.GetTickCount() - (RepublishMessageTimeout * 2);
                     uint lastSequenceNumberToRepublish = m_lastSequenceNumberProcessed - 1;
                     int availableNumbers = availableSequenceNumberList.Count;
                     int republishMessages = 0;
@@ -2057,8 +2066,8 @@ namespace Opc.Ua.Client
                 {
                     m_publishTimer?.Dispose();
                     m_publishTimer = null;
-                    Interlocked.Exchange(ref m_lastNotificationTime, DateTime.UtcNow.Ticks);
-                    m_lastNotificationTickCount = HiResClock.TickCount;
+                    Interlocked.Exchange(ref m_lastNotificationTime, m_timeProvider.GetUtcNow().UtcDateTime.Ticks);
+                    m_lastNotificationTickCount = m_timeProvider.GetTickCount();
                     m_publishTimer = m_timeProvider.CreateTimer(
                         OnKeepAlive,
                         m_keepAliveInterval,
@@ -2526,7 +2535,7 @@ namespace Opc.Ua.Client
                         {
                             // tolerate if a single request was received out of order
                             if (ii.Next.Next != null &&
-                                (HiResClock.TickCount -
+                                (m_timeProvider.GetTickCount() -
                                     ii.Value.TickCount) > RepublishMessageTimeout)
                             {
                                 ii.Value.Republished = true;

--- a/Libraries/Opc.Ua.Client/Subscription/Classic/Subscription.cs
+++ b/Libraries/Opc.Ua.Client/Subscription/Classic/Subscription.cs
@@ -80,7 +80,7 @@ namespace Opc.Ua.Client
         public Subscription(ITelemetryContext telemetry, SubscriptionOptions? options,
             TimeProvider? timeProvider)
         {
-            m_timeProvider = timeProvider ??= TimeProvider.System;
+            m_timeProvider = timeProvider ?? TimeProvider.System;
             Telemetry = telemetry ?? AmbientMessageContext.Telemetry;
             m_logger = Telemetry.CreateLogger<Subscription>();
             State = options ?? new SubscriptionOptions();

--- a/Libraries/Opc.Ua.Client/Subscription/Classic/Subscription.cs
+++ b/Libraries/Opc.Ua.Client/Subscription/Classic/Subscription.cs
@@ -785,8 +785,10 @@ namespace Opc.Ua.Client
         {
             get
             {
-                int timeSinceLastNotification = m_timeProvider.GetTickCount() - m_lastNotificationTickCount;
-                return timeSinceLastNotification > m_keepAliveInterval + kKeepAliveTimerMargin;
+                TimeSpan timeSinceLastNotification = m_timeProvider
+                    .GetElapsedTime(m_lastNotificationTimestamp);
+                return timeSinceLastNotification.TotalMilliseconds >
+                    m_keepAliveInterval + kKeepAliveTimerMargin;
             }
         }
 
@@ -1609,14 +1611,14 @@ namespace Opc.Ua.Client
                 DateTime now = m_timeProvider.GetUtcNow().UtcDateTime;
                 Interlocked.Exchange(ref m_lastNotificationTime, now.Ticks);
 
-                int tickCount = m_timeProvider.GetTickCount();
-                m_lastNotificationTickCount = tickCount;
+                long monotonicTimestamp = m_timeProvider.GetTimestamp();
+                m_lastNotificationTimestamp = monotonicTimestamp;
 
                 // create queue for the first time.
                 m_incomingMessages ??= new LinkedList<IncomingMessage>();
 
                 // find or create an entry for the incoming sequence number.
-                IncomingMessage entry = FindOrCreateEntry(now, tickCount, message.SequenceNumber);
+                IncomingMessage entry = FindOrCreateEntry(now, monotonicTimestamp, message.SequenceNumber);
 
                 // check for keep alive.
                 if (message.NotificationData.Count > 0)
@@ -1637,7 +1639,7 @@ namespace Opc.Ua.Client
                         {
                             SequenceNumber = i - 1,
                             Timestamp = now,
-                            TickCount = tickCount
+                            MonotonicTimestamp = monotonicTimestamp
                         };
                         currentNode = m_incomingMessages.AddBefore(currentNode, placeholder);
 
@@ -1663,7 +1665,7 @@ namespace Opc.Ua.Client
                         {
                             SequenceNumber = entry.SequenceNumber + 1,
                             Timestamp = now,
-                            TickCount = tickCount
+                            MonotonicTimestamp = monotonicTimestamp
                         };
                         node = m_incomingMessages.AddAfter(node, placeholder);
                         continue;
@@ -1686,7 +1688,8 @@ namespace Opc.Ua.Client
                             entry.Republished &&
                             (
                                 entry.RepublishStatus != StatusCodes.Good ||
-                                (tickCount - entry.TickCount) > kRepublishMessageExpiredTimeout)))
+                                m_timeProvider.GetElapsedTime(entry.MonotonicTimestamp)
+                                    .TotalMilliseconds > kRepublishMessageExpiredTimeout)))
                     {
                         break;
                     }
@@ -1997,7 +2000,9 @@ namespace Opc.Ua.Client
                     // triggers the republish mechanism immediately,
                     // if event is in the past
                     DateTime now = m_timeProvider.GetUtcNow().UtcDateTime.AddMilliseconds(-RepublishMessageTimeout * 2);
-                    int tickCount = m_timeProvider.GetTickCount() - (RepublishMessageTimeout * 2);
+                    long backdatedTimestamp = m_timeProvider.GetTimestamp() -
+                        (long)(TimeSpan.FromMilliseconds(RepublishMessageTimeout * 2).TotalSeconds *
+                            m_timeProvider.TimestampFrequency);
                     uint lastSequenceNumberToRepublish = m_lastSequenceNumberProcessed - 1;
                     int availableNumbers = availableSequenceNumberList.Count;
                     int republishMessages = 0;
@@ -2008,7 +2013,7 @@ namespace Opc.Ua.Client
                         {
                             if (lastSequenceNumberToRepublish == sequenceNumber)
                             {
-                                FindOrCreateEntry(now, tickCount, sequenceNumber);
+                                FindOrCreateEntry(now, backdatedTimestamp, sequenceNumber);
                                 found = true;
                                 break;
                             }
@@ -2067,7 +2072,7 @@ namespace Opc.Ua.Client
                     m_publishTimer?.Dispose();
                     m_publishTimer = null;
                     Interlocked.Exchange(ref m_lastNotificationTime, m_timeProvider.GetUtcNow().UtcDateTime.Ticks);
-                    m_lastNotificationTickCount = m_timeProvider.GetTickCount();
+                    m_lastNotificationTimestamp = m_timeProvider.GetTimestamp();
                     m_publishTimer = m_timeProvider.CreateTimer(
                         OnKeepAlive,
                         m_keepAliveInterval,
@@ -2535,8 +2540,8 @@ namespace Opc.Ua.Client
                         {
                             // tolerate if a single request was received out of order
                             if (ii.Next.Next != null &&
-                                (m_timeProvider.GetTickCount() -
-                                    ii.Value.TickCount) > RepublishMessageTimeout)
+                                m_timeProvider.GetElapsedTime(ii.Value.MonotonicTimestamp)
+                                    .TotalMilliseconds > RepublishMessageTimeout)
                             {
                                 ii.Value.Republished = true;
                                 publishStateChangedMask |= PublishStateChangedMask.Republish;
@@ -3085,11 +3090,11 @@ namespace Opc.Ua.Client
         /// Find or create an entry for the incoming sequence number.
         /// </summary>
         /// <param name="utcNow">The current Utc time.</param>
-        /// <param name="tickCount">The current monotonic time</param>
+        /// <param name="monotonicTimestamp">The current monotonic timestamp from <see cref="TimeProvider.GetTimestamp"/>.</param>
         /// <param name="sequenceNumber">The sequence number for the new entry.</param>
         private IncomingMessage FindOrCreateEntry(
             DateTime utcNow,
-            int tickCount,
+            long monotonicTimestamp,
             uint sequenceNumber)
         {
             IncomingMessage? entry = null;
@@ -3105,7 +3110,7 @@ namespace Opc.Ua.Client
                 if (entry.SequenceNumber == sequenceNumber)
                 {
                     entry.Timestamp = utcNow;
-                    entry.TickCount = tickCount;
+                    entry.MonotonicTimestamp = monotonicTimestamp;
                     break;
                 }
 
@@ -3115,7 +3120,7 @@ namespace Opc.Ua.Client
                     {
                         SequenceNumber = sequenceNumber,
                         Timestamp = utcNow,
-                        TickCount = tickCount
+                        MonotonicTimestamp = monotonicTimestamp
                     };
                     m_incomingMessages.AddAfter(node, entry);
                     break;
@@ -3131,7 +3136,7 @@ namespace Opc.Ua.Client
                 {
                     SequenceNumber = sequenceNumber,
                     Timestamp = utcNow,
-                    TickCount = tickCount
+                    MonotonicTimestamp = monotonicTimestamp
                 };
                 m_incomingMessages.AddLast(entry);
             }
@@ -3166,7 +3171,7 @@ namespace Opc.Ua.Client
         private readonly TimeProvider m_timeProvider;
         private ITimer? m_publishTimer;
         private long m_lastNotificationTime;
-        private int m_lastNotificationTickCount;
+        private long m_lastNotificationTimestamp;
         private int m_keepAliveInterval;
         private int m_publishLateCount;
         private bool m_disposed;
@@ -3191,7 +3196,7 @@ namespace Opc.Ua.Client
         {
             public uint SequenceNumber;
             public DateTime Timestamp;
-            public int TickCount;
+            public long MonotonicTimestamp;
             public NotificationMessage? Message;
             public bool Processed;
             public bool Republished;

--- a/Libraries/Opc.Ua.Client/Subscription/MessageProcessor.cs
+++ b/Libraries/Opc.Ua.Client/Subscription/MessageProcessor.cs
@@ -89,7 +89,7 @@ namespace Opc.Ua.Client.Subscriptions
             ITelemetryContext telemetry,
             TimeProvider? timeProvider = null)
         {
-            m_timeProvider = timeProvider ??= TimeProvider.System;
+            m_timeProvider = timeProvider ?? TimeProvider.System;
             Observability = telemetry;
             AvailableInRetransmissionQueue = [];
             Logger = Observability.LoggerFactory.CreateLogger<Subscription>();

--- a/Libraries/Opc.Ua.Client/Subscription/MessageProcessor.cs
+++ b/Libraries/Opc.Ua.Client/Subscription/MessageProcessor.cs
@@ -80,11 +80,16 @@ namespace Opc.Ua.Client.Subscriptions
         /// <param name="services"></param>
         /// <param name="completion"></param>
         /// <param name="telemetry"></param>
+        /// <param name="timeProvider">Optional <see cref="TimeProvider"/>
+        /// for elapsed-time and timestamp calculations. Defaults to
+        /// <see cref="TimeProvider.System"/> when <c>null</c>.</param>
         protected MessageProcessor(
             ISubscriptionServiceSetClientMethods services,
             IMessageAckQueue completion,
-            ITelemetryContext telemetry)
+            ITelemetryContext telemetry,
+            TimeProvider? timeProvider = null)
         {
+            m_timeProvider = timeProvider ??= TimeProvider.System;
             Observability = telemetry;
             AvailableInRetransmissionQueue = [];
             Logger = Observability.LoggerFactory.CreateLogger<Subscription>();
@@ -117,9 +122,9 @@ namespace Opc.Ua.Client.Subscriptions
             {
                 AvailableInRetransmissionQueue = availableSequenceNumbers;
             }
-            LastNotificationTimestamp = TimeProvider.System.GetTimestamp();
+            LastNotificationTimestamp = m_timeProvider.GetTimestamp();
             await m_messages.Writer.WriteAsync(new IncomingMessage(message, stringTable,
-                TimeProvider.System.GetUtcNow())).ConfigureAwait(false);
+                m_timeProvider.GetUtcNow())).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -589,6 +594,8 @@ namespace Opc.Ua.Client.Subscriptions
         internal long m_republishCount;
         internal IReadOnlyList<uint> AvailableInRetransmissionQueue;
         internal readonly ILogger Logger;
+        protected TimeProvider TimeProvider => m_timeProvider;
+        private readonly TimeProvider m_timeProvider;
         private readonly ISubscriptionServiceSetClientMethods m_services;
         // CA2213: m_cts is disposed in DisposeAsync(bool) — suppressed because
         // the analyzer does not track IAsyncDisposable disposal paths.

--- a/Libraries/Opc.Ua.Client/Subscription/Streaming/StreamingSubscriptionExtensions.cs
+++ b/Libraries/Opc.Ua.Client/Subscription/Streaming/StreamingSubscriptionExtensions.cs
@@ -107,25 +107,35 @@ namespace Opc.Ua.Client.Subscriptions.Streaming
         /// completes silently when the timeout expires.
         /// </summary>
         /// <typeparam name="T">The type of items in the source sequence.</typeparam>
+        /// <param name="source">The source sequence.</param>
+        /// <param name="timeout">The timeout duration.</param>
+        /// <param name="timeProvider">
+        /// Optional <see cref="TimeProvider"/> used for the timeout
+        /// scheduler; defaults to <see cref="TimeProvider.System"/>.
+        /// </param>
+        /// <param name="ct">Cancellation token.</param>
         public static IAsyncEnumerable<T> WithTimeoutAsync<T>(
             this IAsyncEnumerable<T> source,
             TimeSpan timeout,
+            TimeProvider? timeProvider = null,
             CancellationToken ct = default)
         {
             if (source == null)
             {
                 throw new ArgumentNullException(nameof(source));
             }
-            return WithTimeoutImpl(source, timeout, ct);
+            return WithTimeoutImpl(source, timeout, timeProvider ?? TimeProvider.System, ct);
         }
 
         private static async IAsyncEnumerable<T> WithTimeoutImpl<T>(
             IAsyncEnumerable<T> source,
             TimeSpan timeout,
+            TimeProvider timeProvider,
             [EnumeratorCancellation] CancellationToken ct)
         {
-            using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-            cts.CancelAfter(timeout);
+            using CancellationTokenSource timeoutCts = timeProvider
+                .CreateCancellationTokenSource(timeout);
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct, timeoutCts.Token);
 
             IAsyncEnumerator<T> enumerator =
                 source.GetAsyncEnumerator(cts.Token);

--- a/Libraries/Opc.Ua.Client/Subscription/Subscription.cs
+++ b/Libraries/Opc.Ua.Client/Subscription/Subscription.cs
@@ -93,7 +93,7 @@ namespace Opc.Ua.Client.Subscriptions
                 {
                     return false;
                 }
-                TimeSpan timeSinceLastNotification = TimeProvider.System
+                TimeSpan timeSinceLastNotification = TimeProvider
                     .GetElapsedTime(lastNotificationTimestamp);
                 return timeSinceLastNotification >
                     m_keepAliveInterval + s_keepAliveTimerMargin;
@@ -113,15 +113,18 @@ namespace Opc.Ua.Client.Subscriptions
         /// <param name="completion"></param>
         /// <param name="options"></param>
         /// <param name="telemetry"></param>
+        /// <param name="timeProvider">Optional <see cref="TimeProvider"/>
+        /// for elapsed-time and timer calculations. Defaults to
+        /// <see cref="TimeProvider.System"/> when <c>null</c>.</param>
         protected Subscription(ISubscriptionContext context, ISubscriptionNotificationHandler handler,
             IMessageAckQueue completion, IOptionsMonitor<SubscriptionOptions> options,
-            ITelemetryContext telemetry)
-            : base(context.SubscriptionServiceSet, completion, telemetry)
+            ITelemetryContext telemetry, TimeProvider? timeProvider = null)
+            : base(context.SubscriptionServiceSet, completion, telemetry, timeProvider)
         {
             m_handler = handler;
             m_context = context;
             m_monitoredItems = new MonitoredItemManager(this, telemetry);
-            m_publishTimer = TimeProvider.System.CreateTimer(OnKeepAlive,
+            m_publishTimer = TimeProvider.CreateTimer(OnKeepAlive,
                 null, Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
             OnOptionsChanged(options.CurrentValue);
             m_changeTracking = options.OnChange((o, _) => OnOptionsChanged(o));
@@ -717,7 +720,7 @@ namespace Opc.Ua.Client.Subscriptions
         private void StartKeepAliveTimer()
         {
             SubscriptionOptions options = Options;
-            LastNotificationTimestamp = TimeProvider.System.GetTimestamp();
+            LastNotificationTimestamp = TimeProvider.GetTimestamp();
             m_keepAliveInterval = CurrentPublishingInterval.Multiply(CurrentKeepAliveCount + 1);
             if (m_keepAliveInterval < s_minKeepAliveTimerInterval)
             {

--- a/Libraries/Opc.Ua.Client/Subscription/SubscriptionManager.cs
+++ b/Libraries/Opc.Ua.Client/Subscription/SubscriptionManager.cs
@@ -61,9 +61,14 @@ namespace Opc.Ua.Client.Subscriptions
         /// <param name="session"></param>
         /// <param name="loggerFactory"></param>
         /// <param name="returnDiagnostics"></param>
+        /// <param name="timeProvider">Optional <see cref="TimeProvider"/>
+        /// used for elapsed-time and timer calculations. Defaults to
+        /// <see cref="TimeProvider.System"/> when <c>null</c>.</param>
         public SubscriptionManager(ISubscriptionManagerContext session,
-            ILoggerFactory loggerFactory, DiagnosticsMasks returnDiagnostics)
+            ILoggerFactory loggerFactory, DiagnosticsMasks returnDiagnostics,
+            TimeProvider? timeProvider = null)
         {
+            m_timeProvider = timeProvider ??= TimeProvider.System;
             m_session = session;
             m_loggerFactory = loggerFactory;
             m_logger = loggerFactory.CreateLogger<SubscriptionManager>();
@@ -690,7 +695,9 @@ namespace Opc.Ua.Client.Subscriptions
             /// <param name="ct"></param>
             private async Task PublishWorkerAsync(CancellationToken ct)
             {
-                var publishLatency = new Stopwatch();
+                long publishLatencyStart = m_outer.m_timeProvider.GetTimestamp();
+                TimeSpan publishLatency = TimeSpan.Zero;
+                bool publishLatencyRunning = false;
                 uint timeoutHint = 0u;
                 bool moreNotifications = true; // Dont wait first time we enter the loop.
                 m_logger.LogInformation("PUBLISH Worker #{Handle} - STARTED.", Index);
@@ -719,8 +726,11 @@ namespace Opc.Ua.Client.Subscriptions
                             break;
                         }
                     }
+                    long currentLatencyMs = publishLatencyRunning
+                        ? (long)m_outer.m_timeProvider.GetElapsedTime(publishLatencyStart).TotalMilliseconds
+                        : (long)publishLatency.TotalMilliseconds;
                     int ackWaitTimeout = CalculateTimeouts(
-                        publishLatency.ElapsedMilliseconds, ref timeoutHint);
+                        currentLatencyMs, ref timeoutHint);
                     ArrayOf<SubscriptionAcknowledgement> acks = GetAcksReadyToSend();
                     uint handle = Utils.IncrementIdentifier(ref m_outer.m_publishRequestCounter);
                     try
@@ -730,7 +740,8 @@ namespace Opc.Ua.Client.Subscriptions
                             // Throttle publishing as we wait for acks to arrive
                             acks = await WaitForAcksAsync(ackWaitTimeout, ct).ConfigureAwait(false);
                         }
-                        publishLatency.Restart();
+                        publishLatencyStart = m_outer.m_timeProvider.GetTimestamp();
+                        publishLatencyRunning = true;
                         if (Interlocked.Increment(ref m_outer.m_activePublishRequests) == 1)
                         {
                             m_outer.m_drainSignal.Reset();
@@ -757,7 +768,8 @@ namespace Opc.Ua.Client.Subscriptions
 
                             // Get the subscription with the provided identifier
                             IManagedSubscription? subscription = m_outer.GetById(subscriptionId);
-                            publishLatency.Stop();
+                            publishLatency = m_outer.m_timeProvider.GetElapsedTime(publishLatencyStart);
+                            publishLatencyRunning = false;
                             if (subscription != null)
                             {
                                 // deliver to subscription
@@ -800,7 +812,8 @@ namespace Opc.Ua.Client.Subscriptions
                     catch (Exception e)
                     {
                         // raise an error event.
-                        publishLatency.Stop();
+                        publishLatency = m_outer.m_timeProvider.GetElapsedTime(publishLatencyStart);
+                        publishLatencyRunning = false;
                         var error = new ServiceResult(e);
 
                         if (error.Code == StatusCodes.BadRequestInterrupted &&
@@ -889,7 +902,7 @@ namespace Opc.Ua.Client.Subscriptions
             {
                 Debug.Assert(maxWaitTime != 0, "Checked before entering");
                 using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-                var sw = Stopwatch.StartNew();
+                long swStart = m_outer.m_timeProvider.GetTimestamp();
                 if (maxWaitTime != Timeout.Infinite)
                 {
 #if FALSE
@@ -924,7 +937,7 @@ namespace Opc.Ua.Client.Subscriptions
                         "PUBLISH Worker #{Handle} - Publish {Count} acks after pausing {Duration}.",
                         Index,
                         acks.Count,
-                        sw.Elapsed);
+                        m_outer.m_timeProvider.GetElapsedTime(swStart));
                     return acks;
                 }
                 catch (OperationCanceledException) when (!ct.IsCancellationRequested)
@@ -932,7 +945,7 @@ namespace Opc.Ua.Client.Subscriptions
                     m_logger.LogInformation(
                         "PUBLISH Worker #{Handle} - Publish with no acks after waiting {Duration}.",
                         Index,
-                        sw.Elapsed);
+                        m_outer.m_timeProvider.GetElapsedTime(swStart));
                     return [];
                 }
             }
@@ -1050,5 +1063,6 @@ namespace Opc.Ua.Client.Subscriptions
         private readonly ISubscriptionManagerContext m_session;
         private readonly ILoggerFactory m_loggerFactory;
         private readonly ILogger m_logger;
+        private readonly TimeProvider m_timeProvider;
     }
 }

--- a/Libraries/Opc.Ua.Client/Subscription/SubscriptionManager.cs
+++ b/Libraries/Opc.Ua.Client/Subscription/SubscriptionManager.cs
@@ -69,7 +69,7 @@ namespace Opc.Ua.Client.Subscriptions
             ILoggerFactory loggerFactory, DiagnosticsMasks returnDiagnostics,
             TimeProvider? timeProvider = null)
         {
-            m_timeProvider = timeProvider ??= TimeProvider.System;
+            m_timeProvider = timeProvider ?? TimeProvider.System;
             m_session = session;
             m_loggerFactory = loggerFactory;
             m_logger = loggerFactory.CreateLogger<SubscriptionManager>();
@@ -508,12 +508,13 @@ namespace Opc.Ua.Client.Subscriptions
                 // SubscriptionId. Items still need ApplyChangesAsync to
                 // round-trip but that runs in the same state-manager
                 // iteration as CreateAsync.
-                using var timeoutCts = CancellationTokenSource
-                    .CreateLinkedTokenSource(ct);
-                timeoutCts.CancelAfter(TimeSpan.FromSeconds(15));
+                using CancellationTokenSource timeoutCts = m_timeProvider
+                    .CreateCancellationTokenSource(TimeSpan.FromSeconds(15));
+                using var linkedCts = CancellationTokenSource
+                    .CreateLinkedTokenSource(ct, timeoutCts.Token);
                 try
                 {
-                    await loaded.WaitForCreatedAsync(timeoutCts.Token)
+                    await loaded.WaitForCreatedAsync(linkedCts.Token)
                         .ConfigureAwait(false);
                 }
                 catch (OperationCanceledException) when (!ct.IsCancellationRequested)
@@ -1132,8 +1133,10 @@ namespace Opc.Ua.Client.Subscriptions
                 CancellationToken ct)
             {
                 Debug.Assert(maxWaitTime != 0, "Checked before entering");
-                using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
                 long swStart = m_outer.m_timeProvider.GetTimestamp();
+                CancellationTokenSource? timeoutCts = null;
+                CancellationTokenSource? linkedCts = null;
+                CancellationToken waitToken;
                 if (maxWaitTime != Timeout.Infinite)
                 {
 #if FALSE
@@ -1148,18 +1151,23 @@ namespace Opc.Ua.Client.Subscriptions
                     m_logger.LogDebug(
                         "PUBLISH Worker #{Handle} - Waiting max {Time}ms for acks to arrive.",
                         Index, maxWaitTime);
-                    cts.CancelAfter(maxWaitTime);
+                    timeoutCts = m_outer.m_timeProvider
+                        .CreateCancellationTokenSource(TimeSpan.FromMilliseconds(maxWaitTime));
+                    linkedCts = CancellationTokenSource
+                        .CreateLinkedTokenSource(ct, timeoutCts.Token);
+                    waitToken = linkedCts.Token;
                 }
                 else
                 {
                     m_logger.LogDebug(
                         "PUBLISH Worker #{Handle} - Waiting for acks to arrive.",
                         Index);
+                    waitToken = ct;
                 }
                 try
                 {
                     SubscriptionAcknowledgement firstAck = await m_outer.m_acks.Reader.ReadAsync(
-                        cts.Token).ConfigureAwait(false);
+                        waitToken).ConfigureAwait(false);
                     ArrayOf<SubscriptionAcknowledgement> restAcks = GetAcksReadyToSend();
                     var ackList = restAcks.ToList();
                     ackList.Insert(0, firstAck);
@@ -1178,6 +1186,11 @@ namespace Opc.Ua.Client.Subscriptions
                         Index,
                         m_outer.m_timeProvider.GetElapsedTime(swStart));
                     return [];
+                }
+                finally
+                {
+                    linkedCts?.Dispose();
+                    timeoutCts?.Dispose();
                 }
             }
 

--- a/Libraries/Opc.Ua.Gds.Client.Common/GlobalDiscoveryServerClient.cs
+++ b/Libraries/Opc.Ua.Gds.Client.Common/GlobalDiscoveryServerClient.cs
@@ -53,7 +53,13 @@ namespace Opc.Ua.Gds.Client
             IUserIdentity? adminUserIdentity = null,
             ISessionFactory? sessionFactory = null,
             DiagnosticsMasks diagnosticsMasks = DiagnosticsMasks.None)
-            : this(configuration, options: null, adminUserIdentity, sessionFactory, diagnosticsMasks)
+            : this(
+                  configuration,
+                  options: null,
+                  adminUserIdentity,
+                  sessionFactory,
+                  diagnosticsMasks,
+                  timeProvider: null)
         {
         }
 
@@ -66,12 +72,16 @@ namespace Opc.Ua.Gds.Client
         /// <param name="adminUserIdentity">The user identity for the administrator.</param>
         /// <param name="sessionFactory">Used to create session to the server.</param>
         /// <param name="diagnosticsMasks">Return diagnostics to use for all requests.</param>
+        /// <param name="timeProvider">Optional <see cref="TimeProvider"/> used for
+        /// connect-retry backoff delays. Defaults to <see cref="TimeProvider.System"/>
+        /// when <c>null</c>.</param>
         public GlobalDiscoveryServerClient(
             ApplicationConfiguration configuration,
             GdsClientOptions? options,
             IUserIdentity? adminUserIdentity = null,
             ISessionFactory? sessionFactory = null,
-            DiagnosticsMasks diagnosticsMasks = DiagnosticsMasks.None)
+            DiagnosticsMasks diagnosticsMasks = DiagnosticsMasks.None,
+            TimeProvider? timeProvider = null)
         {
             Configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
             m_options = options ?? new GdsClientOptions();
@@ -83,6 +93,7 @@ namespace Opc.Ua.Gds.Client
                     ReturnDiagnostics = diagnosticsMasks
                 };
             AdminCredentials = adminUserIdentity;
+            m_timeProvider = timeProvider ??= TimeProvider.System;
         }
 
         /// <inheritdoc/>
@@ -349,7 +360,7 @@ namespace Opc.Ua.Gds.Client
                     m_logger.LogError(e, "Failed to connect {Attempt}. Retrying...", attempt + 1);
                     if (attempt + 1 < maxAttempts)
                     {
-                        await Task.Delay(backoffMs, ct).ConfigureAwait(false);
+                        await m_timeProvider.Delay(TimeSpan.FromMilliseconds(backoffMs), ct).ConfigureAwait(false);
                     }
                 }
             }
@@ -384,7 +395,7 @@ namespace Opc.Ua.Gds.Client
                     m_logger.LogError(e, "Failed to connect {Attempt}. Retrying...", attempt + 1);
                     if (attempt + 1 < maxAttempts)
                     {
-                        await Task.Delay(backoffMs, ct).ConfigureAwait(false);
+                        await m_timeProvider.Delay(TimeSpan.FromMilliseconds(backoffMs), ct).ConfigureAwait(false);
                     }
                 }
             }
@@ -852,6 +863,7 @@ namespace Opc.Ua.Gds.Client
         private readonly ISessionFactory m_sessionFactory;
         private readonly ILogger m_logger;
         private readonly GdsClientOptions m_options;
+        private readonly TimeProvider m_timeProvider;
         private readonly CancellationTokenSource m_disposeCts = new();
         private DirectoryTypeClient? m_directory;
         private CertificateDirectoryTypeClient? m_certificateDirectory;

--- a/Libraries/Opc.Ua.Gds.Client.Common/GlobalDiscoveryServerClient.cs
+++ b/Libraries/Opc.Ua.Gds.Client.Common/GlobalDiscoveryServerClient.cs
@@ -93,7 +93,7 @@ namespace Opc.Ua.Gds.Client
                     ReturnDiagnostics = diagnosticsMasks
                 };
             AdminCredentials = adminUserIdentity;
-            m_timeProvider = timeProvider ??= TimeProvider.System;
+            m_timeProvider = timeProvider ?? TimeProvider.System;
         }
 
         /// <inheritdoc/>

--- a/Libraries/Opc.Ua.Gds.Client.Common/ServerPushConfigurationClient.cs
+++ b/Libraries/Opc.Ua.Gds.Client.Common/ServerPushConfigurationClient.cs
@@ -83,7 +83,7 @@ namespace Opc.Ua.Gds.Client
                 {
                     ReturnDiagnostics = diagnosticsMasks
                 };
-            m_timeProvider = timeProvider ??= TimeProvider.System;
+            m_timeProvider = timeProvider ?? TimeProvider.System;
         }
 
         public NodeId DefaultApplicationGroup { get; private set; }

--- a/Libraries/Opc.Ua.Gds.Client.Common/ServerPushConfigurationClient.cs
+++ b/Libraries/Opc.Ua.Gds.Client.Common/ServerPushConfigurationClient.cs
@@ -52,7 +52,7 @@ namespace Opc.Ua.Gds.Client
             ApplicationConfiguration configuration,
             ISessionFactory? sessionFactory = null,
             DiagnosticsMasks diagnosticsMasks = DiagnosticsMasks.None)
-            : this(configuration, options: null, sessionFactory, diagnosticsMasks)
+            : this(configuration, options: null, sessionFactory, diagnosticsMasks, timeProvider: null)
         {
         }
 
@@ -64,11 +64,15 @@ namespace Opc.Ua.Gds.Client
         /// <param name="options">Client options. Defaults are used when null.</param>
         /// <param name="sessionFactory">Used to create session to the server.</param>
         /// <param name="diagnosticsMasks">Return diagnostics to use for all requests.</param>
+        /// <param name="timeProvider">Optional <see cref="TimeProvider"/> used for
+        /// connect-retry backoff delays. Defaults to <see cref="TimeProvider.System"/>
+        /// when <c>null</c>.</param>
         public ServerPushConfigurationClient(
             ApplicationConfiguration configuration,
             GdsClientOptions? options,
             ISessionFactory? sessionFactory = null,
-            DiagnosticsMasks diagnosticsMasks = DiagnosticsMasks.None)
+            DiagnosticsMasks diagnosticsMasks = DiagnosticsMasks.None,
+            TimeProvider? timeProvider = null)
         {
             Configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
             m_options = options ?? new GdsClientOptions();
@@ -79,6 +83,7 @@ namespace Opc.Ua.Gds.Client
                 {
                     ReturnDiagnostics = diagnosticsMasks
                 };
+            m_timeProvider = timeProvider ??= TimeProvider.System;
         }
 
         public NodeId DefaultApplicationGroup { get; private set; }
@@ -284,7 +289,7 @@ namespace Opc.Ua.Gds.Client
                     m_logger.LogError(e, "Failed to connect {Attempt}. Retrying...", attempt + 1);
                     if (attempt + 1 < maxAttempts)
                     {
-                        await Task.Delay(backoffMs, ct).ConfigureAwait(false);
+                        await m_timeProvider.Delay(TimeSpan.FromMilliseconds(backoffMs), ct).ConfigureAwait(false);
                     }
                 }
             }
@@ -318,7 +323,7 @@ namespace Opc.Ua.Gds.Client
                     m_logger.LogError(e, "Failed to connect {Attempt}. Retrying...", attempt + 1);
                     if (attempt + 1 < maxAttempts)
                     {
-                        await Task.Delay(backoffMs, ct).ConfigureAwait(false);
+                        await m_timeProvider.Delay(TimeSpan.FromMilliseconds(backoffMs), ct).ConfigureAwait(false);
                     }
                 }
             }
@@ -966,6 +971,7 @@ namespace Opc.Ua.Gds.Client
         private readonly ISessionFactory m_sessionFactory;
         private readonly ILogger m_logger;
         private readonly GdsClientOptions m_options;
+        private readonly TimeProvider m_timeProvider;
         private readonly CancellationTokenSource m_disposeCts = new();
         private ConfiguredEndpoint? m_endpoint;
         private ServerConfigurationTypeClient? m_serverConfiguration;

--- a/Libraries/Opc.Ua.Lds.Server/LdsServer.cs
+++ b/Libraries/Opc.Ua.Lds.Server/LdsServer.cs
@@ -51,6 +51,7 @@ namespace Opc.Ua.Lds.Server
     public class LdsServer : DiscoveryServerBase
     {
         private readonly ITelemetryContext m_telemetry;
+        private readonly TimeProvider m_timeProvider;
         private ILogger m_log;
         private readonly SemaphoreSlim m_lock;
         private MulticastDiscovery m_multicast;
@@ -59,12 +60,16 @@ namespace Opc.Ua.Lds.Server
         /// Creates a new LDS server.
         /// </summary>
         /// <param name="telemetry">Telemetry context for logging.</param>
-        public LdsServer(ITelemetryContext telemetry = null)
+        /// <param name="timeProvider">Optional <see cref="System.TimeProvider"/> used by the
+        /// registered-server store for prune scheduling and registration timestamps.
+        /// Defaults to <see cref="TimeProvider.System"/> when <c>null</c>.</param>
+        public LdsServer(ITelemetryContext telemetry = null, TimeProvider timeProvider = null)
             : base(telemetry)
         {
             m_telemetry = telemetry;
+            m_timeProvider = timeProvider ??= TimeProvider.System;
             m_lock = new SemaphoreSlim(1, 1);
-            Store = new RegisteredServerStore();
+            Store = new RegisteredServerStore(timeProvider: m_timeProvider);
         }
 
         /// <summary>

--- a/Libraries/Opc.Ua.Lds.Server/LdsServer.cs
+++ b/Libraries/Opc.Ua.Lds.Server/LdsServer.cs
@@ -67,7 +67,7 @@ namespace Opc.Ua.Lds.Server
             : base(telemetry)
         {
             m_telemetry = telemetry;
-            m_timeProvider = timeProvider ??= TimeProvider.System;
+            m_timeProvider = timeProvider ?? TimeProvider.System;
             m_lock = new SemaphoreSlim(1, 1);
             Store = new RegisteredServerStore(timeProvider: m_timeProvider);
         }

--- a/Libraries/Opc.Ua.Lds.Server/RegisteredServerStore.cs
+++ b/Libraries/Opc.Ua.Lds.Server/RegisteredServerStore.cs
@@ -56,18 +56,24 @@ namespace Opc.Ua.Lds.Server
 
         private readonly List<ServerOnNetworkRecord> m_records = [];
         private readonly ILogger m_logger;
+        private readonly TimeProvider m_timeProvider;
         private uint m_nextRecordId = 1;
         private DateTime m_lastCounterResetTime;
-        private Timer m_pruneTimer;
+        private ITimer m_pruneTimer;
         private bool m_disposed;
 
         /// <summary>
         /// Creates a new in-memory store.
         /// </summary>
-        public RegisteredServerStore(ILogger logger = null)
+        /// <param name="logger">Optional logger; defaults to a null logger.</param>
+        /// <param name="timeProvider">Optional <see cref="System.TimeProvider"/> used for the
+        /// background prune timer and registration timestamps. Defaults to
+        /// <see cref="TimeProvider.System"/> when <c>null</c>.</param>
+        public RegisteredServerStore(ILogger logger = null, TimeProvider timeProvider = null)
         {
             m_logger = logger ?? Microsoft.Extensions.Logging.Abstractions.NullLogger.Instance;
-            m_lastCounterResetTime = DateTime.UtcNow;
+            m_timeProvider = timeProvider ??= TimeProvider.System;
+            m_lastCounterResetTime = m_timeProvider.GetUtcNow().UtcDateTime;
         }
 
         /// <summary>
@@ -144,11 +150,11 @@ namespace Opc.Ua.Lds.Server
         {
             TimeSpan tick = interval ?? TimeSpan.FromSeconds(30);
             m_pruneTimer?.Dispose();
-            m_pruneTimer = new Timer(_ =>
+            m_pruneTimer = m_timeProvider.CreateTimer(_ =>
             {
                 try
                 {
-                    Prune(DateTime.UtcNow);
+                    Prune(m_timeProvider.GetUtcNow().UtcDateTime);
                 }
                 catch (Exception ex)
                 {
@@ -213,7 +219,7 @@ namespace Opc.Ua.Lds.Server
                     : server.DiscoveryUrls.ToList();
                 entry.SemaphoreFilePath = server.SemaphoreFilePath;
                 entry.IsOnline = true;
-                entry.LastSeenUtc = DateTime.UtcNow;
+                entry.LastSeenUtc = m_timeProvider.GetUtcNow().UtcDateTime;
 
                 if (mdnsConfig != null)
                 {
@@ -348,7 +354,7 @@ namespace Opc.Ua.Lds.Server
 
                 if (existing != null)
                 {
-                    existing.LastSeenUtc = DateTime.UtcNow;
+                    existing.LastSeenUtc = m_timeProvider.GetUtcNow().UtcDateTime;
                     existing.ServerName = serverName;
                     existing.ServerCapabilities = capabilities?.ToList() ?? [];
                     return;
@@ -361,7 +367,7 @@ namespace Opc.Ua.Lds.Server
                     ServerName = serverName,
                     DiscoveryUrl = discoveryUrl,
                     ServerCapabilities = capabilities?.ToList() ?? [],
-                    LastSeenUtc = DateTime.UtcNow,
+                    LastSeenUtc = m_timeProvider.GetUtcNow().UtcDateTime,
                     ObservedViaMulticast = true
                 });
             }
@@ -446,7 +452,7 @@ namespace Opc.Ua.Lds.Server
                 m_byUri.Clear();
                 m_records.Clear();
                 m_nextRecordId = 1;
-                m_lastCounterResetTime = DateTime.UtcNow;
+                m_lastCounterResetTime = m_timeProvider.GetUtcNow().UtcDateTime;
             }
             finally
             {
@@ -487,7 +493,7 @@ namespace Opc.Ua.Lds.Server
                     ServerName = entry.MdnsServerName ?? firstName.Text,
                     DiscoveryUrl = url,
                     ServerCapabilities = [.. entry.ServerCapabilities],
-                    LastSeenUtc = DateTime.UtcNow,
+                    LastSeenUtc = m_timeProvider.GetUtcNow().UtcDateTime,
                     ObservedViaMulticast = false
                 });
             }

--- a/Libraries/Opc.Ua.Lds.Server/RegisteredServerStore.cs
+++ b/Libraries/Opc.Ua.Lds.Server/RegisteredServerStore.cs
@@ -72,7 +72,7 @@ namespace Opc.Ua.Lds.Server
         public RegisteredServerStore(ILogger logger = null, TimeProvider timeProvider = null)
         {
             m_logger = logger ?? Microsoft.Extensions.Logging.Abstractions.NullLogger.Instance;
-            m_timeProvider = timeProvider ??= TimeProvider.System;
+            m_timeProvider = timeProvider ?? TimeProvider.System;
             m_lastCounterResetTime = m_timeProvider.GetUtcNow().UtcDateTime;
         }
 

--- a/Libraries/Opc.Ua.PubSub/IntervalRunner.cs
+++ b/Libraries/Opc.Ua.PubSub/IntervalRunner.cs
@@ -42,6 +42,7 @@ namespace Opc.Ua.PubSub
         private const int kMinInterval = 10;
         private readonly Lock m_lock = new();
         private readonly ILogger m_logger;
+        private readonly TimeProvider m_timeProvider;
 
         private double m_interval = kMinInterval;
         private double m_nextPublishTick;
@@ -59,13 +60,15 @@ namespace Opc.Ua.PubSub
             double interval,
             Func<bool> canExecuteFunc,
             Func<Task> intervalActionAsync,
-            ITelemetryContext telemetry)
+            ITelemetryContext telemetry,
+            TimeProvider? timeProvider = null)
         {
             m_logger = telemetry.CreateLogger<IntervalRunner>();
             Id = id;
             Interval = interval;
             CanExecuteFunc = canExecuteFunc;
             IntervalActionAsync = intervalActionAsync;
+            m_timeProvider = timeProvider ??= TimeProvider.System;
         }
 
         /// <summary>
@@ -166,15 +169,17 @@ namespace Opc.Ua.PubSub
         /// </summary>
         private async Task ProcessAsync()
         {
+            bool isSystemProvider = ReferenceEquals(m_timeProvider, TimeProvider.System);
+            long ticksPerMs = Math.Max(1L, m_timeProvider.TimestampFrequency / 1000L);
             lock (m_lock)
             {
-                m_nextPublishTick = HiResClock.Ticks;
+                m_nextPublishTick = m_timeProvider.GetTimestamp();
             }
             // m_cancellationToken is only null after Dispose; ProcessAsync is started
             // by Start before Dispose can be reached in normal usage.
             while (!m_cancellationToken!.IsCancellationRequested)
             {
-                long nowTick = HiResClock.Ticks;
+                long nowTick = m_timeProvider.GetTimestamp();
                 double nextPublishTick = 0;
 
                 lock (m_lock)
@@ -182,30 +187,54 @@ namespace Opc.Ua.PubSub
                     nextPublishTick = m_nextPublishTick;
                 }
 
-                double sleepCycle = (nextPublishTick - nowTick) / HiResClock.TicksPerMillisecond;
+                double sleepCycle = (nextPublishTick - nowTick) / ticksPerMs;
                 if (sleepCycle > 16)
                 {
                     // Use Task.Delay if sleep cycle is larger
-                    await Task.Delay(
+                    await m_timeProvider.Delay(
                         TimeSpan.FromMilliseconds(sleepCycle),
                         m_cancellationToken.Token)
                         .ConfigureAwait(false);
 
                     // Still ticks to consume (spurious wakeup too early), improbable
-                    nowTick = HiResClock.Ticks;
+                    nowTick = m_timeProvider.GetTimestamp();
                     if (nowTick < nextPublishTick)
                     {
-                        SpinWait.SpinUntil(() => HiResClock.Ticks >= nextPublishTick);
+                        if (isSystemProvider)
+                        {
+                            SpinWait.SpinUntil(() => m_timeProvider.GetTimestamp() >= nextPublishTick);
+                        }
+                        else
+                        {
+                            double remainingMs = (nextPublishTick - nowTick) / ticksPerMs;
+                            if (remainingMs > 0)
+                            {
+                                await m_timeProvider.Delay(
+                                    TimeSpan.FromMilliseconds(remainingMs),
+                                    m_cancellationToken.Token)
+                                    .ConfigureAwait(false);
+                            }
+                        }
                     }
                 }
                 else if (sleepCycle is >= 0 and <= 16)
                 {
-                    SpinWait.SpinUntil(() => HiResClock.Ticks >= nextPublishTick);
+                    if (isSystemProvider)
+                    {
+                        SpinWait.SpinUntil(() => m_timeProvider.GetTimestamp() >= nextPublishTick);
+                    }
+                    else if (sleepCycle > 0)
+                    {
+                        await m_timeProvider.Delay(
+                            TimeSpan.FromMilliseconds(sleepCycle),
+                            m_cancellationToken.Token)
+                            .ConfigureAwait(false);
+                    }
                 }
 
                 lock (m_lock)
                 {
-                    double nextCycle = (long)m_interval * HiResClock.TicksPerMillisecond;
+                    double nextCycle = (long)m_interval * ticksPerMs;
                     m_nextPublishTick += nextCycle;
 
                     if (IntervalActionAsync != null && CanExecuteFunc != null && CanExecuteFunc())

--- a/Libraries/Opc.Ua.PubSub/IntervalRunner.cs
+++ b/Libraries/Opc.Ua.PubSub/IntervalRunner.cs
@@ -68,7 +68,7 @@ namespace Opc.Ua.PubSub
             Interval = interval;
             CanExecuteFunc = canExecuteFunc;
             IntervalActionAsync = intervalActionAsync;
-            m_timeProvider = timeProvider ??= TimeProvider.System;
+            m_timeProvider = timeProvider ?? TimeProvider.System;
         }
 
         /// <summary>

--- a/Libraries/Opc.Ua.PubSub/Transport/MqttClientCreator.cs
+++ b/Libraries/Opc.Ua.PubSub/Transport/MqttClientCreator.cs
@@ -56,6 +56,9 @@ namespace Opc.Ua.PubSub.Transport
         /// <param name="receiveMessageHandler">The receiver message handler</param>
         /// <param name="logger">A contextual logger to log to</param>
         /// <param name="topicFilter">The topics to which to subscribe</param>
+        /// <param name="timeProvider">Optional <see cref="TimeProvider"/> used for
+        /// the reconnect delay. Defaults to <see cref="TimeProvider.System"/>
+        /// when <c>null</c>.</param>
         /// <param name="ct"></param>
         internal static async Task<IMqttClient> GetMqttClientAsync(
             int reconnectInterval,
@@ -63,8 +66,10 @@ namespace Opc.Ua.PubSub.Transport
             Func<MqttApplicationMessageReceivedEventArgs, Task> receiveMessageHandler,
             ILogger logger,
             ArrayOf<string> topicFilter = default,
+            TimeProvider? timeProvider = null,
             CancellationToken ct = default)
         {
+            timeProvider ??= TimeProvider.System;
             IMqttClient mqttClient = s_mqttClientFactory.Value.CreateMqttClient();
 
             // Hook the receiveMessageHandler in case we deal with a subscriber
@@ -121,7 +126,8 @@ namespace Opc.Ua.PubSub.Transport
             {
                 try
                 {
-                    await Task.Delay(TimeSpan.FromSeconds(reconnectInterval), ct).ConfigureAwait(false);
+                    await timeProvider.Delay(TimeSpan.FromSeconds(reconnectInterval), ct)
+                        .ConfigureAwait(false);
                 }
                 catch (OperationCanceledException)
                 {

--- a/Libraries/Opc.Ua.PubSub/Transport/MqttMetadataPublisher.cs
+++ b/Libraries/Opc.Ua.PubSub/Transport/MqttMetadataPublisher.cs
@@ -60,7 +60,8 @@ namespace Opc.Ua.PubSub.Transport
             WriterGroupDataType writerGroup,
             DataSetWriterDataType dataSetWriter,
             double metaDataUpdateTime,
-            ITelemetryContext telemetry)
+            ITelemetryContext telemetry,
+            TimeProvider? timeProvider = null)
         {
             m_logger = telemetry.CreateLogger<MqttMetadataPublisher>();
             m_parentConnection = parentConnection;
@@ -71,7 +72,8 @@ namespace Opc.Ua.PubSub.Transport
                 metaDataUpdateTime,
                 CanPublish,
                 PublishMessageAsync,
-                telemetry);
+                telemetry,
+                timeProvider);
         }
 
         /// <summary>

--- a/Libraries/Opc.Ua.PubSub/Transport/MqttPubSubConnection.cs
+++ b/Libraries/Opc.Ua.PubSub/Transport/MqttPubSubConnection.cs
@@ -437,7 +437,8 @@ namespace Opc.Ua.PubSub.Transport
                                 writerGroup,
                                 dataSetWriter,
                                 transport.MetaDataUpdateTime,
-                                Telemetry));
+                                Telemetry,
+                                Application.TimeProvider));
                     }
                 }
 

--- a/Libraries/Opc.Ua.PubSub/Transport/MqttPubSubConnection.cs
+++ b/Libraries/Opc.Ua.PubSub/Transport/MqttPubSubConnection.cs
@@ -479,6 +479,7 @@ namespace Opc.Ua.PubSub.Transport
                             m_publisherMqttClientOptions,
                             null!,
                             m_logger,
+                            timeProvider: Application.TimeProvider,
                             ct: stopToken)
                         .ConfigureAwait(false);
             }
@@ -528,6 +529,7 @@ namespace Opc.Ua.PubSub.Transport
                             ProcessMqttMessage,
                             m_logger,
                             topics,
+                            Application.TimeProvider,
                             stopToken)
                         .ConfigureAwait(false);
             }

--- a/Libraries/Opc.Ua.PubSub/Transport/UdpDiscoveryPublisher.cs
+++ b/Libraries/Opc.Ua.PubSub/Transport/UdpDiscoveryPublisher.cs
@@ -52,13 +52,24 @@ namespace Opc.Ua.PubSub.Transport
         /// </summary>
         private readonly List<ushort> m_metadataWriterIdsToSend;
 
+        private readonly TimeProvider m_timeProvider;
+
         /// <summary>
         /// Create new instance of <see cref="UdpDiscoveryPublisher"/>
         /// </summary>
-        public UdpDiscoveryPublisher(UdpPubSubConnection udpConnection, ITelemetryContext telemetry)
+        /// <param name="udpConnection">The owning UDP PubSub connection.</param>
+        /// <param name="telemetry">Telemetry context.</param>
+        /// <param name="timeProvider">Optional <see cref="TimeProvider"/> used
+        /// for response throttling. Defaults to <see cref="TimeProvider.System"/>
+        /// when <c>null</c>.</param>
+        public UdpDiscoveryPublisher(
+            UdpPubSubConnection udpConnection,
+            ITelemetryContext telemetry,
+            TimeProvider? timeProvider = null)
             : base(udpConnection, telemetry, telemetry.CreateLogger<UdpDiscoveryPublisher>())
         {
             m_metadataWriterIdsToSend = [];
+            m_timeProvider = timeProvider ??= TimeProvider.System;
         }
 
         /// <summary>
@@ -203,7 +214,8 @@ namespace Opc.Ua.PubSub.Transport
         /// </summary>
         private async Task SendResponseDataSetMetaDataAsync()
         {
-            await Task.Delay(kMinimumResponseInterval).ConfigureAwait(false);
+            await m_timeProvider.Delay(TimeSpan.FromMilliseconds(kMinimumResponseInterval))
+                .ConfigureAwait(false);
             ushort[] metadataWriterIdsToSend;
             UdpPubSubConnection connection = m_udpConnection;
             lock (Lock)
@@ -234,7 +246,8 @@ namespace Opc.Ua.PubSub.Transport
         /// </summary>
         private async Task SendResponseDataSetWriterConfigurationAsync()
         {
-            await Task.Delay(kMinimumResponseInterval).ConfigureAwait(false);
+            await m_timeProvider.Delay(TimeSpan.FromMilliseconds(kMinimumResponseInterval))
+                .ConfigureAwait(false);
             UdpPubSubConnection connection = m_udpConnection;
             ushort[] dataSetWriterIdsToSend;
             lock (Lock)
@@ -274,7 +287,8 @@ namespace Opc.Ua.PubSub.Transport
         /// </summary>
         private async Task SendResponsePublisherEndpointsAsync()
         {
-            await Task.Delay(kMinimumResponseInterval).ConfigureAwait(false);
+            await m_timeProvider.Delay(TimeSpan.FromMilliseconds(kMinimumResponseInterval))
+                .ConfigureAwait(false);
 
             UdpPubSubConnection connection = m_udpConnection;
             if (connection == null)

--- a/Libraries/Opc.Ua.PubSub/Transport/UdpDiscoveryPublisher.cs
+++ b/Libraries/Opc.Ua.PubSub/Transport/UdpDiscoveryPublisher.cs
@@ -69,7 +69,7 @@ namespace Opc.Ua.PubSub.Transport
             : base(udpConnection, telemetry, telemetry.CreateLogger<UdpDiscoveryPublisher>())
         {
             m_metadataWriterIdsToSend = [];
-            m_timeProvider = timeProvider ??= TimeProvider.System;
+            m_timeProvider = timeProvider ?? TimeProvider.System;
         }
 
         /// <summary>

--- a/Libraries/Opc.Ua.PubSub/Transport/UdpDiscoverySubscriber.cs
+++ b/Libraries/Opc.Ua.PubSub/Transport/UdpDiscoverySubscriber.cs
@@ -61,7 +61,10 @@ namespace Opc.Ua.PubSub.Transport
         /// <summary>
         /// Create new instance of <see cref="UdpDiscoverySubscriber"/>
         /// </summary>
-        public UdpDiscoverySubscriber(UdpPubSubConnection udpConnection, ITelemetryContext telemetry)
+        public UdpDiscoverySubscriber(
+            UdpPubSubConnection udpConnection,
+            ITelemetryContext telemetry,
+            TimeProvider? timeProvider = null)
             : base(udpConnection, telemetry, telemetry.CreateLogger<UdpDiscoverySubscriber>())
         {
             m_metadataWriterIdsToSend = [];
@@ -70,7 +73,8 @@ namespace Opc.Ua.PubSub.Transport
                 kInitialRequestInterval,
                 CanPublish,
                 RequestDiscoveryMessagesAsync,
-                telemetry);
+                telemetry,
+                timeProvider);
         }
 
         /// <summary>

--- a/Libraries/Opc.Ua.PubSub/Transport/UdpPubSubConnection.cs
+++ b/Libraries/Opc.Ua.PubSub/Transport/UdpPubSubConnection.cs
@@ -188,7 +188,10 @@ namespace Opc.Ua.PubSub.Transport
                 }
 
                 // initialize the discovery channel
-                m_udpDiscoverySubscriber = new UdpDiscoverySubscriber(this, Telemetry);
+                m_udpDiscoverySubscriber = new UdpDiscoverySubscriber(
+                    this,
+                    Telemetry,
+                    Application.TimeProvider);
                 await m_udpDiscoverySubscriber.StartAsync(MessageContext).ConfigureAwait(false);
 
                 // add handler to metaDataReceived event

--- a/Libraries/Opc.Ua.PubSub/Transport/UdpPubSubConnection.cs
+++ b/Libraries/Opc.Ua.PubSub/Transport/UdpPubSubConnection.cs
@@ -153,7 +153,8 @@ namespace Opc.Ua.PubSub.Transport
                         m_logger);
                 }
 
-                m_udpDiscoveryPublisher = new UdpDiscoveryPublisher(this, Telemetry);
+                m_udpDiscoveryPublisher = new UdpDiscoveryPublisher(
+                    this, Telemetry, Application.TimeProvider);
                 await m_udpDiscoveryPublisher.StartAsync(MessageContext).ConfigureAwait(false);
             }
 

--- a/Libraries/Opc.Ua.PubSub/UaPubSubApplication.cs
+++ b/Libraries/Opc.Ua.PubSub/UaPubSubApplication.cs
@@ -106,7 +106,7 @@ namespace Opc.Ua.PubSub
 
             m_telemetry = telemetry;
             DataStore = dataStore ?? new UaPubSubDataStore();
-            TimeProvider = timeProvider ??= TimeProvider.System;
+            TimeProvider = timeProvider ?? TimeProvider.System;
 
             if (!string.IsNullOrEmpty(applicationId))
             {

--- a/Libraries/Opc.Ua.PubSub/UaPubSubApplication.cs
+++ b/Libraries/Opc.Ua.PubSub/UaPubSubApplication.cs
@@ -46,7 +46,6 @@ namespace Opc.Ua.PubSub
         private readonly List<IUaPubSubConnection> m_uaPubSubConnections;
         private readonly ITelemetryContext m_telemetry;
         private readonly ILogger m_logger;
-
         /// <summary>
         /// Event that is triggered when the <see cref="UaPubSubApplication"/> receives a message via its active connections
         /// </summary>
@@ -93,16 +92,21 @@ namespace Opc.Ua.PubSub
         /// <param name="dataStore">The current implementation of <see cref="IUaPubSubDataStore"/>
         /// used by this instance of pub sub application</param>
         /// <param name="applicationId"> The application id for instance.</param>
+        /// <param name="timeProvider">The optional <see cref="System.TimeProvider"/>
+        /// used for timer and duration calculations. Defaults to
+        /// <see cref="TimeProvider.System"/> when <c>null</c>.</param>
         private UaPubSubApplication(
             ITelemetryContext telemetry,
             IUaPubSubDataStore? dataStore = null,
-            string? applicationId = null)
+            string? applicationId = null,
+            TimeProvider? timeProvider = null)
         {
             m_logger = telemetry.CreateLogger<UaPubSubApplication>();
             m_uaPubSubConnections = [];
 
             m_telemetry = telemetry;
             DataStore = dataStore ?? new UaPubSubDataStore();
+            TimeProvider = timeProvider ??= TimeProvider.System;
 
             if (!string.IsNullOrEmpty(applicationId))
             {
@@ -160,16 +164,32 @@ namespace Opc.Ua.PubSub
         internal DataCollector DataCollector { get; }
 
         /// <summary>
+        /// Gets the <see cref="System.TimeProvider"/> used by this PubSub application and
+        /// all components it owns (connections, publishers, discovery, metadata publishers,
+        /// interval runners) for timer and duration calculations.
+        /// </summary>
+        public TimeProvider TimeProvider { get; }
+
+        /// <summary>
         /// Creates a new <see cref="UaPubSubApplication"/> and associates it with a
         /// custom implementation of <see cref="IUaPubSubDataStore"/>.
         /// </summary>
         /// <param name="dataStore"> The current implementation of <see cref="IUaPubSubDataStore"/>
         /// used by this instance of pub sub application</param>
         /// <param name="telemetry">The telemetry context to use to create obvservability instruments</param>
+        /// <param name="timeProvider">Optional <see cref="System.TimeProvider"/> for timer and
+        /// duration calculations. Defaults to <see cref="TimeProvider.System"/> when <c>null</c>.</param>
         /// <returns>New instance of <see cref="UaPubSubApplication"/></returns>
-        public static UaPubSubApplication Create(IUaPubSubDataStore dataStore, ITelemetryContext telemetry)
+        public static UaPubSubApplication Create(
+            IUaPubSubDataStore dataStore,
+            ITelemetryContext telemetry,
+            TimeProvider? timeProvider = null)
         {
-            return Create(new PubSubConfigurationDataType { Enabled = true }, dataStore, telemetry);
+            return Create(
+                new PubSubConfigurationDataType { Enabled = true },
+                dataStore,
+                telemetry,
+                timeProvider);
         }
 
         /// <summary>
@@ -180,13 +200,16 @@ namespace Opc.Ua.PubSub
         /// <param name="telemetry">The telemetry context to use to create obvservability instruments</param>
         /// <param name="dataStore"> The current implementation of <see cref="IUaPubSubDataStore"/>
         /// used by this instance of pub sub application</param>
+        /// <param name="timeProvider">Optional <see cref="System.TimeProvider"/> for timer and
+        /// duration calculations. Defaults to <see cref="TimeProvider.System"/> when <c>null</c>.</param>
         /// <returns>New instance of <see cref="UaPubSubApplication"/></returns>
         /// <exception cref="ArgumentNullException"><paramref name="configFilePath"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException"></exception>
         public static UaPubSubApplication Create(
             string configFilePath,
             ITelemetryContext telemetry,
-            IUaPubSubDataStore? dataStore = null)
+            IUaPubSubDataStore? dataStore = null,
+            TimeProvider? timeProvider = null)
         {
             // validate input argument
             if (configFilePath == null)
@@ -202,7 +225,7 @@ namespace Opc.Ua.PubSub
             PubSubConfigurationDataType pubSubConfiguration =
                 UaPubSubConfigurationHelper.LoadConfiguration(configFilePath, telemetry);
 
-            return Create(pubSubConfiguration, dataStore, telemetry);
+            return Create(pubSubConfiguration, dataStore, telemetry, timeProvider);
         }
 
         /// <summary>
@@ -210,11 +233,14 @@ namespace Opc.Ua.PubSub
         /// specified <see cref="PubSubConfigurationDataType"/> parameter.
         /// </summary>
         /// <param name="telemetry">Telemetry context to use</param>
+        /// <param name="timeProvider">Optional <see cref="System.TimeProvider"/> for timer and
+        /// duration calculations. Defaults to <see cref="TimeProvider.System"/> when <c>null</c>.</param>
         /// <returns>New instance of <see cref="UaPubSubApplication"/></returns>
         public static UaPubSubApplication Create(
-            ITelemetryContext telemetry)
+            ITelemetryContext telemetry,
+            TimeProvider? timeProvider = null)
         {
-            return Create(null!, null, telemetry);
+            return Create(null!, null, telemetry, timeProvider);
         }
 
         /// <summary>
@@ -223,12 +249,15 @@ namespace Opc.Ua.PubSub
         /// </summary>
         /// <param name="pubSubConfiguration">The configuration object.</param>
         /// <param name="telemetry">Telemetry context to use</param>
+        /// <param name="timeProvider">Optional <see cref="System.TimeProvider"/> for timer and
+        /// duration calculations. Defaults to <see cref="TimeProvider.System"/> when <c>null</c>.</param>
         /// <returns>New instance of <see cref="UaPubSubApplication"/></returns>
         public static UaPubSubApplication Create(
             PubSubConfigurationDataType pubSubConfiguration,
-            ITelemetryContext telemetry)
+            ITelemetryContext telemetry,
+            TimeProvider? timeProvider = null)
         {
-            return Create(pubSubConfiguration, null, telemetry);
+            return Create(pubSubConfiguration, null, telemetry, timeProvider);
         }
 
         /// <summary>
@@ -239,16 +268,22 @@ namespace Opc.Ua.PubSub
         /// <param name="dataStore"> The current implementation of <see cref="IUaPubSubDataStore"/>
         /// used by this instance of pub sub application</param>
         /// <param name="telemetry">Telemetry context to use</param>
+        /// <param name="timeProvider">Optional <see cref="System.TimeProvider"/> for timer and
+        /// duration calculations. Defaults to <see cref="TimeProvider.System"/> when <c>null</c>.</param>
         /// <returns>New instance of <see cref="UaPubSubApplication"/></returns>
         public static UaPubSubApplication Create(
             PubSubConfigurationDataType pubSubConfiguration,
             IUaPubSubDataStore? dataStore,
-            ITelemetryContext telemetry)
+            ITelemetryContext telemetry,
+            TimeProvider? timeProvider = null)
         {
             // if no argument received, start with empty configuration
             pubSubConfiguration ??= new PubSubConfigurationDataType { Enabled = true };
 
-            var uaPubSubApplication = new UaPubSubApplication(telemetry, dataStore);
+            var uaPubSubApplication = new UaPubSubApplication(
+                telemetry,
+                dataStore,
+                timeProvider: timeProvider);
             uaPubSubApplication.UaPubSubConfigurator.LoadConfiguration(pubSubConfiguration);
             return uaPubSubApplication;
         }

--- a/Libraries/Opc.Ua.PubSub/UaPubSubConnection.cs
+++ b/Libraries/Opc.Ua.PubSub/UaPubSubConnection.cs
@@ -548,7 +548,11 @@ namespace Opc.Ua.PubSub
                     .FindObjectById(e.ConnectionId) as PubSubConnectionDataType;
             if (PubSubConnectionConfiguration == pubSubConnectionDataType)
             {
-                var publisher = new UaPublisher(this, e.WriterGroupDataType, Telemetry);
+                var publisher = new UaPublisher(
+                    this,
+                    e.WriterGroupDataType,
+                    Telemetry,
+                    Application.TimeProvider);
                 m_publishers.Add(publisher);
             }
         }

--- a/Libraries/Opc.Ua.PubSub/UaPublisher.cs
+++ b/Libraries/Opc.Ua.PubSub/UaPublisher.cs
@@ -55,7 +55,8 @@ namespace Opc.Ua.PubSub
         internal UaPublisher(
             IUaPubSubConnection pubSubConnection,
             WriterGroupDataType writerGroupConfiguration,
-            ITelemetryContext telemetry)
+            ITelemetryContext telemetry,
+            TimeProvider? timeProvider = null)
         {
             m_logger = telemetry.CreateLogger<UaPublisher>();
             PubSubConnection = pubSubConnection ??
@@ -64,13 +65,15 @@ namespace Opc.Ua.PubSub
                 writerGroupConfiguration ??
                 throw new ArgumentNullException(nameof(writerGroupConfiguration));
             m_writerGroupPublishState = new WriterGroupPublishState();
+            timeProvider ??= TimeProvider.System;
 
             m_intervalRunner = new IntervalRunner(
                 WriterGroupConfiguration.Name,
                 WriterGroupConfiguration.PublishingInterval,
                 CanPublish,
                 PublishMessagesAsync,
-                telemetry);
+                telemetry,
+                timeProvider);
         }
 
         /// <summary>

--- a/Libraries/Opc.Ua.Server/Alarms/AlarmRateTracker.cs
+++ b/Libraries/Opc.Ua.Server/Alarms/AlarmRateTracker.cs
@@ -53,6 +53,7 @@ namespace Opc.Ua.Server.Alarms
     {
         private readonly object m_lock = new();
         private readonly Queue<DateTime> m_activations = new();
+        private readonly TimeProvider m_timeProvider;
         private long m_maximumRate;
 
         /// <summary>
@@ -65,8 +66,24 @@ namespace Opc.Ua.Server.Alarms
         /// </summary>
         /// <param name="windowDuration">Window duration; default 1 minute.</param>
         public AlarmRateTracker(TimeSpan? windowDuration = null)
+            : this(windowDuration, timeProvider: null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new tracker with the given window duration and an
+        /// explicit <see cref="TimeProvider"/>.
+        /// </summary>
+        /// <param name="windowDuration">Window duration; default 1 minute.</param>
+        /// <param name="timeProvider">
+        /// Optional <see cref="TimeProvider"/> used to time-stamp activations
+        /// and to trim the sliding window. Falls back to
+        /// <see cref="TimeProvider.System"/> when <c>null</c>.
+        /// </param>
+        public AlarmRateTracker(TimeSpan? windowDuration, TimeProvider? timeProvider)
         {
             WindowDuration = windowDuration ?? TimeSpan.FromMinutes(1);
+            m_timeProvider = timeProvider ??= TimeProvider.System;
         }
 
         /// <summary>
@@ -74,7 +91,7 @@ namespace Opc.Ua.Server.Alarms
         /// </summary>
         public void RecordActivation()
         {
-            RecordActivation(DateTime.UtcNow);
+            RecordActivation(m_timeProvider.GetUtcNow().UtcDateTime);
         }
 
         /// <summary>
@@ -103,7 +120,7 @@ namespace Opc.Ua.Server.Alarms
             {
                 lock (m_lock)
                 {
-                    TrimOldEntries(DateTime.UtcNow);
+                    TrimOldEntries(m_timeProvider.GetUtcNow().UtcDateTime);
                     return m_activations.Count;
                 }
             }
@@ -143,7 +160,7 @@ namespace Opc.Ua.Server.Alarms
         {
             lock (m_lock)
             {
-                TrimOldEntries(DateTime.UtcNow);
+                TrimOldEntries(m_timeProvider.GetUtcNow().UtcDateTime);
                 return m_activations.ToArray();
             }
         }

--- a/Libraries/Opc.Ua.Server/Alarms/AlarmRateTracker.cs
+++ b/Libraries/Opc.Ua.Server/Alarms/AlarmRateTracker.cs
@@ -83,7 +83,7 @@ namespace Opc.Ua.Server.Alarms
         public AlarmRateTracker(TimeSpan? windowDuration, TimeProvider? timeProvider)
         {
             WindowDuration = windowDuration ?? TimeSpan.FromMinutes(1);
-            m_timeProvider = timeProvider ??= TimeProvider.System;
+            m_timeProvider = timeProvider ?? TimeProvider.System;
         }
 
         /// <summary>

--- a/Libraries/Opc.Ua.Server/Configuration/ConfigurationNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/Configuration/ConfigurationNodeManager.cs
@@ -54,7 +54,7 @@ namespace Opc.Ua.Server
         public ConfigurationNodeManager(
             IServerInternal server,
             ApplicationConfiguration configuration)
-            : this(server, configuration, server.Telemetry.CreateLogger<ConfigurationNodeManager>())
+            : this(server, configuration, server.Telemetry.CreateLogger<ConfigurationNodeManager>(), timeProvider: null)
         {
         }
 
@@ -65,8 +65,33 @@ namespace Opc.Ua.Server
             IServerInternal server,
             ApplicationConfiguration configuration,
             ILogger logger)
-            : base(server, configuration, logger)
+            : this(server, configuration, logger, timeProvider: null)
         {
+        }
+
+        /// <summary>
+        /// Initializes the configuration and diagnostics manager with an
+        /// explicit <see cref="TimeProvider"/>.
+        /// </summary>
+        /// <param name="server">The server.</param>
+        /// <param name="configuration">The application configuration.</param>
+        /// <param name="logger">The logger.</param>
+        /// <param name="timeProvider">
+        /// Optional <see cref="TimeProvider"/> used by the certificate-alarm
+        /// timer and by the "apply changes" delay. When <c>null</c>, the time
+        /// provider exposed by the server (via <see cref="ITimeProviderProvider"/>)
+        /// is used, falling back to <see cref="TimeProvider.System"/>.
+        /// </param>
+        public ConfigurationNodeManager(
+            IServerInternal server,
+            ApplicationConfiguration configuration,
+            ILogger logger,
+            TimeProvider? timeProvider)
+            : base(server, configuration, logger, timeProvider)
+        {
+            m_timeProvider = timeProvider
+                ?? (server as ITimeProviderProvider)?.TimeProvider
+                ?? TimeProvider.System;
             string? rejectedStorePath = configuration.SecurityConfiguration.RejectedCertificateStore?
                 .StorePath;
             if (!string.IsNullOrEmpty(rejectedStorePath))
@@ -1442,7 +1467,7 @@ namespace Opc.Ua.Server
 
                     // give the client some time to receive the response
                     // before the certificate update may disconnect all sessions
-                    await Task.Delay(1000).ConfigureAwait(false);
+                    await Task.Delay(TimeSpan.FromMilliseconds(1000), m_timeProvider).ConfigureAwait(false);
 
                     try
                     {
@@ -1775,7 +1800,7 @@ namespace Opc.Ua.Server
                 return;
             }
 
-            m_alarmTimer = new Timer(
+            m_alarmTimer = m_timeProvider.CreateTimer(
                 _ =>
                 {
                     try
@@ -1891,9 +1916,10 @@ namespace Opc.Ua.Server
         private UserManagement.UserManagementBinding? m_userManagementBinding;
 #pragma warning restore CA2213
         private readonly ApplicationConfiguration m_configuration;
+        private readonly TimeProvider m_timeProvider;
         private readonly List<ServerCertificateGroup> m_certificateGroups;
         private readonly CertificateStoreIdentifier? m_rejectedStore;
-        private Timer? m_alarmTimer;
+        private ITimer? m_alarmTimer;
         private readonly Dictionary<string, NamespaceMetadataState> m_namespaceMetadataStates = [];
         private readonly Dictionary<ushort, NamespaceMetadataState> m_namespaceMetadataStatesByIndex = [];
         private readonly Lock m_namespaceMetadataStatesLock = new();

--- a/Libraries/Opc.Ua.Server/Configuration/ConfigurationNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/Configuration/ConfigurationNodeManager.cs
@@ -1467,7 +1467,7 @@ namespace Opc.Ua.Server
 
                     // give the client some time to receive the response
                     // before the certificate update may disconnect all sessions
-                    await Task.Delay(TimeSpan.FromMilliseconds(1000), m_timeProvider).ConfigureAwait(false);
+                    await m_timeProvider.Delay(TimeSpan.FromMilliseconds(1000)).ConfigureAwait(false);
 
                     try
                     {

--- a/Libraries/Opc.Ua.Server/Diagnostics/DiagnosticsNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/Diagnostics/DiagnosticsNodeManager.cs
@@ -50,7 +50,8 @@ namespace Opc.Ua.Server
             : this(
                   server,
                   configuration,
-                  server.Telemetry.CreateLogger<DiagnosticsNodeManager>())
+                  server.Telemetry.CreateLogger<DiagnosticsNodeManager>(),
+                  timeProvider: null)
         {
         }
 
@@ -61,8 +62,34 @@ namespace Opc.Ua.Server
             IServerInternal server,
             ApplicationConfiguration configuration,
             ILogger logger)
+            : this(server, configuration, logger, timeProvider: null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes the node manager with an explicit
+        /// <see cref="TimeProvider"/>.
+        /// </summary>
+        /// <param name="server">The server.</param>
+        /// <param name="configuration">The application configuration.</param>
+        /// <param name="logger">The logger.</param>
+        /// <param name="timeProvider">
+        /// Optional <see cref="TimeProvider"/> used by the diagnostics-scan
+        /// and sampling timers and for the scan-throttle wall-clock checks.
+        /// When <c>null</c>, the time provider exposed by the server
+        /// (via <see cref="ITimeProviderProvider"/>) is used, falling back
+        /// to <see cref="TimeProvider.System"/>.
+        /// </param>
+        public DiagnosticsNodeManager(
+            IServerInternal server,
+            ApplicationConfiguration configuration,
+            ILogger logger,
+            TimeProvider? timeProvider)
             : base(server, configuration, logger)
         {
+            m_timeProvider = timeProvider
+                ?? (server as ITimeProviderProvider)?.TimeProvider
+                ?? TimeProvider.System;
             AliasRoot = "Core";
 
             string[] namespaceUris =
@@ -1639,7 +1666,7 @@ namespace Opc.Ua.Server
                     return;
                 }
 
-                if (HiResClock.UtcNow < m_lastDiagnosticsScanTime.AddSeconds(1))
+                if (m_timeProvider.GetUtcNow().UtcDateTime < m_lastDiagnosticsScanTime.AddSeconds(1))
                 {
                     return;
                 }
@@ -1663,7 +1690,7 @@ namespace Opc.Ua.Server
                     return StatusCodes.BadOutOfService;
                 }
 
-                if (HiResClock.UtcNow < m_lastDiagnosticsScanTime.AddSeconds(1))
+                if (m_timeProvider.GetUtcNow().UtcDateTime < m_lastDiagnosticsScanTime.AddSeconds(1))
                 {
                     // diagnostic nodes already scanned.
                     return ServiceResult.Good;
@@ -1760,7 +1787,7 @@ namespace Opc.Ua.Server
                     {
                         m_doScanBusy = true;
 
-                        m_lastDiagnosticsScanTime = HiResClock.UtcNow;
+                        m_lastDiagnosticsScanTime = m_timeProvider.GetUtcNow().UtcDateTime;
 
                         // update server diagnostics.
                         UpdateServerDiagnosticsSummary();
@@ -1954,7 +1981,11 @@ namespace Opc.Ua.Server
                 {
                     Interlocked.Increment(ref m_diagnosticsMonitoringCount);
 
-                    m_diagnosticsScanTimer ??= new Timer(DoScan, null, 1000, 1000);
+                    m_diagnosticsScanTimer ??= m_timeProvider.CreateTimer(
+                        DoScan,
+                        null,
+                        TimeSpan.FromMilliseconds(1000),
+                        TimeSpan.FromMilliseconds(1000));
 
                     DoScan(true);
                 }
@@ -2037,7 +2068,11 @@ namespace Opc.Ua.Server
             }
             else if (m_diagnosticsScanTimer != null)
             {
-                m_diagnosticsScanTimer = new Timer(DoScan, null, 1000, 1000);
+                m_diagnosticsScanTimer = m_timeProvider.CreateTimer(
+                    DoScan,
+                    null,
+                    TimeSpan.FromMilliseconds(1000),
+                    TimeSpan.FromMilliseconds(1000));
             }
             return default;
         }
@@ -2094,11 +2129,11 @@ namespace Opc.Ua.Server
         {
             m_sampledItems.TryAdd(monitoredItem.Id, monitoredItem);
 
-            m_samplingTimer ??= new Timer(
+            m_samplingTimer ??= m_timeProvider.CreateTimer(
                 DoSample,
                 null,
-                (int)m_minimumSamplingInterval,
-                (int)m_minimumSamplingInterval);
+                TimeSpan.FromMilliseconds(m_minimumSamplingInterval),
+                TimeSpan.FromMilliseconds(m_minimumSamplingInterval));
         }
 
         /// <summary>
@@ -2170,9 +2205,10 @@ namespace Opc.Ua.Server
 
         private readonly SemaphoreSlim m_modifyAddressSpaceSemaphoreSlim = new(1, 1);
         private readonly object m_diagnosticsLock = new();
+        private readonly TimeProvider m_timeProvider;
         private readonly ushort m_namespaceIndex;
         private uint m_lastUsedId;
-        private Timer? m_diagnosticsScanTimer;
+        private ITimer? m_diagnosticsScanTimer;
         private int m_diagnosticsMonitoringCount;
         private bool m_doScanBusy;
         private readonly bool m_durableSubscriptionsEnabled;
@@ -2182,7 +2218,7 @@ namespace Opc.Ua.Server
         private readonly List<SessionDiagnosticsData> m_sessions;
         private readonly List<SubscriptionDiagnosticsData> m_subscriptions;
         private NodeId m_serverLockHolder;
-        private Timer? m_samplingTimer;
+        private ITimer? m_samplingTimer;
         private readonly ConcurrentDictionary<uint, ISampledDataChangeMonitoredItem> m_sampledItems;
         private readonly double m_minimumSamplingInterval;
         private HistoryServerCapabilitiesState? m_historyCapabilities;

--- a/Libraries/Opc.Ua.Server/Diagnostics/DiagnosticsNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/Diagnostics/DiagnosticsNodeManager.cs
@@ -667,7 +667,7 @@ namespace Opc.Ua.Server
         /// <inheritdoc/>
         public void ForceDiagnosticsScan()
         {
-            m_lastDiagnosticsScanTime = DateTime.MinValue;
+            m_forceDiagnosticsScan = true;
         }
 
         /// <inheritdoc/>
@@ -1666,7 +1666,9 @@ namespace Opc.Ua.Server
                     return;
                 }
 
-                if (m_timeProvider.GetUtcNow().UtcDateTime < m_lastDiagnosticsScanTime.AddSeconds(1))
+                if (!m_forceDiagnosticsScan &&
+                    m_timeProvider.GetElapsedTime(m_lastDiagnosticsScanTimestamp) <
+                        TimeSpan.FromSeconds(1))
                 {
                     return;
                 }
@@ -1690,7 +1692,9 @@ namespace Opc.Ua.Server
                     return StatusCodes.BadOutOfService;
                 }
 
-                if (m_timeProvider.GetUtcNow().UtcDateTime < m_lastDiagnosticsScanTime.AddSeconds(1))
+                if (!m_forceDiagnosticsScan &&
+                    m_timeProvider.GetElapsedTime(m_lastDiagnosticsScanTimestamp) <
+                        TimeSpan.FromSeconds(1))
                 {
                     // diagnostic nodes already scanned.
                     return ServiceResult.Good;
@@ -1787,7 +1791,8 @@ namespace Opc.Ua.Server
                     {
                         m_doScanBusy = true;
 
-                        m_lastDiagnosticsScanTime = m_timeProvider.GetUtcNow().UtcDateTime;
+                        m_lastDiagnosticsScanTimestamp = m_timeProvider.GetTimestamp();
+                        m_forceDiagnosticsScan = false;
 
                         // update server diagnostics.
                         UpdateServerDiagnosticsSummary();
@@ -2212,7 +2217,8 @@ namespace Opc.Ua.Server
         private int m_diagnosticsMonitoringCount;
         private bool m_doScanBusy;
         private readonly bool m_durableSubscriptionsEnabled;
-        private DateTime m_lastDiagnosticsScanTime;
+        private long m_lastDiagnosticsScanTimestamp;
+        private bool m_forceDiagnosticsScan = true;
         private ServerDiagnosticsSummaryValue? m_serverDiagnostics;
         private NodeValueSimpleEventHandler? m_serverDiagnosticsCallback;
         private readonly List<SessionDiagnosticsData> m_sessions;

--- a/Libraries/Opc.Ua.Server/Historian/HistorianCaptureSink.cs
+++ b/Libraries/Opc.Ua.Server/Historian/HistorianCaptureSink.cs
@@ -87,15 +87,25 @@ namespace Opc.Ua.Server.Historian
         /// Buffering / batching knobs. <c>null</c> uses
         /// <see cref="HistorianCaptureOptions"/> defaults.
         /// </param>
+        /// <param name="timeProvider">
+        /// Optional <see cref="TimeProvider"/> used for timeout
+        /// scheduling. When <c>null</c>, the server-wide provider exposed
+        /// via <see cref="ITimeProviderProvider"/> is used, falling back
+        /// to <see cref="TimeProvider.System"/>.
+        /// </param>
         public HistorianCaptureSink(
             IHistorianProvider provider,
             ServerSystemContext systemContext,
-            HistorianCaptureOptions? options = null)
+            HistorianCaptureOptions? options = null,
+            TimeProvider? timeProvider = null)
         {
             m_provider = provider ?? throw new ArgumentNullException(nameof(provider));
             m_systemContext = systemContext ?? throw new ArgumentNullException(nameof(systemContext));
             m_options = options ?? new HistorianCaptureOptions();
             m_logger = systemContext.Server?.Telemetry?.CreateLogger<HistorianCaptureSink>();
+            m_timeProvider = timeProvider
+                ?? (systemContext.Server as ITimeProviderProvider)?.TimeProvider
+                ?? TimeProvider.System;
 
             var channelOptions = new BoundedChannelOptions(m_options.MaxQueuedSamples)
             {
@@ -181,7 +191,7 @@ namespace Opc.Ua.Server.Historian
                 // Bound the wait — if the consumer is stuck the host
                 // shutdown should not block forever.
                 await m_consumer
-                    .WaitAsync(TimeSpan.FromSeconds(5))
+                    .WaitAsync(TimeSpan.FromSeconds(5), m_timeProvider)
                     .ConfigureAwait(false);
             }
             catch (TimeoutException)
@@ -242,8 +252,10 @@ namespace Opc.Ua.Server.Historian
             }
 
             // Wait up to BatchWindow for additional items to pack the batch.
-            using var windowCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-            windowCts.CancelAfter(m_options.BatchWindow);
+            using CancellationTokenSource windowTimeoutCts = m_timeProvider
+                .CreateCancellationTokenSource(m_options.BatchWindow);
+            using var windowCts = CancellationTokenSource.CreateLinkedTokenSource(
+                ct, windowTimeoutCts.Token);
             try
             {
                 while (total < m_options.BatchTarget &&
@@ -349,6 +361,7 @@ namespace Opc.Ua.Server.Historian
         private readonly Channel<CaptureEvent> m_channel;
         private readonly Task m_consumer;
         private readonly CancellationTokenSource m_shutdownCts;
+        private readonly TimeProvider m_timeProvider;
         private long m_droppedSamples;
         private bool m_disposed;
     }

--- a/Libraries/Opc.Ua.Server/Hosting/OpcUaServerHostedService.cs
+++ b/Libraries/Opc.Ua.Server/Hosting/OpcUaServerHostedService.cs
@@ -95,7 +95,7 @@ namespace Opc.Ua.Server.Hosting
                 throw new ArgumentNullException(nameof(keyCredentialPushSubjects));
             m_services = services ?? throw new ArgumentNullException(nameof(services));
             m_logger = logger ?? throw new ArgumentNullException(nameof(logger));
-            m_timeProvider = timeProvider ??= TimeProvider.System;
+            m_timeProvider = timeProvider ?? TimeProvider.System;
         }
 
         protected override async Task ExecuteAsync(CancellationToken stoppingToken)

--- a/Libraries/Opc.Ua.Server/Hosting/OpcUaServerHostedService.cs
+++ b/Libraries/Opc.Ua.Server/Hosting/OpcUaServerHostedService.cs
@@ -58,6 +58,7 @@ namespace Opc.Ua.Server.Hosting
         private readonly IEnumerable<OpcUaServerIdentityAugmenterRegistration> m_augmenterRegistrations;
         private readonly IEnumerable<KeyCredentialPushSubject> m_keyCredentialPushSubjects;
         private readonly IServiceProvider m_services;
+        private readonly TimeProvider m_timeProvider;
         private readonly ILogger<OpcUaServerHostedService> m_logger;
         // CA2213: ApplicationInstance is IAsyncDisposable; the lifecycle here is
         // managed via the async StopAsync override which calls m_application.StopAsync.
@@ -75,7 +76,8 @@ namespace Opc.Ua.Server.Hosting
             IEnumerable<OpcUaServerIdentityAugmenterRegistration> augmenterRegistrations,
             IEnumerable<KeyCredentialPushSubject> keyCredentialPushSubjects,
             IServiceProvider services,
-            ILogger<OpcUaServerHostedService> logger)
+            ILogger<OpcUaServerHostedService> logger,
+            TimeProvider? timeProvider = null)
         {
             if (options is null)
             {
@@ -93,6 +95,7 @@ namespace Opc.Ua.Server.Hosting
                 throw new ArgumentNullException(nameof(keyCredentialPushSubjects));
             m_services = services ?? throw new ArgumentNullException(nameof(services));
             m_logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            m_timeProvider = timeProvider ??= TimeProvider.System;
         }
 
         protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -212,7 +215,7 @@ namespace Opc.Ua.Server.Hosting
                     "Application instance certificate invalid.");
             }
 
-            m_server = new StandardServer(m_telemetry);
+            m_server = new StandardServer(m_telemetry, m_timeProvider);
             foreach (OpcUaServerNodeManagerRegistration reg in m_registrations)
             {
                 if (reg.AsyncFactory is not null)

--- a/Libraries/Opc.Ua.Server/NodeManager/MonitoredItem/MonitoredNode.cs
+++ b/Libraries/Opc.Ua.Server/NodeManager/MonitoredItem/MonitoredNode.cs
@@ -65,10 +65,41 @@ namespace Opc.Ua.Server
             IServerInternal server,
             NodeState node,
             bool enableMultipleEventConsumers = false)
+            : this(nodeManager, server, node, enableMultipleEventConsumers, timeProvider: null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MonitoredNode2"/> class
+        /// with an explicit <see cref="TimeProvider"/>.
+        /// </summary>
+        /// <param name="nodeManager">The node manager.</param>
+        /// <param name="server">The server.</param>
+        /// <param name="node">The node.</param>
+        /// <param name="enableMultipleEventConsumers">
+        /// When <c>true</c>, enables dynamic scaling of consumer tasks.
+        /// </param>
+        /// <param name="timeProvider">
+        /// Optional <see cref="TimeProvider"/> used for the operation-context
+        /// cache lifetime and for wall-clock <c>SourceTimestamp</c> /
+        /// <c>ServerTimestamp</c> values produced inside this node. When
+        /// <c>null</c>, the time provider exposed by the server (via
+        /// <see cref="ITimeProviderProvider"/>) is used, falling back to
+        /// <see cref="TimeProvider.System"/>.
+        /// </param>
+        public MonitoredNode2(
+            IAsyncNodeManager nodeManager,
+            IServerInternal server,
+            NodeState node,
+            bool enableMultipleEventConsumers,
+            TimeProvider? timeProvider)
         {
             NodeManager = nodeManager ?? throw new ArgumentNullException(nameof(nodeManager));
             m_server = server ?? throw new ArgumentNullException(nameof(server));
             Node = node ?? throw new ArgumentNullException(nameof(node));
+            m_timeProvider = timeProvider
+                ?? (server as ITimeProviderProvider)?.TimeProvider
+                ?? TimeProvider.System;
             m_logger = server.Telemetry?.CreateLogger<MonitoredNode2>();
             m_useMultipleConsumers = enableMultipleEventConsumers || node.NodeId == ObjectIds.Server;
             m_channel = Channel.CreateBounded<INodeNotification>(new BoundedChannelOptions(k_defaultChannelCapacity)
@@ -308,7 +339,7 @@ namespace Opc.Ua.Server
                 var dataValue = new DataValue(
                     default,
                     StatusCodes.Good,
-                    DateTime.UtcNow,
+                    m_timeProvider.GetUtcNow().UtcDateTime,
                     DateTime.MinValue);
 
                 (ServiceResult readError, attributeSnapshots[attributeId]) = node.ReadAttributeAsync(
@@ -582,7 +613,7 @@ namespace Opc.Ua.Server
                 Variant.Null,
                 StatusCodes.Good,
                 DateTime.MinValue,
-                DateTime.UtcNow);
+                m_timeProvider.GetUtcNow().UtcDateTime);
             (ServiceResult error, value) = await node.ReadAttributeAsync(
                 context,
                 monitoredItem.AttributeId,
@@ -638,7 +669,7 @@ namespace Opc.Ua.Server
             IDataChangeMonitoredItem2 monitoredItem)
         {
             uint monitoredItemId = monitoredItem.Id;
-            int currentTicks = HiResClock.TickCount;
+            int currentTicks = m_timeProvider.GetTickCount();
             OperationContext operationContext;
 
             // Check if the context already exists in the cache
@@ -788,6 +819,7 @@ namespace Opc.Ua.Server
         private readonly int m_cacheLifetimeTicks = (int)TimeSpan.FromMinutes(5).TotalMilliseconds;
 
         private readonly IServerInternal m_server;
+        private readonly TimeProvider m_timeProvider;
         private readonly ILogger? m_logger;
         private readonly Channel<INodeNotification> m_channel;
         private readonly CancellationTokenSource m_consumerCts;

--- a/Libraries/Opc.Ua.Server/NodeManager/MonitoredItem/MonitoredNode.cs
+++ b/Libraries/Opc.Ua.Server/NodeManager/MonitoredItem/MonitoredNode.cs
@@ -669,26 +669,26 @@ namespace Opc.Ua.Server
             IDataChangeMonitoredItem2 monitoredItem)
         {
             uint monitoredItemId = monitoredItem.Id;
-            int currentTicks = m_timeProvider.GetTickCount();
+            long currentTimestamp = m_timeProvider.GetTimestamp();
             OperationContext operationContext;
 
             // Check if the context already exists in the cache
             if (m_contextCache.TryGetValue(
                     monitoredItemId,
-                    out (ServerSystemContext Context, int CreatedAtTicks) cachedEntry))
+                    out (ServerSystemContext Context, long CreatedAtTimestamp) cachedEntry))
             {
                 // Refresh context if the owning session changed (e.g. after subscription transfer)
                 // or if the cache entry has expired.
                 // Note: identity-based invalidation is handled proactively by
                 // InvalidatePermissionCacheForSession when ActivateSession changes the identity.
                 if (cachedEntry.Context.OperationContext!.Session != monitoredItem.Session ||
-                    (currentTicks - cachedEntry.CreatedAtTicks) > m_cacheLifetimeTicks)
+                    m_timeProvider.GetElapsedTime(cachedEntry.CreatedAtTimestamp) > m_cacheLifetime)
                 {
                     operationContext = new OperationContext(monitoredItem);
 
                     ServerSystemContext updatedContext = context.Copy(
                         operationContext);
-                    m_contextCache[monitoredItemId] = (updatedContext, currentTicks);
+                    m_contextCache[monitoredItemId] = (updatedContext, currentTimestamp);
 
                     // Invalidate the permission cache since the session context has changed.
                     m_permissionCache.TryRemove(monitoredItemId, out _);
@@ -702,7 +702,7 @@ namespace Opc.Ua.Server
             // Create a new context and add it to the cache
             operationContext = new OperationContext(monitoredItem);
             ServerSystemContext newContext = context.Copy(operationContext);
-            m_contextCache.TryAdd(monitoredItemId, (newContext, currentTicks));
+            m_contextCache.TryAdd(monitoredItemId, (newContext, currentTimestamp));
 
             return newContext;
         }
@@ -807,7 +807,7 @@ namespace Opc.Ua.Server
             public CancellationTokenSource Cts { get; }
         }
 
-        private readonly ConcurrentDictionary<uint, (ServerSystemContext Context, int CreatedAtTicks)> m_contextCache =
+        private readonly ConcurrentDictionary<uint, (ServerSystemContext Context, long CreatedAtTimestamp)> m_contextCache =
             new();
 
         private readonly ConcurrentDictionary<uint, ServiceResult> m_permissionCache =
@@ -816,7 +816,7 @@ namespace Opc.Ua.Server
         private readonly ConcurrentDictionary<EventPermissionCacheKey, ServiceResult> m_eventPermissionCache =
             new();
 
-        private readonly int m_cacheLifetimeTicks = (int)TimeSpan.FromMinutes(5).TotalMilliseconds;
+        private readonly TimeSpan m_cacheLifetime = TimeSpan.FromMinutes(5);
 
         private readonly IServerInternal m_server;
         private readonly TimeProvider m_timeProvider;

--- a/Libraries/Opc.Ua.Server/NodeManager/MonitoredItem/SamplingGroup.cs
+++ b/Libraries/Opc.Ua.Server/NodeManager/MonitoredItem/SamplingGroup.cs
@@ -51,8 +51,47 @@ namespace Opc.Ua.Server
             OperationContext context,
             double samplingInterval,
             IUserIdentity? savedOwnerIdentity = null)
+            : this(
+                server,
+                nodeManager,
+                samplingRates,
+                context,
+                samplingInterval,
+                savedOwnerIdentity,
+                timeProvider: null)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance of a sampling group with an explicit
+        /// <see cref="TimeProvider"/>.
+        /// </summary>
+        /// <param name="server">The server.</param>
+        /// <param name="nodeManager">The owning node manager.</param>
+        /// <param name="samplingRates">The supported sampling-rate groups.</param>
+        /// <param name="context">The operation context.</param>
+        /// <param name="samplingInterval">The requested sampling interval.</param>
+        /// <param name="savedOwnerIdentity">Owner identity for sessionless groups.</param>
+        /// <param name="timeProvider">
+        /// Optional <see cref="TimeProvider"/> used for the sampling-loop pacing
+        /// and for the wall-clock fallback timestamp emitted when a sampled
+        /// read returns no value. When <c>null</c>, the time provider exposed
+        /// by the server (via <see cref="ITimeProviderProvider"/>) is used,
+        /// falling back to <see cref="TimeProvider.System"/>.
+        /// </param>
+        public SamplingGroup(
+            IServerInternal server,
+            IAsyncNodeManager nodeManager,
+            List<SamplingRateGroup> samplingRates,
+            OperationContext context,
+            double samplingInterval,
+            IUserIdentity? savedOwnerIdentity,
+            TimeProvider? timeProvider)
         {
             m_server = server ?? throw new ArgumentNullException(nameof(server));
+            m_timeProvider = timeProvider
+                ?? (server as ITimeProviderProvider)?.TimeProvider
+                ?? TimeProvider.System;
             m_logger = server.Telemetry.CreateLogger<SamplingGroup>();
             m_nodeManager = nodeManager ?? throw new ArgumentNullException(nameof(nodeManager));
             m_samplingRates = samplingRates ??
@@ -387,7 +426,7 @@ namespace Opc.Ua.Server
 
                 while (m_server.IsRunning)
                 {
-                    DateTime start = HiResClock.UtcNow;
+                    long startTimestamp = m_timeProvider.GetTimestamp();
 
                     // wait till next sample.
                     if (m_shutdownEvent.WaitOne(timeToWait))
@@ -428,7 +467,7 @@ namespace Opc.Ua.Server
                     // sample the values.
                     await DoSampleAsync(items, cancellationToken).ConfigureAwait(false);
 
-                    int delay = (int)(HiResClock.UtcNow - start).TotalMilliseconds;
+                    int delay = (int)m_timeProvider.GetElapsedTime(startTimestamp).TotalMilliseconds;
                     timeToWait = sleepCycle;
 
                     if (delay > sleepCycle)
@@ -503,7 +542,7 @@ namespace Opc.Ua.Server
                         {
                             values[ii] = DataValue.FromStatusCode(
                                 StatusCodes.BadInternalError,
-                                DateTime.UtcNow);
+                                m_timeProvider.GetUtcNow().UtcDateTime);
                         }
 
                         items[ii].QueueValue(values[ii], errors[ii]);
@@ -519,6 +558,7 @@ namespace Opc.Ua.Server
         private readonly Lock m_lock = new();
         private readonly ILogger m_logger;
         private readonly IServerInternal m_server;
+        private readonly TimeProvider m_timeProvider;
         private readonly IAsyncNodeManager m_nodeManager;
         private ISession? m_session;
         private readonly IUserIdentity? m_effectiveIdentity;

--- a/Libraries/Opc.Ua.Server/NodeManager/MonitoredItem/SamplingGroupManager.cs
+++ b/Libraries/Opc.Ua.Server/NodeManager/MonitoredItem/SamplingGroupManager.cs
@@ -39,7 +39,7 @@ namespace Opc.Ua.Server
     public class SamplingGroupManager : IDisposable
     {
         /// <summary>
-        /// Creates a new instance of a sampling group.
+        /// Creates a new instance of a sampling group manager.
         /// </summary>
         public SamplingGroupManager(
             IServerInternal server,
@@ -47,9 +47,44 @@ namespace Opc.Ua.Server
             uint maxQueueSize,
             uint maxDurableQueueSize,
             IEnumerable<SamplingRateGroup> samplingRates)
+            : this(
+                server,
+                nodeManager,
+                maxQueueSize,
+                maxDurableQueueSize,
+                samplingRates,
+                timeProvider: null)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance of a sampling group manager with an explicit
+        /// <see cref="TimeProvider"/>.
+        /// </summary>
+        /// <param name="server">The server.</param>
+        /// <param name="nodeManager">The owning node manager.</param>
+        /// <param name="maxQueueSize">The maximum non-durable monitored-item queue size.</param>
+        /// <param name="maxDurableQueueSize">The maximum durable monitored-item queue size.</param>
+        /// <param name="samplingRates">The supported sampling-rate groups.</param>
+        /// <param name="timeProvider">
+        /// Optional <see cref="TimeProvider"/> propagated to the <see cref="SamplingGroup"/>
+        /// instances created by this manager. When <c>null</c>, the time provider exposed by
+        /// the server (via <see cref="ITimeProviderProvider"/>) is used, falling back to
+        /// <see cref="TimeProvider.System"/>.
+        /// </param>
+        public SamplingGroupManager(
+            IServerInternal server,
+            IAsyncNodeManager nodeManager,
+            uint maxQueueSize,
+            uint maxDurableQueueSize,
+            IEnumerable<SamplingRateGroup> samplingRates,
+            TimeProvider? timeProvider)
         {
             m_server = server ?? throw new ArgumentNullException(nameof(server));
             m_nodeManager = nodeManager ?? throw new ArgumentNullException(nameof(nodeManager));
+            m_timeProvider = timeProvider
+                ?? (server as ITimeProviderProvider)?.TimeProvider
+                ?? TimeProvider.System;
             m_samplingGroups = [];
             m_sampledItems = [];
             m_maxQueueSize = maxQueueSize;
@@ -411,7 +446,8 @@ namespace Opc.Ua.Server
                         m_samplingRates,
                         context,
                         monitoredItem.SamplingInterval,
-                        savedOwnerIdentity);
+                        savedOwnerIdentity,
+                        m_timeProvider);
 
                     tempSamplingGroup.StartMonitoring(context, monitoredItem, savedOwnerIdentity);
 
@@ -510,6 +546,7 @@ namespace Opc.Ua.Server
 
         private readonly Lock m_lock = new();
         private readonly IServerInternal m_server;
+        private readonly TimeProvider m_timeProvider;
         private readonly IAsyncNodeManager m_nodeManager;
         private readonly List<SamplingGroup> m_samplingGroups;
         private readonly Dictionary<ISampledDataChangeMonitoredItem, SamplingGroup> m_sampledItems;

--- a/Libraries/Opc.Ua.Server/Server/ITimeProviderProvider.cs
+++ b/Libraries/Opc.Ua.Server/Server/ITimeProviderProvider.cs
@@ -1,0 +1,60 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+
+namespace Opc.Ua.Server
+{
+    /// <summary>
+    /// Optional opt-in interface that exposes a server's
+    /// <see cref="TimeProvider"/> so subordinate components can resolve
+    /// the server-wide clock without any change to
+    /// <see cref="IServerInternal"/>; external/mocked
+    /// <see cref="IServerInternal"/> implementations remain unaffected
+    /// and can fall back to <see cref="TimeProvider.System"/> when this
+    /// interface is not implemented.
+    /// </summary>
+    /// <remarks>
+    /// Consumers should resolve the time provider in a null-safe manner,
+    /// e.g.:
+    /// <code>
+    /// var tp = (server as ITimeProviderProvider)?.TimeProvider
+    ///          ?? TimeProvider.System;
+    /// </code>
+    /// </remarks>
+    public interface ITimeProviderProvider
+    {
+        /// <summary>
+        /// Gets the server's <see cref="TimeProvider"/>; never
+        /// <c>null</c>. Defaults to <see cref="TimeProvider.System"/>
+        /// when the server was constructed without an explicit provider.
+        /// </summary>
+        TimeProvider TimeProvider { get; }
+    }
+}

--- a/Libraries/Opc.Ua.Server/Server/RequestManager.cs
+++ b/Libraries/Opc.Ua.Server/Server/RequestManager.cs
@@ -43,11 +43,30 @@ namespace Opc.Ua.Server
         /// Initilizes the manager.
         /// </summary>
         public RequestManager(IServerInternal server)
+            : this(server, null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes the manager with an explicit <see cref="TimeProvider"/>
+        /// so the request-expiry timer can be mocked in tests.
+        /// </summary>
+        /// <param name="server">The server context.</param>
+        /// <param name="timeProvider">The time provider used to schedule the
+        /// request-expiry timer and to evaluate request deadlines, or
+        /// <c>null</c> to use the time provider exposed by the server (or
+        /// <see cref="TimeProvider.System"/> as a fallback).</param>
+        /// <exception cref="ArgumentNullException"><paramref name="server"/>
+        /// is <c>null</c>.</exception>
+        public RequestManager(IServerInternal server, TimeProvider? timeProvider)
         {
             m_server = server ?? throw new ArgumentNullException(nameof(server));
             m_logger = server.Telemetry.CreateLogger<RequestManager>();
             m_requests = [];
             m_requestTimer = null;
+            m_timeProvider = timeProvider
+                ?? (server as ITimeProviderProvider)?.TimeProvider
+                ?? TimeProvider.System;
         }
 
         /// <summary>
@@ -121,7 +140,11 @@ namespace Opc.Ua.Server
 
                 if (context.OperationDeadline < DateTime.MaxValue && m_requestTimer == null)
                 {
-                    m_requestTimer = new Timer(OnTimerExpired, null, 1000, 1000);
+                    m_requestTimer = m_timeProvider.CreateTimer(
+                        OnTimerExpired,
+                        null,
+                        TimeSpan.FromSeconds(1),
+                        TimeSpan.FromSeconds(1));
                 }
             }
         }
@@ -213,7 +236,7 @@ namespace Opc.Ua.Server
 
                 foreach (OperationContext request in m_requests.Values)
                 {
-                    if (request.OperationDeadline < DateTime.UtcNow)
+                    if (request.OperationDeadline < m_timeProvider.GetUtcNow().UtcDateTime)
                     {
                         request.RequestLifetime.TryCancel(StatusCodes.BadTimeout);
                         expiredRequests.Add(request.RequestId);
@@ -255,9 +278,10 @@ namespace Opc.Ua.Server
         private readonly Lock m_lock = new();
         private readonly ILogger m_logger;
         private readonly IServerInternal m_server;
+        private readonly TimeProvider m_timeProvider;
         private readonly Dictionary<uint, OperationContext> m_requests;
         private readonly Lock m_requestsLock = new();
-        private Timer? m_requestTimer;
+        private ITimer? m_requestTimer;
         private event RequestCancelledEventHandler? m_RequestCancelled;
     }
 

--- a/Libraries/Opc.Ua.Server/Server/ReverseConnectServer.cs
+++ b/Libraries/Opc.Ua.Server/Server/ReverseConnectServer.cs
@@ -160,7 +160,21 @@ namespace Opc.Ua.Server
         /// Creates a reverse connect server based on a StandardServer.
         /// </summary>
         public ReverseConnectServer(ITelemetryContext telemetry)
-            : base(telemetry)
+            : this(telemetry, null)
+        {
+        }
+
+        /// <summary>
+        /// Creates a reverse connect server with an explicit
+        /// <see cref="TimeProvider"/> so the reverse-connect timer and
+        /// expiry logic can be mocked in tests.
+        /// </summary>
+        /// <param name="telemetry">The telemetry context.</param>
+        /// <param name="timeProvider">The time provider used for all
+        /// time / duration calculations, or <c>null</c> to use
+        /// <see cref="TimeProvider.System"/>.</param>
+        public ReverseConnectServer(ITelemetryContext telemetry, TimeProvider? timeProvider)
+            : base(telemetry, timeProvider)
         {
             m_connectInterval = DefaultReverseConnectInterval;
             m_connectTimeout = DefaultReverseConnectTimeout;
@@ -292,7 +306,7 @@ namespace Opc.Ua.Server
                         if (reverseConnection.LastState == ReverseConnectState.Rejected &&
                             reverseConnection.RejectTime +
                             TimeSpan.FromMilliseconds(m_rejectTimeout) <
-                                DateTime.UtcNow)
+                                TimeProvider.GetUtcNow().UtcDateTime)
                         {
                             reverseConnection.LastState = ReverseConnectState.Closed;
                         }
@@ -364,7 +378,7 @@ namespace Opc.Ua.Server
                         if (e.ChannelStatus.Code == StatusCodes.BadTcpMessageTypeInvalid)
                         {
                             reverseConnection.LastState = ReverseConnectState.Rejected;
-                            reverseConnection.RejectTime = DateTime.UtcNow;
+                            reverseConnection.RejectTime = TimeProvider.GetUtcNow().UtcDateTime;
                             m_logger.LogWarning(
                                 "Client Rejected Connection! [{LastState}][{EndpointUrl}]",
                                 reverseConnection.LastState,
@@ -414,11 +428,11 @@ namespace Opc.Ua.Server
                     m_connections.Count > 0 &&
                     m_reverseConnectTimer == null)
                 {
-                    m_reverseConnectTimer = new Timer(
+                    m_reverseConnectTimer = TimeProvider.CreateTimer(
                         OnReverseConnect,
                         this,
-                        forceRestart ? m_connectInterval : 1000,
-                        Timeout.Infinite);
+                        TimeSpan.FromMilliseconds(forceRestart ? m_connectInterval : 1000),
+                        Timeout.InfiniteTimeSpan);
                 }
             }
         }
@@ -512,7 +526,7 @@ namespace Opc.Ua.Server
             }
         }
 
-        private Timer? m_reverseConnectTimer;
+        private ITimer? m_reverseConnectTimer;
         private int m_connectInterval;
         private int m_connectTimeout;
         private int m_rejectTimeout;

--- a/Libraries/Opc.Ua.Server/Server/ServerInternalData.cs
+++ b/Libraries/Opc.Ua.Server/Server/ServerInternalData.cs
@@ -62,7 +62,8 @@ namespace Opc.Ua.Server
     public class ServerInternalData :
         IServerInternal,
         AliasNames.IAliasNameStoreRegistryProvider,
-        Historian.IHistorianRegistryProvider
+        Historian.IHistorianRegistryProvider,
+        ITimeProviderProvider
     {
         /// <summary>
         /// Initializes the datastore with the server configuration.
@@ -74,7 +75,26 @@ namespace Opc.Ua.Server
             ServerProperties serverDescription,
             ApplicationConfiguration configuration,
             IServiceMessageContext messageContext)
+            : this(serverDescription, configuration, messageContext, null)
         {
+        }
+
+        /// <summary>
+        /// Initializes the datastore with the server configuration.
+        /// </summary>
+        /// <param name="serverDescription">The server description.</param>
+        /// <param name="configuration">The configuration.</param>
+        /// <param name="messageContext">The message context.</param>
+        /// <param name="timeProvider">The time provider used for all
+        /// time / duration calculations performed by the server, or
+        /// <c>null</c> to use <see cref="TimeProvider.System"/>.</param>
+        public ServerInternalData(
+            ServerProperties serverDescription,
+            ApplicationConfiguration configuration,
+            IServiceMessageContext messageContext,
+            TimeProvider? timeProvider)
+        {
+            m_timeProvider = timeProvider ??= TimeProvider.System;
             m_serverDescription = serverDescription;
             m_configuration = configuration;
             MessageContext = messageContext;
@@ -156,6 +176,15 @@ namespace Opc.Ua.Server
         /// <see cref="IServerInternal"/>; never <c>null</c>.
         /// </summary>
         public Historian.IHistorianProviderRegistry HistorianRegistry { get; }
+
+        /// <summary>
+        /// The time provider used for all time / duration calculations
+        /// performed by the server. Surfaces through the optional
+        /// <see cref="ITimeProviderProvider"/> interface so consumers can
+        /// discover it without any change to <see cref="IServerInternal"/>;
+        /// never <c>null</c>.
+        /// </summary>
+        public TimeProvider TimeProvider => m_timeProvider;
 
         /// <summary>
         /// The session manager to use with the server.
@@ -828,10 +857,11 @@ namespace Opc.Ua.Server
             serverObject.ServerDiagnostics.EnabledFlag.MinimumSamplingInterval = 1000;
 
             // initialize status.
+            DateTime nowUtc = m_timeProvider.GetUtcNow().UtcDateTime;
             var serverStatus = new ServerStatusDataType
             {
-                StartTime = DateTime.UtcNow,
-                CurrentTime = DateTime.UtcNow,
+                StartTime = nowUtc,
+                CurrentTime = nowUtc,
                 State = ServerState.Shutdown
             };
 
@@ -861,7 +891,7 @@ namespace Opc.Ua.Server
                 serverStatus,
                 DiagnosticsLock)
             {
-                Timestamp = DateTime.UtcNow,
+                Timestamp = nowUtc,
                 OnBeforeRead = OnReadServerStatus
             };
 
@@ -934,7 +964,7 @@ namespace Opc.Ua.Server
         {
             lock (NonThreadSafeStatus.Lock)
             {
-                DateTime now = DateTime.UtcNow;
+                DateTime now = m_timeProvider.GetUtcNow().UtcDateTime;
                 NonThreadSafeStatus.Timestamp = now;
                 NonThreadSafeStatus.Value.CurrentTime = now;
 
@@ -1062,6 +1092,7 @@ namespace Opc.Ua.Server
         private readonly ServerProperties m_serverDescription;
         private readonly ApplicationConfiguration m_configuration;
         private readonly List<Uri> m_endpointAddresses;
+        private readonly TimeProvider m_timeProvider;
         private RoleStateBinding? m_roleStateBinding;
     }
 }

--- a/Libraries/Opc.Ua.Server/Server/ServerInternalData.cs
+++ b/Libraries/Opc.Ua.Server/Server/ServerInternalData.cs
@@ -94,7 +94,7 @@ namespace Opc.Ua.Server
             IServiceMessageContext messageContext,
             TimeProvider? timeProvider)
         {
-            m_timeProvider = timeProvider ??= TimeProvider.System;
+            m_timeProvider = timeProvider ?? TimeProvider.System;
             m_serverDescription = serverDescription;
             m_configuration = configuration;
             MessageContext = messageContext;

--- a/Libraries/Opc.Ua.Server/Server/StandardServer.cs
+++ b/Libraries/Opc.Ua.Server/Server/StandardServer.cs
@@ -3657,7 +3657,7 @@ namespace Opc.Ua.Server
             IServerInternal server,
             ApplicationConfiguration configuration)
         {
-            return new SessionManager(server, configuration);
+            return new SessionManager(server, configuration, m_timeProvider);
         }
 
         /// <summary>

--- a/Libraries/Opc.Ua.Server/Server/StandardServer.cs
+++ b/Libraries/Opc.Ua.Server/Server/StandardServer.cs
@@ -46,9 +46,30 @@ namespace Opc.Ua.Server
     {
         /// <inheritdoc/>
         public StandardServer(ITelemetryContext telemetry)
-            : base(telemetry)
+            : this(telemetry, null)
         {
         }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="StandardServer"/>
+        /// with an explicit <see cref="TimeProvider"/> so the server's
+        /// timers and duration calculations can be mocked in tests.
+        /// </summary>
+        /// <param name="telemetry">The telemetry context.</param>
+        /// <param name="timeProvider">The time provider used for all
+        /// time / duration calculations performed by the server, or
+        /// <c>null</c> to use <see cref="TimeProvider.System"/>.</param>
+        public StandardServer(ITelemetryContext telemetry, TimeProvider? timeProvider)
+            : base(telemetry)
+        {
+            m_timeProvider = timeProvider ??= TimeProvider.System;
+        }
+
+        /// <summary>
+        /// The <see cref="TimeProvider"/> used by the server for all
+        /// time / duration calculations and timer scheduling.
+        /// </summary>
+        protected TimeProvider TimeProvider => m_timeProvider;
 
         /// <inheritdoc/>
         protected override void Dispose(bool disposing)
@@ -831,7 +852,7 @@ namespace Opc.Ua.Server
             {
                 ServiceResult = exception.StatusCode,
 
-                Timestamp = DateTime.UtcNow,
+                Timestamp = m_timeProvider.GetUtcNow().UtcDateTime,
                 RequestHandle = requestHeader!.RequestHandle
             };
 
@@ -2235,7 +2256,7 @@ namespace Opc.Ua.Server
 
                             var requestHeader = new RequestHeader
                             {
-                                Timestamp = DateTime.UtcNow
+                                Timestamp = m_timeProvider.GetUtcNow().UtcDateTime
                             };
 
                             // create the client.
@@ -2339,11 +2360,11 @@ namespace Opc.Ua.Server
                     {
                         if (m_maxRegistrationInterval > 0)
                         {
-                            m_registrationTimer = new Timer(
+                            m_registrationTimer = m_timeProvider.CreateTimer(
                                 OnRegisterServerAsync,
                                 this,
-                                m_maxRegistrationInterval,
-                                Timeout.Infinite);
+                                TimeSpan.FromMilliseconds(m_maxRegistrationInterval),
+                                Timeout.InfiniteTimeSpan);
 
                             m_lastRegistrationInterval = m_minRegistrationInterval;
                             m_logger.LogInformation(
@@ -2371,11 +2392,11 @@ namespace Opc.Ua.Server
                                 m_lastRegistrationInterval);
 
                             // create timer.
-                            m_registrationTimer = new Timer(
+                            m_registrationTimer = m_timeProvider.CreateTimer(
                                 OnRegisterServerAsync,
                                 this,
-                                m_lastRegistrationInterval,
-                                Timeout.Infinite);
+                                TimeSpan.FromMilliseconds(m_lastRegistrationInterval),
+                                Timeout.InfiniteTimeSpan);
                         }
                     }
                 }
@@ -2900,7 +2921,8 @@ namespace Opc.Ua.Server
                 m_serverInternal = new ServerInternalData(
                     ServerProperties!,
                     configuration,
-                    MessageContext);
+                    MessageContext,
+                    m_timeProvider);
 
                 // create the manager responsible for providing localized string resources.
                 m_logger.LogInformation(Utils.TraceMasks.StartStop, "Server - CreateResourceManager.");
@@ -3070,11 +3092,11 @@ namespace Opc.Ua.Server
                     if (m_maxRegistrationInterval > 0)
                     {
                         m_logger.LogInformation(Utils.TraceMasks.StartStop, "Server - Registration Timer started.");
-                        m_registrationTimer = new Timer(
+                        m_registrationTimer = m_timeProvider.CreateTimer(
                             OnRegisterServerAsync,
                             this,
-                            m_minRegistrationInterval,
-                            Timeout.Infinite);
+                            TimeSpan.FromMilliseconds(m_minRegistrationInterval),
+                            Timeout.InfiniteTimeSpan);
                     }
                 }
             }
@@ -3752,7 +3774,8 @@ namespace Opc.Ua.Server
         private ConfigurationWatcher? m_configurationWatcher;
         private ConfiguredEndpointCollection? m_registrationEndpoints;
         private RegisteredServer? m_registrationInfo;
-        private Timer? m_registrationTimer;
+        private ITimer? m_registrationTimer;
+        private readonly TimeProvider m_timeProvider;
         private int m_minRegistrationInterval;
         private int m_maxRegistrationInterval;
         private int m_lastRegistrationInterval;

--- a/Libraries/Opc.Ua.Server/Server/StandardServer.cs
+++ b/Libraries/Opc.Ua.Server/Server/StandardServer.cs
@@ -62,7 +62,7 @@ namespace Opc.Ua.Server
         public StandardServer(ITelemetryContext telemetry, TimeProvider? timeProvider)
             : base(telemetry)
         {
-            m_timeProvider = timeProvider ??= TimeProvider.System;
+            m_timeProvider = timeProvider ?? TimeProvider.System;
         }
 
         /// <summary>

--- a/Libraries/Opc.Ua.Server/ServerUtils.cs
+++ b/Libraries/Opc.Ua.Server/ServerUtils.cs
@@ -100,7 +100,7 @@ namespace Opc.Ua.Server
                     EventType = EventType.WriteValue,
                     NodeId = nodeId,
                     ServerHandle = 0,
-                    Timestamp = HiResClock.UtcNow,
+                    Timestamp = DateTime.UtcNow,
                     Value = value,
                     Parameters = null,
                     MonitoringMode = MonitoringMode.Disabled
@@ -132,7 +132,7 @@ namespace Opc.Ua.Server
                     EventType = EventType.QueueValue,
                     NodeId = nodeId,
                     ServerHandle = serverHandle,
-                    Timestamp = HiResClock.UtcNow,
+                    Timestamp = DateTime.UtcNow,
                     Value = value,
                     Parameters = null,
                     MonitoringMode = MonitoringMode.Disabled
@@ -158,7 +158,7 @@ namespace Opc.Ua.Server
                     EventType = EventType.FilterValue,
                     NodeId = nodeId,
                     ServerHandle = serverHandle,
-                    Timestamp = HiResClock.UtcNow,
+                    Timestamp = DateTime.UtcNow,
                     Value = value,
                     Parameters = null,
                     MonitoringMode = MonitoringMode.Disabled
@@ -184,7 +184,7 @@ namespace Opc.Ua.Server
                     EventType = EventType.DiscardValue,
                     NodeId = nodeId,
                     ServerHandle = serverHandle,
-                    Timestamp = HiResClock.UtcNow,
+                    Timestamp = DateTime.UtcNow,
                     Value = value,
                     Parameters = null,
                     MonitoringMode = MonitoringMode.Disabled
@@ -210,7 +210,7 @@ namespace Opc.Ua.Server
                     EventType = EventType.PublishValue,
                     NodeId = nodeId,
                     ServerHandle = serverHandle,
-                    Timestamp = HiResClock.UtcNow,
+                    Timestamp = DateTime.UtcNow,
                     Value = value,
                     Parameters = null,
                     MonitoringMode = MonitoringMode.Disabled
@@ -243,7 +243,7 @@ namespace Opc.Ua.Server
                     EventType = EventType.CreateItem,
                     NodeId = nodeId,
                     ServerHandle = serverHandle,
-                    Timestamp = HiResClock.UtcNow,
+                    Timestamp = DateTime.UtcNow,
                     Value = default,
                     Parameters = new MonitoringParameters
                     {
@@ -282,7 +282,7 @@ namespace Opc.Ua.Server
                     EventType = EventType.ModifyItem,
                     NodeId = nodeId,
                     ServerHandle = serverHandle,
-                    Timestamp = HiResClock.UtcNow,
+                    Timestamp = DateTime.UtcNow,
                     Value = default,
                     Parameters = new MonitoringParameters
                     {

--- a/Libraries/Opc.Ua.Server/Session/ISession.cs
+++ b/Libraries/Opc.Ua.Server/Session/ISession.cs
@@ -60,7 +60,7 @@ namespace Opc.Ua.Server
         DateTime ClientLastContactTime { get; }
 
         /// <summary>
-        /// The monotonic tick count (HiResClock.TickCount64) at the last client contact.
+        /// The monotonic tick count (milliseconds) at the last client contact.
         /// Used for timeout calculations that are immune to system time changes.
         /// </summary>
         long LastContactTickCount { get; }

--- a/Libraries/Opc.Ua.Server/Session/Session.cs
+++ b/Libraries/Opc.Ua.Server/Session/Session.cs
@@ -74,6 +74,66 @@ namespace Opc.Ua.Server
             double sessionTimeout,
             int maxBrowseContinuationPoints,
             int maxHistoryContinuationPoints)
+            : this(
+                context,
+                server,
+                serverCertificate,
+                authenticationToken,
+                clientNonce,
+                serverNonce,
+                sessionName,
+                clientDescription,
+                endpointUrl,
+                clientCertificate,
+                clientCertificateChain,
+                sessionTimeout,
+                maxBrowseContinuationPoints,
+                maxHistoryContinuationPoints,
+                timeProvider: null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Session"/> class with an
+        /// explicit <see cref="TimeProvider"/>.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="server">The Server object.</param>
+        /// <param name="serverCertificate">The server certificate.</param>
+        /// <param name="authenticationToken">The unique private identifier assigned to the Session.</param>
+        /// <param name="clientNonce">The client nonce.</param>
+        /// <param name="serverNonce">The server nonce.</param>
+        /// <param name="sessionName">The name assigned to the Session.</param>
+        /// <param name="clientDescription">Application description for the client application.</param>
+        /// <param name="endpointUrl">The endpoint URL.</param>
+        /// <param name="clientCertificate">The client certificate.</param>
+        /// <param name="clientCertificateChain">The client certifiate chain</param>
+        /// <param name="sessionTimeout">The session timeout.</param>
+        /// <param name="maxBrowseContinuationPoints">The maximum number of browse continuation points.</param>
+        /// <param name="maxHistoryContinuationPoints">The maximum number of history continuation points.</param>
+        /// <param name="timeProvider">
+        /// Optional <see cref="TimeProvider"/> used for monotonic timeout
+        /// calculations and last-contact diagnostics. When <c>null</c>, the
+        /// time provider exposed by the server (via
+        /// <see cref="ITimeProviderProvider"/>) is used, falling back to
+        /// <see cref="TimeProvider.System"/>.
+        /// </param>
+        public Session(
+            OperationContext context,
+            IServerInternal server,
+            Certificate serverCertificate,
+            NodeId authenticationToken,
+            ByteString clientNonce,
+            Nonce serverNonce,
+            string sessionName,
+            ApplicationDescription clientDescription,
+            string endpointUrl,
+            Certificate clientCertificate,
+            CertificateCollection clientCertificateChain,
+            double sessionTimeout,
+            int maxBrowseContinuationPoints,
+            int maxHistoryContinuationPoints,
+            TimeProvider? timeProvider)
         {
             if (context == null)
             {
@@ -87,6 +147,9 @@ namespace Opc.Ua.Server
             }
 
             m_server = server ?? throw new ArgumentNullException(nameof(server));
+            m_timeProvider = timeProvider
+                ?? (server as ITimeProviderProvider)?.TimeProvider
+                ?? TimeProvider.System;
             m_logger = server.Telemetry.CreateLogger<Session>();
             ClientNonce = clientNonce;
             m_serverNonce = serverNonce;
@@ -105,8 +168,8 @@ namespace Opc.Ua.Server
             Identity = new UserIdentity();
 
             // initialize diagnostics.
-            DateTime now = DateTime.UtcNow;
-            m_lastContactTickCount = HiResClock.TickCount64;
+            DateTime now = m_timeProvider.GetUtcNow().UtcDateTime;
+            m_lastContactTickCount = m_timeProvider.GetTimestampMilliseconds();
             SessionDiagnostics = new SessionDiagnosticsDataType
             {
                 SessionId = default,
@@ -298,7 +361,7 @@ namespace Opc.Ua.Server
             {
                 lock (DiagnosticsLock)
                 {
-                    return HiResClock.TickCount64 - m_lastContactTickCount >
+                    return m_timeProvider.GetTimestampMilliseconds() - m_lastContactTickCount >
                         (long)SessionDiagnostics.ActualSessionTimeout;
                 }
             }
@@ -319,7 +382,7 @@ namespace Opc.Ua.Server
         }
 
         /// <summary>
-        /// The monotonic tick count (HiResClock.TickCount64) at the last client contact.
+        /// The monotonic tick count (milliseconds) at the last client contact.
         /// Used for timeout calculations that are immune to system time changes.
         /// </summary>
         public long LastContactTickCount
@@ -657,8 +720,8 @@ namespace Opc.Ua.Server
                 // update the contact time.
                 lock (DiagnosticsLock)
                 {
-                    SessionDiagnostics.ClientLastContactTime = DateTime.UtcNow;
-                    m_lastContactTickCount = HiResClock.TickCount64;
+                    SessionDiagnostics.ClientLastContactTime = m_timeProvider.GetUtcNow().UtcDateTime;
+                    m_lastContactTickCount = m_timeProvider.GetTimestampMilliseconds();
                 }
 
                 // indicate whether the user context has changed.
@@ -1207,8 +1270,8 @@ namespace Opc.Ua.Server
             {
                 if (!error)
                 {
-                    SessionDiagnostics.ClientLastContactTime = DateTime.UtcNow;
-                    m_lastContactTickCount = HiResClock.TickCount64;
+                    SessionDiagnostics.ClientLastContactTime = m_timeProvider.GetUtcNow().UtcDateTime;
+                    m_lastContactTickCount = m_timeProvider.GetTimestampMilliseconds();
                 }
 
                 SessionDiagnostics.TotalRequestCount.TotalCount++;
@@ -1342,6 +1405,7 @@ namespace Opc.Ua.Server
         private readonly Lock m_lock = new();
         private readonly ILogger m_logger;
         private readonly IServerInternal m_server;
+        private readonly TimeProvider m_timeProvider;
         private readonly string m_sessionName;
         private Certificate m_serverCertificate;
         private Nonce m_serverNonce;

--- a/Libraries/Opc.Ua.Server/Session/SessionManager.cs
+++ b/Libraries/Opc.Ua.Server/Session/SessionManager.cs
@@ -51,6 +51,27 @@ namespace Opc.Ua.Server
         /// Initializes the manager with its configuration.
         /// </summary>
         public SessionManager(IServerInternal server, ApplicationConfiguration configuration)
+            : this(server, configuration, timeProvider: null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes the manager with its configuration and an explicit
+        /// <see cref="TimeProvider"/>.
+        /// </summary>
+        /// <param name="server">The server instance.</param>
+        /// <param name="configuration">The application configuration.</param>
+        /// <param name="timeProvider">
+        /// Optional <see cref="TimeProvider"/> used for monotonic timeout
+        /// calculations and client-lockout windows. When <c>null</c>, the
+        /// time provider exposed by the server (via
+        /// <see cref="ITimeProviderProvider"/>) is used, falling back to
+        /// <see cref="TimeProvider.System"/>.
+        /// </param>
+        public SessionManager(
+            IServerInternal server,
+            ApplicationConfiguration configuration,
+            TimeProvider? timeProvider)
         {
             if (configuration == null)
             {
@@ -58,6 +79,9 @@ namespace Opc.Ua.Server
             }
 
             m_server = server ?? throw new ArgumentNullException(nameof(server));
+            m_timeProvider = timeProvider
+                ?? (server as ITimeProviderProvider)?.TimeProvider
+                ?? TimeProvider.System;
             m_logger = server.Telemetry.CreateLogger<SessionManager>();
 
             m_minSessionTimeout = configuration.ServerConfiguration!.MinSessionTimeout;
@@ -68,6 +92,12 @@ namespace Opc.Ua.Server
                 .MaxBrowseContinuationPoints;
             m_maxHistoryContinuationPoints = configuration.ServerConfiguration
                 .MaxHistoryContinuationPoints;
+
+            // Lockout duration / failure expiration are stored in TimestampFrequency
+            // ticks so they can be compared directly against TimeProvider.GetTimestamp().
+            long ticksPerSecond = m_timeProvider.TimestampFrequency;
+            m_lockoutDurationTicks = ticksPerSecond * 5 * 60;
+            m_failureExpirationTicks = ticksPerSecond * 1 * 60;
 
             m_sessions = new NodeIdDictionary<ISession>(m_maxSessionCount);
             m_lastSessionId = BitConverter.ToUInt32(Nonce.CreateRandomNonceData(sizeof(uint)), 0);
@@ -338,7 +368,7 @@ namespace Opc.Ua.Server
                     // check if client is locked out due to too many failed authentication attempts.
                     if (IsClientLockedOut(clientKey, out long remainingLockoutTicks))
                     {
-                        long remainingSeconds = remainingLockoutTicks / HiResClock.Frequency;
+                        long remainingSeconds = remainingLockoutTicks / m_timeProvider.TimestampFrequency;
                         m_logger.LogWarning(
                             "Client {ClientKey} is locked out. Remaining lockout time: {RemainingSeconds} seconds.",
                             clientKey,
@@ -1006,7 +1036,8 @@ namespace Opc.Ua.Server
                 clientCertificateChain,
                 sessionTimeout,
                 m_maxBrowseContinuationPoints,
-                m_maxHistoryContinuationPoints);
+                m_maxHistoryContinuationPoints,
+                m_timeProvider);
         }
 
         /// <inheritdoc />
@@ -1100,7 +1131,7 @@ namespace Opc.Ua.Server
                                 .ConfigureAwait(false);
                         }
                         // if a session had no activity for the last m_minSessionTimeout milliseconds, send a keep alive event.
-                        else if (HiResClock.TickCount64 - session.LastContactTickCount > m_minSessionTimeout)
+                        else if (m_timeProvider.GetTimestampMilliseconds() - session.LastContactTickCount > m_minSessionTimeout)
                         {
                             // signal the channel that the session is still active.
                             RaiseSessionEvent(session, SessionEventReason.ChannelKeepAlive);
@@ -1122,6 +1153,7 @@ namespace Opc.Ua.Server
 
         private readonly SemaphoreSlim m_semaphoreSlim = new(1, 1);
         private readonly IServerInternal m_server;
+        private readonly TimeProvider m_timeProvider;
         private readonly ILogger m_logger;
         private readonly NodeIdDictionary<ISession> m_sessions;
         private uint m_lastSessionId;
@@ -1137,8 +1169,8 @@ namespace Opc.Ua.Server
 
         private readonly ConcurrentDictionary<string, ClientLockoutInfo> m_clientLockouts = new();
         private const int kMaxFailedAuthenticationAttempts = 5;
-        private static readonly long s_lockoutDurationTicks = HiResClock.Frequency * 5 * 60;
-        private static readonly long s_failureExpirationTicks = HiResClock.Frequency * 1 * 60;
+        private readonly long m_lockoutDurationTicks;
+        private readonly long m_failureExpirationTicks;
 
         private readonly Lock m_eventLock = new();
         private event SessionEventHandler? m_SessionCreated;
@@ -1343,14 +1375,14 @@ namespace Opc.Ua.Server
 
             if (m_clientLockouts.TryGetValue(clientKey, out ClientLockoutInfo? lockoutInfo))
             {
-                long currentTicks = HiResClock.Ticks;
+                long currentTicks = m_timeProvider.GetTimestamp();
                 if (lockoutInfo.IsLockedOut(currentTicks))
                 {
                     remainingLockoutTicks = lockoutInfo.LockoutEndTicks - currentTicks;
                     return true;
                 }
 
-                if (lockoutInfo.IsExpired(currentTicks, s_failureExpirationTicks))
+                if (lockoutInfo.IsExpired(currentTicks, m_failureExpirationTicks))
                 {
                     m_clientLockouts.TryRemove(clientKey, out _);
                 }
@@ -1369,16 +1401,16 @@ namespace Opc.Ua.Server
                 return;
             }
 
-            long currentTicks = HiResClock.Ticks;
+            long currentTicks = m_timeProvider.GetTimestamp();
             ClientLockoutInfo lockoutInfo = m_clientLockouts.AddOrUpdate(
                 clientKey,
-                _ => new ClientLockoutInfo(1, currentTicks, s_lockoutDurationTicks, kMaxFailedAuthenticationAttempts),
+                _ => new ClientLockoutInfo(1, currentTicks, m_lockoutDurationTicks, kMaxFailedAuthenticationAttempts),
                 (_, existing) => existing.IncrementFailures(
-                    currentTicks, s_lockoutDurationTicks, s_failureExpirationTicks, kMaxFailedAuthenticationAttempts));
+                    currentTicks, m_lockoutDurationTicks, m_failureExpirationTicks, kMaxFailedAuthenticationAttempts));
 
             if (lockoutInfo.IsLockedOut(currentTicks))
             {
-                long remainingSeconds = (lockoutInfo.LockoutEndTicks - currentTicks) / HiResClock.Frequency;
+                long remainingSeconds = (lockoutInfo.LockoutEndTicks - currentTicks) / m_timeProvider.TimestampFrequency;
                 m_logger.LogWarning(
                     "Client {ClientKey} has been locked out after {FailedAttempts} failed authentication attempts. Lockout expires in {RemainingSeconds} seconds.",
                     clientKey,

--- a/Libraries/Opc.Ua.Server/StateMachines/StateMachineBuilder.cs
+++ b/Libraries/Opc.Ua.Server/StateMachines/StateMachineBuilder.cs
@@ -96,7 +96,10 @@ namespace Opc.Ua.Server.StateMachines
             m_definition = definition;
             m_deferredCreateNodeId = deferredCreateNodeId;
             m_deferredCreateBrowseName = deferredCreateBrowseName;
-            m_dispatcher = new StateMachineDispatcher<TState>(stateMachine, context);
+            TimeProvider timeProvider =
+                ((context as ServerSystemContext)?.Server as ITimeProviderProvider)?.TimeProvider
+                ?? TimeProvider.System;
+            m_dispatcher = new StateMachineDispatcher<TState>(stateMachine, context, timeProvider);
         }
 
         private readonly NodeId m_deferredCreateNodeId;
@@ -1139,6 +1142,7 @@ namespace Opc.Ua.Server.StateMachines
     {
         private readonly TState m_stateMachine;
         private readonly ISystemContext m_context;
+        private readonly TimeProvider m_timeProvider;
         private readonly Dictionary<uint, List<Action<ISystemContext, TState>>> m_enterHandlers = [];
         private readonly Dictionary<uint, List<Action<ISystemContext, TState>>> m_exitHandlers = [];
         private readonly List<Action<ISystemContext, TState, uint, uint>> m_transitionObservers = [];
@@ -1177,9 +1181,18 @@ namespace Opc.Ua.Server.StateMachines
             m_pendingFromByThread = new();
 
         public StateMachineDispatcher(TState stateMachine, ISystemContext context)
+            : this(stateMachine, context, TimeProvider.System)
+        {
+        }
+
+        public StateMachineDispatcher(
+            TState stateMachine,
+            ISystemContext context,
+            TimeProvider timeProvider)
         {
             m_stateMachine = stateMachine;
             m_context = context;
+            m_timeProvider = timeProvider ?? TimeProvider.System;
             m_originalBefore = stateMachine.OnBeforeTransition;
             m_originalAfter = stateMachine.OnAfterTransition;
         }
@@ -1435,7 +1448,7 @@ namespace Opc.Ua.Server.StateMachines
         {
             var cts = new CancellationTokenSource();
             entry.Cts = cts;
-            entry.Timer = new Timer(_ =>
+            entry.Timer = m_timeProvider.CreateTimer(_ =>
             {
                 if (cts.IsCancellationRequested)
                 {
@@ -1547,7 +1560,7 @@ namespace Opc.Ua.Server.StateMachines
             public uint TransitionId { get; }
             public uint CauseId { get; }
             public CancellationTokenSource? Cts { get; set; }
-            public Timer? Timer { get; set; }
+            public ITimer? Timer { get; set; }
         }
     }
 }

--- a/Libraries/Opc.Ua.Server/Subscription/MonitoredItem/MonitoredItem.cs
+++ b/Libraries/Opc.Ua.Server/Subscription/MonitoredItem/MonitoredItem.cs
@@ -110,6 +110,54 @@ namespace Opc.Ua.Server
             bool discardOldest,
             double sourceSamplingInterval,
             bool createDurable = false)
+            : this(
+                server,
+                nodeManager,
+                managerHandle,
+                subscriptionId,
+                id,
+                itemToMonitor,
+                diagnosticsMasks,
+                timestampsToReturn,
+                monitoringMode,
+                clientHandle,
+                originalFilter,
+                filterToUse,
+                range,
+                samplingInterval,
+                queueSize,
+                discardOldest,
+                sourceSamplingInterval,
+                createDurable,
+                null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes the object with its node type and an explicit
+        /// <see cref="TimeProvider"/> so the monotonic sampling clock can be
+        /// mocked in tests.
+        /// </summary>
+        public MonitoredItem(
+            IServerInternal server,
+            IAsyncNodeManager nodeManager,
+            object managerHandle,
+            uint subscriptionId,
+            uint id,
+            ReadValueId itemToMonitor,
+            DiagnosticsMasks diagnosticsMasks,
+            TimestampsToReturn timestampsToReturn,
+            MonitoringMode monitoringMode,
+            uint clientHandle,
+            MonitoringFilter? originalFilter,
+            MonitoringFilter? filterToUse,
+            Range? range,
+            double samplingInterval,
+            uint queueSize,
+            bool discardOldest,
+            double sourceSamplingInterval,
+            bool createDurable,
+            TimeProvider? timeProvider)
         {
             if (itemToMonitor == null)
             {
@@ -117,6 +165,9 @@ namespace Opc.Ua.Server
             }
 
             m_logger = server.Telemetry.CreateLogger<MonitoredItem>();
+            m_timeProvider = timeProvider
+                ?? (server as ITimeProviderProvider)?.TimeProvider
+                ?? TimeProvider.System;
 
             Initialize();
 
@@ -143,7 +194,7 @@ namespace Opc.Ua.Server
             m_discardOldest = discardOldest;
             m_sourceSamplingInterval = (int)sourceSamplingInterval;
             m_calculator = null;
-            m_nextSamplingTime = HiResClock.TickCount64;
+            m_nextSamplingTime = m_timeProvider.GetTimestampMilliseconds();
             AlwaysReportUpdates = false;
             m_monitoredItemQueueFactory = m_server.MonitoredItemQueueFactory;
             m_subscriptionStore = m_server.SubscriptionStore;
@@ -209,12 +260,29 @@ namespace Opc.Ua.Server
             IAsyncNodeManager nodeManager,
             object managerHandle,
             IStoredMonitoredItem storedMonitoredItem)
+            : this(server, nodeManager, managerHandle, storedMonitoredItem, null)
+        {
+        }
+
+        /// <summary>
+        /// Restore a MonitoredItem afer a restart with an explicit
+        /// <see cref="TimeProvider"/>.
+        /// </summary>
+        public MonitoredItem(
+            IServerInternal server,
+            IAsyncNodeManager nodeManager,
+            object managerHandle,
+            IStoredMonitoredItem storedMonitoredItem,
+            TimeProvider? timeProvider)
         {
             if (storedMonitoredItem == null)
             {
                 throw new ArgumentNullException(nameof(storedMonitoredItem));
             }
             m_logger = server.Telemetry.CreateLogger<MonitoredItem>();
+            m_timeProvider = timeProvider
+                ?? (server as ITimeProviderProvider)?.TimeProvider
+                ?? TimeProvider.System;
 
             Initialize();
 
@@ -241,7 +309,7 @@ namespace Opc.Ua.Server
             m_discardOldest = storedMonitoredItem.DiscardOldest;
             m_sourceSamplingInterval = storedMonitoredItem.SourceSamplingInterval;
             m_calculator = null;
-            m_nextSamplingTime = HiResClock.TickCount64;
+            m_nextSamplingTime = m_timeProvider.GetTimestampMilliseconds();
             m_monitoredItemQueueFactory = m_server.MonitoredItemQueueFactory;
             m_subscriptionStore = m_server.SubscriptionStore;
             IsDurable = storedMonitoredItem.IsDurable;
@@ -369,7 +437,7 @@ namespace Opc.Ua.Server
                 if (m_sourceSamplingInterval == 0)
                 {
                     // re-queue if too little time has passed since the last publish, in case it doesn't ResendData
-                    long now = HiResClock.TickCount64;
+                    long now = m_timeProvider.GetTimestampMilliseconds();
 
                     if (m_nextSamplingTime > now)
                     {
@@ -838,7 +906,7 @@ namespace Opc.Ua.Server
 
                 if (previousMode == MonitoringMode.Disabled)
                 {
-                    m_nextSamplingTime = HiResClock.TickCount64;
+                    m_nextSamplingTime = m_timeProvider.GetTimestampMilliseconds();
                     m_lastError = null;
                     m_lastValue = default;
                 }
@@ -1217,7 +1285,7 @@ namespace Opc.Ua.Server
         private void IncrementSampleTime()
         {
             // update next sample time.
-            long now = HiResClock.TickCount64;
+            long now = m_timeProvider.GetTimestampMilliseconds();
             long samplingInterval = (long)m_samplingInterval;
 
             if (m_nextSamplingTime > 0)
@@ -1588,7 +1656,7 @@ namespace Opc.Ua.Server
                         return 0;
                     }
 
-                    long now = HiResClock.TickCount64;
+                    long now = m_timeProvider.GetTimestampMilliseconds();
 
                     if (m_nextSamplingTime <= now)
                     {
@@ -1981,6 +2049,7 @@ namespace Opc.Ua.Server
 
         private readonly Lock m_lock = new();
         private readonly ILogger m_logger;
+        private readonly TimeProvider m_timeProvider;
         private IServerInternal m_server;
         private string? m_indexRange;
         private NumericRange m_parsedIndexRange;

--- a/Libraries/Opc.Ua.Server/Subscription/MonitoredItem/QueueHandler/DataChangeQueueHandler.cs
+++ b/Libraries/Opc.Ua.Server/Subscription/MonitoredItem/QueueHandler/DataChangeQueueHandler.cs
@@ -113,7 +113,7 @@ namespace Opc.Ua.Server
         {
             m_logger = telemetry.CreateLogger<DataChangeQueueHandler>();
             m_dataValueQueue = queueFactory.CreateDataChangeQueue(createDurable, monitoredItemId);
-            m_timeProvider = timeProvider ??= TimeProvider.System;
+            m_timeProvider = timeProvider ?? TimeProvider.System;
 
             m_discardedValueHandler = discardedValueHandler!;
             m_monitoredItemId = monitoredItemId;
@@ -159,7 +159,7 @@ namespace Opc.Ua.Server
             m_nextSampleTime = 0;
             m_overflow = default;
             m_overflowPending = false;
-            m_timeProvider = timeProvider ??= TimeProvider.System;
+            m_timeProvider = timeProvider ?? TimeProvider.System;
             SetSamplingInterval(samplingInterval);
         }
 

--- a/Libraries/Opc.Ua.Server/Subscription/MonitoredItem/QueueHandler/DataChangeQueueHandler.cs
+++ b/Libraries/Opc.Ua.Server/Subscription/MonitoredItem/QueueHandler/DataChangeQueueHandler.cs
@@ -94,9 +94,26 @@ namespace Opc.Ua.Server
             IMonitoredItemQueueFactory queueFactory,
             ITelemetryContext telemetry,
             Action? discardedValueHandler = null)
+            : this(monitoredItemId, createDurable, queueFactory, telemetry, discardedValueHandler, null)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new Queue with an explicit <see cref="TimeProvider"/> so
+        /// the per-sample timestamp used for sampling-interval throttling can
+        /// be mocked in tests.
+        /// </summary>
+        public DataChangeQueueHandler(
+            uint monitoredItemId,
+            bool createDurable,
+            IMonitoredItemQueueFactory queueFactory,
+            ITelemetryContext telemetry,
+            Action? discardedValueHandler,
+            TimeProvider? timeProvider)
         {
             m_logger = telemetry.CreateLogger<DataChangeQueueHandler>();
             m_dataValueQueue = queueFactory.CreateDataChangeQueue(createDurable, monitoredItemId);
+            m_timeProvider = timeProvider ??= TimeProvider.System;
 
             m_discardedValueHandler = discardedValueHandler!;
             m_monitoredItemId = monitoredItemId;
@@ -117,6 +134,21 @@ namespace Opc.Ua.Server
             double samplingInterval,
             ITelemetryContext telemetry,
             Action? discardedValueHandler = null)
+            : this(dataValueQueue, discardOldest, samplingInterval, telemetry, discardedValueHandler, null)
+        {
+        }
+
+        /// <summary>
+        /// Create a DatachangeQueueHandler from an existing queue with an
+        /// explicit <see cref="TimeProvider"/>.
+        /// </summary>
+        public DataChangeQueueHandler(
+            IDataChangeMonitoredItemQueue dataValueQueue,
+            bool discardOldest,
+            double samplingInterval,
+            ITelemetryContext telemetry,
+            Action? discardedValueHandler,
+            TimeProvider? timeProvider)
         {
             m_logger = telemetry.CreateLogger<DataChangeQueueHandler>();
 
@@ -127,6 +159,7 @@ namespace Opc.Ua.Server
             m_nextSampleTime = 0;
             m_overflow = default;
             m_overflowPending = false;
+            m_timeProvider = timeProvider ??= TimeProvider.System;
             SetSamplingInterval(samplingInterval);
         }
 
@@ -214,7 +247,7 @@ namespace Opc.Ua.Server
         /// <returns>true of overflow occured</returns>
         public bool QueueValue(in DataValue value, ServiceResult error)
         {
-            long now = HiResClock.TickCount64;
+            long now = m_timeProvider.GetTimestampMilliseconds();
 
             if (m_dataValueQueue.ItemsInQueue > 0)
             {
@@ -422,6 +455,7 @@ namespace Opc.Ua.Server
 
         private readonly IDataChangeMonitoredItemQueue m_dataValueQueue;
         private readonly ILogger m_logger;
+        private readonly TimeProvider m_timeProvider;
         private readonly uint m_monitoredItemId;
         private bool m_discardOldest;
         private long m_nextSampleTime;

--- a/Libraries/Opc.Ua.Server/Subscription/SessionPublishQueue.cs
+++ b/Libraries/Opc.Ua.Server/Subscription/SessionPublishQueue.cs
@@ -588,7 +588,7 @@ namespace Opc.Ua.Server
                     : TimeSpan.Zero;
                 if (operationTimeout < DateTime.MaxValue && timeOut.TotalMilliseconds > 0)
                 {
-                    m_cancellationTokenSource = new CancellationTokenSource(timeOut, timeProvider);
+                    m_cancellationTokenSource = timeProvider.CreateCancellationTokenSource(timeOut);
                     m_cancellationTokenRegistration2 = m_cancellationTokenSource.Token.Register(
                     () => Tcs.TrySetException(new ServiceResultException(StatusCodes.BadTimeout)));
                 }

--- a/Libraries/Opc.Ua.Server/Subscription/SessionPublishQueue.cs
+++ b/Libraries/Opc.Ua.Server/Subscription/SessionPublishQueue.cs
@@ -45,6 +45,18 @@ namespace Opc.Ua.Server
         /// Creates a new queue.
         /// </summary>
         public SessionPublishQueue(IServerInternal server, ISession session, int maxPublishRequests)
+            : this(server, session, maxPublishRequests, timeProvider: null)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new queue.
+        /// </summary>
+        public SessionPublishQueue(
+            IServerInternal server,
+            ISession session,
+            int maxPublishRequests,
+            TimeProvider? timeProvider)
         {
             m_server = server ?? throw new ArgumentNullException(nameof(server));
             m_logger = server.Telemetry.CreateLogger<SessionPublishQueue>();
@@ -52,6 +64,9 @@ namespace Opc.Ua.Server
             m_queuedRequests = new LinkedList<QueuedPublishRequest>();
             m_queuedSubscriptions = new ConcurrentDictionary<uint, QueuedSubscription>();
             m_maxRequestCount = maxPublishRequests;
+            m_timeProvider = timeProvider
+                ?? (server as ITimeProviderProvider)?.TimeProvider
+                ?? TimeProvider.System;
         }
 
         /// <summary>
@@ -126,7 +141,7 @@ namespace Opc.Ua.Server
                 }
 
                 // add to queue.
-                var request = new QueuedPublishRequest(secureChannelId, operationTimeout, cancellationToken);
+                var request = new QueuedPublishRequest(secureChannelId, operationTimeout, m_timeProvider, cancellationToken);
 
                 if (requeue)
                 {
@@ -555,7 +570,11 @@ namespace Opc.Ua.Server
         /// </summary>
         private sealed class QueuedPublishRequest : IDisposable
         {
-            public QueuedPublishRequest(string secureChannelId, DateTime operationTimeout, CancellationToken cancellationToken)
+            public QueuedPublishRequest(
+                string secureChannelId,
+                DateTime operationTimeout,
+                TimeProvider timeProvider,
+                CancellationToken cancellationToken)
             {
                 SecureChannelId = secureChannelId;
                 OperationTimeout = operationTimeout;
@@ -564,10 +583,12 @@ namespace Opc.Ua.Server
                 m_cancellationTokenRegistration = cancellationToken.Register(
                     () => Tcs.TrySetCanceled());
                 // Cancel publish request if it times out
-                TimeSpan timeOut = operationTimeout < DateTime.MaxValue ? operationTimeout.AddMilliseconds(500) - DateTime.UtcNow : TimeSpan.Zero;
+                TimeSpan timeOut = operationTimeout < DateTime.MaxValue
+                    ? operationTimeout.AddMilliseconds(500) - timeProvider.GetUtcNow().UtcDateTime
+                    : TimeSpan.Zero;
                 if (operationTimeout < DateTime.MaxValue && timeOut.TotalMilliseconds > 0)
                 {
-                    m_cancellationTokenSource = new CancellationTokenSource(timeOut);
+                    m_cancellationTokenSource = new CancellationTokenSource(timeOut, timeProvider);
                     m_cancellationTokenRegistration2 = m_cancellationTokenSource.Token.Register(
                     () => Tcs.TrySetException(new ServiceResultException(StatusCodes.BadTimeout)));
                 }
@@ -672,5 +693,6 @@ namespace Opc.Ua.Server
         private readonly LinkedList<QueuedPublishRequest> m_queuedRequests;
         private readonly ConcurrentDictionary<uint, QueuedSubscription> m_queuedSubscriptions;
         private readonly int m_maxRequestCount;
+        private readonly TimeProvider m_timeProvider;
     }
 }

--- a/Libraries/Opc.Ua.Server/Subscription/Subscription.cs
+++ b/Libraries/Opc.Ua.Server/Subscription/Subscription.cs
@@ -56,18 +56,53 @@ namespace Opc.Ua.Server
             byte priority,
             bool publishingEnabled,
             uint maxMessageCount)
+            : this(
+                server,
+                session,
+                subscriptionId,
+                publishingInterval,
+                maxLifetimeCount,
+                maxKeepAliveCount,
+                maxNotificationsPerPublish,
+                priority,
+                publishingEnabled,
+                maxMessageCount,
+                null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes the subscription with an explicit
+        /// <see cref="TimeProvider"/> so the monotonic publish-timer expiry can
+        /// be mocked in tests.
+        /// </summary>
+        public Subscription(
+            IServerInternal server,
+            ISession session,
+            uint subscriptionId,
+            double publishingInterval,
+            uint maxLifetimeCount,
+            uint maxKeepAliveCount,
+            uint maxNotificationsPerPublish,
+            byte priority,
+            bool publishingEnabled,
+            uint maxMessageCount,
+            TimeProvider? timeProvider)
         {
             Id = subscriptionId;
             Session = session ?? throw new ArgumentNullException(nameof(session));
             m_server = server ?? throw new ArgumentNullException(nameof(server));
             m_logger = server.Telemetry.CreateLogger<Subscription>();
+            m_timeProvider = timeProvider
+                ?? (server as ITimeProviderProvider)?.TimeProvider
+                ?? TimeProvider.System;
             m_publishingInterval = publishingInterval;
             m_maxLifetimeCount = maxLifetimeCount;
             m_maxKeepAliveCount = maxKeepAliveCount;
             m_maxNotificationsPerPublish = maxNotificationsPerPublish;
             m_publishingEnabled = publishingEnabled;
             Priority = priority;
-            m_publishTimerExpiry = HiResClock.TickCount64 + (long)publishingInterval;
+            m_publishTimerExpiry = m_timeProvider.GetTimestampMilliseconds() + (long)publishingInterval;
             //Per OPC UA spec Part 4 Section 5.13.1.2, the server must send a message (notification or keep-alive)
             //at the end of the first publishing cycle to inform the client the subscription is operational
             //So we initialize the keep-alive counter to maxKeepAliveCount to force a message at the end of the first publish cycle
@@ -135,12 +170,25 @@ namespace Opc.Ua.Server
         /// <summary>
         /// Restore a subscription and its monitored items after a restart from a template
         /// </summary>
-        public static async ValueTask<Subscription> RestoreAsync(
+        public static ValueTask<Subscription> RestoreAsync(
             IServerInternal server,
             IStoredSubscription storedSubscription,
             CancellationToken cancellationToken = default)
         {
-            var subscription = new Subscription(server, storedSubscription);
+            return RestoreAsync(server, storedSubscription, null, cancellationToken);
+        }
+
+        /// <summary>
+        /// Restore a subscription and its monitored items after a restart from a template
+        /// with an explicit <see cref="TimeProvider"/>.
+        /// </summary>
+        public static async ValueTask<Subscription> RestoreAsync(
+            IServerInternal server,
+            IStoredSubscription storedSubscription,
+            TimeProvider? timeProvider,
+            CancellationToken cancellationToken = default)
+        {
+            var subscription = new Subscription(server, storedSubscription, timeProvider);
 
             await subscription.RestoreMonitoredItemsAsync(storedSubscription.MonitoredItems, cancellationToken)
                 .ConfigureAwait(false);
@@ -152,6 +200,18 @@ namespace Opc.Ua.Server
         /// Initialize subscription after a restart from a template
         /// </summary>
         protected Subscription(IServerInternal server, IStoredSubscription storedSubscription)
+            : this(server, storedSubscription, null)
+        {
+        }
+
+        /// <summary>
+        /// Initialize subscription after a restart from a template with an
+        /// explicit <see cref="TimeProvider"/>.
+        /// </summary>
+        protected Subscription(
+            IServerInternal server,
+            IStoredSubscription storedSubscription,
+            TimeProvider? timeProvider)
         {
             if (server.IsRunning)
             {
@@ -161,6 +221,9 @@ namespace Opc.Ua.Server
 
             m_server = server;
             m_logger = server.Telemetry.CreateLogger<Subscription>();
+            m_timeProvider = timeProvider
+                ?? (server as ITimeProviderProvider)?.TimeProvider
+                ?? TimeProvider.System;
             Session = null!;
             Id = storedSubscription.Id;
             m_publishingInterval = storedSubscription.PublishingInterval;
@@ -170,7 +233,7 @@ namespace Opc.Ua.Server
             m_maxNotificationsPerPublish = storedSubscription.MaxNotificationsPerPublish;
             m_publishingEnabled = false;
             Priority = storedSubscription.Priority;
-            m_publishTimerExpiry = HiResClock.TickCount64 +
+            m_publishTimerExpiry = m_timeProvider.GetTimestampMilliseconds() +
                 (long)storedSubscription.PublishingInterval;
             m_keepAliveCounter = 0;
             m_waitingForPublish = false;
@@ -441,7 +504,7 @@ namespace Opc.Ua.Server
         {
             lock (m_lock)
             {
-                long currentTime = HiResClock.TickCount64;
+                long currentTime = m_timeProvider.GetTimestampMilliseconds();
 
                 // check if publish interval has elapsed.
                 if (m_publishTimerExpiry >= currentTime)
@@ -1280,7 +1343,7 @@ namespace Opc.Ua.Server
                 if (publishingInterval != m_publishingInterval)
                 {
                     m_publishingInterval = publishingInterval;
-                    m_publishTimerExpiry = HiResClock.TickCount64 + (long)publishingInterval;
+                    m_publishTimerExpiry = m_timeProvider.GetTimestampMilliseconds() + (long)publishingInterval;
                     ResetKeepaliveCount();
                 }
 
@@ -2744,6 +2807,7 @@ namespace Opc.Ua.Server
 
         private readonly object m_lock = new();
         private readonly IServerInternal m_server;
+        private readonly TimeProvider m_timeProvider;
         private IUserIdentity? m_savedOwnerIdentity;
         private double m_publishingInterval;
         private uint m_maxLifetimeCount;

--- a/Libraries/Opc.Ua.Server/Subscription/SubscriptionManager.cs
+++ b/Libraries/Opc.Ua.Server/Subscription/SubscriptionManager.cs
@@ -2127,7 +2127,7 @@ namespace Opc.Ua.Server
                         break;
                     }
 
-                    await Task.Delay(TimeSpan.FromMilliseconds(timeToWait), m_timeProvider, cancellationToken).ConfigureAwait(false);
+                    await m_timeProvider.Delay(TimeSpan.FromMilliseconds(timeToWait), cancellationToken).ConfigureAwait(false);
                 }
             }
             catch (ObjectDisposedException)

--- a/Libraries/Opc.Ua.Server/Subscription/SubscriptionManager.cs
+++ b/Libraries/Opc.Ua.Server/Subscription/SubscriptionManager.cs
@@ -47,6 +47,17 @@ namespace Opc.Ua.Server
         /// Initializes the manager with its configuration.
         /// </summary>
         public SubscriptionManager(IServerInternal server, ApplicationConfiguration configuration)
+            : this(server, configuration, timeProvider: null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes the manager with its configuration.
+        /// </summary>
+        public SubscriptionManager(
+            IServerInternal server,
+            ApplicationConfiguration configuration,
+            TimeProvider? timeProvider)
         {
             if (configuration == null)
             {
@@ -55,6 +66,9 @@ namespace Opc.Ua.Server
 
             m_server = server ?? throw new ArgumentNullException(nameof(server));
             m_logger = server.Telemetry.CreateLogger<SubscriptionManager>();
+            m_timeProvider = timeProvider
+                ?? (server as ITimeProviderProvider)?.TimeProvider
+                ?? TimeProvider.System;
 
             m_minPublishingInterval = configuration.ServerConfiguration!.MinPublishingInterval;
             m_maxPublishingInterval = configuration.ServerConfiguration.MaxPublishingInterval;
@@ -873,7 +887,8 @@ namespace Opc.Ua.Server
                         var queue = new SessionPublishQueue(
                             m_server,
                             session,
-                            m_maxPublishRequestCount);
+                            m_maxPublishRequestCount,
+                            m_timeProvider);
 
                         queue.Add(subscription);
                         return queue;
@@ -1465,7 +1480,8 @@ namespace Opc.Ua.Server
                                 = publishQueue = new SessionPublishQueue(
                                 m_server,
                                 context.Session,
-                                m_maxPublishRequestCount);
+                                m_maxPublishRequestCount,
+                                m_timeProvider);
                         }
                         publishQueue.Add(subscription);
                     }
@@ -2111,7 +2127,7 @@ namespace Opc.Ua.Server
                         break;
                     }
 
-                    await Task.Delay(timeToWait, cancellationToken).ConfigureAwait(false);
+                    await Task.Delay(TimeSpan.FromMilliseconds(timeToWait), m_timeProvider, cancellationToken).ConfigureAwait(false);
                 }
             }
             catch (ObjectDisposedException)
@@ -2281,6 +2297,7 @@ namespace Opc.Ua.Server
         private uint m_lastSubscriptionId;
         private readonly ILogger m_logger;
         private readonly IServerInternal m_server;
+        private readonly TimeProvider m_timeProvider;
         private readonly double m_minPublishingInterval;
         private readonly double m_maxPublishingInterval;
         private readonly int m_publishingResolution;

--- a/Stack/Opc.Ua.Core.Types/Opc.Ua.Core.Types.csproj
+++ b/Stack/Opc.Ua.Core.Types/Opc.Ua.Core.Types.csproj
@@ -17,6 +17,9 @@
   <ItemGroup>
     <ProjectReference Include="..\Opc.Ua.Types\Opc.Ua.Types.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Bcl.TimeProvider" />
+  </ItemGroup>
   <!-- Stack source generation -->
   <ItemGroup>
     <ProjectReference Include="..\..\Tools\Opc.Ua.SourceGeneration.Stack\Opc.Ua.SourceGeneration.Stack.csproj">

--- a/Stack/Opc.Ua.Core.Types/State/AlarmConditionState.cs
+++ b/Stack/Opc.Ua.Core.Types/State/AlarmConditionState.cs
@@ -45,9 +45,24 @@ namespace Opc.Ua
         /// <param name="telemetry">The telemetry context to use to create obvservability instruments</param>
         /// <param name="parent"></param>
         public AlarmConditionState(ITelemetryContext telemetry, NodeState parent)
+            : this(telemetry, parent, null)
+        {
+        }
+
+        /// <summary>
+        /// Create alarm condition with an explicit time provider.
+        /// </summary>
+        /// <param name="telemetry">The telemetry context to use to create obvservability instruments</param>
+        /// <param name="parent">The parent node.</param>
+        /// <param name="timeProvider">Time provider used for unshelve scheduling and durations.</param>
+        public AlarmConditionState(
+            ITelemetryContext telemetry,
+            NodeState parent,
+            TimeProvider? timeProvider = null)
             : this(parent)
         {
             m_logger = telemetry.CreateLogger<AlarmConditionState>();
+            m_timeProvider = timeProvider ??= TimeProvider.System;
         }
 
         /// <inheritdoc/>
@@ -291,19 +306,19 @@ namespace Opc.Ua
                 }
 
                 shelvingState.UnshelveTime!.Value = shelveTime; // UnshelveTime is created with ShelvingState
-                UnshelveTime = DateTime.UtcNow.AddMilliseconds((int)shelveTime);
+                UnshelveTime = m_timeProvider.GetUtcNow().UtcDateTime.AddMilliseconds((int)shelveTime);
 
-                m_updateUnshelveTimer = new Timer(
+                m_updateUnshelveTimer = m_timeProvider.CreateTimer(
                     OnUnshelveTimeUpdate,
                     context,
-                    UnshelveTimeUpdateRate,
-                    UnshelveTimeUpdateRate);
+                    TimeSpan.FromMilliseconds(UnshelveTimeUpdateRate),
+                    TimeSpan.FromMilliseconds(UnshelveTimeUpdateRate));
 
-                m_unshelveTimer = new Timer(
+                m_unshelveTimer = m_timeProvider.CreateTimer(
                     OnTimerExpired,
                     context,
-                    (int)shelveTime,
-                    Timeout.Infinite);
+                    TimeSpan.FromMilliseconds((int)shelveTime),
+                    Timeout.InfiniteTimeSpan);
                 shelvingState.CauseProcessingCompleted(context, state);
             }
 
@@ -482,7 +497,7 @@ namespace Opc.Ua
 
             if (UnshelveTime != DateTime.MinValue)
             {
-                delta = (UnshelveTime - DateTime.UtcNow).TotalMilliseconds;
+                delta = (UnshelveTime - m_timeProvider.GetUtcNow().UtcDateTime).TotalMilliseconds;
 
                 if (delta < 0)
                 {
@@ -807,9 +822,10 @@ namespace Opc.Ua
         }
 
         private readonly ILogger m_logger;
+        private readonly TimeProvider m_timeProvider = TimeProvider.System;
         private bool m_oneShot;
-        private Timer? m_unshelveTimer;
-        private Timer? m_updateUnshelveTimer;
+        private ITimer? m_unshelveTimer;
+        private ITimer? m_updateUnshelveTimer;
     }
 
     /// <summary>

--- a/Stack/Opc.Ua.Core.Types/State/AlarmConditionState.cs
+++ b/Stack/Opc.Ua.Core.Types/State/AlarmConditionState.cs
@@ -62,7 +62,7 @@ namespace Opc.Ua
             : this(parent)
         {
             m_logger = telemetry.CreateLogger<AlarmConditionState>();
-            m_timeProvider = timeProvider ??= TimeProvider.System;
+            m_timeProvider = timeProvider ?? TimeProvider.System;
         }
 
         /// <inheritdoc/>

--- a/Stack/Opc.Ua.Core/Security/Certificates/CertificateManager/CertificateLifecycleMonitor.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/CertificateManager/CertificateLifecycleMonitor.cs
@@ -76,7 +76,7 @@ namespace Opc.Ua
             m_getCertificates = getCertificates ?? throw new ArgumentNullException(nameof(getCertificates));
             m_expiryThreshold = expiryThreshold;
             m_logger = telemetry.CreateLogger<CertificateLifecycleMonitor>();
-            m_timeProvider = timeProvider ??= TimeProvider.System;
+            m_timeProvider = timeProvider ?? TimeProvider.System;
 
             m_timer = m_timeProvider.CreateTimer(CheckExpiry, null, TimeSpan.Zero, checkInterval);
         }

--- a/Stack/Opc.Ua.Core/Security/Certificates/CertificateManager/CertificateLifecycleMonitor.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/CertificateManager/CertificateLifecycleMonitor.cs
@@ -60,28 +60,35 @@ namespace Opc.Ua
         /// <param name="telemetry">
         /// The telemetry context used for logging.
         /// </param>
+        /// <param name="timeProvider">
+        /// The <see cref="TimeProvider"/> used for timer scheduling and
+        /// expiry comparison. Defaults to <see cref="TimeProvider.System"/>.
+        /// </param>
         public CertificateLifecycleMonitor(
             CertificateChangeSubject subject,
             Func<IReadOnlyList<CertificateEntry>> getCertificates,
             TimeSpan expiryThreshold,
             TimeSpan checkInterval,
-            ITelemetryContext telemetry)
+            ITelemetryContext telemetry,
+            TimeProvider? timeProvider = null)
         {
             m_subject = subject ?? throw new ArgumentNullException(nameof(subject));
             m_getCertificates = getCertificates ?? throw new ArgumentNullException(nameof(getCertificates));
             m_expiryThreshold = expiryThreshold;
             m_logger = telemetry.CreateLogger<CertificateLifecycleMonitor>();
+            m_timeProvider = timeProvider ??= TimeProvider.System;
 
-            m_timer = new Timer(CheckExpiry, null, TimeSpan.Zero, checkInterval);
+            m_timer = m_timeProvider.CreateTimer(CheckExpiry, null, TimeSpan.Zero, checkInterval);
         }
 
         private void CheckExpiry(object? state)
         {
             try
             {
+                DateTime now = m_timeProvider.GetUtcNow().UtcDateTime;
                 foreach (CertificateEntry entry in m_getCertificates())
                 {
-                    if (entry.IsNearExpiry(m_expiryThreshold) &&
+                    if (now.Add(m_expiryThreshold) >= entry.NotAfter &&
                         m_alreadyNotified.Add(entry.Certificate.Thumbprint))
                     {
                         m_logger.LogWarning(
@@ -123,7 +130,8 @@ namespace Opc.Ua
         private readonly CertificateChangeSubject m_subject;
         private readonly Func<IReadOnlyList<CertificateEntry>> m_getCertificates;
         private readonly TimeSpan m_expiryThreshold;
-        private readonly Timer m_timer;
+        private readonly TimeProvider m_timeProvider;
+        private readonly ITimer m_timer;
         private readonly ILogger m_logger;
         private readonly HashSet<string> m_alreadyNotified = new(StringComparer.OrdinalIgnoreCase);
     }

--- a/Stack/Opc.Ua.Core/Security/Certificates/CertificateManager/CertificateManager.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/CertificateManager/CertificateManager.cs
@@ -68,6 +68,20 @@ namespace Opc.Ua
             IEnumerable<ICertificateStoreProvider>? storeProviders = null,
             int maxRejectedCertificates = 5,
             TimeSpan? expiryWarningThreshold = null)
+            : this(telemetry, storeProviders, maxRejectedCertificates, expiryWarningThreshold, null)
+        {
+        }
+
+        /// <summary>
+        /// Creates a certificate manager with the supplied
+        /// <see cref="TimeProvider"/> used for expiry monitoring.
+        /// </summary>
+        public CertificateManager(
+            ITelemetryContext telemetry,
+            IEnumerable<ICertificateStoreProvider>? storeProviders,
+            int maxRejectedCertificates,
+            TimeSpan? expiryWarningThreshold,
+            TimeProvider? timeProvider)
         {
             m_telemetry = telemetry ?? throw new ArgumentNullException(nameof(telemetry));
             m_logger = telemetry.CreateLogger<CertificateManager>();
@@ -77,6 +91,7 @@ namespace Opc.Ua
                     new DirectoryStoreProvider(),
                     new X509StoreProvider()
                 ];
+            m_timeProvider = timeProvider ??= TimeProvider.System;
 
             TimeSpan threshold = expiryWarningThreshold ?? TimeSpan.FromDays(14);
             m_lifecycleMonitor = new CertificateLifecycleMonitor(
@@ -84,7 +99,8 @@ namespace Opc.Ua
                 () => m_applicationCertificates,
                 threshold,
                 TimeSpan.FromHours(1),
-                m_telemetry);
+                m_telemetry,
+                m_timeProvider);
 
             m_certificateProvider = new CertificateProvider(m_telemetry);
         }
@@ -1268,6 +1284,7 @@ namespace Opc.Ua
         private readonly CertificateChangeSubject m_changeSubject = new();
         private readonly ITelemetryContext m_telemetry;
         private readonly ILogger m_logger;
+        private readonly TimeProvider m_timeProvider;
         private int m_maxRejectedCertificates;
 
         /// <summary>

--- a/Stack/Opc.Ua.Core/Security/Certificates/CertificateManager/CertificateManager.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/CertificateManager/CertificateManager.cs
@@ -91,7 +91,7 @@ namespace Opc.Ua
                     new DirectoryStoreProvider(),
                     new X509StoreProvider()
                 ];
-            m_timeProvider = timeProvider ??= TimeProvider.System;
+            m_timeProvider = timeProvider ?? TimeProvider.System;
 
             TimeSpan threshold = expiryWarningThreshold ?? TimeSpan.FromDays(14);
             m_lifecycleMonitor = new CertificateLifecycleMonitor(

--- a/Stack/Opc.Ua.Core/Security/Certificates/DirectoryCertificateStore.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/DirectoryCertificateStore.cs
@@ -96,7 +96,7 @@ namespace Opc.Ua
             m_cache = new CertificateCache(telemetry);
             m_noSubDirs = noSubDirs;
             m_certificates = [];
-            m_timeProvider = timeProvider ??= TimeProvider.System;
+            m_timeProvider = timeProvider ?? TimeProvider.System;
         }
 
         /// <summary>

--- a/Stack/Opc.Ua.Core/Security/Certificates/DirectoryCertificateStore.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/DirectoryCertificateStore.cs
@@ -67,7 +67,7 @@ namespace Opc.Ua
         /// Initializes a store for a directory path.
         /// </summary>
         public DirectoryCertificateStore(ITelemetryContext telemetry)
-            : this(false, telemetry)
+            : this(false, telemetry, timeProvider: null)
         {
         }
 
@@ -75,11 +75,28 @@ namespace Opc.Ua
         /// Initializes a store with a directory path.
         /// </summary>
         public DirectoryCertificateStore(bool noSubDirs, ITelemetryContext telemetry)
+            : this(noSubDirs, telemetry, timeProvider: null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a store with a directory path.
+        /// </summary>
+        /// <param name="noSubDirs">Whether the store uses the legacy flat layout.</param>
+        /// <param name="telemetry">Telemetry context used for logging.</param>
+        /// <param name="timeProvider">Optional <see cref="TimeProvider"/> used for
+        /// retry delays and the in-memory directory-cache timestamps. Defaults to
+        /// <see cref="TimeProvider.System"/> when <c>null</c>.</param>
+        public DirectoryCertificateStore(
+            bool noSubDirs,
+            ITelemetryContext telemetry,
+            TimeProvider? timeProvider = null)
         {
             m_logger = telemetry.CreateLogger<DirectoryCertificateStore>();
             m_cache = new CertificateCache(telemetry);
             m_noSubDirs = noSubDirs;
             m_certificates = [];
+            m_timeProvider = timeProvider ??= TimeProvider.System;
         }
 
         /// <summary>
@@ -302,7 +319,7 @@ namespace Opc.Ua
                 // sync cache if necessary.
                 Load(thumbprint: null);
 
-                DateTime now = DateTime.UtcNow;
+                DateTime now = m_timeProvider.GetUtcNow().UtcDateTime;
                 int entries = 0;
                 foreach (Certificate certificate in certificates)
                 {
@@ -380,7 +397,7 @@ namespace Opc.Ua
                     }
                 }
 
-                m_lastDirectoryCheck = reload ? DateTime.MinValue : DateTime.UtcNow;
+                m_lastDirectoryCheck = reload ? DateTime.MinValue : m_timeProvider.GetUtcNow().UtcDateTime;
             }
             finally
             {
@@ -490,7 +507,7 @@ namespace Opc.Ua
 
                 if (retry > 0)
                 {
-                    await Task.Delay(kRetryDelay, ct).ConfigureAwait(false);
+                    await m_timeProvider.Delay(TimeSpan.FromMilliseconds(kRetryDelay), ct).ConfigureAwait(false);
                 }
             } while (retry > 0);
 
@@ -894,7 +911,7 @@ namespace Opc.Ua
                     "Retry to import private key for certificate with thumbprint [{Thumbprint}] after {Duration} ms.",
                     thumbprint ?? "Unknown",
                     retryDelay);
-                await Task.Delay(retryDelay, ct).ConfigureAwait(false);
+                await m_timeProvider.Delay(TimeSpan.FromMilliseconds(retryDelay), ct).ConfigureAwait(false);
             }
 
             return null;
@@ -1122,7 +1139,7 @@ namespace Opc.Ua
         /// </summary>
         private Dictionary<string, Entry> Load(string? thumbprint)
         {
-            DateTime now = DateTime.UtcNow;
+            DateTime now = m_timeProvider.GetUtcNow().UtcDateTime;
 
             // refresh the directories.
             DirectoryInfo? certSubdir = m_certificateSubdir;
@@ -1457,6 +1474,7 @@ namespace Opc.Ua
         private readonly SemaphoreSlim m_lock = new(1, 1);
         private readonly ILogger m_logger;
         private readonly CertificateCache m_cache;
+        private readonly TimeProvider m_timeProvider;
 #pragma warning restore CA2213
         private readonly bool m_noSubDirs;
         private DirectoryInfo? m_certificateSubdir;

--- a/Stack/Opc.Ua.Core/Security/Identity/Defaults/JwtBearerAccessTokenProvider.cs
+++ b/Stack/Opc.Ua.Core/Security/Identity/Defaults/JwtBearerAccessTokenProvider.cs
@@ -49,6 +49,20 @@ namespace Opc.Ua.Identity
             byte[] tokenBytes,
             DateTime expiresAt,
             string displayName = "")
+            : this(authorityUri, tokenBytes, expiresAt, displayName, null)
+        {
+        }
+
+        /// <summary>
+        /// Creates a provider for a pre-supplied JWT payload with a
+        /// caller-supplied <see cref="TimeProvider"/> for expiry checks.
+        /// </summary>
+        public JwtBearerAccessTokenProvider(
+            string authorityUri,
+            byte[] tokenBytes,
+            DateTime expiresAt,
+            string displayName,
+            TimeProvider? timeProvider)
         {
             if (tokenBytes == null)
             {
@@ -59,6 +73,7 @@ namespace Opc.Ua.Identity
             m_tokenBytes = (byte[])tokenBytes.Clone();
             m_expiresAt = expiresAt;
             m_displayName = displayName ?? string.Empty;
+            m_timeProvider = timeProvider ??= TimeProvider.System;
         }
 
         /// <summary>
@@ -70,6 +85,20 @@ namespace Opc.Ua.Identity
             DateTime expiresAt,
             string displayName = "")
         {
+            return FromJwtString(authorityUri, jwt, expiresAt, displayName, null);
+        }
+
+        /// <summary>
+        /// Creates a provider by UTF-8 encoding a compact JWT string,
+        /// using the supplied <see cref="TimeProvider"/> for expiry checks.
+        /// </summary>
+        public static JwtBearerAccessTokenProvider FromJwtString(
+            string authorityUri,
+            string jwt,
+            DateTime expiresAt,
+            string displayName,
+            TimeProvider? timeProvider)
+        {
             if (jwt == null)
             {
                 throw new ArgumentNullException(nameof(jwt));
@@ -79,7 +108,8 @@ namespace Opc.Ua.Identity
                 authorityUri,
                 Encoding.UTF8.GetBytes(jwt),
                 expiresAt,
-                displayName);
+                displayName,
+                timeProvider);
         }
 
         /// <inheritdoc/>
@@ -91,7 +121,7 @@ namespace Opc.Ua.Identity
             CancellationToken ct = default)
         {
             ct.ThrowIfCancellationRequested();
-            if (m_expiresAt <= TimeProvider.System.GetUtcNow().UtcDateTime)
+            if (m_expiresAt <= m_timeProvider.GetUtcNow().UtcDateTime)
             {
                 throw ServiceResultException.Create(
                     StatusCodes.BadIdentityTokenRejected,
@@ -115,5 +145,6 @@ namespace Opc.Ua.Identity
         private readonly byte[] m_tokenBytes;
         private readonly DateTime m_expiresAt;
         private readonly string m_displayName;
+        private readonly TimeProvider m_timeProvider;
     }
 }

--- a/Stack/Opc.Ua.Core/Security/Identity/Defaults/JwtBearerAccessTokenProvider.cs
+++ b/Stack/Opc.Ua.Core/Security/Identity/Defaults/JwtBearerAccessTokenProvider.cs
@@ -73,7 +73,7 @@ namespace Opc.Ua.Identity
             m_tokenBytes = (byte[])tokenBytes.Clone();
             m_expiresAt = expiresAt;
             m_displayName = displayName ?? string.Empty;
-            m_timeProvider = timeProvider ??= TimeProvider.System;
+            m_timeProvider = timeProvider ?? TimeProvider.System;
         }
 
         /// <summary>

--- a/Stack/Opc.Ua.Core/Stack/Configuration/ApplicationConfiguration.cs
+++ b/Stack/Opc.Ua.Core/Stack/Configuration/ApplicationConfiguration.cs
@@ -694,6 +694,7 @@ namespace Opc.Ua
             }
 
             // toggle the state of the hi-res clock.
+#pragma warning disable CS0618 // Type / member is obsolete.
             HiResClock.Disabled = DisableHiResClock;
 
             if (HiResClock.Disabled &&
@@ -702,6 +703,7 @@ namespace Opc.Ua
             {
                 ServerConfiguration.PublishingResolution = 50;
             }
+#pragma warning restore CS0618
 
             // Eagerly create a CertificateManager from the security
             // configuration so consumers (Session, ClientChannelManager,

--- a/Stack/Opc.Ua.Core/Stack/Configuration/ConfigurationWatcher.cs
+++ b/Stack/Opc.Ua.Core/Stack/Configuration/ConfigurationWatcher.cs
@@ -64,7 +64,7 @@ namespace Opc.Ua
             }
 
             m_logger = telemetry.CreateLogger<ConfigurationWatcher>();
-            m_timeProvider = timeProvider ??= TimeProvider.System;
+            m_timeProvider = timeProvider ?? TimeProvider.System;
 
             var fileInfo = new FileInfo(configuration.SourceFilePath!);
 

--- a/Stack/Opc.Ua.Core/Stack/Configuration/ConfigurationWatcher.cs
+++ b/Stack/Opc.Ua.Core/Stack/Configuration/ConfigurationWatcher.cs
@@ -29,6 +29,7 @@
 
 using System;
 using System.IO;
+using System.Threading;
 using Microsoft.Extensions.Logging;
 
 namespace Opc.Ua
@@ -44,6 +45,18 @@ namespace Opc.Ua
         public ConfigurationWatcher(
             ApplicationConfiguration configuration,
             ITelemetryContext telemetry)
+            : this(configuration, telemetry, null)
+        {
+        }
+
+        /// <summary>
+        /// Creates the watcher for the configuration using the supplied
+        /// <see cref="TimeProvider"/> for polling.
+        /// </summary>
+        public ConfigurationWatcher(
+            ApplicationConfiguration configuration,
+            ITelemetryContext telemetry,
+            TimeProvider? timeProvider)
         {
             if (configuration == null)
             {
@@ -51,6 +64,7 @@ namespace Opc.Ua
             }
 
             m_logger = telemetry.CreateLogger<ConfigurationWatcher>();
+            m_timeProvider = timeProvider ??= TimeProvider.System;
 
             var fileInfo = new FileInfo(configuration.SourceFilePath!);
 
@@ -63,7 +77,11 @@ namespace Opc.Ua
 
             m_configuration = configuration;
             m_lastWriteTime = fileInfo.LastWriteTimeUtc;
-            m_watcher = new System.Threading.Timer(Watcher_Changed, null, 5000, 5000);
+            m_watcher = m_timeProvider.CreateTimer(
+                Watcher_Changed,
+                null,
+                TimeSpan.FromSeconds(5),
+                TimeSpan.FromSeconds(5));
         }
 
         /// <summary>
@@ -133,7 +151,8 @@ namespace Opc.Ua
 
         private readonly ILogger m_logger;
         private readonly ApplicationConfiguration m_configuration;
-        private System.Threading.Timer? m_watcher;
+        private readonly TimeProvider m_timeProvider;
+        private ITimer? m_watcher;
         private DateTime m_lastWriteTime;
         private event EventHandler<ConfigurationWatcherEventArgs>? m_Changed;
     }

--- a/Stack/Opc.Ua.Core/Stack/Https/HttpsTransportChannel.cs
+++ b/Stack/Opc.Ua.Core/Stack/Https/HttpsTransportChannel.cs
@@ -99,11 +99,20 @@ namespace Opc.Ua.Bindings
         /// <summary>
         /// Create a transport channel based on the uri scheme.
         /// </summary>
-        public HttpsTransportChannel(string uriScheme, ITelemetryContext telemetry)
+        /// <param name="uriScheme">The uri scheme.</param>
+        /// <param name="telemetry">The telemetry context.</param>
+        /// <param name="timeProvider">Optional <see cref="TimeProvider"/>
+        /// used for timeout scheduling. Defaults to
+        /// <see cref="TimeProvider.System"/> when <c>null</c>.</param>
+        public HttpsTransportChannel(
+            string uriScheme,
+            ITelemetryContext telemetry,
+            TimeProvider? timeProvider = null)
         {
             UriScheme = uriScheme;
             m_telemetry = telemetry;
             m_logger = telemetry.CreateLogger<HttpsTransportChannel>();
+            m_timeProvider = timeProvider ?? TimeProvider.System;
         }
 
         /// <inheritdoc/>
@@ -223,7 +232,8 @@ namespace Opc.Ua.Bindings
             IServiceMessageContext context = m_quotas?.MessageContext ?? throw BadNotConnected();
             HttpClient client = m_client ?? throw BadNotConnected();
             using Activity? activity = m_telemetry.StartActivity();
-            using var cts = new CancellationTokenSource(OperationTimeout);
+            using var cts = m_timeProvider.CreateCancellationTokenSource(
+                TimeSpan.FromMilliseconds(OperationTimeout));
             using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cts.Token, ct);
             try
             {
@@ -562,6 +572,7 @@ namespace Opc.Ua.Bindings
         private bool m_disposed;
         private readonly ITelemetryContext m_telemetry;
         private readonly ILogger m_logger;
+        private readonly TimeProvider m_timeProvider;
 
         private static readonly MediaTypeHeaderValue s_mediaTypeHeaderValue = new(
             "application/octet-stream");

--- a/Stack/Opc.Ua.Core/Stack/Server/EndpointBase.EndpointIncomingRequest.cs
+++ b/Stack/Opc.Ua.Core/Stack/Server/EndpointBase.EndpointIncomingRequest.cs
@@ -83,7 +83,8 @@ namespace Opc.Ua
             public async ValueTask CallAsync(CancellationToken cancellationToken = default)
             {
                 using CancellationTokenSource? timeoutHintCts = (int)Request.RequestHeader.TimeoutHint > 0 ?
-                    new CancellationTokenSource((int)Request.RequestHeader.TimeoutHint) : null;
+                    TimeProvider.System.CreateCancellationTokenSource(
+                        TimeSpan.FromMilliseconds((int)Request.RequestHeader.TimeoutHint)) : null;
 
                 using var requestLifetime = new RequestLifetime(
                     timeoutHintCts != null ?

--- a/Stack/Opc.Ua.Core/Stack/Tcp/ChannelAsyncOperation.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/ChannelAsyncOperation.cs
@@ -65,7 +65,7 @@ namespace Opc.Ua.Bindings
             m_synchronous = false;
             m_completed = false;
             m_logger = logger;
-            m_timeProvider = timeProvider ??= TimeProvider.System;
+            m_timeProvider = timeProvider ?? TimeProvider.System;
 
             if (timeout is > 0 and not int.MaxValue)
             {
@@ -269,7 +269,7 @@ namespace Opc.Ua.Bindings
                     if (timeout != int.MaxValue)
                     {
                         awaitableTask = m_tcs.Task
-                            .WaitAsync(TimeSpan.FromMilliseconds(timeout), ct);
+                            .WaitAsync(TimeSpan.FromMilliseconds(timeout), m_timeProvider, ct);
                     }
                     else if (ct != default)
                     {

--- a/Stack/Opc.Ua.Core/Stack/Tcp/ChannelAsyncOperation.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/ChannelAsyncOperation.cs
@@ -45,16 +45,35 @@ namespace Opc.Ua.Bindings
         /// Initializes the object with a callback
         /// </summary>
         public ChannelAsyncOperation(int timeout, AsyncCallback? callback, object? asyncState, ILogger logger)
+            : this(timeout, callback, asyncState, logger, null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes the object with a callback using the supplied
+        /// <see cref="TimeProvider"/> for timeout scheduling.
+        /// </summary>
+        public ChannelAsyncOperation(
+            int timeout,
+            AsyncCallback? callback,
+            object? asyncState,
+            ILogger logger,
+            TimeProvider? timeProvider)
         {
             m_callback = callback;
             m_asyncState = asyncState;
             m_synchronous = false;
             m_completed = false;
             m_logger = logger;
+            m_timeProvider = timeProvider ??= TimeProvider.System;
 
             if (timeout is > 0 and not int.MaxValue)
             {
-                m_timer = new Timer(new TimerCallback(OnTimeout), null, timeout, Timeout.Infinite);
+                m_timer = m_timeProvider.CreateTimer(
+                    new TimerCallback(OnTimeout),
+                    null,
+                    TimeSpan.FromMilliseconds(timeout),
+                    Timeout.InfiniteTimeSpan);
             }
         }
 
@@ -439,12 +458,13 @@ namespace Opc.Ua.Bindings
         private readonly object? m_asyncState;
         private readonly bool m_synchronous;
         private readonly ILogger m_logger;
+        private readonly TimeProvider m_timeProvider;
         private bool m_completed;
         private ManualResetEvent? m_event;
         private TaskCompletionSource<bool>? m_tcs;
         private T? m_response;
         private ServiceResult? m_error;
-        private Timer? m_timer;
+        private ITimer? m_timer;
         private Dictionary<string, object>? m_properties;
     }
 }

--- a/Stack/Opc.Ua.Core/Stack/Tcp/ChannelToken.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/ChannelToken.cs
@@ -99,7 +99,7 @@ namespace Opc.Ua.Bindings
 
         /// <summary>
         /// When the token was created (refers to the local tick count).
-        /// Used for calculation of renewals. Uses <see cref="HiResClock.TickCount"/>.
+        /// Used for calculation of renewals. Uses <c>HiResClock.TickCount</c>.
         /// </summary>
         public int CreatedAtTickCount { get; set; }
 
@@ -108,6 +108,7 @@ namespace Opc.Ua.Bindings
         /// </summary>
         public int Lifetime { get; set; }
 
+#pragma warning disable CS0618 // Back-compat surface; new code uses IsExpired(TimeProvider).
         /// <summary>
         /// Whether the token has expired.
         /// </summary>
@@ -119,6 +120,7 @@ namespace Opc.Ua.Bindings
         public bool ActivationRequired =>
             (HiResClock.TickCount - CreatedAtTickCount) >
             (int)Math.Round(Lifetime * TcpMessageLimits.TokenActivationPeriod);
+#pragma warning restore CS0618
 
         /// <summary>
         /// Whether the token has expired according to the supplied

--- a/Stack/Opc.Ua.Core/Stack/Tcp/ChannelToken.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/ChannelToken.cs
@@ -98,18 +98,9 @@ namespace Opc.Ua.Bindings
         public DateTime CreatedAt { get; set; }
 
         /// <summary>
-        /// When the token was created (refers to the local tick count).
-        /// Used for calculation of renewals. Uses <c>HiResClock.TickCount</c>.
-        /// </summary>
-        [Obsolete("Use CreatedAtTimestamp via IsExpired(TimeProvider) / " +
-            "IsActivationRequired(TimeProvider) for monotonic, non-wrapping duration math.")]
-        public int CreatedAtTickCount { get; set; }
-
-        /// <summary>
         /// When the token was created (monotonic timestamp from
         /// <see cref="TimeProvider.GetTimestamp"/>).
-        /// Used internally for renewal calculations to avoid the 32-bit wrap of
-        /// <see cref="CreatedAtTickCount"/>.
+        /// Used internally for renewal calculations.
         /// </summary>
         internal long CreatedAtTimestamp { get; set; }
 
@@ -117,24 +108,6 @@ namespace Opc.Ua.Bindings
         /// The lifetime of the token in milliseconds.
         /// </summary>
         public int Lifetime { get; set; }
-
-#pragma warning disable CS0618 // Back-compat surface; new code uses IsExpired(TimeProvider).
-        /// <summary>
-        /// Whether the token has expired.
-        /// </summary>
-        [Obsolete("Use IsExpired(TimeProvider) instead — the supplied TimeProvider " +
-            "participates in mocking and avoids the 32-bit tick wrap.")]
-        public bool Expired => (HiResClock.TickCount - CreatedAtTickCount) > Lifetime;
-
-        /// <summary>
-        /// Whether the token should be activated in case a new one is already created.
-        /// </summary>
-        [Obsolete("Use IsActivationRequired(TimeProvider) instead — the supplied " +
-            "TimeProvider participates in mocking and avoids the 32-bit tick wrap.")]
-        public bool ActivationRequired =>
-            (HiResClock.TickCount - CreatedAtTickCount) >
-            (int)Math.Round(Lifetime * TcpMessageLimits.TokenActivationPeriod);
-#pragma warning restore CS0618
 
         /// <summary>
         /// Whether the token has expired according to the supplied

--- a/Stack/Opc.Ua.Core/Stack/Tcp/ChannelToken.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/ChannelToken.cs
@@ -121,6 +121,25 @@ namespace Opc.Ua.Bindings
             (int)Math.Round(Lifetime * TcpMessageLimits.TokenActivationPeriod);
 
         /// <summary>
+        /// Whether the token has expired according to the supplied
+        /// <see cref="TimeProvider"/>.
+        /// </summary>
+        internal bool IsExpired(TimeProvider timeProvider)
+        {
+            return unchecked(timeProvider.GetTickCount() - CreatedAtTickCount) > Lifetime;
+        }
+
+        /// <summary>
+        /// Whether activation is required according to the supplied
+        /// <see cref="TimeProvider"/>.
+        /// </summary>
+        internal bool IsActivationRequired(TimeProvider timeProvider)
+        {
+            return unchecked(timeProvider.GetTickCount() - CreatedAtTickCount) >
+                (int)Math.Round(Lifetime * TcpMessageLimits.TokenActivationPeriod);
+        }
+
+        /// <summary>
         /// The SecurityPolicy used to encrypt and sign the messages.
         /// </summary>
         public SecurityPolicyInfo? SecurityPolicy { get; set; }

--- a/Stack/Opc.Ua.Core/Stack/Tcp/ChannelToken.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/ChannelToken.cs
@@ -101,7 +101,17 @@ namespace Opc.Ua.Bindings
         /// When the token was created (refers to the local tick count).
         /// Used for calculation of renewals. Uses <c>HiResClock.TickCount</c>.
         /// </summary>
+        [Obsolete("Use CreatedAtTimestamp via IsExpired(TimeProvider) / " +
+            "IsActivationRequired(TimeProvider) for monotonic, non-wrapping duration math.")]
         public int CreatedAtTickCount { get; set; }
+
+        /// <summary>
+        /// When the token was created (monotonic timestamp from
+        /// <see cref="TimeProvider.GetTimestamp"/>).
+        /// Used internally for renewal calculations to avoid the 32-bit wrap of
+        /// <see cref="CreatedAtTickCount"/>.
+        /// </summary>
+        internal long CreatedAtTimestamp { get; set; }
 
         /// <summary>
         /// The lifetime of the token in milliseconds.
@@ -112,11 +122,15 @@ namespace Opc.Ua.Bindings
         /// <summary>
         /// Whether the token has expired.
         /// </summary>
+        [Obsolete("Use IsExpired(TimeProvider) instead — the supplied TimeProvider " +
+            "participates in mocking and avoids the 32-bit tick wrap.")]
         public bool Expired => (HiResClock.TickCount - CreatedAtTickCount) > Lifetime;
 
         /// <summary>
         /// Whether the token should be activated in case a new one is already created.
         /// </summary>
+        [Obsolete("Use IsActivationRequired(TimeProvider) instead — the supplied " +
+            "TimeProvider participates in mocking and avoids the 32-bit tick wrap.")]
         public bool ActivationRequired =>
             (HiResClock.TickCount - CreatedAtTickCount) >
             (int)Math.Round(Lifetime * TcpMessageLimits.TokenActivationPeriod);
@@ -128,7 +142,7 @@ namespace Opc.Ua.Bindings
         /// </summary>
         internal bool IsExpired(TimeProvider timeProvider)
         {
-            return unchecked(timeProvider.GetTickCount() - CreatedAtTickCount) > Lifetime;
+            return timeProvider.GetElapsedTime(CreatedAtTimestamp).TotalMilliseconds > Lifetime;
         }
 
         /// <summary>
@@ -137,8 +151,8 @@ namespace Opc.Ua.Bindings
         /// </summary>
         internal bool IsActivationRequired(TimeProvider timeProvider)
         {
-            return unchecked(timeProvider.GetTickCount() - CreatedAtTickCount) >
-                (int)Math.Round(Lifetime * TcpMessageLimits.TokenActivationPeriod);
+            return timeProvider.GetElapsedTime(CreatedAtTimestamp).TotalMilliseconds >
+                Math.Round(Lifetime * TcpMessageLimits.TokenActivationPeriod);
         }
 
         /// <summary>

--- a/Stack/Opc.Ua.Core/Stack/Tcp/TcpListenerChannel.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/TcpListenerChannel.cs
@@ -52,6 +52,31 @@ namespace Opc.Ua.Bindings
             ICertificateRegistry serverCertificates,
             List<EndpointDescription> endpoints,
             ITelemetryContext telemetry)
+            : this(
+                contextId,
+                listener,
+                bufferManager,
+                quotas,
+                serverCertificates,
+                endpoints,
+                telemetry,
+                null)
+        {
+        }
+
+        /// <summary>
+        /// Attaches the object to an existing socket using the supplied
+        /// <see cref="TimeProvider"/> for activity tracking.
+        /// </summary>
+        public TcpListenerChannel(
+            string contextId,
+            ITcpChannelListener listener,
+            BufferManager bufferManager,
+            ChannelQuotas quotas,
+            ICertificateRegistry serverCertificates,
+            List<EndpointDescription> endpoints,
+            ITelemetryContext telemetry,
+            TimeProvider? timeProvider)
             : base(
                 contextId,
                 bufferManager,
@@ -60,7 +85,8 @@ namespace Opc.Ua.Bindings
                 endpoints,
                 MessageSecurityMode.None,
                 SecurityPolicies.None,
-                telemetry)
+                telemetry,
+                timeProvider)
         {
             m_logger = telemetry.CreateLogger<TcpListenerChannel>();
             Listener = listener;
@@ -193,7 +219,14 @@ namespace Opc.Ua.Bindings
         /// The time in milliseconds elapsed since the channel received or sent messages
         /// or received a keep alive.
         /// </summary>
-        public int ElapsedSinceLastActiveTime => HiResClock.TickCount - LastActiveTickCount;
+        public int ElapsedSinceLastActiveTime
+        {
+            get
+            {
+                long ms = (long)GetElapsedSinceLastActive().TotalMilliseconds;
+                return (int)Math.Min(int.MaxValue, Math.Max(0, ms));
+            }
+        }
 
         /// <summary>
         /// Has the channel been used in a session

--- a/Stack/Opc.Ua.Core/Stack/Tcp/TcpReverseConnectChannel.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/TcpReverseConnectChannel.cs
@@ -49,7 +49,23 @@ namespace Opc.Ua.Bindings
             ChannelQuotas quotas,
             List<EndpointDescription> endpoints,
             ITelemetryContext telemetry)
-            : base(contextId, listener, bufferManager, quotas, null!, endpoints, telemetry)
+            : this(contextId, listener, bufferManager, quotas, endpoints, telemetry, null)
+        {
+        }
+
+        /// <summary>
+        /// Attaches the object to an existing socket using the supplied
+        /// <see cref="TimeProvider"/> for activity tracking.
+        /// </summary>
+        public TcpReverseConnectChannel(
+            string contextId,
+            ITcpChannelListener listener,
+            BufferManager bufferManager,
+            ChannelQuotas quotas,
+            List<EndpointDescription> endpoints,
+            ITelemetryContext telemetry,
+            TimeProvider? timeProvider)
+            : base(contextId, listener, bufferManager, quotas, null!, endpoints, telemetry, timeProvider)
         {
             m_logger = telemetry.CreateLogger<TcpReverseConnectChannel>();
         }

--- a/Stack/Opc.Ua.Core/Stack/Tcp/TcpServerChannel.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/TcpServerChannel.cs
@@ -55,6 +55,31 @@ namespace Opc.Ua.Bindings
             ICertificateRegistry serverCertificates,
             List<EndpointDescription> endpoints,
             ITelemetryContext telemetry)
+            : this(
+                contextId,
+                listener,
+                bufferManager,
+                quotas,
+                serverCertificates,
+                endpoints,
+                telemetry,
+                null)
+        {
+        }
+
+        /// <summary>
+        /// Attaches the object to an existing socket using the supplied
+        /// <see cref="TimeProvider"/> for activity tracking.
+        /// </summary>
+        public TcpServerChannel(
+            string contextId,
+            ITcpChannelListener listener,
+            BufferManager bufferManager,
+            ChannelQuotas quotas,
+            ICertificateRegistry serverCertificates,
+            List<EndpointDescription> endpoints,
+            ITelemetryContext telemetry,
+            TimeProvider? timeProvider)
             : base(
                 contextId,
                 listener,
@@ -62,7 +87,8 @@ namespace Opc.Ua.Bindings
                 quotas,
                 serverCertificates,
                 endpoints,
-                telemetry)
+                telemetry,
+                timeProvider)
         {
             m_logger = telemetry.CreateLogger<TcpServerChannel>();
             m_queuedResponses = [];
@@ -1144,7 +1170,7 @@ namespace Opc.Ua.Bindings
                     throw new ServiceResultException(StatusCodes.BadSequenceNumberInvalid);
                 }
 
-                if (token == CurrentToken && PreviousToken != null && !PreviousToken.Expired)
+                if (token == CurrentToken && PreviousToken != null && !PreviousToken.IsExpired(TimeProvider))
                 {
                     m_logger.LogInformation(
                         "ChannelId {Id}: Server Current Token #{CurrentToken}, Revoked Token #{PreviousToken}.",

--- a/Stack/Opc.Ua.Core/Stack/Tcp/TcpTransportListener.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/TcpTransportListener.cs
@@ -85,14 +85,15 @@ namespace Opc.Ua.Bindings
         /// <summary>
         /// Constructor
         /// </summary>
-        public ActiveClientTracker(ITelemetryContext telemetry)
+        public ActiveClientTracker(ITelemetryContext telemetry, TimeProvider timeProvider)
         {
+            m_timeProvider = timeProvider;
             m_logger = telemetry.CreateLogger<ActiveClientTracker>();
-            m_cleanupTimer = new Timer(
+            m_cleanupTimer = m_timeProvider.CreateTimer(
                 CleanupExpiredEntries,
                 null,
-                kCleanupIntervalMs,
-                kCleanupIntervalMs);
+                TimeSpan.FromMilliseconds(kCleanupIntervalMs),
+                TimeSpan.FromMilliseconds(kCleanupIntervalMs));
         }
 
         /// <summary>
@@ -102,7 +103,7 @@ namespace Opc.Ua.Bindings
         {
             if (m_activeClients.TryGetValue(ipAddress, out ActiveClient? client))
             {
-                int currentTicks = HiResClock.TickCount;
+                int currentTicks = m_timeProvider.GetTickCount();
                 return IsBlockedTicks(client.BlockedUntilTicks, currentTicks);
             }
             return false;
@@ -113,7 +114,7 @@ namespace Opc.Ua.Bindings
         /// </summary>
         public void AddClientAction(IPAddress ipAddress)
         {
-            int currentTicks = HiResClock.TickCount;
+            int currentTicks = m_timeProvider.GetTickCount();
 
             m_activeClients.AddOrUpdate(
                 ipAddress,
@@ -177,7 +178,7 @@ namespace Opc.Ua.Bindings
         /// </summary>
         private void CleanupExpiredEntries(object? state)
         {
-            int currentTicks = HiResClock.TickCount;
+            int currentTicks = m_timeProvider.GetTickCount();
 
             foreach (KeyValuePair<IPAddress, ActiveClient> entry in m_activeClients)
             {
@@ -245,7 +246,8 @@ namespace Opc.Ua.Bindings
         private const int kEntryExpirationMs = 600_000;
 
         private readonly ILogger m_logger;
-        private readonly Timer m_cleanupTimer;
+        private readonly TimeProvider m_timeProvider;
+        private readonly ITimer m_cleanupTimer;
     }
 
     /// <summary>
@@ -263,9 +265,20 @@ namespace Opc.Ua.Bindings
         /// </summary>
         /// <param name="telemetry">Telemetry context to use</param>
         public TcpTransportListener(ITelemetryContext telemetry)
+            : this(telemetry, null)
+        {
+        }
+
+        /// <summary>
+        /// Create listener
+        /// </summary>
+        /// <param name="telemetry">Telemetry context to use</param>
+        /// <param name="timeProvider">Time provider to use for timers and durations.</param>
+        public TcpTransportListener(ITelemetryContext telemetry, TimeProvider? timeProvider = null)
         {
             m_telemetry = telemetry;
             m_logger = telemetry.CreateLogger<TcpTransportListener>();
+            m_timeProvider = timeProvider ??= TimeProvider.System;
         }
 
         /// <summary>
@@ -588,7 +601,7 @@ namespace Opc.Ua.Bindings
                 if (m_descriptions != null &&
                     m_descriptions.Any(d => d.SecurityPolicyUri == SecurityPolicies.Basic128Rsa15))
                 {
-                    m_activeClientTracker = new ActiveClientTracker(m_telemetry);
+                    m_activeClientTracker = new ActiveClientTracker(m_telemetry, m_timeProvider);
                 }
 
                 // ensure a valid port.
@@ -622,11 +635,11 @@ namespace Opc.Ua.Bindings
                     m_listeningSocket.Bind(endpoint);
                     m_listeningSocket.Listen(kSocketBacklog);
 
-                    m_inactivityDetectionTimer = new Timer(
+                    m_inactivityDetectionTimer = m_timeProvider.CreateTimer(
                         DetectInactiveChannels,
                         null,
-                        m_inactivityDetectPeriod,
-                        m_inactivityDetectPeriod);
+                        TimeSpan.FromMilliseconds(m_inactivityDetectPeriod),
+                        TimeSpan.FromMilliseconds(m_inactivityDetectPeriod));
 
                     SocketAsyncEventArgs? args = null;
                     try
@@ -936,7 +949,8 @@ namespace Opc.Ua.Bindings
                                         m_bufferManager,
                                         m_quotas,
                                         m_descriptions,
-                                        m_telemetry);
+                                        m_telemetry,
+                                        m_timeProvider);
                                 }
                                 else
                                 {
@@ -948,7 +962,8 @@ namespace Opc.Ua.Bindings
                                         m_quotas,
                                         m_serverCertificates,
                                         m_descriptions,
-                                        m_telemetry);
+                                        m_telemetry,
+                                        m_timeProvider);
                                 }
 
                                 if (m_callback != null)
@@ -1217,6 +1232,7 @@ namespace Opc.Ua.Bindings
         private readonly Lock m_lock = new();
         private readonly ITelemetryContext m_telemetry;
         private readonly ILogger m_logger;
+        private readonly TimeProvider m_timeProvider;
 
         /// <summary>
         /// These fields are populated by Open(); they remain non-null
@@ -1234,7 +1250,7 @@ namespace Opc.Ua.Bindings
         private ITransportListenerCallback? m_callback;
         private bool m_reverseConnectListener;
         private int m_inactivityDetectPeriod;
-        private Timer? m_inactivityDetectionTimer;
+        private ITimer? m_inactivityDetectionTimer;
         private ActiveClientTracker? m_activeClientTracker;
     }
 

--- a/Stack/Opc.Ua.Core/Stack/Tcp/TcpTransportListener.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/TcpTransportListener.cs
@@ -278,7 +278,7 @@ namespace Opc.Ua.Bindings
         {
             m_telemetry = telemetry;
             m_logger = telemetry.CreateLogger<TcpTransportListener>();
-            m_timeProvider = timeProvider ??= TimeProvider.System;
+            m_timeProvider = timeProvider ?? TimeProvider.System;
         }
 
         /// <summary>

--- a/Stack/Opc.Ua.Core/Stack/Tcp/UaSCBinaryChannel.Symmetric.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/UaSCBinaryChannel.Symmetric.cs
@@ -66,8 +66,8 @@ namespace Opc.Ua.Bindings
             {
                 ChannelId = Id,
                 TokenId = 0,
-                CreatedAt = DateTime.UtcNow,
-                CreatedAtTickCount = HiResClock.TickCount,
+                CreatedAt = TimeProvider.GetUtcNow().UtcDateTime,
+                CreatedAtTickCount = TimeProvider.GetTickCount(),
                 Lifetime = Quotas.SecurityTokenLifetime
             };
 
@@ -604,7 +604,7 @@ namespace Opc.Ua.Bindings
             }
 
             // check if token has expired.
-            if (token.Expired)
+            if (token.IsExpired(TimeProvider))
             {
                 throw ServiceResultException.Create(
                     StatusCodes.BadTcpSecureChannelUnknown,

--- a/Stack/Opc.Ua.Core/Stack/Tcp/UaSCBinaryChannel.Symmetric.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/UaSCBinaryChannel.Symmetric.cs
@@ -67,21 +67,16 @@ namespace Opc.Ua.Bindings
                 ChannelId = Id,
                 TokenId = 0,
                 CreatedAt = TimeProvider.GetUtcNow().UtcDateTime,
-#pragma warning disable CS0618 // Back-compat: keep populating CreatedAtTickCount for callers
-                CreatedAtTickCount = TimeProvider.GetTickCount(),
-#pragma warning restore CS0618
                 CreatedAtTimestamp = TimeProvider.GetTimestamp(),
                 Lifetime = Quotas.SecurityTokenLifetime
             };
 
-#pragma warning disable CS0618 // Back-compat: log CreatedAtTickCount for diagnostic parity.
             m_logger.LogInformation(
-                "ChannelId {ChannelId}: New Token created. CreatedAt={CreatedAt:HH:mm:ss.fff}-{CreatedAtTickCount}. Lifetime={Lifetime}.",
+                "ChannelId {ChannelId}: New Token created. CreatedAt={CreatedAt:HH:mm:ss.fff}-{CreatedAtTimestamp}. Lifetime={Lifetime}.",
                 Id,
                 token.CreatedAt,
-                token.CreatedAtTickCount,
+                token.CreatedAtTimestamp,
                 token.Lifetime);
-#pragma warning restore CS0618
 
             return token;
         }
@@ -101,15 +96,13 @@ namespace Opc.Ua.Bindings
 
             OnTokenActivated?.Invoke(token, PreviousToken);
 
-#pragma warning disable CS0618 // Back-compat: log CreatedAtTickCount for diagnostic parity.
             m_logger.LogInformation(
-                "ChannelId {Id}: Token #{TokenId} activated. CreatedAt={CreatedAt:HH:mm:ss.fff}-{CreatedAtTickCount}. Lifetime={Lifetime}.",
+                "ChannelId {Id}: Token #{TokenId} activated. CreatedAt={CreatedAt:HH:mm:ss.fff}-{CreatedAtTimestamp}. Lifetime={Lifetime}.",
                 Id,
                 token.TokenId,
                 token.CreatedAt,
-                token.CreatedAtTickCount,
+                token.CreatedAtTimestamp,
                 token.Lifetime);
-#pragma warning restore CS0618
         }
 
         /// <summary>
@@ -119,15 +112,13 @@ namespace Opc.Ua.Bindings
         {
             RenewedToken?.Dispose();
             RenewedToken = token;
-#pragma warning disable CS0618 // Back-compat: log CreatedAtTickCount for diagnostic parity.
             m_logger.LogInformation(
-                "ChannelId {Id}: Renewed Token #{TokenId} set. CreatedAt={CreatedAt:HH:mm:ss.fff}-{CreatedAtTickCount}. Lifetime={Lifetime}.",
+                "ChannelId {Id}: Renewed Token #{TokenId} set. CreatedAt={CreatedAt:HH:mm:ss.fff}-{CreatedAtTimestamp}. Lifetime={Lifetime}.",
                 Id,
                 token.TokenId,
                 token.CreatedAt,
-                token.CreatedAtTickCount,
+                token.CreatedAtTimestamp,
                 token.Lifetime);
-#pragma warning restore CS0618
         }
 
         /// <summary>
@@ -574,14 +565,14 @@ namespace Opc.Ua.Bindings
             }
 
             // check if activation of the new token should be forced.
-            else if (RenewedToken != null && CurrentToken is { } currentTokenForLog &&
-                currentTokenForLog.IsActivationRequired(TimeProvider))
+            else if (RenewedToken != null && CurrentToken != null &&
+                CurrentToken.IsActivationRequired(TimeProvider))
             {
                 ActivateToken(RenewedToken);
                 m_logger.LogInformation(
                     "ChannelId {Id}: Token #{TokenId} activated forced.",
                     Id,
-                    currentTokenForLog.TokenId);
+                    CurrentToken.TokenId);
             }
 
             // check for valid token.
@@ -616,15 +607,13 @@ namespace Opc.Ua.Bindings
             // check if token has expired.
             if (token.IsExpired(TimeProvider))
             {
-#pragma warning disable CS0618 // Back-compat: log CreatedAtTickCount for diagnostic parity.
                 throw ServiceResultException.Create(
                     StatusCodes.BadTcpSecureChannelUnknown,
                     "Channel{0}: Token #{1} has expired. Lifetime={2:HH:mm:ss.fff}-{3}",
                     Id,
                     token.TokenId,
                     token.CreatedAt,
-                    token.CreatedAtTickCount);
-#pragma warning restore CS0618
+                    token.CreatedAtTimestamp);
             }
 
             int headerSize = decoder.Position;

--- a/Stack/Opc.Ua.Core/Stack/Tcp/UaSCBinaryChannel.Symmetric.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/UaSCBinaryChannel.Symmetric.cs
@@ -67,16 +67,21 @@ namespace Opc.Ua.Bindings
                 ChannelId = Id,
                 TokenId = 0,
                 CreatedAt = TimeProvider.GetUtcNow().UtcDateTime,
+#pragma warning disable CS0618 // Back-compat: keep populating CreatedAtTickCount for callers
                 CreatedAtTickCount = TimeProvider.GetTickCount(),
+#pragma warning restore CS0618
+                CreatedAtTimestamp = TimeProvider.GetTimestamp(),
                 Lifetime = Quotas.SecurityTokenLifetime
             };
 
+#pragma warning disable CS0618 // Back-compat: log CreatedAtTickCount for diagnostic parity.
             m_logger.LogInformation(
                 "ChannelId {ChannelId}: New Token created. CreatedAt={CreatedAt:HH:mm:ss.fff}-{CreatedAtTickCount}. Lifetime={Lifetime}.",
                 Id,
                 token.CreatedAt,
                 token.CreatedAtTickCount,
                 token.Lifetime);
+#pragma warning restore CS0618
 
             return token;
         }
@@ -96,6 +101,7 @@ namespace Opc.Ua.Bindings
 
             OnTokenActivated?.Invoke(token, PreviousToken);
 
+#pragma warning disable CS0618 // Back-compat: log CreatedAtTickCount for diagnostic parity.
             m_logger.LogInformation(
                 "ChannelId {Id}: Token #{TokenId} activated. CreatedAt={CreatedAt:HH:mm:ss.fff}-{CreatedAtTickCount}. Lifetime={Lifetime}.",
                 Id,
@@ -103,6 +109,7 @@ namespace Opc.Ua.Bindings
                 token.CreatedAt,
                 token.CreatedAtTickCount,
                 token.Lifetime);
+#pragma warning restore CS0618
         }
 
         /// <summary>
@@ -112,6 +119,7 @@ namespace Opc.Ua.Bindings
         {
             RenewedToken?.Dispose();
             RenewedToken = token;
+#pragma warning disable CS0618 // Back-compat: log CreatedAtTickCount for diagnostic parity.
             m_logger.LogInformation(
                 "ChannelId {Id}: Renewed Token #{TokenId} set. CreatedAt={CreatedAt:HH:mm:ss.fff}-{CreatedAtTickCount}. Lifetime={Lifetime}.",
                 Id,
@@ -119,6 +127,7 @@ namespace Opc.Ua.Bindings
                 token.CreatedAt,
                 token.CreatedAtTickCount,
                 token.Lifetime);
+#pragma warning restore CS0618
         }
 
         /// <summary>
@@ -565,7 +574,8 @@ namespace Opc.Ua.Bindings
             }
 
             // check if activation of the new token should be forced.
-            else if (RenewedToken != null && CurrentToken is { ActivationRequired: true } currentTokenForLog)
+            else if (RenewedToken != null && CurrentToken is { } currentTokenForLog &&
+                currentTokenForLog.IsActivationRequired(TimeProvider))
             {
                 ActivateToken(RenewedToken);
                 m_logger.LogInformation(
@@ -606,6 +616,7 @@ namespace Opc.Ua.Bindings
             // check if token has expired.
             if (token.IsExpired(TimeProvider))
             {
+#pragma warning disable CS0618 // Back-compat: log CreatedAtTickCount for diagnostic parity.
                 throw ServiceResultException.Create(
                     StatusCodes.BadTcpSecureChannelUnknown,
                     "Channel{0}: Token #{1} has expired. Lifetime={2:HH:mm:ss.fff}-{3}",
@@ -613,6 +624,7 @@ namespace Opc.Ua.Bindings
                     token.TokenId,
                     token.CreatedAt,
                     token.CreatedAtTickCount);
+#pragma warning restore CS0618
             }
 
             int headerSize = decoder.Position;

--- a/Stack/Opc.Ua.Core/Stack/Tcp/UaSCBinaryChannel.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/UaSCBinaryChannel.cs
@@ -63,7 +63,36 @@ namespace Opc.Ua.Bindings
                 endpoints,
                 securityMode,
                 securityPolicyUri,
-                telemetry)
+                telemetry,
+                null)
+        {
+        }
+
+        /// <summary>
+        /// Attaches the object to an existing socket using the supplied
+        /// <see cref="TimeProvider"/> for token-lifetime tracking.
+        /// </summary>
+        public UaSCUaBinaryChannel(
+            string contextId,
+            BufferManager bufferManager,
+            ChannelQuotas quotas,
+            Certificate? serverCertificate,
+            List<EndpointDescription>? endpoints,
+            MessageSecurityMode securityMode,
+            string? securityPolicyUri,
+            ITelemetryContext telemetry,
+            TimeProvider? timeProvider)
+            : this(
+                contextId,
+                bufferManager,
+                quotas,
+                null,
+                serverCertificate,
+                endpoints,
+                securityMode,
+                securityPolicyUri,
+                telemetry,
+                timeProvider)
         {
         }
 
@@ -88,7 +117,36 @@ namespace Opc.Ua.Bindings
                 endpoints,
                 securityMode,
                 securityPolicyUri,
-                telemetry)
+                telemetry,
+                null)
+        {
+        }
+
+        /// <summary>
+        /// Attaches the object to an existing socket using the supplied
+        /// <see cref="TimeProvider"/> for token-lifetime tracking.
+        /// </summary>
+        public UaSCUaBinaryChannel(
+            string contextId,
+            BufferManager bufferManager,
+            ChannelQuotas quotas,
+            ICertificateRegistry? serverCertificates,
+            List<EndpointDescription>? endpoints,
+            MessageSecurityMode securityMode,
+            string? securityPolicyUri,
+            ITelemetryContext telemetry,
+            TimeProvider? timeProvider)
+            : this(
+                contextId,
+                bufferManager,
+                quotas,
+                serverCertificates,
+                null,
+                endpoints,
+                securityMode,
+                securityPolicyUri,
+                telemetry,
+                timeProvider)
         {
         }
 
@@ -104,12 +162,15 @@ namespace Opc.Ua.Bindings
             List<EndpointDescription>? endpoints,
             MessageSecurityMode securityMode,
             string? securityPolicyUri,
-            ITelemetryContext telemetry)
+            ITelemetryContext telemetry,
+            TimeProvider? timeProvider)
         {
             // create a unique contex if none provided.
             m_contextId = contextId;
             Telemetry = telemetry;
             m_logger = telemetry.CreateLogger<UaSCUaBinaryChannel>();
+            TimeProvider = timeProvider ??= TimeProvider.System;
+            m_lastActiveTimestamp = TimeProvider.GetTimestamp();
 
             if (string.IsNullOrEmpty(m_contextId))
             {
@@ -239,6 +300,12 @@ namespace Opc.Ua.Bindings
         protected ITelemetryContext Telemetry { get; }
 
         /// <summary>
+        /// The <see cref="System.TimeProvider"/> used by this channel for
+        /// time and duration calculations.
+        /// </summary>
+        protected TimeProvider TimeProvider { get; }
+
+        /// <summary>
         /// The identifier assigned to the channel by the server.
         /// </summary>
         public uint Id { get; private set; }
@@ -272,6 +339,16 @@ namespace Opc.Ua.Bindings
         /// The tickcount in milliseconds when the channel received/sent the last message.
         /// </summary>
         protected int LastActiveTickCount { get; private set; } = HiResClock.TickCount;
+
+        /// <summary>
+        /// Returns the monotonic elapsed time since the channel last
+        /// received or sent a message, measured against the channel's
+        /// <see cref="TimeProvider"/>.
+        /// </summary>
+        internal TimeSpan GetElapsedSinceLastActive()
+        {
+            return TimeProvider.GetElapsedTime(m_lastActiveTimestamp);
+        }
 
         /// <summary>
         /// Reports that the channel state has changed (in another thread).
@@ -891,7 +968,21 @@ namespace Opc.Ua.Bindings
             /// Initializes the object with a callback
             /// </summary>
             public WriteOperation(int timeout, AsyncCallback? callback, object? asyncState, ILogger logger)
-                : base(timeout, callback, asyncState, logger)
+                : this(timeout, callback, asyncState, logger, null)
+            {
+            }
+
+            /// <summary>
+            /// Initializes the object with a callback and supplied
+            /// <see cref="TimeProvider"/>.
+            /// </summary>
+            public WriteOperation(
+                int timeout,
+                AsyncCallback? callback,
+                object? asyncState,
+                ILogger logger,
+                TimeProvider? timeProvider)
+                : base(timeout, callback, asyncState, logger, timeProvider)
             {
             }
 
@@ -964,6 +1055,7 @@ namespace Opc.Ua.Bindings
         public void UpdateLastActiveTime()
         {
             LastActiveTickCount = HiResClock.TickCount;
+            m_lastActiveTimestamp = TimeProvider.GetTimestamp();
         }
 
         /// <summary>
@@ -971,6 +1063,7 @@ namespace Opc.Ua.Bindings
         /// </summary>
         private int m_state;
         private int m_activeWriteRequests;
+        private long m_lastActiveTimestamp;
         private readonly string m_contextId;
         private readonly ILogger m_logger;
         private long m_sequenceNumber;

--- a/Stack/Opc.Ua.Core/Stack/Tcp/UaSCBinaryChannel.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/UaSCBinaryChannel.cs
@@ -338,9 +338,9 @@ namespace Opc.Ua.Bindings
         /// <summary>
         /// The tickcount in milliseconds when the channel received/sent the last message.
         /// </summary>
-#pragma warning disable CS0618 // Back-compat surface; new code uses GetElapsedSinceLastActive().
+        [Obsolete("Use the TimeProvider-based monotonic equivalent via GetElapsedSinceLastActive(). " +
+            "Sourcing HiResClock.TickCount directly defeats TimeProvider mocking.")]
         protected int LastActiveTickCount { get; private set; } = HiResClock.TickCount;
-#pragma warning restore CS0618
 
         /// <summary>
         /// Returns the monotonic elapsed time since the channel last
@@ -1056,8 +1056,8 @@ namespace Opc.Ua.Bindings
         /// </summary>
         public void UpdateLastActiveTime()
         {
-#pragma warning disable CS0618 // Back-compat surface kept in sync with m_lastActiveTimestamp.
-            LastActiveTickCount = HiResClock.TickCount;
+#pragma warning disable CS0618 // Back-compat: keep populating LastActiveTickCount for derived classes.
+            LastActiveTickCount = TimeProvider.GetTickCount();
 #pragma warning restore CS0618
             m_lastActiveTimestamp = TimeProvider.GetTimestamp();
         }

--- a/Stack/Opc.Ua.Core/Stack/Tcp/UaSCBinaryChannel.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/UaSCBinaryChannel.cs
@@ -336,13 +336,6 @@ namespace Opc.Ua.Bindings
         }
 
         /// <summary>
-        /// The tickcount in milliseconds when the channel received/sent the last message.
-        /// </summary>
-        [Obsolete("Use the TimeProvider-based monotonic equivalent via GetElapsedSinceLastActive(). " +
-            "Sourcing HiResClock.TickCount directly defeats TimeProvider mocking.")]
-        protected int LastActiveTickCount { get; private set; } = HiResClock.TickCount;
-
-        /// <summary>
         /// Returns the monotonic elapsed time since the channel last
         /// received or sent a message, measured against the channel's
         /// <see cref="TimeProvider"/>.
@@ -1056,9 +1049,6 @@ namespace Opc.Ua.Bindings
         /// </summary>
         public void UpdateLastActiveTime()
         {
-#pragma warning disable CS0618 // Back-compat: keep populating LastActiveTickCount for derived classes.
-            LastActiveTickCount = TimeProvider.GetTickCount();
-#pragma warning restore CS0618
             m_lastActiveTimestamp = TimeProvider.GetTimestamp();
         }
 

--- a/Stack/Opc.Ua.Core/Stack/Tcp/UaSCBinaryChannel.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/UaSCBinaryChannel.cs
@@ -169,7 +169,7 @@ namespace Opc.Ua.Bindings
             m_contextId = contextId;
             Telemetry = telemetry;
             m_logger = telemetry.CreateLogger<UaSCUaBinaryChannel>();
-            TimeProvider = timeProvider ??= TimeProvider.System;
+            TimeProvider = timeProvider ?? TimeProvider.System;
             m_lastActiveTimestamp = TimeProvider.GetTimestamp();
 
             if (string.IsNullOrEmpty(m_contextId))

--- a/Stack/Opc.Ua.Core/Stack/Tcp/UaSCBinaryChannel.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/UaSCBinaryChannel.cs
@@ -338,7 +338,9 @@ namespace Opc.Ua.Bindings
         /// <summary>
         /// The tickcount in milliseconds when the channel received/sent the last message.
         /// </summary>
+#pragma warning disable CS0618 // Back-compat surface; new code uses GetElapsedSinceLastActive().
         protected int LastActiveTickCount { get; private set; } = HiResClock.TickCount;
+#pragma warning restore CS0618
 
         /// <summary>
         /// Returns the monotonic elapsed time since the channel last
@@ -1054,7 +1056,9 @@ namespace Opc.Ua.Bindings
         /// </summary>
         public void UpdateLastActiveTime()
         {
+#pragma warning disable CS0618 // Back-compat surface kept in sync with m_lastActiveTimestamp.
             LastActiveTickCount = HiResClock.TickCount;
+#pragma warning restore CS0618
             m_lastActiveTimestamp = TimeProvider.GetTimestamp();
         }
 

--- a/Stack/Opc.Ua.Core/Stack/Tcp/UaSCBinaryClientChannel.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/UaSCBinaryClientChannel.cs
@@ -1447,7 +1447,7 @@ namespace Opc.Ua.Bindings
             int timeToRenewal =
                 (int)Math.Round(token.Lifetime * TcpMessageLimits.TokenRenewalPeriod) +
                 jitter -
-                unchecked(TimeProvider.GetTickCount() - token.CreatedAtTickCount);
+                (int)TimeProvider.GetElapsedTime(token.CreatedAtTimestamp).TotalMilliseconds;
             if (timeToRenewal < 0)
             {
                 timeToRenewal = 0;

--- a/Stack/Opc.Ua.Core/Stack/Tcp/UaSCBinaryClientChannel.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/UaSCBinaryClientChannel.cs
@@ -59,6 +59,35 @@ namespace Opc.Ua.Bindings
             Certificate? serverCertificate,
             EndpointDescription? endpoint,
             ITelemetryContext telemetry)
+            : this(
+                contextId,
+                bufferManager,
+                socketFactory,
+                quotas,
+                clientCertificate,
+                clientCertificateChain,
+                serverCertificate,
+                endpoint,
+                telemetry,
+                null)
+        {
+        }
+
+        /// <summary>
+        /// Creates a channel for a client using the supplied
+        /// <see cref="TimeProvider"/> for handshake / token timing.
+        /// </summary>
+        public UaSCUaBinaryClientChannel(
+            string contextId,
+            BufferManager bufferManager,
+            IMessageSocketFactory socketFactory,
+            ChannelQuotas quotas,
+            Certificate? clientCertificate,
+            CertificateCollection? clientCertificateChain,
+            Certificate? serverCertificate,
+            EndpointDescription? endpoint,
+            ITelemetryContext telemetry,
+            TimeProvider? timeProvider)
             : base(
                 contextId,
                 bufferManager,
@@ -67,7 +96,8 @@ namespace Opc.Ua.Bindings
                 endpoint is not null ? [.. new EndpointDescription[] { endpoint }] : null,
                 endpoint is not null ? endpoint.SecurityMode : MessageSecurityMode.None,
                 endpoint is not null ? endpoint.SecurityPolicyUri : SecurityPolicies.None,
-                telemetry)
+                telemetry,
+                timeProvider)
         {
             m_telemetry = telemetry;
             m_logger = m_telemetry.CreateLogger<UaSCUaBinaryClientChannel>();
@@ -1372,11 +1402,11 @@ namespace Opc.Ua.Bindings
                     ChannelId,
                     m_waitBetweenReconnects,
                     reason.ToLongString());
-                m_handshakeTimer = new Timer(
+                m_handshakeTimer = TimeProvider.CreateTimer(
                     m_startHandshake,
                     null,
-                    m_waitBetweenReconnects,
-                    Timeout.Infinite);
+                    TimeSpan.FromMilliseconds(m_waitBetweenReconnects),
+                    Timeout.InfiniteTimeSpan);
 
                 // set next reconnect period.
                 m_waitBetweenReconnects *= 2;
@@ -1417,7 +1447,7 @@ namespace Opc.Ua.Bindings
             int timeToRenewal =
                 (int)Math.Round(token.Lifetime * TcpMessageLimits.TokenRenewalPeriod) +
                 jitter -
-                (HiResClock.TickCount - token.CreatedAtTickCount);
+                unchecked(TimeProvider.GetTickCount() - token.CreatedAtTickCount);
             if (timeToRenewal < 0)
             {
                 timeToRenewal = 0;
@@ -1427,10 +1457,14 @@ namespace Opc.Ua.Bindings
                 "ChannelId {ChannelId}: Token Expiry {Expiration:HH:mm:ss.fff}, renewal scheduled at {Renewal:HH:mm:ss.fff} in {Duration} ms.",
                 ChannelId,
                 token.CreatedAt.AddMilliseconds(token.Lifetime),
-                HiResClock.UtcTickCount(token.CreatedAtTickCount + timeToRenewal),
+                TimeProvider.GetUtcNow().AddMilliseconds(timeToRenewal).UtcDateTime,
                 timeToRenewal);
 
-            m_handshakeTimer = new Timer(m_startHandshake, token, timeToRenewal, Timeout.Infinite);
+            m_handshakeTimer = TimeProvider.CreateTimer(
+                m_startHandshake,
+                token,
+                TimeSpan.FromMilliseconds(timeToRenewal),
+                Timeout.InfiniteTimeSpan);
         }
 
         /// <summary>
@@ -1444,7 +1478,7 @@ namespace Opc.Ua.Bindings
             {
                 requestId = Utils.IncrementIdentifier(ref m_lastRequestId);
             }
-            var operation = new WriteOperation(timeout, callback, state, m_logger)
+            var operation = new WriteOperation(timeout, callback, state, m_logger, TimeProvider)
             {
                 RequestId = requestId
             };
@@ -1766,7 +1800,7 @@ namespace Opc.Ua.Bindings
         private readonly ConcurrentDictionary<uint, WriteOperation> m_requests;
         private WriteOperation? m_handshakeOperation;
         private ChannelToken? m_requestedToken;
-        private Timer? m_handshakeTimer;
+        private ITimer? m_handshakeTimer;
         private bool m_reconnecting;
         private int m_waitBetweenReconnects;
         private readonly IMessageSocketFactory m_socketFactory;

--- a/Stack/Opc.Ua.Core/Stack/Tcp/UaSCBinaryTransportChannel.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/UaSCBinaryTransportChannel.cs
@@ -71,7 +71,7 @@ namespace Opc.Ua.Bindings
             m_messageSocketFactory = messageSocketFactory;
             m_telemetry = telemetry;
             m_logger = m_telemetry.CreateLogger<UaSCUaBinaryTransportChannel>();
-            m_timeProvider = timeProvider ??= TimeProvider.System;
+            m_timeProvider = timeProvider ?? TimeProvider.System;
         }
 
         /// <summary>

--- a/Stack/Opc.Ua.Core/Stack/Tcp/UaSCBinaryTransportChannel.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/UaSCBinaryTransportChannel.cs
@@ -53,10 +53,25 @@ namespace Opc.Ua.Bindings
         public UaSCUaBinaryTransportChannel(
             IMessageSocketFactory messageSocketFactory,
             ITelemetryContext telemetry)
+            : this(messageSocketFactory, telemetry, null)
+        {
+        }
+
+        /// <summary>
+        /// Create a transport channel from a message socket factory.
+        /// </summary>
+        /// <param name="messageSocketFactory">The message socket factory.</param>
+        /// <param name="telemetry">Telemetry context to use</param>
+        /// <param name="timeProvider">Time provider to use for timers and durations.</param>
+        public UaSCUaBinaryTransportChannel(
+            IMessageSocketFactory messageSocketFactory,
+            ITelemetryContext telemetry,
+            TimeProvider? timeProvider = null)
         {
             m_messageSocketFactory = messageSocketFactory;
             m_telemetry = telemetry;
             m_logger = m_telemetry.CreateLogger<UaSCUaBinaryTransportChannel>();
+            m_timeProvider = timeProvider ??= TimeProvider.System;
         }
 
         /// <summary>
@@ -464,7 +479,8 @@ namespace Opc.Ua.Bindings
                 m_settings.ClientCertificateChain,
                 m_settings.ServerCertificate,
                 m_settings.Description,
-                telemetry);
+                telemetry,
+                m_timeProvider);
 
             // use socket for reverse connections, ignore otherwise
             if (socket != null)
@@ -502,5 +518,6 @@ namespace Opc.Ua.Bindings
         private event ChannelTokenActivatedEventHandler? m_OnTokenActivated;
         private readonly IMessageSocketFactory m_messageSocketFactory;
         private readonly ITelemetryContext m_telemetry;
+        private readonly TimeProvider m_timeProvider;
     }
 }

--- a/Stack/Opc.Ua.Core/Stack/Transport/AsyncResultBase.cs
+++ b/Stack/Opc.Ua.Core/Stack/Transport/AsyncResultBase.cs
@@ -92,7 +92,7 @@ namespace Opc.Ua
             m_startTimestamp = 0;
             m_logger = logger ?? LoggerUtils.Null.Logger;
             m_cts = cts;
-            m_timeProvider = timeProvider ??= TimeProvider.System;
+            m_timeProvider = timeProvider ?? TimeProvider.System;
 
             if (timeout > 0)
             {

--- a/Stack/Opc.Ua.Core/Stack/Transport/AsyncResultBase.cs
+++ b/Stack/Opc.Ua.Core/Stack/Transport/AsyncResultBase.cs
@@ -51,7 +51,7 @@ namespace Opc.Ua
             object? callbackData,
             int timeout,
             ILogger? logger = null)
-            : this(callback, callbackData, timeout, null, logger)
+            : this(callback, callbackData, timeout, null, logger, null)
         {
         }
 
@@ -69,20 +69,43 @@ namespace Opc.Ua
             int timeout,
             CancellationTokenSource? cts,
             ILogger? logger = null)
+            : this(callback, callbackData, timeout, cts, logger, null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AsyncResultBase"/>
+        /// class using the supplied <see cref="TimeProvider"/> for timeout
+        /// scheduling and elapsed-time calculations.
+        /// </summary>
+        public AsyncResultBase(
+            AsyncCallback? callback,
+            object? callbackData,
+            int timeout,
+            CancellationTokenSource? cts,
+            ILogger? logger,
+            TimeProvider? timeProvider)
         {
             m_callback = callback;
             AsyncState = callbackData;
-            m_deadline = DateTime.MinValue;
+            m_timeoutMs = -1;
+            m_startTimestamp = 0;
             m_logger = logger ?? LoggerUtils.Null.Logger;
             m_cts = cts;
+            m_timeProvider = timeProvider ??= TimeProvider.System;
 
             if (timeout > 0)
             {
-                m_deadline = DateTime.UtcNow.AddMilliseconds(timeout);
+                m_timeoutMs = timeout;
+                m_startTimestamp = m_timeProvider.GetTimestamp();
 
                 if (m_callback != null)
                 {
-                    m_timer = new Timer(OnTimeout, null, timeout, Timeout.Infinite);
+                    m_timer = m_timeProvider.CreateTimer(
+                        OnTimeout,
+                        null,
+                        TimeSpan.FromMilliseconds(timeout),
+                        Timeout.InfiniteTimeSpan);
                 }
             }
         }
@@ -188,14 +211,15 @@ namespace Opc.Ua
                             StatusCodes.BadCommunicationError);
                     }
 
-                    if (m_deadline != DateTime.MinValue)
+                    if (m_timeoutMs > 0)
                     {
-                        timeout = (int)(m_deadline - DateTime.UtcNow).TotalMilliseconds;
-
-                        if (timeout <= 0)
+                        TimeSpan elapsed = m_timeProvider.GetElapsedTime(m_startTimestamp);
+                        long remaining = m_timeoutMs - (long)elapsed.TotalMilliseconds;
+                        if (remaining <= 0)
                         {
                             return false;
                         }
+                        timeout = (int)Math.Min(int.MaxValue, remaining);
                     }
 
                     if (IsCompleted)
@@ -396,8 +420,10 @@ namespace Opc.Ua
 
         private readonly AsyncCallback? m_callback;
         private ManualResetEvent? m_waitHandle;
-        private readonly DateTime m_deadline;
-        private Timer? m_timer;
+        private readonly TimeProvider m_timeProvider;
+        private readonly long m_startTimestamp;
+        private readonly int m_timeoutMs;
+        private ITimer? m_timer;
         private CancellationTokenSource? m_cts;
     }
 }

--- a/Stack/Opc.Ua.Core/Types/Utils/HiResClock.cs
+++ b/Stack/Opc.Ua.Core/Types/Utils/HiResClock.cs
@@ -44,6 +44,7 @@ namespace Opc.Ua
         /// This Utc time does not change if the system time is changed.
         /// It returns the Utc time elapsed since the application started.
         /// </remarks>
+        [Obsolete(kObsoleteMessage)]
         public static DateTime UtcNow
         {
             get
@@ -61,22 +62,26 @@ namespace Opc.Ua
         /// <summary>
         /// Returns a monotonic increasing tick count in milliseconds.
         /// </summary>
+        [Obsolete(kObsoleteMessage)]
         public static long TickCount64
             => (long)(s_default.m_ticksDelegate() / s_default.m_ticksPerMillisecond);
 
         /// <summary>
         /// Returns a monotonic increasing tick count based on the frequency of the underlying timer.
         /// </summary>
+        [Obsolete(kObsoleteMessage)]
         public static long Ticks => s_default.m_ticksDelegate();
 
         /// <summary>
         /// Return the frequency of the ticks.
         /// </summary>
+        [Obsolete(kObsoleteMessage)]
         public static long Frequency => s_default.m_frequency;
 
         /// <summary>
         /// Return the number of ticks per millisecond.
         /// </summary>
+        [Obsolete(kObsoleteMessage)]
         public static double TicksPerMillisecond => s_default.m_ticksPerMillisecond;
 
         /// <summary>
@@ -90,21 +95,26 @@ namespace Opc.Ua
         /// Use for relative time measurements which do not require a high resolution and
         /// which should be independent of the system time, which can be changed by a user.
         /// </remarks>
+        [Obsolete(kObsoleteMessage)]
         public static int TickCount => Environment.TickCount;
 
         /// <summary>
         /// Returns the Utc time with respect to the current tick count.
         /// </summary>
+        [Obsolete(kObsoleteMessage)]
         public static DateTime UtcTickCount(int tickCount)
         {
             DateTime utcNow = DateTime.UtcNow;
+#pragma warning disable CS0618 // Internal call to obsolete TickCount.
             int delta = tickCount - TickCount;
+#pragma warning restore CS0618
             return utcNow.AddMilliseconds(delta);
         }
 
         /// <summary>
         /// Disables the hires clock.
         /// </summary>
+        [Obsolete(kObsoleteMessage)]
         public static bool Disabled
         {
             get => s_default.m_disabled;
@@ -135,6 +145,7 @@ namespace Opc.Ua
         /// <summary>
         /// Reset the baseline and allow a new initialization.
         /// </summary>
+        [Obsolete(kObsoleteMessage)]
         public static void Reset()
         {
             // reset baseline
@@ -189,5 +200,8 @@ namespace Opc.Ua
         private readonly decimal m_ratio;
         private readonly bool m_disabled;
         private bool m_initialized;
+
+        private const string kObsoleteMessage
+            = "Use TimeProvider for time / duration calculations. See docs/MigrationGuide.md";
     }
 }

--- a/Stack/Opc.Ua.Core/Types/Utils/TimeProviderExtensions.cs
+++ b/Stack/Opc.Ua.Core/Types/Utils/TimeProviderExtensions.cs
@@ -37,11 +37,11 @@ namespace Opc.Ua
     /// and for bridging legacy public APIs that expose <see cref="int"/> tick counts.
     /// </summary>
     /// <remarks>
-    /// These helpers are intentionally <c>internal</c> because they exist purely to
-    /// support the migration off <see cref="HiResClock"/>; new public APIs should
-    /// consume <see cref="TimeProvider"/> directly via constructor injection.
+    /// These helpers exist primarily to support the migration off
+    /// <see cref="HiResClock"/>; new public APIs should consume
+    /// <see cref="TimeProvider"/> directly via constructor injection.
     /// </remarks>
-    internal static class TimeProviderExtensions
+    public static class TimeProviderExtensions
     {
         /// <summary>
         /// Returns the current monotonic timestamp normalised to milliseconds.

--- a/Stack/Opc.Ua.Core/Types/Utils/TimeProviderExtensions.cs
+++ b/Stack/Opc.Ua.Core/Types/Utils/TimeProviderExtensions.cs
@@ -1,0 +1,96 @@
+/* ========================================================================
+ * Copyright (c) 2005-2026 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+
+namespace Opc.Ua
+{
+    /// <summary>
+    /// Helpers for working with <see cref="TimeProvider"/> in monotonic duration math
+    /// and for bridging legacy public APIs that expose <see cref="int"/> tick counts.
+    /// </summary>
+    /// <remarks>
+    /// These helpers are intentionally <c>internal</c> because they exist purely to
+    /// support the migration off <see cref="HiResClock"/>; new public APIs should
+    /// consume <see cref="TimeProvider"/> directly via constructor injection.
+    /// </remarks>
+    internal static class TimeProviderExtensions
+    {
+        /// <summary>
+        /// Returns the current monotonic timestamp normalised to milliseconds.
+        /// </summary>
+        /// <remarks>
+        /// Equivalent to <see cref="HiResClock.TickCount64"/>, computed from
+        /// <see cref="TimeProvider.GetTimestamp"/> and the provider's
+        /// <see cref="TimeProvider.TimestampFrequency"/>.
+        /// </remarks>
+        public static long GetTimestampMilliseconds(this TimeProvider timeProvider)
+        {
+            if (timeProvider == null)
+            {
+                throw new ArgumentNullException(nameof(timeProvider));
+            }
+            long ticks = timeProvider.GetTimestamp();
+            long frequency = timeProvider.TimestampFrequency;
+            return ticks / (frequency / 1000L);
+        }
+
+        /// <summary>
+        /// Returns a monotonic 32-bit tick count derived from the provider's
+        /// millisecond timestamp.
+        /// </summary>
+        /// <remarks>
+        /// Provided strictly for back-compatibility with public APIs that still
+        /// expose <see cref="int"/> tick values (e.g.
+        /// <c>Session.LastKeepAliveTickCount</c>). The value wraps every
+        /// ~49.7 days, matching the semantics of <see cref="Environment.TickCount"/>.
+        /// New code should store the underlying <see cref="long"/> timestamp instead.
+        /// </remarks>
+        public static int GetTickCount(this TimeProvider timeProvider)
+        {
+            return unchecked((int)timeProvider.GetTimestampMilliseconds());
+        }
+
+        /// <summary>
+        /// Returns the elapsed time since the supplied start timestamp obtained
+        /// from <see cref="TimeProvider.GetTimestamp"/>.
+        /// </summary>
+        public static TimeSpan GetElapsedTimeSince(
+            this TimeProvider timeProvider,
+            long startTimestamp)
+        {
+            if (timeProvider == null)
+            {
+                throw new ArgumentNullException(nameof(timeProvider));
+            }
+            return timeProvider.GetElapsedTime(startTimestamp);
+        }
+    }
+}

--- a/Stack/Opc.Ua.Core/Types/Utils/TimeProviderExtensions.cs
+++ b/Stack/Opc.Ua.Core/Types/Utils/TimeProviderExtensions.cs
@@ -40,7 +40,7 @@ namespace Opc.Ua
     /// </summary>
     /// <remarks>
     /// These helpers exist primarily to support the migration off
-    /// <see cref="HiResClock"/>; new public APIs should consume
+    /// <c>HiResClock</c>; new public APIs should consume
     /// <see cref="TimeProvider"/> directly via constructor injection.
     /// </remarks>
     public static class TimeProviderExtensions
@@ -49,7 +49,7 @@ namespace Opc.Ua
         /// Returns the current monotonic timestamp normalised to milliseconds.
         /// </summary>
         /// <remarks>
-        /// Equivalent to <see cref="HiResClock.TickCount64"/>, computed from
+        /// Equivalent to <c>HiResClock.TickCount64</c>, computed from
         /// <see cref="TimeProvider.GetTimestamp"/> and the provider's
         /// <see cref="TimeProvider.TimestampFrequency"/>.
         /// </remarks>

--- a/Stack/Opc.Ua.Core/Types/Utils/TimeProviderExtensions.cs
+++ b/Stack/Opc.Ua.Core/Types/Utils/TimeProviderExtensions.cs
@@ -29,6 +29,8 @@
  * ======================================================================*/
 
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Opc.Ua
 {
@@ -91,6 +93,147 @@ namespace Opc.Ua
                 throw new ArgumentNullException(nameof(timeProvider));
             }
             return timeProvider.GetElapsedTime(startTimestamp);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="Task"/> that completes after the supplied
+        /// <paramref name="delay"/> measured by the supplied
+        /// <paramref name="timeProvider"/>, or when the
+        /// <paramref name="cancellationToken"/> is cancelled.
+        /// </summary>
+        /// <remarks>
+        /// Polyfill for the .NET 8+ <c>Task.Delay(TimeSpan, TimeProvider,
+        /// CancellationToken)</c> static method that is not available on
+        /// netstandard2.0 / .NET Framework. On .NET 8+ this delegates to the
+        /// built-in BCL overload; on older targets it is implemented manually
+        /// using <see cref="TimeProvider.CreateTimer"/>.
+        /// </remarks>
+        public static Task Delay(
+            this TimeProvider timeProvider,
+            TimeSpan delay,
+            CancellationToken cancellationToken = default)
+        {
+            if (timeProvider == null)
+            {
+                throw new ArgumentNullException(nameof(timeProvider));
+            }
+#if NET8_0_OR_GREATER
+            return Task.Delay(delay, timeProvider, cancellationToken);
+#else
+            if (timeProvider == TimeProvider.System)
+            {
+                return Task.Delay(delay, cancellationToken);
+            }
+            if (delay != Timeout.InfiniteTimeSpan && delay < TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(nameof(delay));
+            }
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return Task.FromCanceled(cancellationToken);
+            }
+            if (delay == TimeSpan.Zero)
+            {
+                return Task.CompletedTask;
+            }
+            var state = new DelayState(cancellationToken);
+            state.Timer = timeProvider.CreateTimer(
+                static obj =>
+                {
+                    var s = (DelayState)obj!;
+                    s.TrySetResult(true);
+                    s.Registration.Dispose();
+                    s.Timer?.Dispose();
+                },
+                state,
+                delay,
+                Timeout.InfiniteTimeSpan);
+            if (cancellationToken.CanBeCanceled)
+            {
+                state.Registration = cancellationToken.Register(
+                    static obj =>
+                    {
+                        var s = (DelayState)obj!;
+                        s.TrySetCanceled(s.Token);
+                        s.Timer?.Dispose();
+                    },
+                    state);
+            }
+            return state.Task;
+#endif
+        }
+
+#if !NET8_0_OR_GREATER
+        private sealed class DelayState : TaskCompletionSource<bool>
+        {
+            public DelayState(CancellationToken cancellationToken)
+                : base(TaskCreationOptions.RunContinuationsAsynchronously)
+            {
+                Token = cancellationToken;
+            }
+
+            public CancellationToken Token { get; }
+            public ITimer? Timer { get; set; }
+            public CancellationTokenRegistration Registration { get; set; }
+        }
+#endif
+
+        /// <summary>
+        /// Creates a <see cref="CancellationTokenSource"/> that cancels
+        /// automatically after the supplied <paramref name="delay"/> measured
+        /// by the supplied <paramref name="timeProvider"/>.
+        /// </summary>
+        /// <remarks>
+        /// Polyfill for the .NET 8+
+        /// <c>CancellationTokenSource(TimeSpan, TimeProvider)</c> constructor
+        /// that is not available on netstandard2.0 / .NET Framework. On
+        /// .NET 8+ this delegates to the built-in BCL constructor; on older
+        /// targets it is implemented manually using
+        /// <see cref="TimeProvider.CreateTimer"/>.
+        /// </remarks>
+        public static CancellationTokenSource CreateCancellationTokenSource(
+            this TimeProvider timeProvider,
+            TimeSpan delay)
+        {
+            if (timeProvider == null)
+            {
+                throw new ArgumentNullException(nameof(timeProvider));
+            }
+#if NET8_0_OR_GREATER
+            return new CancellationTokenSource(delay, timeProvider);
+#else
+            if (timeProvider == TimeProvider.System)
+            {
+                return new CancellationTokenSource(delay);
+            }
+            if (delay != Timeout.InfiniteTimeSpan && delay < TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(nameof(delay));
+            }
+            var cts = new CancellationTokenSource();
+            if (delay == Timeout.InfiniteTimeSpan)
+            {
+                return cts;
+            }
+            ITimer? timer = null;
+            timer = timeProvider.CreateTimer(
+                static state =>
+                {
+                    var inner = (CancellationTokenSource)state!;
+                    try
+                    {
+                        inner.Cancel();
+                    }
+                    catch (ObjectDisposedException)
+                    {
+                    }
+                },
+                cts,
+                delay,
+                Timeout.InfiniteTimeSpan);
+            cts.Token.Register(static t => ((ITimer)t!).Dispose(), timer);
+            return cts;
+#endif
         }
     }
 }

--- a/Tests/Opc.Ua.Client.Tests/Streaming/StreamingSubscriptionExtensionsTests.cs
+++ b/Tests/Opc.Ua.Client.Tests/Streaming/StreamingSubscriptionExtensionsTests.cs
@@ -166,7 +166,7 @@ namespace Opc.Ua.Client.Tests.Streaming
             Assert.That(async () =>
             {
                 await foreach (int _ in InfiniteWithDelay(10)
-                    .WithTimeoutAsync(TimeSpan.FromSeconds(5), cts.Token))
+                    .WithTimeoutAsync(TimeSpan.FromSeconds(5), ct: cts.Token))
                 {
                     // Drains until the outer CT cancels — should throw OCE,
                     // not silently complete the way the internal timeout

--- a/Tests/Opc.Ua.Core.Tests/Opc.Ua.Core.Tests.csproj
+++ b/Tests/Opc.Ua.Core.Tests/Opc.Ua.Core.Tests.csproj
@@ -6,9 +6,13 @@
     <GenerateProgramFile>false</GenerateProgramFile>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net48' or '$(TargetFramework)' == 'net472'">
+    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" PrivateAssets="all" />
     <PackageReference Include="Moq" />
     <PackageReference Include="NUnit" />
     <PackageReference Include="NUnit.Console" />

--- a/Tests/Opc.Ua.Core.Tests/Security/Identity/JwksIssuerKeyResolverTests.cs
+++ b/Tests/Opc.Ua.Core.Tests/Security/Identity/JwksIssuerKeyResolverTests.cs
@@ -36,6 +36,7 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Time.Testing;
 using NUnit.Framework;
 using Opc.Ua.Identity;
 
@@ -76,7 +77,7 @@ namespace Opc.Ua.Core.Tests.Security.Identity
             using var handler = new QueueMessageHandler(
                 CreateJwks(CreateRsaJwk(first, "kid-1", "sig")),
                 CreateJwks(CreateRsaJwk(second, "kid-2", "sig")));
-            using var httpClient = new HttpClient(handler, disposeHandler: false);
+            using HttpClient httpClient = new HttpClient(handler, disposeHandler: false);
             using var resolver = new JwksIssuerKeyResolver(
                 "https://issuer.example.test",
                 "https://issuer.example.test/keys",
@@ -216,21 +217,6 @@ namespace Opc.Ua.Core.Tests.Security.Identity
                     Content = new StringContent(m_responses.Dequeue(), Encoding.UTF8, "application/json")
                 };
                 return Task.FromResult(response);
-            }
-        }
-
-        private sealed class FakeTimeProvider : TimeProvider
-        {
-            private DateTimeOffset m_now = new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
-
-            public override DateTimeOffset GetUtcNow()
-            {
-                return m_now;
-            }
-
-            public void Advance(TimeSpan interval)
-            {
-                m_now += interval;
             }
         }
     }

--- a/Tests/Opc.Ua.Core.Tests/Types/Utils/HiResClock.cs
+++ b/Tests/Opc.Ua.Core.Tests/Types/Utils/HiResClock.cs
@@ -33,6 +33,8 @@ using System.Runtime.InteropServices;
 using BenchmarkDotNet.Attributes;
 using NUnit.Framework;
 
+#pragma warning disable CS0618 // Self-test for the [Obsolete] HiResClock API.
+
 namespace Opc.Ua.Core.Tests.Types.UtilsTests
 {
     /// <summary>

--- a/Tests/Opc.Ua.PubSub.Tests/Configuration/UaPublisherTests.cs
+++ b/Tests/Opc.Ua.PubSub.Tests/Configuration/UaPublisherTests.cs
@@ -73,7 +73,7 @@ namespace Opc.Ua.PubSub.Tests.Configuration
                 {
                     lock (s_lock)
                     {
-                        s_publishTicks.Add(HiResClock.Ticks);
+                        s_publishTicks.Add(TimeProvider.System.GetTimestamp());
                     }
                 });
 
@@ -123,7 +123,7 @@ namespace Opc.Ua.PubSub.Tests.Configuration
                 {
                     lock (s_lock)
                     {
-                        s_publishTicks.Add(HiResClock.Ticks);
+                        s_publishTicks.Add(TimeProvider.System.GetTimestamp());
                     }
                 });
 
@@ -180,7 +180,7 @@ namespace Opc.Ua.PubSub.Tests.Configuration
             for (int i = 1; i < publishTicks.Count; i++)
             {
                 double interval = (publishTicks[i] - publishTicks[i - 1]) /
-                    HiResClock.TicksPerMillisecond;
+                    (TimeProvider.System.TimestampFrequency / 1000.0);
                 if (interval != 0)
                 {
                     double deviation = -1;

--- a/Tests/Opc.Ua.PubSub.Tests/IntervalRunnerTests.cs
+++ b/Tests/Opc.Ua.PubSub.Tests/IntervalRunnerTests.cs
@@ -30,8 +30,10 @@
 // CA2000: test code; many disposables are ownership-transferred to test fixtures or short-lived,
 // making CA2000 noisy without a real leak risk. Disabled file-level for the suite.
 #pragma warning disable CA2000
+using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Time.Testing;
 using NUnit.Framework;
 using Opc.Ua.Tests;
 
@@ -262,6 +264,94 @@ namespace Opc.Ua.PubSub.Tests
                 42, 100, () => true, () => Task.CompletedTask, m_telemetry);
 
             Assert.That(runner.Id, Is.EqualTo(42));
+        }
+
+        [Test]
+        public async Task FakeTimeProviderDrivesDeterministicSchedulingAsync()
+        {
+            var fake = new FakeTimeProvider();
+            int executionCount = 0;
+            using var runner = new IntervalRunner(
+                "fake-runner",
+                100,
+                () => true,
+                () =>
+                {
+                    Interlocked.Increment(ref executionCount);
+                    return Task.CompletedTask;
+                },
+                m_telemetry,
+                fake);
+
+            runner.Start();
+
+            // The first loop iteration runs synchronously (sleepCycle == 0)
+            // and queues the action on the thread pool.
+            await WaitForAsync(() => Volatile.Read(ref executionCount) >= 1)
+                .ConfigureAwait(false);
+            int afterStart = Volatile.Read(ref executionCount);
+
+            // Advance the fake clock by one interval; the awaited Delay completes
+            // deterministically and the next action fires.
+            fake.Advance(TimeSpan.FromMilliseconds(100));
+            await WaitForAsync(() => Volatile.Read(ref executionCount) >= afterStart + 1)
+                .ConfigureAwait(false);
+
+            // Advance three intervals at once; expect three more actions.
+            int afterFirstAdvance = Volatile.Read(ref executionCount);
+            fake.Advance(TimeSpan.FromMilliseconds(300));
+            await WaitForAsync(
+                () => Volatile.Read(ref executionCount) >= afterFirstAdvance + 3)
+                .ConfigureAwait(false);
+
+            runner.Stop();
+        }
+
+        [Test]
+        public async Task FakeTimeProviderWithoutAdvanceDoesNotExecuteRepeatedlyAsync()
+        {
+            var fake = new FakeTimeProvider();
+            int executionCount = 0;
+            using var runner = new IntervalRunner(
+                "fake-runner-no-advance",
+                100,
+                () => true,
+                () =>
+                {
+                    Interlocked.Increment(ref executionCount);
+                    return Task.CompletedTask;
+                },
+                m_telemetry,
+                fake);
+
+            runner.Start();
+
+            // The first iteration runs immediately (sleepCycle == 0) and queues an action.
+            await WaitForAsync(() => Volatile.Read(ref executionCount) >= 1)
+                .ConfigureAwait(false);
+
+            // Without advancing the fake clock, subsequent iterations stay parked in
+            // Delay; assert the count stays at 1 for a long real-time window.
+            await Task.Delay(200).ConfigureAwait(false);
+
+            runner.Stop();
+            Assert.That(Volatile.Read(ref executionCount), Is.EqualTo(1));
+        }
+
+        private static async Task WaitForAsync(
+            Func<bool> condition,
+            TimeSpan? timeout = null)
+        {
+            TimeSpan deadline = timeout ?? TimeSpan.FromSeconds(5);
+            DateTime end = DateTime.UtcNow + deadline;
+            while (!condition())
+            {
+                if (DateTime.UtcNow > end)
+                {
+                    Assert.Fail($"Condition not satisfied within {deadline.TotalMilliseconds}ms.");
+                }
+                await Task.Delay(5).ConfigureAwait(false);
+            }
         }
     }
 }

--- a/Tests/Opc.Ua.PubSub.Tests/Opc.Ua.PubSub.Tests.csproj
+++ b/Tests/Opc.Ua.PubSub.Tests/Opc.Ua.PubSub.Tests.csproj
@@ -22,6 +22,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Moq" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" PrivateAssets="all" />
     <PackageReference Include="coverlet.collector">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Tests/Opc.Ua.Server.Tests/SubscriptionTests.cs
+++ b/Tests/Opc.Ua.Server.Tests/SubscriptionTests.cs
@@ -129,7 +129,7 @@ namespace Opc.Ua.Server.Tests
             ResetKeepAlive(subscription);
 
             // Set expiry in far future
-            SetExpiryTime(subscription, HiResClock.TickCount64 + 100000);
+            SetExpiryTime(subscription, TimeProvider.System.GetTimestampMilliseconds() + 100000);
 
             PublishingState state = subscription.PublishTimerExpired();
 
@@ -142,7 +142,7 @@ namespace Opc.Ua.Server.Tests
             using Subscription subscription = CreateSubscription(1000);
             // Don't reset keepalive, it should be maxKeepAliveCount initially.
 
-            SetExpiryTime(subscription, HiResClock.TickCount64 - 100);
+            SetExpiryTime(subscription, TimeProvider.System.GetTimestampMilliseconds() - 100);
 
             PublishingState state = subscription.PublishTimerExpired();
 
@@ -154,7 +154,7 @@ namespace Opc.Ua.Server.Tests
         {
             using Subscription subscription = CreateSubscription(1000);
             ResetKeepAlive(subscription);
-            SetExpiryTime(subscription, HiResClock.TickCount64 - 100);
+            SetExpiryTime(subscription, TimeProvider.System.GetTimestampMilliseconds() - 100);
 
             // Mock Monitored Item
             var itemMock = new Mock<IMonitoredItem>();
@@ -174,7 +174,7 @@ namespace Opc.Ua.Server.Tests
         {
             using Subscription subscription = CreateSubscription(1000);
             ResetKeepAlive(subscription);
-            SetExpiryTime(subscription, HiResClock.TickCount64 - 100);
+            SetExpiryTime(subscription, TimeProvider.System.GetTimestampMilliseconds() - 100);
 
             // Mock Monitored Item
             var itemMock = new Mock<IMonitoredItem>();
@@ -194,7 +194,7 @@ namespace Opc.Ua.Server.Tests
         {
             using Subscription subscription = CreateSubscription(1000);
             ResetKeepAlive(subscription);
-            SetExpiryTime(subscription, HiResClock.TickCount64 - 100);
+            SetExpiryTime(subscription, TimeProvider.System.GetTimestampMilliseconds() - 100);
 
             Assert.That(subscription.Diagnostics.CurrentKeepAliveCount, Is.Zero);
 
@@ -208,7 +208,7 @@ namespace Opc.Ua.Server.Tests
         {
             using Subscription subscription = CreateSubscription(1000);
             ResetKeepAlive(subscription);
-            SetExpiryTime(subscription, HiResClock.TickCount64 - 100);
+            SetExpiryTime(subscription, TimeProvider.System.GetTimestampMilliseconds() - 100);
 
             // Item A: Triggering item. Ready to publish, Ready to trigger.
             var itemAMock = new Mock<IMonitoredItem>();
@@ -303,7 +303,7 @@ namespace Opc.Ua.Server.Tests
             itemMock.SetupGet(i => i.MonitoredItemType).Returns(MonitoredItemTypeMask.DataChange);
 
             AddMonitoredItem(subscription, itemMock.Object);
-            SetExpiryTime(subscription, HiResClock.TickCount64 - 100);
+            SetExpiryTime(subscription, TimeProvider.System.GetTimestampMilliseconds() - 100);
             PublishingState state = subscription.PublishTimerExpired();
 
             AddMonitoredItemToPublish(subscription, itemMock.Object);

--- a/Tests/Opc.Ua.Sessions.Tests/ClientTest.cs
+++ b/Tests/Opc.Ua.Sessions.Tests/ClientTest.cs
@@ -1180,10 +1180,6 @@ namespace Opc.Ua.Sessions.Tests
             TestContext.Out.WriteLine("SubscriptionCount: {0}", Session.SubscriptionCount);
             TestContext.Out.WriteLine("DefaultSubscription: {0}", Session.DefaultSubscription);
             TestContext.Out.WriteLine("LastKeepAliveTime: {0}", Session.LastKeepAliveTime);
-#pragma warning disable CS0618 // Verify legacy LastKeepAliveTickCount still exposed.
-            TestContext.Out
-                .WriteLine("LastKeepAliveTickCount: {0}", Session.LastKeepAliveTickCount);
-#pragma warning restore CS0618
             TestContext.Out
                 .WriteLine("LastKeepAliveTimestamp: {0}", Session.LastKeepAliveTimestamp);
             TestContext.Out.WriteLine("KeepAliveInterval: {0}", Session.KeepAliveInterval);

--- a/Tests/Opc.Ua.Sessions.Tests/ClientTest.cs
+++ b/Tests/Opc.Ua.Sessions.Tests/ClientTest.cs
@@ -1180,8 +1180,12 @@ namespace Opc.Ua.Sessions.Tests
             TestContext.Out.WriteLine("SubscriptionCount: {0}", Session.SubscriptionCount);
             TestContext.Out.WriteLine("DefaultSubscription: {0}", Session.DefaultSubscription);
             TestContext.Out.WriteLine("LastKeepAliveTime: {0}", Session.LastKeepAliveTime);
+#pragma warning disable CS0618 // Verify legacy LastKeepAliveTickCount still exposed.
             TestContext.Out
                 .WriteLine("LastKeepAliveTickCount: {0}", Session.LastKeepAliveTickCount);
+#pragma warning restore CS0618
+            TestContext.Out
+                .WriteLine("LastKeepAliveTimestamp: {0}", Session.LastKeepAliveTimestamp);
             TestContext.Out.WriteLine("KeepAliveInterval: {0}", Session.KeepAliveInterval);
             Session.KeepAliveInterval += 1000;
             TestContext.Out.WriteLine("KeepAliveInterval: {0}", Session.KeepAliveInterval);


### PR DESCRIPTION
# Description

Adopt [`System.TimeProvider`](https://learn.microsoft.com/dotnet/api/system.timeprovider) across the stack so that every place that creates timers, runs duration math, or schedules periodic work is mockable, deterministic in tests, and immune to wall-clock changes.

The migration touches Core, Core.Types, Server, Client, PubSub, Configuration, Gds (server + client), Lds, and the Quickstarts/Console reference apps. Per-component changes follow the same pattern:

1. Add a `private readonly TimeProvider m_timeProvider;` field.
2. Accept a nullable `TimeProvider? timeProvider = null` as the **last** constructor parameter (new overload; legacy constructor stays for binary compatibility and delegates with `timeProvider: null`).
3. Initialise the field with `m_timeProvider = timeProvider ??= TimeProvider.System;`.
4. Replace `new Timer(...)`, `Stopwatch`, `HiResClock.*`, `DateTime.UtcNow`-based duration math, and `Task.Delay(delay, ct)` in timing loops with the matching `m_timeProvider` API (`CreateTimer`, `GetTimestamp` / `GetElapsedTime`, `GetUtcNow().UtcDateTime`, `Task.Delay(delay, m_timeProvider, ct)`).
5. Wire the provider through DI: `AddOpcUaServerBuilder` / `AddOpcUaClientBuilder` register `TimeProvider.System` via `TryAddSingleton<TimeProvider>()` so tests can swap in `Microsoft.Extensions.Time.Testing.FakeTimeProvider`.

`HiResClock` itself is kept (so the `ApplicationConfiguration.DisableHiResClock` schema flag still round-trips), but **every public member** is now `[Obsolete]` with a single shared message pointing to the new migration-guide section. The few internal call sites that still need to set/read `HiResClock` are wrapped with `#pragma warning disable CS0618`.

### Highlights per component

- **Core / Stack** — `Opc.Ua.Core`, `Opc.Ua.Core.Types`, channel pipeline (`UaSCBinaryClientChannel`, `ChannelToken`, `UaSCBinaryChannel`), `ApplicationConfiguration`, certificate validators, `JwksIssuerKeyResolver`, `TimeProviderExtensions` polyfills (`GetTimestampMilliseconds`, `GetTickCount`, `CancellationTokenSource(timeout, timeProvider)`, `Task.Delay(delay, provider, ct)` polyfill for older TFMs).
- **Server** — session lockout, subscription pipeline (publish/sample/keep-alive/lifetime), `MonitoredItemQueue`, alarm sampling rate, `IntervalRunner`, server diagnostics, configuration state machines, hosted services.
- **Client** — `Session`, managed/V2 subscription engines, reconnect handlers, channel keep-alive, periodic publishing, complex-type discovery polling.
- **PubSub** — `IntervalRunner` pipeline, message-receive timers, MQTT/UDP keep-alive, publishers/readers.
- **Gds / Lds** — `LdsServer`, `LinqApplicationsDatabase` expiry housekeeping, GDS clients (push, pull), `DirectoryCertificateStore`, `ConnectionStateMachine`, classic subscription engine.
- **Quickstarts / Console samples** — `SampleNodeManager`, `ReferenceNodeManager`, `AlarmNodeManager`, `BoilerState`, `MemoryBufferState`, `PublishedValuesWrites`. Samples resolve via `(Server as ITimeProviderProvider)?.TimeProvider ?? TimeProvider.System` so existing ctor signatures stay binary-compatible.
- **Tests** — `Opc.Ua.PubSub.Tests` adds `IntervalRunnerTests`; existing `SubscriptionTests`, `UaPublisherTests`, and `TestDataSystem` move off `HiResClock`. Added `Microsoft.Extensions.TimeProvider.Testing` package for `FakeTimeProvider` (project-load warning surfaces on net48/net472 only — runtime is .NET 8+).

### Migration guide

New section [**Time and Timer abstraction (`TimeProvider`)**](Docs/MigrationGuide.md#time-and-timer-abstraction-timeprovider) documents:

- The canonical replacement table (`HiResClock.UtcNow` → `timeProvider.GetUtcNow().UtcDateTime`, `HiResClock.TickCount64` → `timeProvider.GetTimestamp()`, `new Timer` → `timeProvider.CreateTimer`, `Task.Delay(delay, ct)` → `Task.Delay(delay, timeProvider, ct)`, …).
- The `TimeProvider? timeProvider = null` + `??=` constructor pattern.
- DI wiring and how to swap in `FakeTimeProvider` in tests.
- Before/after snippets for `HiResClock.TickCount64`, `HiResClock.UtcNow`, and `new Timer(...)`.

## Related Issues

- Fixes #2458

## Checklist

- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf) and read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [x] I have added all necessary documentation.
- [x] I have verified that my changes do not introduce (new) build or analyzer warnings.
- [ ] I ran **all** tests locally using the **UA.slnx** solution against at least .net **framework** and .net **10**, and all passed.
- [ ] I fixed **all** failing and flaky tests in the CI pipelines and **all** CodeQL warnings.
- [ ] I have addressed **all** PR feedback received.
