### PR TITLE
Add Bad_MethodInvalid interop fallback for generated ObjectType proxy method calls

### DIFF
--- a/Docs/WoTConnectivity.md
+++ b/Docs/WoTConnectivity.md
@@ -185,6 +185,12 @@ These work on any `FileType` instance, including ones that are not
 anchored under `Server.FileSystem` (e.g. the WoT asset file living
 under `WoTAssetConnectionManagement/<asset>`).
 
+### Method invocation and server interoperability
+
+The generated `…TypeClient` proxies invoke methods through the shared `ObjectTypeClient.CallMethodAsync` helper using the **type-declaration** `MethodId` (the Method node on the `ObjectType`). This is fully spec-conformant: OPC UA Part 4 §5.12.2.2 (v1.04 §5.11.2.2) states that, for a `Call` on an `Object` instance, the `methodId` may be **either** the instance Method's NodeId **or** the NodeId of the Method on the `ObjectType` that defines it. This stack's own server accepts both forms.
+
+A few non-conformant servers only bind the method handler on the instance and reject the type-declaration `MethodId` with `Bad_MethodInvalid`. To interoperate with those servers, `CallMethodAsync` transparently falls back: on `Bad_MethodInvalid` it resolves the instance `MethodId` via a `HasComponent` browse path (`TranslateBrowsePathsToNodeIds`), caches it on the proxy, and retries the call once. Conformant servers never trigger the fallback and therefore pay no extra round-trip; subsequent calls against a non-conformant server reuse the cached instance `MethodId`.
+
 ---
 
 ## 4. Persistence limits

