### PR TITLE
Revert "Prune extra decoded children that should stay on the type defnition only. (#3843)"

### DIFF
--- a/Stack/Opc.Ua.Types/State/BaseInstanceState.cs
+++ b/Stack/Opc.Ua.Types/State/BaseInstanceState.cs
@@ -48,7 +48,7 @@ namespace Opc.Ua
         }
 
         /// <inheritdoc/>
-        protected override bool PruneNonRuntimeInstanceChildrenOnCreate => true;
+        protected override bool RemovePlaceholderChildrenOnCreate => true;
 
         /// <summary>
         /// Initializes the instance from another instance.

--- a/Stack/Opc.Ua.Types/State/NodeState.cs
+++ b/Stack/Opc.Ua.Types/State/NodeState.cs
@@ -2710,9 +2710,9 @@ namespace Opc.Ua
         {
             Initialize(context);
 
-            if (PruneNonRuntimeInstanceChildrenOnCreate)
+            if (RemovePlaceholderChildrenOnCreate)
             {
-                PruneNonRuntimeInstanceChildren(context);
+                RemovePlaceholderChildren(context);
             }
 
             // Call OnBeforeCreate on all children.
@@ -2824,9 +2824,9 @@ namespace Opc.Ua
         {
             Initialize(context, source);
 
-            if (PruneNonRuntimeInstanceChildrenOnCreate)
+            if (RemovePlaceholderChildrenOnCreate)
             {
-                PruneNonRuntimeInstanceChildren(context);
+                RemovePlaceholderChildren(context);
             }
 
             CallOnBeforeCreate(context);
@@ -2837,14 +2837,14 @@ namespace Opc.Ua
         }
 
         /// <summary>
-        /// Whether generated children that should not exist on runtime instances should be removed during creation.
+        /// Whether placeholder declarations should be removed during runtime creation.
         /// </summary>
-        protected virtual bool PruneNonRuntimeInstanceChildrenOnCreate => false;
+        protected virtual bool RemovePlaceholderChildrenOnCreate => false;
 
         /// <summary>
-        /// Removes generated children that should not exist on runtime instances.
+        /// Removes instantiated placeholder declarations from runtime instances.
         /// </summary>
-        private void PruneNonRuntimeInstanceChildren(ISystemContext context)
+        private void RemovePlaceholderChildren(ISystemContext context)
         {
             var children = new List<BaseInstanceState>();
             GetChildren(context, children);
@@ -2853,7 +2853,7 @@ namespace Opc.Ua
             {
                 BaseInstanceState child = children[ii];
 
-                if (ShouldPruneChildOnCreate(child))
+                if (IsPlaceholderChild(child))
                 {
                     RemoveChild(child);
 
@@ -2865,25 +2865,17 @@ namespace Opc.Ua
                     continue;
                 }
 
-                child.PruneNonRuntimeInstanceChildren(context);
+                child.RemovePlaceholderChildren(context);
             }
         }
 
         /// <summary>
-        /// Returns true if the child should not be kept on a runtime instance.
+        /// Returns true if the child represents a placeholder declaration.
         /// </summary>
-        private bool ShouldPruneChildOnCreate(BaseInstanceState child)
+        private static bool IsPlaceholderChild(BaseInstanceState child)
         {
             if (child.ModellingRuleId == ObjectIds.ModellingRule_OptionalPlaceholder ||
                 child.ModellingRuleId == ObjectIds.ModellingRule_MandatoryPlaceholder)
-            {
-                return true;
-            }
-
-            if (IsDynamicChild(child) &&
-                HasGeneratedNumericNodeIdentity(child) &&
-                child.ModellingRuleId != ObjectIds.ModellingRule_Mandatory &&
-                child.ModellingRuleId != ObjectIds.ModellingRule_Optional)
             {
                 return true;
             }
@@ -2892,8 +2884,9 @@ namespace Opc.Ua
 
             // Some generated placeholder declarations reach runtime without their
             // placeholder modelling rule; the fallback is limited to model-defined
-            // nodes that still carry the generated <PlaceholderName> browse-name form.
-            return HasGeneratedNumericNodeIdentity(child) &&
+            // standard nodes that still carry the generated <PlaceholderName>
+            // browse-name form.
+            return IsGeneratedStandardNumericNode(child) &&
                 browseName != null &&
                 browseName.Length > 1 &&
                 browseName[0] == '<' &&
@@ -2901,42 +2894,16 @@ namespace Opc.Ua
         }
 
         /// <summary>
-        /// Returns true if the child still has its generated numeric node identity.
+        /// Returns true if the child still has its generated standard numeric node identity.
         /// </summary>
-        private static bool HasGeneratedNumericNodeIdentity(BaseInstanceState child)
+        private static bool IsGeneratedStandardNumericNode(BaseInstanceState child)
         {
             return child.NumericId != 0 &&
                 child.NodeId != null &&
+                child.NodeId.NamespaceIndex == 0 &&
                 child.NodeId.IdType == IdType.Numeric &&
                 child.NodeId.Identifier is uint identifier &&
                 identifier == child.NumericId;
-        }
-
-        /// <summary>
-        /// Returns true if the child is stored in the dynamic child list.
-        /// These are extra children decoded from the InitializationString that
-        /// do not match a strongly typed generated child and are stored in the
-        /// generic m_children list.
-        /// </summary>
-        private bool IsDynamicChild(BaseInstanceState child)
-        {
-            lock (m_childrenLock)
-            {
-                if (m_children == null)
-                {
-                    return false;
-                }
-
-                for (int ii = 0; ii < m_children.Count; ii++)
-                {
-                    if (ReferenceEquals(m_children[ii], child))
-                    {
-                        return true;
-                    }
-                }
-            }
-
-            return false;
         }
 
         /// <summary>

--- a/Tests/Opc.Ua.Core.Tests/Stack/State/NodeStateTests.cs
+++ b/Tests/Opc.Ua.Core.Tests/Stack/State/NodeStateTests.cs
@@ -141,28 +141,6 @@ namespace Opc.Ua.Core.Tests.Stack.State
         }
 
         /// <summary>
