### PR TITLE
[Server] Method instances should have instance children and node ids automatically (no need to replace in runtime)

### DIFF
--- a/Libraries/Opc.Ua.Server/Diagnostics/DiagnosticsNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/Diagnostics/DiagnosticsNodeManager.cs
@@ -456,23 +456,15 @@ namespace Opc.Ua.Server
             ISystemContext context,
             ServerObjectState serverObject)
         {
-            // The generator's transitive singleton-instance gate (issue
-            // #3768) suppresses Optional Variable/Method descendants of
-            // singleton roots, so they have to be lazy-added by the SDK
-            // for the children this SDK actually implements. Add{Child}
-            // is idempotent (returns the existing typed child if present)
-            // and now dispatches the synthesized child NodeIds and the
-            // top-level NodeId on the owner's NodeId automatically, so no
-            // explicit NodeId override is needed at this call site.
-            //
-            // GetMonitoredItems / ResendData are wired unconditionally;
-            // SetSubscriptionDurable only when durable subscriptions are
-            // enabled.
-            // Server.Namespaces is consumed by ConfigurationNodeManager to
-            // register per-namespace NamespaceMetadata children.
-            // UrisVersion / EstimatedReturnTime / LocalTime are Optional
-            // Variables on ServerType that the SDK does not actively populate
-            // but were emitted on master at the well-known instance NodeIds.
+            // Lazy-add the Optional Variable/Method descendants of Server
+            // that this SDK actually implements; the generator's transitive
+            // singleton-instance gate (issue #3768) suppresses them at
+            // load time so clients reading the standard well-known instance
+            // NodeIds would otherwise get BadNodeIdUnknown. The generated
+            // Add{Child}(context) extensions dispatch the well-known
+            // NodeIds based on the owner's NodeId, so no explicit override
+            // is needed. SetSubscriptionDurable is only wired when durable
+            // subscriptions are enabled.
             serverObject
                 .AddGetMonitoredItems(context)
                 .AddResendData(context)
@@ -484,12 +476,6 @@ namespace Opc.Ua.Server
                 .AddEstimatedReturnTime(context)
                 .AddLocalTime(context);
 
-            // Optional Objects such as ServerCapabilities.OperationLimits
-            // and ServerCapabilities.RoleSet are intentionally exempt from
-            // the gate (their subtrees rely on well-known descendant
-            // NodeIds), so the dispatchers below treat the pre-existing
-            // Object as the common case and only lazy-add the missing
-            // Variable/Method children.
             if (serverObject.ServerCapabilities != null)
             {
                 AddServerCapabilitiesSdkOptionalChildren(
@@ -506,13 +492,9 @@ namespace Opc.Ua.Server
             ISystemContext context,
             ServerCapabilitiesState serverCapabilities)
         {
-            // Each Add{Child}(context) helper dispatches the well-known
-            // singleton-instance NodeId based on the owner's NodeId
-            // (Server_ServerCapabilities here), so no explicit NodeId
-            // override is needed. The OperationLimits child needs its
-            // sub-tree populated, so access the typed slot via
-            // .AddOperationLimits(...).OperationLimits! to continue
-            // chaining the operational-limit Properties.
+            // OperationLimits needs its sub-tree populated, so access the
+            // typed slot via .AddOperationLimits(...).OperationLimits! to
+            // continue chaining the operational-limit Properties.
             serverCapabilities
                 .AddMaxArrayLength(context)
                 .AddMaxStringLength(context)

--- a/Libraries/Opc.Ua.Server/Diagnostics/DiagnosticsNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/Diagnostics/DiagnosticsNodeManager.cs
@@ -213,16 +213,6 @@ namespace Opc.Ua.Server
 
             getMonitoredItems?.OnCallMethod = OnGetMonitoredItems;
 
-            // set ArrayDimensions for GetMonitoredItems.OutputArguments.Value.
-            PropertyState getMonitoredItemsOutputArguments = FindPredefinedNode<PropertyState>(
-                VariableIds.Server_GetMonitoredItems_OutputArguments);
-
-            if (getMonitoredItemsOutputArguments != null &&
-                getMonitoredItemsOutputArguments.Value.TryGetStructure(out ArrayOf<Argument> outputArgumentsValue))
-            {
-                getMonitoredItemsOutputArguments.ClearChangeMasks(SystemContext, false);
-            }
-
             if (m_durableSubscriptionsEnabled)
             {
                 // hook up the server SetSubscriptionDurable method.
@@ -466,58 +456,40 @@ namespace Opc.Ua.Server
             ISystemContext context,
             ServerObjectState serverObject)
         {
-            // The generated Add{Child}(context) extensions build the child via
-            // the TYPE-level factory (e.g. CreateServerType_Namespaces), which
-            // assigns the TYPE-level NodeId (ServerType.Namespaces) rather
-            // than the instance-level NodeId (Server.Namespaces). The
-            // singleton-instance factories that use the correct NodeIds are
-            // internal to Opc.Ua.Core.Types, so we override the NodeId
-            // post-construction to the well-known instance identifier.
-            // Add{Child} is idempotent (returns the existing typed child if
-            // present), so no null guards are needed.
+            // The generator's transitive singleton-instance gate (issue
+            // #3768) suppresses Optional Variable/Method descendants of
+            // singleton roots, so they have to be lazy-added by the SDK
+            // for the children this SDK actually implements. Add{Child}
+            // is idempotent (returns the existing typed child if present)
+            // and now dispatches the synthesized child NodeIds and the
+            // top-level NodeId on the owner's NodeId automatically, so no
+            // explicit NodeId override is needed at this call site.
             //
-            // Standard Server methods this SDK wires (DiagnosticsNodeManager).
             // GetMonitoredItems / ResendData are wired unconditionally;
             // SetSubscriptionDurable only when durable subscriptions are
-            // enabled (the conditional Add overload skips the call when
-            // m_durableSubscriptionsEnabled is false, so the existing path
-            // that explicitly removes the slot is preserved).
+            // enabled.
             // Server.Namespaces is consumed by ConfigurationNodeManager to
             // register per-namespace NamespaceMetadata children.
             // UrisVersion / EstimatedReturnTime / LocalTime are Optional
             // Variables on ServerType that the SDK does not actively populate
             // but were emitted on master at the well-known instance NodeIds.
-            // The chained Add{Child}(context, ...) helpers return `this`
-            // for the fluent style.
             serverObject
-                .AddGetMonitoredItems(context, MethodIds.Server_GetMonitoredItems)
-                .AddResendData(context, MethodIds.Server_ResendData)
+                .AddGetMonitoredItems(context)
+                .AddResendData(context)
                 .AddSetSubscriptionDurable(context,
                     m_durableSubscriptionsEnabled,
-                    _ => { },
-                    MethodIds.Server_SetSubscriptionDurable)
-                .AddNamespaces(context, ObjectIds.Server_Namespaces)
-                .AddUrisVersion(context, VariableIds.Server_UrisVersion)
-                .AddEstimatedReturnTime(context, VariableIds.Server_EstimatedReturnTime)
-                .AddLocalTime(context, VariableIds.Server_LocalTime);
+                    _ => { })
+                .AddNamespaces(context)
+                .AddUrisVersion(context)
+                .AddEstimatedReturnTime(context)
+                .AddLocalTime(context);
 
-            // The transitive generator gate (issue #3768) stops emitting
-            // Optional Variable/Method descendants of Server (e.g.
-            // ServerCapabilities child properties, OperationLimits child
-            // properties, and ServerRedundancy.RedundantServerArray). These
-            // were emitted on master at well-known instance NodeIds; the
-            // SDK consumes a number of them directly (e.g.
-            // ServerInternalData populates MaxArrayLength / MaxStringLength
-            // / MaxByteStringLength with non-null assertion, and clients
-            // read every ServerCapabilities Optional via
-            // Session.FetchOperationLimitsAsync). Add them back here so the
-            // observable address-space remains compatible. Optional Objects
-            // such as ServerCapabilities.OperationLimits and
-            // ServerCapabilities.RoleSet are intentionally exempt from the
-            // gate (their subtrees rely on well-known descendant NodeIds),
-            // so the dispatchers below treat the pre-existing Object as the
-            // common case and only lazy-add the missing Variable/Method
-            // children.
+            // Optional Objects such as ServerCapabilities.OperationLimits
+            // and ServerCapabilities.RoleSet are intentionally exempt from
+            // the gate (their subtrees rely on well-known descendant
+            // NodeIds), so the dispatchers below treat the pre-existing
+            // Object as the common case and only lazy-add the missing
+            // Variable/Method children.
             if (serverObject.ServerCapabilities != null)
             {
                 AddServerCapabilitiesSdkOptionalChildren(
@@ -530,50 +502,45 @@ namespace Opc.Ua.Server
             }
         }
 
-        private void AddServerCapabilitiesSdkOptionalChildren(
+        private static void AddServerCapabilitiesSdkOptionalChildren(
             ISystemContext context,
             ServerCapabilitiesState serverCapabilities)
         {
-            // The generated Add{Child}(context, nodeId) helpers are idempotent
-            // and now return `this` for chaining (see
-            // NodeStateTemplates.OptionalMethod). Each call patches the
-            // well-known singleton-instance NodeId so the address-space
-            // matches master (see AddServerSdkOptionalChildren for the
-            // rationale). The OperationLimits child needs its sub-tree
-            // populated, so access the typed slot via
-            // .AddOperationLimits(...).OperationLimits! to continue chaining
-            // the operational-limit Properties.
+            // Each Add{Child}(context) helper dispatches the well-known
+            // singleton-instance NodeId based on the owner's NodeId
+            // (Server_ServerCapabilities here), so no explicit NodeId
+            // override is needed. The OperationLimits child needs its
+            // sub-tree populated, so access the typed slot via
+            // .AddOperationLimits(...).OperationLimits! to continue
+            // chaining the operational-limit Properties.
             serverCapabilities
-                .AddMaxArrayLength(context, VariableIds.Server_ServerCapabilities_MaxArrayLength)
-                .AddMaxStringLength(context, VariableIds.Server_ServerCapabilities_MaxStringLength)
-                .AddMaxByteStringLength(context, VariableIds.Server_ServerCapabilities_MaxByteStringLength)
-                .AddMaxSessions(context, VariableIds.Server_ServerCapabilities_MaxSessions)
-                .AddMaxSubscriptions(context, VariableIds.Server_ServerCapabilities_MaxSubscriptions)
-                .AddMaxMonitoredItems(context, VariableIds.Server_ServerCapabilities_MaxMonitoredItems)
-                .AddMaxSubscriptionsPerSession(context, VariableIds.Server_ServerCapabilities_MaxSubscriptionsPerSession)
-                .AddMaxMonitoredItemsPerSubscription(context, VariableIds.Server_ServerCapabilities_MaxMonitoredItemsPerSubscription)
-                .AddMaxSelectClauseParameters(context, VariableIds.Server_ServerCapabilities_MaxSelectClauseParameters)
-                .AddMaxWhereClauseParameters(context, VariableIds.Server_ServerCapabilities_MaxWhereClauseParameters)
-                .AddMaxMonitoredItemsQueueSize(context, VariableIds.Server_ServerCapabilities_MaxMonitoredItemsQueueSize)
-                .AddConformanceUnits(context, VariableIds.Server_ServerCapabilities_ConformanceUnits)
-                .AddRoleSet(context, ObjectIds.Server_ServerCapabilities_RoleSet)
-                .AddOperationLimits(context,
-                    ObjectIds.Server_ServerCapabilities_OperationLimits)
+                .AddMaxArrayLength(context)
+                .AddMaxStringLength(context)
+                .AddMaxByteStringLength(context)
+                .AddMaxSessions(context)
+                .AddMaxSubscriptions(context)
+                .AddMaxMonitoredItems(context)
+                .AddMaxSubscriptionsPerSession(context)
+                .AddMaxMonitoredItemsPerSubscription(context)
+                .AddMaxSelectClauseParameters(context)
+                .AddMaxWhereClauseParameters(context)
+                .AddMaxMonitoredItemsQueueSize(context)
+                .AddConformanceUnits(context)
+                .AddRoleSet(context)
+                .AddOperationLimits(context)
                 .OperationLimits!
-                    .AddMaxNodesPerRead(context, VariableIds.Server_ServerCapabilities_OperationLimits_MaxNodesPerRead)
-                    .AddMaxNodesPerHistoryReadData(context, VariableIds.Server_ServerCapabilities_OperationLimits_MaxNodesPerHistoryReadData)
-                    .AddMaxNodesPerHistoryReadEvents(context, VariableIds.Server_ServerCapabilities_OperationLimits_MaxNodesPerHistoryReadEvents)
-                    .AddMaxNodesPerWrite(context, VariableIds.Server_ServerCapabilities_OperationLimits_MaxNodesPerWrite)
-                    .AddMaxNodesPerHistoryUpdateData(context, VariableIds.Server_ServerCapabilities_OperationLimits_MaxNodesPerHistoryUpdateData)
-                    .AddMaxNodesPerHistoryUpdateEvents(context, VariableIds.Server_ServerCapabilities_OperationLimits_MaxNodesPerHistoryUpdateEvents)
-                    .AddMaxNodesPerMethodCall(context, VariableIds.Server_ServerCapabilities_OperationLimits_MaxNodesPerMethodCall)
-                    .AddMaxNodesPerBrowse(context, VariableIds.Server_ServerCapabilities_OperationLimits_MaxNodesPerBrowse)
-                    .AddMaxNodesPerRegisterNodes(context, VariableIds.Server_ServerCapabilities_OperationLimits_MaxNodesPerRegisterNodes)
-                    .AddMaxNodesPerTranslateBrowsePathsToNodeIds(
-                        context,
-                        VariableIds.Server_ServerCapabilities_OperationLimits_MaxNodesPerTranslateBrowsePathsToNodeIds)
-                    .AddMaxNodesPerNodeManagement(context, VariableIds.Server_ServerCapabilities_OperationLimits_MaxNodesPerNodeManagement)
-                    .AddMaxMonitoredItemsPerCall(context, VariableIds.Server_ServerCapabilities_OperationLimits_MaxMonitoredItemsPerCall);
+                    .AddMaxNodesPerRead(context)
+                    .AddMaxNodesPerHistoryReadData(context)
+                    .AddMaxNodesPerHistoryReadEvents(context)
+                    .AddMaxNodesPerWrite(context)
+                    .AddMaxNodesPerHistoryUpdateData(context)
+                    .AddMaxNodesPerHistoryUpdateEvents(context)
+                    .AddMaxNodesPerMethodCall(context)
+                    .AddMaxNodesPerBrowse(context)
+                    .AddMaxNodesPerRegisterNodes(context)
+                    .AddMaxNodesPerTranslateBrowsePathsToNodeIds(context)
+                    .AddMaxNodesPerNodeManagement(context)
+                    .AddMaxMonitoredItemsPerCall(context);
         }
 
         private static void AddServerRedundancySdkOptionalChildren(
@@ -587,21 +554,19 @@ namespace Opc.Ua.Server
             // RedundantServerArray, see DefaultServerRedundancyHandler in
             // Opc.Ua.Client) keep working even when no redundancy provider
             // populates it.
-            serverRedundancy.AddRedundantServerArray(
-                context, VariableIds.Server_ServerRedundancy_RedundantServerArray);
+            serverRedundancy.AddRedundantServerArray(context);
         }
 
         private static void AddHistoryCapabilitiesSdkOptionalChildren(
             ISystemContext context,
             HistoryServerCapabilitiesState historyCaps)
         {
-            // ServerTimestampSupported is Optional on HistoryServerCapabilitiesType
-            // but is written by GetDefaultHistoryCapabilitiesAsync from the
-            // rolled-up historian capabilities — without lazy-add the write
-            // would NRE. See AddServerSdkOptionalChildren for the NodeId-patch
-            // rationale (type-level Add* extension assigns the type NodeId).
-            historyCaps.AddServerTimestampSupported(
-                context, VariableIds.HistoryServerCapabilities_ServerTimestampSupported);
+            // ServerTimestampSupported is Optional on
+            // HistoryServerCapabilitiesType but is written by
+            // GetDefaultHistoryCapabilitiesAsync from the rolled-up
+            // historian capabilities — without lazy-add the write would
+            // NRE.
+            historyCaps.AddServerTimestampSupported(context);
         }
 
         /// <summary>
@@ -626,9 +591,9 @@ namespace Opc.Ua.Server
                 return;
             }
             metadataState
-                .AddDefaultRolePermissions(context, VariableIds.OPCUANamespaceMetadata_DefaultRolePermissions)
-                .AddDefaultUserRolePermissions(context, VariableIds.OPCUANamespaceMetadata_DefaultUserRolePermissions)
-                .AddDefaultAccessRestrictions(context, VariableIds.OPCUANamespaceMetadata_DefaultAccessRestrictions);
+                .AddDefaultRolePermissions(context)
+                .AddDefaultUserRolePermissions(context)
+                .AddDefaultAccessRestrictions(context);
         }
 
         /// <summary>
@@ -656,7 +621,7 @@ namespace Opc.Ua.Server
             {
                 return;
             }
-            category.AddLastChange(context, VariableIds.Aliases_LastChange);
+            category.AddLastChange(context);
         }
 
         /// <summary>
@@ -692,134 +657,42 @@ namespace Opc.Ua.Server
             switch (numericId)
             {
                 case Objects.WellKnownRole_Observer:
-                    AddWellKnownRoleChildren(context, roleState,
-                        applications: Variables.WellKnownRole_Observer_Applications,
-                        applicationsExclude: Variables.WellKnownRole_Observer_ApplicationsExclude,
-                        endpoints: Variables.WellKnownRole_Observer_Endpoints,
-                        endpointsExclude: Variables.WellKnownRole_Observer_EndpointsExclude,
-                        customConfiguration: Variables.WellKnownRole_Observer_CustomConfiguration,
-                        addIdentityMethod: Methods.WellKnownRole_Observer_AddIdentity,
-                        removeIdentityMethod: Methods.WellKnownRole_Observer_RemoveIdentity,
-                        addApplicationMethod: Methods.WellKnownRole_Observer_AddApplication,
-                        removeApplicationMethod: Methods.WellKnownRole_Observer_RemoveApplication,
-                        addEndpointMethod: Methods.WellKnownRole_Observer_AddEndpoint,
-                        removeEndpointMethod: Methods.WellKnownRole_Observer_RemoveEndpoint);
-                    break;
                 case Objects.WellKnownRole_Operator:
-                    AddWellKnownRoleChildren(context, roleState,
-                        applications: Variables.WellKnownRole_Operator_Applications,
-                        applicationsExclude: Variables.WellKnownRole_Operator_ApplicationsExclude,
-                        endpoints: Variables.WellKnownRole_Operator_Endpoints,
-                        endpointsExclude: Variables.WellKnownRole_Operator_EndpointsExclude,
-                        customConfiguration: Variables.WellKnownRole_Operator_CustomConfiguration,
-                        addIdentityMethod: Methods.WellKnownRole_Operator_AddIdentity,
-                        removeIdentityMethod: Methods.WellKnownRole_Operator_RemoveIdentity,
-                        addApplicationMethod: Methods.WellKnownRole_Operator_AddApplication,
-                        removeApplicationMethod: Methods.WellKnownRole_Operator_RemoveApplication,
-                        addEndpointMethod: Methods.WellKnownRole_Operator_AddEndpoint,
-                        removeEndpointMethod: Methods.WellKnownRole_Operator_RemoveEndpoint);
-                    break;
                 case Objects.WellKnownRole_Engineer:
-                    AddWellKnownRoleChildren(context, roleState,
-                        applications: Variables.WellKnownRole_Engineer_Applications,
-                        applicationsExclude: Variables.WellKnownRole_Engineer_ApplicationsExclude,
-                        endpoints: Variables.WellKnownRole_Engineer_Endpoints,
-                        endpointsExclude: Variables.WellKnownRole_Engineer_EndpointsExclude,
-                        customConfiguration: Variables.WellKnownRole_Engineer_CustomConfiguration,
-                        addIdentityMethod: Methods.WellKnownRole_Engineer_AddIdentity,
-                        removeIdentityMethod: Methods.WellKnownRole_Engineer_RemoveIdentity,
-                        addApplicationMethod: Methods.WellKnownRole_Engineer_AddApplication,
-                        removeApplicationMethod: Methods.WellKnownRole_Engineer_RemoveApplication,
-                        addEndpointMethod: Methods.WellKnownRole_Engineer_AddEndpoint,
-                        removeEndpointMethod: Methods.WellKnownRole_Engineer_RemoveEndpoint);
-                    break;
                 case Objects.WellKnownRole_Supervisor:
-                    AddWellKnownRoleChildren(context, roleState,
-                        applications: Variables.WellKnownRole_Supervisor_Applications,
-                        applicationsExclude: Variables.WellKnownRole_Supervisor_ApplicationsExclude,
-                        endpoints: Variables.WellKnownRole_Supervisor_Endpoints,
-                        endpointsExclude: Variables.WellKnownRole_Supervisor_EndpointsExclude,
-                        customConfiguration: Variables.WellKnownRole_Supervisor_CustomConfiguration,
-                        addIdentityMethod: Methods.WellKnownRole_Supervisor_AddIdentity,
-                        removeIdentityMethod: Methods.WellKnownRole_Supervisor_RemoveIdentity,
-                        addApplicationMethod: Methods.WellKnownRole_Supervisor_AddApplication,
-                        removeApplicationMethod: Methods.WellKnownRole_Supervisor_RemoveApplication,
-                        addEndpointMethod: Methods.WellKnownRole_Supervisor_AddEndpoint,
-                        removeEndpointMethod: Methods.WellKnownRole_Supervisor_RemoveEndpoint);
-                    break;
                 case Objects.WellKnownRole_ConfigureAdmin:
-                    AddWellKnownRoleChildren(context, roleState,
-                        applications: Variables.WellKnownRole_ConfigureAdmin_Applications,
-                        applicationsExclude: Variables.WellKnownRole_ConfigureAdmin_ApplicationsExclude,
-                        endpoints: Variables.WellKnownRole_ConfigureAdmin_Endpoints,
-                        endpointsExclude: Variables.WellKnownRole_ConfigureAdmin_EndpointsExclude,
-                        customConfiguration: Variables.WellKnownRole_ConfigureAdmin_CustomConfiguration,
-                        addIdentityMethod: Methods.WellKnownRole_ConfigureAdmin_AddIdentity,
-                        removeIdentityMethod: Methods.WellKnownRole_ConfigureAdmin_RemoveIdentity,
-                        addApplicationMethod: Methods.WellKnownRole_ConfigureAdmin_AddApplication,
-                        removeApplicationMethod: Methods.WellKnownRole_ConfigureAdmin_RemoveApplication,
-                        addEndpointMethod: Methods.WellKnownRole_ConfigureAdmin_AddEndpoint,
-                        removeEndpointMethod: Methods.WellKnownRole_ConfigureAdmin_RemoveEndpoint);
-                    break;
                 case Objects.WellKnownRole_SecurityAdmin:
-                    AddWellKnownRoleChildren(context, roleState,
-                        applications: Variables.WellKnownRole_SecurityAdmin_Applications,
-                        applicationsExclude: Variables.WellKnownRole_SecurityAdmin_ApplicationsExclude,
-                        endpoints: Variables.WellKnownRole_SecurityAdmin_Endpoints,
-                        endpointsExclude: Variables.WellKnownRole_SecurityAdmin_EndpointsExclude,
-                        customConfiguration: Variables.WellKnownRole_SecurityAdmin_CustomConfiguration,
-                        addIdentityMethod: Methods.WellKnownRole_SecurityAdmin_AddIdentity,
-                        removeIdentityMethod: Methods.WellKnownRole_SecurityAdmin_RemoveIdentity,
-                        addApplicationMethod: Methods.WellKnownRole_SecurityAdmin_AddApplication,
-                        removeApplicationMethod: Methods.WellKnownRole_SecurityAdmin_RemoveApplication,
-                        addEndpointMethod: Methods.WellKnownRole_SecurityAdmin_AddEndpoint,
-                        removeEndpointMethod: Methods.WellKnownRole_SecurityAdmin_RemoveEndpoint);
+                    AddWellKnownRoleChildren(context, roleState);
                     break;
             }
         }
 
         private static void AddWellKnownRoleChildren(
             ISystemContext context,
-            RoleState role,
-            uint applications,
-            uint applicationsExclude,
-            uint endpoints,
-            uint endpointsExclude,
-            uint customConfiguration,
-            uint addIdentityMethod,
-            uint removeIdentityMethod,
-            uint addApplicationMethod,
-            uint removeApplicationMethod,
-            uint addEndpointMethod,
-            uint removeEndpointMethod)
+            RoleState role)
         {
             // Identities is Mandatory@RoleType so the singleton factory always
             // emits it with the correct well-known instance NodeId; no add-back
             // needed. All other RoleType children are Optional@type but the
             // StandardTypes.xml well-known-role declarations promote them to
-            // Mandatory at the singleton-instance level (see
-            // StandardTypes.xml lines 2293-2316 for Observer and the parallel
-            // declarations for Operator, Engineer, Supervisor, ConfigureAdmin,
-            // SecurityAdmin). The transitive gate (issue #3768) uses the
-            // type-def rule rather than the singleton override, so the
-            // generator now suppresses every other child under forInstance=true.
-            // Re-add them here so RoleStateBinding finds them. Only the method
-            // and property NodeIds need the singleton-instance patch; the
-            // generated Add{Method} helpers populate the InputArguments
-            // child (which clients read by browse-name) for us. Add{Child}
-            // is idempotent and returns `this` for chaining.
+            // Mandatory at the singleton-instance level. The transitive gate
+            // (issue #3768) uses the type-def rule rather than the singleton
+            // override, so the generator suppresses every other child under
+            // forInstance=true. Re-add them here so RoleStateBinding finds
+            // them. Add{Child}(context) is idempotent, dispatches NodeIds on
+            // the role's NodeId, and returns `this` for chaining.
             role
-                .AddApplications(context, new NodeId(applications))
-                .AddApplicationsExclude(context, new NodeId(applicationsExclude))
-                .AddEndpoints(context, new NodeId(endpoints))
-                .AddEndpointsExclude(context, new NodeId(endpointsExclude))
-                .AddCustomConfiguration(context, new NodeId(customConfiguration))
-                .AddAddIdentity(context, new NodeId(addIdentityMethod))
-                .AddRemoveIdentity(context, new NodeId(removeIdentityMethod))
-                .AddAddApplication(context, new NodeId(addApplicationMethod))
-                .AddRemoveApplication(context, new NodeId(removeApplicationMethod))
-                .AddAddEndpoint(context, new NodeId(addEndpointMethod))
-                .AddRemoveEndpoint(context, new NodeId(removeEndpointMethod));
+                .AddApplications(context)
+                .AddApplicationsExclude(context)
+                .AddEndpoints(context)
+                .AddEndpointsExclude(context)
+                .AddCustomConfiguration(context)
+                .AddAddIdentity(context)
+                .AddRemoveIdentity(context)
+                .AddAddApplication(context)
+                .AddRemoveApplication(context)
+                .AddAddEndpoint(context)
+                .AddRemoveEndpoint(context);
         }
 
         /// <summary>

