### PR TITLE
Binary encoder: read NodeId accessors once in the write path

### DIFF
--- a/Stack/Opc.Ua.Types/BuiltIn/NodeId.cs
+++ b/Stack/Opc.Ua.Types/BuiltIn/NodeId.cs
@@ -537,7 +537,7 @@ namespace Opc.Ua
                     break;
                 case IdType.Opaque:
                     buffer.Append("b=")
-                        .Append(OpaqueIdentifer.ToBase64());
+                        .Append(OpaqueIdentifier.ToBase64());
                     break;
                 case IdType.String:
                     buffer.Append("s=")
@@ -1091,7 +1091,7 @@ namespace Opc.Ua
                 // TODO: avoid recalculation of hashcode
                 IdType.String => new NodeId(StringIdentifier, value),
                 IdType.Guid => new NodeId(GuidIdentifier, value),
-                IdType.Opaque => new NodeId(OpaqueIdentifer, value),
+                IdType.Opaque => new NodeId(OpaqueIdentifier, value),
                 _ => new NodeId(NumericIdentifier, value)
             };
         }
@@ -1191,7 +1191,7 @@ namespace Opc.Ua
                 IdType.Guid =>
                     GuidIdentifier.CompareTo(nodeId.GuidIdentifier),
                 IdType.Opaque =>
-                    OpaqueIdentifer.CompareTo(nodeId.OpaqueIdentifer),
+                    OpaqueIdentifier.CompareTo(nodeId.OpaqueIdentifier),
                 _ => -1
             };
         }
@@ -1259,7 +1259,7 @@ namespace Opc.Ua
             {
                 return -1;
             }
-            return OpaqueIdentifer.CompareTo(obj);
+            return OpaqueIdentifier.CompareTo(obj);
         }
 
         /// <inheritdoc/>
@@ -1366,7 +1366,7 @@ namespace Opc.Ua
                 case IdType.Guid:
                     return GuidIdentifier == other.GuidIdentifier;
                 case IdType.Opaque:
-                    return OpaqueIdentifer == other.OpaqueIdentifer;
+                    return OpaqueIdentifier == other.OpaqueIdentifier;
             }
             return false;
         }
@@ -1408,7 +1408,7 @@ namespace Opc.Ua
             {
                 return false;
             }
-            return OpaqueIdentifer == other;
+            return OpaqueIdentifier == other;
         }
 
         /// <inheritdoc/>
@@ -1450,9 +1450,9 @@ namespace Opc.Ua
                     break;
                 case IdType.Opaque:
 #if NET6_0_OR_GREATER
-                    hashCode.AddBytes(OpaqueIdentifer);
+                    hashCode.AddBytes(OpaqueIdentifier);
 #else
-                    foreach (byte id in OpaqueIdentifer)
+                    foreach (byte id in OpaqueIdentifier)
                     {
                         hashCode.Add(id);
                     }
@@ -1555,7 +1555,7 @@ namespace Opc.Ua
         /// <summary>
         /// Identifier as bytes
         /// </summary>
-        internal ByteString OpaqueIdentifer =>
+        internal ByteString OpaqueIdentifier =>
             m_identifier == null ? ByteString.Empty : (ByteString)m_identifier;
 
         /// <summary>
@@ -1590,7 +1590,7 @@ namespace Opc.Ua
             IdType.Numeric => NumericIdentifier,
             IdType.String => StringIdentifier,
             IdType.Guid => GuidIdentifier,
-            IdType.Opaque => OpaqueIdentifer,
+            IdType.Opaque => OpaqueIdentifier,
             _ => throw ServiceResultException.Unexpected(
                 $"Unexpected IdType value {IdType}.")
         };
@@ -1604,7 +1604,7 @@ namespace Opc.Ua
             IdType.Numeric => NumericIdentifier.ToString(CultureInfo.InvariantCulture),
             IdType.String => StringIdentifier,
             IdType.Guid => GuidIdentifier.ToString(),
