### PR TITLE
Validate issuer/CA certificate KeyUsage (keyCertSign, cRLSign) [master378 backport]

### DIFF
--- a/Docs/Certificates.md
+++ b/Docs/Certificates.md
@@ -669,13 +669,17 @@ The following validation errors can be suppressed by handling the `CertificateVa
 - **BadCertificateIssuerRevocationUnknown**: The revocation status of the issuer cannot be determined.
 - **BadCertificateChainIncomplete**: The certificate chain is incomplete (missing issuer certificates).
 - **BadCertificateIssuerTimeInvalid**: The issuer certificate has expired or is not yet valid.
-- **BadCertificateIssuerUseNotAllowed**: The issuer certificate is not valid for the intended use.
+- **BadCertificateIssuerUseNotAllowed**: An issuer/CA certificate in the chain is not valid for use as a CA — for example it does not assert the `keyCertSign` and `cRLSign` KeyUsage bits required for a CA (see [CA (issuer) KeyUsage validation](#ca-issuer-keyusage-validation)).
 - **BadCertificateRevocationUnknown**: The revocation status of the certificate cannot be determined.
 - **BadCertificateTimeInvalid**: The certificate has expired or is not yet valid.
 - **BadCertificatePolicyCheckFailed**: The certificate does not meet policy requirements (e.g., key size, signature algorithm).
 - **BadCertificateUseNotAllowed**: The certificate is not valid for the intended use (missing key usage flags).
 
 All other validation errors are **non-suppressible** and will always cause the validation to fail.
+
+#### CA (issuer) KeyUsage validation
+
+OPC UA requires every CA (issuer) certificate in a chain to carry a KeyUsage extension that asserts both `keyCertSign` and `cRLSign` (OPC 10000-6 §6.2.4, Table 52 — Issuer Certificate). During chain validation the stack verifies this for each issuer certificate and reports the suppressible `BadCertificateIssuerUseNotAllowed` error (OPC 10000-4 §6.1.3, Table 100 — "Certificate Usage") when a CA certificate is missing these bits, including the case where the CA has no KeyUsage extension at all. This matches the behaviour of strict third-party OPC UA stacks, which reject such CA certificates (typically with `BadCertificateInvalid`). CA certificates created by this stack's `CertificateBuilder` always include the required bits; to interoperate with a legacy CA that does not, suppress the error as described above.
 
 ### Registering a Certificate Validation Callback
 

--- a/Stack/Opc.Ua.Core/Security/Certificates/CertificateValidator.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/CertificateValidator.cs
@@ -1615,6 +1615,31 @@ namespace Opc.Ua
                     sresult);
             }
 
+            // check that each Issuer/CA certificate in the chain asserts the
+            // KeyUsage required for a CA (keyCertSign and cRLSign).
+            // OPC 10000-6 (Mappings) §6.2.4 Table 52 (Issuer Certificate)
+            // requires these bits; OPC 10000-4 (Services) §6.1.3 Table 100
+            // ("Certificate Usage") maps a mismatch to the suppressible
+            // Bad_CertificateIssuerUseNotAllowed. The platform X509Chain does
+            // not reject a CA whose KeyUsage extension is absent (RFC 5280
+            // §4.2.1.3), so this is verified explicitly here.
+            foreach (CertificateIdentifier issuer in issuers)
+            {
+                if (issuer.Certificate != null &&
+                    !X509Utils.HasRequiredIssuerKeyUsage(issuer.Certificate))
+                {
+                    sresult = new ServiceResult(
+                        null,
+                        StatusCodes.BadCertificateIssuerUseNotAllowed,
+                        Utils.Format(
+                            "Issuer certificate '{0}' does not assert the KeyUsage " +
+                            "(keyCertSign, cRLSign) required for a CA.",
+                            issuer.Certificate.Subject),
+                        null,
+                        sresult);
+                }
+            }
+
             // check if minimum requirements are met
             if (m_rejectSHA1SignedCertificates &&
                 IsSHA1SignatureAlgorithm(certificate.SignatureAlgorithm))
@@ -1949,9 +1974,9 @@ namespace Opc.Ua
                 case X509ChainStatusFlags.NotValidForUsage:
                     return ServiceResult.Create(
                         isIssuer
-                            ? StatusCodes.BadCertificateUseNotAllowed
-                            : StatusCodes.BadCertificateIssuerUseNotAllowed,
-                        "Certificate may not be used as an application instance certificate. {Status}: {Information}",
+                            ? StatusCodes.BadCertificateIssuerUseNotAllowed
+                            : StatusCodes.BadCertificateUseNotAllowed,
+                        "Certificate is not valid for the requested usage. {0}: {1}",
                         status.Status,
                         status.StatusInformation);
                 case X509ChainStatusFlags.NoError:

--- a/Stack/Opc.Ua.Core/Security/Certificates/X509Utils.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/X509Utils.cs
@@ -356,6 +356,33 @@ namespace Opc.Ua
         }
 
         /// <summary>
+        /// Returns whether a certificate that acts as an Issuer/CA in a chain
+        /// asserts the KeyUsage required by OPC UA for CA Certificates.
+        /// </summary>
+        /// <remarks>
+        /// OPC 10000-6 (Mappings) §6.2.4, Table 52 (Issuer Certificate)
+        /// requires CA Certificates to carry a KeyUsage extension that asserts
+        /// both keyCertSign and cRLSign. A CA whose KeyUsage extension is absent
+        /// yields <see cref="X509KeyUsageFlags.None"/> and therefore also fails
+        /// this check. OPC 10000-4 (Services) §6.1.3, Table 100
+        /// ("Certificate Usage") maps a mismatch to the (suppressible)
+        /// Bad_CertificateIssuerUseNotAllowed status. This has to be verified
+        /// explicitly because the platform X509Chain does not reject a CA whose
+        /// KeyUsage extension is absent (RFC 5280 §4.2.1.3: absence implies no
+        /// usage restriction).
+        /// </remarks>
+        /// <param name="certificate">The issuer/CA certificate to check.</param>
+        /// <returns>
+        /// True if both keyCertSign and cRLSign are asserted; otherwise false.
+        /// </returns>
+        internal static bool HasRequiredIssuerKeyUsage(X509Certificate2 certificate)
+        {
+            const X509KeyUsageFlags required =
+                X509KeyUsageFlags.KeyCertSign | X509KeyUsageFlags.CrlSign;
+            return (GetKeyUsage(certificate) & required) == required;
+        }
+
+        /// <summary>
         /// Check for self signed certificate if there is match of the Subject/Issuer.
         /// </summary>
         /// <param name="certificate">The certificate to test.</param>

--- a/Tests/Opc.Ua.Core.Tests/Security/Certificates/CertificateValidatorTest.cs
+++ b/Tests/Opc.Ua.Core.Tests/Security/Certificates/CertificateValidatorTest.cs
@@ -2077,6 +2077,210 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
         {
         }
 
+        /// <summary>
+        /// Verify the issuer KeyUsage helper enforces the CA KeyUsage required
+        /// by OPC 10000-6 §6.2.4 Table 52 (keyCertSign and cRLSign) and treats
+        /// an absent / empty KeyUsage as non-compliant (issue #3944).
+        /// </summary>
+        [Test]
+        public void HasRequiredIssuerKeyUsageEnforcesCaKeyUsage()
+        {
+            // compliant: the default the builder emits for a CA
+            // (digitalSignature + keyCertSign + cRLSign).
+            using X509Certificate2 defaultCa = CreateRootCa(null, "default");
+            Assert.IsTrue(X509Utils.HasRequiredIssuerKeyUsage(defaultCa));
+
+            // compliant: keyCertSign + cRLSign only.
+            using X509Certificate2 compliant = CreateRootCa(
+                X509KeyUsageFlags.KeyCertSign | X509KeyUsageFlags.CrlSign,
+                "compliant");
+            Assert.IsTrue(X509Utils.HasRequiredIssuerKeyUsage(compliant));
+
+            // non-compliant: empty KeyUsage (equivalent to an absent extension).
+            using X509Certificate2 emptyUsage = CreateRootCa(X509KeyUsageFlags.None, "empty");
+            Assert.IsFalse(X509Utils.HasRequiredIssuerKeyUsage(emptyUsage));
+
+            // non-compliant: keyCertSign only (cannot sign CRLs).
+            using X509Certificate2 certSignOnly = CreateRootCa(
+                X509KeyUsageFlags.KeyCertSign,
+                "certsign");
+            Assert.IsFalse(X509Utils.HasRequiredIssuerKeyUsage(certSignOnly));
+
+            // non-compliant: cRLSign only (cannot sign certificates).
+            using X509Certificate2 crlSignOnly = CreateRootCa(X509KeyUsageFlags.CrlSign, "crlsign");
+            Assert.IsFalse(X509Utils.HasRequiredIssuerKeyUsage(crlSignOnly));
+
+            // non-compliant: digitalSignature only (as reported in #3944).
+            using X509Certificate2 digitalSignatureOnly = CreateRootCa(
+                X509KeyUsageFlags.DigitalSignature,
+                "digsig");
+            Assert.IsFalse(X509Utils.HasRequiredIssuerKeyUsage(digitalSignatureOnly));
+        }
+
+        /// <summary>
+        /// Verify that a chain whose CA does not assert the required KeyUsage
+        /// (keyCertSign, cRLSign) is rejected with
+        /// Bad_CertificateIssuerUseNotAllowed even when the CA is trusted
+        /// (OPC 10000-4 §6.1.3 Table 100 "Certificate Usage").
+        /// </summary>
+        [Test]
+        public async Task RejectCaWithoutRequiredIssuerKeyUsageAsync()
+        {
+            ITelemetryContext telemetry = NUnitTelemetryContext.Create();
+
+            (X509Certificate2 rootCa, X509CRL rootCrl, X509Certificate2 appCert) =
+                CreateIssuerKeyUsageChain(X509KeyUsageFlags.None, "reject");
+            using (rootCa)
+            using (appCert)
+            {
+                using var validator = TemporaryCertValidator.Create(telemetry);
+                await validator.TrustedStore.AddAsync(rootCa).ConfigureAwait(false);
+                await validator.TrustedStore.AddCRLAsync(rootCrl).ConfigureAwait(false);
+                CertificateValidator certValidator = validator.Update();
+
+                var certs = new X509Certificate2Collection { appCert, rootCa };
+                ServiceResultException sre = NUnit.Framework.Assert
+                    .ThrowsAsync<ServiceResultException>(
+                        async () => await certValidator
+                            .ValidateAsync(certs, CancellationToken.None)
+                            .ConfigureAwait(false));
+                Assert.IsTrue(
+                    ContainsStatusCode(
+                        sre.Result,
+                        StatusCodes.BadCertificateIssuerUseNotAllowed),
+                    sre.Message);
+            }
+        }
+
+        /// <summary>
+        /// Verify that the Bad_CertificateIssuerUseNotAllowed error raised for a
+        /// non-compliant CA KeyUsage can be suppressed via the
+        /// CertificateValidation event (the error is suppressible per
+        /// OPC 10000-4 §6.1.3 Table 100).
+        /// </summary>
+        [Test]
+        public async Task SuppressedCaWithoutRequiredIssuerKeyUsageIsAcceptedAsync()
+        {
+            ITelemetryContext telemetry = NUnitTelemetryContext.Create();
+
+            (X509Certificate2 rootCa, X509CRL rootCrl, X509Certificate2 appCert) =
+                CreateIssuerKeyUsageChain(X509KeyUsageFlags.None, "suppress");
+            using (rootCa)
+            using (appCert)
+            {
+                using var validator = TemporaryCertValidator.Create(telemetry);
+                await validator.TrustedStore.AddAsync(rootCa).ConfigureAwait(false);
+                await validator.TrustedStore.AddCRLAsync(rootCrl).ConfigureAwait(false);
+                CertificateValidator certValidator = validator.Update();
+
+                var approver = new CertValidationApprover(
+                    [
+                        StatusCodes.BadCertificateIssuerUseNotAllowed,
+                        StatusCodes.BadCertificateUseNotAllowed,
+                        StatusCodes.BadCertificateRevocationUnknown,
+                        StatusCodes.BadCertificateIssuerRevocationUnknown
+                    ]);
+                certValidator.CertificateValidation += approver.OnCertificateValidation;
+
+                var certs = new X509Certificate2Collection { appCert, rootCa };
+                await certValidator.ValidateAsync(certs, CancellationToken.None)
+                    .ConfigureAwait(false);
+                certValidator.CertificateValidation -= approver.OnCertificateValidation;
+
+                Assert.Greater(approver.AcceptedCount, 0);
+            }
+        }
+
+        /// <summary>
+        /// Verify that a chain whose CA asserts the required KeyUsage
+        /// (the default keyCertSign + cRLSign) passes validation.
+        /// </summary>
+        [Test]
+        public async Task AcceptCaWithRequiredIssuerKeyUsageAsync()
+        {
+            ITelemetryContext telemetry = NUnitTelemetryContext.Create();
+
+            (X509Certificate2 rootCa, X509CRL rootCrl, X509Certificate2 appCert) =
+                CreateIssuerKeyUsageChain(null, "accept");
+            using (rootCa)
+            using (appCert)
+            {
+                using var validator = TemporaryCertValidator.Create(telemetry);
+                await validator.TrustedStore.AddAsync(rootCa).ConfigureAwait(false);
+                await validator.TrustedStore.AddCRLAsync(rootCrl).ConfigureAwait(false);
+                CertificateValidator certValidator = validator.Update();
+
+                var certs = new X509Certificate2Collection { appCert, rootCa };
+                await certValidator.ValidateAsync(certs, CancellationToken.None)
+                    .ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
+        /// Creates a self-signed root CA. When <paramref name="keyUsage"/> is
+        /// null the builder emits its default CA KeyUsage
+        /// (digitalSignature + keyCertSign + cRLSign); otherwise the supplied
+        /// KeyUsage overrides the default so non-compliant CAs can be built.
+        /// </summary>
+        private static X509Certificate2 CreateRootCa(X509KeyUsageFlags? keyUsage, string slug)
+        {
+            var baseTime = new DateTime(
+                DateTime.UtcNow.Year - 1,
+                1,
+                1,
+                0,
+                0,
+                0,
+                DateTimeKind.Utc);
+            ICertificateBuilder builder = CertificateFactory
+                .CreateCertificate($"CN=Issuer KeyUsage {slug} Root, O=OPC Foundation")
+                .SetNotBefore(baseTime)
+                .SetLifeTime(120)
+                .SetCAConstraint();
+            if (keyUsage.HasValue)
+            {
+                builder = builder.AddExtension(
+                    new X509KeyUsageExtension(keyUsage.Value, true));
+            }
+            return builder.SetRSAKeySize(2048).CreateForRSA();
+        }
+
+        /// <summary>
+        /// Creates a root CA (optionally with a non-compliant KeyUsage), its
+        /// CRL and an application certificate issued by that CA.
+        /// </summary>
+        private static (X509Certificate2 rootCa, X509CRL rootCrl, X509Certificate2 appCert)
+            CreateIssuerKeyUsageChain(X509KeyUsageFlags? issuerKeyUsage, string slug)
+        {
+            X509Certificate2 rootCa = CreateRootCa(issuerKeyUsage, slug);
+            X509CRL rootCrl = CertificateFactory.RevokeCertificate(rootCa, null, null);
+            X509Certificate2 appCert = CertificateFactory
+                .CreateCertificate(
+                    $"urn:opcfoundation.org:{slug}:app",
+                    $"Issuer KeyUsage {slug} App",
+                    $"CN=Issuer KeyUsage {slug} App, O=OPC Foundation",
+                    new List<string> { "localhost" })
+                .SetIssuer(rootCa)
+                .CreateForRSA();
+            return (rootCa, rootCrl, appCert);
+        }
+
+        /// <summary>
+        /// Returns whether the supplied status code appears anywhere in the
+        /// (possibly nested) validation error result.
+        /// </summary>
+        private static bool ContainsStatusCode(ServiceResult error, uint expectedCode)
+        {
+            for (ServiceResult sr = error; sr != null; sr = sr.InnerResult)
+            {
+                if (sr.StatusCode.Code == expectedCode)
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
         private void OnCertificateValidation(object sender, CertificateValidationEventArgs e)
         {
         }

--- a/Tests/Opc.Ua.Core.Tests/Security/Certificates/CertificateValidatorTest.cs
+++ b/Tests/Opc.Ua.Core.Tests/Security/Certificates/CertificateValidatorTest.cs
@@ -2179,14 +2179,22 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
                 await validator.TrustedStore.AddCRLAsync(rootCrl).ConfigureAwait(false);
                 CertificateValidator certValidator = validator.Update();
 
-                var approver = new CertValidationApprover(
-                    [
-                        StatusCodes.BadCertificateIssuerUseNotAllowed,
-                        StatusCodes.BadCertificateUseNotAllowed,
-                        StatusCodes.BadCertificateRevocationUnknown,
-                        StatusCodes.BadCertificateIssuerRevocationUnknown
-                    ]);
-                certValidator.CertificateValidation += approver.OnCertificateValidation;
+                // Approve every error the platform's certificate chain engine
+                // raises for this chain; the exact set of (suppressible) errors
+                // differs across OS chain implementations (Windows CryptoAPI vs
+                // OpenSSL). The test asserts that the issuer-use error is among
+                // them and that approving it lets validation succeed.
+                bool sawIssuerUseError = false;
+                void ApproveAll(object sender, CertificateValidationEventArgs e)
+                {
+                    if (e.Error.StatusCode.Code
+                        == StatusCodes.BadCertificateIssuerUseNotAllowed)
+                    {
+                        sawIssuerUseError = true;
+                    }
+                    e.Accept = true;
+                }
+                certValidator.CertificateValidation += ApproveAll;
                 try
                 {
                     var certs = new X509Certificate2Collection { appCert, rootCa };
@@ -2195,10 +2203,12 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
                 }
                 finally
                 {
-                    certValidator.CertificateValidation -= approver.OnCertificateValidation;
+                    certValidator.CertificateValidation -= ApproveAll;
                 }
 
-                Assert.Greater(approver.AcceptedCount, 0);
+                Assert.IsTrue(
+                    sawIssuerUseError,
+                    "Expected the issuer-use error to be raised and offered for suppression.");
             }
         }
 

--- a/Tests/Opc.Ua.Core.Tests/Security/Certificates/CertificateValidatorTest.cs
+++ b/Tests/Opc.Ua.Core.Tests/Security/Certificates/CertificateValidatorTest.cs
@@ -2096,9 +2096,15 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
                 "compliant");
             Assert.IsTrue(X509Utils.HasRequiredIssuerKeyUsage(compliant));
 
-            // non-compliant: empty KeyUsage (equivalent to an absent extension).
+            // non-compliant: empty (present-but-zero) KeyUsage extension.
             using X509Certificate2 emptyUsage = CreateRootCa(X509KeyUsageFlags.None, "empty");
             Assert.IsFalse(X509Utils.HasRequiredIssuerKeyUsage(emptyUsage));
+
+            // non-compliant: KeyUsage extension omitted entirely — the exact
+            // scenario reported in #3944 (the platform X509Chain does not flag
+            // this, so the explicit check must).
+            using X509Certificate2 absentUsage = CreateCertificateWithoutKeyUsage();
+            Assert.IsFalse(X509Utils.HasRequiredIssuerKeyUsage(absentUsage));
 
             // non-compliant: keyCertSign only (cannot sign CRLs).
             using X509Certificate2 certSignOnly = CreateRootCa(
@@ -2181,11 +2187,16 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
                         StatusCodes.BadCertificateIssuerRevocationUnknown
                     ]);
                 certValidator.CertificateValidation += approver.OnCertificateValidation;
-
-                var certs = new X509Certificate2Collection { appCert, rootCa };
-                await certValidator.ValidateAsync(certs, CancellationToken.None)
-                    .ConfigureAwait(false);
-                certValidator.CertificateValidation -= approver.OnCertificateValidation;
+                try
+                {
+                    var certs = new X509Certificate2Collection { appCert, rootCa };
+                    await certValidator.ValidateAsync(certs, CancellationToken.None)
+                        .ConfigureAwait(false);
+                }
+                finally
+                {
+                    certValidator.CertificateValidation -= approver.OnCertificateValidation;
+                }
 
                 Assert.Greater(approver.AcceptedCount, 0);
             }
@@ -2224,14 +2235,9 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
         /// </summary>
         private static X509Certificate2 CreateRootCa(X509KeyUsageFlags? keyUsage, string slug)
         {
-            var baseTime = new DateTime(
-                DateTime.UtcNow.Year - 1,
-                1,
-                1,
-                0,
-                0,
-                0,
-                DateTimeKind.Utc);
+            // Relative validity window with a long lifetime so the generated CA
+            // is always valid regardless of when the tests run.
+            DateTime baseTime = DateTime.UtcNow.AddDays(-1);
             ICertificateBuilder builder = CertificateFactory
                 .CreateCertificate($"CN=Issuer KeyUsage {slug} Root, O=OPC Foundation")
                 .SetNotBefore(baseTime)
@@ -2243,6 +2249,28 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
                     new X509KeyUsageExtension(keyUsage.Value, true));
             }
             return builder.SetRSAKeySize(2048).CreateForRSA();
+        }
+
+        /// <summary>
+        /// Creates a self-signed CA certificate whose KeyUsage extension is
+        /// omitted entirely (only basicConstraints cA=true is set). Built via
+        /// <see cref="CertificateRequest"/> so that no default KeyUsage is
+        /// added, reproducing the absent-KeyUsage scenario from issue #3944.
+        /// </summary>
+        private static X509Certificate2 CreateCertificateWithoutKeyUsage()
+        {
+            using var rsa = RSA.Create(2048);
+            var request = new CertificateRequest(
+                "CN=Issuer KeyUsage absent Root, O=OPC Foundation",
+                rsa,
+                HashAlgorithmName.SHA256,
+                RSASignaturePadding.Pkcs1);
+            // CA basic constraints but deliberately no KeyUsage extension.
+            request.CertificateExtensions.Add(
+                new X509BasicConstraintsExtension(true, false, 0, true));
+            return request.CreateSelfSigned(
+                DateTimeOffset.UtcNow.AddDays(-1),
+                DateTimeOffset.UtcNow.AddYears(1));
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

**Backport of the #3944 fix to the `master378` (1.5.378) maintenance branch.** See the 2.0 PR #3947 for the primary change; this PR applies the equivalent fix to the 1.5.378 code.

The stack did not verify that **CA/issuer certificates** in a chain assert the KeyUsage required for a CA. Per **OPC 10000-6 §6.2.4, Table 52**, a CA certificate must carry a KeyUsage extension asserting `keyCertSign` and `cRLSign`, and **OPC 10000-4 §6.1.3, Table 100 ("Certificate Usage")** requires validators to check issuer usage and report `Bad_CertificateIssuerUseNotAllowed`.

The validator only checked the **leaf** certificate's KeyUsage and delegated issuer/CA usage to .NET `X509Chain`, which (RFC 5280 §4.2.1.3) does **not** reject a CA whose KeyUsage extension is *absent* — so a CA with no KeyUsage was accepted while strict third-party stacks reject the chain with `BadCertificateInvalid`.

## Changes

- `X509Utils.HasRequiredIssuerKeyUsage(X509Certificate2)` — returns whether both `keyCertSign` and `cRLSign` are asserted (absent KeyUsage → `None` → fails).
- `CertificateValidator.InternalValidateAsync` — after the leaf KeyUsage check, verifies every issuer/CA certificate in the chain and appends a **suppressible** `Bad_CertificateIssuerUseNotAllowed` when the required bits are missing.
- **Two coupled defects fixed in `CheckChainStatus`**:
  1. A `FormatException` from a named-placeholder format string (`{Status}: {Information}` → positional `{0}: {1}`) that crashed validation on any `NotValidForUsage` chain status.
  2. An inverted `isIssuer` status-code ternary (issuer↔leaf codes swapped, contrary to Part 4 Table 100).
- `Docs/Certificates.md` — new "CA (issuer) KeyUsage validation" subsection.

Every new check/helper carries an in-code citation to the governing spec sections.

## Testing

- New tests in `CertificateValidatorTest.cs` (matching the branch's existing style: `X509Certificate2`, classic asserts, throwing contract, event-based approver): a deterministic helper unit test plus reject / suppress / accept integration tests.
- Full `CertificateValidator` fixture green on **net8.0** and **net48**, no regressions.

## Compatibility

- This is long-standing behaviour on both `master` and `master378` — not a 2.0 regression. No public API change; the new error is suppressible.

Relates to #3944 · 2.0 PR: #3947