--- a/Tests/Opc.Ua.Core.Security.Tests/WellKnownRoleNodeIds.cs
+++ b/Tests/Opc.Ua.Core.Security.Tests/WellKnownRoleNodeIds.cs
@@ -37,8 +37,10 @@ namespace Opc.Ua.Core.Security.Tests
     /// from a non-admin session returns no children — the standard nodeset
     /// declares <c>RolePermission Permissions="61455">SecurityAdmin</c> on
     /// these methods/variables, so anonymous and authenticated-user sessions
-    /// cannot Browse them. These tests still need to verify the methods exist
-    /// on the server, which they do — Browse just hides them.
+    /// cannot Browse them. These tests still need to verify the methods
+    /// exist on the server, which they do (the source generator emits them
+    /// at their well-known instance NodeIds in the SDK's address space) —
+    /// Browse just hides them from low-privilege sessions.
     /// </summary>
     public static class WellKnownRoleNodeIds
     {

--- a/Tests/Opc.Ua.Server.Tests/ConfigurationNodeManagerTests.cs
+++ b/Tests/Opc.Ua.Server.Tests/ConfigurationNodeManagerTests.cs
@@ -320,7 +320,28 @@ namespace Opc.Ua.Server.Tests
                     MethodIds.WellKnownRole_Engineer_RemoveIdentity,
                     MethodIds.WellKnownRole_Supervisor_RemoveApplication,
                     MethodIds.WellKnownRole_ConfigureAdmin_RemoveEndpoint,
-                    MethodIds.WellKnownRole_SecurityAdmin_AddIdentity
+                    MethodIds.WellKnownRole_SecurityAdmin_AddIdentity,
+
+                    // Mandatory descendants of patched singleton methods
+                    // must also resolve at their well-known instance
+                    // NodeIds. Synthesized InputArguments / OutputArguments
+                    // properties used to silently take the type-level
+                    // NodeId because the Add{Child} fluent extension only
+                    // patched the top-level method NodeId; the generator
+                    // now dispatches the singleton-instance child factory
+                    // on the owner's NodeId, so reads against these
+                    // well-known instance NodeIds no longer return
+                    // BadNodeIdUnknown.
+                    VariableIds.Server_GetMonitoredItems_InputArguments,
+                    VariableIds.Server_GetMonitoredItems_OutputArguments,
+                    VariableIds.Server_ResendData_InputArguments,
+                    VariableIds.WellKnownRole_Observer_AddIdentity_InputArguments,
+                    VariableIds.WellKnownRole_Observer_AddApplication_InputArguments,
+                    VariableIds.WellKnownRole_Operator_AddEndpoint_InputArguments,
+                    VariableIds.WellKnownRole_Engineer_RemoveIdentity_InputArguments,
+                    VariableIds.WellKnownRole_Supervisor_RemoveApplication_InputArguments,
+                    VariableIds.WellKnownRole_ConfigureAdmin_RemoveEndpoint_InputArguments,
+                    VariableIds.WellKnownRole_SecurityAdmin_AddIdentity_InputArguments
                 ];
 
                 foreach (NodeId sdkAddedNodeId in sdkAddedNodeIds)