-            IdType.Opaque => OpaqueIdentifer.ToBase64(),
+            IdType.Opaque => OpaqueIdentifier.ToBase64(),
             _ => throw ServiceResultException.Unexpected(
                 $"Unexpected IdType value {IdType}.")
         };
@@ -1630,7 +1630,7 @@ namespace Opc.Ua
         {
             if (IdType == IdType.Opaque)
             {
-                identifier = OpaqueIdentifer;
+                identifier = OpaqueIdentifier;
                 return true;
             }
             identifier = default;
@@ -1676,7 +1676,7 @@ namespace Opc.Ua
             IdType.Numeric => NumericIdentifier == 0,
             IdType.String => string.IsNullOrEmpty(StringIdentifier),
             IdType.Guid => GuidIdentifier == Guid.Empty,
-            IdType.Opaque => OpaqueIdentifer.Length == 0,
+            IdType.Opaque => OpaqueIdentifier.Length == 0,
             _ => false
         };
 

--- a/Stack/Opc.Ua.Types/Encoders/BinaryEncoder.cs
+++ b/Stack/Opc.Ua.Types/Encoders/BinaryEncoder.cs
@@ -595,16 +595,15 @@ namespace Opc.Ua
         /// <inheritdoc/>
         public void WriteNodeId(string? fieldName, NodeId value)
         {
-            var nodeId = new NodeIdSnapshot(value);
-
             // write a null node id.
-            if (nodeId.IsNull)
+            if (value.IsNull)
             {
                 WriteUInt16(null, 0);
                 return;
             }
 
-            ushort namespaceIndex = nodeId.NamespaceIndex;
+            IdType idType = value.IdType;
+            ushort namespaceIndex = value.NamespaceIndex;
 
             if (m_namespaceMappings != null && m_namespaceMappings.Length > namespaceIndex)
             {
@@ -612,31 +611,30 @@ namespace Opc.Ua
             }
 
             // get the node encoding.
-            byte encoding = GetNodeIdEncoding(in nodeId, namespaceIndex);
+            byte encoding = GetNodeIdEncoding(idType, in value, namespaceIndex);
 
             // write the encoding.
             WriteByte(null, encoding);
 
             // write the node.
-            WriteNodeIdBody(encoding, in nodeId, namespaceIndex);
+            WriteNodeIdBody(encoding, in value, namespaceIndex);
         }
 
         /// <inheritdoc/>
         public void WriteExpandedNodeId(string? fieldName, ExpandedNodeId value)
         {
-            NodeId innerNodeId = value.InnerNodeId;
-            var nodeId = new NodeIdSnapshot(innerNodeId);
-            string? namespaceUri = value.NamespaceUri;
-            uint serverIndex = value.ServerIndex;
-
             // write a null node id.
-            if (string.IsNullOrEmpty(namespaceUri) && serverIndex == 0 && nodeId.IsNull)
+            if (value.IsNull)
             {
                 WriteUInt16(null, 0);
                 return;
             }
 
-            ushort namespaceIndex = nodeId.NamespaceIndex;
+            NodeId innerNodeId = value.InnerNodeId;
+            string? namespaceUri = value.NamespaceUri;
+            uint serverIndex = value.ServerIndex;
+
+            ushort namespaceIndex = value.NamespaceIndex;
 
             if (m_namespaceMappings != null && m_namespaceMappings.Length > namespaceIndex)
             {
@@ -649,7 +647,7 @@ namespace Opc.Ua
             }
 
             // get the node encoding.
-            byte encoding = GetNodeIdEncoding(in nodeId, namespaceIndex);
+            byte encoding = GetNodeIdEncoding(innerNodeId.IdType, in innerNodeId, namespaceIndex);
 
             // add the bit indicating a uri string is encoded as well.
             if (!string.IsNullOrEmpty(namespaceUri))
@@ -667,7 +665,7 @@ namespace Opc.Ua
             WriteByte(null, encoding);
 
             // write the node id.
-            WriteNodeIdBody(encoding, in nodeId, namespaceIndex);
+            WriteNodeIdBody(encoding, in innerNodeId, namespaceIndex);
 
             // write the namespace uri.
             if ((encoding & 0x80) != 0)
@@ -2106,10 +2104,10 @@ namespace Opc.Ua
         /// Returns the node id encoding byte for a node id value.
         /// </summary>
         /// <exception cref="ServiceResultException"></exception>
-        private static byte GetNodeIdEncoding(in NodeIdSnapshot nodeId, int namespaceIndex)
+        private static byte GetNodeIdEncoding(IdType idType, in NodeId nodeId, int namespaceIndex)
         {
             NodeIdEncodingBits encoding;
-            switch (nodeId.IdType)
+            switch (idType)
             {
                 case IdType.String:
                     encoding = NodeIdEncodingBits.String;
@@ -2146,7 +2144,7 @@ namespace Opc.Ua
         /// Writes the body of a node id to the stream.
         /// </summary>
         /// <exception cref="ServiceResultException"></exception>
-        private void WriteNodeIdBody(byte encoding, in NodeIdSnapshot nodeId, ushort namespaceIndex)
+        private void WriteNodeIdBody(byte encoding, in NodeId nodeId, ushort namespaceIndex)
         {
             // write the node id.
             switch ((NodeIdEncodingBits)(0x3F & encoding))
@@ -2211,56 +2209,6 @@ namespace Opc.Ua
                     Context.MaxEncodingNestingLevels);
             }
             m_nestingLevel++;
-        }
-
-        private readonly struct NodeIdSnapshot
-        {
-            public NodeIdSnapshot(NodeId nodeId)
-            {
-                IdType = nodeId.IdType;
-                NamespaceIndex = nodeId.NamespaceIndex;
-                NumericIdentifier = default;
-                StringIdentifier = string.Empty;
-                GuidIdentifier = default;
-                OpaqueIdentifier = default;
-
-                switch (IdType)
-                {
-                    case IdType.String:
-                        StringIdentifier = nodeId.StringIdentifier;
-                        break;
-                    case IdType.Guid:
-                        GuidIdentifier = nodeId.GuidIdentifier;
-                        break;
-                    case IdType.Opaque:
-                        OpaqueIdentifier = nodeId.OpaqueIdentifer;
-                        break;
-                    default:
-                        NumericIdentifier = nodeId.NumericIdentifier;
-                        break;
-                }
-            }
-
-            public IdType IdType { get; }
-
-            public ushort NamespaceIndex { get; }
-
-            public uint NumericIdentifier { get; }
-
-            public string StringIdentifier { get; }
-
-            public Guid GuidIdentifier { get; }
-
-            public ByteString OpaqueIdentifier { get; }
-
-            public bool IsNull => NamespaceIndex == 0 && IdType switch
-            {
-                IdType.Numeric => NumericIdentifier == 0,
-                IdType.String => string.IsNullOrEmpty(StringIdentifier),
-                IdType.Guid => GuidIdentifier == Guid.Empty,
-                IdType.Opaque => OpaqueIdentifier.Length == 0,
-                _ => false
-            };
         }
 
         private readonly ILogger m_logger;

--- a/Stack/Opc.Ua.Types/Encoders/BinaryEncoder.cs
+++ b/Stack/Opc.Ua.Types/Encoders/BinaryEncoder.cs
@@ -595,14 +595,16 @@ namespace Opc.Ua
         /// <inheritdoc/>
         public void WriteNodeId(string? fieldName, NodeId value)
         {
+            var nodeId = new NodeIdSnapshot(value);
+
             // write a null node id.
-            if (value.IsNull)
+            if (nodeId.IsNull)
             {
                 WriteUInt16(null, 0);
                 return;
             }
 
-            ushort namespaceIndex = value.NamespaceIndex;
+            ushort namespaceIndex = nodeId.NamespaceIndex;
 
             if (m_namespaceMappings != null && m_namespaceMappings.Length > namespaceIndex)
             {
@@ -610,33 +612,36 @@ namespace Opc.Ua
             }
 
             // get the node encoding.
-            byte encoding = GetNodeIdEncoding(value, namespaceIndex);
+            byte encoding = GetNodeIdEncoding(in nodeId, namespaceIndex);
 
             // write the encoding.
             WriteByte(null, encoding);
 
             // write the node.
-            WriteNodeIdBody(encoding, value, namespaceIndex);
+            WriteNodeIdBody(encoding, in nodeId, namespaceIndex);
         }
 
         /// <inheritdoc/>
         public void WriteExpandedNodeId(string? fieldName, ExpandedNodeId value)
         {
+            NodeId innerNodeId = value.InnerNodeId;
+            var nodeId = new NodeIdSnapshot(innerNodeId);
+            string? namespaceUri = value.NamespaceUri;
+            uint serverIndex = value.ServerIndex;
+
             // write a null node id.
-            if (value.IsNull)
+            if (string.IsNullOrEmpty(namespaceUri) && serverIndex == 0 && nodeId.IsNull)
             {
                 WriteUInt16(null, 0);
                 return;
             }
 
-            ushort namespaceIndex = value.NamespaceIndex;
+            ushort namespaceIndex = nodeId.NamespaceIndex;
 
             if (m_namespaceMappings != null && m_namespaceMappings.Length > namespaceIndex)
             {
                 namespaceIndex = m_namespaceMappings[namespaceIndex];
             }
-
-            uint serverIndex = value.ServerIndex;
 
             if (m_serverMappings != null && m_serverMappings.Length > serverIndex)
             {
@@ -644,10 +649,10 @@ namespace Opc.Ua
             }
 
             // get the node encoding.
-            byte encoding = GetNodeIdEncoding(value.InnerNodeId, namespaceIndex);
+            byte encoding = GetNodeIdEncoding(in nodeId, namespaceIndex);
 
             // add the bit indicating a uri string is encoded as well.
-            if (!string.IsNullOrEmpty(value.NamespaceUri))
+            if (!string.IsNullOrEmpty(namespaceUri))
             {
                 encoding |= 0x80;
             }
@@ -662,12 +667,12 @@ namespace Opc.Ua
             WriteByte(null, encoding);
 
             // write the node id.
-            WriteNodeIdBody(encoding, value.InnerNodeId, namespaceIndex);
+            WriteNodeIdBody(encoding, in nodeId, namespaceIndex);
 
             // write the namespace uri.
             if ((encoding & 0x80) != 0)
             {
-                WriteString(null, value.NamespaceUri);
+                WriteString(null, namespaceUri);
             }
 
             // write the server index.
@@ -2101,7 +2106,7 @@ namespace Opc.Ua
         /// Returns the node id encoding byte for a node id value.
         /// </summary>
         /// <exception cref="ServiceResultException"></exception>
-        private static byte GetNodeIdEncoding(NodeId nodeId, int namespaceIndex)
+        private static byte GetNodeIdEncoding(in NodeIdSnapshot nodeId, int namespaceIndex)
         {
             NodeIdEncodingBits encoding;
             switch (nodeId.IdType)
@@ -2141,7 +2146,7 @@ namespace Opc.Ua
         /// Writes the body of a node id to the stream.
         /// </summary>
         /// <exception cref="ServiceResultException"></exception>
-        private void WriteNodeIdBody(byte encoding, NodeId nodeId, ushort namespaceIndex)
+        private void WriteNodeIdBody(byte encoding, in NodeIdSnapshot nodeId, ushort namespaceIndex)
         {
             // write the node id.
             switch ((NodeIdEncodingBits)(0x3F & encoding))
@@ -2167,7 +2172,7 @@ namespace Opc.Ua
                     break;
                 case NodeIdEncodingBits.ByteString:
                     WriteUInt16(null, namespaceIndex);
-                    WriteByteString(null, nodeId.OpaqueIdentifer);
+                    WriteByteString(null, nodeId.OpaqueIdentifier);
                     break;
             }
         }
@@ -2206,6 +2211,56 @@ namespace Opc.Ua
                     Context.MaxEncodingNestingLevels);
             }
             m_nestingLevel++;