--- a/Stack/Opc.Ua.Core/Stack/Client/ObjectTypeClient.cs
+++ b/Stack/Opc.Ua.Core/Stack/Client/ObjectTypeClient.cs
@@ -171,7 +171,7 @@ namespace Opc.Ua
             // Bad_MethodInvalid. Resolve the instance MethodId via
             // HasComponent, cache it, and retry once.
             if (usedTypeMethodId &&
-                response.Results[0].StatusCode.Code == StatusCodes.BadMethodInvalid)
+                response.Results[0].StatusCode.CodeBits == StatusCodes.BadMethodInvalid)
             {
                 NodeId instanceMethodId = await ResolveChildNodeIdAsync(
                     methodNamespaceUri,

--- a/Stack/Opc.Ua.Core/Stack/Client/ObjectTypeClient.cs
+++ b/Stack/Opc.Ua.Core/Stack/Client/ObjectTypeClient.cs
@@ -28,6 +28,7 @@
  * ======================================================================*/
 
 using System;
+using System.Collections.Concurrent;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -43,8 +44,8 @@ namespace Opc.Ua
     /// inheritance tree); proxies for types that derive directly from
     /// <c>BaseObjectType</c> ultimately inherit from this class. The base
     /// class holds the per-instance plumbing (session, object NodeId,
-    /// telemetry) and exposes a single <see cref="CallMethodAsync"/>
-    /// helper used by every generated wrapper.
+    /// telemetry) and exposes the <c>CallMethodAsync</c> helpers used by
+    /// every generated wrapper.
     /// </remarks>
     public abstract class ObjectTypeClient
     {
@@ -106,36 +107,86 @@ namespace Opc.Ua
             CancellationToken ct,
             params Variant[] args)
         {
-            var request = new CallMethodRequest
+            CallResponse response = await CallOnceAsync(methodId, ct, args)
+                .ConfigureAwait(false);
+            return ThrowOrGetOutputArguments(response);
+        }
+
+        /// <summary>
+        /// Calls the method identified by <paramref name="methodId"/> on
+        /// the wrapped object and returns the raw output arguments, with
+        /// an interoperability fallback for non-conformant servers.
+        /// </summary>
+        /// <remarks>
+        /// The <paramref name="methodId"/> is the type-declaration
+        /// MethodId (the Method on the ObjectType). Per OPC UA Part 4
+        /// (v1.04 §5.11.2.2 / v1.05.07 §5.12.2.2) a Call on an Object
+        /// instance may use <b>either</b> the instance MethodId <b>or</b>
+        /// the type-declaration MethodId, so this is the spec-conformant
+        /// happy path and conformant servers (including this stack's own
+        /// server) accept it. Some non-conformant servers only bind the
+        /// method handler on the instance and reject the type-declaration
+        /// MethodId with <see cref="StatusCodes.BadMethodInvalid"/>. To
+        /// interoperate with those servers, the instance MethodId is
+        /// resolved once via a <c>HasComponent</c> browse path, cached on
+        /// this proxy, and the call is retried. Subsequent calls reuse the
+        /// cached instance MethodId, so conformant servers pay no extra
+        /// cost.
+        /// </remarks>
+        /// <param name="methodId">The type-declaration NodeId of the
+        /// method to invoke.</param>
+        /// <param name="methodNamespaceUri">The namespace URI of the
+        /// method's browse name, used for the fallback resolution.</param>
+        /// <param name="methodBrowseName">The unqualified browse name of
+        /// the method, used for the fallback resolution.</param>
+        /// <param name="ct">Cancellation token for the request.</param>
+        /// <param name="args">The boxed input arguments.</param>
+        /// <returns>The output arguments returned by the server.</returns>
+        /// <exception cref="ServiceResultException">
+        /// Thrown if the call fails or returns a Bad status.
+        /// </exception>
+        protected async ValueTask<ArrayOf<Variant>> CallMethodAsync(
+            NodeId methodId,
+            string methodNamespaceUri,
+            string methodBrowseName,
+            CancellationToken ct,
+            params Variant[] args)
+        {
+            // Reuse a previously resolved instance MethodId if we already
+            // had to fall back for this method against a non-conformant
+            // server; otherwise start with the type-declaration MethodId.
+            bool usedTypeMethodId = !m_instanceMethodIdCache.TryGetValue(
+                methodId,
+                out NodeId callMethodId);
+            if (usedTypeMethodId)
             {
-                ObjectId = ObjectId,
-                MethodId = methodId,
-                InputArguments = args
-            };
-
-            ArrayOf<CallMethodRequest> requests = [request];
-
-            CallResponse response = await Session.CallAsync(
-                null,
-                requests,
-                ct).ConfigureAwait(false);
-
-            ArrayOf<CallMethodResult> results = response.Results;
-            ArrayOf<DiagnosticInfo> diagnosticInfos = response.DiagnosticInfos;
-
-            ClientBase.ValidateResponse(results, requests);
-            ClientBase.ValidateDiagnosticInfos(diagnosticInfos, requests);
-
-            if (StatusCode.IsBad(results[0].StatusCode))
-            {
-                throw ServiceResultException.Create(
-                    results[0].StatusCode,
-                    0,
-                    diagnosticInfos,
-                    response.ResponseHeader.StringTable);
+                callMethodId = methodId;
             }
 
-            return results[0].OutputArguments;
+            CallResponse response = await CallOnceAsync(callMethodId, ct, args)
+                .ConfigureAwait(false);
+
+            // Interoperability fallback: a conformant server accepts the
+            // type-declaration MethodId, but a non-conformant one returns
+            // Bad_MethodInvalid. Resolve the instance MethodId via
+            // HasComponent, cache it, and retry once.
+            if (usedTypeMethodId &&
+                response.Results[0].StatusCode.Code == StatusCodes.BadMethodInvalid)
+            {
+                NodeId instanceMethodId = await ResolveChildNodeIdAsync(
+                    methodNamespaceUri,
+                    methodBrowseName,
+                    ct).ConfigureAwait(false);
+
+                if (!instanceMethodId.IsNull && !instanceMethodId.Equals(methodId))
+                {
+                    m_instanceMethodIdCache[methodId] = instanceMethodId;
+                    response = await CallOnceAsync(instanceMethodId, ct, args)
+                        .ConfigureAwait(false);
+                }
+            }
+
+            return ThrowOrGetOutputArguments(response);
         }
 
         /// <summary>
@@ -196,5 +247,66 @@ namespace Opc.Ua
                 response.Results[0].Targets[0].TargetId,
                 Session.MessageContext.NamespaceUris);
         }
