### PR TITLE
Fix weekly per-TFM solution build (net8/net9 McpServer ref + netstandard CS8021)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -111,11 +111,14 @@
   <!-- MQTTnet 5.x dropped net48/net472/netstandard2.1 support. Per-TFM pinning is
        required because CentralPackageTransitivePinningEnabled lets the central pin
        win over PubSub's VersionOverride for transitive consumers (e.g. samples
-       that ProjectReference Opc.Ua.PubSub). See Libraries/Opc.Ua.PubSub.csproj. -->
-  <ItemGroup Condition="'$(TargetFramework)' == 'net472' OR '$(TargetFramework)' == 'net48' OR '$(TargetFramework)' == 'netstandard2.1'">
+       that ProjectReference Opc.Ua.PubSub). See Libraries/Opc.Ua.PubSub.csproj.
+       When the solution is pinned to netstandard2.1 (CustomTestTarget=netstandard2.1)
+       the libraries build as netstandard2.1 (MQTTnet v4) while their tests/apps build
+       as net8.0, so the net8.0 consumers must also use v4 to match the libraries. -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472' OR '$(TargetFramework)' == 'net48' OR '$(TargetFramework)' == 'netstandard2.1' OR '$(CustomTestTarget)' == 'netstandard2.1'">
     <PackageVersion Include="MQTTnet" Version="4.3.7.1207" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' != 'net472' AND '$(TargetFramework)' != 'net48' AND '$(TargetFramework)' != 'netstandard2.1'">
+  <ItemGroup Condition="('$(TargetFramework)' != 'net472' AND '$(TargetFramework)' != 'net48' AND '$(TargetFramework)' != 'netstandard2.1') AND '$(CustomTestTarget)' != 'netstandard2.1'">
     <PackageVersion Include="MQTTnet" Version="5.1.0.1559" />
   </ItemGroup>
 </Project>

--- a/Fuzzing/Opc.Ua.Network.Fuzz.Tests/Opc.Ua.Network.Fuzz.Tests.csproj
+++ b/Fuzzing/Opc.Ua.Network.Fuzz.Tests/Opc.Ua.Network.Fuzz.Tests.csproj
@@ -6,6 +6,10 @@
          the rationale. -->
     <TargetFrameworks Condition="'$(CustomTestTarget)' == ''">net8.0;net9.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(CustomTestTarget)' == 'net8.0' OR '$(CustomTestTarget)' == 'net9.0' OR '$(CustomTestTarget)' == 'net10.0'">$(CustomTestTarget)</TargetFrameworks>
+    <!-- netstandard2.0/2.1 can't host the empty $(RestrictForLegacyTfm) shell
+         (CS8021 - no reference assembly defines System.Object), so build those
+         shells as net10.0. net472/net48 shells compile empty fine. -->
+    <TargetFrameworks Condition="'$(TargetFrameworks)' == '' AND ('$(CustomTestTarget)' == 'netstandard2.0' OR '$(CustomTestTarget)' == 'netstandard2.1')">net10.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">$(CustomTestTarget)</TargetFrameworks>
     <RestrictForLegacyTfm>true</RestrictForLegacyTfm>
     <AssemblyName>Opc.Ua.Network.Fuzz.Tests</AssemblyName>

--- a/Fuzzing/Opc.Ua.Network.Fuzz.Tools/Opc.Ua.Network.Fuzz.Tools.csproj
+++ b/Fuzzing/Opc.Ua.Network.Fuzz.Tools/Opc.Ua.Network.Fuzz.Tools.csproj
@@ -6,6 +6,10 @@
          the rationale. -->
     <TargetFrameworks Condition="'$(CustomTestTarget)' == ''">net8.0;net9.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(CustomTestTarget)' == 'net8.0' OR '$(CustomTestTarget)' == 'net9.0' OR '$(CustomTestTarget)' == 'net10.0'">$(CustomTestTarget)</TargetFrameworks>
+    <!-- netstandard2.0/2.1 can't host the empty $(RestrictForLegacyTfm) shell
+         (CS8021 - no reference assembly defines System.Object), so build those
+         shells as net10.0. net472/net48 shells compile empty fine. -->
+    <TargetFrameworks Condition="'$(TargetFrameworks)' == '' AND ('$(CustomTestTarget)' == 'netstandard2.0' OR '$(CustomTestTarget)' == 'netstandard2.1')">net10.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">$(CustomTestTarget)</TargetFrameworks>
     <RestrictForLegacyTfm>true</RestrictForLegacyTfm>
     <AssemblyName>Opc.Ua.Network.Fuzz.Tools</AssemblyName>

