### PR TITLE
Promote V2 SubscriptionManager to ISession.TryGetSubscriptionManager (#3925)

### DIFF
--- a/Docs/Sessions.md
+++ b/Docs/Sessions.md
@@ -182,8 +182,8 @@ an `ISession` facade that wraps a raw `Session` and adds:
   failover, so consumers see one transparent retry rather than a torn
   state.
 - A **default V2 subscription engine** so the new options-based
-  subscription API (`ISubscriptionManager`) is available on
-  `ManagedSession.SubscriptionManager` out of the box.
+  subscription API (`ISubscriptionManager`) is available via
+  `ISession.TryGetSubscriptionManager(out var manager)` out of the box.
 
 ```csharp
 ManagedSession session = await ManagedSession.CreateAsync(
@@ -799,8 +799,9 @@ the `ISubscriptionEngine` contract. It owns:
   `OnKeepAliveNotificationAsync`.
 
 `DefaultSubscriptionEngine.SubscriptionManager` exposes the
-`ISubscriptionManager` API; on `ManagedSession` it surfaces directly as
-`SubscriptionManager`.
+`ISubscriptionManager` API; on any `ISession` it is surfaced through
+`TryGetSubscriptionManager(out var manager)`, which returns `true` and the
+manager for V2-engine sessions and `false` for classic-engine sessions.
 
 ```csharp
 // V2 engine is the default for ManagedSession
@@ -959,11 +960,12 @@ channel/transport layer.
 |---|---|
 | Existing code using `session.AddSubscription(new Subscription(...))` and the classic event-driven API | `ClassicSubscriptionEngine` (the default for raw `Session`) |
 | New code, options-based subscriptions, DI / Microsoft.Extensions.Options friendly | `DefaultSubscriptionEngine` (the default for `ManagedSession`) |
-| Migrating a managed session but you still need a classic subscription you cannot rewrite | `ManagedSession` with `UseSubscriptionEngine(ClassicSubscriptionEngineFactory.Instance)`; `SubscriptionManager` then throws `InvalidOperationException` and you keep using `Subscriptions` |
+| Migrating a managed session but you still need a classic subscription you cannot rewrite | `ManagedSession` with `UseSubscriptionEngine(ClassicSubscriptionEngineFactory.Instance)`; `TryGetSubscriptionManager` then returns `false` and you keep using `Subscriptions` |
 
 The two engines can co-exist on a `ManagedSession`:
 `ManagedSession.Subscriptions` (classic API) keeps working alongside
-`ManagedSession.SubscriptionManager` (V2 API) when the V2 engine is
+the V2 subscription manager obtained via
+`ISession.TryGetSubscriptionManager(out var manager)` when the V2 engine is
 active. Internally, classic subscriptions are bridged onto the V2
 publish pipeline.
 

--- a/Docs/Subscriptions.md
+++ b/Docs/Subscriptions.md
@@ -321,7 +321,8 @@ The engine handles these as follows:
 
 The V2 subscription engine
 (`Opc.Ua.Client.Subscriptions.ISubscription`, returned from
-`ManagedSession.SubscriptionManager.Add(...)`) lets a single logical
+`session.TryGetSubscriptionManager(out var manager)` then `manager.Add(...)`)
+lets a single logical
 subscription hold an effectively unlimited number of monitored items.
 When the per-subscription cap (`MaxMonitoredItemsPerSubscription` from
 the server's capabilities, OPC UA Part 4 §5.13.2) would be exceeded,
@@ -835,7 +836,7 @@ reconciliation, etc.) along with the recommended V2 alternative.
 |---|---|
 | `Session.SubscriptionEngineFactory` defaulted to `ClassicSubscriptionEngineFactory.Instance` | Defaulted to `DefaultSubscriptionEngineFactory.Instance` on `ManagedSession`. Raw `Session` constructed with `DefaultSessionFactory` defaults to classic for backwards compatibility; opt in by passing `SubscriptionEngineFactory = DefaultSubscriptionEngineFactory.Instance`. |
 | `Session.AddSubscription(Subscription)` (classic-typed) | Unchanged — classic subscriptions are still added via this API on classic-engine sessions. On a V2-engine `ManagedSession`, classic subscriptions are bridged onto the V2 publish pipeline by an internal `SubscriptionBridge`. |
-| `ManagedSession.SubscriptionManager` (V2) | Available alongside `ManagedSession.Subscriptions` (classic API), so both surfaces coexist on the same session. |
+| `ISession.TryGetSubscriptionManager` (V2) | Returns the V2 manager alongside `ManagedSession.Subscriptions` (classic API), so both surfaces coexist on the same session. |
 
 ### Per-item options mapping
 