+
+        /// <summary>
+        /// Issues a single <c>Call</c> for the wrapped object and returns
+        /// the validated response without throwing on a Bad operation
+        /// status, so callers can inspect the status and optionally retry.
+        /// </summary>
+        /// <param name="methodId">The NodeId of the method to invoke.</param>
+        /// <param name="ct">Cancellation token for the request.</param>
+        /// <param name="args">The boxed input arguments.</param>
+        private async ValueTask<CallResponse> CallOnceAsync(
+            NodeId methodId,
+            CancellationToken ct,
+            params Variant[] args)
+        {
+            var request = new CallMethodRequest
+            {
+                ObjectId = ObjectId,
+                MethodId = methodId,
+                InputArguments = args
+            };
+
+            ArrayOf<CallMethodRequest> requests = [request];
+
+            CallResponse response = await Session.CallAsync(
+                null,
+                requests,
+                ct).ConfigureAwait(false);
+
+            ClientBase.ValidateResponse(response.Results, requests);
+            ClientBase.ValidateDiagnosticInfos(response.DiagnosticInfos, requests);
+
+            return response;
+        }
+
+        /// <summary>
+        /// Returns the output arguments of the first (and only) Call
+        /// result, or throws a <see cref="ServiceResultException"/> when
+        /// the operation status is Bad.
+        /// </summary>
+        /// <param name="response">The validated Call response.</param>
+        private static ArrayOf<Variant> ThrowOrGetOutputArguments(CallResponse response)
+        {
+            CallMethodResult result = response.Results[0];
+
+            if (StatusCode.IsBad(result.StatusCode))
+            {
+                throw ServiceResultException.Create(
+                    result.StatusCode,
+                    0,
+                    response.DiagnosticInfos,
+                    response.ResponseHeader.StringTable);
+            }
+
+            return result.OutputArguments;
+        }
+
+        /// <summary>
+        /// Per-proxy cache mapping a type-declaration MethodId to the
+        /// instance MethodId resolved via the interoperability fallback.
+        /// </summary>
+        private readonly ConcurrentDictionary<NodeId, NodeId> m_instanceMethodIdCache = new();
     }
 }

