### PR TITLE
Dispose canceled managed session creation and expand server utility coverage

### DIFF
--- a/Libraries/Opc.Ua.Client/Session/ManagedSession.cs
+++ b/Libraries/Opc.Ua.Client/Session/ManagedSession.cs
@@ -278,7 +278,9 @@ namespace Opc.Ua.Client
                 catch (Exception disposeException) when (
                     disposeException is not OutOfMemoryException)
                 {
-                    // Preserve the connection failure or cancellation reported to the caller.
+                    logger.LogError(
+                        disposeException,
+                        "ManagedSession: Disposal after initial connection failure failed.");
                 }
                 throw;
             }

--- a/Libraries/Opc.Ua.Client/Session/ManagedSession.cs
+++ b/Libraries/Opc.Ua.Client/Session/ManagedSession.cs
@@ -263,9 +263,25 @@ namespace Opc.Ua.Client
             managed.StateMachine.Start();
             managed.StateMachine.RequestConnect();
 
-            await managed.StateMachine
-                .WaitForConnectedAsync(ct)
-                .ConfigureAwait(false);
+            try
+            {
+                await managed.StateMachine
+                    .WaitForConnectedAsync(ct)
+                    .ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ex is not OutOfMemoryException)
+            {
+                try
+                {
+                    await managed.DisposeAsync().ConfigureAwait(false);
+                }
+                catch (Exception disposeException) when (
+                    disposeException is not OutOfMemoryException)
+                {
+                    // Preserve the connection failure or cancellation reported to the caller.
+                }
+                throw;
+            }
 
             return managed;
         }

--- a/Tests/Opc.Ua.Client.Tests/Session/ManagedSessionTests.cs
+++ b/Tests/Opc.Ua.Client.Tests/Session/ManagedSessionTests.cs
@@ -408,6 +408,153 @@ namespace Opc.Ua.Client.Tests.ManagedSession
                     sessionFactory: mockFactory.Object).ConfigureAwait(false));
         }
 
