### PR TITLE
Fix publish queue lost wake-up

### DIFF
--- a/Libraries/Opc.Ua.Server/Subscription/SessionPublishQueue.cs
+++ b/Libraries/Opc.Ua.Server/Subscription/SessionPublishQueue.cs
@@ -108,7 +108,7 @@ namespace Opc.Ua.Server
             }
 
             QueuedSubscription subscriptionToPublish;
-            lock (m_subscriptionPublishLock)
+            lock (m_lock)
             {
                 // find the waiting subscription with the highest priority.
                 subscriptionToPublish = GetSubscriptionToPublish();
@@ -117,10 +117,7 @@ namespace Opc.Ua.Server
                 {
                     return Task.FromResult(subscriptionToPublish.Subscription);
                 }
-            }
 
-            lock (m_lock)
-            {
                 // check if queue is full.
                 if (m_queuedRequests.Count >= m_maxRequestCount)
                 {
@@ -150,6 +147,8 @@ namespace Opc.Ua.Server
         /// <returns>The list of subscriptions in the queue.</returns>
         public IList<ISubscription> Close()
         {
+            var subscriptions = new List<ISubscription>();
+
             lock (m_lock)
             {
                 // TraceState("SESSION CLOSED");
@@ -164,19 +163,21 @@ namespace Opc.Ua.Server
                 }
 
                 // tell the subscriptions that the session is closed.
-                var subscriptions = new List<ISubscription>(m_queuedSubscriptions.Count);
-
                 foreach (KeyValuePair<uint, QueuedSubscription> entry in m_queuedSubscriptions)
                 {
                     subscriptions.Add(entry.Value.Subscription);
-                    entry.Value.Subscription.SessionClosed();
                 }
 
                 // clear the queue.
                 m_queuedSubscriptions.Clear();
-
-                return subscriptions;
             }
+
+            foreach (ISubscription subscription in subscriptions)
+            {
+                subscription.SessionClosed();
+            }
+
+            return subscriptions;
         }
 
         /// <summary>
@@ -375,19 +376,19 @@ namespace Opc.Ua.Server
             if (m_queuedSubscriptions.TryGetValue(subscription.Id,
                 out QueuedSubscription queuedSubscription))
             {
-                queuedSubscription.Publishing = false;
-
-                if (moreNotifications)
+                lock (m_lock)
                 {
-                    lock (m_subscriptionPublishLock)
+                    queuedSubscription.Publishing = false;
+
+                    if (moreNotifications)
                     {
                         AssignSubscriptionToRequest(queuedSubscription);
                     }
-                }
-                else
-                {
-                    queuedSubscription.ReadyToPublish = false;
-                    queuedSubscription.Timestamp = DateTime.UtcNow;
+                    else
+                    {
+                        queuedSubscription.ReadyToPublish = false;
+                        queuedSubscription.Timestamp = DateTime.UtcNow;
+                    }
                 }
             }
         }
@@ -399,8 +400,11 @@ namespace Opc.Ua.Server
         {
             if (m_queuedSubscriptions.TryGetValue(subscription.Id, out QueuedSubscription queuedSubscription))
             {
-                queuedSubscription.Publishing = false;
-                queuedSubscription.ReadyToPublish = true;
+                lock (m_lock)
+                {
+                    queuedSubscription.Publishing = false;
+                    queuedSubscription.ReadyToPublish = true;
+                }
             }
         }
 
@@ -443,9 +447,12 @@ namespace Opc.Ua.Server
                 // assign subscription to request if one is available.
                 if (!subscription.Publishing)
                 {
-                    lock (m_subscriptionPublishLock)
+                    lock (m_lock)
                     {
-                        AssignSubscriptionToRequest(subscription);
+                        if (!subscription.Publishing)
+                        {
+                            AssignSubscriptionToRequest(subscription);
+                        }
                     }
                 }
             }
@@ -663,7 +670,6 @@ namespace Opc.Ua.Server
         }
 
         private readonly Lock m_lock = new();
-        private readonly Lock m_subscriptionPublishLock = new();
         private readonly ILogger m_logger;
         private readonly IServerInternal m_server;
         private readonly ISession m_session;