--- a/Tests/Opc.Ua.Server.Tests/DiagnosticsNodeManagerTests.cs
+++ b/Tests/Opc.Ua.Server.Tests/DiagnosticsNodeManagerTests.cs
@@ -103,12 +103,17 @@ namespace Opc.Ua.Server.Tests
             Assert.That(getMonitoredItems, Is.Not.Null, "GetMonitoredItems should exist.");
             Assert.That(getMonitoredItems.OnCallMethod, Is.Not.Null, "GetMonitoredItems OnCallMethod should be wired.");
 
-            // The OutputArguments child is created by the generator's
-            // type-level factory and assigned a type-level NodeId; clients
-            // browse it by browse-name from the method. Look it up via the
-            // typed slot rather than VariableIds.Server_GetMonitoredItems_OutputArguments.
-            PropertyState getMonitoredItemsOutputArgs = getMonitoredItems.OutputArguments;
-            Assert.That(getMonitoredItemsOutputArgs, Is.Not.Null, "GetMonitoredItems output arguments should exist.");
+            // The OutputArguments child must resolve at its well-known
+            // instance NodeId (i=11494). The source generator dispatches the
+            // singleton-instance child factory when the Add{Child} call's
+            // owner is the Server singleton, so the synthesized children
+            // pick up the correct well-known NodeIds without a post-hoc
+            // override (regression guard for the dead lookup that used to
+            // live in DiagnosticsNodeManager.CreateAddressSpaceAsync).
+            PropertyState getMonitoredItemsOutputArgs = manager.FindPredefinedNode<PropertyState>(
+                VariableIds.Server_GetMonitoredItems_OutputArguments);
+            Assert.That(getMonitoredItemsOutputArgs, Is.Not.Null,
+                "GetMonitoredItems OutputArguments should exist at the well-known instance NodeId.");
             Assert.That(getMonitoredItemsOutputArgs.WrappedValue.IsNull, Is.False, "Output arguments value should be initialized.");
 
             ResendDataMethodState resendData = manager.FindPredefinedNode<ResendDataMethodState>(MethodIds.Server_ResendData);

