### PR TITLE
Prune extra decoded children that should stay on the type definition only.

### DIFF
--- a/Stack/Opc.Ua.Types/State/BaseInstanceState.cs
+++ b/Stack/Opc.Ua.Types/State/BaseInstanceState.cs
@@ -48,7 +48,7 @@ namespace Opc.Ua
         }
 
         /// <inheritdoc/>
-        protected override bool RemovePlaceholderChildrenOnCreate => true;
+        protected override bool PruneNonRuntimeInstanceChildrenOnCreate => true;
 
         /// <summary>
         /// Initializes the instance from another instance.

--- a/Stack/Opc.Ua.Types/State/NodeState.cs
+++ b/Stack/Opc.Ua.Types/State/NodeState.cs
@@ -2710,9 +2710,9 @@ namespace Opc.Ua
         {
             Initialize(context);
 
-            if (RemovePlaceholderChildrenOnCreate)
+            if (PruneNonRuntimeInstanceChildrenOnCreate)
             {
-                RemovePlaceholderChildren(context);
+                PruneNonRuntimeInstanceChildren(context);
             }
 
             // Call OnBeforeCreate on all children.
@@ -2824,9 +2824,9 @@ namespace Opc.Ua
         {
             Initialize(context, source);
 
-            if (RemovePlaceholderChildrenOnCreate)
+            if (PruneNonRuntimeInstanceChildrenOnCreate)
             {
-                RemovePlaceholderChildren(context);
+                PruneNonRuntimeInstanceChildren(context);
             }
 
             CallOnBeforeCreate(context);
@@ -2837,14 +2837,14 @@ namespace Opc.Ua
         }
 
         /// <summary>
-        /// Whether placeholder declarations should be removed during runtime creation.
+        /// Whether generated children that should not exist on runtime instances should be removed during creation.
         /// </summary>
-        protected virtual bool RemovePlaceholderChildrenOnCreate => false;
+        protected virtual bool PruneNonRuntimeInstanceChildrenOnCreate => false;
 
         /// <summary>
-        /// Removes instantiated placeholder declarations from runtime instances.
+        /// Removes generated children that should not exist on runtime instances.
         /// </summary>
-        private void RemovePlaceholderChildren(ISystemContext context)
+        private void PruneNonRuntimeInstanceChildren(ISystemContext context)
         {
             var children = new List<BaseInstanceState>();
             GetChildren(context, children);
@@ -2853,7 +2853,7 @@ namespace Opc.Ua
             {
                 BaseInstanceState child = children[ii];
 
-                if (IsPlaceholderChild(child))
+                if (ShouldPruneChildOnCreate(child))
                 {
                     RemoveChild(child);
 
@@ -2865,17 +2865,25 @@ namespace Opc.Ua
                     continue;
                 }
 
-                child.RemovePlaceholderChildren(context);
+                child.PruneNonRuntimeInstanceChildren(context);
             }
         }
 
         /// <summary>
-        /// Returns true if the child represents a placeholder declaration.
+        /// Returns true if the child should not be kept on a runtime instance.
         /// </summary>
-        private static bool IsPlaceholderChild(BaseInstanceState child)
+        private bool ShouldPruneChildOnCreate(BaseInstanceState child)
         {
             if (child.ModellingRuleId == ObjectIds.ModellingRule_OptionalPlaceholder ||
                 child.ModellingRuleId == ObjectIds.ModellingRule_MandatoryPlaceholder)
+            {
+                return true;
+            }
+
+            if (IsDynamicChild(child) &&
+                HasGeneratedNumericNodeIdentity(child) &&
+                child.ModellingRuleId != ObjectIds.ModellingRule_Mandatory &&
+                child.ModellingRuleId != ObjectIds.ModellingRule_Optional)
             {
                 return true;
             }
@@ -2884,9 +2892,8 @@ namespace Opc.Ua
 
             // Some generated placeholder declarations reach runtime without their
             // placeholder modelling rule; the fallback is limited to model-defined
-            // standard nodes that still carry the generated <PlaceholderName>
-            // browse-name form.
-            return IsGeneratedStandardNumericNode(child) &&
+            // nodes that still carry the generated <PlaceholderName> browse-name form.
+            return HasGeneratedNumericNodeIdentity(child) &&
                 browseName != null &&
                 browseName.Length > 1 &&
                 browseName[0] == '<' &&
@@ -2894,16 +2901,42 @@ namespace Opc.Ua
         }
 
         /// <summary>
-        /// Returns true if the child still has its generated standard numeric node identity.
+        /// Returns true if the child still has its generated numeric node identity.
         /// </summary>
-        private static bool IsGeneratedStandardNumericNode(BaseInstanceState child)
+        private static bool HasGeneratedNumericNodeIdentity(BaseInstanceState child)
         {
             return child.NumericId != 0 &&
                 child.NodeId != null &&
-                child.NodeId.NamespaceIndex == 0 &&
                 child.NodeId.IdType == IdType.Numeric &&
                 child.NodeId.Identifier is uint identifier &&
                 identifier == child.NumericId;
+        }
+
+        /// <summary>
+        /// Returns true if the child is stored in the dynamic child list.
+        /// These are extra children decoded from the InitializationString that
+        /// do not match a strongly typed generated child and are stored in the
+        /// generic m_children list.
+        /// </summary>
+        private bool IsDynamicChild(BaseInstanceState child)
+        {
+            lock (m_childrenLock)
+            {
+                if (m_children == null)
+                {
+                    return false;
+                }
+
+                for (int ii = 0; ii < m_children.Count; ii++)
+                {
+                    if (ReferenceEquals(m_children[ii], child))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
         }
 
         /// <summary>

--- a/Tests/Opc.Ua.Core.Tests/Stack/State/NodeStateTests.cs
+++ b/Tests/Opc.Ua.Core.Tests/Stack/State/NodeStateTests.cs
@@ -141,6 +141,28 @@ namespace Opc.Ua.Core.Tests.Stack.State
         }
 
         /// <summary>
+        /// Verify generated state machine declarations without modelling rules are not instantiated.
+        /// </summary>
+        [Test]
+        public void ProgramStateMachineState_ShouldNotInstantiateChildrenWithoutMandatoryOrOptionalModellingRule()
+        {
+            ITelemetryContext telemetry = NUnitTelemetryContext.Create();
+            var context = new SystemContext(telemetry) { NamespaceUris = Context.NamespaceUris };
+            var stateMachine = new ProgramStateMachineState(null);
+
+            stateMachine.Create(context, new NodeId(300000), "Name", "DisplayName", true);
+
+            Assert.NotNull(
+                stateMachine.FindChild(context, BrowseNames.CurrentState),
+                "Mandatory child CurrentState should be instantiated.");
+            Assert.Null(
+                stateMachine.FindChild(context, BrowseNames.Suspended),
+                "State declaration Suspended has no Mandatory or Optional modelling rule.");
+
+            stateMachine.Dispose();
+        }
+
+        /// <summary>
         /// Verify placeholder declarations remain available on type definitions.
         /// </summary>
         [Test]


### PR DESCRIPTION
Keep the generated children that belong on instances, and prune the extra decoded children that should stay on the type definition only, such as Optional/Mandatory placeholders and ones that do not have Mandatory/Optional ModellingRules.

# Description

Currently child nodes that are type definition detailes such as ones that do not have Mandatory/Optional ModellingRules are instantiated in the runtime instance of such type definitions. This PR proposes to correct this behaviour during NodeState creation as an alternative from it being fixed by the ModelCompiler.

## Related Issues

- Fixes #3770 

## Checklist

_Put an `x` in the boxes that apply. You can complete these step by step after opening the PR._

- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf) and read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added all necessary documentation.
- [ ] I have verified that my changes do not introduce (new) build or analyzer warnings.
- [ ] I ran **all** tests locally using the **UA.slnx** solution against at least .net **framework** and .net **10**, and all passed.
- [ ] I fixed **all** failing and flaky tests in the CI pipelines and **all** CodeQL warnings.
- [ ] I have addressed **all** PR feedback received.