+        }
+
+        private readonly struct NodeIdSnapshot
+        {
+            public NodeIdSnapshot(NodeId nodeId)
+            {
+                IdType = nodeId.IdType;
+                NamespaceIndex = nodeId.NamespaceIndex;
+                NumericIdentifier = default;
+                StringIdentifier = string.Empty;
+                GuidIdentifier = default;
+                OpaqueIdentifier = default;
+
+                switch (IdType)
+                {
+                    case IdType.String:
+                        StringIdentifier = nodeId.StringIdentifier;
+                        break;
+                    case IdType.Guid:
+                        GuidIdentifier = nodeId.GuidIdentifier;
+                        break;
+                    case IdType.Opaque:
+                        OpaqueIdentifier = nodeId.OpaqueIdentifer;
+                        break;
+                    default:
+                        NumericIdentifier = nodeId.NumericIdentifier;
+                        break;
+                }
+            }
+
+            public IdType IdType { get; }
+
+            public ushort NamespaceIndex { get; }
+
+            public uint NumericIdentifier { get; }
+
+            public string StringIdentifier { get; }
+
+            public Guid GuidIdentifier { get; }
+
+            public ByteString OpaqueIdentifier { get; }
+
+            public bool IsNull => NamespaceIndex == 0 && IdType switch
+            {
+                IdType.Numeric => NumericIdentifier == 0,
+                IdType.String => string.IsNullOrEmpty(StringIdentifier),
+                IdType.Guid => GuidIdentifier == Guid.Empty,
+                IdType.Opaque => OpaqueIdentifier.Length == 0,
+                _ => false
+            };
         }
 
         private readonly ILogger m_logger;