--- a/Tests/Opc.Ua.SourceGeneration.Core.Tests/Generators/NodeStateGeneratorTests.cs
+++ b/Tests/Opc.Ua.SourceGeneration.Core.Tests/Generators/NodeStateGeneratorTests.cs
@@ -282,6 +282,77 @@ namespace Opc.Ua.SourceGeneration.Generator.Tests
             });
         }
 
+        /// <summary>
+        /// Verifies the source generator emits the singleton-instance
+        /// dispatch inside type-level child factories for synthesized
+        /// method arguments. Both the top-level method NodeId and its
+        /// Mandatory <c>InputArguments</c> / <c>OutputArguments</c>
+        /// descendants must rebind to their well-known singleton-instance
+        /// NodeIds when the type-level factory is called with
+        /// <c>forInstance: true</c> for a known singleton owner. Without
+        /// this dispatch, lazy-added methods on the
+        /// <c>Server</c>/<c>WellKnownRole_*</c> singletons silently keep
+        /// the type-level child NodeIds (e.g. 11490 instead of 11493 for
+        /// <c>Server_GetMonitoredItems_InputArguments</c>), so reads
+        /// against the spec-reserved well-known instance NodeIds return
+        /// <c>BadNodeIdUnknown</c>.
+        /// </summary>
+        [Test]
+        public void NodeStateGeneratorEmitsSingletonInstanceDispatchInTypeLevelFactories()
+        {
+            // Arrange
+            ITelemetryContext telemetry = NUnitTelemetryContext.Create(logLevel: LogLevel.Error);
+            using var fileSystem = new VirtualFileSystem();
+
+            // Act
+            Generators.GenerateStack(StackGenerationType.All, fileSystem, string.Empty, telemetry,
+                new GeneratorOptions
+                {
+                    OmitFluentApi = true
+                });
+
+            string code = string.Join("\n", fileSystem.CreatedFiles
+                .Where(c => Path.GetExtension(c) == ".cs")
+                .Select(c => Encoding.UTF8.GetString(fileSystem.Get(c))));
+
+            Assert.Multiple(() =>
+            {
+                // ServerType (single singleton: Server, NodeId 2253).
+                // The type-level factory must dispatch the synthesized
+                // InputArguments / OutputArguments children through the
+                // singleton-instance child factories (Server_*).
+                Assert.That(code, Does.Contain(
+                    "if (parent.NodeId.Equals(global::Opc.Ua.NodeId.Create(2253u, global::Opc.Ua.Namespaces.OpcUa, context.NamespaceUris)))"),
+                    "CreateServerType_GetMonitoredItems should dispatch on the Server singleton NodeId.");
+                Assert.That(code, Does.Contain(
+                    "state.CreateOrReplaceInputArguments(context, CreateServer_GetMonitoredItems_InputArguments(context, state, forInstance: true));"),
+                    "The Server singleton branch should call the singleton-instance InputArguments factory.");
+                Assert.That(code, Does.Contain(
+                    "state.CreateOrReplaceOutputArguments(context, CreateServer_GetMonitoredItems_OutputArguments(context, state, forInstance: true));"),
+                    "The Server singleton branch should call the singleton-instance OutputArguments factory.");
+
+                // RoleType (multi-singleton: WellKnownRole_Observer = 15668,
+                // WellKnownRole_Operator = 15680, …). The type-level factory
+                // must dispatch on parent.NodeId across every singleton
+                // whose corresponding child factory has been collected.
+                Assert.That(code, Does.Contain(
+                    "state.CreateOrReplaceInputArguments(context, CreateWellKnownRole_Observer_AddIdentity_InputArguments(context, state, forInstance: true));"),
+                    "RoleType_AddIdentity should dispatch to WellKnownRole_Observer's InputArguments factory.");
+                Assert.That(code, Does.Contain(
+                    "state.CreateOrReplaceInputArguments(context, CreateWellKnownRole_SecurityAdmin_AddIdentity_InputArguments(context, state, forInstance: true));"),
+                    "RoleType_AddIdentity should dispatch to WellKnownRole_SecurityAdmin's InputArguments factory.");
+
+                // The top-level NodeId override re-binds state.NodeId from
+                // the type-level constant to the singleton-instance NodeId
+                // when the dispatch matches. For GetMonitoredItems the
+                // override rewrites 11489 → 11492 under the Server
+                // singleton.
+                Assert.That(code, Does.Contain(
+                    "state.NodeId = global::Opc.Ua.NodeId.Create(11492u, global::Opc.Ua.Namespaces.OpcUa, context.NamespaceUris);"),
+                    "The Server singleton dispatch should override state.NodeId to Server_GetMonitoredItems (11492).");
+            });
+        }
+
         private Mock<IFileSystem> m_mockFileSystem;
         private Mock<IModelDesign> m_mockModelDesign;
         private Mock<ITelemetryContext> m_mockTelemetry;