--- a/Libraries/Opc.Ua.Server/Subscription/SessionPublishQueue.cs
+++ b/Libraries/Opc.Ua.Server/Subscription/SessionPublishQueue.cs
@@ -147,10 +147,12 @@ namespace Opc.Ua.Server
         /// <returns>The list of subscriptions in the queue.</returns>
         public IList<ISubscription> Close()
         {
-            var subscriptions = new List<ISubscription>();
+            List<ISubscription> subscriptions;
 
             lock (m_lock)
             {
+                subscriptions = new List<ISubscription>(m_queuedSubscriptions.Count);
+
                 // TraceState("SESSION CLOSED");
 
                 // set any waiting publish requests to Status BadSessionClosed.

--- a/Libraries/Opc.Ua.Server/Subscription/SessionPublishQueue.cs
+++ b/Libraries/Opc.Ua.Server/Subscription/SessionPublishQueue.cs
@@ -440,12 +440,6 @@ namespace Opc.Ua.Server
                     continue;
                 }
 
-                // do nothing if subscription has already been flagged as available.
-                if (subscription.ReadyToPublish)
-                {
-                    continue;
-                }
-
                 // assign subscription to request if one is available.
                 if (!subscription.Publishing)
                 {

--- a/Tests/Opc.Ua.Server.Tests/SessionPublishQueueRaceTests.cs
+++ b/Tests/Opc.Ua.Server.Tests/SessionPublishQueueRaceTests.cs
@@ -28,6 +28,7 @@
  * ======================================================================*/
 
 using System;
+using System.Linq;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
@@ -39,7 +40,7 @@ namespace Opc.Ua.Server.Tests
 {
     [TestFixture]
     [Category("Subscription")]
-    [Parallelizable]
+    [NonParallelizable]
     public sealed class SessionPublishQueueRaceTests
     {
         [Test]
@@ -61,8 +62,7 @@ namespace Opc.Ua.Server.Tests
             subscription.Setup(s => s.Id).Returns(1);
             queue.Add(subscription.Object);
 
-            Lock queueLock = GetPrivateLock(queue, "m_lock");
-            Lock splitPublishLock = TryGetPrivateLock(queue, "m_subscriptionPublishLock");
+            (Lock queueLock, Lock splitPublishLock) = GetPrivateLocks(queue);
             using var publishStarted = new ManualResetEventSlim();
             Task<ISubscription> publishTask;
 
@@ -95,10 +95,11 @@ namespace Opc.Ua.Server.Tests
 
                 if (splitPublishLock != null)
                 {
-                    Thread.Sleep(100);
-                    splitPublishLock.Enter();
-                    splitPublishLock.Exit();
+                    WaitForSplitLockTransition(splitPublishLock);
                 }
+
+                // System.Threading.Lock is reentrant. Keeping the queue lock
+                // held preserves the historical check-before-enqueue window.
                 queue.Requeue(subscription.Object);
             }
             finally
@@ -119,17 +120,66 @@ namespace Opc.Ua.Server.Tests
                 Is.SameAs(subscription.Object));
         }
 
-        private static Lock GetPrivateLock(SessionPublishQueue queue, string fieldName)
+        private static (Lock QueueLock, Lock SplitPublishLock) GetPrivateLocks(
+            SessionPublishQueue queue)
         {
-            return TryGetPrivateLock(queue, fieldName) ??
-                throw new InvalidOperationException($"Field '{fieldName}' was not found.");
+            FieldInfo[] lockFields = [.. typeof(SessionPublishQueue)
+                .GetFields(BindingFlags.Instance | BindingFlags.NonPublic)
+                .Where(field => field.FieldType == typeof(Lock))];
+            if (lockFields.Length is 0 or > 2)
+            {
+                throw new InvalidOperationException(
+                    $"Expected one or two private Lock fields, found: " +
+                    $"{string.Join(", ", lockFields.Select(field => field.Name))}.");
+            }
+
+            FieldInfo queueLockField = lockFields.FirstOrDefault(field => field.Name == "m_lock") ??
+                (lockFields.Length == 1
+                    ? lockFields[0]
+                    : throw new InvalidOperationException(
+                        $"Could not identify the queue lock from: " +
+                        $"{string.Join(", ", lockFields.Select(field => field.Name))}."));
+            var queueLock = (Lock)queueLockField.GetValue(queue);
+            Lock splitPublishLock = lockFields
+                .Where(field => !ReferenceEquals(field, queueLockField))
+                .Select(field => (Lock)field.GetValue(queue))
+                .SingleOrDefault();
+            return (queueLock, splitPublishLock);
         }
 
-        private static Lock TryGetPrivateLock(SessionPublishQueue queue, string fieldName)
+        private static void WaitForSplitLockTransition(Lock splitPublishLock)
         {
-            return typeof(SessionPublishQueue)
-                .GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic)?
-                .GetValue(queue) as Lock;
+            bool enteredByPublisher = SpinWait.SpinUntil(
+                () =>
+                {
+                    if (!splitPublishLock.TryEnter())
+                    {
+                        return true;
+                    }
+                    splitPublishLock.Exit();
+                    return false;
+                },
+                TimeSpan.FromSeconds(2));
+            Assert.That(
+                enteredByPublisher,
+                Is.True,
+                "PublishAsync did not enter the legacy split lock.");
+
+            bool releasedByPublisher = SpinWait.SpinUntil(
+                () =>
+                {
+                    if (!splitPublishLock.TryEnter())
+                    {
+                        return false;
+                    }
+                    splitPublishLock.Exit();
+                    return true;
+                },
+                TimeSpan.FromSeconds(2));
+            Assert.That(
+                releasedByPublisher,
+                Is.True,
+                "PublishAsync did not leave the legacy split lock.");
         }
     }
 }

