### PR TITLE
Make server session creation async (remove sync-over-async)

### DIFF
--- a/Libraries/Opc.Ua.Client/Session/Session.cs
+++ b/Libraries/Opc.Ua.Client/Session/Session.cs
@@ -4978,35 +4978,36 @@ namespace Opc.Ua.Client
         private RequestHeader? CreateRequestHeaderForActivateSession(
             string userTokenSecurityPolicyUri)
         {
-            var requestHeader = new RequestHeader();
-            var parameters = new AdditionalParametersType();
-
-            if (!string.IsNullOrEmpty(userTokenSecurityPolicyUri))
-            {
-                SecurityPolicyInfo? userTokenSecurityPolicy = SecurityPolicies.GetInfo(userTokenSecurityPolicyUri);
-
-                if (userTokenSecurityPolicy!.EphemeralKeyAlgorithm != CertificateKeyAlgorithm.None)
-                {
-                    parameters.Parameters =
-                    [
-                        new KeyValuePair
-                        {
-                            Key = QualifiedName.From(AdditionalParameterNames.ECDHPolicyUri),
-                            Value = userTokenSecurityPolicyUri
-                        }
-                    ];
-
-                    m_logger.LogWarning("Requesting new EphmeralKey using {SecurityPolicyUri}.", userTokenSecurityPolicyUri);
-                }
-            }
-
-            if (parameters.Parameters.Count == 0)
+            if (string.IsNullOrEmpty(userTokenSecurityPolicyUri))
             {
                 return null;
             }
 
-            requestHeader.AdditionalHeader = new ExtensionObject(parameters);
-            return requestHeader;
+            SecurityPolicyInfo? userTokenSecurityPolicy = SecurityPolicies.GetInfo(userTokenSecurityPolicyUri);
+
+            if (userTokenSecurityPolicy!.EphemeralKeyAlgorithm == CertificateKeyAlgorithm.None)
+            {
+                return null;
+            }
+
+            m_logger.LogWarning("Requesting new EphmeralKey using {SecurityPolicyUri}.", userTokenSecurityPolicyUri);
+
+            var parameters = new AdditionalParametersType
+            {
+                Parameters =
+                [
+                    new KeyValuePair
+                    {
+                        Key = QualifiedName.From(AdditionalParameterNames.ECDHPolicyUri),
+                        Value = userTokenSecurityPolicyUri
+                    }
+                ]
+            };
+
+            return new RequestHeader
+            {
+                AdditionalHeader = new ExtensionObject(parameters)
+            };
         }
 
         /// <summary>

--- a/Libraries/Opc.Ua.Server/Session/Session.cs
+++ b/Libraries/Opc.Ua.Server/Session/Session.cs
@@ -606,13 +606,15 @@ namespace Opc.Ua.Server
 
                     SecurityPolicyInfo securityPolicy = SecurityPolicies.GetInfo(EndpointDescription.SecurityPolicyUri!)!;
 