--- a/Fuzzing/Opc.Ua.Network.Fuzz/Opc.Ua.Network.Fuzz.csproj
+++ b/Fuzzing/Opc.Ua.Network.Fuzz/Opc.Ua.Network.Fuzz.csproj
@@ -9,6 +9,10 @@
          $(RestrictForLegacyTfm), so this fuzz project follows suit. -->
     <TargetFrameworks Condition="'$(CustomTestTarget)' == ''">net8.0;net9.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(CustomTestTarget)' == 'net8.0' OR '$(CustomTestTarget)' == 'net9.0' OR '$(CustomTestTarget)' == 'net10.0'">$(CustomTestTarget)</TargetFrameworks>
+    <!-- netstandard2.0/2.1 can't host the empty $(RestrictForLegacyTfm) shell
+         (CS8021 - no reference assembly defines System.Object), so build those
+         shells as net10.0. net472/net48 shells compile empty fine. -->
+    <TargetFrameworks Condition="'$(TargetFrameworks)' == '' AND ('$(CustomTestTarget)' == 'netstandard2.0' OR '$(CustomTestTarget)' == 'netstandard2.1')">net10.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">$(CustomTestTarget)</TargetFrameworks>
     <RestrictForLegacyTfm>true</RestrictForLegacyTfm>
     <AssemblyName>Opc.Ua.Network.Fuzz</AssemblyName>

--- a/Stack/Opc.Ua.Core.Diagnostics/Opc.Ua.Core.Diagnostics.csproj
+++ b/Stack/Opc.Ua.Core.Diagnostics/Opc.Ua.Core.Diagnostics.csproj
@@ -9,6 +9,11 @@
          project to an empty no-op shell via $(RestrictForLegacyTfm). -->
     <TargetFrameworks Condition="'$(CustomTestTarget)' == ''">net8.0;net9.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(CustomTestTarget)' == 'net8.0' OR '$(CustomTestTarget)' == 'net9.0' OR '$(CustomTestTarget)' == 'net10.0'">$(CustomTestTarget)</TargetFrameworks>
+    <!-- netstandard2.0/2.1 can't host the empty $(RestrictForLegacyTfm) shell
+         (CS8021 - no reference assembly defines System.Object), so build those
+         shells as net10.0 (same as the other .NET 8+-only no-op shells, e.g.
+         McpServer). net472/net48 shells compile empty fine and pass through. -->
+    <TargetFrameworks Condition="'$(TargetFrameworks)' == '' AND ('$(CustomTestTarget)' == 'netstandard2.0' OR '$(CustomTestTarget)' == 'netstandard2.1')">net10.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">$(CustomTestTarget)</TargetFrameworks>
     <RestrictForLegacyTfm>true</RestrictForLegacyTfm>
     <AssemblyName>$(AssemblyPrefix).Core.Diagnostics</AssemblyName>

--- a/Tests/Opc.Ua.Core.Diagnostics.Tests/McpServerTools/McpServerOptionsTests.cs
+++ b/Tests/Opc.Ua.Core.Diagnostics.Tests/McpServerTools/McpServerOptionsTests.cs
@@ -27,6 +27,9 @@
  * http://opcfoundation.org/License/MIT/1.00/
  * ======================================================================*/
 
+// Opc.Ua.Mcp targets net10.0 only and is loaded reflectively from its net10.0
+// build output, so these tests only build and run on net10.0.
+#if NET10_0_OR_GREATER
 using System;
 using System.IO;
 using System.Linq;
@@ -296,3 +299,4 @@ namespace Opc.Ua.Pcap.Tests.McpServerTools
         }
     }
 }
+#endif

--- a/Tests/Opc.Ua.Core.Diagnostics.Tests/McpServerTools/PacketDecodePathValidationTests.cs
+++ b/Tests/Opc.Ua.Core.Diagnostics.Tests/McpServerTools/PacketDecodePathValidationTests.cs
@@ -27,6 +27,9 @@
  * http://opcfoundation.org/License/MIT/1.00/
  * ======================================================================*/
 
+// Opc.Ua.Mcp targets net10.0 only and is loaded reflectively from its net10.0
+// build output, so these tests only build and run on net10.0.
+#if NET10_0_OR_GREATER
 using System;
 using System.IO;
 using System.Linq;
@@ -225,3 +228,4 @@ namespace Opc.Ua.Pcap.Tests.McpServerTools
         }
     }
 }
+#endif