--- a/Tests/Opc.Ua.Server.Tests/SessionPublishQueueRaceTests.cs
+++ b/Tests/Opc.Ua.Server.Tests/SessionPublishQueueRaceTests.cs
@@ -1,0 +1,135 @@
+/* ========================================================================
+ * Copyright (c) 2005-2026 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using NUnit.Framework;
+using Opc.Ua.Tests;
+
+namespace Opc.Ua.Server.Tests
+{
+    [TestFixture]
+    [Category("Subscription")]
+    [Parallelizable]
+    public sealed class SessionPublishQueueRaceTests
+    {
+        [Test]
+        [CancelAfter(10000)]
+        public async Task PublishReadyTransitionCompletesQueuedRequestAsync()
+        {
+            ITelemetryContext telemetry = NUnitTelemetryContext.Create();
+            var subscriptionManager = new Mock<ISubscriptionManager>();
+            var server = new Mock<IServerInternal>();
+            server.Setup(s => s.Telemetry).Returns(telemetry);
+            server.Setup(s => s.SubscriptionManager).Returns(subscriptionManager.Object);
+
+            var session = new Mock<ISession>();
+            session.Setup(s => s.Id).Returns(new NodeId(Guid.NewGuid()));
+            session.Setup(s => s.IsSecureChannelValid(It.IsAny<string>())).Returns(true);
+
+            using var queue = new SessionPublishQueue(server.Object, session.Object, 10);
+            var subscription = new Mock<ISubscription>();
+            subscription.Setup(s => s.Id).Returns(1);
+            queue.Add(subscription.Object);
+
+            Lock queueLock = GetPrivateLock(queue, "m_lock");
+            Lock splitPublishLock = TryGetPrivateLock(queue, "m_subscriptionPublishLock");
+            using var publishStarted = new ManualResetEventSlim();
+            Task<ISubscription> publishTask;
+
+            // The legacy split lock lets PublishAsync finish its ready check
+            // before it blocks on the request-queue lock.
+            queueLock.Enter();
+            try
+            {
+                splitPublishLock?.Enter();
+                try
+                {
+                    publishTask = Task.Run(() =>
+                    {
+                        publishStarted.Set();
+                        return queue.PublishAsync(
+                            "channel1",
+                            DateTime.MaxValue,
+                            false,
+                            CancellationToken.None);
+                    });
+                    Assert.That(
+                        publishStarted.Wait(TimeSpan.FromSeconds(2)),
+                        Is.True,
+                        "The Publish request did not start.");
+                }
+                finally
+                {
+                    splitPublishLock?.Exit();
+                }
+
+                if (splitPublishLock != null)
+                {
+                    Thread.Sleep(100);
+                    splitPublishLock.Enter();
+                    splitPublishLock.Exit();
+                }
+                queue.Requeue(subscription.Object);
+            }
+            finally
+            {
+                queueLock.Exit();
+            }
+
+            Task completed = await Task.WhenAny(
+                publishTask,
+                Task.Delay(TimeSpan.FromSeconds(2))).ConfigureAwait(false);
+
+            Assert.That(
+                completed,
+                Is.SameAs(publishTask),
+                "The ready Subscription and queued Publish request lost their wake-up.");
+            Assert.That(
+                await publishTask.ConfigureAwait(false),
+                Is.SameAs(subscription.Object));
+        }
+
+        private static Lock GetPrivateLock(SessionPublishQueue queue, string fieldName)
+        {
+            return TryGetPrivateLock(queue, fieldName) ??
+                throw new InvalidOperationException($"Field '{fieldName}' was not found.");
+        }
+
+        private static Lock TryGetPrivateLock(SessionPublishQueue queue, string fieldName)
+        {
+            return typeof(SessionPublishQueue)
+                .GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic)?
+                .GetValue(queue) as Lock;
+        }
+    }
+}

--- a/Tests/Opc.Ua.Server.Tests/SessionPublishQueueRaceTests.cs
+++ b/Tests/Opc.Ua.Server.Tests/SessionPublishQueueRaceTests.cs
@@ -120,6 +120,60 @@ namespace Opc.Ua.Server.Tests
                 Is.SameAs(subscription.Object));
         }
 
+        [Test]
+        [CancelAfter(10000)]
+        public async Task PublishTimerAssignsRequeuedSubscriptionToWaitingRequestAsync()
+        {
+            ITelemetryContext telemetry = NUnitTelemetryContext.Create();
+            var subscriptionManager = new Mock<ISubscriptionManager>();
+            var server = new Mock<IServerInternal>();
+            server.Setup(s => s.Telemetry).Returns(telemetry);
+            server.Setup(s => s.SubscriptionManager).Returns(subscriptionManager.Object);
+
+            var session = new Mock<ISession>();
+            session.Setup(s => s.Id).Returns(new NodeId(Guid.NewGuid()));
+            session.Setup(s => s.IsSecureChannelValid(It.IsAny<string>())).Returns(true);
+
+            using var queue = new SessionPublishQueue(server.Object, session.Object, 10);
+            var subscription = new Mock<ISubscription>();
+            subscription.Setup(s => s.Id).Returns(1);
+            subscription
+                .Setup(s => s.PublishTimerExpired())
+                .Returns(PublishingState.NotificationsAvailable);
+            queue.Add(subscription.Object);
+
+            queue.Requeue(subscription.Object);
+            Assert.That(
+                await queue.PublishAsync(
+                    "channel1",
+                    DateTime.MaxValue,
+                    false,
+                    CancellationToken.None).ConfigureAwait(false),
+                Is.SameAs(subscription.Object));
+
+            Task<ISubscription> publishTask = queue.PublishAsync(
+                "channel1",
+                DateTime.MaxValue,
+                false,
+                CancellationToken.None);
+            Assert.That(publishTask.IsCompleted, Is.False);
+
+            queue.Requeue(subscription.Object);
+            queue.PublishTimerExpired();
+
+            Task completed = await Task.WhenAny(
+                publishTask,
+                Task.Delay(TimeSpan.FromSeconds(2))).ConfigureAwait(false);
+
+            Assert.That(
+                completed,
+                Is.SameAs(publishTask),
+                "The timer did not assign the already-ready Subscription to the queued Publish request.");
+            Assert.That(
+                await publishTask.ConfigureAwait(false),
+                Is.SameAs(subscription.Object));
+        }
+
         private static (Lock QueueLock, Lock SplitPublishLock) GetPrivateLocks(
             SessionPublishQueue queue)
         {


### PR DESCRIPTION
# Description

Fixes a server-side lost wake-up in `SessionPublishQueue` that can permanently stop monitored-item notifications while the Session and SecureChannel remain healthy.

In 1.5.378, `PublishAsync` checked for a ready Subscription under `m_subscriptionPublishLock` and then queued the Publish request under `m_lock`. A Subscription could become ready between those operations, be marked `ReadyToPublish` because no request was queued yet, and then leave the newly queued request stranded. Later timer ticks skipped assignment because the Subscription was already marked ready.

This change backports the relevant `SessionPublishQueue` correction from #3611 and incorporates the review follow-up:

- Makes the ready-Subscription check and Publish-request enqueue atomic under `m_lock`.
- Synchronizes `PublishCompleted`, `Requeue`, and timer-driven assignment with the same lock.
- Removes `m_subscriptionPublishLock`.
- Invokes `SessionClosed` callbacks outside the queue lock.
- Retries timer-driven assignment for already-ready, non-publishing Subscriptions instead of skipping them.
- Adds deterministic regression tests for the lost-wakeup and requeue paths.

## Related Issues

- Fixes #3997
- Backports the relevant queue fix from #3611

## Testing

- The focused `SessionPublishQueueRaceTests` fixture passes on net472, net48, net8.0, net9.0, and net10.0.
- Earlier branch validation ran the full `UA.slnx` on net10.0 and net48 with zero failures.
- Three pre-existing Quickstarts CA1823 warnings remain unchanged.