### PR TITLE
[master378] Use request.SessionId instead of request.Session.Id in the ReportAuditCancelEvent call from CancelRequests.

### DIFF
--- a/Libraries/Opc.Ua.Server/Server/RequestManager.cs
+++ b/Libraries/Opc.Ua.Server/Server/RequestManager.cs
@@ -164,7 +164,7 @@ namespace Opc.Ua.Server
 
                         // report the AuditCancelEventType
                         m_server.ReportAuditCancelEvent(
-                            request.Session.Id,
+                            request.SessionId,
                             requestHandle,
                             StatusCodes.Good,
                             m_logger);

--- a/Tests/Opc.Ua.Server.Tests/RequestManagerTests.cs
+++ b/Tests/Opc.Ua.Server.Tests/RequestManagerTests.cs
@@ -1,0 +1,37 @@
+using Moq;
+using NUnit.Framework;
+using Opc.Ua.Tests;
+
+namespace Opc.Ua.Server.Tests
+{
+    [TestFixture]
+    [Category("Server")]
+    [Parallelizable]
+    public class RequestManagerTests
+    {
+        [Test]
+        public void CancelRequestsShouldCancelActivateSessionRequestWithoutSession()
+        {
+            const uint requestHandle = 1234;
+            var serverMock = new Mock<IServerInternal>();
+            serverMock.Setup(s => s.Telemetry).Returns(NUnitTelemetryContext.Create());
+
+            using var requestManager = new RequestManager(serverMock.Object);
+            var context = new OperationContext(
+                new RequestHeader { RequestHandle = requestHandle },
+                null,
+                RequestType.ActivateSession);
+
+            requestManager.RequestReceived(context);
+
+            uint cancelCount = 0;
+            Assert.DoesNotThrow(
+                () => requestManager.CancelRequests(requestHandle, out cancelCount));
+
+            Assert.That(cancelCount, Is.EqualTo(1));
+            Assert.That(
+                context.OperationStatus.Code,
+                Is.EqualTo(StatusCodes.BadRequestCancelledByRequest));
+        }
+    }
+}


### PR DESCRIPTION
# Description

Use request.SessionId instead of request.Session.Id in the ReportAuditCancelEvent call from CancelRequests to avoid accessing Session in case ActivateSession.

Cancel service is returning BadUnexpectedError because audit reporting crashes on request.Session.Id in case the ActivateSession service call is in-flight and its cancelation is requested becasue Session is null.

## Related Issues

- Fixes issue 3850 on branch master378

## Checklist

_Put an `x` in the boxes that apply. You can complete these step by step after opening the PR._

- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf) and read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added all necessary documentation.
- [ ] I have verified that my changes do not introduce (new) build or analyzer warnings.
- [ ] I ran **all** tests locally using the **UA.slnx** solution against at least .net **framework** and .net **10**, and all passed.
- [ ] I fixed **all** failing and flaky tests in the CI pipelines and **all** CodeQL warnings.
- [ ] I have addressed **all** PR feedback received.
