### PR TITLE
Add test coverage for JSON user database and state machine availability

### DIFF
--- a/Tests/Opc.Ua.Client.Tests/StateMachines/FiniteStateMachineTypeClientExtensionsTests.cs
+++ b/Tests/Opc.Ua.Client.Tests/StateMachines/FiniteStateMachineTypeClientExtensionsTests.cs
@@ -231,6 +231,117 @@ namespace Opc.Ua.Client.Tests.StateMachines
         }
 
         [Test]
+        public async Task GetAvailableStatesAsyncReturnsEmptyWhenAvailablePropertyResolvesToNullNodeIdAsync()
+        {
+            var sessionMock = new Mock<ISessionClient>(MockBehavior.Loose);
+            FiniteStateMachineTypeClient client = CreateClient(sessionMock);
+
+            sessionMock.Setup(s => s.TranslateBrowsePathsToNodeIdsAsync(
+                    It.IsAny<RequestHeader>(),
+                    It.IsAny<ArrayOf<BrowsePath>>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns<RequestHeader, ArrayOf<BrowsePath>, CancellationToken>(
+                    (_, _, _) => new ValueTask<TranslateBrowsePathsToNodeIdsResponse>(
+                        new TranslateBrowsePathsToNodeIdsResponse
+                        {
+                            ResponseHeader = new ResponseHeader(),
+                            Results =
+                            [
+                                new BrowsePathResult
+                                {
+                                    StatusCode = StatusCodes.Good,
+                                    Targets =
+                                    [
+                                        new BrowsePathTarget
+                                        {
+                                            TargetId = ExpandedNodeId.Null,
+                                            RemainingPathIndex = uint.MaxValue
+                                        }
+                                    ]
+                                }
+                            ],
+                            DiagnosticInfos = []
+                        }));
+
+            IReadOnlyList<FiniteStateInfo> states = await client
+                .GetAvailableStatesAsync().ConfigureAwait(false);
+
+            Assert.That(states, Is.Empty);
+            sessionMock.Verify(s => s.ReadAsync(
+                It.IsAny<RequestHeader>(),
+                It.IsAny<double>(),
+                It.IsAny<TimestampsToReturn>(),
+                It.IsAny<ArrayOf<ReadValueId>>(),
+                It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [Test]
+        public async Task GetAvailableTransitionsAsyncReturnsEmptyWhenAvailableNodeIdsAreAllNullAsync()
+        {
+            var sessionMock = new Mock<ISessionClient>(MockBehavior.Loose);
+            FiniteStateMachineTypeClient client = CreateClient(sessionMock);
+            NodeId availableTransitionsNode = new(106u, 2);
+
+            sessionMock.Setup(s => s.TranslateBrowsePathsToNodeIdsAsync(
+                    It.IsAny<RequestHeader>(),
+                    It.IsAny<ArrayOf<BrowsePath>>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns<RequestHeader, ArrayOf<BrowsePath>, CancellationToken>(
+                    (_, _, _) => new ValueTask<TranslateBrowsePathsToNodeIdsResponse>(
+                        new TranslateBrowsePathsToNodeIdsResponse
+                        {
+                            ResponseHeader = new ResponseHeader(),
+                            Results =
+                            [
+                                new BrowsePathResult
+                                {
+                                    StatusCode = StatusCodes.Good,
+                                    Targets =
+                                    [
+                                        new BrowsePathTarget
+                                        {
+                                            TargetId = availableTransitionsNode,
+                                            RemainingPathIndex = uint.MaxValue
+                                        }
+                                    ]
+                                }
+                            ],
+                            DiagnosticInfos = []
+                        }));
+            sessionMock.Setup(s => s.ReadAsync(
+                    It.IsAny<RequestHeader>(),
+                    0,
+                    TimestampsToReturn.Neither,
+                    It.IsAny<ArrayOf<ReadValueId>>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns<RequestHeader, double, TimestampsToReturn, ArrayOf<ReadValueId>, CancellationToken>(
+                    (_, _, _, _, _) => new ValueTask<ReadResponse>(new ReadResponse
+                    {
+                        ResponseHeader = new ResponseHeader(),
+                        Results =
+                        [
+                            new DataValue(Variant.From(new[] { NodeId.Null, NodeId.Null }.ToArrayOf()))
+                        ],
+                        DiagnosticInfos = []
+                    }));
+
+            IReadOnlyList<FiniteTransitionInfo> transitions = await client
+                .GetAvailableTransitionsAsync().ConfigureAwait(false);
+
+            Assert.That(transitions, Is.Empty);
+            sessionMock.Verify(s => s.TranslateBrowsePathsToNodeIdsAsync(
+                It.IsAny<RequestHeader>(),
+                It.IsAny<ArrayOf<BrowsePath>>(),
+                It.IsAny<CancellationToken>()), Times.Once);
+            sessionMock.Verify(s => s.ReadAsync(
+                It.IsAny<RequestHeader>(),
+                It.IsAny<double>(),
+                It.IsAny<TimestampsToReturn>(),
+                It.IsAny<ArrayOf<ReadValueId>>(),
+                It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Test]
         public async Task GetCurrentFiniteStateAsyncReturnsBadNotFoundEmptySnapshotWhenAllBrowsePathsResolveNull()
         {
             var sessionMock = new Mock<ISessionClient>(MockBehavior.Loose);

--- a/Tests/Opc.Ua.Server.Tests/JsonUserDatabaseTests.cs
+++ b/Tests/Opc.Ua.Server.Tests/JsonUserDatabaseTests.cs
@@ -179,8 +179,7 @@ namespace Opc.Ua.Server.Tests
                   "isNull": true,
                   "isAbsolute": false,
                   "namespaceIndex": 0,
-                  "idType": "numeric",
-                  "identifier": null
+                  "idType": "numeric"
                 }
                 """;
 

--- a/Tests/Opc.Ua.Server.Tests/JsonUserDatabaseTests.cs
+++ b/Tests/Opc.Ua.Server.Tests/JsonUserDatabaseTests.cs
@@ -28,8 +28,10 @@
  * ======================================================================*/
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text.Json;
 using NUnit.Framework;
 using Opc.Ua.Server.UserDatabase;
 using Opc.Ua.Tests;
@@ -152,6 +154,122 @@ namespace Opc.Ua.Server.Tests
         }
 
         [Test]
+        public void LoadCurrentStringRoleIdPreservesAbsoluteIdentifier()
+        {
+            var expectedRoleId = new ExpandedNodeId(
+                "maintenance",
+                0,
+                "urn:example:roles",
+                2);
+            string json = CreateDatabaseJson(JsonSerializer.Serialize(expectedRoleId.ToString()));
+
+            JsonUserDatabase loaded = LoadDatabase(json);
+
+            Assert.That(loaded.GetUsers().Single().UserName, Is.EqualTo("alice"));
+            Assert.That(loaded.GetUserRoles("alice").Single().Name, Is.EqualTo("Custom"));
+            Assert.That(loaded.GetUserRoles("alice").Single().RoleId, Is.EqualTo(expectedRoleId));
+        }
+
+        [Test]
+        public void LoadLegacyNullRoleIdPreservesNullIdentifier()
+        {
+            const string roleIdJson = """
+                {
+                  "serverIndex": 0,
+                  "isNull": true,
+                  "isAbsolute": false,
+                  "namespaceIndex": 0,
+                  "idType": "numeric",
+                  "identifier": null
+                }
+                """;
+
+            JsonUserDatabase loaded = LoadDatabase(CreateDatabaseJson(roleIdJson));
+
+            Assert.That(loaded.GetUsers().Single().UserName, Is.EqualTo("alice"));
+            Assert.That(loaded.GetUserRoles("alice").Single().RoleId, Is.EqualTo(ExpandedNodeId.Null));
+        }
+
+        [Test]
+        public void LoadLegacyStringRoleIdPreservesIdentifier()
+        {
+            const string roleIdJson = """
+                {
+                  "serverIndex": 0,
+                  "isNull": false,
+                  "isAbsolute": false,
+                  "namespaceIndex": 2,
+                  "idType": "string",
+                  "identifier": "custom-role"
+                }
+                """;
+
+            JsonUserDatabase loaded = LoadDatabase(CreateDatabaseJson(roleIdJson));
+
+            Assert.That(
+                loaded.GetUserRoles("alice").Single().RoleId,
+                Is.EqualTo(new ExpandedNodeId("custom-role", 2)));
+        }
+
+        [Test]
+        public void LoadLegacyGuidRoleIdPreservesIdentifier()
+        {
+            const string roleIdJson = """
+                {
+                  "serverIndex": 0,
+                  "isNull": false,
+                  "isAbsolute": true,
+                  "namespaceIndex": 0,
+                  "namespaceUri": "urn:example:roles",
+                  "idType": "guid",
+                  "identifier": "65c5a128-701c-4a46-9d64-9c4dfc78bc9d"
+                }
+                """;
+
+            JsonUserDatabase loaded = LoadDatabase(CreateDatabaseJson(roleIdJson));
+
+            Assert.That(
+                loaded.GetUserRoles("alice").Single().RoleId,
+                Is.EqualTo(
+                    new ExpandedNodeId(
+                        Guid.Parse("65c5a128-701c-4a46-9d64-9c4dfc78bc9d"),
+                        0,
+                        "urn:example:roles",
+                        0)));
+        }
+
+        [Test]
+        public void LoadLegacyOpaqueRoleIdPreservesIdentifier()
+        {
+            const string roleIdJson = """
+                {
+                  "serverIndex": 3,
+                  "isNull": false,
+                  "isAbsolute": true,
+                  "namespaceIndex": 1,
+                  "idType": "opaque",
+                  "identifier": {
+                    "memory": "AQIDBA=="
+                  }
+                }
+                """;
+
+            JsonUserDatabase loaded = LoadDatabase(CreateDatabaseJson(roleIdJson));
+
+            Assert.That(
+                loaded.GetUserRoles("alice").Single().RoleId,
+                Is.EqualTo(new ExpandedNodeId(ByteString.From([1, 2, 3, 4]), 1, null, 3)));
+        }
+
+        [TestCaseSource(nameof(InvalidRoleIdJson))]
+        public void LoadInvalidRoleIdReturnsEmptyDatabase(string roleIdJson)
+        {
+            JsonUserDatabase loaded = LoadDatabase(CreateDatabaseJson(roleIdJson));
+
+            Assert.That(loaded.GetUsers(), Is.Empty);
+        }
+
+        [Test]
         public void LoadExistingEmptyJsonPreservesFileName()
         {
             string fileName = CreateDatabasePath();
@@ -173,6 +291,132 @@ namespace Opc.Ua.Server.Tests
 
             Assert.That(((JsonUserDatabase)loaded).FileName, Is.EqualTo(fileName));
             Assert.That(loaded.GetUsers(), Is.Empty);
+        }
+
+        private static IEnumerable<TestCaseData> InvalidRoleIdJson()
+        {
+            yield return new TestCaseData("\"not-an-expanded-node-id\"")
+                .SetName("LoadInvalidRoleIdReturnsEmptyDatabaseForInvalidString");
+            yield return new TestCaseData("42")
+                .SetName("LoadInvalidRoleIdReturnsEmptyDatabaseForUnexpectedToken");
+            yield return new TestCaseData(
+                """
+                {
+                  "serverIndex": 0,
+                  "isNull": false,
+                  "isAbsolute": true,
+                  "namespaceIndex": 0,
+                  "idType": "numeric",
+                  "identifier": 1
+                }
+                """)
+                .SetName("LoadInvalidRoleIdReturnsEmptyDatabaseForInvalidNamespace");
+            yield return new TestCaseData(
+                """
+                {
+                  "serverIndex": 1,
+                  "isNull": true,
+                  "isAbsolute": true,
+                  "namespaceIndex": 0,
+                  "idType": "numeric",
+                  "identifier": null
+                }
+                """)
+                .SetName("LoadInvalidRoleIdReturnsEmptyDatabaseForInvalidNull");
+            yield return new TestCaseData(
+                """
+                {
+                  "serverIndex": 0,
+                  "isNull": false,
+                  "isAbsolute": false,
+                  "namespaceIndex": 0,
+                  "idType": "unknown",
+                  "identifier": 1
+                }
+                """)
+                .SetName("LoadInvalidRoleIdReturnsEmptyDatabaseForUnknownIdentifierType");
+            yield return new TestCaseData(
+                """
+                {
+                  "serverIndex": 0,
+                  "isNull": false,
+                  "isAbsolute": false,
+                  "namespaceIndex": 0,
+                  "idType": null,
+                  "identifier": 1
+                }
+                """)
+                .SetName("LoadInvalidRoleIdReturnsEmptyDatabaseForMissingIdentifierType");
+            yield return new TestCaseData(
+                """
+                {
+                  "serverIndex": 0,
+                  "isNull": false,
+                  "isAbsolute": false,
+                  "namespaceIndex": 0,
+                  "idType": "string",
+                  "identifier": null
+                }
+                """)
+                .SetName("LoadInvalidRoleIdReturnsEmptyDatabaseForNullStringIdentifier");
+            yield return new TestCaseData(
+                """
+                {
+                  "serverIndex": 0,
+                  "isNull": false,
+                  "isAbsolute": false,
+                  "namespaceIndex": 0,
+                  "idType": "opaque",
+                  "identifier": {
+                    "memory": "not-base64"
+                  }
+                }
+                """)
+                .SetName("LoadInvalidRoleIdReturnsEmptyDatabaseForInvalidOpaqueIdentifier");
+            yield return new TestCaseData(
+                """
+                {
+                  "serverIndex": 0,
+                  "isNull": false,
+                  "isAbsolute": false,
+                  "namespaceIndex": 0,
+                  "idType": "opaque",
+                  "identifier": {
+                    "memory": null
+                  }
+                }
+                """)
+                .SetName("LoadInvalidRoleIdReturnsEmptyDatabaseForNullOpaqueIdentifier");
+        }
+
+        private static JsonUserDatabase LoadDatabase(string json)
+        {
+            string fileName = CreateDatabasePath();
+            File.WriteAllText(fileName, json);
+            return (JsonUserDatabase)JsonUserDatabase.Load(
+                fileName,
+                NUnitTelemetryContext.Create());
+        }
+
+        private static string CreateDatabaseJson(string roleIdJson)
+        {
+            return $$"""
+                {
+                  "users": [
+                    {
+                      "Id": "5ffc097e-566f-4e98-9a45-fa662826a6aa",
+                      "UserName": "alice",
+                      "Hash": "100000.fBXDf\u002BXgck10FwkXXEVetxGpOsM=.83/yGZTA1roMWqRsDO6TiuWllGOHfipTm01UaTduYJo=",
+                      "Roles": [
+                        {
+                          "Name": "Custom",
+                          "RoleId": {{roleIdJson}}
+                        }
+                      ]
+                    }
+                  ]
+                }
+                """;
         }
 
         private static string CreateDatabasePath()


### PR DESCRIPTION
# Description

Adds focused tests for production paths introduced in #3980 that remained below the repository's 80% Codecov patch-coverage threshold.

The existing fixtures now cover:

- Current and legacy `ExpandedNodeId` JSON representations used by `JsonUserDatabase`, including numeric, string, GUID, opaque, null, absolute, and malformed role identifiers.
- Optional or null `AvailableStates` and `AvailableTransitions` values in `FiniteStateMachineTypeClientExtensions`.

The tests assert the exact loaded users, roles, identifiers, fallback behavior, and state-machine results rather than only executing converter branches.

Local changed-line measurement reports:

- `JsonUserDatabase.cs`: 100% line coverage.
- Changed executable lines in `FiniteStateMachineTypeClientExtensions.cs`: 100% coverage.

Focused validation passes on .NET 10 and .NET Framework 4.8: 58 tests passed.

## Related Issues

Follow-up to #3980.

## Checklist

- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf) and read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [x] I have added all necessary documentation.
- [x] I have verified that my changes do not introduce (new) build or analyzer warnings.
- [ ] I ran **all** tests locally using the **UA.slnx** solution against at least .net **framework** and .net **10**, and all passed.
- [ ] I fixed **all** failing and flaky tests in the CI pipelines and **all** CodeQL warnings.
- [x] I have addressed **all** PR feedback received.