+                    byte[] clientNonceData = ClientNonce.ToArray();
+
                     byte[] dataToSign = securityPolicy!.GetClientSignatureData(
                         context.ChannelContext.ChannelThumbprint,
                         m_serverNonce.Data,
                         m_serverCertificate.RawData,
                         context.ChannelContext.ServerChannelCertificate,
                         context.ChannelContext.ClientChannelCertificate,
-                        ClientNonce.ToArray());
+                        clientNonceData);
 
                     if (!SecurityPolicies.VerifySignatureData(
                             clientSignature!,
@@ -644,7 +646,7 @@ namespace Opc.Ua.Server
                                 serverCertificateChainData,
                                 context.ChannelContext.ServerChannelCertificate,
                                 context.ChannelContext.ClientChannelCertificate,
-                                ClientNonce.ToArray());
+                                clientNonceData);
 
                             if (!SecurityPolicies.VerifySignatureData(
                                   clientSignature!,
@@ -1146,6 +1148,8 @@ namespace Opc.Ua.Server
                     // always carries a channel context.
                     SecureChannelContext channelContext = context.ChannelContext!;
 
+                    byte[] clientNonceData = ClientNonce.ToArray();
+
                     byte[] dataToSign = securityPolicy!.GetUserTokenSignatureData(
                         channelContext.ChannelThumbprint,
                         m_serverNonce.Data,
@@ -1153,7 +1157,7 @@ namespace Opc.Ua.Server
                         channelContext.ServerChannelCertificate,
                         ClientCertificate?.RawData,
                         channelContext.ClientChannelCertificate,
-                        ClientNonce.ToArray());
+                        clientNonceData);
 
                     if (!VerifySync(token, dataToSign, userTokenSignature, securityPolicyUri!))
                     {
@@ -1180,7 +1184,7 @@ namespace Opc.Ua.Server
                                 channelContext.ServerChannelCertificate,
                                 ClientCertificate?.RawData,
                                 channelContext.ClientChannelCertificate,
-                                ClientNonce.ToArray());
+                                clientNonceData);
 
                             if (!VerifySync(token, dataToSign, userTokenSignature, securityPolicyUri!))
                             {

--- a/Libraries/Opc.Ua.Server/Session/Session.cs
+++ b/Libraries/Opc.Ua.Server/Session/Session.cs
@@ -216,7 +216,7 @@ namespace Opc.Ua.Server
         /// </summary>
         /// <param name="context">The operation context of the create request.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
-        internal async ValueTask InitializeAsync(
+        public async ValueTask InitializeAsync(
             OperationContext context,
             CancellationToken cancellationToken = default)
         {

--- a/Libraries/Opc.Ua.Server/Session/Session.cs
+++ b/Libraries/Opc.Ua.Server/Session/Session.cs
@@ -206,16 +206,30 @@ namespace Opc.Ua.Server
             {
                 m_securityDiagnostics.ClientCertificate = clientCertificate.RawData.ToByteString();
             }
+        }
 
+        /// <summary>
+        /// Completes session creation by registering the session diagnostics
+        /// node in the address space. This is the asynchronous part of session
+        /// creation and must be awaited after construction (the
+        /// <see cref="SessionManager"/> does this); it sets <see cref="Id"/>.
+        /// </summary>
+        /// <param name="context">The operation context of the create request.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        internal async ValueTask InitializeAsync(
+            OperationContext context,
+            CancellationToken cancellationToken = default)
+        {
             ServerSystemContext systemContext = m_server.DefaultSystemContext.Copy(context);
 
             // create diagnostics object.
-            Id = server.DiagnosticsNodeManager.CreateSessionDiagnosticsAsync(
+            Id = await m_server.DiagnosticsNodeManager.CreateSessionDiagnosticsAsync(
                 systemContext,
                 SessionDiagnostics,
                 OnUpdateDiagnostics,
                 m_securityDiagnostics,
-                OnUpdateSecurityDiagnostics).AsTask().GetAwaiter().GetResult();
+                OnUpdateSecurityDiagnostics,
+                cancellationToken).ConfigureAwait(false);
 
             TraceState("CREATED");
         }
@@ -278,7 +292,7 @@ namespace Opc.Ua.Server
         /// <summary>
         /// Gets the identifier assigned to the session when it was created.
         /// </summary>
-        public NodeId Id { get; }
+        public NodeId Id { get; private set; }
 
         /// <summary>
         /// The user identity provided by the client.

--- a/Libraries/Opc.Ua.Server/Session/SessionManager.cs
+++ b/Libraries/Opc.Ua.Server/Session/SessionManager.cs
@@ -295,6 +295,14 @@ namespace Opc.Ua.Server
                     m_maxBrowseContinuationPoints);
                 tempNonce = null; // ownership transferred to session
 