-        /// Verify generated state machine declarations without modelling rules are not instantiated.
-        /// </summary>
-        [Test]
-        public void ProgramStateMachineState_ShouldNotInstantiateChildrenWithoutMandatoryOrOptionalModellingRule()
-        {
-            ITelemetryContext telemetry = NUnitTelemetryContext.Create();
-            var context = new SystemContext(telemetry) { NamespaceUris = Context.NamespaceUris };
-            var stateMachine = new ProgramStateMachineState(null);
-
-            stateMachine.Create(context, new NodeId(300000), "Name", "DisplayName", true);
-
-            Assert.NotNull(
-                stateMachine.FindChild(context, BrowseNames.CurrentState),
-                "Mandatory child CurrentState should be instantiated.");
-            Assert.Null(
-                stateMachine.FindChild(context, BrowseNames.Suspended),
-                "State declaration Suspended has no Mandatory or Optional modelling rule.");
-
-            stateMachine.Dispose();
-        }
-
-        /// <summary>
         /// Verify placeholder declarations remain available on type definitions.
         /// </summary>
         [Test]


### PR DESCRIPTION

This reverts commit 00519fa6dd9e439e448ea5badc6eff3f57cb37c4.

# Description

Due to longer investigation time needed on ModelCompiler the pruning of the extra decoded children that should stay on the type definition only is reverted 

## Related Issues

_Reference all GitHub issues this PR addresses. If there is no issue yet, open one and link it here._

_If this is a relatively large or complex change, a design must have been discussed in the related tracking issue and signed off (which becomes the Architectural Decision Record (ADR))._

- Fixes #github-issue-number, ...

## Checklist

_Put an `x` in the boxes that apply. You can complete these step by step after opening the PR._

- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf) and read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added all necessary documentation.
- [ ] I have verified that my changes do not introduce (new) build or analyzer warnings.
- [ ] I ran **all** tests locally using the **UA.slnx** solution against at least .net **framework** and .net **10**, and all passed.
- [ ] I fixed **all** failing and flaky tests in the CI pipelines and **all** CodeQL warnings.
- [ ] I have addressed **all** PR feedback received.
