### PR TITLE
Fix legacy password verification and JSON QualifiedName decoding

### DIFF
--- a/Libraries/Opc.Ua.Server/RoleBasedUserManagement/UserDatabase/LinqUserDatabase.cs
+++ b/Libraries/Opc.Ua.Server/RoleBasedUserManagement/UserDatabase/LinqUserDatabase.cs
@@ -334,7 +334,7 @@ namespace Opc.Ua.Server.UserDatabase
             byte[] keyToCheck = Rfc2898DeriveBytes.Pbkdf2(
                 password,
                 salt,
-                kIterations,
+                iterations,
                 HashAlgorithmName.SHA512,
                 key.Length);
             return keyToCheck.SequenceEqual(key);

--- a/Libraries/Opc.Ua.Server/RoleBasedUserManagement/UserDatabase/LinqUserDatabase.cs
+++ b/Libraries/Opc.Ua.Server/RoleBasedUserManagement/UserDatabase/LinqUserDatabase.cs
@@ -59,6 +59,13 @@ namespace Opc.Ua.Server.UserDatabase
         private const int kKeySize = 32;
 
         /// <summary>
+        /// Upper bound for the persisted PBKDF2 iteration count accepted during
+        /// verification. Guards against corrupt or malicious hash records that would
+        /// otherwise cause unbounded key-derivation work.
+        /// </summary>
+        private const int kMaxIterations = 10_000_000;
+
+        /// <summary>
         /// The representation of a user in the Linq database.
         /// </summary>
         [DataContract(Namespace = Namespaces.UserDatabase)]
@@ -326,9 +333,27 @@ namespace Opc.Ua.Server.UserDatabase
                     "Unexpected hash format. Should be formatted as `{iterations}.{salt}.{hash}`");
             }
 
-            int iterations = Convert.ToInt32(parts[0], CultureInfo.InvariantCulture.NumberFormat);
+            if (!int.TryParse(
+                    parts[0],
+                    NumberStyles.Integer,
+                    CultureInfo.InvariantCulture,
+                    out int iterations) ||
+                iterations is <= 0 or > kMaxIterations)
+            {
+                // A non-positive or excessively large iteration count cannot come from
+                // Hash() and would either throw or cause unbounded CPU work below. Fail
+                // closed so a corrupt or malicious hash record cannot authenticate.
+                return false;
+            }
+
             byte[] salt = Convert.FromBase64String(parts[1]);
             byte[] key = Convert.FromBase64String(parts[2]);
