### PR TITLE
Add integration test for server side complex types (#3961)

### DIFF
--- a/Tests/Opc.Ua.Server.Tests/ComplexTypes/ServerComplexTypeSystemIntegrationTests.cs
+++ b/Tests/Opc.Ua.Server.Tests/ComplexTypes/ServerComplexTypeSystemIntegrationTests.cs
@@ -152,6 +152,7 @@ namespace Opc.Ua.Server.Tests
         /// runtime-loaded structure and enumeration DataTypes.
         /// </summary>
         [Test]
+        [Order(100)]
         public void ServerRegistersRuntimeStandInTypes()
         {
             IServerInternal server = m_server.CurrentInstance;
@@ -193,6 +194,7 @@ namespace Opc.Ua.Server.Tests
         /// via its stand-in and the client decodes it into a structured value.
         /// </summary>
         [Test]
+        [Order(200)]
         public async Task ClientReadsRuntimeStructureValue()
         {
             NodeId nodeId = ClientNodeId(ServerComplexTypesTestNodeManager.PointValueVariable);
@@ -218,6 +220,7 @@ namespace Opc.Ua.Server.Tests
         /// enumeration value.
         /// </summary>
         [Test]
+        [Order(300)]
         public async Task ClientReadsRuntimeEnumValue()
         {
             NodeId nodeId = ClientNodeId(ServerComplexTypesTestNodeManager.ColorValueVariable);
@@ -237,6 +240,7 @@ namespace Opc.Ua.Server.Tests
         /// on the next read.
         /// </summary>
         [Test]
+        [Order(400)]
         public async Task ClientWritesRuntimeStructureValue()
         {
             NodeId nodeId = ClientNodeId(ServerComplexTypesTestNodeManager.PointValueVariable);

--- a/Tests/Opc.Ua.Server.Tests/ComplexTypes/ServerComplexTypeSystemIntegrationTests.cs
+++ b/Tests/Opc.Ua.Server.Tests/ComplexTypes/ServerComplexTypeSystemIntegrationTests.cs
@@ -1,0 +1,296 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using System.Globalization;
+using System.IO;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Opc.Ua.Client;
+using Opc.Ua.Client.ComplexTypes;
+using Opc.Ua.Client.TestFramework;
+using Opc.Ua.Encoders;
+using Opc.Ua.Server.TestFramework;
+using Opc.Ua.Tests;
+
+namespace Opc.Ua.Server.Tests
+{
+    /// <summary>
+    /// Integration tests for the server side complex type system. A server
+    /// hosts custom DataTypes that were loaded from a NodeSet at runtime and
+    /// have no compiled .NET backing; the server builds dynamic stand-in
+    /// encodeables for them. A real client then reads and writes values of
+    /// those types over the wire, exercising the full server encode / decode
+    /// round-trip (issue #3961).
+    /// </summary>
+    [TestFixture]
+    [Category("Server")]
+    [Category("ComplexTypes")]
+    [SetCulture("en-us")]
+    [SetUICulture("en-us")]
+    [NonParallelizable]
+    public sealed class ServerComplexTypeSystemIntegrationTests
+    {
+        private ITelemetryContext m_telemetry;
+        private ServerFixture<ServerComplexTypesTestServer> m_serverFixture;
+        private ClientFixture m_clientFixture;
+        private ServerComplexTypesTestServer m_server;
+        private Opc.Ua.Client.ISession m_session;
+        private string m_pkiRoot;
+
+        /// <summary>
+        /// Starts a server that hosts the runtime-loaded complex types, connects
+        /// a client and loads the client complex type system.
+        /// </summary>
+        [OneTimeSetUp]
+        public async Task OneTimeSetUpAsync()
+        {
+            m_telemetry = NUnitTelemetryContext.Create();
+            m_pkiRoot = Path.GetTempPath() + Path.GetRandomFileName();
+
+            m_serverFixture = new ServerFixture<ServerComplexTypesTestServer>(
+                t => new ServerComplexTypesTestServer(t))
+            {
+                UriScheme = Utils.UriSchemeOpcTcp,
+                SecurityNone = true,
+                AutoAccept = true,
+                OperationLimits = true
+            };
+
+            m_server = await m_serverFixture.StartAsync(m_pkiRoot).ConfigureAwait(false);
+
+            m_clientFixture = new ClientFixture(m_telemetry);
+            await m_clientFixture.LoadClientConfigurationAsync(m_pkiRoot).ConfigureAwait(false);
+
+            var url = new Uri(
+                Utils.UriSchemeOpcTcp +
+                "://localhost:" +
+                m_serverFixture.Port.ToString(CultureInfo.InvariantCulture));
+
+            try
+            {
+                m_session = await m_clientFixture
+                    .ConnectAsync(url, SecurityPolicies.Basic256Sha256)
+                    .ConfigureAwait(false);
+            }
+            catch (Exception e)
+            {
+                Assert.Ignore(
+                    $"OneTimeSetup failed to create session, tests skipped. Error: {e.Message}");
+            }
+
+            // Load the client complex type system so the runtime types are
+            // registered in the session factory and read values decode.
+            var clientTypeSystem = ComplexTypeSystem.Create(m_session, m_telemetry);
+            clientTypeSystem.DisableDataTypeDictionary = true;
+            bool loaded = await clientTypeSystem.LoadAsync(false, true).ConfigureAwait(false);
+            Assert.That(loaded, Is.True, "the client complex type system should load");
+        }
+
+        /// <summary>
+        /// Closes the session and stops the server.
+        /// </summary>
+        [OneTimeTearDown]
+        public async Task OneTimeTearDownAsync()
+        {
+            if (m_session != null)
+            {
+                await m_session.CloseAsync().ConfigureAwait(false);
+                m_session.Dispose();
+                m_session = null;
+            }
+            await m_serverFixture.StopAsync().ConfigureAwait(false);
+            m_clientFixture?.Dispose();
+            m_server?.Dispose();
+        }
+
+        /// <summary>
+        /// The server must build and register stand-in encodeables for the
+        /// runtime-loaded structure and enumeration DataTypes.
+        /// </summary>
+        [Test]
+        public void ServerRegistersRuntimeStandInTypes()
+        {
+            IServerInternal server = m_server.CurrentInstance;
+            ushort namespaceIndex = ServerNamespaceIndex(server);
+
+            ExpandedNodeId structureTypeId = NodeId.ToExpandedNodeId(
+                new NodeId(ServerComplexTypesTestNodeManager.TestPointDataType, namespaceIndex),
+                server.NamespaceUris);
+            ExpandedNodeId binaryEncodingId = NodeId.ToExpandedNodeId(
+                new NodeId(ServerComplexTypesTestNodeManager.TestPointBinaryEncoding, namespaceIndex),
+                server.NamespaceUris);
+            ExpandedNodeId enumTypeId = NodeId.ToExpandedNodeId(
+                new NodeId(ServerComplexTypesTestNodeManager.TestColorDataType, namespaceIndex),
+                server.NamespaceUris);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(
+                    server.Factory.TryGetEncodeableType(structureTypeId, out IEncodeableType structType),
+                    Is.True,
+                    "the runtime TestPoint structure should be registered in the server factory");
+                Assert.That(structType, Is.Not.Null);
+
+                Assert.That(
+                    server.Factory.TryGetEncodeableType(binaryEncodingId, out _),
+                    Is.True,
+                    "the TestPoint binary encoding id should resolve to the structure stand-in");
+
+                Assert.That(
+                    server.Factory.TryGetEnumeratedType(enumTypeId, out IEnumeratedType enumType),
+                    Is.True,
+                    "the runtime TestColor enumeration should be registered in the server factory");
+                Assert.That(enumType, Is.Not.Null);
+            });
+        }
+
+        /// <summary>
+        /// A client reads the runtime structure variable; the server encodes it
+        /// via its stand-in and the client decodes it into a structured value.
+        /// </summary>
+        [Test]
+        public async Task ClientReadsRuntimeStructureValue()
+        {
+            NodeId nodeId = ClientNodeId(ServerComplexTypesTestNodeManager.PointValueVariable);
+
+            DataValue dataValue = await m_session.ReadValueAsync(nodeId).ConfigureAwait(false);
+            Assert.That(dataValue.IsNull, Is.False);
+            Assert.That(StatusCode.IsGood(dataValue.StatusCode), Is.True);
+
+            IStructure point = ReadStructure(dataValue);
+            Assert.Multiple(() =>
+            {
+                Assert.That(point["X"].TryGetValue(out int x), Is.True);
+                Assert.That(x, Is.EqualTo(3));
+                Assert.That(point["Y"].TryGetValue(out int y), Is.True);
+                Assert.That(y, Is.EqualTo(4));
+                Assert.That(point["Name"].TryGetValue(out string name), Is.True);
+                Assert.That(name, Is.EqualTo("origin"));
+            });
+        }
+
+        /// <summary>
+        /// A client reads the runtime enumeration variable and gets the raw
+        /// enumeration value.
+        /// </summary>
+        [Test]
+        public async Task ClientReadsRuntimeEnumValue()
+        {
+            NodeId nodeId = ClientNodeId(ServerComplexTypesTestNodeManager.ColorValueVariable);
+
+            DataValue dataValue = await m_session.ReadValueAsync(nodeId).ConfigureAwait(false);
+            Assert.That(dataValue.IsNull, Is.False);
+            Assert.That(StatusCode.IsGood(dataValue.StatusCode), Is.True);
+
+            // TestColor.Green == 1
+            Assert.That(dataValue.WrappedValue.TryGetValue(out int color), Is.True);
+            Assert.That(color, Is.EqualTo(1));
+        }
+
+        /// <summary>
+        /// A client writes a modified runtime structure value; the server
+        /// decodes it via its stand-in, stores it, and returns the updated value
+        /// on the next read.
+        /// </summary>
+        [Test]
+        public async Task ClientWritesRuntimeStructureValue()
+        {
+            NodeId nodeId = ClientNodeId(ServerComplexTypesTestNodeManager.PointValueVariable);
+
+            DataValue dataValue = await m_session.ReadValueAsync(nodeId).ConfigureAwait(false);
+            IStructure point = ReadStructure(dataValue);
+
+            point["X"] = new Variant(7);
+            point["Y"] = new Variant(8);
+            point["Name"] = new Variant("updated");
+
+            ArrayOf<WriteValue> writeValues =
+            [
+                new WriteValue
+                {
+                    NodeId = nodeId,
+                    AttributeId = Attributes.Value,
+                    Value = new DataValue(dataValue.WrappedValue)
+                }
+            ];
+
+            WriteResponse response = await m_session
+                .WriteAsync(null, writeValues, default)
+                .ConfigureAwait(false);
+            Assert.That(response.Results.IsNull, Is.False);
+            Assert.That(StatusCode.IsGood(response.Results[0]), Is.True,
+                "the server should decode and accept the runtime structure value");
+
+            DataValue readBack = await m_session.ReadValueAsync(nodeId).ConfigureAwait(false);
+            IStructure updated = ReadStructure(readBack);
+            Assert.Multiple(() =>
+            {
+                Assert.That(updated["X"].TryGetValue(out int x), Is.True);
+                Assert.That(x, Is.EqualTo(7));
+                Assert.That(updated["Y"].TryGetValue(out int y), Is.True);
+                Assert.That(y, Is.EqualTo(8));
+                Assert.That(updated["Name"].TryGetValue(out string name), Is.True);
+                Assert.That(name, Is.EqualTo("updated"));
+            });
+        }
+
+        /// <summary>
+        /// Extracts the decoded structured value from a read <see cref="DataValue"/>.
+        /// </summary>
+        private static IStructure ReadStructure(DataValue dataValue)
+        {
+            Assert.That(dataValue.WrappedValue.TryGetValue(out ExtensionObject extensionObject), Is.True);
+            Assert.That(extensionObject.TryGetValue(out IEncodeable encodeable), Is.True);
+            var structure = encodeable as IStructure;
+            Assert.That(structure, Is.Not.Null, "the decoded value should be a complex structure");
+            return structure;
+        }
+
+        /// <summary>
+        /// Resolves a node id in the test namespace on the client side.
+        /// </summary>
+        private NodeId ClientNodeId(uint identifier)
+        {
+            return new NodeId(
+                identifier,
+                (ushort)m_session.NamespaceUris.GetIndex(
+                    ServerComplexTypesTestNodeManager.NamespaceUri));
+        }
+
+        /// <summary>
+        /// Resolves the test namespace index on the server side.
+        /// </summary>
+        private static ushort ServerNamespaceIndex(IServerInternal server)
+        {
+            return (ushort)server.NamespaceUris.GetIndex(
+                ServerComplexTypesTestNodeManager.NamespaceUri);
+        }
+    }
+}

--- a/Tests/Opc.Ua.Server.Tests/ComplexTypes/ServerComplexTypeSystemIntegrationTests.cs
+++ b/Tests/Opc.Ua.Server.Tests/ComplexTypes/ServerComplexTypeSystemIntegrationTests.cs
@@ -106,7 +106,7 @@ namespace Opc.Ua.Server.Tests
             }
 
             // Load the client complex type system so the runtime types are
-            // registered in the session factory and read values decode.
+            // registered in the session factory and read values decode correctly.
             var clientTypeSystem = ComplexTypeSystem.Create(m_session, m_telemetry);
             clientTypeSystem.DisableDataTypeDictionary = true;
             bool loaded = await clientTypeSystem.LoadAsync(false, true).ConfigureAwait(false);
@@ -125,9 +125,26 @@ namespace Opc.Ua.Server.Tests
                 m_session.Dispose();
                 m_session = null;
             }
-            await m_serverFixture.StopAsync().ConfigureAwait(false);
+
             m_clientFixture?.Dispose();
             m_server?.Dispose();
+
+            if (m_serverFixture != null)
+            {
+                await m_serverFixture.StopAsync().ConfigureAwait(false);
+            }
+
+            try
+            {
+                if (!string.IsNullOrEmpty(m_pkiRoot) && Directory.Exists(m_pkiRoot))
+                {
+                    Directory.Delete(m_pkiRoot, recursive: true);
+                }
+            }
+            catch
+            {
+                // best-effort cleanup
+            }
         }
 
         /// <summary>