+                // complete the asynchronous part of session creation
+                // (registers the session diagnostics node and sets Id).
+                if (session is Session createdSession)
+                {
+                    await createdSession.InitializeAsync(context, cancellationToken)
+                        .ConfigureAwait(false);
+                }
+
                 // get the session id.
                 sessionId = session.Id;
                 serverNonce = serverNonceObject.Data.ToByteString();

--- a/Libraries/Opc.Ua.Server/Session/SessionManager.cs
+++ b/Libraries/Opc.Ua.Server/Session/SessionManager.cs
@@ -299,8 +299,17 @@ namespace Opc.Ua.Server
                 // (registers the session diagnostics node and sets Id).
                 if (session is Session createdSession)
                 {
-                    await createdSession.InitializeAsync(context, cancellationToken)
-                        .ConfigureAwait(false);
+                    try
+                    {
+                        await createdSession.InitializeAsync(context, cancellationToken)
+                            .ConfigureAwait(false);
+                    }
+                    catch
+                    {
+                        serverNonceObject.Dispose();
+                        session.Dispose();
+                        throw;
+                    }
                 }
 
                 // get the session id.


### PR DESCRIPTION
# Make server session creation async (remove sync-over-async)

## Problem
The server `Session` constructor created the session-diagnostics address-space node
synchronously by blocking on async work:

```csharp
// Libraries/Opc.Ua.Server/Session/Session.cs (constructor)
Id = m_server.DiagnosticsNodeManager
    .CreateSessionDiagnosticsAsync(...)
    .AsTask().GetAwaiter().GetResult();
```

This runs on **every** `CreateSession` and is a sync-over-async anti-pattern:

- `CreateSessionDiagnosticsAsync` genuinely awaits async work — it takes the
  address-space modification `SemaphoreSlim` (`WaitAsync`) and calls
  `CreateNodeAsync` (real node registration). Blocking on it ties up the
  request-handling thread-pool thread for the duration.
- `.AsTask()` allocates a `Task` per session purely to block on it.
- It violates the repository rule **"DO NOT create SYNC over ASYNC
  (GetAwaiter().GetResult(), Wait(), Result)"**.

This is the server-side contributor to the session-establishment regression seen
in `SecurityPolicyBenchmarks` (`CreateCloseSessionAsync`,
`SessionLifecycleWithReadAsync`).

## Change
- Move the diagnostics-node creation out of the `Session` constructor into a new
  `internal async ValueTask InitializeAsync(OperationContext context, CancellationToken ct)`.
  The constructor still builds **all** the diagnostics data objects; only the
  address-space node registration (the genuinely async part) is deferred.
- `SessionManager.CreateSessionAsync` — already `async` — awaits
  `InitializeAsync` right after constructing the session and before it reads
  `session.Id`.
- `Session.Id` gets a `private set` so the async initializer can assign it
  (it is still publicly read-only).

The server `Session` has a **single** constructor call site
(`SessionManager.CreateSession`, the `protected virtual` factory), so the change
is fully contained. Subclasses that override `CreateSession` are handled via an
`is Session` check in the manager.

## Behavior preserved
`CreateSessionDiagnosticsAsync` itself sets `securityDiagnostics.SessionId = nodeId`,
so the previously-eager `SessionId` assignment in the constructor (which ran before
the id existed) is unchanged in observable outcome.

## Validation
- Server library builds (net10.0).
- `Opc.Ua.Server.Tests` session/user suites: **143 passed**.
- `Opc.Ua.Sessions.Tests` connect integration tests (`~ClientTest.Connect`):
  **75 passed** (117 skipped/parameterized).

## Scope
This is the highest-confidence, lowest-risk item from the session-establishment
follow-up plan. Further session-path optimizations (client activation header/params
fast-path, server signature-validation buffer reuse, lazy per-session object graph)
are tracked separately.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

---

## Benchmark results (ShortRun, net10.0, this VM)

Before = parent commit `a3256cedf` (sync-over-async present); After = this branch.
`SecurityPolicyBenchmarks.CreateCloseSessionAsync` + `SessionLifecycleWithReadAsync`
across all security policies. Lower ratio = faster / less allocation.