+            if (key.Length == 0)
+            {
+                // An empty derived key cannot come from Hash() and would make the
+                // net10 span overload derive zero bytes; reject it explicitly.
+                return false;
+            }
 #if NET10_0_OR_GREATER
             // Use span overloads
             byte[] keyToCheck = Rfc2898DeriveBytes.Pbkdf2(

--- a/Stack/Opc.Ua.Types/Encoders/JsonDecoder.cs
+++ b/Stack/Opc.Ua.Types/Encoders/JsonDecoder.cs
@@ -2455,11 +2455,20 @@ namespace Opc.Ua
                     value = QualifiedName.Null;
                     return true;
                 case JsonValueKind.String:
-                    value = QualifiedName.Parse(
-                        Context,
-                        element.GetString()!,
-                        m_options.UpdateNamespaceTable);
-                    return true;
+                    try
+                    {
+                        value = QualifiedName.Parse(
+                            Context,
+                            element.GetString()!,
+                            m_options.UpdateNamespaceTable);
+                        return true;
+                    }
+                    catch (ServiceResultException sre)
+                        when (sre.StatusCode == StatusCodes.BadNodeIdInvalid)
+                    {
+                        value = QualifiedName.Null;
+                        return false;
+                    }
                 default:
                     value = QualifiedName.Null;
                     return false;

--- a/Tests/Opc.Ua.Server.Tests/LinqUserDatabaseTests.cs
+++ b/Tests/Opc.Ua.Server.Tests/LinqUserDatabaseTests.cs
@@ -1,3 +1,32 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -14,6 +43,23 @@ namespace Opc.Ua.Server.Tests
     public sealed class LinqUserDatabaseTests
     {
         private static readonly string[] s_createdUsers = ["TestUser1", "TestUser2"];
+
+        /// <summary>
+        /// Deterministic PBKDF2-SHA512 vector persisted with 10,000 iterations, generated
+        /// offline for the password "Correct.Horse.Battery9!" using the persisted format
+        /// `{iterations}.{saltBase64}.{keyBase64}`. Represents a legacy hash created before
+        /// the default iteration count was raised to 100,000.
+        /// </summary>
+        private const string kPbkdf2Vector10000Iterations =
+            "10000.AQIDBAUGBwgJCgsMDQ4PEBESExQ=.m11DHtGqddtFRM3j/jT625QRQ94Wr77OQ6JVDB3wkOM=";
+
+        /// <summary>
+        /// Deterministic PBKDF2-SHA512 vector persisted with 100,000 iterations, generated
+        /// offline for the password "Correct.Horse.Battery9!" using the persisted format
+        /// `{iterations}.{saltBase64}.{keyBase64}`. Matches the current default iteration count.
+        /// </summary>
+        private const string kPbkdf2Vector100000Iterations =
+            "100000.FRYXGBkaGxwdHh8gISIjJCUmJyg=.ZTa2BfHDODFt/dLxiIyZQECswP3Rzd3KCmu6TxeE3Wo=";
 
         [Test]
         public void CreateInvalidUser()
@@ -137,6 +183,68 @@ namespace Opc.Ua.Server.Tests
             Assert.That(users.Select(user => user.UserName), Is.EquivalentTo(s_createdUsers));
             Assert.That(users.All(user => user.UserConfiguration == (uint)UserConfigurationMask.None), Is.True);
             Assert.That(users.Select(user => user.Description), Is.All.Empty);
+        }
+
+        [Test]
+        public void CheckCredentialsSucceedsForPersistedPbkdf2VectorWith10000Iterations()
+        {
+            // Arrange
+            var usersDb = new LinqUserDatabase
+            {
+                Users =
+                [
+                    new LinqUserDatabase.User
+                    {
+                        ID = Guid.NewGuid(),
+                        UserName = "LegacyUser10000",
+                        Hash = kPbkdf2Vector10000Iterations,
+                        Roles = [Role.AuthenticatedUser]
+                    }
+                ]
+            };
+
+            // Act
+            bool correctPassword = usersDb.CheckCredentials(
+                "LegacyUser10000",
+                "Correct.Horse.Battery9!"u8);
+            bool wrongPassword = usersDb.CheckCredentials(
+                "LegacyUser10000",
+                "Wrong.Horse.Battery9!"u8);
+
+            // Assert
+            Assert.That(correctPassword, Is.True);
+            Assert.That(wrongPassword, Is.False);
+        }
+
+        [Test]
+        public void CheckCredentialsSucceedsForPersistedPbkdf2VectorWith100000Iterations()
+        {
+            // Arrange
+            var usersDb = new LinqUserDatabase
+            {
+                Users =
+                [
+                    new LinqUserDatabase.User
+                    {
+                        ID = Guid.NewGuid(),
+                        UserName = "CurrentUser100000",
+                        Hash = kPbkdf2Vector100000Iterations,
+                        Roles = [Role.AuthenticatedUser]
+                    }
+                ]
+            };
+
+            // Act
+            bool correctPassword = usersDb.CheckCredentials(
+                "CurrentUser100000",
+                "Correct.Horse.Battery9!"u8);
+            bool wrongPassword = usersDb.CheckCredentials(
+                "CurrentUser100000",
+                "Wrong.Horse.Battery9!"u8);
+
+            // Assert
+            Assert.That(correctPassword, Is.True);
+            Assert.That(wrongPassword, Is.False);
         }
     }
 }