--- a/Tests/Opc.Ua.Core.Diagnostics.Tests/Opc.Ua.Core.Diagnostics.Tests.csproj
+++ b/Tests/Opc.Ua.Core.Diagnostics.Tests/Opc.Ua.Core.Diagnostics.Tests.csproj
@@ -8,6 +8,10 @@
          via $(RestrictForLegacyTfm). -->
     <TargetFrameworks Condition="'$(CustomTestTarget)' == ''">net10.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(CustomTestTarget)' == 'net8.0' OR '$(CustomTestTarget)' == 'net9.0' OR '$(CustomTestTarget)' == 'net10.0'">$(CustomTestTarget)</TargetFrameworks>
+    <!-- netstandard2.0/2.1 can't host the empty $(RestrictForLegacyTfm) shell
+         (CS8021 - no reference assembly defines System.Object), so build those
+         shells as net10.0. net472/net48 shells compile empty fine. -->
+    <TargetFrameworks Condition="'$(TargetFrameworks)' == '' AND ('$(CustomTestTarget)' == 'netstandard2.0' OR '$(CustomTestTarget)' == 'netstandard2.1')">net10.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">$(CustomTestTarget)</TargetFrameworks>
     <RestrictForLegacyTfm>true</RestrictForLegacyTfm>
     <RootNamespace>Opc.Ua.Pcap.Tests</RootNamespace>
@@ -60,6 +64,7 @@
       reflectively, deliberately).
     -->
     <ProjectReference Include="..\..\Applications\McpServer\Opc.Ua.Mcp.csproj"
+                      Condition="'$(TargetFramework)' == 'net10.0'"
                       ReferenceOutputAssembly="false"
                       PrivateAssets="all" />
   </ItemGroup>

--- a/Tests/Opc.Ua.PubSub.Tests/Transport/MqttPubSubConnectionTests.Mqtts.cs
+++ b/Tests/Opc.Ua.PubSub.Tests/Transport/MqttPubSubConnectionTests.Mqtts.cs
@@ -29,7 +29,12 @@
 
 using System.Collections.Generic;
 using System.Threading;
-#if !NET8_0_OR_GREATER
+// MQTTnet 4.x (used on net48/net472 and when the solution is pinned to
+// netstandard2.1, where the libraries build as netstandard2.1) keeps the client
+// option types in the MQTTnet.Client namespace; MQTTnet 5.x (modern TFMs) moved
+// them to MQTTnet. NET_STANDARD_TESTS marks the netstandard CI build of this
+// test project, whose net8.0 consumer resolves MQTTnet 4.x to match the libs.
+#if !NET8_0_OR_GREATER || NET_STANDARD_TESTS
 using MQTTnet.Client;
 #endif
 using NUnit.Framework;

--- a/Tests/Opc.Ua.Types.Tests/Utils/Buffers/ReadOnlyMemoryTests.cs
+++ b/Tests/Opc.Ua.Types.Tests/Utils/Buffers/ReadOnlyMemoryTests.cs
@@ -50,7 +50,12 @@ namespace Opc.Ua.Types.Buffers.Tests
             Assert.That(memory.Index, Is.EqualTo(1));
         }
 
