### PR TITLE
Fix macOS CI: avoid empty-KeyUsage test cert

### DIFF
--- a/Tests/Opc.Ua.Core.Tests/Security/Certificates/CertificateValidatorTest.cs
+++ b/Tests/Opc.Ua.Core.Tests/Security/Certificates/CertificateValidatorTest.cs
@@ -2096,13 +2096,11 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
                 "compliant");
             Assert.IsTrue(X509Utils.HasRequiredIssuerKeyUsage(compliant));
 
-            // non-compliant: empty (present-but-zero) KeyUsage extension.
-            using X509Certificate2 emptyUsage = CreateRootCa(X509KeyUsageFlags.None, "empty");
-            Assert.IsFalse(X509Utils.HasRequiredIssuerKeyUsage(emptyUsage));
-
             // non-compliant: KeyUsage extension omitted entirely — the exact
             // scenario reported in #3944 (the platform X509Chain does not flag
-            // this, so the explicit check must).
+            // this, so the explicit check must). This also covers the
+            // GetKeyUsage()==None code path without building a degenerate
+            // empty-KeyUsage extension (which macOS/AppleCrypto refuses to load).
             using X509Certificate2 absentUsage = CreateCertificateWithoutKeyUsage();
             Assert.IsFalse(X509Utils.HasRequiredIssuerKeyUsage(absentUsage));
 
@@ -2135,7 +2133,7 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
             ITelemetryContext telemetry = NUnitTelemetryContext.Create();
 
             (X509Certificate2 rootCa, X509CRL rootCrl, X509Certificate2 appCert) =
-                CreateIssuerKeyUsageChain(X509KeyUsageFlags.None, "reject");
+                CreateIssuerKeyUsageChain(X509KeyUsageFlags.DigitalSignature, "reject");
             using (rootCa)
             using (appCert)
             {
@@ -2170,7 +2168,7 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
             ITelemetryContext telemetry = NUnitTelemetryContext.Create();
 
             (X509Certificate2 rootCa, X509CRL rootCrl, X509Certificate2 appCert) =
-                CreateIssuerKeyUsageChain(X509KeyUsageFlags.None, "suppress");
+                CreateIssuerKeyUsageChain(X509KeyUsageFlags.DigitalSignature, "suppress");
             using (rootCa)
             using (appCert)
             {


### PR DESCRIPTION
## Summary

Follow-up to #3948 (merged) that fixes a **macOS-only** CI failure introduced by the issuer/CA KeyUsage tests.

On the macOS Core test job, three tests failed with:

```
Interop+AppleCrypto+AppleCommonCryptoCryptographicException : Unknown format in import.
   at System.Security.Cryptography.X509Certificates.X509Pal.AppleX509Pal.GetCertContentType(...)
   at System.Security.Cryptography.X509Certificates.X509CertificateLoader.LoadCertificate(...)
```

The affected tests built a test CA with an **empty** KeyUsage extension (`new X509KeyUsageExtension(X509KeyUsageFlags.None, true)` → a zero-bit `BIT STRING`). Windows (CryptoAPI) and Linux (OpenSSL) load such a certificate, but macOS (AppleCrypto) rejects it as an unknown format. The production code is unaffected — this is purely a test-certificate artifact.

## Changes

- Removed the degenerate empty-KeyUsage test certificate. The **truly-absent** KeyUsage case (built via `CertificateRequest` so no KeyUsage extension is emitted) already covers the `GetKeyUsage() == None` code path.
- The reject/suppress integration tests now use a present-but-insufficient `DigitalSignature` KeyUsage (a valid, macOS-loadable certificate that is still missing `keyCertSign`/`cRLSign`).

## Testing

- `CertificateValidator` IssuerKeyUsage tests pass on **Windows** and **Linux** (net10.0). The change directly removes the macOS root cause (the empty-KeyUsage extension); all remaining test certificates use standard formats that macOS already loads (the compliant-CA test passed on macOS).

Relates to #3944 · follow-up to #3948