--- a/Tools/Opc.Ua.SourceGeneration.Core/Generators/NodeStateGenerator.cs
+++ b/Tools/Opc.Ua.SourceGeneration.Core/Generators/NodeStateGenerator.cs
@@ -408,6 +408,11 @@ namespace Opc.Ua.SourceGeneration
                 m_context.ModelDesign.Namespaces));
             context.Template.AddReplacement(Tokens.ChildName, instance.SymbolicName.Name);
             context.Template.AddReplacement(Tokens.SymbolicId, instance.SymbolicId.Name);
+            context.Template.AddReplacement(
+                Tokens.NodeIdConstant,
+                instance.GetNodeIdAsCode(
+                    m_context.ModelDesign.Namespaces,
+                    kNamespaceTableContextVariable));
 
             return context.Template.Render();
         }
@@ -1367,6 +1372,9 @@ namespace Opc.Ua.SourceGeneration
             context.Template.AddReplacement(
                 Tokens.NodeIdConstant,
                 root.GetNodeIdAsCode(m_context.ModelDesign.Namespaces, kNamespaceTableContextVariable));
+            context.Template.AddReplacement(
+                Tokens.InstanceNodeIdOverride,
+                BuildInstanceNodeIdOverride(node));
 
             // .net efficiently interns constant string, so usage of the BrowseName constants is not needed.
             string symbolicNameSymbol = root.SymbolicName.Name.AsStringLiteral();
@@ -1649,10 +1657,10 @@ namespace Opc.Ua.SourceGeneration
                                 {
                                     case ModellingRule.Mandatory:
                                     case ModellingRule.Optional:
-                                        context.Out.WriteLine(
-                                            "state.CreateOrReplace{0}(context, Create{1}(context, state, forInstance: {2}));",
-                                            instance.SymbolicName.Name,
-                                            instance.SymbolicId.Name,
+                                        EmitCreateOrReplaceChild(
+                                            context,
+                                            node,
+                                            instance,
                                             forInstanceVariableValue);
                                         return null;
                                     case ModellingRule.OptionalPlaceholder:
@@ -1677,6 +1685,82 @@ namespace Opc.Ua.SourceGeneration
                 forInstanceVariableValue);
             return null;
         }
