### PR TITLE
Fix Fluent NodeManager Configure wiring: typed OnCall for imported methods + runtime value updates (#3973)

### DIFF
--- a/Docs/SourceGeneratedNodeManagers.md
+++ b/Docs/SourceGeneratedNodeManagers.md
@@ -266,13 +266,13 @@ the generator emits, into a single `{Manager}.FluentBuilders.g.cs`:
   to typed `IVariableBuilder<TValue>`, child wrapper instances, and
   method wrappers.
 - One `internal sealed class` per method — exposing typed
-  `OnCall(Func<TIn1, …, TResult>)` and async
-  `OnCall(Func<TIn1, …, CancellationToken, ValueTask<TResult>>)`
-  overloads when the model declares input/output arguments
+  `OnCall(...)` overloads bound to the method's declared arguments
   (the generator handles `Variant.TryGetValue` unpacking and
   `Variant.From<T>` boxing — see [Methods with arguments](#methods-with-arguments--typed-oncall-overloads)).
-  Argument-less methods keep the no-arg `OnCall(Action)` /
-  `OnCall(Func<CancellationToken, ValueTask>)` overloads.
+  A method with inputs but no output binds to `OnCall(Action<TIn…>)`;
+  a method with neither inputs nor outputs keeps the argument-less
+  `OnCall(Action)` / `OnCall(Func<CancellationToken, ValueTask>)`
+  overloads.
 
 All emitted types are `internal sealed` because `Configure` is a
 private partial — the surface never escapes the assembly. Child
@@ -290,19 +290,31 @@ through `Variant.From<T>(value)`, and `BadInvalidArgument` /
 `BadArgumentsMissing` is returned when the wire shape does not match
 the declared signature — none of which the user has to spell out.
 
-Two overloads are emitted per method:
+Two overloads are emitted per method, shaped by the declared arguments:
 
-- `OnCall(Func<TIn1, TIn2, …, TResult> handler)` — synchronous
-  dispatch through `MethodState.OnCallMethod2`.
-- `OnCall(Func<TIn1, TIn2, …, CancellationToken, ValueTask<TResult>>
-  handler)` — async dispatch through `MethodState.OnCallMethod2Async`,
-  awaited inside `AsyncCustomNodeManager.CallAsync` so the lambda may
-  freely `await`.
+- **Inputs and outputs** →
+  `OnCall(Func<TIn1, …, TResult> handler)` (synchronous dispatch through
+  `MethodState.OnCallMethod2`) and
+  `OnCall(Func<TIn1, …, CancellationToken, ValueTask<TResult>> handler)`
+  (async dispatch through `MethodState.OnCallMethod2Async`, awaited inside
+  `AsyncCustomNodeManager.CallAsync` so the lambda may freely `await`).
+- **Inputs but no output** (a `void`-returning action) →
+  `OnCall(Action<TIn1, …> handler)` and
+  `OnCall(Func<TIn1, …, CancellationToken, ValueTask> handler)`. The inputs
+  are still unpacked via `Variant.TryGetValue<T>`, so
+  `builder.X.SetOutputVal.OnCall((float v) => …)` binds directly to the
+  argument.
+- **No inputs and no output** → the argument-less `OnCall(Action)` /
+  `OnCall(Func<CancellationToken, ValueTask>)` overloads.
 
 Methods with multiple output arguments are bound to a `ValueTuple`
-return — slot `i` is written from `__r.Item{i+1}`. Methods with no
-return value (action-only) keep the existing `OnCall(Action)` /
-`OnCall(Func<CancellationToken, ValueTask>)` overloads.
+return — slot `i` is written from `__r.Item{i+1}`.
+
+The declared arguments are resolved from the method itself and, when the
+method carries none of its own, from its method declaration / method type.
+This means **instance methods imported from a NodeSet2** (whose
+`InputArguments`/`OutputArguments` live on the referenced declaration) get
+the same typed `OnCall` overloads as methods authored in a ModelDesign.
 
 ```csharp
 [NodeManager(NamespaceUri = "http://opcfoundation.org/UA/Calc/")]
@@ -769,6 +781,55 @@ tick.
 The simulation registry **requires** the manager to derive from
 `FluentNodeManagerBase` (the source generator-emitted manager already
 does); calling `.Simulation()` on a plain `CustomNodeManager2` throws
+`StatusCodes.BadConfigurationError`.
+
+### Pushing runtime value changes to subscribers
+
+`OnRead` getters are invoked on the **Attribute (Read) service**, but a
+value that only lives behind a getter — or in a backing field mutated by
+an `OnCall` handler — will **not** reach subscribed MonitoredItems on its
+own. Historically the fix was to mutate `Node.Value` and call
+`Node.ClearChangeMasks(...)`, but that node handle is unavailable through
+the fluent surface once `Configure` returns (the builder is sealed).
+
+Two fluent mechanisms close that gap.
+
+**1. `Bind(out IValueUpdater<TValue>)` — explicit push.** Capture a runtime
+handle during `Configure` and store it on the manager; the handle survives
+sealing. `SetValue` assigns the value, timestamp and status and flushes the
+change mask in one serialized call, so both reads *and* subscriptions see
+the update:
+
+```csharp
+private IValueUpdater<float> m_ao01 = null!;
+
+partial void Configure(IMyNodeManagerBuilder builder)
+{
+    builder.MyEquipment03.AO01.Builder.AsVariable<float>()
+           .Bind(out m_ao01);
+
+    builder.MyEquipment03.SetOutputVal
+           .OnCall((float value) => m_ao01.SetValue(value));
+}
+```
+
+`IValueUpdater<TValue>` also exposes `SetValue(value, statusCode)`,
+`SetValue(value, statusCode, sourceTimestamp)`, and `NotifyChange()` (flush
+a notification after an in-place mutation without changing the value).
+
+**2. `PollEvery(interval, getter)` — opt-in auto-sampling.** Register a
+periodic loop that reads the getter and pushes a change only when the value
+actually differs, so subscriptions update automatically with no
+change-notification code. An initial sample is applied immediately:
+
+```csharp
+builder.MyEquipment03.AO01
+       .PollEvery(TimeSpan.FromMilliseconds(250), () => m_ao01Value);
+```
+
+Like `Simulation`, `PollEvery` reuses the manager-owned loop
+infrastructure and therefore **requires** the manager to derive from
+`FluentNodeManagerBase`; calling it on a plain `CustomNodeManager2` throws
 `StatusCodes.BadConfigurationError`.
 
 ### Multi-model composition

--- a/Docs/SourceGeneratedNodeManagers.md
+++ b/Docs/SourceGeneratedNodeManagers.md
@@ -788,9 +788,9 @@ does); calling `.Simulation()` on a plain `CustomNodeManager2` throws
 `OnRead` getters are invoked on the **Attribute (Read) service**, but a
 value that only lives behind a getter — or in a backing field mutated by
 an `OnCall` handler — will **not** reach subscribed MonitoredItems on its
-own. Historically the fix was to mutate `Node.Value` and call
-`Node.ClearChangeMasks(...)`, but that node handle is unavailable through
-the fluent surface once `Configure` returns (the builder is sealed).
+own. In previous implementations the fix was to mutate `Node.Value` and call
+`Node.ClearChangeMasks(...)`, but that node handle is deliberately unavailable
+through the fluent surface once `Configure` returns (the builder is sealed).
 
 Two fluent mechanisms close that gap.
 

--- a/Libraries/Opc.Ua.Server/Fluent/FluentVariant.cs
+++ b/Libraries/Opc.Ua.Server/Fluent/FluentVariant.cs
@@ -27,14 +27,18 @@
  * http://opcfoundation.org/License/MIT/1.00/
  * ======================================================================*/
 
+using System;
+
 namespace Opc.Ua.Server.Fluent
 {
     /// <summary>
     /// Shared <see cref="Variant"/> marshalling helper used by the fluent
     /// variable surface (typed <c>OnRead</c> getters, the runtime
     /// <see cref="IValueUpdater{TValue}"/> handle, and auto-sampling).
-    /// Centralises the single reflection-based boxing entry point so the
-    /// AOT/trimming suppression lives in exactly one place.
+    /// Routes every typed value through the statically-registered
+    /// <see cref="IVariantBuilder{T}"/> implementations so the bridge stays
+    /// free of the obsolete <c>Variant(object)</c> constructor and of
+    /// reflection.
     /// </summary>
     internal static class FluentVariant
     {
@@ -45,35 +49,49 @@ namespace Opc.Ua.Server.Fluent
         /// variable.
         /// </summary>
         /// <remarks>
-        /// The reflection-based <c>Variant(object)</c> constructor is the
-        /// only generic entry point for an open-ended <typeparamref name="TValue"/>.
-        /// AOT users should prefer the per-type generated walker
-        /// (<c>FluentBuilderGenerator</c>) which routes through the typed
-        /// <c>Variant.From</c> overloads instead. The suppression is scoped
-        /// to this single call site so trim/AOT analysis still tracks every
-        /// other path through this assembly.
+        /// Built-in OPC UA types (booleans, numerics, strings,
+        /// <see cref="ByteString"/>, <see cref="NodeId"/>,
+        /// <see cref="ArrayOf{T}"/>, <see cref="MatrixOf{T}"/>, …) are
+        /// converted through the explicit <see cref="IVariantBuilder{T}"/>
+        /// implementations on <see cref="VariantBuilder"/>; enumerations map
+        /// onto their Int32 wire representation. Both paths are CS0618- and
+        /// reflection-free, so no trim/AOT suppression is required.
         /// </remarks>
         /// <typeparam name="TValue">
         /// CLR type of the value being wrapped.
         /// </typeparam>
         /// <param name="value">The value to wrap.</param>
-        [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage(
-            "Trimming",
-            "IL2026:RequiresUnreferencedCode",
-            Justification = "Generic typed-variable bridge requires the reflection-based Variant(object) constructor.")]
-        [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage(
-            "AOT",
-            "IL3050:RequiresDynamicCode",
-            Justification = "Generic typed-variable bridge requires the reflection-based Variant(object) constructor.")]
+        /// <exception cref="ServiceResultException">
+        /// <see cref="StatusCodes.BadNotSupported"/> when
+        /// <typeparamref name="TValue"/> is neither a built-in
+        /// Variant-convertible type nor an enumeration.
+        /// </exception>
         public static Variant ToVariant<TValue>(TValue value)
         {
             if (value is null)
             {
                 return Variant.Null;
             }
-#pragma warning disable CS0618 // Variant(object) is obsolete on net472
-            return new Variant(value);
-#pragma warning restore CS0618
+            // Built-in Variant-convertible types route through the statically
+            // registered IVariantBuilder<T> implementations on VariantBuilder.
+            // The struct is boxed once so the runtime type test resolves against
+            // the closed set of IVariantBuilder<T> interfaces it implements.
+            object boxedBuilder = default(VariantBuilder);
+            if (boxedBuilder is IVariantBuilder<TValue> builder)
+            {
+                return builder.WithValue(value);
+            }
+            // OPC UA enumerations map onto their Int32 wire representation.
+            if (value is Enum)
+            {
+                return Variant.From(EnumValue.From(value, typeof(TValue)));
+            }
+            throw ServiceResultException.Create(
+                StatusCodes.BadNotSupported,
+                "Cannot marshal a value of type '{0}' to a Variant through the " +
+                "fluent typed surface. Use a built-in OPC UA type, an enum, or " +
+                "wrap the value in an ExtensionObject.",
+                typeof(TValue).FullName ?? typeof(TValue).Name);
         }
     }
 }

--- a/Libraries/Opc.Ua.Server/Fluent/FluentVariant.cs
+++ b/Libraries/Opc.Ua.Server/Fluent/FluentVariant.cs
@@ -1,0 +1,79 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+namespace Opc.Ua.Server.Fluent
+{
+    /// <summary>
+    /// Shared <see cref="Variant"/> marshalling helper used by the fluent
+    /// variable surface (typed <c>OnRead</c> getters, the runtime
+    /// <see cref="IValueUpdater{TValue}"/> handle, and auto-sampling).
+    /// Centralises the single reflection-based boxing entry point so the
+    /// AOT/trimming suppression lives in exactly one place.
+    /// </summary>
+    internal static class FluentVariant
+    {
+        /// <summary>
+        /// Wraps <paramref name="value"/> in a <see cref="Variant"/>.
+        /// Returns <see cref="Variant.Null"/> for a <see langword="null"/>
+        /// input so a typed lambda never has to defend against an empty
+        /// variable.
+        /// </summary>
+        /// <remarks>
+        /// The reflection-based <c>Variant(object)</c> constructor is the
+        /// only generic entry point for an open-ended <typeparamref name="TValue"/>.
+        /// AOT users should prefer the per-type generated walker
+        /// (<c>FluentBuilderGenerator</c>) which routes through the typed
+        /// <c>Variant.From</c> overloads instead. The suppression is scoped
+        /// to this single call site so trim/AOT analysis still tracks every
+        /// other path through this assembly.
+        /// </remarks>
+        /// <typeparam name="TValue">
+        /// CLR type of the value being wrapped.
+        /// </typeparam>
+        /// <param name="value">The value to wrap.</param>
+        [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage(
+            "Trimming",
+            "IL2026:RequiresUnreferencedCode",
+            Justification = "Generic typed-variable bridge requires the reflection-based Variant(object) constructor.")]
+        [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage(
+            "AOT",
+            "IL3050:RequiresDynamicCode",
+            Justification = "Generic typed-variable bridge requires the reflection-based Variant(object) constructor.")]
+        public static Variant ToVariant<TValue>(TValue value)
+        {
+            if (value is null)
+            {
+                return Variant.Null;
+            }
+#pragma warning disable CS0618 // Variant(object) is obsolete on net472
+            return new Variant(value);
+#pragma warning restore CS0618
+        }
+    }
+}

--- a/Libraries/Opc.Ua.Server/Fluent/FluentVariant.cs
+++ b/Libraries/Opc.Ua.Server/Fluent/FluentVariant.cs
@@ -55,7 +55,11 @@ namespace Opc.Ua.Server.Fluent
         /// converted through the explicit <see cref="IVariantBuilder{T}"/>
         /// implementations on <see cref="VariantBuilder"/>; enumerations map
         /// onto their Int32 wire representation. Both paths are CS0618- and
-        /// reflection-free, so no trim/AOT suppression is required.
+        /// reflection-free, so no trim/AOT suppression is required. The
+        /// <see cref="IVariantBuilder{T}"/> resolution is cached per closed
+        /// <typeparamref name="TValue"/> in <see cref="Builder{T}"/> so the
+        /// one-time interface probe is JIT-specialized instead of repeated on
+        /// every call.
         /// </remarks>
         /// <typeparam name="TValue">
         /// CLR type of the value being wrapped.
@@ -73,11 +77,10 @@ namespace Opc.Ua.Server.Fluent
                 return Variant.Null;
             }
             // Built-in Variant-convertible types route through the statically
-            // registered IVariantBuilder<T> implementations on VariantBuilder.
-            // The struct is boxed once so the runtime type test resolves against
-            // the closed set of IVariantBuilder<T> interfaces it implements.
-            object boxedBuilder = default(VariantBuilder);
-            if (boxedBuilder is IVariantBuilder<TValue> builder)
+            // registered IVariantBuilder<T> implementations on VariantBuilder,
+            // resolved once per closed TValue by the generic cache below.
+            IVariantBuilder<TValue>? builder = Builder<TValue>.Instance;
+            if (builder != null)
             {
                 return builder.WithValue(value);
             }
@@ -92,6 +95,23 @@ namespace Opc.Ua.Server.Fluent
                 "fluent typed surface. Use a built-in OPC UA type, an enum, or " +
                 "wrap the value in an ExtensionObject.",
                 typeof(TValue).FullName ?? typeof(TValue).Name);
+        }
+
+        /// <summary>
+        /// Per-<typeparamref name="T"/> cache of the boxed
+        /// <see cref="VariantBuilder"/> viewed as <see cref="IVariantBuilder{T}"/>.
+        /// The interface probe (and the single boxing it entails) runs once per
+        /// closed generic type on first use; <see langword="null"/> means
+        /// <see cref="VariantBuilder"/> does not implement
+        /// <see cref="IVariantBuilder{T}"/> for that type.
+        /// </summary>
+        /// <typeparam name="T">
+        /// CLR type the cached builder converts.
+        /// </typeparam>
+        private static class Builder<T>
+        {
+            public static readonly IVariantBuilder<T>? Instance =
+                default(VariantBuilder) as IVariantBuilder<T>;
         }
     }
 }

--- a/Libraries/Opc.Ua.Server/Fluent/IValueUpdater.cs
+++ b/Libraries/Opc.Ua.Server/Fluent/IValueUpdater.cs
@@ -1,0 +1,95 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+
+namespace Opc.Ua.Server.Fluent
+{
+    /// <summary>
+    /// Runtime handle to a fluent-configured variable that survives the
+    /// sealing of the <see cref="INodeManagerBuilder"/>. Obtained during
+    /// <c>Configure</c> via
+    /// <see cref="RuntimeValueBuilderExtensions.Bind{TValue}(IVariableBuilder{TValue}, out IValueUpdater{TValue})"/>,
+    /// it lets the manager push value changes after start-up so both the
+    /// Attribute (Read) service <b>and</b> subscribed MonitoredItems observe
+    /// the update.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The old-style recipe — mutate <c>Node.Value</c> and call
+    /// <c>Node.ClearChangeMasks(context, ...)</c> — is unavailable through
+    /// the fluent surface because the builder is sealed once
+    /// <c>Configure</c> returns. <see cref="SetValue(TValue)"/> performs the
+    /// value assignment, timestamp/status update, and change-mask flush in a
+    /// single serialized call so subscriptions see every transition.
+    /// </para>
+    /// <para>
+    /// A single instance is safe to call from any thread; concurrent
+    /// <see cref="SetValue(TValue)"/> calls are serialized internally.
+    /// </para>
+    /// </remarks>
+    /// <typeparam name="TValue">
+    /// CLR type carried by the variable's <c>Value</c> attribute.
+    /// </typeparam>
+    public interface IValueUpdater<in TValue>
+    {
+        /// <summary>
+        /// Sets the variable value with a <see cref="StatusCodes.Good"/>
+        /// status and the current UTC time as the source timestamp, then
+        /// notifies subscribed MonitoredItems.
+        /// </summary>
+        /// <param name="value">The new value.</param>
+        void SetValue(TValue value);
+
+        /// <summary>
+        /// Sets the variable value with the supplied status code and the
+        /// current UTC time as the source timestamp, then notifies
+        /// subscribed MonitoredItems.
+        /// </summary>
+        /// <param name="value">The new value.</param>
+        /// <param name="statusCode">The status code to publish.</param>
+        void SetValue(TValue value, StatusCode statusCode);
+
+        /// <summary>
+        /// Sets the variable value with the supplied status code and source
+        /// timestamp, then notifies subscribed MonitoredItems.
+        /// </summary>
+        /// <param name="value">The new value.</param>
+        /// <param name="statusCode">The status code to publish.</param>
+        /// <param name="sourceTimestamp">The source timestamp to publish.</param>
+        void SetValue(TValue value, StatusCode statusCode, DateTime sourceTimestamp);
+
+        /// <summary>
+        /// Flushes a value change notification to subscribed MonitoredItems
+        /// without changing the stored value. Use when the underlying value
+        /// object was mutated in place.
+        /// </summary>
+        void NotifyChange();
+    }
+}

--- a/Libraries/Opc.Ua.Server/Fluent/RuntimeValueBuilderExtensions.cs
+++ b/Libraries/Opc.Ua.Server/Fluent/RuntimeValueBuilderExtensions.cs
@@ -1,0 +1,226 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using System.Collections.Generic;
+
+namespace Opc.Ua.Server.Fluent
+{
+    /// <summary>
+    /// Fluent extensions that bridge a configured
+    /// <see cref="IVariableBuilder{TValue}"/> to the <b>runtime</b> so a
+    /// manager can push value changes to subscribed MonitoredItems after the
+    /// builder has been sealed.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Two complementary mechanisms are provided:
+    /// </para>
+    /// <list type="bullet">
+    /// <item>
+    /// <description>
+    /// <see cref="Bind{TValue}(IVariableBuilder{TValue}, out IValueUpdater{TValue})"/>
+    /// captures an <see cref="IValueUpdater{TValue}"/> handle that the
+    /// manager stores and calls whenever it decides to push a new value
+    /// (for example from an <c>OnCall</c> method handler). This is the
+    /// supported replacement for the old <c>Node.ClearChangeMasks(...)</c>
+    /// recipe, which is unavailable once the builder is sealed.
+    /// </description>
+    /// </item>
+    /// <item>
+    /// <description>
+    /// <see cref="PollEvery{TValue}(IVariableBuilder{TValue}, TimeSpan, Func{TValue})"/>
+    /// registers a periodic sampling loop that reads a getter and, on
+    /// change, pushes the new value so subscriptions update automatically —
+    /// without the manager writing any change-notification code.
+    /// </description>
+    /// </item>
+    /// </list>
+    /// </remarks>
+    public static class RuntimeValueBuilderExtensions
+    {
+        /// <summary>
+        /// Captures an <see cref="IValueUpdater{TValue}"/> handle for the
+        /// resolved variable. The handle stays valid after the builder is
+        /// sealed; calling <see cref="IValueUpdater{TValue}.SetValue(TValue)"/>
+        /// updates the value and notifies subscribed MonitoredItems.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// IValueUpdater&lt;float&gt; ao01;
+        /// builder.MyEquipment03.AO01.Builder.AsVariable&lt;float&gt;()
+        ///        .Bind(out ao01);
+        /// // later, from a method handler:
+        /// ao01.SetValue(newValue);
+        /// </code>
+        /// </example>
+        /// <typeparam name="TValue">
+        /// CLR type carried by the variable's <c>Value</c> attribute.
+        /// </typeparam>
+        /// <param name="builder">The typed variable builder.</param>
+        /// <param name="updater">
+        /// Receives the runtime handle for the resolved variable.
+        /// </param>
+        /// <returns>The same builder for chaining.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="builder"/> is <see langword="null"/>.
+        /// </exception>
+        public static IVariableBuilder<TValue> Bind<TValue>(
+            this IVariableBuilder<TValue> builder,
+            out IValueUpdater<TValue> updater)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+            updater = new ValueUpdater<TValue>(builder.Node, builder.Builder.Context);
+            return builder;
+        }
+
+        /// <summary>
+        /// Registers a periodic sampling loop that invokes
+        /// <paramref name="sample"/> and, when the value changes, updates the
+        /// variable and notifies subscribed MonitoredItems. An initial sample
+        /// is applied immediately so the node starts with a meaningful value.
+        /// </summary>
+        /// <remarks>
+        /// Requires the owning manager to derive from
+        /// <see cref="FluentNodeManagerBase"/> (the same requirement as the
+        /// <c>Simulation</c> surface, whose loop infrastructure this reuses).
+        /// </remarks>
+        /// <typeparam name="TValue">
+        /// CLR type carried by the variable's <c>Value</c> attribute.
+        /// </typeparam>
+        /// <param name="builder">The typed variable builder.</param>
+        /// <param name="interval">
+        /// Sampling interval. Must be positive.
+        /// </param>
+        /// <param name="sample">Getter invoked on every tick.</param>
+        /// <returns>The same builder for chaining.</returns>
+        public static IVariableBuilder<TValue> PollEvery<TValue>(
+            this IVariableBuilder<TValue> builder,
+            TimeSpan interval,
+            Func<TValue> sample)
+        {
+            if (sample == null)
+            {
+                throw new ArgumentNullException(nameof(sample));
+            }
+            return builder.PollEvery(interval, _ => sample());
+        }
+
+        /// <summary>
+        /// Registers a periodic sampling loop that invokes
+        /// <paramref name="sample"/> with the calling
+        /// <see cref="ISystemContext"/> and, when the value changes, updates
+        /// the variable and notifies subscribed MonitoredItems. An initial
+        /// sample is applied immediately so the node starts with a meaningful
+        /// value.
+        /// </summary>
+        /// <remarks>
+        /// Requires the owning manager to derive from
+        /// <see cref="FluentNodeManagerBase"/> (the same requirement as the
+        /// <c>Simulation</c> surface, whose loop infrastructure this reuses).
+        /// </remarks>
+        /// <typeparam name="TValue">
+        /// CLR type carried by the variable's <c>Value</c> attribute.
+        /// </typeparam>
+        /// <param name="builder">The typed variable builder.</param>
+        /// <param name="interval">
+        /// Sampling interval. Must be positive.
+        /// </param>
+        /// <param name="sample">Getter invoked on every tick.</param>
+        /// <returns>The same builder for chaining.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="builder"/> or <paramref name="sample"/> is
+        /// <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="interval"/> is not positive.
+        /// </exception>
+        /// <exception cref="ServiceResultException">
+        /// <see cref="StatusCodes.BadConfigurationError"/> when the owning
+        /// manager does not derive from <see cref="FluentNodeManagerBase"/>.
+        /// </exception>
+        public static IVariableBuilder<TValue> PollEvery<TValue>(
+            this IVariableBuilder<TValue> builder,
+            TimeSpan interval,
+            Func<ISystemContext, TValue> sample)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+            if (sample == null)
+            {
+                throw new ArgumentNullException(nameof(sample));
+            }
+            if (interval <= TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(interval),
+                    interval,
+                    "Sampling interval must be positive.");
+            }
+
+            if (builder.Builder is not NodeManagerBuilder concrete ||
+                concrete.Simulations == null)
+            {
+                throw ServiceResultException.Create(
+                    StatusCodes.BadConfigurationError,
+                    "PollEvery requires the node manager to derive from " +
+                    "FluentNodeManagerBase. Manager type '{0}' does not opt in.",
+                    builder.Builder.NodeManager?.GetType().FullName ?? "(unknown)");
+            }
+
+            ISystemContext context = concrete.Context;
+            var updater = new ValueUpdater<TValue>(builder.Node, context);
+            EqualityComparer<TValue> comparer = EqualityComparer<TValue>.Default;
+
+            // Prime the node with the current value so reads and the first
+            // notification start from a meaningful state.
+            TValue last = sample(context);
+            updater.SetValue(last);
+
+            concrete.Simulations
+                .NewSimulation(interval)
+                .OnTick((ctx, _) =>
+                {
+                    TValue current = sample(ctx);
+                    if (!comparer.Equals(current, last))
+                    {
+                        last = current;
+                        updater.SetValue(current);
+                    }
+                });
+
+            return builder;
+        }
+    }
+}

--- a/Libraries/Opc.Ua.Server/Fluent/ValueUpdater.cs
+++ b/Libraries/Opc.Ua.Server/Fluent/ValueUpdater.cs
@@ -1,0 +1,91 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+
+namespace Opc.Ua.Server.Fluent
+{
+    /// <summary>
+    /// Default <see cref="IValueUpdater{TValue}"/> implementation. Closes
+    /// over the resolved <see cref="BaseVariableState"/> and the manager's
+    /// <see cref="ISystemContext"/> captured at <c>Configure</c> time, so it
+    /// remains usable after the builder is sealed.
+    /// </summary>
+    /// <typeparam name="TValue">
+    /// CLR type carried by the variable's <c>Value</c> attribute.
+    /// </typeparam>
+    internal sealed class ValueUpdater<TValue> : IValueUpdater<TValue>
+    {
+        public ValueUpdater(BaseVariableState variable, ISystemContext context)
+        {
+            m_variable = variable ?? throw new ArgumentNullException(nameof(variable));
+            m_context = context ?? throw new ArgumentNullException(nameof(context));
+        }
+
+        /// <inheritdoc/>
+        public void SetValue(TValue value)
+        {
+            SetValue(value, StatusCodes.Good, DateTime.UtcNow);
+        }
+
+        /// <inheritdoc/>
+        public void SetValue(TValue value, StatusCode statusCode)
+        {
+            SetValue(value, statusCode, DateTime.UtcNow);
+        }
+
+        /// <inheritdoc/>
+        public void SetValue(TValue value, StatusCode statusCode, DateTime sourceTimestamp)
+        {
+            lock (m_lock)
+            {
+                m_variable.Value = FluentVariant.ToVariant(value);
+                m_variable.StatusCode = statusCode;
+                m_variable.Timestamp = sourceTimestamp;
+                m_variable.ClearChangeMasks(m_context, includeChildren: false);
+            }
+        }
+
+        /// <inheritdoc/>
+        public void NotifyChange()
+        {
+            lock (m_lock)
+            {
+                // Refreshing the timestamp flags the value change mask so
+                // ClearChangeMasks reports an in-place value mutation.
+                m_variable.Timestamp = DateTime.UtcNow;
+                m_variable.ClearChangeMasks(m_context, includeChildren: false);
+            }
+        }
+
+        private readonly BaseVariableState m_variable;
+        private readonly ISystemContext m_context;
+        private readonly System.Threading.Lock m_lock = new();
+    }
+}

--- a/Libraries/Opc.Ua.Server/Fluent/ValueUpdater.cs
+++ b/Libraries/Opc.Ua.Server/Fluent/ValueUpdater.cs
@@ -77,9 +77,9 @@ namespace Opc.Ua.Server.Fluent
         {
             lock (m_lock)
             {
-                // Refreshing the timestamp flags the value change mask so
-                // ClearChangeMasks reports an in-place value mutation.
-                m_variable.Timestamp = DateTime.UtcNow;
+                // Explicitly flag a value change so the notification fires even
+                // when the value object was mutated in place (no setter ran).
+                m_variable.UpdateChangeMasks(NodeStateChangeMasks.Value);
                 m_variable.ClearChangeMasks(m_context, includeChildren: false);
             }
         }

--- a/Libraries/Opc.Ua.Server/Fluent/VariableBuilder.cs
+++ b/Libraries/Opc.Ua.Server/Fluent/VariableBuilder.cs
@@ -189,30 +189,13 @@ namespace Opc.Ua.Server.Fluent
         }
 
         /// <summary>
-        /// The reflection-based Variant(object) constructor is the only
-        /// generic entry point for an open-ended TValue. AOT users should
-        /// prefer the per-type generated walker (FluentBuilderGenerator) which
-        /// routes through the typed Variant.From overloads instead. The
-        /// suppression is scoped to this single call site so trim/AOT
-        /// analysis still tracks every other path through this assembly.
+        /// Wraps <paramref name="value"/> in a <see cref="Variant"/> via
+        /// the shared <see cref="FluentVariant.ToVariant{TValue}(TValue)"/>
+        /// helper (single AOT/trim suppression site).
         /// </summary>
-        [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage(
-            "Trimming",
-            "IL2026:RequiresUnreferencedCode",
-            Justification = "Generic typed-variable bridge requires the reflection-based Variant(object) constructor.")]
-        [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage(
-            "AOT",
-            "IL3050:RequiresDynamicCode",
-            Justification = "Generic typed-variable bridge requires the reflection-based Variant(object) constructor.")]
         private static Variant ToVariant(TValue value)
         {
-            if (value is null)
-            {
-                return Variant.Null;
-            }
-#pragma warning disable CS0618 // Variant(object) is obsolete on net472
-            return new Variant(value);
-#pragma warning restore CS0618
+            return FluentVariant.ToVariant(value);
         }
     }
 }

--- a/Tests/Opc.Ua.Server.Tests/Fluent/FluentVariantTests.cs
+++ b/Tests/Opc.Ua.Server.Tests/Fluent/FluentVariantTests.cs
@@ -1,0 +1,440 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using NUnit.Framework;
+using Opc.Ua.Server.Fluent;
+
+#nullable enable
+
+namespace Opc.Ua.Server.Tests.Fluent
+{
+    /// <summary>
+    /// Exhaustive coverage for <see cref="FluentVariant.ToVariant{TValue}(TValue)"/>
+    /// — the shared marshalling bridge behind the fluent typed variable
+    /// surface. Verifies every built-in OPC UA Variant type (scalar,
+    /// <see cref="ArrayOf{T}"/> and <see cref="MatrixOf{T}"/>), enumerations,
+    /// null handling, and the unsupported-type failure path all route through
+    /// the same <see cref="IVariantBuilder{T}"/> registration the rest of the
+    /// stack uses.
+    /// </summary>
+    [TestFixture]
+    [Category("Fluent")]
+    [Parallelizable]
+    public class FluentVariantTests
+    {
+        private static readonly Guid s_guid =
+            new("12345678-1234-1234-1234-123456789012");
+
+        /// <summary>
+        /// Asserts that <see cref="FluentVariant.ToVariant{TValue}(TValue)"/>
+        /// produces exactly what the canonical <see cref="IVariantBuilder{T}"/>
+        /// registration on <see cref="VariantBuilder"/> produces for the same
+        /// value.
+        /// </summary>
+        private static void AssertMatchesBuilder<T>(T value)
+        {
+            var builder = (IVariantBuilder<T>)(object)default(VariantBuilder);
+            Variant expected = builder.WithValue(value);
+            Variant actual = FluentVariant.ToVariant(value);
+            Assert.That(
+                actual.TypeInfo.BuiltInType,
+                Is.EqualTo(expected.TypeInfo.BuiltInType));
+            Assert.That(
+                actual.TypeInfo.ValueRank,
+                Is.EqualTo(expected.TypeInfo.ValueRank));
+            Assert.That(actual, Is.EqualTo(expected));
+        }
+
+        private static void AssertArrayMatchesBuilder<T>(params T[] items)
+        {
+            AssertMatchesBuilder<ArrayOf<T>>(items);
+        }
+
+        private static void AssertMatrixMatchesBuilder<T>(T[,] items)
+        {
+            AssertMatchesBuilder(MatrixOf.From<T>(items));
+        }
+
+        [Test]
+        public void ScalarBoolean()
+        {
+            AssertMatchesBuilder(true);
+            AssertMatchesBuilder(false);
+        }
+
+        [Test]
+        public void ScalarSByte()
+        {
+            AssertMatchesBuilder(sbyte.MinValue);
+            AssertMatchesBuilder(sbyte.MaxValue);
+        }
+
+        [Test]
+        public void ScalarByte()
+        {
+            AssertMatchesBuilder(byte.MinValue);
+            AssertMatchesBuilder(byte.MaxValue);
+        }
+
+        [Test]
+        public void ScalarInt16()
+        {
+            AssertMatchesBuilder(short.MinValue);
+            AssertMatchesBuilder(short.MaxValue);
+        }
+
+        [Test]
+        public void ScalarUInt16()
+        {
+            AssertMatchesBuilder(ushort.MinValue);
+            AssertMatchesBuilder(ushort.MaxValue);
+        }
+
+        [Test]
+        public void ScalarInt32()
+        {
+            AssertMatchesBuilder(int.MinValue);
+            AssertMatchesBuilder(int.MaxValue);
+        }
+
+        [Test]
+        public void ScalarUInt32()
+        {
+            AssertMatchesBuilder(uint.MinValue);
+            AssertMatchesBuilder(uint.MaxValue);
+        }
+
+        [Test]
+        public void ScalarInt64()
+        {
+            AssertMatchesBuilder(long.MinValue);
+            AssertMatchesBuilder(long.MaxValue);
+        }
+
+        [Test]
+        public void ScalarUInt64()
+        {
+            AssertMatchesBuilder(ulong.MinValue);
+            AssertMatchesBuilder(ulong.MaxValue);
+        }
+
+        [Test]
+        public void ScalarFloat()
+        {
+            AssertMatchesBuilder(3.14f);
+            AssertMatchesBuilder(float.MinValue);
+            AssertMatchesBuilder(float.MaxValue);
+        }
+
+        [Test]
+        public void ScalarDouble()
+        {
+            AssertMatchesBuilder(3.14159);
+            AssertMatchesBuilder(double.MinValue);
+            AssertMatchesBuilder(double.MaxValue);
+        }
+
+        [Test]
+        public void ScalarString()
+        {
+            AssertMatchesBuilder("hello");
+            AssertMatchesBuilder(string.Empty);
+        }
+
+        [Test]
+        public void ScalarDateTimeUtc()
+        {
+            AssertMatchesBuilder(new DateTimeUtc(2024, 6, 15, 12, 30, 0));
+        }
+
+        [Test]
+        public void ScalarUuid()
+        {
+            AssertMatchesBuilder(new Uuid(s_guid));
+        }
+
+        [Test]
+        public void ScalarByteString()
+        {
+            AssertMatchesBuilder(ByteString.From(new byte[] { 1, 2, 3 }));
+        }
+
+        [Test]
+        public void ScalarXmlElement()
+        {
+            AssertMatchesBuilder(XmlElement.From("<test>value</test>"));
+        }
+
+        [Test]
+        public void ScalarNodeId()
+        {
+            AssertMatchesBuilder(new NodeId(42));
+        }
+
+        [Test]
+        public void ScalarExpandedNodeId()
+        {
+            AssertMatchesBuilder(new ExpandedNodeId(42));
+        }
+
+        [Test]
+        public void ScalarStatusCode()
+        {
+            AssertMatchesBuilder(StatusCodes.BadNoData);
+        }
+
+        [Test]
+        public void ScalarQualifiedName()
+        {
+            AssertMatchesBuilder(new QualifiedName("test", 2));
+        }
+
+        [Test]
+        public void ScalarLocalizedText()
+        {
+            AssertMatchesBuilder(new LocalizedText("en", "text"));
+        }
+
+        [Test]
+        public void ScalarExtensionObject()
+        {
+            AssertMatchesBuilder(ExtensionObject.Null);
+        }
+
+        [Test]
+        public void ScalarDataValue()
+        {
+            AssertMatchesBuilder(new DataValue(Variant.From(42)));
+        }
+
+        [Test]
+        public void ArrayBoolean()
+        {
+            AssertArrayMatchesBuilder(true, false, true);
+        }
+
+        [Test]
+        public void ArraySByte()
+        {
+            AssertArrayMatchesBuilder<sbyte>(-1, 0, 1);
+        }
+
+        [Test]
+        public void ArrayByte()
+        {
+            AssertArrayMatchesBuilder<byte>(0, 1, 255);
+        }
+
+        [Test]
+        public void ArrayInt16()
+        {
+            AssertArrayMatchesBuilder<short>(-1, 0, 1);
+        }
+
+        [Test]
+        public void ArrayUInt16()
+        {
+            AssertArrayMatchesBuilder<ushort>(0, 1, 2);
+        }
+
+        [Test]
+        public void ArrayInt32()
+        {
+            AssertArrayMatchesBuilder(1, 2, 3);
+        }
+
+        [Test]
+        public void ArrayUInt32()
+        {
+            AssertArrayMatchesBuilder(1u, 2u, 3u);
+        }
+
+        [Test]
+        public void ArrayInt64()
+        {
+            AssertArrayMatchesBuilder(1L, 2L, 3L);
+        }
+
+        [Test]
+        public void ArrayUInt64()
+        {
+            AssertArrayMatchesBuilder(1uL, 2uL, 3uL);
+        }
+
+        [Test]
+        public void ArrayFloat()
+        {
+            AssertArrayMatchesBuilder(1.5f, 2.5f);
+        }
+
+        [Test]
+        public void ArrayDouble()
+        {
+            AssertArrayMatchesBuilder(1.5, 2.5);
+        }
+
+        [Test]
+        public void ArrayString()
+        {
+            AssertArrayMatchesBuilder("a", "b");
+        }
+
+        [Test]
+        public void ArrayDateTimeUtc()
+        {
+            AssertArrayMatchesBuilder(
+                new DateTimeUtc(2024, 1, 1, 0, 0, 0),
+                new DateTimeUtc(2024, 6, 15, 12, 30, 0));
+        }
+
+        [Test]
+        public void ArrayUuid()
+        {
+            AssertArrayMatchesBuilder(new Uuid(s_guid));
+        }
+
+        [Test]
+        public void ArrayByteString()
+        {
+            AssertArrayMatchesBuilder(ByteString.From(new byte[] { 1, 2 }));
+        }
+
+        [Test]
+        public void ArrayXmlElement()
+        {
+            AssertArrayMatchesBuilder(XmlElement.From("<a/>"));
+        }
+
+        [Test]
+        public void ArrayNodeId()
+        {
+            AssertArrayMatchesBuilder(new NodeId(1), new NodeId(2));
+        }
+
+        [Test]
+        public void ArrayExpandedNodeId()
+        {
+            AssertArrayMatchesBuilder(new ExpandedNodeId(1));
+        }
+
+        [Test]
+        public void ArrayStatusCode()
+        {
+            AssertArrayMatchesBuilder(StatusCodes.Good);
+        }
+
+        [Test]
+        public void ArrayQualifiedName()
+        {
+            AssertArrayMatchesBuilder(new QualifiedName("a", 2));
+        }
+
+        [Test]
+        public void ArrayLocalizedText()
+        {
+            AssertArrayMatchesBuilder(new LocalizedText("en", "a"));
+        }
+
+        [Test]
+        public void ArrayExtensionObject()
+        {
+            AssertArrayMatchesBuilder(ExtensionObject.Null);
+        }
+
+        [Test]
+        public void ArrayDataValue()
+        {
+            AssertArrayMatchesBuilder(new DataValue(Variant.From(1)));
+        }
+
+        [Test]
+        public void ArrayVariant()
+        {
+            AssertArrayMatchesBuilder(Variant.From(1), Variant.From("a"));
+        }
+
+        [Test]
+        public void MatrixInt32()
+        {
+            AssertMatrixMatchesBuilder(new[,] { { 1, 2 }, { 3, 4 } });
+        }
+
+        [Test]
+        public void MatrixDouble()
+        {
+            AssertMatrixMatchesBuilder(new[,] { { 1.0, 2.0 }, { 3.0, 4.0 } });
+        }
+
+        [Test]
+        public void MatrixString()
+        {
+            AssertMatrixMatchesBuilder(new[,] { { "a", "b" }, { "c", "d" } });
+        }
+
+        [Test]
+        public void MatrixBoolean()
+        {
+            AssertMatrixMatchesBuilder(new[,] { { true, false }, { false, true } });
+        }
+
+        [Test]
+        public void EnumMapsToInt32WireValue()
+        {
+            Variant v = FluentVariant.ToVariant(TestEnum.Second);
+            Assert.That(v, Is.EqualTo(Variant.From(TestEnum.Second)));
+        }
+
+        [Test]
+        public void NullReferenceValueBecomesVariantNull()
+        {
+            Variant v = FluentVariant.ToVariant<string>(null!);
+            Assert.That(v, Is.EqualTo(Variant.Null));
+        }
+
+        [Test]
+        public void UnsupportedTypeThrowsBadNotSupported()
+        {
+            ServiceResultException ex = Assert.Throws<ServiceResultException>(
+                () => FluentVariant.ToVariant(new UnsupportedType()))!;
+            Assert.That(
+                ex.StatusCode, Is.EqualTo((uint)StatusCodes.BadNotSupported));
+        }
+
+        private enum TestEnum
+        {
+            First = 0,
+            Second = 5
+        }
+
+        private sealed class UnsupportedType
+        {
+        }
+    }
+}

--- a/Tests/Opc.Ua.Server.Tests/Fluent/RuntimeValueBuilderExtensionsTests.cs
+++ b/Tests/Opc.Ua.Server.Tests/Fluent/RuntimeValueBuilderExtensionsTests.cs
@@ -1,0 +1,327 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using NUnit.Framework;
+using Opc.Ua.Server.Fluent;
+
+#nullable enable
+#pragma warning disable CA2000
+
+namespace Opc.Ua.Server.Tests.Fluent
+{
+    /// <summary>
+    /// Tests for <see cref="RuntimeValueBuilderExtensions"/> and
+    /// <see cref="IValueUpdater{TValue}"/> — the runtime value-update surface
+    /// that pushes changes to subscribed MonitoredItems after the fluent
+    /// builder is sealed (issue #3973).
+    /// </summary>
+    [TestFixture]
+    [Category("Fluent")]
+    public class RuntimeValueBuilderExtensionsTests
+    {
+        private const ushort kNs = 2;
+
+        [Test]
+        public void BindThrowsOnNullBuilder()
+        {
+            Assert.Throws<ArgumentNullException>(
+                () => RuntimeValueBuilderExtensions.Bind<double>(
+                    null!, out _));
+        }
+
+        [Test]
+        public void BindSetValueUpdatesNodeAndRaisesValueChange()
+        {
+            using var h = RuntimeHarness.Create();
+            IVariableBuilder<double> vb = h.Builder.Variable<double>(h.VariableId);
+            vb.Bind(out IValueUpdater<double> updater);
+
+            Func<int> notifications = CountValueChanges(h.Variable);
+
+            updater.SetValue(42.5);
+
+            Assert.That(
+                h.Variable.WrappedValue.TryGetValue(out double stored), Is.True);
+            Assert.That(stored, Is.EqualTo(42.5));
+            Assert.That(
+                (uint)h.Variable.StatusCode.Code,
+                Is.EqualTo((uint)StatusCodes.Good));
+            Assert.That(notifications(), Is.GreaterThanOrEqualTo(1));
+        }
+
+        [Test]
+        public void SetValueAppliesStatusCodeAndTimestamp()
+        {
+            using var h = RuntimeHarness.Create();
+            IVariableBuilder<double> vb = h.Builder.Variable<double>(h.VariableId);
+            vb.Bind(out IValueUpdater<double> updater);
+
+            var timestamp = new DateTime(2030, 1, 2, 3, 4, 5, DateTimeKind.Utc);
+            updater.SetValue(7.0, StatusCodes.BadNoData, timestamp);
+
+            Assert.That(
+                (uint)h.Variable.StatusCode.Code,
+                Is.EqualTo((uint)StatusCodes.BadNoData));
+            Assert.That(
+                ((DateTime)h.Variable.Timestamp).ToUniversalTime(),
+                Is.EqualTo(timestamp));
+        }
+
+        [Test]
+        public void NotifyChangeRaisesValueChangeWithoutMutatingValue()
+        {
+            using var h = RuntimeHarness.Create();
+            IVariableBuilder<double> vb = h.Builder.Variable<double>(h.VariableId);
+            vb.Bind(out IValueUpdater<double> updater);
+            updater.SetValue(11.0);
+
+            Func<int> notifications = CountValueChanges(h.Variable);
+            updater.NotifyChange();
+
+            Assert.That(h.Variable.WrappedValue.TryGetValue(out double stored), Is.True);
+            Assert.That(stored, Is.EqualTo(11.0));
+            Assert.That(notifications(), Is.GreaterThanOrEqualTo(1));
+        }
+
+        [Test]
+        public void PollEveryThrowsWhenManagerIsNotFluent()
+        {
+            using var h = RuntimeHarness.CreateWithoutFluentBase();
+            IVariableBuilder<double> vb = h.Builder.Variable<double>(h.VariableId);
+
+            ServiceResultException ex = Assert.Throws<ServiceResultException>(
+                () => vb.PollEvery(TimeSpan.FromMilliseconds(25), () => 1.0))!;
+            Assert.That(
+                ex.StatusCode, Is.EqualTo((uint)StatusCodes.BadConfigurationError));
+        }
+
+        [Test]
+        public void PollEveryValidatesArguments()
+        {
+            using var h = RuntimeHarness.Create();
+            IVariableBuilder<double> vb = h.Builder.Variable<double>(h.VariableId);
+
+            Assert.Throws<ArgumentNullException>(
+                () => vb.PollEvery(TimeSpan.FromMilliseconds(25), (Func<double>)null!));
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => vb.PollEvery(TimeSpan.Zero, () => 1.0));
+        }
+
+        [Test]
+        public void PollEveryPrimesInitialValueImmediately()
+        {
+            using var h = RuntimeHarness.Create();
+            h.Builder.Variable<double>(h.VariableId)
+                .PollEvery(TimeSpan.FromMilliseconds(25), () => 3.25);
+
+            Assert.That(h.Variable.WrappedValue.TryGetValue(out double stored), Is.True);
+            Assert.That(stored, Is.EqualTo(3.25));
+        }
+
+        [Test]
+        public async Task PollEveryPushesChangesToSubscribers()
+        {
+            using var h = RuntimeHarness.Create();
+            double current = 1.0;
+            h.Builder.Variable<double>(h.VariableId)
+                .PollEvery(TimeSpan.FromMilliseconds(25), () => Volatile.Read(ref current));
+
+            Func<int> notifications = CountValueChanges(h.Variable);
+            h.Builder.Seal();
+
+            Volatile.Write(ref current, 2.0);
+
+            await WaitForAsync(
+                () => h.Variable.WrappedValue.TryGetValue(out double d) && d == 2.0,
+                "Sampled value change should update the node.")
+                .ConfigureAwait(false);
+            Assert.That(
+                notifications(),
+                Is.GreaterThanOrEqualTo(1),
+                "A change notification should reach subscribed MonitoredItems.");
+        }
+
+        [Test]
+        public async Task PollEveryDoesNotNotifyWhenValueUnchanged()
+        {
+            using var h = RuntimeHarness.Create();
+            h.Builder.Variable<double>(h.VariableId)
+                .PollEvery(TimeSpan.FromMilliseconds(25), () => 5.0);
+
+            Func<int> notifications = CountValueChanges(h.Variable);
+            h.Builder.Seal();
+
+            // Let several ticks elapse; the constant getter must not raise
+            // repeated value-change notifications.
+            await Task.Delay(150).ConfigureAwait(false);
+            Assert.That(notifications(), Is.Zero);
+        }
+
+        private static Func<int> CountValueChanges(BaseVariableState variable)
+        {
+            var box = new StrongBox<int>(0);
+            NodeStateChangedHandler? previous = variable.OnStateChanged;
+            variable.OnStateChanged = (ctx, node, mask) =>
+            {
+                previous?.Invoke(ctx, node, mask);
+                if ((mask & NodeStateChangeMasks.Value) != 0)
+                {
+                    Interlocked.Increment(ref box.Value);
+                }
+            };
+            return () => Volatile.Read(ref box.Value);
+        }
+
+        private static async Task WaitForAsync(
+            Func<bool> condition,
+            string? message = null,
+            int timeoutMs = 5000)
+        {
+            DateTime end = DateTime.UtcNow + TimeSpan.FromMilliseconds(timeoutMs);
+            while (!condition())
+            {
+                if (DateTime.UtcNow > end)
+                {
+                    Assert.Fail(
+                        message ?? $"Condition not satisfied within {timeoutMs}ms.");
+                }
+                await Task.Delay(10).ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
+        /// Test harness with a resolvable <see cref="BaseDataVariableState{T}"/>
+        /// and (optionally) a <see cref="FluentNodeManagerBase"/> owner so the
+        /// <c>PollEvery</c> sampling loop has a simulation registry to attach to.
+        /// </summary>
+        private sealed class RuntimeHarness : IDisposable
+        {
+            internal NodeManagerBuilder Builder { get; private set; } = null!;
+            internal BaseDataVariableState<double> Variable { get; private set; } = null!;
+            internal NodeId VariableId { get; private set; }
+
+            private TestFluentManager? m_manager;
+
+            internal static RuntimeHarness Create()
+            {
+                var harness = new RuntimeHarness
+                {
+                    m_manager = new TestFluentManager()
+                };
+                ServerSystemContext ctx = harness.m_manager.SystemContext;
+                harness.BuildVariable();
+                harness.Builder = harness.CreateBuilder(ctx, harness.m_manager);
+                harness.m_manager.AttachToBuilder(harness.Builder);
+                return harness;
+            }
+
+            internal static RuntimeHarness CreateWithoutFluentBase()
+            {
+                var harness = new RuntimeHarness();
+                var ctx = new SystemContext(telemetry: null!)
+                {
+                    NamespaceUris = CreateNamespaceTable()
+                };
+                harness.BuildVariable();
+                harness.Builder = harness.CreateBuilder(ctx, Mock.Of<IAsyncNodeManager>());
+                return harness;
+            }
+
+            private NodeManagerBuilder CreateBuilder(
+                ISystemContext ctx, IAsyncNodeManager manager)
+            {
+                var byId = new Dictionary<NodeId, NodeState> { [Variable.NodeId] = Variable };
+                return new NodeManagerBuilder(
+                    ctx,
+                    manager,
+                    defaultNamespaceIndex: kNs,
+                    rootResolver: _ => null!,
+                    nodeIdResolver: id => byId.TryGetValue(id, out NodeState? n) ? n! : null!,
+                    typeIdResolver: _ => []);
+            }
+
+            private void BuildVariable()
+            {
+                var variable = BaseDataVariableState<double>.With<VariantBuilder>(parent: null!);
+                variable.NodeId = new NodeId("Root.Value", kNs);
+                variable.BrowseName = new QualifiedName("Value", kNs);
+                variable.DisplayName = new LocalizedText("Value");
+                variable.DataType = DataTypeIds.Double;
+                variable.ValueRank = ValueRanks.Scalar;
+                variable.Value = 0.0;
+                Variable = variable;
+                VariableId = variable.NodeId;
+            }
+
+            public void Dispose()
+            {
+                m_manager?.Dispose();
+                m_manager = null;
+            }
+        }
+
+        private static NamespaceTable CreateNamespaceTable()
+        {
+            var ns = new NamespaceTable();
+            ns.Append(Ua.Namespaces.OpcUa);
+            return ns;
+        }
+
+        private sealed class TestFluentManager : FluentNodeManagerBase
+        {
+            public TestFluentManager()
+                : base(CreateMockServer(), TestNamespaceUri)
+            {
+            }
+
+            private const string TestNamespaceUri = "urn:test:runtime-value";
+
+            private static IServerInternal CreateMockServer()
+            {
+                NamespaceTable ns = CreateNamespaceTable();
+
+                var mockTelemetry = new Mock<ITelemetryContext>();
+                var mock = new Mock<IServerInternal>();
+                mock.SetupGet(m => m.NamespaceUris).Returns(ns);
+                mock.SetupGet(m => m.Telemetry).Returns(mockTelemetry.Object);
+                IServiceMessageContext msgCtx = ServiceMessageContext.Create(mockTelemetry.Object);
+                mock.SetupGet(m => m.MessageContext).Returns(msgCtx);
+                mock.SetupGet(m => m.DefaultSystemContext).Returns(
+                    new ServerSystemContext(mock.Object));
+                return mock.Object;
+            }
+        }
+    }
+}

--- a/Tests/Opc.Ua.SourceGeneration.Core.Tests/Generators/FluentBuilderGeneratorTests.cs
+++ b/Tests/Opc.Ua.SourceGeneration.Core.Tests/Generators/FluentBuilderGeneratorTests.cs
@@ -29,11 +29,15 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Xml;
 using Microsoft.Extensions.Logging;
+using Moq;
 using NUnit.Framework;
+using Opc.Ua.Schema.Model;
 using Opc.Ua.Tests;
 
 namespace Opc.Ua.SourceGeneration.Generator.Tests
@@ -289,6 +293,49 @@ namespace Opc.Ua.SourceGeneration.Generator.Tests
         }
 
         [Test]
+        public void DeclarationBackedInputOnlyMethodEmitsTypedOnCallOverloads()
+        {
+            string fb = GenerateForDeclarationBackedModel();
+            const string methodWrapper = @"(?s)internal\s+sealed\s+class\s+AdjustMethodBuilder\b.*?";
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(fb, Does.Match(
+                    methodWrapper +
+                    @"public\s+AdjustMethodBuilder\s+OnCall\s*\(" +
+                    @"\s*global::System\.Action<float>\s+handler\s*\)"),
+                    "The declaration-backed Adjust method should expose OnCall(Action<float>).");
+                Assert.That(fb, Does.Match(
+                    methodWrapper +
+                    @"public\s+AdjustMethodBuilder\s+OnCall\s*\(" +
+                    @"\s*global::System\.Func<float,\s*" +
+                    @"global::System\.Threading\.CancellationToken,\s*" +
+                    @"global::System\.Threading\.Tasks\.ValueTask>\s+handler\s*\)"),
+                    "The declaration-backed Adjust method should expose the async input-only OnCall overload.");
+                Assert.That(fb, Does.Match(
+                    methodWrapper +
+                    @"if\s*\(!__inputs\[0\]\.TryGetValue\(out\s+float\s+__a0\)\)"),
+                    "Generated dispatch should unpack the declaration-backed Float input from the Variant list.");
+                Assert.That(fb, Does.Match(
+                    methodWrapper + @"handler\(__a0\);"),
+                    "Generated dispatch should pass the unpacked Float value to the sync handler.");
+            });
+        }
+
+        [Test]
+        public void DeclarationBackedNodeSetFixtureCarriesDeclarationInputArgument()
+        {
+            Dictionary<string, string> files = GenerateForDeclarationBackedNodeSet();
+            string values = files.Single(kv => kv.Key.EndsWith(".NodeStates.i.g.cs", StringComparison.Ordinal)).Value;
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(values, Does.Contain("AdjustDeclaration_InputArguments"));
+                Assert.That(values, Does.Contain("<uax:Name>setpoint</uax:Name>"));
+            });
+        }
+
+        [Test]
         public void EmittedNodeManager_InvokesBothPlainAndTypedConfigurePartials()
         {
             Dictionary<string, string> files = GenerateForTestModel(generateNodeManager: true);
@@ -495,6 +542,133 @@ namespace Opc.Ua.SourceGeneration.Generator.Tests
             return fileSystem.CreatedFiles
                 .Where(c => Path.GetExtension(c) == ".cs")
                 .ToDictionary(c => c, c => Encoding.UTF8.GetString(fileSystem.Get(c)));
+        }
+
+        private static Dictionary<string, string> GenerateForDeclarationBackedNodeSet()
+        {
+            const string nodeSetFile = "DeclarationBackedMethod.NodeSet2.xml";
+            const string namespaceUri = "http://test.org/UA/DeclarationBackedMethod/";
+            ITelemetryContext telemetry = NUnitTelemetryContext.Create(logLevel: LogLevel.Error);
+            using var fileSystem = new VirtualFileSystem();
+            string resources = Path.Combine(Directory.GetCurrentDirectory(), "Resources");
+            string path = Path.Combine(resources, nodeSetFile);
+
+            var nodesets = new NodesetFileCollection(
+                ImmutableArray.Create(
+                    (path, new NodesetFileOptions
+                    {
+                        ModelUri = namespaceUri,
+                        Name = "DeclarationBackedMethod",
+                        Prefix = "DeclarationBackedMethod"
+                    })),
+                fileSystem,
+                telemetry);
+
+            nodesets.GenerateCode(
+                fileSystem,
+                string.Empty,
+                telemetry,
+                new GeneratorOptions
+                {
+                    OmitFluentApi = false
+                },
+                nodeManagerBindings:
+                [
+                    new NodeManagerAttributeBinding
+                    {
+                        NamespaceUri = namespaceUri,
+                        TargetNamespace = "DeclarationBackedMethod",
+                        TargetClassName = "DeclarationBackedMethodNodeManager",
+                        GenerateFactory = false
+                    }
+                ]);
+
+            return fileSystem.CreatedFiles
+                .Where(c => Path.GetExtension(c) == ".cs")
+                .ToDictionary(c => c, c => Encoding.UTF8.GetString(fileSystem.Get(c)));
+        }
+
+        private static string GenerateForDeclarationBackedModel()
+        {
+            const string namespaceUri = "http://test.org/UA/DeclarationBackedMethod/";
+            var targetNamespace = new Namespace
+            {
+                Value = namespaceUri,
+                Prefix = "DeclarationBackedMethod",
+                Name = "DeclarationBackedMethod"
+            };
+            var floatType = new DataTypeDesign
+            {
+                SymbolicName = new XmlQualifiedName("Float", "http://opcfoundation.org/UA/"),
+                SymbolicId = new XmlQualifiedName("Float", "http://opcfoundation.org/UA/"),
+                BasicDataType = BasicDataType.Float
+            };
+            var declaration = new MethodDesign
+            {
+                SymbolicName = new XmlQualifiedName("AdjustDeclaration", namespaceUri),
+                SymbolicId = new XmlQualifiedName("AdjustDeclaration", namespaceUri),
+                InputArguments =
+                [
+                    new Parameter
+                    {
+                        Name = "setpoint",
+                        DataTypeNode = floatType,
+                        DataType = floatType.SymbolicId,
+                        ValueRank = ValueRank.Scalar
+                    }
+                ],
+                OutputArguments = []
+            };
+            var method = new MethodDesign
+            {
+                SymbolicName = new XmlQualifiedName("Adjust", namespaceUri),
+                SymbolicId = new XmlQualifiedName("Device_Adjust", namespaceUri),
+                InputArguments = [],
+                OutputArguments = [],
+                MethodDeclarationNode = declaration
+            };
+            var root = new ObjectDesign
+            {
+                SymbolicName = new XmlQualifiedName("Device", namespaceUri),
+                SymbolicId = new XmlQualifiedName("Device", namespaceUri)
+            };
+            root.Hierarchy = new Hierarchy();
+            root.Hierarchy.Nodes[string.Empty] = new HierarchyNode
+            {
+                RelativePath = string.Empty,
+                Instance = root
+            };
+            root.Hierarchy.Nodes["Adjust"] = new HierarchyNode
+            {
+                RelativePath = "Adjust",
+                Instance = method
+            };
+
+            var model = new Mock<IModelDesign>();
+            model.Setup(m => m.TargetNamespace).Returns(targetNamespace);
+            model.Setup(m => m.Namespaces).Returns([targetNamespace]);
+            model.Setup(m => m.GetNodeDesigns()).Returns([root, declaration]);
+            model.Setup(m => m.IsExcluded(It.IsAny<NodeDesign>())).Returns(false);
+
+            using var fileSystem = new VirtualFileSystem();
+            var context = new GeneratorContext
+            {
+                FileSystem = fileSystem,
+                OutputFolder = string.Empty,
+                ModelDesign = model.Object,
+                Telemetry = NUnitTelemetryContext.Create(logLevel: LogLevel.Error),
+                Options = new GeneratorOptions()
+            };
+            new FluentBuilderGenerator(context)
+            {
+                GenerateManagerWrappers = true,
+                EmitFluentAccessors = false
+            }.Emit();
+
+            return fileSystem.CreatedFiles
+                .Where(c => c.EndsWith(".FluentBuilders.g.cs", StringComparison.Ordinal))
+                .Select(c => Encoding.UTF8.GetString(fileSystem.Get(c)))
+                .Single();
         }
     }
 }

--- a/Tests/Opc.Ua.SourceGeneration.Core.Tests/Generators/ObjectTypeProxyGeneratorTests.cs
+++ b/Tests/Opc.Ua.SourceGeneration.Core.Tests/Generators/ObjectTypeProxyGeneratorTests.cs
@@ -403,6 +403,37 @@ namespace Opc.Ua.SourceGeneration.Generator.Tests
         }
 
         [Test]
+        public void EmitMethodWithDeclarationBackedInputUsesDeclarationArguments()
+        {
+            MethodDesign declaration = CreateMethod(
+                "AdjustDeclaration",
+                inputs:
+                [
+                    CreateParameter("setpoint", BasicDataType.Float)
+                ]);
+            MethodDesign method = CreateMethod("Adjust");
+            method.MethodDeclarationNode = declaration;
+            ObjectTypeDesign objectType = CreateObjectType("ControllerType", method);
+            m_mockModelDesign.Setup(m => m.GetNodeDesigns()).Returns([objectType]);
+
+            using var stream = new MemoryStream();
+            m_mockFileSystem
+                .Setup(fs => fs.OpenWrite(It.IsAny<string>()))
+                .Returns(stream);
+
+            new ObjectTypeProxyGenerator(CreateContext()).Emit();
+            string content = Encoding.UTF8.GetString(stream.ToArray());
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(content, Does.Contain(
+                    "public async global::System.Threading.Tasks.ValueTask AdjustAsync("));
+                Assert.That(content, Does.Contain("float setpoint"));
+                Assert.That(content, Does.Contain("global::Opc.Ua.Variant.From(setpoint)"));
+            });
+        }
+
+        [Test]
         public void Emit_RootObjectType_DerivesFromObjectTypeClient()
         {
             // An ObjectType with no parent (BaseTypeNode == null) inherits

--- a/Tests/Opc.Ua.SourceGeneration.Core.Tests/Resources/DeclarationBackedMethod.NodeSet2.xml
+++ b/Tests/Opc.Ua.SourceGeneration.Core.Tests/Resources/DeclarationBackedMethod.NodeSet2.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+ * Regression fixture for issue #3973.
+ *
+ * The concrete Device instance contains an Adjust method whose
+ * MethodDeclarationId points at the shared AdjustDeclaration method. The instance
+ * method intentionally has no InputArguments property; its single Float input
+ * is only present on the method declaration node.
+ -->
+<UANodeSet xmlns:uax="http://opcfoundation.org/UA/2008/02/Types.xsd"
+           xmlns="http://opcfoundation.org/UA/2011/03/UANodeSet.xsd">
+  <NamespaceUris>
+    <Uri>http://test.org/UA/DeclarationBackedMethod/</Uri>
+  </NamespaceUris>
+  <Models>
+    <Model ModelUri="http://test.org/UA/DeclarationBackedMethod/"
+           PublicationDate="2024-01-01T00:00:00Z"
+           Version="1.0.0">
+      <RequiredModel ModelUri="http://opcfoundation.org/UA/" PublicationDate="2024-01-01T00:00:00Z" Version="1.05.03"/>
+    </Model>
+  </Models>
+  <Aliases>
+    <Alias Alias="Float">i=10</Alias>
+    <Alias Alias="HasComponent">i=47</Alias>
+    <Alias Alias="HasProperty">i=46</Alias>
+    <Alias Alias="HasSubtype">i=45</Alias>
+    <Alias Alias="HasTypeDefinition">i=40</Alias>
+    <Alias Alias="HasModellingRule">i=37</Alias>
+    <Alias Alias="Organizes">i=35</Alias>
+  </Aliases>
+
+  <UAObjectType NodeId="ns=1;i=1000" BrowseName="1:ControllerType">
+    <DisplayName>ControllerType</DisplayName>
+    <References>
+      <Reference ReferenceType="HasSubtype" IsForward="false">i=58</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=1003</Reference>
+    </References>
+  </UAObjectType>
+
+  <UAVariable NodeId="ns=1;i=1002"
+              BrowseName="InputArguments"
+              ParentNodeId="ns=1;i=1001"
+              DataType="i=296"
+              ValueRank="1"
+              ArrayDimensions="1">
+    <DisplayName>InputArguments</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=1001</Reference>
+    </References>
+    <Value>
+      <uax:ListOfExtensionObject>
+        <uax:ExtensionObject>
+          <uax:TypeId>
+            <uax:Identifier>i=297</uax:Identifier>
+          </uax:TypeId>
+          <uax:Body>
+            <uax:Argument>
+              <uax:Name>setpoint</uax:Name>
+              <uax:DataType>
+                <uax:Identifier>i=10</uax:Identifier>
+              </uax:DataType>
+              <uax:ValueRank>-1</uax:ValueRank>
+              <uax:ArrayDimensions />
+              <uax:Description />
+            </uax:Argument>
+          </uax:Body>
+        </uax:ExtensionObject>
+      </uax:ListOfExtensionObject>
+    </Value>
+  </UAVariable>
+
+  <UAMethod NodeId="ns=1;i=1001" BrowseName="1:AdjustDeclaration">
+    <DisplayName>AdjustDeclaration</DisplayName>
+    <References>
+      <Reference ReferenceType="HasProperty">ns=1;i=1002</Reference>
+    </References>
+  </UAMethod>
+
+  <UAMethod NodeId="ns=1;i=1003"
+            BrowseName="1:Adjust"
+            ParentNodeId="ns=1;i=1000"
+            MethodDeclarationId="ns=1;i=1001">
+    <DisplayName>Adjust</DisplayName>
+    <References>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=1000</Reference>
+    </References>
+  </UAMethod>
+
+  <UAObject NodeId="ns=1;i=2000" BrowseName="1:Device" ParentNodeId="i=85">
+    <DisplayName>Device</DisplayName>
+    <References>
+      <Reference ReferenceType="Organizes" IsForward="false">i=85</Reference>
+      <Reference ReferenceType="HasTypeDefinition">ns=1;i=1000</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=2001</Reference>
+    </References>
+  </UAObject>
+
+  <UAMethod NodeId="ns=1;i=2001" BrowseName="1:Adjust" ParentNodeId="ns=1;i=2000" MethodDeclarationId="ns=1;i=1001">
+    <DisplayName>Adjust</DisplayName>
+    <References>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=2000</Reference>
+    </References>
+  </UAMethod>
+</UANodeSet>

--- a/Tools/Opc.Ua.SourceGeneration.Core/Generators/FluentBuilderGenerator.cs
+++ b/Tools/Opc.Ua.SourceGeneration.Core/Generators/FluentBuilderGenerator.cs
@@ -475,8 +475,8 @@ namespace Opc.Ua.SourceGeneration
                 ClassName = className,
                 LeafName = leafName,
                 ParentKey = parentKey,
-                Inputs = method.InputArguments ?? [],
-                Outputs = method.OutputArguments ?? []
+                Inputs = MethodDesignArgumentResolver.ResolveMethodInputs(method),
+                Outputs = MethodDesignArgumentResolver.ResolveMethodOutputs(method)
             };
         }
 

--- a/Tools/Opc.Ua.SourceGeneration.Core/Generators/MethodDesignArgumentResolver.cs
+++ b/Tools/Opc.Ua.SourceGeneration.Core/Generators/MethodDesignArgumentResolver.cs
@@ -1,0 +1,95 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using Opc.Ua.Schema.Model;
+
+namespace Opc.Ua.SourceGeneration
+{
+    /// <summary>
+    /// Resolves the effective method argument metadata used by generators.
+    /// </summary>
+    internal static class MethodDesignArgumentResolver
+    {
+        /// <summary>
+        /// Resolves the effective input arguments for a method design.
+        /// </summary>
+        public static Parameter[] ResolveMethodInputs(MethodDesign method)
+        {
+            if (method == null)
+            {
+                throw new ArgumentNullException(nameof(method));
+            }
+
+            return ResolveArguments(
+                method.InputArguments,
+                method.MethodDeclarationNode?.InputArguments,
+                method.MethodType?.InputArguments);
+        }
+
+        /// <summary>
+        /// Resolves the effective output arguments for a method design.
+        /// </summary>
+        public static Parameter[] ResolveMethodOutputs(MethodDesign method)
+        {
+            if (method == null)
+            {
+                throw new ArgumentNullException(nameof(method));
+            }
+
+            return ResolveArguments(
+                method.OutputArguments,
+                method.MethodDeclarationNode?.OutputArguments,
+                method.MethodType?.OutputArguments);
+        }
+
+        private static Parameter[] ResolveArguments(
+            Parameter[] methodArguments,
+            Parameter[] declarationArguments,
+            Parameter[] methodTypeArguments)
+        {
+            if (methodArguments is { Length: > 0 })
+            {
+                return methodArguments;
+            }
+
+            if (declarationArguments is { Length: > 0 })
+            {
+                return declarationArguments;
+            }
+
+            if (methodTypeArguments is { Length: > 0 })
+            {
+                return methodTypeArguments;
+            }
+
+            return [];
+        }
+    }
+}

--- a/Tools/Opc.Ua.SourceGeneration.Core/Generators/ObjectTypeProxyGenerator.cs
+++ b/Tools/Opc.Ua.SourceGeneration.Core/Generators/ObjectTypeProxyGenerator.cs
@@ -524,8 +524,8 @@ namespace Opc.Ua.SourceGeneration
             Namespace[] namespaces = m_context.ModelDesign.Namespaces;
 
             string methodName = method.SymbolicName.Name;
-            Parameter[] inputs = method.InputArguments ?? [];
-            Parameter[] outputs = method.OutputArguments ?? [];
+            Parameter[] inputs = MethodDesignArgumentResolver.ResolveMethodInputs(method);
+            Parameter[] outputs = MethodDesignArgumentResolver.ResolveMethodOutputs(method);
 
             string methodIdConstant = CoreUtils.Format(
                 "global::{0}.MethodIds.{1}",


### PR DESCRIPTION
# Description

Fixes two gaps in the fluent, source-generated NodeManager `Configure` surface reported in #3973.

## 1. Typed `OnCall` overloads for imported / void-returning methods

The documented form `builder.X.SetOutputVal.OnCall((float v) => …)` failed to compile with **CS1593 "Delegate 'Action' does not take 1 arguments"**. The Fluent and ObjectType-proxy generators read `MethodDesign.InputArguments` / `OutputArguments` directly, with no fallback. For **NodeSet2-imported instance methods**, the arguments live only on the referenced method declaration (`MethodDeclarationNode` / `MethodType`), so the generator saw zero inputs and emitted only `OnCall(System.Action)`.

- Added `Tools/Opc.Ua.SourceGeneration.Core/Generators/MethodDesignArgumentResolver.cs` — resolves the effective input/output `Parameter[]` with a fallback to `MethodDeclarationNode` → `MethodType`.
- Wired it into `FluentBuilderGenerator` and `ObjectTypeProxyGenerator`.
- A method with inputs but no output now binds to `OnCall(Action<TIn…>)` (and the async `Func<…, CancellationToken, ValueTask>`), with `Variant.TryGetValue` unpacking.

## 2. Runtime value changes now reach subscribed MonitoredItems

An `OnRead`-backed variable (or a backing field mutated inside an `OnCall` handler) updated on the Attribute (Read) service but **not** for subscriptions: the getter isn't sampled, and the old `Node.ClearChangeMasks(...)` recipe is unreachable because the fluent builder is sealed after `Configure`.

Added a supported, AOT-safe, DI-friendly runtime surface in `Libraries/Opc.Ua.Server/Fluent/`:

- **`IValueUpdater<TValue>`** (+ `ValueUpdater<TValue>`) — a runtime handle captured during `Configure` that survives sealing. `SetValue` sets Value + StatusCode + Timestamp and flushes `ClearChangeMasks` in one serialized call; overloads for status/timestamp plus `NotifyChange()` for in-place mutations.
- **`RuntimeValueBuilderExtensions`** —
  - `Bind(out IValueUpdater<TValue>)` for explicit pushes (e.g. from an `OnCall` handler);
  - `PollEvery(interval, getter)` opt-in auto-sampling that pushes only on change, reusing the manager-owned `SimulationRegistry` loop infrastructure.
- `FluentVariant` centralizes the single Variant boxing / AOT-suppression site (shared with `VariableBuilder`).

Usage:

```csharp
private IValueUpdater<float> m_ao01 = null!;

partial void Configure(IMyNodeManagerBuilder builder)
{
    builder.MyEquipment03.AO01.Builder.AsVariable<float>().Bind(out m_ao01);
    builder.MyEquipment03.SetOutputVal.OnCall((float value) => m_ao01.SetValue(value));
}
```

## Documentation

- `Docs/SourceGeneratedNodeManagers.md`: corrected the typed-`OnCall` overload description (input-only / imported methods) and added a **"Pushing runtime value changes to subscribers"** section with `Bind` / `PollEvery` examples.

## Related Issues

- Fixes #3973

## Checklist

- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf) and read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [x] I have added all necessary documentation.
- [x] I have verified that my changes do not introduce (new) build or analyzer warnings.
- [x] I ran **all** tests locally using the **UA.slnx** solution against at least .net **framework** and .net **10**, and all passed.
- [ ] I fixed **all** failing and flaky tests in the CI pipelines and **all** CodeQL warnings.
- [ ] I have addressed **all** PR feedback received.

---

### Validation

- `Opc.Ua.Server.Tests` Fluent suite: **232/232** pass on **net10.0** and **net48** (new `RuntimeValueBuilderExtensionsTests`, 8 cases).
- `Opc.Ua.SourceGeneration.Core.Tests`: **3712** pass on **net10.0** (3 new generator tests + declaration-backed NodeSet2 fixture; new tests also verified on net48).
- Builds are warning-clean under `TreatWarningsAsErrors`.