--- a/Tests/Opc.Ua.Server.Tests/LinqUserDatabaseTests.cs
+++ b/Tests/Opc.Ua.Server.Tests/LinqUserDatabaseTests.cs
@@ -246,5 +246,69 @@ namespace Opc.Ua.Server.Tests
             Assert.That(correctPassword, Is.True);
             Assert.That(wrongPassword, Is.False);
         }
+
+        [Theory]
+        [TestCase("0")]
+        [TestCase("-1")]
+        [TestCase("100000000")]
+        [TestCase("99999999999999999999")]
+        [TestCase("notanumber")]
+        public void CheckCredentialsReturnsFalseForHashWithInvalidIterationCount(string iterations)
+        {
+            // Arrange - reuse the valid salt/key segments from a known-good vector but
+            // replace the iteration count with an out-of-range or unparsable value.
+            string[] parts = kPbkdf2Vector100000Iterations.Split('.');
+            string corruptHash = $"{iterations}.{parts[1]}.{parts[2]}";
+            var usersDb = new LinqUserDatabase
+            {
+                Users =
+                [
+                    new LinqUserDatabase.User
+                    {
+                        ID = Guid.NewGuid(),
+                        UserName = "CorruptIterationsUser",
+                        Hash = corruptHash,
+                        Roles = [Role.AuthenticatedUser]
+                    }
+                ]
+            };
+
+            // Act
+            bool result = usersDb.CheckCredentials(
+                "CorruptIterationsUser",
+                "Correct.Horse.Battery9!"u8);
+
+            // Assert - fail closed, never throw.
+            Assert.That(result, Is.False);
+        }
+
+        [Test]
+        public void CheckCredentialsReturnsFalseForHashWithEmptyKey()
+        {
+            // Arrange - a persisted hash with an empty derived key segment.
+            string[] parts = kPbkdf2Vector100000Iterations.Split('.');
+            string corruptHash = $"{parts[0]}.{parts[1]}.";
+            var usersDb = new LinqUserDatabase
+            {
+                Users =
+                [
+                    new LinqUserDatabase.User
+                    {
+                        ID = Guid.NewGuid(),
+                        UserName = "EmptyKeyUser",
+                        Hash = corruptHash,
+                        Roles = [Role.AuthenticatedUser]
+                    }
+                ]
+            };
+
+            // Act
+            bool result = usersDb.CheckCredentials(
+                "EmptyKeyUser",
+                "Correct.Horse.Battery9!"u8);
+
+            // Assert - fail closed, never throw.
+            Assert.That(result, Is.False);
+        }
     }
 }

--- a/Tests/Opc.Ua.Types.Tests/Encoders/JsonDecoderTests.cs
+++ b/Tests/Opc.Ua.Types.Tests/Encoders/JsonDecoderTests.cs
@@ -1416,6 +1416,79 @@ namespace Opc.Ua.Types.Tests.Encoders
         }
 
         [Test]