--- a/Docs/migrate/2.0.x/sessions-subscriptions.md
+++ b/Docs/migrate/2.0.x/sessions-subscriptions.md
@@ -190,9 +190,20 @@ ManagedSession session = await new ManagedSessionBuilder(configuration, telemetr
 
 `Build()` returns an immutable `ManagedSessionOptions` snapshot; `ConnectAsync()` wraps `Build()` and `ManagedSession.CreateAsync(...)` so most callers can use the builder directly.
 
-**New subscription API on `ManagedSession`:**
+**New subscription API on `ISession`:**
 
-`ManagedSession` now exposes an `ISubscriptionManager` (the V2 options-based API) alongside the classic `Subscriptions` property. The V2 engine is the default for `ManagedSession`. Use `UseSubscriptionEngine(ClassicSubscriptionEngineFactory.Instance)` on the builder if you need the legacy classic engine instead — accessing `SubscriptionManager` then throws `InvalidOperationException`.
+The V2 options-based subscription manager (`ISubscriptionManager`) is exposed on `ISession` through `bool TryGetSubscriptionManager(out ISubscriptionManager? manager)` — it returns `true` and the manager for V2-engine sessions (the default for `ManagedSession`) and `false` for classic-engine sessions. The classic `Subscriptions` property remains available alongside it. Use `UseSubscriptionEngine(ClassicSubscriptionEngineFactory.Instance)` on the builder if you need the legacy classic engine instead.
+
+> **Source-breaking (2.0 preview):** the earlier throwing `ManagedSession.SubscriptionManager` property has been **removed** in favor of `ISession.TryGetSubscriptionManager`. Replace `var manager = session.SubscriptionManager;` (which threw `InvalidOperationException` on classic-engine sessions) with:
+>
+> ```csharp
+> if (session.TryGetSubscriptionManager(out ISubscriptionManager? manager))
+> {
+>     // use manager (V2 engine)
+> }
+> ```
+>
+> The `session.AddSubscription(...)` fluent extensions are unchanged.
 
 ```csharp
 using Opc.Ua.Client;

--- a/Libraries/Opc.Ua.Client/Fluent/ManagedSessionExtensions.cs
+++ b/Libraries/Opc.Ua.Client/Fluent/ManagedSessionExtensions.cs
@@ -50,6 +50,10 @@ namespace Opc.Ua.Client
         private static Subscriptions.ISubscriptionManager GetSubscriptionManager(
             this ManagedSession session)
         {
+            if (session == null)
+            {
+                throw new ArgumentNullException(nameof(session));
+            }
             if (!session.TryGetSubscriptionManager(
                     out Subscriptions.ISubscriptionManager? manager))
             {

--- a/Libraries/Opc.Ua.Client/Fluent/ManagedSessionExtensions.cs
+++ b/Libraries/Opc.Ua.Client/Fluent/ManagedSessionExtensions.cs
@@ -47,10 +47,25 @@ namespace Opc.Ua.Client
     /// </summary>
     public static class ManagedSessionExtensions
     {
+        private static Subscriptions.ISubscriptionManager GetSubscriptionManager(
+            this ManagedSession session)
+        {
+            if (!session.TryGetSubscriptionManager(
+                    out Subscriptions.ISubscriptionManager? manager))
+            {
+                throw new InvalidOperationException(
+                    "The managed session does not expose a V2 subscription manager. " +
+                    "The session is using the classic engine; recreate the ManagedSession " +
+                    "with the V2 subscription engine factory.");
+            }
+            return manager;
+        }
+
         /// <summary>
         /// Add a new subscription to the session using the supplied options
-        /// snapshot. The subscription is registered with
-        /// <see cref="ManagedSession.SubscriptionManager"/> and starts
+        /// snapshot. The subscription is registered with the session's V2
+        /// subscription manager (see
+        /// <see cref="ISession.TryGetSubscriptionManager"/>) and starts
         /// asynchronously.
         /// </summary>
         /// <exception cref="ArgumentNullException"><paramref name="session"/> is <c>null</c>.</exception>
@@ -72,7 +87,7 @@ namespace Opc.Ua.Client
                 throw new ArgumentNullException(nameof(options));
             }
             var monitor = new OptionsMonitor<Subscriptions.SubscriptionOptions>(options);
-            return session.SubscriptionManager.Add(handler, monitor);
+            return session.GetSubscriptionManager().Add(handler, monitor);
         }
 
         /// <summary>
@@ -170,8 +185,8 @@ namespace Opc.Ua.Client
         /// portable across sessions whose tables index URIs in different
         /// positions.
         /// </summary>
-        /// <param name="session">Session whose
-        /// <see cref="ManagedSession.SubscriptionManager"/> is being
+        /// <param name="session">Session whose V2 subscription manager (see
+        /// <see cref="ISession.TryGetSubscriptionManager"/>) is being
         /// snapshotted.</param>
         /// <param name="destination">Writable destination stream.</param>
         /// <param name="subscriptions">Optional subset of subscriptions
@@ -189,15 +204,15 @@ namespace Opc.Ua.Client
             {
                 throw new ArgumentNullException(nameof(session));
             }
-            return session.SubscriptionManager.SaveAsync(
+            return session.GetSubscriptionManager().SaveAsync(
                 destination, session.MessageContext, subscriptions, ct);
         }
 
         /// <summary>
         /// Restore subscriptions previously persisted by
         /// <see cref="SaveSubscriptionsAsync"/>. Each restored subscription is
-        /// re-registered with
-        /// <see cref="ManagedSession.SubscriptionManager"/>.
+        /// re-registered with the session's V2 subscription manager (see
+        /// <see cref="ISession.TryGetSubscriptionManager"/>).
         /// </summary>
         /// <param name="session">Session that owns the V2 subscription
         /// manager and supplies the active message context.</param>
@@ -223,7 +238,7 @@ namespace Opc.Ua.Client
             {
                 throw new ArgumentNullException(nameof(session));
             }
-            return session.SubscriptionManager.LoadAsync(source,
+            return session.GetSubscriptionManager().LoadAsync(source,
                 session.MessageContext, handlerFactory,
                 transferSubscriptions, ct);
         }
@@ -246,7 +261,7 @@ namespace Opc.Ua.Client
                 throw new ArgumentNullException(nameof(session));
             }
             var result = new List<SubscriptionStateSnapshot>();
-            foreach (ISubscription s in session.SubscriptionManager.Items)
+            foreach (ISubscription s in session.GetSubscriptionManager().Items)
             {
                 if (s is LogicalSubscription logical)
                 {
@@ -308,7 +323,7 @@ namespace Opc.Ua.Client
             }
             var result = new List<ISubscription>(states.Count);
             var manager =
-                (SubscriptionManager)session.SubscriptionManager;
+                (SubscriptionManager)session.GetSubscriptionManager();
 
             // Group by LogicalGroupId; null group = standalone. The
             // grouping logic mirrors the stream-based LoadAsync

--- a/Libraries/Opc.Ua.Client/Session/ISession.cs
+++ b/Libraries/Opc.Ua.Client/Session/ISession.cs
@@ -29,6 +29,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -378,6 +379,25 @@ namespace Opc.Ua.Client
             Stream stream,
             bool transferSubscriptions = false,
             IEnumerable<Type>? knownTypes = null);
+
+        /// <summary>
+        /// Gets the options-based V2 subscription manager for this session.
+        /// The manager is available when the session was created with the V2
+        /// subscription engine (the default for
+        /// <see cref="ManagedSession"/>). Sessions using the classic
+        /// subscription engine do not expose a manager.
+        /// </summary>
+        /// <param name="manager">
+        /// When this method returns <c>true</c>, contains the session's
+        /// <see cref="Subscriptions.ISubscriptionManager"/>; otherwise
+        /// <c>null</c>.
+        /// </param>
+        /// <returns>
+        /// <c>true</c> if the session uses the V2 subscription engine and a
+        /// manager is available; otherwise <c>false</c>.
+        /// </returns>
+        bool TryGetSubscriptionManager(
+            [NotNullWhen(true)] out Subscriptions.ISubscriptionManager? manager);
 
         /// <summary>
         /// Returns the active session configuration and writes it to a stream.

--- a/Libraries/Opc.Ua.Client/Session/ManagedSession.Streaming.cs
+++ b/Libraries/Opc.Ua.Client/Session/ManagedSession.Streaming.cs
@@ -53,7 +53,8 @@ namespace Opc.Ua.Client
 
         /// <summary>
         /// A shared lazy <see cref="IStreamingSubscription"/> over this
-        /// session's <see cref="SubscriptionManager"/>. Backs both
+        /// session's V2 subscription manager (see
+        /// <see cref="ISession.TryGetSubscriptionManager"/>). Backs both
         /// <see cref="ModelChange"/> (when enabled) and ad-hoc
         /// <see cref="IAsyncEnumerable{T}"/>-based subscriptions.
         /// </summary>
@@ -78,7 +79,15 @@ namespace Opc.Ua.Client
                         return m_defaultStreaming;
                     }
 
-                    m_defaultStreaming = new StreamingSubscription(SubscriptionManager);
+                    if (!TryGetSubscriptionManager(
+                            out Subscriptions.ISubscriptionManager? manager))
+                    {
+                        throw new InvalidOperationException(
+                            "Streaming subscriptions require the V2 subscription engine. " +
+                            "The session is using the classic engine; recreate the " +
+                            "ManagedSession with the V2 subscription engine factory.");
+                    }
+                    m_defaultStreaming = new StreamingSubscription(manager);
                     return m_defaultStreaming;
                 }
             }

--- a/Libraries/Opc.Ua.Client/Session/ManagedSession.cs
+++ b/Libraries/Opc.Ua.Client/Session/ManagedSession.cs
@@ -139,7 +139,8 @@ namespace Opc.Ua.Client
         /// the server certificate.</param>
         /// <param name="engineFactory">Optional subscription engine
         /// factory. Defaults to <see cref="DefaultSubscriptionEngineFactory"/>
-        /// (V2 engine) so that <see cref="SubscriptionManager"/> is
+        /// (V2 engine) so that the V2 subscription manager (see
+        /// <see cref="ISession.TryGetSubscriptionManager"/>) is
         /// available. Pass <see cref="ClassicSubscriptionEngineFactory"/>
         /// for legacy classic-engine behavior.</param>
         /// <param name="transferSubscriptionsOnRecreate">When
@@ -348,26 +349,12 @@ namespace Opc.Ua.Client
         public IEnumerable<Subscription> Subscriptions
             => m_session?.Subscriptions ?? [];
 
-        /// <summary>
-        /// The new options-based <see cref="Subscriptions.ISubscriptionManager"/>.
-        /// Available when the underlying session was created with the V2
-        /// subscription engine (the default for <see cref="ManagedSession"/>).
-        /// </summary>
-        /// <exception cref="InvalidOperationException">when the session
-        /// is using the classic engine.</exception>
-        public Subscriptions.ISubscriptionManager SubscriptionManager
+        /// <inheritdoc/>
+        public bool TryGetSubscriptionManager(
+            [System.Diagnostics.CodeAnalysis.NotNullWhen(true)]
+            out Subscriptions.ISubscriptionManager? manager)
         {
-            get
-            {
-                if (InnerSession.SubscriptionEngine is DefaultSubscriptionEngine v2)
-                {
-                    return v2.SubscriptionManager;
-                }
-                throw new InvalidOperationException(
-                    "ManagedSession.SubscriptionManager requires the V2 subscription engine. " +
-                    "The session is using the classic engine; use Subscriptions/AddSubscription " +
-                    "for the legacy API or recreate the ManagedSession with the V2 engine factory.");
-            }
+            return InnerSession.TryGetSubscriptionManager(out manager);
         }
 
         /// <inheritdoc/>

--- a/Libraries/Opc.Ua.Client/Session/ManagedSessionOptions.cs
+++ b/Libraries/Opc.Ua.Client/Session/ManagedSessionOptions.cs
@@ -103,8 +103,9 @@ namespace Opc.Ua.Client
 
         /// <summary>
         /// Optional subscription engine factory. When null, defaults to the
-        /// V2 engine (<see cref="DefaultSubscriptionEngineFactory"/>) so
-        /// <see cref="ManagedSession.SubscriptionManager"/> is available.
+        /// V2 engine (<see cref="DefaultSubscriptionEngineFactory"/>) so the
+        /// session's V2 subscription manager (see
+        /// <see cref="ISession.TryGetSubscriptionManager"/>) is available.
         /// </summary>
         public ISubscriptionEngineFactory? SubscriptionEngineFactory { get; init; }
 

--- a/Libraries/Opc.Ua.Client/Session/Session.cs
+++ b/Libraries/Opc.Ua.Client/Session/Session.cs
@@ -633,6 +633,20 @@ namespace Opc.Ua.Client
         /// </summary>
         internal ISubscriptionEngine SubscriptionEngine => m_engine;
 
+        /// <inheritdoc/>
+        public bool TryGetSubscriptionManager(
+            [System.Diagnostics.CodeAnalysis.NotNullWhen(true)]
+            out Subscriptions.ISubscriptionManager? manager)
+        {
+            if (m_engine is DefaultSubscriptionEngine v2)
+            {
+                manager = v2.SubscriptionManager;
+                return true;
+            }
+            manager = null;
+            return false;
+        }
+
         /// <summary>
         /// Gets the endpoint used to connect to the server.
         /// </summary>

--- a/Libraries/Opc.Ua.PubSub.Adapter/Session/ServerSession.cs
+++ b/Libraries/Opc.Ua.PubSub.Adapter/Session/ServerSession.cs
@@ -189,7 +189,11 @@ namespace Opc.Ua.PubSub.Adapter.Session
             {
                 throw ServiceResultException.Create(
                     StatusCodes.BadNotSupported,
-                    "The external server session does not expose a V2 subscription manager.");
+                    "The external server session for endpoint '{0}' does not expose a V2 " +
+                    "subscription manager. Data-change subscriptions require the V2 subscription " +
+                    "engine (the ManagedSession default); recreate the session with the V2 " +
+                    "engine (DefaultSubscriptionEngineFactory) rather than the classic engine.",
+                    m_options.EndpointUrl);
             }
             return new DataChangeSubscription(
                 subscriptionManager,
@@ -211,9 +215,17 @@ namespace Opc.Ua.PubSub.Adapter.Session
                 ISession session = await EnsureConnectedAsync(ct).ConfigureAwait(false);
                 if (!session.TryGetSubscriptionManager(out ISubscriptionManager? subscriptionManager))
                 {
+                    // Model-change monitoring is an optional, best-effort enhancement
+                    // (unlike data-change subscriptions, which are required and throw):
+                    // the whole method already swallows failures and continues, so a
+                    // classic-engine session simply skips it rather than faulting.
                     m_logger.LogInformation(
-                        "ServerSession: model-change event monitoring requires a V2 " +
-                        "subscription manager, which this session does not expose.");
+                        "ServerSession: model-change event monitoring is not available for " +
+                        "endpoint {EndpointUrl} because the session does not expose a V2 " +
+                        "subscription manager (requires the V2 subscription engine / " +
+                        "DefaultSubscriptionEngineFactory). Monitoring is optional; continuing " +
+                        "without it.",
+                        m_options.EndpointUrl);
                     return;
                 }
 

--- a/Libraries/Opc.Ua.PubSub.Adapter/Session/ServerSession.cs
+++ b/Libraries/Opc.Ua.PubSub.Adapter/Session/ServerSession.cs
@@ -94,6 +94,22 @@ namespace Opc.Ua.PubSub.Adapter.Session
             m_logger = telemetry.CreateLogger<ServerSession>();
         }
 
+        /// <summary>
+        /// Test seam: creates a server session bound to an already-established
+        /// <see cref="ISession"/> instead of building one lazily via the
+        /// managed-session builder. Enables exercising the session-capability
+        /// guards (e.g. classic-engine sessions that expose no V2 subscription
+        /// manager) without standing up a real server.
+        /// </summary>
+        internal ServerSession(
+            ServerConnectionOptions options,
+            ITelemetryContext telemetry,
+            ISession session)
+            : this(options, telemetry)
+        {
+            m_session = session ?? throw new ArgumentNullException(nameof(session));
+        }
+
         /// <inheritdoc/>
         public bool IsConnected => m_session?.Connected ?? false;
 

--- a/Libraries/Opc.Ua.PubSub.Adapter/Session/ServerSession.cs
+++ b/Libraries/Opc.Ua.PubSub.Adapter/Session/ServerSession.cs
@@ -50,9 +50,12 @@ namespace Opc.Ua.PubSub.Adapter.Session
     /// modern <see cref="ManagedSession"/> built from
     /// <see cref="ServerConnectionOptions"/> and an
     /// <see cref="ITelemetryContext"/>. Read/Write/Call services delegate to
-    /// the managed session; data-change subscriptions use the session's
-    /// <see cref="ISubscriptionManager"/>. Reconnect and keep-alive are owned by
-    /// the managed session.
+    /// the managed session; data-change subscriptions use the session's V2
+    /// subscription manager (see
+    /// <see cref="ISession.TryGetSubscriptionManager"/>). Reconnect and
+    /// keep-alive are owned by the managed session. The session is held via
+    /// the <see cref="ISession"/> abstraction to avoid coupling to the
+    /// concrete <see cref="ManagedSession"/>.
     /// </summary>
     public sealed class ServerSession : IServerSession
     {
@@ -66,12 +69,6 @@ namespace Opc.Ua.PubSub.Adapter.Session
         private readonly SemaphoreSlim m_connectLock = new(1, 1);
         private readonly System.Threading.Lock m_disposeGate = new();
         private readonly ConcurrentDictionary<string, NodeId> m_resolvedPaths = new(StringComparer.Ordinal);
-        [System.Diagnostics.CodeAnalysis.SuppressMessage(
-            "Performance",
-            "CA1859:Use concrete types when possible for improved performance",
-            Justification = "Intentionally typed as ISession per PR review feedback to avoid coupling " +
-                "to the concrete ManagedSession; the few ManagedSession-only members are downcast " +
-                "where required (tracked by #3925).")]
         private ISession? m_session;
         private ISubscription? m_modelChangeSubscription;
         private long m_lastModelChangeTicks;
@@ -187,10 +184,15 @@ namespace Opc.Ua.PubSub.Adapter.Session
             double publishingIntervalMs,
             CancellationToken ct = default)
         {
-            // TODO(#3925): SubscriptionManager is not on ISession yet; downcast required.
-            var session = (ManagedSession)await EnsureConnectedAsync(ct).ConfigureAwait(false);
+            ISession session = await EnsureConnectedAsync(ct).ConfigureAwait(false);
+            if (!session.TryGetSubscriptionManager(out ISubscriptionManager? subscriptionManager))
+            {
+                throw ServiceResultException.Create(
+                    StatusCodes.BadNotSupported,
+                    "The external server session does not expose a V2 subscription manager.");
+            }
             return new DataChangeSubscription(
-                session.SubscriptionManager,
+                subscriptionManager,
                 publishingIntervalMs,
                 m_telemetry);
         }
@@ -206,15 +208,21 @@ namespace Opc.Ua.PubSub.Adapter.Session
 
             try
             {
-                // TODO(#3925): SubscriptionManager is not on ISession yet; downcast required.
-                var session = (ManagedSession)await EnsureConnectedAsync(ct).ConfigureAwait(false);
+                ISession session = await EnsureConnectedAsync(ct).ConfigureAwait(false);
+                if (!session.TryGetSubscriptionManager(out ISubscriptionManager? subscriptionManager))
+                {
+                    m_logger.LogInformation(
+                        "ServerSession: model-change event monitoring requires a V2 " +
+                        "subscription manager, which this session does not expose.");
+                    return;
+                }
 
                 var subscriptionOptions = new SubscriptionOptions
                 {
                     PublishingInterval = TimeSpan.FromMilliseconds(1000),
                     PublishingEnabled = true
                 };
-                ISubscription subscription = session.SubscriptionManager.Add(
+                ISubscription subscription = subscriptionManager.Add(
                     new ModelChangeNotifier(this),
                     new SingletonOptionsMonitor<SubscriptionOptions>(subscriptionOptions));
 
@@ -298,8 +306,7 @@ namespace Opc.Ua.PubSub.Adapter.Session
                 return cached;
             }
 
-            // TODO(#3925): MessageContext is not on ISession yet; downcast required.
-            var session = (ManagedSession)await EnsureConnectedAsync(ct).ConfigureAwait(false);
+            ISession session = await EnsureConnectedAsync(ct).ConfigureAwait(false);
 
             var request = new Opc.Ua.BrowsePath
             {
@@ -463,7 +470,7 @@ namespace Opc.Ua.PubSub.Adapter.Session
             }
         }
 
-        private async Task<ManagedSession> CreateSessionAsync(CancellationToken ct)
+        private async Task<ISession> CreateSessionAsync(CancellationToken ct)
         {
             ApplicationConfiguration configuration = m_options.ApplicationConfiguration
                 ?? await BuildApplicationConfigurationAsync(ct).ConfigureAwait(false);

--- a/Tests/Opc.Ua.Client.TestFramework/Extensions.cs
+++ b/Tests/Opc.Ua.Client.TestFramework/Extensions.cs
@@ -33,6 +33,26 @@ namespace Opc.Ua.Client.TestFramework
 {
     public static class Extensions
     {
+        /// <summary>
+        /// Test helper that returns the session's V2 subscription manager,
+        /// throwing when the session does not expose one (classic engine).
+        /// Replaces the removed ManagedSession.SubscriptionManager property in
+        /// tests that require the V2 engine (see
+        /// <see cref="ISession.TryGetSubscriptionManager"/>).
+        /// </summary>
+        public static Subscriptions.ISubscriptionManager RequireSubscriptionManager(
+            this ISession session)
+        {
+            ArgumentNullException.ThrowIfNull(session);
+            if (!session.TryGetSubscriptionManager(
+                    out Subscriptions.ISubscriptionManager? manager))
+            {
+                throw new InvalidOperationException(
+                    "The session does not expose a V2 subscription manager.");
+            }
+            return manager;
+        }
+
         public static bool HasArgsOfType(
             this ArrayOf<CallMethodRequest> requests,
             params Type[] argTypes)

--- a/Tests/Opc.Ua.Client.TestFramework/Extensions.cs
+++ b/Tests/Opc.Ua.Client.TestFramework/Extensions.cs
@@ -43,7 +43,10 @@ namespace Opc.Ua.Client.TestFramework
         public static Subscriptions.ISubscriptionManager RequireSubscriptionManager(
             this ISession session)
         {
-            ArgumentNullException.ThrowIfNull(session);
+            if (session == null)
+            {
+                throw new ArgumentNullException(nameof(session));
+            }
             if (!session.TryGetSubscriptionManager(
                     out Subscriptions.ISubscriptionManager? manager))
             {

--- a/Tests/Opc.Ua.PubSub.Adapter.Tests/ServerSessionCapabilityGuardTests.cs
+++ b/Tests/Opc.Ua.PubSub.Adapter.Tests/ServerSessionCapabilityGuardTests.cs
@@ -1,0 +1,89 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System.Threading.Tasks;
+using Moq;
+using NUnit.Framework;
+using Opc.Ua.Client;
+using Opc.Ua.Client.Subscriptions;
+using Opc.Ua.PubSub.Adapter.Session;
+
+namespace Opc.Ua.PubSub.Adapter.Tests
+{
+    /// <summary>
+    /// Unit tests for the V2 subscription-manager capability guards in
+    /// <see cref="ServerSession"/> when the bound <see cref="ISession"/> does
+    /// not expose a manager (e.g. a classic-engine session). Uses the internal
+    /// session-injecting constructor so the guards are exercised without a
+    /// real server.
+    /// </summary>
+    [TestFixture]
+    public sealed class ServerSessionCapabilityGuardTests
+    {
+        private static ServerSession CreateSessionWithoutManager()
+        {
+            var mockSession = new Mock<ISession>();
+            ISubscriptionManager? manager = null;
+            mockSession
+                .Setup(s => s.TryGetSubscriptionManager(out manager))
+                .Returns(false);
+            mockSession.SetupGet(s => s.Connected).Returns(true);
+
+            var options = new ServerConnectionOptions
+            {
+                EndpointUrl = "opc.tcp://localhost:4840"
+            };
+            return new ServerSession(
+                options, AdapterTestHelpers.Telemetry(), mockSession.Object);
+        }
+
+        [Test]
+        public void CreateDataChangeSubscriptionThrowsWhenNoV2Manager()
+        {
+            ServerSession session = CreateSessionWithoutManager();
+
+            Assert.That(
+                async () => await session.CreateDataChangeSubscriptionAsync(1000),
+                Throws.TypeOf<ServiceResultException>()
+                    .With.Property("StatusCode").EqualTo((StatusCode)StatusCodes.BadNotSupported));
+        }
+
+        [Test]
+        public void StartModelChangeMonitoringNoOpsWhenNoV2Manager()
+        {
+            ServerSession session = CreateSessionWithoutManager();
+
+            // Model-change monitoring is optional/best-effort: a session without a
+            // V2 manager must skip it silently rather than fault.
+            Assert.That(
+                async () => await session.StartModelChangeMonitoringAsync(),
+                Throws.Nothing);
+        }
+    }
+}

--- a/Tests/Opc.Ua.Sessions.Tests/ManagedSessionReconnectIntegrationTests.cs
+++ b/Tests/Opc.Ua.Sessions.Tests/ManagedSessionReconnectIntegrationTests.cs
@@ -1059,7 +1059,7 @@ namespace Opc.Ua.Sessions.Tests
                 // SubscriptionManager type is internal but accessible
                 // to this test project via InternalsVisibleTo.
                 var concreteManager =
-                    (Client.Subscriptions.SubscriptionManager)session.SubscriptionManager;
+                    (Client.Subscriptions.SubscriptionManager)session.RequireSubscriptionManager();
                 concreteManager.TransferSubscriptionsOnRecreate = true;
 
                 int snapshotCountBeforeTransfer = handler.DataChangeCount;
@@ -1134,7 +1134,7 @@ namespace Opc.Ua.Sessions.Tests
                 // After connect the V2 manager must already report the
                 // opt-in flag set.
                 var manager =
-                    (Client.Subscriptions.SubscriptionManager)session.SubscriptionManager;
+                    (Client.Subscriptions.SubscriptionManager)session.RequireSubscriptionManager();
                 Assert.That(
                     manager.TransferSubscriptionsOnRecreate, Is.True,
                     "Builder.WithTransferSubscriptionsOnRecreate must " +
@@ -1212,7 +1212,7 @@ namespace Opc.Ua.Sessions.Tests
                     Is.True,
                     "InnerSession must remain the same instance.");
                 Assert.That(
-                    ReferenceEquals(session.SubscriptionManager, manager),
+                    ReferenceEquals(session.RequireSubscriptionManager(), manager),
                     Is.True,
                     "V2 SubscriptionManager must survive the failover.");
                 Assert.That(

--- a/Tests/Opc.Ua.Stress.Tests/Channels/Chaos/SubscriptionSurvivalChaosTests.cs
+++ b/Tests/Opc.Ua.Stress.Tests/Channels/Chaos/SubscriptionSurvivalChaosTests.cs
@@ -38,6 +38,7 @@ using System.Threading.Tasks;
 using NUnit.Framework;
 using Opc.Ua.Client;
 using Opc.Ua.Client.Subscriptions;
+using Opc.Ua.Client.TestFramework;
 using Opc.Ua.Stress.Tests.Channels.Fakes;
 using Opc.Ua.Stress.Tests.Channels.Helpers;
 using Opc.Ua.Stress.Tests.Channels.Integration;
@@ -353,7 +354,7 @@ namespace Opc.Ua.Stress.Tests.Channels.Chaos
             Assert.That(
                 await WaitForAsync(
                     () => sessions.All(static session =>
-                        session.SubscriptionManager.Count == SubscriptionsPerSession) &&
+                        session.RequireSubscriptionManager().Count == SubscriptionsPerSession) &&
                         subscriptions.All(static tracker =>
                             tracker.Subscription.Created && tracker.MonitoredItem.Created),
                     timeout,

--- a/Tests/Opc.Ua.Subscriptions.Tests/ManagedSessionSubscriptionManagerIntegrationTests.cs
+++ b/Tests/Opc.Ua.Subscriptions.Tests/ManagedSessionSubscriptionManagerIntegrationTests.cs
@@ -234,6 +234,16 @@ namespace Opc.Ua.Subscriptions.Tests
                     session.TryGetSubscriptionManager(out ISubscriptionManager? manager),
                     Is.False);
                 Assert.That(manager, Is.Null);
+
+                // The V2-only fluent surfaces are unavailable on the classic
+                // engine and fail fast (InvalidOperationException) rather than
+                // silently no-op'ing.
+                Assert.Throws<InvalidOperationException>(
+                    () => session.AddSubscription(
+                        new RecordingHandler(),
+                        new Client.Subscriptions.SubscriptionOptions()));
+                Assert.Throws<InvalidOperationException>(
+                    () => _ = session.DefaultStreaming);
             }
             finally
             {

--- a/Tests/Opc.Ua.Subscriptions.Tests/ManagedSessionSubscriptionManagerIntegrationTests.cs
+++ b/Tests/Opc.Ua.Subscriptions.Tests/ManagedSessionSubscriptionManagerIntegrationTests.cs
@@ -50,8 +50,8 @@ namespace Opc.Ua.Subscriptions.Tests
     /// End-to-end integration tests for <see cref="ManagedSessionBuilder"/>
     /// + <see cref="ManagedSessionExtensions"/> against the
     /// in-process reference fixture server. Verifies that the V2
-    /// subscription engine, exposed through the new
-    /// <see cref="ManagedSessionType.SubscriptionManager"/> property, can
+    /// subscription engine, exposed through
+    /// <see cref="ISession.TryGetSubscriptionManager"/>, can
     /// drive subscriptions and deliver data change notifications.
     /// </summary>
     [TestFixture]
@@ -112,7 +112,9 @@ namespace Opc.Ua.Subscriptions.Tests
                 Assert.That(session, Is.Not.Null);
                 Assert.That(session.Connected, Is.True);
 
-                ISubscriptionManager manager = session.SubscriptionManager;
+                Assert.That(
+                    session.TryGetSubscriptionManager(out ISubscriptionManager? manager),
+                    Is.True);
                 Assert.That(manager, Is.Not.Null);
                 Assert.That(manager.Count, Is.Zero);
 
@@ -158,7 +160,7 @@ namespace Opc.Ua.Subscriptions.Tests
                     });
 
                 Assert.That(subscription, Is.Not.Null);
-                Assert.That(session.SubscriptionManager.Count, Is.EqualTo(1));
+                Assert.That(session.RequireSubscriptionManager().Count, Is.EqualTo(1));
 
                 // Wait for the subscription state machine to create
                 // the subscription on the server (asynchronously after
@@ -210,7 +212,7 @@ namespace Opc.Ua.Subscriptions.Tests
         [Test]
         [Order(300)]
         [CancelAfter(60_000)]
-        public async Task ClassicEngineThrowsWhenAccessingSubscriptionManager(
+        public async Task ClassicEngineDoesNotExposeSubscriptionManager(
             CancellationToken ct)
         {
             ConfiguredEndpoint endpoint = await ClientFixture
@@ -220,7 +222,7 @@ namespace Opc.Ua.Subscriptions.Tests
             ManagedSessionType session = await new ManagedSessionBuilder(
                     ClientFixture.Config, Telemetry)
                 .UseEndpoint(endpoint)
-                .WithSessionName(nameof(ClassicEngineThrowsWhenAccessingSubscriptionManager))
+                .WithSessionName(nameof(ClassicEngineDoesNotExposeSubscriptionManager))
                 .UseSubscriptionEngine(ClassicSubscriptionEngineFactory.Instance)
                 .ConnectAsync(ct)
                 .ConfigureAwait(false);
@@ -228,8 +230,10 @@ namespace Opc.Ua.Subscriptions.Tests
             try
             {
                 Assert.That(session.Connected, Is.True);
-                Assert.Throws<InvalidOperationException>(
-                    () => _ = session.SubscriptionManager);
+                Assert.That(
+                    session.TryGetSubscriptionManager(out ISubscriptionManager? manager),
+                    Is.False);
+                Assert.That(manager, Is.Null);
             }
             finally
             {

--- a/Tests/Opc.Ua.Subscriptions.Tests/SubscriptionCoverageTests.cs
+++ b/Tests/Opc.Ua.Subscriptions.Tests/SubscriptionCoverageTests.cs
@@ -398,7 +398,9 @@ namespace Opc.Ua.Subscriptions.Tests
                 target = await ConnectV2Async(
                     nameof(SnapshotEmptySubscriptionRoundTripV2Async) + "_target", ct)
                     .ConfigureAwait(false);
-                ISubscription restored = await ((SubscriptionManager)target.RequireSubscriptionManager())
+                ISubscriptionManager targetManager = target.RequireSubscriptionManager();
+                Assert.That(targetManager, Is.InstanceOf<SubscriptionManager>());
+                ISubscription restored = await ((SubscriptionManager)targetManager)
                     .RestoreAsync(
                         new RecordingSubscriptionHandler(),
                         snap,
@@ -504,7 +506,9 @@ namespace Opc.Ua.Subscriptions.Tests
                 target = await ConnectV2Async(
                     nameof(SnapshotWithDataChangeFilterRoundTripV2Async) + "_target", ct)
                     .ConfigureAwait(false);
-                ISubscription restored = await ((SubscriptionManager)target.RequireSubscriptionManager())
+                ISubscriptionManager targetManager = target.RequireSubscriptionManager();
+                Assert.That(targetManager, Is.InstanceOf<SubscriptionManager>());
+                ISubscription restored = await ((SubscriptionManager)targetManager)
                     .RestoreAsync(
                         new RecordingSubscriptionHandler(),
                         snap,

--- a/Tests/Opc.Ua.Subscriptions.Tests/SubscriptionCoverageTests.cs
+++ b/Tests/Opc.Ua.Subscriptions.Tests/SubscriptionCoverageTests.cs
@@ -398,7 +398,7 @@ namespace Opc.Ua.Subscriptions.Tests
                 target = await ConnectV2Async(
                     nameof(SnapshotEmptySubscriptionRoundTripV2Async) + "_target", ct)
                     .ConfigureAwait(false);
-                ISubscription restored = await ((SubscriptionManager)target.SubscriptionManager)
+                ISubscription restored = await ((SubscriptionManager)target.RequireSubscriptionManager())
                     .RestoreAsync(
                         new RecordingSubscriptionHandler(),
                         snap,
@@ -504,7 +504,7 @@ namespace Opc.Ua.Subscriptions.Tests
                 target = await ConnectV2Async(
                     nameof(SnapshotWithDataChangeFilterRoundTripV2Async) + "_target", ct)
                     .ConfigureAwait(false);
-                ISubscription restored = await ((SubscriptionManager)target.SubscriptionManager)
+                ISubscription restored = await ((SubscriptionManager)target.RequireSubscriptionManager())
                     .RestoreAsync(
                         new RecordingSubscriptionHandler(),
                         snap,

--- a/Tests/Opc.Ua.Subscriptions.Tests/SubscriptionEngineIntegrationTests.cs
+++ b/Tests/Opc.Ua.Subscriptions.Tests/SubscriptionEngineIntegrationTests.cs
@@ -94,7 +94,7 @@ namespace Opc.Ua.Subscriptions.Tests
             try
             {
                 Assert.That(session.Connected, Is.True);
-                ISubscriptionManager manager = session.SubscriptionManager;
+                ISubscriptionManager manager = session.RequireSubscriptionManager();
                 Assert.That(manager, Is.Not.Null,
                     "V2 session must expose ISubscriptionManager");
                 Assert.That(manager.Count, Is.Zero);
@@ -127,7 +127,7 @@ namespace Opc.Ua.Subscriptions.Tests
                         Priority = 0
                     });
 
-                Assert.That(session.SubscriptionManager.Count, Is.EqualTo(1));
+                Assert.That(session.RequireSubscriptionManager().Count, Is.EqualTo(1));
 
                 bool created = await WaitForAsync(
                     () => subscription.Created,
@@ -180,7 +180,7 @@ namespace Opc.Ua.Subscriptions.Tests
                 nameof(V2EnginePublishRequestCountScalesAsync), ct).ConfigureAwait(false);
             try
             {
-                ISubscriptionManager manager = session.SubscriptionManager;
+                ISubscriptionManager manager = session.RequireSubscriptionManager();
                 int initial = manager.GoodPublishRequestCount;
                 TestContext.Out.WriteLine("Initial V2 GoodPublishRequestCount: {0}",
                     initial);

--- a/Tests/Opc.Ua.Subscriptions.Tests/SubscriptionTests.cs
+++ b/Tests/Opc.Ua.Subscriptions.Tests/SubscriptionTests.cs
@@ -108,7 +108,7 @@ namespace Opc.Ua.Subscriptions.Tests
                         Priority = 0
                     });
 
-                Assert.That(session.SubscriptionManager.Count, Is.EqualTo(1));
+                Assert.That(session.RequireSubscriptionManager().Count, Is.EqualTo(1));
 
                 bool created = await WaitForAsync(() => subscription.Created,
                     TimeSpan.FromSeconds(10), ct).ConfigureAwait(false);
@@ -227,7 +227,7 @@ namespace Opc.Ua.Subscriptions.Tests
                 }
                 using (FileStream output = File.Create(s_saveFile))
                 {
-                    await session.SubscriptionManager.SaveAsync(
+                    await session.RequireSubscriptionManager().SaveAsync(
                         output, session.MessageContext, null, ct)
                         .ConfigureAwait(false);
                 }
@@ -242,7 +242,7 @@ namespace Opc.Ua.Subscriptions.Tests
                     var reloadHandler = new RecordingSubscriptionHandler();
                     using FileStream input = File.OpenRead(s_saveFile);
                     IReadOnlyList<ISubscription> loaded = await reloadSession
-                        .SubscriptionManager.LoadAsync(input,
+                        .RequireSubscriptionManager().LoadAsync(input,
                             reloadSession.MessageContext,
                             _ => reloadHandler,
                             transferSubscriptions: false,
@@ -435,7 +435,7 @@ namespace Opc.Ua.Subscriptions.Tests
             ManagedSession session = await ConnectV2Async(nameof(PublishRequestCountV2Async), ct).ConfigureAwait(false);
             try
             {
-                ISubscriptionManager manager = session.SubscriptionManager;
+                ISubscriptionManager manager = session.RequireSubscriptionManager();
                 manager.MinPublishWorkerCount = 3;
 
                 const int subscriptionCount = 5;

--- a/Tests/Opc.Ua.Subscriptions.Tests/TransferSubscriptionTests.cs
+++ b/Tests/Opc.Ua.Subscriptions.Tests/TransferSubscriptionTests.cs
@@ -290,7 +290,7 @@ namespace Opc.Ua.Subscriptions.Tests
 
                 using (var output = File.Create(saveFile))
                 {
-                    await originSession.SubscriptionManager.SaveAsync(
+                    await originSession.RequireSubscriptionManager().SaveAsync(
                         output, originSession.MessageContext, null, ct)
                         .ConfigureAwait(false);
                 }
@@ -303,7 +303,7 @@ namespace Opc.Ua.Subscriptions.Tests
                 IReadOnlyList<ISubscription> loaded;
                 using (var input = File.OpenRead(saveFile))
                 {
-                    loaded = await targetSession.SubscriptionManager
+                    loaded = await targetSession.RequireSubscriptionManager()
                         .LoadAsync(input, targetSession.MessageContext,
                             _ => targetHandler,
                             transferSubscriptions: false, ct)
@@ -371,7 +371,7 @@ namespace Opc.Ua.Subscriptions.Tests
                 // The option lives on the V2 SubscriptionManager. We can
                 // verify the manager has the property set so the recreate
                 // path will request transfer when it runs.
-                ISubscriptionManager manager = session.SubscriptionManager;
+                ISubscriptionManager manager = session.RequireSubscriptionManager();
                 Assert.That(manager, Is.Not.Null);
                 // The interface itself doesn't surface the flag (it's on
                 // the concrete SubscriptionManager). We exercise the
@@ -455,7 +455,7 @@ namespace Opc.Ua.Subscriptions.Tests
 
                 using (var output = File.Create(saveFile))
                 {
-                    await session.SubscriptionManager.SaveAsync(
+                    await session.RequireSubscriptionManager().SaveAsync(
                         output, session.MessageContext, null, ct)
                         .ConfigureAwait(false);
                 }
@@ -468,7 +468,7 @@ namespace Opc.Ua.Subscriptions.Tests
                 IReadOnlyList<ISubscription> loaded;
                 using (var input = File.OpenRead(saveFile))
                 {
-                    loaded = await target.SubscriptionManager.LoadAsync(input,
+                    loaded = await target.RequireSubscriptionManager().LoadAsync(input,
                         target.MessageContext, _ => targetHandler,
                         transferSubscriptions: false, ct).ConfigureAwait(false);
                 }


### PR DESCRIPTION
Follow-up to the merged PR #3892 implementing issue #3925.

## Summary
Promotes the V2 options-based subscription manager onto `ISession` so the PubSub external-server adapter no longer downcasts to the concrete `ManagedSession`.

The V2 `ISubscriptionManager` is backed by the session's subscription engine, so it is a **Session** capability rather than a managed-only one. It is now exposed on `ISession` via a non-throwing accessor:

```csharp
bool TryGetSubscriptionManager([NotNullWhen(true)] out ISubscriptionManager? manager)
```

Returns `true` + the manager for V2-engine sessions (the default for `ManagedSession`) and `false` for classic-engine sessions (the default for the unmanaged `Session`).

## Changes
- **`ISession`**: add `TryGetSubscriptionManager`.
- **`Session`** (unmanaged): implement off the active subscription engine.
- **`ManagedSession`**: implement by delegating to the inner session. The throwing `ManagedSession.SubscriptionManager` property is **removed** (source-breaking, 2.0 preview) in favour of the `ISession` accessor.
- **Callers migrated**: public `ManagedSessionExtensions` helpers (signatures unchanged, via a private resolver), `ManagedSession.Streaming`, and the client subscription/session/stress test suites (via a `RequireSubscriptionManager` test helper).
- **PubSub adapter** (#3925): `ServerSession` reaches the subscription manager through `TryGetSubscriptionManager` and `MessageContext` through `ISession` directly (it was already on `ISession` via `IClientBase`). All three `(ManagedSession)` downcasts and the `CA1859` suppression are removed; `CreateSessionAsync` returns `ISession`. An internal session-injecting constructor was added as a test seam for the classic-engine capability guards.
- **Docs**: `Sessions.md` / `Subscriptions.md` updated; `migrate/2.0.x/sessions-subscriptions.md` documents the property removal.

## Review feedback addressed
- Actionable `BadNotSupported` message (names the V2 engine + endpoint); classic-engine model-change monitoring log clarified as optional/best-effort.
- `GetSubscriptionManager` argument null-check.
- Tests assert the concrete `SubscriptionManager` type before downcasting.

## CI fixes
- Replaced `ArgumentNullException.ThrowIfNull` (unavailable on net472/net48/netstandard2.0) with the classic throw form in the test helper.
- Added tests covering the new classic-engine guard branches (`AddSubscription`/`DefaultStreaming` throws; `ServerSession` data-change throw + model-change no-op) to keep PR diff coverage above target.

## Validation
- `Opc.Ua.Client` + `Opc.Ua.PubSub.Adapter` build 0-warning on **net10** and **net48**.
- `Opc.Ua.Subscriptions.Tests` and `Opc.Ua.PubSub.Adapter.Tests` pass; no `(ManagedSession)` casts remain in product code.

Closes #3925