+        [Test]
+        public async Task CreateAsyncDisposesManagedSessionWhenInitialWaitIsCanceledAsync()
+        {
+            ITelemetryContext telemetry = NUnitTelemetryContext.Create();
+            ApplicationConfiguration configuration = CreateClientConfiguration(telemetry);
+            ConfiguredEndpoint endpoint = CreateEndpoint();
+            IServiceMessageContext messageContext = configuration.CreateMessageContext();
+
+            var channel = new Mock<IManagedTransportChannel>();
+            channel.SetupGet(c => c.MessageContext).Returns(messageContext);
+            var innerSession = new Session(
+                channel.Object,
+                configuration,
+                endpoint,
+                engineFactory: DefaultSubscriptionEngineFactory.Instance);
+
+            var sessionFactory = new Mock<ISessionFactory>();
+            sessionFactory.SetupGet(f => f.Telemetry).Returns(telemetry);
+            sessionFactory.Setup(f => f.CreateAsync(
+                    It.IsAny<ApplicationConfiguration>(),
+                    It.IsAny<ConfiguredEndpoint>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<string>(),
+                    It.IsAny<uint>(),
+                    It.IsAny<IUserIdentity?>(),
+                    It.IsAny<ArrayOf<string>>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync((ISession)innerSession);
+
+            Client.ManagedSession? managedSession = null;
+            var fetchStarted = new TaskCompletionSource<bool>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            var fetchCompletion = new TaskCompletionSource<ServerRedundancyInfo>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            var redundancyHandler = new Mock<IServerRedundancyHandler>();
+            redundancyHandler.Setup(h => h.FetchRedundancyInfoAsync(
+                    It.IsAny<ISession>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns((ISession session, CancellationToken ct) =>
+                {
+                    managedSession = (Client.ManagedSession)session;
+                    fetchStarted.TrySetResult(true);
+                    ct.Register(() => fetchCompletion.TrySetCanceled());
+                    return new ValueTask<ServerRedundancyInfo>(fetchCompletion.Task);
+                });
+
+            using var cancellation = new CancellationTokenSource();
+            Task<Client.ManagedSession> createTask = Client.ManagedSession.CreateAsync(
+                configuration,
+                endpoint,
+                sessionFactory.Object,
+                redundancyHandler: redundancyHandler.Object,
+                ct: cancellation.Token);
+
+            Task startedTask = await Task.WhenAny(
+                    fetchStarted.Task,
+                    Task.Delay(TimeSpan.FromSeconds(5)))
+                .ConfigureAwait(false);
+            Assert.That(startedTask, Is.SameAs(fetchStarted.Task));
+
+            cancellation.Cancel();
+
+            Task completedTask = await Task.WhenAny(
+                    createTask,
+                    Task.Delay(TimeSpan.FromSeconds(5)))
+                .ConfigureAwait(false);
+            Assert.That(completedTask, Is.SameAs(createTask));
+            Assert.CatchAsync<OperationCanceledException>(() => createTask);
+            Assert.That(fetchCompletion.Task.IsCanceled, Is.True);
+            Assert.That(managedSession, Is.Not.Null);
+            Assert.That(
+                managedSession!.StateMachine.State,
+                Is.EqualTo(ConnectionState.Closed));
+            Assert.Throws<ServiceResultException>(() => _ = managedSession.InnerSession);
+        }
+
+        [Test]
+        public async Task CreateAsyncLogsDisposeFailureAndPreservesCancellationAsync()
+        {
+            var logger = new Mock<ILogger>();
+            var disposeFailure = new InvalidOperationException("Test cleanup failure.");
+            logger.Setup(l => l.Log(
+                    It.IsAny<LogLevel>(),
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>(
+                        (value, _) => value.ToString() ==
+                            "ConnectionStateMachine: Worker exiting."),
+                    It.IsAny<Exception?>(),
+                    It.IsAny<Func<It.IsAnyType, Exception?, string>>()))
+                .Throws(disposeFailure);
+
+            var loggerFactory = new Mock<ILoggerFactory>();
+            loggerFactory.Setup(f => f.CreateLogger(It.IsAny<string>()))
+                .Returns(logger.Object);
+            var telemetry = new Mock<ITelemetryContext>();
+            telemetry.SetupGet(t => t.LoggerFactory).Returns(loggerFactory.Object);
+
+            var sessionFactory = new Mock<ISessionFactory>();
+            sessionFactory.SetupGet(f => f.Telemetry).Returns(telemetry.Object);
+            var connectStarted = new TaskCompletionSource<bool>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            var connectCompletion = new TaskCompletionSource<IDisposable>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            var connectGate = new Mock<IClientConnectGate>();
+            connectGate.Setup(g => g.AcquireAsync(It.IsAny<CancellationToken>()))
+                .Returns((CancellationToken ct) =>
+                {
+                    connectStarted.TrySetResult(true);
+                    ct.Register(() => connectCompletion.TrySetCanceled());
+                    return new ValueTask<IDisposable>(connectCompletion.Task);
+                });
+
+            using var cancellation = new CancellationTokenSource();
+            Task<Client.ManagedSession> createTask = Client.ManagedSession.CreateAsync(
+                CreateClientConfiguration(telemetry.Object),
+                CreateEndpoint(),
+                sessionFactory.Object,
+                connectGate: connectGate.Object,
+                ct: cancellation.Token);
+
+            Task startedTask = await Task.WhenAny(
+                    connectStarted.Task,
+                    Task.Delay(TimeSpan.FromSeconds(5)))
+                .ConfigureAwait(false);
+            Assert.That(startedTask, Is.SameAs(connectStarted.Task));
+
+            cancellation.Cancel();
+
+            Task completedTask = await Task.WhenAny(
+                    createTask,
+                    Task.Delay(TimeSpan.FromSeconds(5)))
+                .ConfigureAwait(false);
+            Assert.That(completedTask, Is.SameAs(createTask));
+            Assert.CatchAsync<OperationCanceledException>(() => createTask);
+            logger.Verify(
+                l => l.Log(
+                    LogLevel.Error,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>(
+                        (value, _) => value.ToString() ==
+                            "ManagedSession: Disposal after initial connection failure failed."),
+                    It.Is<Exception?>(exception => ReferenceEquals(exception, disposeFailure)),
+                    It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+                Times.Once);
+        }
+
 #pragma warning disable IDE0051, RCS1213 // Test scaffold kept for reconnect-path tests that need the private handler.
         private static Task<ServiceResult> InvokeHandleReconnectAsync(
             Client.ManagedSession managedSession,

--- a/Tests/Opc.Ua.Server.Tests/QuickstartsServerUtilitiesTests.cs
+++ b/Tests/Opc.Ua.Server.Tests/QuickstartsServerUtilitiesTests.cs
@@ -1,0 +1,120 @@
+/* ========================================================================
+ * Copyright (c) 2005-2026 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using Moq;
+using NUnit.Framework;
+using Opc.Ua.Server;
+using Opc.Ua.Test;
+using Opc.Ua.Tests;
+using Quickstarts.ReferenceServer;
+
+namespace Opc.Ua.Server.Tests
+{
+    /// <summary>
+    /// Tests the reusable Quickstarts server helpers.
+    /// </summary>
+    [TestFixture]
+    [Category("Server")]
+    public class QuickstartsServerUtilitiesTests
+    {
+        /// <summary>
+        /// Registers the classic and asynchronous Quickstarts factories.
+        /// </summary>
+        [Test]
+        public void AddDefaultNodeManagersRegistersClassicAndAsyncFactories()
+        {
+            var server = new Mock<IStandardServer>();
+
+            Quickstarts.Servers.Utils.AddDefaultNodeManagers(server.Object);
+
+            server.Verify(
+                s => s.AddNodeManager(It.Is<INodeManagerFactory>(
+                    factory => factory is MemoryBuffer.MemoryBufferNodeManagerFactory)),
+                Times.Once);
+            server.Verify(
+                s => s.AddNodeManager(It.Is<INodeManagerFactory>(
+                    factory => factory is Boiler.BoilerNodeManagerFactory)),
+                Times.Once);
+            server.Verify(
+                s => s.AddNodeManager(It.Is<IAsyncNodeManagerFactory>(
+                    factory => factory is TestData.TestDataNodeManagerFactory)),
+                Times.Once);
+            server.Verify(
+                s => s.AddNodeManager(It.Is<IAsyncNodeManagerFactory>(
+                    factory => factory is global::Alarms.AlarmNodeManagerFactory)),
+                Times.Once);
+        }
+
+        /// <summary>
+        /// Exposes each factory through the interface that its node manager supports.
+        /// </summary>
+        [Test]
+        public void DefaultNodeManagerFactoriesPreserveClassicAndAsyncCompatibility()
+        {
+            ArrayOf<INodeManagerFactory> classicFactories =
+                Quickstarts.Servers.Utils.NodeManagerFactories;
+            ArrayOf<IAsyncNodeManagerFactory> asyncFactories =
+                Quickstarts.Servers.Utils.AsyncNodeManagerFactories;
+
+            Assert.That(
+                classicFactories,
+                Has.Count.EqualTo(2));
+            Assert.That(
+                classicFactories[0],
+                Is.TypeOf<MemoryBuffer.MemoryBufferNodeManagerFactory>());
+            Assert.That(
+                classicFactories[1],
+                Is.TypeOf<Boiler.BoilerNodeManagerFactory>());
+            Assert.That(
+                asyncFactories,
+                Has.Count.EqualTo(2));
+            Assert.That(
+                asyncFactories[0],
+                Is.TypeOf<TestData.TestDataNodeManagerFactory>());
+            Assert.That(
+                asyncFactories[1],
+                Is.TypeOf<global::Alarms.AlarmNodeManagerFactory>());
+        }
+
+        /// <summary>
+        /// Enables the optional Reference Server behaviors without starting the server.
+        /// </summary>
+        [Test]
+        public void ReferenceServerHelpersEnableRequestedBehaviors()
+        {
+            var server = new ReferenceServer(NUnitTelemetryContext.Create());
+
+            Quickstarts.Servers.Utils.UseSamplingGroupsInReferenceNodeManager(server);
+            Quickstarts.Servers.Utils.EnableProvisioningMode(server);
+
+            Assert.That(server.UseSamplingGroupsInReferenceNodeManager, Is.True);
+            Assert.That(server.ProvisioningMode, Is.True);
+        }
+    }
+}

--- a/Tests/Opc.Ua.Server.Tests/QuickstartsServerUtilitiesTests.cs
+++ b/Tests/Opc.Ua.Server.Tests/QuickstartsServerUtilitiesTests.cs
@@ -108,7 +108,7 @@ namespace Opc.Ua.Server.Tests
         [Test]
         public void ReferenceServerHelpersEnableRequestedBehaviors()
         {
-            var server = new ReferenceServer(NUnitTelemetryContext.Create());
+            using var server = new ReferenceServer(NUnitTelemetryContext.Create());
 
             Quickstarts.Servers.Utils.UseSamplingGroupsInReferenceNodeManager(server);
             Quickstarts.Servers.Utils.EnableProvisioningMode(server);


### PR DESCRIPTION
# Description

Dispose a `ManagedSession` when its initial connection wait fails or is canceled so the background state machine and owned resources do not outlive a failed `CreateAsync` call. Log cleanup failures while preserving the original connection failure or cancellation.

Add regression coverage for canceled managed-session creation and cleanup logging, plus coverage for Quickstarts default node manager registration and the reusable Reference Server helper flags.

## Related Issues

None.

## Checklist

- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf) and read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [x] I have added all necessary documentation.
- [x] I have verified that my changes do not introduce (new) build or analyzer warnings.
- [ ] I ran **all** tests locally using the **UA.slnx** solution against at least .net **framework** and .net **10**, and all passed.
- [ ] I fixed **all** failing and flaky tests in the CI pipelines and **all** CodeQL warnings.
- [x] I have addressed **all** PR feedback received.