### PR TITLE
Fix Race condition in OnPublishComplete

### DIFF
--- a/Libraries/Opc.Ua.Client/Session/Session.cs
+++ b/Libraries/Opc.Ua.Client/Session/Session.cs
@@ -3570,7 +3570,16 @@ namespace Opc.Ua.Client
             }
             catch (Exception e)
             {
-                if (m_subscriptions.Count == 0)
+                int subscriptionCount;
+                bool hasCreatedSubscriptions;
+
+                lock (m_lock)
+                {
+                    subscriptionCount = m_subscriptions.Count;
+                    hasCreatedSubscriptions = m_subscriptions.Any(s => s.Created);
+                }
+
+                if (subscriptionCount == 0)
                 {
                     // Publish responses with error should occur after deleting the last subscription.
                     m_logger.LogWarning(
@@ -3591,7 +3600,7 @@ namespace Opc.Ua.Client
                 var error = new ServiceResult(e);
 
                 // raise publish error even for BadNoSubscription if there are active subscriptions.
-                if (error.Code != StatusCodes.BadNoSubscription || m_subscriptions.Any(s => s.Created))
+                if (error.Code != StatusCodes.BadNoSubscription || hasCreatedSubscriptions)
                 {
                     PublishErrorEventHandler? callback = m_PublishError;
 


### PR DESCRIPTION
# Description

The catch block in OnPublishComplete reads m_subscriptions.Count and m_subscriptions.Any(s => s.Created) without holding m_lock, while all other accesses (AddSubscription, RemoveSubscriptionAsync, RemoveTransferredSubscription) correctly lock before modifying the list.

This causes an InvalidOperationException ("Collection was modified; enumeration operation may not execute") when a publish response errors concurrently with a subscription being removed during reconnect.

Snapshot both values under m_lock, consistent with all other call sites.

## Related Issues

- Fixes #3835

## Checklist

_Put an `x` in the boxes that apply. You can complete these step by step after opening the PR._

- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf) and read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added all necessary documentation.
- [x] I have verified that my changes do not introduce (new) build or analyzer warnings.
- [ ] I ran **all** tests locally using the **UA.slnx** solution against at least .net **framework** and .net **10**, and all passed.
- [ ] I fixed **all** failing and flaky tests in the CI pipelines and **all** CodeQL warnings.
- [ ] I have addressed **all** PR feedback received.