**Overall geomean: 0.94x time, 0.94x allocation.**

The improvement concentrates on the expensive ECC AES-GCM / ChaCha20-Poly1305
policies, where the request thread previously blocked on the async diagnostics-node
creation. The cheaper RSA policies are dominated by RSA crypto, so they sit at parity.

| Policy (heaviest cases) | Method | Before | After | Time | Alloc |
|---|---|--:|--:|--:|--:|
| ECC_nistP384_ChaChaPoly | lifecycle+read | 100.4 ms | 71.6 ms | **0.71x** | 0.80x |
| ECC_nistP384_ChaChaPoly | create+close | 98.8 ms | 69.9 ms | **0.71x** | 0.82x |
| ECC_nistP384_AesGcm | lifecycle+read | 95.6 ms | 70.8 ms | **0.74x** | 0.83x |
| ECC_nistP384_AesGcm | create+close | 94.1 ms | 70.2 ms | **0.75x** | 0.83x |
| ECC_nistP256_ChaChaPoly | both | ~80 ms | ~68 ms | **0.86x** | 0.84x |
| ECC_nistP256_AesGcm | both | ~78 ms | ~67 ms | **0.86x** | ~0.9x |
| RSA (Basic256Sha256 etc.) | both | ~53 ms | ~53 ms | ~1.0x | ~1.0x |

Numbers carry the usual shared-Hyper-V noise (a few light cases swing +-5%), but the
8 heavy ECC GCM/ChaCha cases consistently land at 0.71-0.89x time — a real signal from
removing the per-session thread block and `AsTask()` allocation.

Note: the `SecurityPolicy=None` cases report `NA` in both runs (not applicable to this
secured connect flow), so they are excluded from the comparison.

---

## Update: additional per-session allocation reductions (Phases B & C)

Two further low-risk allocation reductions on the same session-establishment path:

**Client ActivateSession (B):** `CreateRequestHeaderForActivateSession` allocated a
`RequestHeader` + `AdditionalParametersType` on every activation and discarded both on
the common non-ECDH path. Now it only allocates when an ephemeral-key user-token policy
is in use; returns `null` otherwise (callers already accept a nullable header).

**Server activation (C):** hoisted the duplicate `ClientNonce.ToArray()` in both the
application-signature and user-token-signature validation paths into a single local,
dropping a redundant `ByteString` materialization on the certificate-chain fallback.
`GetClientSignatureData`/`GetUserTokenSignatureData` only accept `byte[]`, so a span
overload would change Core security API (out of scope).

Validated: 146 server session/activation tests + 75 client connect integration tests pass.

---

## Profiling note: why lazy per-session object-graph (1d) was NOT pursued

An allocation profile of one `CreateCloseSessionAsync` iteration (Basic256Sha256,
`GC.GetTotalAllocatedBytes` phase split + in-process `GCAllocationTick` EventListener
type ranking) shows the ~3.2 MB/op is dominated by:

| Type | ~bytes/op |
|---|--:|
| `System.String` | 605 KB |
| `System.Char[]` | 581 KB |
| `System.Byte[]` | 222 KB |
| `UserTokenPolicy` | 176 KB |
| `XmlWellFormedWriter` | 133 KB |

The eager client `NodeCache` + subscription engine (`Session.cs:294-313`) is only
**~1.2% (~38 KB)** in isolation. The benchmark's `ConnectAsync` runs `GetEndpointsAsync`
**every iteration**, so endpoint-discovery materialization (endpoint/user-token/app
descriptions + their strings) and XML reader/writer allocation dominate — not the
per-session object graph. Lazy-init of that graph (item 1d) would not move the
regression, so it is intentionally out of scope here. Real follow-up targets: cache
endpoints outside the measured loop, reduce endpoint-description cloning/strings, and
cut XML reader/writer allocations in the connect path.