-#if NET8_0_OR_GREATER
+        // ReadOnlyMemoryHelper.ReinterpretAs/From are net8.0+-only library helpers
+        // (unsafe ref reinterpretation). In the netstandard tests jobs the consumed
+        // Opc.Ua.Types is built as netstandard2.x, which does not provide them, so
+        // exclude these cases there (NET_STANDARD_TESTS is defined by the netstandard
+        // CI build of this test project).
+#if NET8_0_OR_GREATER && !NET_STANDARD_TESTS
         [Test]
         public void ReinterpretAsReturnsExpectedType()
         {

--- a/targets.props
+++ b/targets.props
@@ -49,9 +49,15 @@
     <When Condition="'$(CustomTestTarget)' == 'netstandard2.1'">
       <PropertyGroup>
         <NetStandardTests>true</NetStandardTests>
-        <AppTargetFrameworks>net10.0</AppTargetFrameworks>
-        <AppTargetFramework>net10.0</AppTargetFramework>
-        <TestsTargetFrameworks>net10.0</TestsTargetFrameworks>
+        <!-- netstandard2.1 is a library-only TFM; its build is validated by a net8.0
+             consumer (apps/tests). net8.0 (unlike net9.0+/net10.0) does not define
+             System.Threading.Lock or X509CertificateLoader in its BCL, so the
+             netstandard2.1 libraries' public polyfills for those types do not collide
+             with the consumer's BCL. This matches the net8.0 framework the netstandard2.1
+             test stage already runs (azure-pipelines.yml). -->
+        <AppTargetFrameworks>net8.0</AppTargetFrameworks>
+        <AppTargetFramework>net8.0</AppTargetFramework>
+        <TestsTargetFrameworks>net8.0</TestsTargetFrameworks>
         <LibTargetFrameworks>netstandard2.1</LibTargetFrameworks>
         <LibCoreTargetFrameworks>netstandard2.1</LibCoreTargetFrameworks>
         <LibxTargetFrameworks>netstandard2.1</LibxTargetFrameworks>


### PR DESCRIPTION
## Problem

The weekly all-TFM **Build Solution** matrix (build 14931) — which pins `UA.slnx` to a single TFM via `/p:CustomTestTarget=<tfm>` — fails on **net8.0, net9.0, netstandard2.0 and netstandard2.1**. These per-TFM solution builds are not part of the regular PR matrix (net10.0/net48 only), so two recent merges greened their PRs but broke the weekly build.

### Category A — net8.0 / net9.0 (regression from #3888)
`Opc.Ua.Core.Diagnostics.Tests` referenced the **net10.0-only** `Opc.Ua.Mcp.csproj`. A net8.0/net9.0 project cannot reference a net10.0 project, even with `ReferenceOutputAssembly="false"`:

```
error : Project '..\..\Applications\McpServer\Opc.Ua.Mcp.csproj' targets 'net10.0'.
It cannot be referenced by a project that targets '.NETCoreApp,Version=v8.0'.
```

The MCP assembly is loaded **reflectively** from its net10.0 build output, so the two MCP tests are inherently net10.0-only.

### Category B — netstandard2.0 / netstandard2.1 (regression from #3888 / #3884)
Five `RestrictForLegacyTfm` projects (`Opc.Ua.Core.Diagnostics`, its tests, and the three `Opc.Ua.Network.Fuzz` projects) are stripped to an empty no-op shell for legacy TFMs. An empty **netstandard2.0/2.1** compilation fails — unlike an empty net48/net472/net10.0 shell, whose targeting-pack reference assemblies are always supplied:

```
error CS8021: No value for RuntimeMetadataVersion found. No assembly containing
System.Object was found nor was a value for RuntimeMetadataVersion specified...
```

## Fix

- **A:** make the `Opc.Ua.Mcp` `ProjectReference` `Condition="'$(TargetFramework)' == 'net10.0'"`, and guard `McpServerOptionsTests` / `PacketDecodePathValidationTests` with `#if NET10_0_OR_GREATER` (placed before the `using`s so no unused-using warnings under `TreatWarningsAsErrors`).
- **B:** build the netstandard2.0/2.1 no-op shells as **net10.0** (the same TFM the existing `Opc.Ua.Mcp` shell already uses successfully). All consumers of the five projects are themselves `RestrictForLegacyTfm`, so no `net48 → net10.0` reference edge is introduced in legacy builds.

## Verification

Full `UA.slnx` solution builds on a clean `master` tree:
- `net8.0` — **Build succeeded**
- `netstandard2.0` — **Build succeeded**
- `net9.0` / `net10.0` — `Opc.Ua.Core.Diagnostics.Tests` builds (net10.0 keeps the MCP tests + reference)

## Category C (netstandard2.1 polyfill collisions) - now also fixed

The netstandard2.1 job builds libraries as netstandard2.1 but its tests/apps as net10.0, so
the libraries' public TFM-conditional polyfills collided with the net10.0 BCL
(`CS0433 Lock`, `CS0433 X509CertificateLoader`, `CS0117 ReadOnlyMemoryHelper`). Fixed by
building that job's tests/apps as **net8.0** (whose BCL defines neither `Lock` nor
`X509CertificateLoader`, matching the framework the netstandard2.1 test stage already runs),
skipping the net8+-library-only `ReinterpretAs/From` test cases under `NET_STANDARD_TESTS`,
and pinning MQTTnet to v4 for the netstandard2.1 job (so the net8.0 consumers match the
netstandard2.1 libraries). Internal-izing the polyfills was rejected (`Lock` is used in ~80
files across ~15 assemblies; the collision is also a CI artifact - real net9+ consumers
resolve the net9+ assembly via NuGet).

**Verified:** full clean `dotnet build UA.slnx /p:CustomTestTarget=netstandard2.1 -c Release`
succeeds with 0 errors. This PR now fixes **all** of build 14931 (net8.0, net9.0,
netstandard2.0 and netstandard2.1).