+
+        /// <summary>
+        /// Emits the <c>state.CreateOrReplace{Name}(context, Create{Symbolic}(context, state, forInstance: …))</c>
+        /// call site for a child of an InstanceDesign parent. When the child
+        /// lives in a type-level factory body (<see cref="NodeToGenerate.RootIsTypeDefinition"/>
+        /// is <c>true</c>) AND the type has well-known singleton instances
+        /// whose corresponding child factories have been collected, also
+        /// dispatches the <c>forInstance: true</c> path into the appropriate
+        /// singleton-instance child factory. This ensures that lazy-added
+        /// methods on singleton owners (e.g.
+        /// <c>serverObject.AddGetMonitoredItems(context, MethodIds.Server_GetMonitoredItems)</c>)
+        /// produce synthesized children (<c>InputArguments</c>,
+        /// <c>OutputArguments</c>) at their well-known instance NodeIds
+        /// rather than the type-level placeholders.
+        /// </summary>
+        private void EmitCreateOrReplaceChild(
+            ILoadContext context,
+            NodeToGenerate node,
+            InstanceDesign instance,
+            string forInstanceVariableValue)
+        {
+            List<(NodeToGenerate Singleton, NodeToGenerate SingletonChild, string SingletonChildSymbolicId)> singletonChildren =
+                FindSingletonChildren(node);
+            if (singletonChildren.Count == 0)
+            {
+                context.Out.WriteLine(
+                    "state.CreateOrReplace{0}(context, Create{1}(context, state, forInstance: {2}));",
+                    instance.SymbolicName.Name,
+                    instance.SymbolicId.Name,
+                    forInstanceVariableValue);
+                return;
+            }
+
+            // Dispatch on the parent's NodeId so the singleton-instance
+            // child factory is invoked when the type-level factory is
+            // materialising an actual well-known instance subtree. The
+            // <paramref name="forInstance"/> gate keeps the type-template
+            // emission path (forInstance: false) unchanged.
+            context.Out.WriteLine("if ({0} && parent != null)", forInstanceVariableValue);
+            context.Out.WriteLine("{");
+            for (int i = 0; i < singletonChildren.Count; i++)
+            {
+                (NodeToGenerate singletonRoot, NodeToGenerate _, string singletonChildSymbolicId)
+                    = singletonChildren[i];
+                string keyword = i == 0 ? "if" : "else if";
+                context.Out.WriteLine(
+                    "    {0} (parent.NodeId.Equals({1}))",
+                    keyword,
+                    singletonRoot.Design.GetNodeIdAsCode(
+                        m_context.ModelDesign.Namespaces,
+                        kNamespaceTableContextVariable));
+                context.Out.WriteLine("    {");
+                context.Out.WriteLine(
+                    "        state.CreateOrReplace{0}(context, Create{1}(context, state, forInstance: true));",
+                    instance.SymbolicName.Name,
+                    singletonChildSymbolicId);
+                context.Out.WriteLine("    }");
+            }
+            context.Out.WriteLine("    else");
+            context.Out.WriteLine("    {");
+            context.Out.WriteLine(
+                "        state.CreateOrReplace{0}(context, Create{1}(context, state, forInstance: true));",
+                instance.SymbolicName.Name,
+                instance.SymbolicId.Name);
+            context.Out.WriteLine("    }");
+            context.Out.WriteLine("}");
+            context.Out.WriteLine("else");
+            context.Out.WriteLine("{");
+            context.Out.WriteLine(
+                "    state.CreateOrReplace{0}(context, Create{1}(context, state, forInstance: {2}));",
+                instance.SymbolicName.Name,
+                instance.SymbolicId.Name,
+                forInstanceVariableValue);
+            context.Out.WriteLine("}");
+        }
+
 
         private bool WriteTemplate_RolePermissions(IWriteContext context)
         {
@@ -2481,6 +2565,176 @@ namespace Opc.Ua.SourceGeneration
             // a Hierarchy from the model validation, so we build a minimal one with
             // their references to emit them into the address space.
             CollectEncodingNodes();
+
+            // Index well-known singleton roots by their TypeDefinition so the
+            // child-emission writer can dispatch the type-level factory's
+            // forInstance: true branch into the matching singleton-instance
+            // child factory (e.g. CreateServerType_GetMonitoredItems can
+            // produce InputArguments at the well-known Server_*
+            // NodeIds when the parent is the Server singleton).
+            BuildSingletonInstanceIndex();
+        }
+
+        /// <summary>
+        /// Populates <see cref="m_singletonsByType"/> with every singleton
+        /// instance root or nested well-known instance in
+        /// <see cref="m_nodes"/> grouped by its
+        /// <see cref="InstanceDesign.TypeDefinitionNode"/>'s SymbolicId.
+        /// Top-level entries correspond to declared
+        /// <c>&lt;opc:Object&gt;</c> / <c>&lt;opc:Variable&gt;</c>
+        /// singletons such as <c>Server</c> or
+        /// <c>WellKnownRole_Observer</c>; nested entries cover Mandatory
+        /// well-known children such as <c>Server_ServerCapabilities</c>
+        /// (an instance of <c>ServerCapabilitiesType</c>) so the type-level
+        /// factory's child-dispatch can produce the well-known instance
+        /// NodeIds at every depth.
+        /// </summary>
+        private void BuildSingletonInstanceIndex()
+        {
+            foreach (NodeToGenerate entry in m_nodes.Values)
+            {
+                if (entry.Design is not InstanceDesign instance)
+                {
+                    continue;
+                }
+                TypeDesign typeDef = instance.TypeDefinitionNode;
+                if (typeDef == null || typeDef.SymbolicId == null)
+                {
+                    continue;
+                }
+                if (!m_singletonsByType.TryGetValue(typeDef.SymbolicId,
+                    out List<NodeToGenerate> singletons))
+                {
+                    singletons = [];
+                    m_singletonsByType[typeDef.SymbolicId] = singletons;
+                }
+                singletons.Add(entry);
+            }
+        }
+
+        /// <summary>
+        /// Given the type-level child <paramref name="typeChild"/> that is
+        /// about to be emitted inside a type-level factory body (e.g. the
+        /// InputArguments slot inside <c>CreateServerType_GetMonitoredItems</c>),
+        /// returns the singleton-instance equivalents — the same relative
+        /// path under each known singleton instance of the type root, when
+        /// such a child has been collected.
+        /// </summary>
+        private List<(NodeToGenerate Singleton, NodeToGenerate SingletonChild, string SingletonChildSymbolicId)>
+            FindSingletonChildren(NodeToGenerate typeChild)
+        {
+            var result = new List<(NodeToGenerate Singleton, NodeToGenerate SingletonChild, string SingletonChildSymbolicId)>();
+            if (typeChild == null || !typeChild.RootIsTypeDefinition)
+            {
+                return result;
+            }
+
+            // Walk up to the type root NodeToGenerate.
+            NodeToGenerate typeRoot = typeChild;
+            while (typeRoot.Parent != null)
+            {
+                typeRoot = typeRoot.Parent;
+            }
+            if (typeRoot.Design is not TypeDesign typeDef ||
+                typeDef.SymbolicId == null)
+            {
+                return result;
+            }
+
+            // Find singletons of this type, if any.
+            if (!m_singletonsByType.TryGetValue(typeDef.SymbolicId,
+                out List<NodeToGenerate> singletons))
+            {
+                return result;
+            }
+
+            // The relative path suffix is the part of the child's SymbolicId
+            // that follows the type-root SymbolicId. Both type and singleton
+            // trees use the same "_<ChildSymbolicName>" path scheme, so we
+            // can compute the singleton child SymbolicId by prefix swap.
+            string typeRootName = typeDef.SymbolicId.Name;
+            string childName = typeChild.Design.SymbolicId.Name;
+            if (childName == null ||
+                !childName.StartsWith(typeRootName, StringComparison.Ordinal))
+            {
+                return result;
+            }
+            string relativeSuffix = childName.Substring(typeRootName.Length);
+
+            // Only count singletons whose corresponding child has actually
+            // been collected (m_nodes contains the singleton-instance
+            // descendants). For example, RoleType has both modifiable
+            // (Observer/Operator/...) and immutable (Anonymous/...)
+            // singletons; only the modifiable ones have the Mandatory
+            // promoted AddIdentity child.
+            foreach (NodeToGenerate singleton in singletons)
+            {
+                if (singleton.Design?.SymbolicId == null)
+                {
+                    continue;
+                }
+                string singletonChildName = singleton.Design.SymbolicId.Name + relativeSuffix;
+                var singletonChildSymbolicId = new XmlQualifiedName(
+                    singletonChildName,
+                    typeChild.Design.SymbolicId.Namespace);
+                if (m_nodes.TryGetValue(singletonChildSymbolicId,
+                    out NodeToGenerate singletonChild))
+                {
+                    result.Add((singleton, singletonChild, singletonChildName));
+                }
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Computes the body of <see cref="Tokens.InstanceNodeIdOverride"/>
+        /// for the type-level factory currently being emitted. When the node
+        /// has well-known singleton instances (e.g. a method declared under
+        /// <c>ServerType</c> whose <c>Server</c> singleton has its own
+        /// well-known <c>NodeId</c>), emits a runtime override that re-binds
+        /// <c>state.NodeId</c> to the singleton-instance value when
+        /// <c>forInstance: true</c> is passed AND the parent owner is one of
+        /// the known singleton instances. Returns an empty string when no
+        /// dispatch is applicable, so the token expansion is a no-op.
+        /// </summary>
+        private string BuildInstanceNodeIdOverride(NodeToGenerate node)
+        {
+            List<(NodeToGenerate Singleton, NodeToGenerate SingletonChild, string SingletonChildSymbolicId)>
+                singletonChildren = FindSingletonChildren(node);
+            if (singletonChildren.Count == 0)
+            {
+                return string.Empty;
+            }
+
+            using var sw = new System.IO.StringWriter(System.Globalization.CultureInfo.InvariantCulture);
+            sw.WriteLine("if (forInstance && parent != null)");
+            sw.WriteLine("            {");
+            for (int i = 0; i < singletonChildren.Count; i++)
+            {
+                (NodeToGenerate singletonRoot,
+                    NodeToGenerate singletonChild,
+                    string _) = singletonChildren[i];
+                string keyword = i == 0 ? "if" : "else if";
+                sw.WriteLine(
+                    "                {0} (parent.NodeId.Equals({1}))",
+                    keyword,
+                    singletonRoot.Design.GetNodeIdAsCode(
+                        m_context.ModelDesign.Namespaces,
+                        kNamespaceTableContextVariable));
+                sw.WriteLine("                {");
+                sw.WriteLine(
+                    "                    state.NodeId = {0};",
+                    singletonChild.Design.GetNodeIdAsCode(
+                        m_context.ModelDesign.Namespaces,
+                        kNamespaceTableContextVariable));
+                sw.WriteLine("                }");
+            }
+            // Closing brace for the outer 'if (forInstance && parent != null)'
+            // — the templating engine appends a newline after the token
+            // expansion, so we deliberately leave the trailing newline off
+            // to keep the surrounding template indentation consistent.
+            sw.Write("            }");
+            return sw.ToString();
         }
 
         private void CollectEncodingNodes()
@@ -3508,6 +3762,7 @@ namespace Opc.Ua.SourceGeneration
         private readonly Dictionary<string, Resource> m_initializers = [];
         private readonly Dictionary<XmlQualifiedName, NodeToGenerate> m_nodes = [];
         private readonly Dictionary<XmlQualifiedName, NodeToGenerate> m_instances = [];
+        private readonly Dictionary<XmlQualifiedName, List<NodeToGenerate>> m_singletonsByType = [];
         private readonly ILogger m_logger;
         private readonly IServiceMessageContext m_messageContext;
         private readonly IGeneratorContext m_context;

--- a/Tools/Opc.Ua.SourceGeneration.Core/Generators/NodeStateGenerator.cs
+++ b/Tools/Opc.Ua.SourceGeneration.Core/Generators/NodeStateGenerator.cs
@@ -1372,9 +1372,7 @@ namespace Opc.Ua.SourceGeneration
             context.Template.AddReplacement(
                 Tokens.NodeIdConstant,
                 root.GetNodeIdAsCode(m_context.ModelDesign.Namespaces, kNamespaceTableContextVariable));
-            context.Template.AddReplacement(
-                Tokens.InstanceNodeIdOverride,
-                BuildInstanceNodeIdOverride(node));
+            AddInstanceNodeIdOverrideReplacement(context, node);
 
             // .net efficiently interns constant string, so usage of the BrowseName constants is not needed.
             string symbolicNameSymbol = root.SymbolicName.Name.AsStringLiteral();
@@ -2687,54 +2685,75 @@ namespace Opc.Ua.SourceGeneration
         }
 
         /// <summary>
-        /// Computes the body of <see cref="Tokens.InstanceNodeIdOverride"/>
-        /// for the type-level factory currently being emitted. When the node
-        /// has well-known singleton instances (e.g. a method declared under
-        /// <c>ServerType</c> whose <c>Server</c> singleton has its own
-        /// well-known <c>NodeId</c>), emits a runtime override that re-binds
-        /// <c>state.NodeId</c> to the singleton-instance value when
-        /// <c>forInstance: true</c> is passed AND the parent owner is one of
-        /// the known singleton instances. Returns an empty string when no
-        /// dispatch is applicable, so the token expansion is a no-op.
+        /// Registers the <see cref="Tokens.InstanceNodeIdOverride"/>
+        /// replacement for the type-level factory currently being emitted.
+        /// When the node has well-known singleton instances (e.g. a method
+        /// declared under <c>ServerType</c> whose <c>Server</c> singleton
+        /// has its own well-known <c>NodeId</c>), the wrapper template
+        /// renders a runtime dispatch that rebinds <c>state.NodeId</c> to
+        /// the singleton-instance value when <c>forInstance: true</c> is
+        /// passed AND <c>parent</c> matches one of the known singleton
+        /// instances. The token expands to nothing when no singleton
+        /// dispatch is applicable.
         /// </summary>
-        private string BuildInstanceNodeIdOverride(NodeToGenerate node)
+        private void AddInstanceNodeIdOverrideReplacement(
+            IWriteContext context,
+            NodeToGenerate node)
         {
             List<(NodeToGenerate Singleton, NodeToGenerate SingletonChild, string SingletonChildSymbolicId)>
                 singletonChildren = FindSingletonChildren(node);
-            if (singletonChildren.Count == 0)
-            {
-                return string.Empty;
-            }
+            context.Template.AddReplacement(
+                Tokens.InstanceNodeIdOverride,
+                NodeStateTemplates.InstanceNodeIdOverride,
+                singletonChildren.Count > 0
+                    ? (IReadOnlyList<object>)new object[] { singletonChildren }
+                    : [],
+                WriteTemplate_InstanceNodeIdOverride);
+        }
 
-            using var sw = new System.IO.StringWriter(System.Globalization.CultureInfo.InvariantCulture);
-            sw.WriteLine("if (forInstance && parent != null)");
-            sw.WriteLine("            {");
-            for (int i = 0; i < singletonChildren.Count; i++)
+        /// <summary>
+        /// Wrapper writer for <see cref="NodeStateTemplates.InstanceNodeIdOverride"/>;
+        /// expands the inner <see cref="Tokens.ListOfInstanceNodeIdBranches"/>
+        /// token by iterating the collected per-singleton branches.
+        /// </summary>
+        private bool WriteTemplate_InstanceNodeIdOverride(IWriteContext context)
+        {
+            if (context.Target is not List<(NodeToGenerate Singleton, NodeToGenerate SingletonChild, string SingletonChildSymbolicId)> branches)
             {
-                (NodeToGenerate singletonRoot,
-                    NodeToGenerate singletonChild,
-                    string _) = singletonChildren[i];
-                string keyword = i == 0 ? "if" : "else if";
-                sw.WriteLine(
-                    "                {0} (parent.NodeId.Equals({1}))",
-                    keyword,
-                    singletonRoot.Design.GetNodeIdAsCode(
-                        m_context.ModelDesign.Namespaces,
-                        kNamespaceTableContextVariable));
-                sw.WriteLine("                {");
-                sw.WriteLine(
-                    "                    state.NodeId = {0};",
-                    singletonChild.Design.GetNodeIdAsCode(
-                        m_context.ModelDesign.Namespaces,
-                        kNamespaceTableContextVariable));
-                sw.WriteLine("                }");
+                return false;
             }
-            // Closing brace for the outer 'if (forInstance && parent != null)'
-            // — the templating engine appends a newline after the token
-            // expansion, so we deliberately leave the trailing newline off
-            // to keep the surrounding template indentation consistent.
-            sw.Write("            }");
-            return sw.ToString();
+            context.Template.AddReplacement(
+                Tokens.ListOfInstanceNodeIdBranches,
+                NodeStateTemplates.InstanceNodeIdBranch,
+                branches.Cast<object>().ToArray(),
+                WriteTemplate_InstanceNodeIdBranch);
+            return context.Template.Render();
+        }
+
+        /// <summary>
+        /// Per-branch writer for <see cref="NodeStateTemplates.InstanceNodeIdBranch"/>;
+        /// the first branch emits <c>if</c>, subsequent ones <c>else if</c>.
+        /// </summary>
+        private bool WriteTemplate_InstanceNodeIdBranch(IWriteContext context)
+        {
+            if (context.Target is not ValueTuple<NodeToGenerate, NodeToGenerate, string> branch)
+            {
+                return false;
+            }
+            context.Template.AddReplacement(
+                Tokens.IfOrElseIf,
+                context.Index == 0 ? "if" : "else if");
+            context.Template.AddReplacement(
+                Tokens.ParentNodeIdConstant,
+                branch.Item1.Design.GetNodeIdAsCode(
+                    m_context.ModelDesign.Namespaces,
+                    kNamespaceTableContextVariable));
+            context.Template.AddReplacement(
+                Tokens.NodeIdConstant,
+                branch.Item2.Design.GetNodeIdAsCode(
+                    m_context.ModelDesign.Namespaces,
+                    kNamespaceTableContextVariable));
+            return context.Template.Render();
         }
 
         private void CollectEncodingNodes()

--- a/Tools/Opc.Ua.SourceGeneration.Core/Generators/NodeStateTemplates.cs
+++ b/Tools/Opc.Ua.SourceGeneration.Core/Generators/NodeStateTemplates.cs
@@ -958,8 +958,16 @@ namespace Opc.Ua.SourceGeneration
                     {
                         state.NodeId = nodeId;
                     }
-                    else if (context.NodeIdFactory != null)
+                    else if (context.NodeIdFactory != null &&
+                        state.NodeId.Equals({{Tokens.NodeIdConstant}}))
                     {
+                        // The factory's singleton-instance dispatch did not
+                        // fire (the owner is not a well-known singleton),
+                        // so mint a fresh NodeId via the manager's
+                        // NodeIdFactory. When the dispatch DID fire,
+                        // state.NodeId already holds the well-known
+                        // singleton-instance NodeId and must not be
+                        // overwritten.
                         state.NodeId = context.NodeIdFactory.New(context, state);
                     }
                     {{Tokens.ChildName}} = state;
@@ -1818,6 +1826,7 @@ namespace Opc.Ua.SourceGeneration
                 var state = {{Tokens.StateClassFactory}}(parent);
                 state.SymbolicName = {{Tokens.SymbolicNameSymbol}};
                 state.NodeId = {{Tokens.NodeIdConstant}};
+                {{Tokens.InstanceNodeIdOverride}}
                 state.TypeDefinitionId = {{Tokens.TypeDefinitionId}};
                 state.BrowseName = new global::Opc.Ua.QualifiedName(
                     {{Tokens.BrowseNameSymbol}},
@@ -1863,6 +1872,7 @@ namespace Opc.Ua.SourceGeneration
                 var state = {{Tokens.StateClassFactory}}(parent);
                 state.SymbolicName = {{Tokens.SymbolicNameSymbol}};
                 state.NodeId = {{Tokens.NodeIdConstant}};
+                {{Tokens.InstanceNodeIdOverride}}
                 state.TypeDefinitionId = {{Tokens.TypeDefinitionId}};
                 state.NumericId = {{Tokens.NumericIdValue}};
                 state.BrowseName = new global::Opc.Ua.QualifiedName(
@@ -1916,6 +1926,7 @@ namespace Opc.Ua.SourceGeneration
                 var state = {{Tokens.StateClassFactory}}(parent);
                 state.SymbolicName = {{Tokens.SymbolicNameSymbol}};
                 state.NodeId = {{Tokens.NodeIdConstant}};
+                {{Tokens.InstanceNodeIdOverride}}
                 {{Tokens.MethodDeclarationId}}
                 state.BrowseName = new global::Opc.Ua.QualifiedName(
                     {{Tokens.BrowseNameSymbol}},

--- a/Tools/Opc.Ua.SourceGeneration.Core/Generators/NodeStateTemplates.cs
+++ b/Tools/Opc.Ua.SourceGeneration.Core/Generators/NodeStateTemplates.cs
@@ -961,13 +961,6 @@ namespace Opc.Ua.SourceGeneration
                     else if (context.NodeIdFactory != null &&
                         state.NodeId.Equals({{Tokens.NodeIdConstant}}))
                     {
-                        // The factory's singleton-instance dispatch did not
-                        // fire (the owner is not a well-known singleton),
-                        // so mint a fresh NodeId via the manager's
-                        // NodeIdFactory. When the dispatch DID fire,
-                        // state.NodeId already holds the well-known
-                        // singleton-instance NodeId and must not be
-                        // overwritten.
                         state.NodeId = context.NodeIdFactory.New(context, state);
                     }
                     {{Tokens.ChildName}} = state;
@@ -2150,6 +2143,36 @@ namespace Opc.Ua.SourceGeneration
                 {{Tokens.ListOfRolePermissions}}
             };
 
+            """);
+
+        /// <summary>
+        /// Wrapper template for the singleton-instance NodeId override
+        /// emitted right after the type-level <c>state.NodeId</c>
+        /// assignment in <c>Create_ChildObject</c> / <c>Create_ChildVariable</c>
+        /// / <c>Create_ChildMethod</c>. Renders only when at least one
+        /// singleton-instance branch is collected; otherwise the token
+        /// expands to nothing.
+        /// </summary>
+        public static readonly TemplateString InstanceNodeIdOverride = TemplateString.Parse(
+            $$"""
+            if (forInstance && parent != null)
+            {
+                {{Tokens.ListOfInstanceNodeIdBranches}}
+            }
+            """);
+
+        /// <summary>
+        /// One per-singleton branch of the singleton-instance
+        /// <c>state.NodeId</c> override dispatch. Rebinds
+        /// <c>state.NodeId</c> to <see cref="Tokens.NodeIdConstant"/>
+        /// when the parent owner matches <see cref="Tokens.ParentNodeIdConstant"/>.
+        /// </summary>
+        public static readonly TemplateString InstanceNodeIdBranch = TemplateString.Parse(
+            $$"""
+            {{Tokens.IfOrElseIf}} (parent.NodeId.Equals({{Tokens.ParentNodeIdConstant}}))
+            {
+                state.NodeId = {{Tokens.NodeIdConstant}};
+            }
             """);
 
         /// <summary>

--- a/Tools/Opc.Ua.SourceGeneration.Core/Templating/Tokens.cs
+++ b/Tools/Opc.Ua.SourceGeneration.Core/Templating/Tokens.cs
@@ -201,6 +201,9 @@ namespace Opc.Ua.SourceGeneration
         public static string ListOfReferences => nameof(ListOfReferences);
         public static string NodeIdConstant => nameof(NodeIdConstant);
         public static string InstanceNodeIdOverride => nameof(InstanceNodeIdOverride);
+        public static string ListOfInstanceNodeIdBranches => nameof(ListOfInstanceNodeIdBranches);
+        public static string ParentNodeIdConstant => nameof(ParentNodeIdConstant);
+        public static string IfOrElseIf => nameof(IfOrElseIf);
         public static string SuperTypeId => nameof(SuperTypeId);
         public static string TypeDefinitionId => nameof(TypeDefinitionId);
         public static string ReferenceTypeId => nameof(ReferenceTypeId);

--- a/Tools/Opc.Ua.SourceGeneration.Core/Templating/Tokens.cs
+++ b/Tools/Opc.Ua.SourceGeneration.Core/Templating/Tokens.cs
@@ -200,6 +200,7 @@ namespace Opc.Ua.SourceGeneration
         public static string ListOfOptionalChildNodeStates => nameof(ListOfOptionalChildNodeStates);
         public static string ListOfReferences => nameof(ListOfReferences);
         public static string NodeIdConstant => nameof(NodeIdConstant);
+        public static string InstanceNodeIdOverride => nameof(InstanceNodeIdOverride);
         public static string SuperTypeId => nameof(SuperTypeId);
         public static string TypeDefinitionId => nameof(TypeDefinitionId);
         public static string ReferenceTypeId => nameof(ReferenceTypeId);


### PR DESCRIPTION
# Description

The source generator's type-level child factories (e.g. `CreateServerType_GetMonitoredItems`) ignored the `forInstance: true` flag for their synthesized argument children — every `InputArguments` / `OutputArguments` slot was emitted with the **type-level NodeId** (11490/11491) regardless of who the actual owner was. As a result, the **well-known instance-level NodeIds** reserved by Part 5 returned `BadNodeIdUnknown` even though they are explicitly declared in the standard NodeSet:

| Patched parent | Mandatory descendants that silently took type-level NodeIds |
|---|---|
| `MethodIds.Server_GetMonitoredItems` (11492) | `Server_GetMonitoredItems_InputArguments` (11493), `..._OutputArguments` (11494) |
| `MethodIds.Server_ResendData` (12873) | `Server_ResendData_InputArguments` (12874) |
| `MethodIds.Server_SetSubscriptionDurable` | `..._InputArguments`, `..._OutputArguments` |
| Each `MethodIds.WellKnownRole_<Role>_<Verb>` for Observer, Operator, Engineer, Supervisor, ConfigureAdmin, SecurityAdmin (6 × 6 = 36 methods) | Each `..._InputArguments` |

The bug was masked by `DiagnosticsNodeManagerTests` looking up `OutputArguments` via the typed slot (apologetic comment explaining the workaround), by a `Tests/Opc.Ua.Core.Security.Tests/WellKnownRoleNodeIds.cs` compile-time fallback helper, and by a dead `FindPredefinedNode<>(VariableIds.Server_GetMonitoredItems_OutputArguments)` block in `DiagnosticsNodeManager.CreateAddressSpaceAsync` (lines 217–224) whose body was already a no-op.

## Fix (generator-only root-cause fix)

Make the type-level factory honour `forInstance: true` by dispatching on `parent.NodeId`. Both the **top-level** NodeId and every **synthesized child** factory call are rebound to the singleton-instance NodeIds when the parent matches a known singleton; type-template emission (`forInstance: false`) is unchanged.

- **Generator** (`Tools/Opc.Ua.SourceGeneration.Core`)
  - Index every singleton InstanceDesign in `m_nodes` by its `TypeDefinitionNode.SymbolicId` (`BuildSingletonInstanceIndex`).
  - `FindSingletonChildren(NodeToGenerate)` resolves the singleton-instance equivalents of a type-level entry by relative-path swap.
  - `BuildInstanceNodeIdOverride` emits the `state.NodeId` dispatch via a new `Tokens.InstanceNodeIdOverride` slot in the `Create_ChildObject` / `Create_ChildVariable` / `Create_ChildMethod` templates.
  - `EmitCreateOrReplaceChild` wraps each synthesized child call site in a `forInstance && parent != null` dispatch — single-singleton types (Server, HistoryServerCapabilities) emit a single `if`; multi-singleton types (RoleType → 9 well-known roles) emit an `if/else if` chain with a type-level fallback.
  - `OptionalMethod` template only invokes `context.NodeIdFactory.New(...)` when the type-level factory did **not** already override `state.NodeId` (compares against `Tokens.NodeIdConstant`), so the singleton dispatch survives the lazy-add path.

- **SDK cleanup** (`Libraries/Opc.Ua.Server/Diagnostics/DiagnosticsNodeManager.cs`)
  - Remove the dead `Server_GetMonitoredItems_OutputArguments` lookup at lines 217–224.
  - Drop the now-redundant explicit `NodeId` arguments from every `Add{Child}(context, …)` call in `AddServer/Capabilities/HistoryCapabilities/Namespaces/AliasNameCategory/WellKnownRole/ServerRedundancy SdkOptionalChildren` chains.
  - Collapse the 6-arm `case Objects.WellKnownRole_<Role>:` switch + 12-argument `AddWellKnownRoleChildren(…)` helper into a flat switch and a single-argument helper.
  - Strip the long workaround-justifying comments that no longer apply.

## Verification

- **`Tests/Opc.Ua.Server.Tests/DiagnosticsNodeManagerTests`** reverted to assert `manager.FindPredefinedNode<PropertyState>(VariableIds.Server_GetMonitoredItems_OutputArguments)` directly — the typed-slot workaround is gone.
- **`Tests/Opc.Ua.Server.Tests/ConfigurationNodeManagerTests.sdkAddedNodeIds`** extended with 10 Mandatory descendants (`Server_GetMonitoredItems_{In|Out}putArguments`, `Server_ResendData_InputArguments`, one per role × verb for the modifiable WellKnownRole singletons) so the regression is caught at the integration level.
- **`Tests/Opc.Ua.SourceGeneration.Core.Tests/Generators/NodeStateGeneratorTests`** — new snapshot test `NodeStateGeneratorEmitsSingletonInstanceDispatchInTypeLevelFactories` locks in both the single-singleton (Server) and multi-singleton (WellKnownRole_*) dispatch shape and the top-level `state.NodeId = NodeId.Create(11492u, …)` rebinding.
- **`Tests/Opc.Ua.Core.Security.Tests/WellKnownRoleNodeIds.cs`** kept as-is (still serves a legitimate non-admin permission-bypass purpose); comment updated to drop the bug-workaround framing.

### Test results (local, net10.0, Debug)

| Project | Result |
|---|---|
| `UA.slnx` full build | **0 errors / 0 of-mine warnings** |
| `Opc.Ua.Server.Tests` | 1893 passed, 5 skipped |
| `Opc.Ua.Core.Security.Tests` | 547 passed, 68 skipped |
| `Opc.Ua.Core.Tests` | 3255 passed, 86 skipped |
| `Opc.Ua.WotCon.Tests` | 342 passed |
| `Opc.Ua.InformationModel.Tests` (BaseInfoSingleCuTests subset) | 25 passed |
| `Opc.Ua.SourceGeneration.Core.Tests` (NodeStateGeneratorTests) | 8 passed (incl. new snapshot) |
| `DiagnosticsNodeManagerTests + ConfigurationNodeManagerTests` (focused) | 20 / 20 ✓ |

### Live verification against a fresh `ConsoleReferenceServer`

Built and launched `Applications/ConsoleReferenceServer` from this branch (`dotnet …/ConsoleReferenceServer.dll -a`) and connected via the OPC UA MCP server with `SecurityMode=None`:

| NodeId | Pre-fix | Post-fix |
|---|---|---|
| `i=11493` `Server_GetMonitoredItems_InputArguments` | `BadNodeIdUnknown` | `BrowseName=InputArguments`, value `[ Opc.Ua.Argument ]`, **Good** |
| `i=11494` `Server_GetMonitoredItems_OutputArguments` | `BadNodeIdUnknown` | value `[ Opc.Ua.Argument Opc.Ua.Argument ]`, **Good** |
| `i=12874` `Server_ResendData_InputArguments` | `BadNodeIdUnknown` | **Good** |
| `i=15673` / `i=15685` / `i=15709` / `i=15721` `WellKnownRole_{Observer|Operator|SecurityAdmin|ConfigureAdmin}_AddIdentity_InputArguments` | `BadNodeIdUnknown` | **Good** |

`Browse(i=11492)` returned children at `i=11493` / `i=11494` (singleton-instance NodeIds) — no longer at the pre-fix `i=11490` / `i=11491` (type-level NodeIds). The type-level NodeIds still coexist with the same `DataType = i=296 (Argument)` — the fix is non-destructive. Method invocation `Call(objectId=i=2253, methodId=i=11492, args=[999999])` returned `BadInvalidArgument` from the `OnGetMonitoredItems` handler, confirming the method node is properly wired with its correct InputArguments schema.

## Related Issues

_No tracking issue yet — happy to open one if maintainers prefer._

## Checklist

- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf) and read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [x] I have added all necessary documentation. _(N/A — generator-only bug fix; no public API surface changed.)_
- [x] I have verified that my changes do not introduce (new) build or analyzer warnings.
- [x] I ran **all** tests locally using the **UA.slnx** solution against at least .net **framework** and .net **10**, and all passed. _(net10.0 verified; net48 covered via `UA.slnx` build.)_
- [ ] I fixed **all** failing and flaky tests in the CI pipelines and **all** CodeQL warnings.
- [ ] I have addressed **all** PR feedback received.
