### PR TITLE
Validate issuer/CA certificate KeyUsage (keyCertSign, cRLSign)

### DIFF
--- a/Docs/Certificates.md
+++ b/Docs/Certificates.md
@@ -716,13 +716,17 @@ The following validation errors can be suppressed by handling the `CertificateVa
 - **BadCertificateIssuerRevocationUnknown**: The revocation status of the issuer cannot be determined.
 - **BadCertificateChainIncomplete**: The certificate chain is incomplete (missing issuer certificates).
 - **BadCertificateIssuerTimeInvalid**: The issuer certificate has expired or is not yet valid.
-- **BadCertificateIssuerUseNotAllowed**: The issuer certificate is not valid for the intended use.
+- **BadCertificateIssuerUseNotAllowed**: An issuer/CA certificate in the chain is not valid for use as a CA — for example it does not assert the `keyCertSign` and `cRLSign` KeyUsage bits required for a CA (see [CA (issuer) KeyUsage validation](#ca-issuer-keyusage-validation)).
 - **BadCertificateRevocationUnknown**: The revocation status of the certificate cannot be determined.
 - **BadCertificateTimeInvalid**: The certificate has expired or is not yet valid.
 - **BadCertificatePolicyCheckFailed**: The certificate does not meet policy requirements (e.g., key size, signature algorithm).
 - **BadCertificateUseNotAllowed**: The certificate is not valid for the intended use (missing key usage flags).
 
 All other validation errors are **non-suppressible** and will always cause the validation to fail.
+
+#### CA (issuer) KeyUsage validation
+
+OPC UA requires every CA (issuer) certificate in a chain to carry a KeyUsage extension that asserts both `keyCertSign` and `cRLSign` (OPC 10000-6 §6.2.4, Table 52 — Issuer Certificate). During chain validation the stack verifies this for each issuer certificate and reports the suppressible `BadCertificateIssuerUseNotAllowed` error (OPC 10000-4 §6.1.3, Table 100 — "Certificate Usage") when a CA certificate is missing these bits, including the case where the CA has no KeyUsage extension at all. This matches the behaviour of strict third-party OPC UA stacks, which reject such CA certificates (typically with `BadCertificateInvalid`). CA certificates created by this stack's `CertificateBuilder` always include the required bits; to interoperate with a legacy CA that does not, suppress the error as described above.
 
 ### Inspecting Certificate Validation Results
 

--- a/Stack/Opc.Ua.Core/Security/Certificates/CertificateManager/CertificateValidationCore.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/CertificateManager/CertificateValidationCore.cs
@@ -991,6 +991,30 @@ namespace Opc.Ua
                         sresult);
                 }
 
+                // check that each Issuer/CA certificate in the chain asserts the
+                // KeyUsage required for a CA (keyCertSign and cRLSign).
+                // OPC 10000-6 (Mappings) §6.2.4 Table 52 (Issuer Certificate)
+                // requires these bits; OPC 10000-4 (Services) §6.1.3 Table 100
+                // ("Certificate Usage") maps a mismatch to the suppressible
+                // Bad_CertificateIssuerUseNotAllowed. The platform X509Chain does
+                // not reject a CA whose KeyUsage extension is absent (RFC 5280
+                // §4.2.1.3), so this is verified explicitly here.
+                foreach (CertificateIssuerReference issuer in issuers)
+                {
+                    if (!CertificateValidationHelpers.HasRequiredIssuerKeyUsage(issuer.Certificate))
+                    {
+                        sresult = new ServiceResult(
+                            null,
+                            StatusCodes.BadCertificateIssuerUseNotAllowed,
+                            LocalizedText.From(Utils.Format(
+                                "Issuer certificate '{0}' does not assert the KeyUsage " +
+                                "(keyCertSign, cRLSign) required for a CA.",
+                                issuer.Certificate.Subject)),
+                            null,
+                            sresult);
+                    }
+                }
+
                 // check if minimum requirements are met
                 if (RejectSHA1SignedCertificates &&
                     CertificateValidationHelpers.IsSHA1SignatureAlgorithm(certificate.SignatureAlgorithm))
@@ -1509,9 +1533,9 @@ namespace Opc.Ua
                 case X509ChainStatusFlags.NotValidForUsage:
                     return ServiceResult.Create(
                         isIssuer
-                            ? StatusCodes.BadCertificateUseNotAllowed
-                            : StatusCodes.BadCertificateIssuerUseNotAllowed,
-                        "Certificate may not be used as an application instance certificate. {Status}: {Information}",
+                            ? StatusCodes.BadCertificateIssuerUseNotAllowed
+                            : StatusCodes.BadCertificateUseNotAllowed,
+                        "Certificate is not valid for the requested usage. {0}: {1}",
                         status.Status,
                         status.StatusInformation);
                 case X509ChainStatusFlags.NoError:

--- a/Stack/Opc.Ua.Core/Security/Certificates/CertificateManager/CertificateValidationHelpers.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/CertificateManager/CertificateValidationHelpers.cs
@@ -30,6 +30,7 @@
 using System;
 using System.Collections.Generic;
 using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
 using Opc.Ua.Security.Certificates;
 
 namespace Opc.Ua
@@ -83,6 +84,33 @@ namespace Opc.Ua
         internal static bool IsSignatureValid(Certificate cert)
         {
             return X509Utils.VerifySelfSigned(cert);
+        }
+
+        /// <summary>
+        /// Returns whether a certificate that acts as an Issuer/CA in a chain
+        /// asserts the KeyUsage required by OPC UA for CA Certificates.
+        /// </summary>
+        /// <remarks>
+        /// OPC 10000-6 (Mappings) §6.2.4, Table 52 (Issuer Certificate)
+        /// requires CA Certificates to carry a KeyUsage extension that asserts
+        /// both keyCertSign and cRLSign. A CA whose KeyUsage extension is absent
+        /// yields <see cref="X509KeyUsageFlags.None"/> and therefore also fails
+        /// this check. OPC 10000-4 (Services) §6.1.3, Table 100
+        /// ("Certificate Usage") maps a mismatch to the (suppressible)
+        /// Bad_CertificateIssuerUseNotAllowed status. This has to be verified
+        /// explicitly because the platform X509Chain does not reject a CA whose
+        /// KeyUsage extension is absent (RFC 5280 §4.2.1.3: absence implies no
+        /// usage restriction).
+        /// </remarks>
+        /// <param name="certificate">The issuer/CA certificate to check.</param>
+        /// <returns>
+        /// True if both keyCertSign and cRLSign are asserted; otherwise false.
+        /// </returns>
+        internal static bool HasRequiredIssuerKeyUsage(Certificate certificate)
+        {
+            const X509KeyUsageFlags required =
+                X509KeyUsageFlags.KeyCertSign | X509KeyUsageFlags.CrlSign;
+            return (X509Utils.GetKeyUsage(certificate) & required) == required;
         }
 
         /// <summary>

--- a/Tests/Opc.Ua.Core.Tests/Security/Certificates/CertificateValidatorTest.cs
+++ b/Tests/Opc.Ua.Core.Tests/Security/Certificates/CertificateValidatorTest.cs
@@ -2259,10 +2259,18 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
                 CertificateValidationHelpers.HasRequiredIssuerKeyUsage(compliant),
                 Is.True);
 
-            // non-compliant: empty KeyUsage (equivalent to an absent extension).
+            // non-compliant: empty (present-but-zero) KeyUsage extension.
             using Certificate emptyUsage = CreateRootCa(X509KeyUsageFlags.None, "empty");
             Assert.That(
                 CertificateValidationHelpers.HasRequiredIssuerKeyUsage(emptyUsage),
+                Is.False);
+
+            // non-compliant: KeyUsage extension omitted entirely — the exact
+            // scenario reported in #3944 (the platform X509Chain does not flag
+            // this, so the explicit check must).
+            using Certificate absentUsage = CreateCertificateWithoutKeyUsage();
+            Assert.That(
+                CertificateValidationHelpers.HasRequiredIssuerKeyUsage(absentUsage),
                 Is.False);
 
             // non-compliant: keyCertSign only (cannot sign CRLs).
@@ -2400,14 +2408,9 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
         /// </summary>
         private static Certificate CreateRootCa(X509KeyUsageFlags? keyUsage, string slug)
         {
-            var baseTime = new DateTime(
-                DateTime.UtcNow.Year - 1,
-                1,
-                1,
-                0,
-                0,
-                0,
-                DateTimeKind.Utc);
+            // Relative validity window with a long lifetime so the generated CA
+            // is always valid regardless of when the tests run.
+            DateTime baseTime = DateTime.UtcNow.AddDays(-1);
             ICertificateBuilder builder = s_factory
                 .CreateCertificate($"CN=Issuer KeyUsage {slug} Root, O=OPC Foundation")
                 .SetNotBefore(baseTime)
@@ -2419,6 +2422,29 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
                     new X509KeyUsageExtension(keyUsage.Value, true));
             }
             return builder.SetRSAKeySize(2048).CreateForRSA();
+        }
+
+        /// <summary>
+        /// Creates a self-signed CA certificate whose KeyUsage extension is
+        /// omitted entirely (only basicConstraints cA=true is set). Built via
+        /// <see cref="CertificateRequest"/> so that no default KeyUsage is
+        /// added, reproducing the absent-KeyUsage scenario from issue #3944.
+        /// </summary>
+        private static Certificate CreateCertificateWithoutKeyUsage()
+        {
+            using var rsa = RSA.Create(2048);
+            var request = new CertificateRequest(
+                "CN=Issuer KeyUsage absent Root, O=OPC Foundation",
+                rsa,
+                HashAlgorithmName.SHA256,
+                RSASignaturePadding.Pkcs1);
+            // CA basic constraints but deliberately no KeyUsage extension.
+            request.CertificateExtensions.Add(
+                new X509BasicConstraintsExtension(true, false, 0, true));
+            using X509Certificate2 certificate = request.CreateSelfSigned(
+                DateTimeOffset.UtcNow.AddDays(-1),
+                DateTimeOffset.UtcNow.AddYears(1));
+            return Certificate.FromRawData(certificate.RawData);
         }
 
         /// <summary>

--- a/Tests/Opc.Ua.Core.Tests/Security/Certificates/CertificateValidatorTest.cs
+++ b/Tests/Opc.Ua.Core.Tests/Security/Certificates/CertificateValidatorTest.cs
@@ -2237,6 +2237,232 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
         }
 
         /// <summary>
+        /// Verify the issuer KeyUsage helper enforces the CA KeyUsage required
+        /// by OPC 10000-6 §6.2.4 Table 52 (keyCertSign and cRLSign) and treats
+        /// an absent / empty KeyUsage as non-compliant (issue #3944).
+        /// </summary>
+        [Test]
+        public void HasRequiredIssuerKeyUsageEnforcesCaKeyUsage()
+        {
+            // compliant: the default the builder emits for a CA
+            // (digitalSignature + keyCertSign + cRLSign).
+            using Certificate defaultCa = CreateRootCa(null, "default");
+            Assert.That(
+                CertificateValidationHelpers.HasRequiredIssuerKeyUsage(defaultCa),
+                Is.True);
+
+            // compliant: keyCertSign + cRLSign only.
+            using Certificate compliant = CreateRootCa(
+                X509KeyUsageFlags.KeyCertSign | X509KeyUsageFlags.CrlSign,
+                "compliant");
+            Assert.That(
+                CertificateValidationHelpers.HasRequiredIssuerKeyUsage(compliant),
+                Is.True);
+
+            // non-compliant: empty KeyUsage (equivalent to an absent extension).
+            using Certificate emptyUsage = CreateRootCa(X509KeyUsageFlags.None, "empty");
+            Assert.That(
+                CertificateValidationHelpers.HasRequiredIssuerKeyUsage(emptyUsage),
+                Is.False);
+
+            // non-compliant: keyCertSign only (cannot sign CRLs).
+            using Certificate certSignOnly = CreateRootCa(
+                X509KeyUsageFlags.KeyCertSign,
+                "certsign");
+            Assert.That(
+                CertificateValidationHelpers.HasRequiredIssuerKeyUsage(certSignOnly),
+                Is.False);
+
+            // non-compliant: cRLSign only (cannot sign certificates).
+            using Certificate crlSignOnly = CreateRootCa(X509KeyUsageFlags.CrlSign, "crlsign");
+            Assert.That(
+                CertificateValidationHelpers.HasRequiredIssuerKeyUsage(crlSignOnly),
+                Is.False);
+
+            // non-compliant: digitalSignature only (as reported in #3944).
+            using Certificate digitalSignatureOnly = CreateRootCa(
+                X509KeyUsageFlags.DigitalSignature,
+                "digsig");
+            Assert.That(
+                CertificateValidationHelpers.HasRequiredIssuerKeyUsage(digitalSignatureOnly),
+                Is.False);
+        }
+
+        /// <summary>
+        /// Verify that a chain whose CA does not assert the required KeyUsage
+        /// (keyCertSign, cRLSign) is rejected with
+        /// Bad_CertificateIssuerUseNotAllowed even when the CA is trusted
+        /// (OPC 10000-4 §6.1.3 Table 100 "Certificate Usage").
+        /// </summary>
+        [Test]
+        public async Task RejectCaWithoutRequiredIssuerKeyUsageAsync()
+        {
+            ITelemetryContext telemetry = NUnitTelemetryContext.Create();
+
+            (Certificate rootCa, X509CRL rootCrl, Certificate appCert) =
+                CreateIssuerKeyUsageChain(X509KeyUsageFlags.None, "reject");
+            using (rootCa)
+            using (appCert)
+            {
+                using var validator = TemporaryCertificateManager.Create(telemetry);
+                await validator.TrustedStore.AddAsync(rootCa).ConfigureAwait(false);
+                await validator.TrustedStore.AddCRLAsync(rootCrl).ConfigureAwait(false);
+                CertificateManager certValidator = validator.Update();
+
+                using var certs = new CertificateCollection([appCert, rootCa]);
+                CertificateValidationResult result = await certValidator
+                    .ValidateAsync(certs, ct: CancellationToken.None)
+                    .ConfigureAwait(false);
+
+                Assert.That(result.IsValid, Is.False);
+                Assert.That(
+                    ContainsStatusCode(
+                        result.Errors,
+                        StatusCodes.BadCertificateIssuerUseNotAllowed),
+                    Is.True,
+                    $"Expected an issuer-use error, got: {result.StatusCode}");
+            }
+        }
+
+        /// <summary>
+        /// Verify that the Bad_CertificateIssuerUseNotAllowed error raised for a
+        /// non-compliant CA KeyUsage can be suppressed via the AcceptError
+        /// callback (the error is suppressible per OPC 10000-4 §6.1.3
+        /// Table 100).
+        /// </summary>
+        [Test]
+        public async Task SuppressedCaWithoutRequiredIssuerKeyUsageIsAcceptedAsync()
+        {
+            ITelemetryContext telemetry = NUnitTelemetryContext.Create();
+
+            (Certificate rootCa, X509CRL rootCrl, Certificate appCert) =
+                CreateIssuerKeyUsageChain(X509KeyUsageFlags.None, "suppress");
+            using (rootCa)
+            using (appCert)
+            {
+                using var validator = TemporaryCertificateManager.Create(telemetry);
+                await validator.TrustedStore.AddAsync(rootCa).ConfigureAwait(false);
+                await validator.TrustedStore.AddCRLAsync(rootCrl).ConfigureAwait(false);
+                CertificateManager certValidator = validator.Update();
+
+                var approver = new CertValidationApprover(
+                    [
+                        StatusCodes.BadCertificateIssuerUseNotAllowed,
+                        StatusCodes.BadCertificateUseNotAllowed,
+                        StatusCodes.BadCertificateRevocationUnknown,
+                        StatusCodes.BadCertificateIssuerRevocationUnknown
+                    ]);
+                certValidator.AcceptError = approver.AcceptError;
+
+                using var certs = new CertificateCollection([appCert, rootCa]);
+                CertificateValidationResult result = await certValidator
+                    .ValidateAsync(certs, ct: CancellationToken.None)
+                    .ConfigureAwait(false);
+
+                Assert.That(result.IsValid, Is.True, result.StatusCode.ToString());
+                Assert.That(approver.AcceptedCount, Is.GreaterThan(0));
+            }
+        }
+
+        /// <summary>
+        /// Verify that a chain whose CA asserts the required KeyUsage
+        /// (the default keyCertSign + cRLSign) passes validation.
+        /// </summary>
+        [Test]
+        public async Task AcceptCaWithRequiredIssuerKeyUsageAsync()
+        {
+            ITelemetryContext telemetry = NUnitTelemetryContext.Create();
+
+            (Certificate rootCa, X509CRL rootCrl, Certificate appCert) =
+                CreateIssuerKeyUsageChain(null, "accept");
+            using (rootCa)
+            using (appCert)
+            {
+                using var validator = TemporaryCertificateManager.Create(telemetry);
+                await validator.TrustedStore.AddAsync(rootCa).ConfigureAwait(false);
+                await validator.TrustedStore.AddCRLAsync(rootCrl).ConfigureAwait(false);
+                CertificateManager certValidator = validator.Update();
+
+                using var certs = new CertificateCollection([appCert, rootCa]);
+                CertificateValidationResult result = await certValidator
+                    .ValidateAsync(certs, ct: CancellationToken.None)
+                    .ConfigureAwait(false);
+
+                Assert.That(result.IsValid, Is.True, result.StatusCode.ToString());
+            }
+        }
+
+        /// <summary>
+        /// Creates a self-signed root CA. When <paramref name="keyUsage"/> is
+        /// null the builder emits its default CA KeyUsage
+        /// (digitalSignature + keyCertSign + cRLSign); otherwise the supplied
+        /// KeyUsage overrides the default so non-compliant CAs can be built.
+        /// </summary>
+        private static Certificate CreateRootCa(X509KeyUsageFlags? keyUsage, string slug)
+        {
+            var baseTime = new DateTime(
+                DateTime.UtcNow.Year - 1,
+                1,
+                1,
+                0,
+                0,
+                0,
+                DateTimeKind.Utc);
+            ICertificateBuilder builder = s_factory
+                .CreateCertificate($"CN=Issuer KeyUsage {slug} Root, O=OPC Foundation")
+                .SetNotBefore(baseTime)
+                .SetLifeTime(120)
+                .SetCAConstraint();
+            if (keyUsage.HasValue)
+            {
+                builder = builder.AddExtension(
+                    new X509KeyUsageExtension(keyUsage.Value, true));
+            }
+            return builder.SetRSAKeySize(2048).CreateForRSA();
+        }
+
+        /// <summary>
+        /// Creates a root CA (optionally with a non-compliant KeyUsage), its
+        /// CRL and an application certificate issued by that CA.
+        /// </summary>
+        private static (Certificate rootCa, X509CRL rootCrl, Certificate appCert)
+            CreateIssuerKeyUsageChain(X509KeyUsageFlags? issuerKeyUsage, string slug)
+        {
+            Certificate rootCa = CreateRootCa(issuerKeyUsage, slug);
+            X509CRL rootCrl = s_issuer.RevokeCertificates(rootCa, null, null);
+            Certificate appCert = s_factory
+                .CreateApplicationCertificate(
+                    $"urn:opcfoundation.org:{slug}:app",
+                    $"Issuer KeyUsage {slug} App",
+                    $"CN=Issuer KeyUsage {slug} App, O=OPC Foundation",
+                    new List<string> { "localhost" })
+                .SetIssuer(rootCa)
+                .CreateForRSA();
+            return (rootCa, rootCrl, appCert);
+        }
+
+        /// <summary>
+        /// Returns whether the supplied status code appears anywhere in the
+        /// (possibly nested) validation error results.
+        /// </summary>
+        private static bool ContainsStatusCode(
+            IReadOnlyList<ServiceResult> errors,
+            StatusCode expectedCode)
+        {
+            foreach (ServiceResult error in errors)
+            {
+                for (ServiceResult sr = error; sr != null; sr = sr.InnerResult)
+                {
+                    if (sr.StatusCode.Code == expectedCode.Code)
+                    {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+
+        /// <summary>
         /// Polls the rejected storeuntil the certificate count satisfies <paramref name="predicate"/>
         /// or the <paramref name="timeout"/> elapses, then returns the most recently read collection.
         /// Used to reliably wait for the fire-and-forget background task fired by

--- a/Tests/Opc.Ua.Core.Tests/Security/Certificates/CertificateValidatorTest.cs
+++ b/Tests/Opc.Ua.Core.Tests/Security/Certificates/CertificateValidatorTest.cs
@@ -2259,15 +2259,11 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
                 CertificateValidationHelpers.HasRequiredIssuerKeyUsage(compliant),
                 Is.True);
 
-            // non-compliant: empty (present-but-zero) KeyUsage extension.
-            using Certificate emptyUsage = CreateRootCa(X509KeyUsageFlags.None, "empty");
-            Assert.That(
-                CertificateValidationHelpers.HasRequiredIssuerKeyUsage(emptyUsage),
-                Is.False);
-
             // non-compliant: KeyUsage extension omitted entirely — the exact
             // scenario reported in #3944 (the platform X509Chain does not flag
-            // this, so the explicit check must).
+            // this, so the explicit check must). This also covers the
+            // GetKeyUsage()==None code path without building a degenerate
+            // empty-KeyUsage extension (which macOS/AppleCrypto refuses to load).
             using Certificate absentUsage = CreateCertificateWithoutKeyUsage();
             Assert.That(
                 CertificateValidationHelpers.HasRequiredIssuerKeyUsage(absentUsage),
@@ -2308,7 +2304,7 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
             ITelemetryContext telemetry = NUnitTelemetryContext.Create();
 
             (Certificate rootCa, X509CRL rootCrl, Certificate appCert) =
-                CreateIssuerKeyUsageChain(X509KeyUsageFlags.None, "reject");
+                CreateIssuerKeyUsageChain(X509KeyUsageFlags.DigitalSignature, "reject");
             using (rootCa)
             using (appCert)
             {
@@ -2344,7 +2340,7 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
             ITelemetryContext telemetry = NUnitTelemetryContext.Create();
 
             (Certificate rootCa, X509CRL rootCrl, Certificate appCert) =
-                CreateIssuerKeyUsageChain(X509KeyUsageFlags.None, "suppress");
+                CreateIssuerKeyUsageChain(X509KeyUsageFlags.DigitalSignature, "suppress");
             using (rootCa)
             using (appCert)
             {

--- a/Tests/Opc.Ua.Core.Tests/Security/Certificates/CertificateValidatorTest.cs
+++ b/Tests/Opc.Ua.Core.Tests/Security/Certificates/CertificateValidatorTest.cs
@@ -2353,14 +2353,21 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
                 await validator.TrustedStore.AddCRLAsync(rootCrl).ConfigureAwait(false);
                 CertificateManager certValidator = validator.Update();
 
-                var approver = new CertValidationApprover(
-                    [
-                        StatusCodes.BadCertificateIssuerUseNotAllowed,
-                        StatusCodes.BadCertificateUseNotAllowed,
-                        StatusCodes.BadCertificateRevocationUnknown,
-                        StatusCodes.BadCertificateIssuerRevocationUnknown
-                    ]);
-                certValidator.AcceptError = approver.AcceptError;
+                // Approve every error the platform's certificate chain engine
+                // raises for this chain; the exact set of (suppressible) errors
+                // differs across OS chain implementations (Windows CryptoAPI vs
+                // OpenSSL). The test asserts that the issuer-use error is among
+                // them and that approving it lets validation succeed.
+                bool sawIssuerUseError = false;
+                certValidator.AcceptError = (cert, error) =>
+                {
+                    if (error.StatusCode.Code
+                        == StatusCodes.BadCertificateIssuerUseNotAllowed.Code)
+                    {
+                        sawIssuerUseError = true;
+                    }
+                    return true;
+                };
 
                 using var certs = new CertificateCollection([appCert, rootCa]);
                 CertificateValidationResult result = await certValidator
@@ -2368,7 +2375,10 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
                     .ConfigureAwait(false);
 
                 Assert.That(result.IsValid, Is.True, result.StatusCode.ToString());
-                Assert.That(approver.AcceptedCount, Is.GreaterThan(0));
+                Assert.That(
+                    sawIssuerUseError,
+                    Is.True,
+                    "Expected the issuer-use error to be raised and offered for suppression.");
             }
         }
 


### PR DESCRIPTION
## Summary

Fixes a certificate-validation compliance gap: the stack did not verify that **CA/issuer certificates** in a chain assert the KeyUsage required for a CA.

Per **OPC 10000-6 §6.2.4, Table 52 (Issuer Certificate)**, a CA certificate must carry a KeyUsage extension asserting `keyCertSign` and `cRLSign`, and **OPC 10000-4 §6.1.3, Table 100 ("Certificate Usage")** requires validators to check issuer usage and report `Bad_CertificateIssuerUseNotAllowed`.

The validator only checked the **leaf** certificate's KeyUsage and delegated all issuer/CA usage to .NET `X509Chain`. Per RFC 5280 §4.2.1.3, `X509Chain` does **not** reject a CA whose KeyUsage extension is *absent* (absence implies no usage restriction), so a root/intermediate CA with no KeyUsage — exactly the scenario reported in #3944 — was accepted by two .NET peers while strict third-party OPC UA stacks reject the same chain with `BadCertificateInvalid`.

## Changes

- `CertificateValidationHelpers.HasRequiredIssuerKeyUsage(Certificate)` — returns whether both `keyCertSign` and `cRLSign` are asserted (absent KeyUsage → `None` → fails).
- `CertificateValidationCore.InternalValidateAsync` — after the leaf KeyUsage check, verifies every resolved issuer/CA certificate in the chain and appends a **suppressible** `Bad_CertificateIssuerUseNotAllowed` when the required bits are missing. Existing deployments that must interoperate with a non-compliant CA can suppress it via the validation callback.
- **Two coupled defects fixed in `CheckChainStatus`** (surfaced while testing the `NotValidForUsage` path):
  1. A `FormatException` — `ServiceResult.Create` was given a named-placeholder format string (`{Status}: {Information}`) where positional `{0}: {1}` is required; this crashed validation whenever `X509Chain` reported `NotValidForUsage`.
  2. An inverted `isIssuer` status-code ternary (issuer↔leaf codes were swapped, contrary to Part 4 Table 100).
- `Docs/Certificates.md` — new "CA (issuer) KeyUsage validation" subsection.

Every new check/helper carries an in-code citation to the governing spec sections.

## Testing

- New tests in `CertificateValidatorTest.cs`: a deterministic helper unit test (absent / partial / compliant KeyUsage) plus integration tests for reject / suppress / accept.
- Full `CertificateValidator` fixture green on **net10.0** and **net48**, no regressions.

## Compatibility

- Long-standing behaviour present in both `master` (2.0) and `master378` (1.5.378) — **not** a 2.0 regression. The 1.5.378 backport is submitted separately.
- No public API change; the new error is suppressible, preserving backward compatibility.

Relates to #3944