--- a/Tests/Opc.Ua.Server.Tests/ComplexTypes/ServerComplexTypesTestModel.NodeSet2.xml
+++ b/Tests/Opc.Ua.Server.Tests/ComplexTypes/ServerComplexTypesTestModel.NodeSet2.xml
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- ========================================================================
+     Synthetic NodeSet2 for the server side complex type integration test
+     (issue #3961). It declares custom DataTypes that have NO compiled .NET
+     backing so the server must build dynamic stand-in encodeables from the
+     DataTypeDefinition attribute at runtime:
+       - TestColor  : an Enumeration (Red/Green/Blue)
+       - TestPoint  : a Structure (X:Int32, Y:Int32, Name:String) with a
+                      Default Binary encoding node
+     plus two instance variables (PointValue, ColorValue) that a client reads
+     and writes to exercise the round-trip. Kept intentionally minimal.
+     ======================================================================== -->
+<UANodeSet xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+           xmlns:uax="http://opcfoundation.org/UA/2008/02/Types.xsd"
+           xmlns="http://opcfoundation.org/UA/2011/03/UANodeSet.xsd">
+  <NamespaceUris>
+    <Uri>http://opcfoundation.org/UA/ServerComplexTypesTest/</Uri>
+  </NamespaceUris>
+  <Models>
+    <Model ModelUri="http://opcfoundation.org/UA/ServerComplexTypesTest/"
+           Version="1.0.0"
+           PublicationDate="2024-01-01T00:00:00Z">
+      <RequiredModel ModelUri="http://opcfoundation.org/UA/"
+                     PublicationDate="2023-12-15T00:00:00Z"
+                     Version="1.05.03" />
+    </Model>
+  </Models>
+  <Aliases>
+    <Alias Alias="Int32">i=6</Alias>
+    <Alias Alias="String">i=12</Alias>
+    <Alias Alias="LocalizedText">i=21</Alias>
+    <Alias Alias="Enumeration">i=29</Alias>
+    <Alias Alias="Structure">i=22</Alias>
+    <Alias Alias="Organizes">i=35</Alias>
+    <Alias Alias="HasModellingRule">i=37</Alias>
+    <Alias Alias="HasEncoding">i=38</Alias>
+    <Alias Alias="HasProperty">i=46</Alias>
+    <Alias Alias="HasComponent">i=47</Alias>
+    <Alias Alias="HasSubtype">i=45</Alias>
+    <Alias Alias="HasTypeDefinition">i=40</Alias>
+  </Aliases>
+
+  <!-- ============================== TestColor (Enumeration) ============= -->
+  <UADataType NodeId="ns=1;i=15001" BrowseName="1:TestColor">
+    <DisplayName>TestColor</DisplayName>
+    <Description>A runtime-loaded enumeration with no compiled backing type.</Description>
+    <References>
+      <Reference ReferenceType="HasProperty">ns=1;i=15002</Reference>
+      <Reference ReferenceType="HasSubtype" IsForward="false">i=29</Reference>
+    </References>
+    <Definition Name="1:TestColor" BaseType="Enumeration">
+      <Field Name="Red" Value="0" />
+      <Field Name="Green" Value="1" />
+      <Field Name="Blue" Value="2" />
+    </Definition>
+  </UADataType>
+  <UAVariable NodeId="ns=1;i=15002" BrowseName="EnumStrings" ParentNodeId="ns=1;i=15001"
+              DataType="LocalizedText" ValueRank="1" ArrayDimensions="3">
+    <DisplayName>EnumStrings</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=15001</Reference>
+    </References>
+    <Value>
+      <uax:ListOfLocalizedText>
+        <uax:LocalizedText><uax:Text>Red</uax:Text></uax:LocalizedText>
+        <uax:LocalizedText><uax:Text>Green</uax:Text></uax:LocalizedText>
+        <uax:LocalizedText><uax:Text>Blue</uax:Text></uax:LocalizedText>
+      </uax:ListOfLocalizedText>
+    </Value>
+  </UAVariable>
+
+  <!-- ============================== TestPoint (Structure) ============== -->
+  <UADataType NodeId="ns=1;i=15010" BrowseName="1:TestPoint">
+    <DisplayName>TestPoint</DisplayName>
+    <Description>A runtime-loaded structure with no compiled backing type.</Description>
+    <References>
+      <Reference ReferenceType="HasEncoding">ns=1;i=15011</Reference>
+      <Reference ReferenceType="HasSubtype" IsForward="false">i=22</Reference>
+    </References>
+    <Definition Name="1:TestPoint" BaseType="Structure">
+      <Field Name="X" DataType="Int32" />
+      <Field Name="Y" DataType="Int32" />
+      <Field Name="Name" DataType="String" />
+    </Definition>
+  </UADataType>
+  <UAObject NodeId="ns=1;i=15011" BrowseName="Default Binary" SymbolicName="DefaultBinary">
+    <DisplayName>Default Binary</DisplayName>
+    <References>
+      <Reference ReferenceType="HasEncoding" IsForward="false">ns=1;i=15010</Reference>
+      <Reference ReferenceType="HasTypeDefinition">i=76</Reference>
+    </References>
+  </UAObject>
+
+  <!-- ============================== Instances ========================== -->
+  <UAObject NodeId="ns=1;i=15020" BrowseName="1:ComplexTypesTestData">
+    <DisplayName>ComplexTypesTestData</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=61</Reference>
+      <Reference ReferenceType="Organizes">ns=1;i=15021</Reference>
+      <Reference ReferenceType="Organizes">ns=1;i=15022</Reference>
+      <Reference ReferenceType="Organizes" IsForward="false">i=85</Reference>
+    </References>
+  </UAObject>
+  <UAVariable NodeId="ns=1;i=15021" BrowseName="1:PointValue" ParentNodeId="ns=1;i=15020"
+              DataType="ns=1;i=15010" ValueRank="-1" AccessLevel="3" UserAccessLevel="3">
+    <DisplayName>PointValue</DisplayName>
+    <Description>A scalar value of the runtime-loaded TestPoint structure.</Description>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+      <Reference ReferenceType="Organizes" IsForward="false">ns=1;i=15020</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=15022" BrowseName="1:ColorValue" ParentNodeId="ns=1;i=15020"
+              DataType="ns=1;i=15001" ValueRank="-1" AccessLevel="3" UserAccessLevel="3">
+    <DisplayName>ColorValue</DisplayName>
+    <Description>A scalar value of the runtime-loaded TestColor enumeration.</Description>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+      <Reference ReferenceType="Organizes" IsForward="false">ns=1;i=15020</Reference>
+    </References>
+  </UAVariable>
+</UANodeSet>

--- a/Tests/Opc.Ua.Server.Tests/ComplexTypes/ServerComplexTypesTestNodeManager.cs
+++ b/Tests/Opc.Ua.Server.Tests/ComplexTypes/ServerComplexTypesTestNodeManager.cs
@@ -29,7 +29,6 @@
 
 using System;
 using System.IO;
-using System.Reflection;
 
 namespace Opc.Ua.Server.Tests
 {

--- a/Tests/Opc.Ua.Server.Tests/ComplexTypes/ServerComplexTypesTestNodeManager.cs
+++ b/Tests/Opc.Ua.Server.Tests/ComplexTypes/ServerComplexTypesTestNodeManager.cs
@@ -1,0 +1,117 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using System.IO;
+using System.Reflection;
+
+namespace Opc.Ua.Server.Tests
+{
+    /// <summary>
+    /// A minimal node manager that loads the synthetic
+    /// <c>ServerComplexTypesTestModel.NodeSet2.xml</c> from an embedded
+    /// resource at runtime. The custom DataTypes in that NodeSet have no
+    /// compiled .NET backing, so the server must build dynamic stand-in
+    /// encodeables from their <c>DataTypeDefinition</c> attributes. This is the
+    /// integration fixture for the server side complex type system.
+    /// </summary>
+    internal sealed class ServerComplexTypesTestNodeManager : CustomNodeManager2
+    {
+        /// <summary>
+        /// The namespace URI of the runtime-loaded test model.
+        /// </summary>
+        public const string NamespaceUri = "http://opcfoundation.org/UA/ServerComplexTypesTest/";
+
+        /// <summary>
+        /// Identifier of the runtime <c>TestColor</c> enumeration DataType.
+        /// </summary>
+        public const uint TestColorDataType = 15001;
+
+        /// <summary>
+        /// Identifier of the runtime <c>TestPoint</c> structure DataType.
+        /// </summary>
+        public const uint TestPointDataType = 15010;
+
+        /// <summary>
+        /// Identifier of the <c>TestPoint</c> Default Binary encoding node.
+        /// </summary>
+        public const uint TestPointBinaryEncoding = 15011;
+
+        /// <summary>
+        /// Identifier of the <c>PointValue</c> variable (of type TestPoint).
+        /// </summary>
+        public const uint PointValueVariable = 15021;
+
+        /// <summary>
+        /// Identifier of the <c>ColorValue</c> variable (of type TestColor).
+        /// </summary>
+        public const uint ColorValueVariable = 15022;
+
+        /// <summary>
+        /// Initializes the node manager for the test namespace.
+        /// </summary>
+        /// <param name="server">The server that owns the node manager.</param>
+        /// <param name="configuration">The application configuration.</param>
+        public ServerComplexTypesTestNodeManager(
+            IServerInternal server,
+            ApplicationConfiguration configuration)
+            : base(server, configuration, NamespaceUri)
+        {
+        }
+
+        /// <inheritdoc/>
+        protected override NodeStateCollection LoadPredefinedNodes(ISystemContext context)
+        {
+            var predefinedNodes = new NodeStateCollection();
+
+            using Stream stream = typeof(ServerComplexTypesTestNodeManager).Assembly
+                .GetManifestResourceStream(ResourceName)
+                ?? throw new InvalidOperationException(
+                    $"Embedded NodeSet2 resource '{ResourceName}' was not found.");
+
+            Export.UANodeSet nodeSet = Export.UANodeSet.Read(stream);
+
+            // Ensure the model namespaces exist in the server namespace table so
+            // the imported node ids map to the correct server indexes.
+            if (nodeSet.NamespaceUris != null)
+            {
+                foreach (string namespaceUri in nodeSet.NamespaceUris)
+                {
+                    context.NamespaceUris.GetIndexOrAppend(namespaceUri);
+                }
+            }
+
+            nodeSet.Import(context, predefinedNodes);
+            return predefinedNodes;
+        }
+
+        private const string ResourceName =
+            "Opc.Ua.Server.Tests.ComplexTypes.ServerComplexTypesTestModel.NodeSet2.xml";
+    }
+}

--- a/Tests/Opc.Ua.Server.Tests/ComplexTypes/ServerComplexTypesTestNodeManagerFactory.cs
+++ b/Tests/Opc.Ua.Server.Tests/ComplexTypes/ServerComplexTypesTestNodeManagerFactory.cs
@@ -1,0 +1,53 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+namespace Opc.Ua.Server.Tests
+{
+    /// <summary>
+    /// <see cref="INodeManagerFactory"/> for the
+    /// <see cref="ServerComplexTypesTestNodeManager"/> so it can be plugged into
+    /// a server through the standard node manager factory collection.
+    /// </summary>
+    internal sealed class ServerComplexTypesTestNodeManagerFactory : INodeManagerFactory
+    {
+        /// <inheritdoc/>
+        public ArrayOf<string> NamespacesUris => [ServerComplexTypesTestNodeManager.NamespaceUri];
+
+        /// <inheritdoc/>
+        public INodeManager Create(
+            IServerInternal server,
+            ApplicationConfiguration configuration)
+        {
+            // Ownership of the node manager is transferred to the server.
+#pragma warning disable CA2000
+            return new ServerComplexTypesTestNodeManager(server, configuration);
+#pragma warning restore CA2000
+        }
+    }
+}

--- a/Tests/Opc.Ua.Server.Tests/ComplexTypes/ServerComplexTypesTestNodeManagerFactory.cs
+++ b/Tests/Opc.Ua.Server.Tests/ComplexTypes/ServerComplexTypesTestNodeManagerFactory.cs
@@ -45,7 +45,7 @@ namespace Opc.Ua.Server.Tests
             ApplicationConfiguration configuration)
         {
             // Ownership of the node manager is transferred to the server.
-#pragma warning disable CA2000
+#pragma warning disable CA2000 // Ownership of the node manager is transferred to the server.
             return new ServerComplexTypesTestNodeManager(server, configuration);
 #pragma warning restore CA2000
         }

--- a/Tests/Opc.Ua.Server.Tests/ComplexTypes/ServerComplexTypesTestServer.cs
+++ b/Tests/Opc.Ua.Server.Tests/ComplexTypes/ServerComplexTypesTestServer.cs
@@ -1,0 +1,131 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System.Threading;
+using System.Threading.Tasks;
+using Opc.Ua.Encoders;
+using Quickstarts.ReferenceServer;
+
+namespace Opc.Ua.Server.Tests
+{
+    /// <summary>
+    /// A <see cref="ReferenceServer"/> that additionally hosts the
+    /// <see cref="ServerComplexTypesTestNodeManager"/> (runtime-loaded custom
+    /// DataTypes with no compiled backing) and, once the server has built its
+    /// stand-in encodeables, assigns a value of the runtime <c>TestPoint</c>
+    /// structure to the <c>PointValue</c> variable. This exercises the server
+    /// side complex type system end-to-end.
+    /// </summary>
+    internal sealed class ServerComplexTypesTestServer : ReferenceServer
+    {
+        /// <summary>
+        /// Initializes the server and registers the complex type test node
+        /// manager before the address space is created.
+        /// </summary>
+        /// <param name="telemetry">The telemetry context.</param>
+        public ServerComplexTypesTestServer(ITelemetryContext telemetry)
+            : base(telemetry)
+        {
+            AddNodeManager(new ServerComplexTypesTestNodeManagerFactory());
+        }
+
+        /// <inheritdoc/>
+        protected override async ValueTask OnNodeManagerStartedAsync(
+            IServerInternal server,
+            CancellationToken cancellationToken = default)
+        {
+            // Build the stand-in encodeables for the runtime-loaded DataTypes.
+            await base.OnNodeManagerStartedAsync(server, cancellationToken)
+                .ConfigureAwait(false);
+
+            // Now that the runtime stand-ins exist in the server factory,
+            // populate the sample variables with values so a client can read
+            // (and the server encode) them over the wire.
+            await PopulateSampleValuesAsync(server, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Assigns a <c>TestPoint</c> structured value to the <c>PointValue</c>
+        /// variable (using the server's runtime stand-in encodeable) and a
+        /// <c>TestColor</c> enumeration value to the <c>ColorValue</c> variable.
+        /// </summary>
+        private static async ValueTask PopulateSampleValuesAsync(
+            IServerInternal server,
+            CancellationToken cancellationToken)
+        {
+            ushort namespaceIndex = (ushort)server.NamespaceUris
+                .GetIndex(ServerComplexTypesTestNodeManager.NamespaceUri);
+
+            var pointVariableId = new NodeId(
+                ServerComplexTypesTestNodeManager.PointValueVariable,
+                namespaceIndex);
+
+            NodeState node = await server.NodeManager
+                .FindNodeInAddressSpaceAsync(pointVariableId, cancellationToken)
+                .ConfigureAwait(false);
+            if (node is BaseVariableState pointVariable)
+            {
+                ExpandedNodeId pointTypeId = NodeId.ToExpandedNodeId(
+                    new NodeId(
+                        ServerComplexTypesTestNodeManager.TestPointDataType,
+                        namespaceIndex),
+                    server.NamespaceUris);
+
+                if (server.Factory.TryGetEncodeableType(pointTypeId, out IEncodeableType pointType))
+                {
+                    IEncodeable body = pointType.CreateInstance();
+                    if (body is Structure structure)
+                    {
+                        structure["X"] = new Variant(3);
+                        structure["Y"] = new Variant(4);
+                        structure["Name"] = new Variant("origin");
+                    }
+
+                    pointVariable.Value = new Variant(new ExtensionObject(body));
+                    pointVariable.ClearChangeMasks(server.DefaultSystemContext, false);
+                }
+            }
+
+            // TestColor.Green == 1; the wire form of an enumeration is Int32.
+            var colorVariableId = new NodeId(
+                ServerComplexTypesTestNodeManager.ColorValueVariable,
+                namespaceIndex);
+
+            NodeState colorNode = await server.NodeManager
+                .FindNodeInAddressSpaceAsync(colorVariableId, cancellationToken)
+                .ConfigureAwait(false);
+            if (colorNode is BaseVariableState colorVariable)
+            {
+                colorVariable.Value = new Variant(1);
+                colorVariable.ClearChangeMasks(server.DefaultSystemContext, false);
+            }
+        }
+    }
+}

--- a/Tests/Opc.Ua.Server.Tests/Opc.Ua.Server.Tests.csproj
+++ b/Tests/Opc.Ua.Server.Tests/Opc.Ua.Server.Tests.csproj
@@ -32,6 +32,11 @@
     <Compile Include="..\Common\Main.cs" />
   </ItemGroup>
   <ItemGroup>
+    <EmbeddedResource Include="ComplexTypes\ServerComplexTypesTestModel.NodeSet2.xml">
+      <LogicalName>Opc.Ua.Server.Tests.ComplexTypes.ServerComplexTypesTestModel.NodeSet2.xml</LogicalName>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
     <None Update="test-memorybuffer-config.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
@@ -50,6 +55,7 @@
     <ProjectReference Include="..\..\Stack\Opc.Ua.Bindings.Https\Opc.Ua.Bindings.Https.csproj" />
     <ProjectReference Include="..\Opc.Ua.Core.Tests\Opc.Ua.Core.Tests.csproj" />
     <ProjectReference Include="..\Opc.Ua.Server.TestFramework\Opc.Ua.Server.TestFramework.csproj" />
+    <ProjectReference Include="..\Opc.Ua.Client.TestFramework\Opc.Ua.Client.TestFramework.csproj" />
     <ProjectReference Include="..\Opc.Ua.Test.Common\Opc.Ua.Test.Common.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
# Description

Adds a client↔server **integration test** for the server side complex type system
(`ServerComplexTypeSystem.LoadComplexTypesAsync` / the `AddComplexTypeSystem` builder extension). Until now this
feature was only covered by mock-based unit tests (`ServerComplexTypeSystemTests`); there was no end-to-end test
proving a real server that hosts runtime-loaded custom DataTypes (no compiled .NET backing) can encode/decode them
over the wire.

The new test (`Tests/Opc.Ua.Server.Tests/ComplexTypes/`):

- A `ReferenceServer` subclass hosts a small hand-authored **NodeSet2** (embedded resource) loaded at runtime by a
  test node manager. It declares custom types with no compiled backing:
  - `TestPoint` — a `Structure` (`X:Int32`, `Y:Int32`, `Name:String`) with a Default Binary encoding node.
  - `TestColor` — an `Enumeration` (Red/Green/Blue).
- The server builds dynamic stand-in encodeables via the default `OnNodeManagerStartedAsync` path and then
  populates the sample variables (the runtime struct value is built through
  `server.Factory.TryGetEncodeableType(...).CreateInstance()`).
- A real client connects, loads its complex type system, and exercises the round-trip.

**Assertions:**

1. The server `IEncodeableFactory` registers the runtime `TestPoint` stand-in (+ its binary encoding id) and the
   `TestColor` enumeration.
2. Server→client read: the client decodes the runtime structure (`X`/`Y`/`Name`).
3. Enum read round-trips.
4. Client→server write: the server decodes the runtime structure via its stand-in and returns the updated value.

This is a **test-only** change — no production code is modified.

## Related Issues

- Fixes #3961

## Checklist

- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf) and read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [x] I have added all necessary documentation.
- [x] I have verified that my changes do not introduce (new) build or analyzer warnings.
- [x] I ran the affected tests locally against .net **framework (net48)** and .net **10**, and all passed (4/4 on each TFM).
- [ ] I fixed **all** failing and flaky tests in the CI pipelines and **all** CodeQL warnings.
- [ ] I have addressed **all** PR feedback received.