### PR DESCRIPTION
# Binary encoder: read NodeId accessors once in the write path

Follow-up perf work (companion to #3899 / #3902). Small, correctness-preserving
micro-optimization in the binary encoder hot path.

## Problem
`BinaryEncoder.WriteNodeId` / `WriteExpandedNodeId` repeatedly re-read the v2 `NodeId`
readonly-struct accessors (`IdType`, `NamespaceIndex`), each of which switches on the
identifier kind, and passed the `NodeId` to the private helpers by value (a struct copy).

## Change
- `WriteNodeId` / `WriteExpandedNodeId` read `IdType` and `NamespaceIndex` into locals
  once, and pass the `IdType` plus the `NodeId` **by `in`** (no copy) to the private
  `GetNodeIdEncoding` / `WriteNodeIdBody` helpers, which read the single active
  identifier exactly once.
- No wrapper type is introduced — individual values are kept on the stack and passed as
  arguments (per review feedback).
- Fixed the misspelled internal `NodeId` member `OpaqueIdentifer` → `OpaqueIdentifier`
  (and all 15 usages). It is `internal`, so there is no public-API / compatibility impact.

## Not changed
`DateTimeUtc` / `WriteDateTime`: `WriteDateTime` already reads `.Value` once, and
`.Value` preserves the existing `MaxValue => long.MaxValue` wire behavior, so a
raw-ticks accessor would not be correctness-preserving. Left as-is.

## Validation
- `Opc.Ua.Types` builds clean (0 warnings/errors) on net10.0 and all target frameworks.
- Encoder correctness suite: 3475 passed, 0 failed.
- NodeId / ExpandedNodeId tests: 17 passed, 0 failed.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