--- a/Stack/Opc.Ua.Core/Stack/Client/ObjectTypeClient.cs
+++ b/Stack/Opc.Ua.Core/Stack/Client/ObjectTypeClient.cs
@@ -171,7 +171,7 @@ namespace Opc.Ua
             // Bad_MethodInvalid. Resolve the instance MethodId via
             // HasComponent, cache it, and retry once.
             if (usedTypeMethodId &&
-                response.Results[0].StatusCode.CodeBits == StatusCodes.BadMethodInvalid)
+                response.Results[0].StatusCode == StatusCodes.BadMethodInvalid)
             {
                 NodeId instanceMethodId = await ResolveChildNodeIdAsync(
                     methodNamespaceUri,

--- a/Tests/Opc.Ua.Client.Tests/ObjectTypeClientCallFallbackTests.cs
+++ b/Tests/Opc.Ua.Client.Tests/ObjectTypeClientCallFallbackTests.cs
@@ -93,10 +93,7 @@ namespace Opc.Ua.Client.Tests
         [Test]
         public async Task NonConformantServerResolvesInstanceMethodIdAndRetriesAsync()
         {
-            // The non-conformant server returns BadMethodInvalid with a
-            // non-zero InfoBit set in the low 16 bits; the fallback must
-            // still trigger, which exercises the CodeBits-based comparison.
-            SetupCall(req => req.MethodId.Equals(m_typeMethodId) ? BadMethodInvalid(infoBits: 1) : Good(new Variant(7)));
+            SetupCall(req => req.MethodId.Equals(m_typeMethodId) ? BadMethodInvalid() : Good(new Variant(7)));
             SetupTranslate(m_instanceMethodId);
             TestObjectTypeClient client = CreateClient();
 
@@ -112,7 +109,7 @@ namespace Opc.Ua.Client.Tests
         [Test]
         public async Task ResolvedInstanceMethodIdIsCachedAcrossCallsAsync()
         {
-            SetupCall(req => req.MethodId.Equals(m_typeMethodId) ? BadMethodInvalid(infoBits: 1) : Good(new Variant(1)));
+            SetupCall(req => req.MethodId.Equals(m_typeMethodId) ? BadMethodInvalid() : Good(new Variant(1)));
             SetupTranslate(m_instanceMethodId);
             TestObjectTypeClient client = CreateClient();
 
@@ -232,11 +229,11 @@ namespace Opc.Ua.Client.Tests
             };
         }
 
-        private static CallMethodResult BadMethodInvalid(uint infoBits = 0)
+        private static CallMethodResult BadMethodInvalid()
         {
             return new CallMethodResult
             {
-                StatusCode = StatusCodes.BadMethodInvalid.Code | infoBits,
+                StatusCode = StatusCodes.BadMethodInvalid,
                 OutputArguments = default
             };
         }

--- a/Tests/Opc.Ua.Client.Tests/ObjectTypeClientCallFallbackTests.cs
+++ b/Tests/Opc.Ua.Client.Tests/ObjectTypeClientCallFallbackTests.cs
@@ -93,7 +93,10 @@ namespace Opc.Ua.Client.Tests
         [Test]
         public async Task NonConformantServerResolvesInstanceMethodIdAndRetriesAsync()
         {
-            SetupCall(req => req.MethodId.Equals(m_typeMethodId) ? BadMethodInvalid() : Good(new Variant(7)));
+            // The non-conformant server returns BadMethodInvalid with a
+            // non-zero InfoBit set in the low 16 bits; the fallback must
+            // still trigger, which exercises the CodeBits-based comparison.
+            SetupCall(req => req.MethodId.Equals(m_typeMethodId) ? BadMethodInvalid(infoBits: 1) : Good(new Variant(7)));
             SetupTranslate(m_instanceMethodId);
             TestObjectTypeClient client = CreateClient();
 
@@ -109,7 +112,7 @@ namespace Opc.Ua.Client.Tests
         [Test]
         public async Task ResolvedInstanceMethodIdIsCachedAcrossCallsAsync()
         {
-            SetupCall(req => req.MethodId.Equals(m_typeMethodId) ? BadMethodInvalid() : Good(new Variant(1)));
+            SetupCall(req => req.MethodId.Equals(m_typeMethodId) ? BadMethodInvalid(infoBits: 1) : Good(new Variant(1)));
             SetupTranslate(m_instanceMethodId);
             TestObjectTypeClient client = CreateClient();
 
@@ -229,11 +232,11 @@ namespace Opc.Ua.Client.Tests
             };
         }
 
-        private static CallMethodResult BadMethodInvalid()
+        private static CallMethodResult BadMethodInvalid(uint infoBits = 0)
         {
             return new CallMethodResult
             {
-                StatusCode = StatusCodes.BadMethodInvalid,
+                StatusCode = StatusCodes.BadMethodInvalid.Code | infoBits,
                 OutputArguments = default
             };
         }

--- a/Tests/Opc.Ua.Client.Tests/ObjectTypeClientCallFallbackTests.cs
+++ b/Tests/Opc.Ua.Client.Tests/ObjectTypeClientCallFallbackTests.cs
@@ -1,0 +1,266 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+#nullable enable
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using NUnit.Framework;
+using Opc.Ua.Tests;
+
+namespace Opc.Ua.Client.Tests
+{
+    /// <summary>
+    /// Tests for the <see cref="ObjectTypeClient"/> method-call
+    /// interoperability fallback (issue #3914). Calling a method with the
+    /// type-declaration MethodId is spec-conformant (OPC UA Part 4
+    /// §5.12.2.2) and is the zero-cost happy path. When a non-conformant
+    /// server rejects it with <see cref="StatusCodes.BadMethodInvalid"/>,
+    /// the instance MethodId is resolved via a HasComponent browse path,
+    /// cached, and the call is retried.
+    /// </summary>
+    [TestFixture]
+    [Category("Client")]
+    [Parallelizable]
+    public sealed class ObjectTypeClientCallFallbackTests
+    {
+        private const string kMethodNamespaceUri = "http://test.org/UA/fallback/";
+        private const string kMethodBrowseName = "DoIt";
+
+        private Mock<ISessionClient> m_sessionMock = null!;
+        private NodeId m_objectId;
+        private NodeId m_typeMethodId;
+        private NodeId m_instanceMethodId;
+
+        [SetUp]
+        public void SetUp()
+        {
+            ITelemetryContext telemetry = NUnitTelemetryContext.Create();
+            ServiceMessageContext messageContext = ServiceMessageContext.Create(telemetry);
+            ushort nsIndex = messageContext.NamespaceUris.GetIndexOrAppend(kMethodNamespaceUri);
+
+            m_objectId = new NodeId(100u, nsIndex);
+            m_typeMethodId = new NodeId(26u, nsIndex);
+            m_instanceMethodId = new NodeId(32u, nsIndex);
+
+            m_sessionMock = new Mock<ISessionClient>(MockBehavior.Strict);
+            m_sessionMock.SetupGet(s => s.MessageContext).Returns(messageContext);
+        }
+
+        [Test]
+        public async Task ConformantServerCallsOnceWithTypeMethodIdAndDoesNotResolveAsync()
+        {
+            SetupCall(_ => Good(new Variant(42)));
+            TestObjectTypeClient client = CreateClient();
+
+            ArrayOf<Variant> outputs = await client
+                .InvokeAsync(m_typeMethodId, kMethodNamespaceUri, kMethodBrowseName, CancellationToken.None)
+                .ConfigureAwait(false);
+
+            Assert.That(outputs.Count, Is.EqualTo(1));
+            VerifyCallCount(Times.Once());
+            VerifyTranslateCount(Times.Never());
+        }
+
+        [Test]
+        public async Task NonConformantServerResolvesInstanceMethodIdAndRetriesAsync()
+        {
+            SetupCall(req => req.MethodId.Equals(m_typeMethodId) ? BadMethodInvalid() : Good(new Variant(7)));
+            SetupTranslate(m_instanceMethodId);
+            TestObjectTypeClient client = CreateClient();
+
+            ArrayOf<Variant> outputs = await client
+                .InvokeAsync(m_typeMethodId, kMethodNamespaceUri, kMethodBrowseName, CancellationToken.None)
+                .ConfigureAwait(false);
+
+            Assert.That(outputs.Count, Is.EqualTo(1));
+            VerifyTranslateCount(Times.Once());
+            VerifyCallCount(Times.Exactly(2));
+        }
+
+        [Test]
+        public async Task ResolvedInstanceMethodIdIsCachedAcrossCallsAsync()
+        {
+            SetupCall(req => req.MethodId.Equals(m_typeMethodId) ? BadMethodInvalid() : Good(new Variant(1)));
+            SetupTranslate(m_instanceMethodId);
+            TestObjectTypeClient client = CreateClient();
+
+            _ = await client
+                .InvokeAsync(m_typeMethodId, kMethodNamespaceUri, kMethodBrowseName, CancellationToken.None)
+                .ConfigureAwait(false);
+            _ = await client
+                .InvokeAsync(m_typeMethodId, kMethodNamespaceUri, kMethodBrowseName, CancellationToken.None)
+                .ConfigureAwait(false);
+
+            // Exactly one resolution total. The first invocation tries the
+            // type MethodId then the instance MethodId (2 calls); the second
+            // invocation uses the cached instance MethodId directly (1 call).
+            VerifyTranslateCount(Times.Once());
+            VerifyCallCount(Times.Exactly(3));
+        }
+
+        [Test]
+        public void UnresolvedInstanceMethodIdSurfacesOriginalBadMethodInvalid()
+        {
+            SetupCall(_ => BadMethodInvalid());
+            SetupTranslate(NodeId.Null);
+            TestObjectTypeClient client = CreateClient();
+
+            ServiceResultException ex = Assert.ThrowsAsync<ServiceResultException>(
+                async () => await client
+                    .InvokeAsync(m_typeMethodId, kMethodNamespaceUri, kMethodBrowseName, CancellationToken.None)
+                    .ConfigureAwait(false))!;
+
+            Assert.That(ex.StatusCode, Is.EqualTo(StatusCodes.BadMethodInvalid));
+            // Only the initial attempt is made; the missed resolution means no retry.
+            VerifyCallCount(Times.Once());
+            VerifyTranslateCount(Times.Once());
+        }
+
+        private TestObjectTypeClient CreateClient()
+        {
+            return new TestObjectTypeClient(
+                m_sessionMock.Object,
+                m_objectId,
+                NUnitTelemetryContext.Create());
+        }
+
+        private void SetupCall(Func<CallMethodRequest, CallMethodResult> handler)
+        {
+            m_sessionMock
+                .Setup(s => s.CallAsync(
+                    It.IsAny<RequestHeader>(),
+                    It.IsAny<ArrayOf<CallMethodRequest>>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns<RequestHeader, ArrayOf<CallMethodRequest>, CancellationToken>(
+                    (_, requests, _) =>
+                    {
+                        CallMethodResult result = handler(requests[0]);
+                        return new ValueTask<CallResponse>(new CallResponse
+                        {
+                            ResponseHeader = new ResponseHeader(),
+                            Results = ArrayOf.Wrapped(new[] { result }),
+                            DiagnosticInfos = default
+                        });
+                    });
+        }
+
+        private void SetupTranslate(NodeId resolved)
+        {
+            BrowsePathResult result = resolved.IsNull
+                ? new BrowsePathResult { StatusCode = StatusCodes.Good, Targets = default }
+                : new BrowsePathResult
+                {
+                    StatusCode = StatusCodes.Good,
+                    Targets = ArrayOf.Wrapped(new[]
+                    {
+                        new BrowsePathTarget
+                        {
+                            TargetId = new ExpandedNodeId(resolved),
+                            RemainingPathIndex = uint.MaxValue
+                        }
+                    })
+                };
+
+            m_sessionMock
+                .Setup(s => s.TranslateBrowsePathsToNodeIdsAsync(
+                    It.IsAny<RequestHeader>(),
+                    It.IsAny<ArrayOf<BrowsePath>>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns(new ValueTask<TranslateBrowsePathsToNodeIdsResponse>(
+                    new TranslateBrowsePathsToNodeIdsResponse
+                    {
+                        ResponseHeader = new ResponseHeader(),
+                        Results = ArrayOf.Wrapped(new[] { result }),
+                        DiagnosticInfos = default
+                    }));
+        }
+
+        private void VerifyCallCount(Times times)
+        {
+            m_sessionMock.Verify(s => s.CallAsync(
+                It.IsAny<RequestHeader>(),
+                It.IsAny<ArrayOf<CallMethodRequest>>(),
+                It.IsAny<CancellationToken>()), times);
+        }
+
+        private void VerifyTranslateCount(Times times)
+        {
+            m_sessionMock.Verify(s => s.TranslateBrowsePathsToNodeIdsAsync(
+                It.IsAny<RequestHeader>(),
+                It.IsAny<ArrayOf<BrowsePath>>(),
+                It.IsAny<CancellationToken>()), times);
+        }
+
+        private static CallMethodResult Good(params Variant[] outputs)
+        {
+            return new CallMethodResult
+            {
+                StatusCode = StatusCodes.Good,
+                OutputArguments = ArrayOf.Wrapped(outputs)
+            };
+        }
+
+        private static CallMethodResult BadMethodInvalid()
+        {
+            return new CallMethodResult
+            {
+                StatusCode = StatusCodes.BadMethodInvalid,
+                OutputArguments = default
+            };
+        }
+
+        /// <summary>
+        /// Minimal concrete proxy exposing the protected fallback overload
+        /// of <see cref="ObjectTypeClient.CallMethodAsync(NodeId, string, string, CancellationToken, Variant[])"/>.
+        /// </summary>
+        private sealed class TestObjectTypeClient : ObjectTypeClient
+        {
+            public TestObjectTypeClient(
+                ISessionClient session,
+                NodeId objectId,
+                ITelemetryContext telemetry)
+                : base(session, objectId, telemetry)
+            {
+            }
+
+            public ValueTask<ArrayOf<Variant>> InvokeAsync(
+                NodeId methodId,
+                string methodNamespaceUri,
+                string methodBrowseName,
+                CancellationToken ct,
+                params Variant[] args)
+            {
+                return CallMethodAsync(methodId, methodNamespaceUri, methodBrowseName, ct, args);
+            }
+        }
+    }
+}

--- a/Tests/Opc.Ua.SourceGeneration.Core.Tests/CompilerUtils.cs
+++ b/Tests/Opc.Ua.SourceGeneration.Core.Tests/CompilerUtils.cs
@@ -531,6 +531,13 @@ namespace Opc.Ua.SourceGeneration
                         CancellationToken ct,
                         params Variant[] args)
                         => default;
+                    protected ValueTask<ArrayOf<Variant>> CallMethodAsync(
+                        NodeId methodId,
+                        string methodNamespaceUri,
+                        string methodBrowseName,
+                        CancellationToken ct,
+                        params Variant[] args)
+                        => default;
                     protected ValueTask<NodeId> ResolveChildNodeIdAsync(
                         string namespaceUri,
                         string browseName,
@@ -986,6 +993,15 @@ namespace Opc.Ua.SourceGeneration
                     protected ITelemetryContext Telemetry { get; }
                     protected System.Threading.Tasks.ValueTask<ArrayOf<Variant>> CallMethodAsync(
                         NodeId methodId,
+                        System.Threading.CancellationToken ct,
+                        params Variant[] inputArguments)
+                    {
+                        return default;
+                    }
+                    protected System.Threading.Tasks.ValueTask<ArrayOf<Variant>> CallMethodAsync(
+                        NodeId methodId,
+                        string methodNamespaceUri,
+                        string methodBrowseName,
                         System.Threading.CancellationToken ct,
                         params Variant[] inputArguments)
                     {

--- a/Tests/Opc.Ua.SourceGeneration.Core.Tests/Generators/ObjectTypeProxyGeneratorTests.cs
+++ b/Tests/Opc.Ua.SourceGeneration.Core.Tests/Generators/ObjectTypeProxyGeneratorTests.cs
@@ -205,6 +205,53 @@ namespace Opc.Ua.SourceGeneration.Generator.Tests
         }
 
         [Test]
+        public void Emit_Method_EmitsBrowseNameAndNamespaceForInteropFallback()
+        {
+            // Regression for the interoperability fallback (issue #3914):
+            // each generated method must pass the method BrowseName and its
+            // namespace URI to CallMethodAsync (after the type-declaration
+            // MethodId) so the runtime can resolve the instance MethodId via
+            // a HasComponent browse path against non-conformant servers.
+            MethodDesign method = CreateMethod(
+                "DoIt",
+                inputs: [
+                    CreateParameter("requestId", BasicDataType.Int32)
+                ]);
+            ObjectTypeDesign objectType = CreateObjectType("FooType", method);
+            m_mockModelDesign.Setup(m => m.GetNodeDesigns()).Returns([objectType]);
+
+            using var stream = new MemoryStream();
+            m_mockFileSystem
+                .Setup(fs => fs.OpenWrite(It.IsAny<string>()))
+                .Returns(stream);
+
+            new ObjectTypeProxyGenerator(CreateContext()).Emit();
+            string content = Encoding.UTF8.GetString(stream.ToArray());
+
+            // Happy-path argument: the type-declaration MethodId constant.
+            int methodIdIndex = content.IndexOf(
+                $"global::{kTestNamespacePrefix}.MethodIds.FooType_DoIt",
+                StringComparison.Ordinal);
+            // Fallback arguments: namespace URI literal then BrowseName literal.
+            int namespaceIndex = content.IndexOf(
+                $"\"{kTestNamespaceUri}\"",
+                StringComparison.Ordinal);
+            int browseNameIndex = content.IndexOf(
+                "\"DoIt\"",
+                StringComparison.Ordinal);
+
+            Assert.That(methodIdIndex, Is.GreaterThan(-1));
+            Assert.That(
+                namespaceIndex,
+                Is.GreaterThan(methodIdIndex),
+                "namespace URI literal must follow the type-declaration MethodId argument");
+            Assert.That(
+                browseNameIndex,
+                Is.GreaterThan(namespaceIndex),
+                "BrowseName literal must follow the namespace URI argument");
+        }
+
+        [Test]
         public void Emit_VoidMethod_EmitsAsyncWithoutReturnType()
         {
             MethodDesign method = CreateMethod("Reset");

--- a/Tools/Opc.Ua.SourceGeneration.Core/Generators/ObjectTypeProxyGenerator.cs
+++ b/Tools/Opc.Ua.SourceGeneration.Core/Generators/ObjectTypeProxyGenerator.cs
@@ -31,6 +31,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using Opc.Ua.Schema.Model;
+using Opc.Ua.SourceGeneration.Templating;
 
 namespace Opc.Ua.SourceGeneration
 {
@@ -531,6 +532,21 @@ namespace Opc.Ua.SourceGeneration
                 m_context.ModelDesign.TargetNamespace.Prefix,
                 method.SymbolicId.Name);
 
+            // The instance-method browse name + namespace are emitted as
+            // string literals so the runtime can perform the
+            // Bad_MethodInvalid interoperability fallback against
+            // non-conformant servers (resolve the instance MethodId via a
+            // HasComponent browse path). Mirrors the child-accessor path.
+            string methodBrowseNamespaceUri = method.SymbolicName?.Namespace;
+            if (string.IsNullOrEmpty(methodBrowseNamespaceUri))
+            {
+                methodBrowseNamespaceUri = targetNamespace;
+            }
+            string methodBrowseNamespaceLiteral =
+                StringLiteralEscaper.AsCSharpStringLiteralContent(methodBrowseNamespaceUri);
+            string methodBrowseNameLiteral =
+                StringLiteralEscaper.AsCSharpStringLiteralContent(methodName);
+
             // Compute the strongly typed return signature.
             string returnTypeAnnotation = GetReturnTypeAnnotation(
                 outputs, targetNamespace, namespaces);
@@ -607,6 +623,8 @@ namespace Opc.Ua.SourceGeneration
             context.Out.WriteLine(
                 "        global::Opc.Ua.ExpandedNodeId.ToNodeId({0}, Session.MessageContext.NamespaceUris),",
                 methodIdConstant);
+            context.Out.WriteLine("        \"{0}\",", methodBrowseNamespaceLiteral);
+            context.Out.WriteLine("        \"{0}\",", methodBrowseNameLiteral);
             context.Out.Write("        ct");
             for (int ii = 0; ii < inputs.Length; ii++)
             {


### PR DESCRIPTION
# Description

Adds a transparent **interoperability fallback** to the source-generated `…TypeClient` ObjectType proxies so that calling methods works against servers that do not accept the type-declaration `MethodId`.

**Spec validation first (important context):** the symptom reported in #3914 — generated proxies sending the type-declaration `MethodId` together with the instance `ObjectId` — is **spec-conformant**, not a compliance bug. OPC UA Part 4 **v1.04 §5.11.2.2** and **v1.05.07 §5.12.2.2** both state that, for a `Call` on an `Object` instance, the `methodId` may be **either** the instance Method's NodeId **or** the NodeId of the Method on the `ObjectType` that defines it. This stack's own server already resolves both forms on purpose (`CustomNodeManager.FindMethodState` → `FindMethodInTypeHierarchy`, added by #3692, with a passing test). The third-party servers that return `Bad_MethodInvalid` for this are the non-conformant party.

Because calling with the **instance** `MethodId` is universally interoperable, this PR hardens the client as an **enhancement** (not a correctness fix):

- **Happy path is unchanged** — the proxy calls with the type-declaration `MethodId`. Against conformant servers (including this stack's server) there is **zero** extra round-trip.
- **Fallback** — on `Bad_MethodInvalid`, `ObjectTypeClient.CallMethodAsync` resolves the instance `MethodId` via a `HasComponent` `TranslateBrowsePathsToNodeIds`, caches it on the proxy, and retries the call once. Subsequent calls reuse the cached instance `MethodId`.

Changes:
- `Stack/Opc.Ua.Core/Stack/Client/ObjectTypeClient.cs` — new `CallMethodAsync` overload carrying the method namespace URI + BrowseName, a non-throwing `CallOnceAsync` core, and a per-proxy instance-`MethodId` cache. The existing overload is retained (additive, non-breaking; generated public API unchanged).
- `Tools/Opc.Ua.SourceGeneration.Core/Generators/ObjectTypeProxyGenerator.cs` — emits the method namespace URI + BrowseName literals so regenerated proxies drive the new overload.
- `Tests/Opc.Ua.SourceGeneration.Core.Tests/Generators/ObjectTypeProxyGeneratorTests.cs` — generator emission assertion.
- `Tests/Opc.Ua.SourceGeneration.Core.Tests/CompilerUtils.cs` — added the new `CallMethodAsync` overload to the in-memory `ObjectTypeClient` test stubs so the generated proxy output (which now drives the new overload) compiles in the SourceGeneration generator-test in-memory compilations. This file is linked into the `Opc.Ua.SourceGeneration(.Stack).Tests` projects.
- `Tests/Opc.Ua.Client.Tests/ObjectTypeClientCallFallbackTests.cs` — runtime fallback unit tests (zero-overhead happy path, resolve+retry, caching, resolution-miss surfaces the original `Bad_MethodInvalid`).
- `Docs/WoTConnectivity.md` — documents the method-invocation behavior and the fallback.

**Verification:** Core + WotCon build clean on **net10.0** and **net48** (0 warnings/errors). Generator tests 14/14; new fallback tests 4/4; regression WotCon 342/342 and generated-proxy areas (StateMachines/Alarms/FileSystem) 194/194. All CI **SourceGeneration** jobs are green across every OS/TFM.

> Note for maintainers: since the SDK behavior is spec-conformant, this is an interoperability enhancement rather than a compliance fix — consider re-labeling #3914 from `bug`/`compliance` to `enhancement`.

## Related Issues

- Fixes #3914

## Checklist

_Put an `x` in the boxes that apply. You can complete these step by step after opening the PR._

- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf) and read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [x] I have added all necessary documentation.
- [x] I have verified that my changes do not introduce (new) build or analyzer warnings.
- [ ] I ran **all** tests locally using the **UA.slnx** solution against at least .net **framework** and .net **10**, and all passed.
- [ ] I fixed **all** failing and flaky tests in the CI pipelines and **all** CodeQL warnings.
- [ ] I have addressed **all** PR feedback received.