+        public void ReadQualifiedNameWithMalformedNamespaceUri()
+        {
+            // "nsu=urn:test" is missing the mandatory ';' separator before the name.
+            using JsonDecoder reader = NewDecoder(Body(@"""nsu=urn:test"""));
+            QualifiedName result = reader.ReadQualifiedName(JsonProperties.Value);
+            Assert.That(result, Is.EqualTo(QualifiedName.Null));
+        }
+
+        [Test]
+        public void ReadQualifiedNameWithMalformedNamespaceUriThrowsWhenStrict()
+        {
+            using JsonDecoder reader = NewDecoder(Body(@"""nsu=urn:test"""), true);
+            try
+            {
+                reader.ReadQualifiedName(JsonProperties.Value);
+            }
+            catch (ServiceResultException sre)
+            {
+                Assert.That(sre.StatusCode, Is.EqualTo(StatusCodes.BadDecodingError));
+                return;
+            }
+            Assert.Fail("Exception not thrown");
+        }
+
+        [Test]
+        public void ReadQualifiedNameArrayWithMalformedNamespaceUri()
+        {
+            using JsonDecoder reader = NewDecoder(Body(/*lang=json,strict*/ """[ "nsu=urn:test" ]"""));
+            ArrayOf<QualifiedName> result = reader.ReadQualifiedNameArray(JsonProperties.Value);
+            Assert.That(result, Is.EqualTo(ArrayOf.Null<QualifiedName>()));
+        }
+
+        [Test]
+        public void ReadQualifiedNameArrayWithMalformedNamespaceUriThrowsWhenStrict()
+        {
+            using JsonDecoder reader = NewDecoder(Body(/*lang=json,strict*/ """[ "nsu=urn:test" ]"""), true);
+            try
+            {
+                reader.ReadQualifiedNameArray(JsonProperties.Value);
+            }
+            catch (ServiceResultException sre)
+            {
+                Assert.That(sre.StatusCode, Is.EqualTo(StatusCodes.BadDecodingError));
+                return;
+            }
+            Assert.Fail("Exception not thrown");
+        }
+
+        [Test]
+        public void ReadVariantWithQualifiedNameMalformedNamespaceUri()
+        {
+            using JsonDecoder reader = NewDecoder(Body(/*lang=json,strict*/ """{"UaType":20, "Value":"nsu=urn:test"}"""));
+            Variant result = reader.ReadVariant(JsonProperties.Value);
+            Assert.That(result, Is.EqualTo(Variant.Null));
+        }
+
+        [Test]
+        public void ReadVariantWithQualifiedNameMalformedNamespaceUriThrowsWhenStrict()
+        {
+            using JsonDecoder reader = NewDecoder(Body(/*lang=json,strict*/ """{"UaType":20, "Value":"nsu=urn:test"}"""), true);
+            try
+            {
+                reader.ReadVariant(JsonProperties.Value);
+            }
+            catch (ServiceResultException sre)
+            {
+                Assert.That(sre.StatusCode, Is.EqualTo(StatusCodes.BadDecodingError));
+                return;
+            }
+            Assert.Fail("Exception not thrown");
+        }
+
+        [Test]
         public void ReadSByteArrayWithBadStringValue()
         {
             using JsonDecoder reader = NewDecoder(Body(@"""ääää"""));


### PR DESCRIPTION
# Description

Fix two compatibility and decoding regressions:

- Verify persisted PBKDF2 password hashes using the iteration count stored with each hash. This preserves authentication for user databases created with the previous 10,000-iteration policy when running on .NET 10.
- Normalize malformed string-form JSON `QualifiedName` values through the decoder's existing strict/lenient contract. Lenient parsing now returns `QualifiedName.Null`, while strict parsing reports `BadDecodingError` instead of leaking `BadNodeIdInvalid`.

The change adds deterministic legacy/current password-hash vectors and scalar, array, and Variant JSON decoder coverage.

## Related Issues

- No related issue.

## Checklist

- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf) and read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [x] I have added all necessary documentation.
- [x] I have verified that my changes do not introduce (new) build or analyzer warnings.
- [ ] I ran **all** tests locally using the **UA.slnx** solution against at least .net **framework** and .net **10**, and all passed.
- [ ] I fixed **all** failing and flaky tests in the CI pipelines and **all** CodeQL warnings.
- [ ] I have addressed **all** PR feedback received.

## Validation

- `LinqUserDatabaseTests`: 10/10 passed on `net10.0` and `net48`.
- `JsonDecoderTests`: 262/262 passed on `net10.0` and `net48`.
- Deterministic JSON fuzz regression tests: 1368/1368 passed on `net10.0` and `net48`.
- Affected test projects build with zero warnings and errors on `net10.0` and `net48`.
