### PR TITLE
Fix generated configuration namespace resolution

### DIFF
--- a/docs/SourceGeneratedDataTypes.md
+++ b/docs/SourceGeneratedDataTypes.md
@@ -101,6 +101,8 @@ The generator resolves the OPC UA namespace URI in this order:
 2. `[DataContract(Namespace = "...")]` — from `System.Runtime.Serialization`
 3. `urn:<dotnet.namespace.lowered>` — automatic fallback (e.g. `urn:myapp.configuration`)
 
+An explicit `Namespace` expression must be resolvable from the source compilation before generators run. Use a string literal or a `const string` declared in ordinary source or a referenced assembly. Do not reference a `Namespaces` constant emitted from a model file by the same generator run; generated symbols are not available while `[DataType]` attributes are analyzed. An unresolved explicit expression produces `MODELGEN021` instead of silently falling back to a different namespace.
+
 ## The `[DataTypeField]` Attribute
 
 Applied to properties to control which fields participate in encoding and in

--- a/docs/migrate/2.0.x/configuration.md
+++ b/docs/migrate/2.0.x/configuration.md
@@ -19,6 +19,7 @@ All configuration DTO classes (`ApplicationConfiguration`, `ServerConfiguration`
 **Change code as follows:**
 
 - Replace `[DataContract(Namespace = ...)]` with `[DataType(Namespace = ...)]` and `[DataMember(...)]` with `[DataTypeField(...)]` on custom configuration subtypes.
+- If the old namespace expression references a `Namespaces` constant generated from a model file in the same project, replace it with the URI literal or a `const string` from ordinary source. Same-run generated constants are unavailable while `[DataType]` attributes are analyzed and now produce `MODELGEN021`.
 - Add the `partial` keyword to any subclass of these configuration types.
 - Custom configuration extension types must implement `IEncodeable` (the `[DataType]` source generator handles this automatically for `partial` classes).
 - Code using reflection to inspect `[DataContract]`/`[DataMember]` attributes must switch to `[DataType]`/`[DataTypeField]`.
@@ -87,4 +88,3 @@ context.Factory.Builder.AddOpcUaClientDataTypes();
 - Related: [packages.md](packages.md), [certificates.md](certificates.md), [identity.md](identity.md).
 - [2.0 migration index](README.md) — analyzer quick-start + symptom → sub-doc table.
 - [Migration Guide](../../MigrationGuide.md) — landing page across versions.
-

--- a/samples/Quickstarts.Servers/MemoryBuffer/MemoryBufferConfiguration.cs
+++ b/samples/Quickstarts.Servers/MemoryBuffer/MemoryBufferConfiguration.cs
@@ -34,7 +34,8 @@ namespace MemoryBuffer
     /// <summary>
     /// Stores the configuration the test node manager
     /// </summary>
-    [DataType(Namespace = Namespaces.MemoryBuffer)]
+    // Namespaces.MemoryBuffer is generated in the same pass and is unavailable to the [DataType] generator.
+    [DataType(Namespace = "http://samples.org/UA/MemoryBuffer")]
     public partial class MemoryBufferConfiguration
     {
         /// <summary>
@@ -54,7 +55,8 @@ namespace MemoryBuffer
     /// <summary>
     /// Stores the configuration for a memory buffer instance.
     /// </summary>
-    [DataType(Namespace = Namespaces.MemoryBuffer)]
+    // Namespaces.MemoryBuffer is generated in the same pass and is unavailable to the [DataType] generator.
+    [DataType(Namespace = "http://samples.org/UA/MemoryBuffer")]
     public partial class MemoryBufferInstance
     {
         /// <summary>

--- a/samples/Quickstarts.Servers/TestData/TestDataNodeManagerConfiguration.cs
+++ b/samples/Quickstarts.Servers/TestData/TestDataNodeManagerConfiguration.cs
@@ -34,7 +34,8 @@ namespace TestData
     /// <summary>
     /// Stores the configuration the test node manager
     /// </summary>
-    [DataType(Namespace = Namespaces.TestData)]
+    // Namespaces.TestData is generated in the same pass and is unavailable to the [DataType] generator.
+    [DataType(Namespace = "http://test.org/UA/Data/")]
     public partial class TestDataNodeManagerConfiguration
     {
         /// <summary>

--- a/tests/Opc.Ua.Server.Tests/ConfigurationRoundTripTests.cs
+++ b/tests/Opc.Ua.Server.Tests/ConfigurationRoundTripTests.cs
@@ -28,8 +28,6 @@
  * ======================================================================*/
 
 using System.IO;
-using System.Text;
-using System.Xml;
 using MemoryBuffer;
 using NUnit.Framework;
 using Opc.Ua.Tests;
@@ -71,31 +69,21 @@ namespace Opc.Ua.Server.Tests
                 ]
             };
 
-            IServiceMessageContext ctx = CreateMessageContext();
+            MemoryBufferConfiguration decoded = RoundTripExtension(
+                original,
+                out string xml);
 
-            string xml = EncodeMemoryBufferConfiguration(original, ctx);
-            MemoryBufferConfiguration decoded =
-                DecodeMemoryBufferConfiguration(xml, ctx);
-
+            Assert.That(xml, Does.Contain("http://samples.org/UA/MemoryBuffer"));
+            Assert.That(xml, Does.Not.Contain("urn:memorybuffer"));
             VerifyMemoryBufferConfiguration(decoded, original);
         }
 
         [Test]
-        public void MemoryBufferConfigurationXmlRoundTripFromFixture()
+        public void MemoryBufferConfigurationParseExtensionFromFixture()
         {
-            IServiceMessageContext ctx = CreateMessageContext();
-
-            string filePath = Path.Combine(
-                TestContext.CurrentContext.WorkDirectory,
-                "test-memorybuffer-config.xml");
-
-            MemoryBufferConfiguration first;
-            using (var stream = new FileStream(
-                filePath, FileMode.Open, FileAccess.Read))
-            {
-                first = DecodeMemoryBufferConfigurationFromStream(
-                    stream, ctx);
-            }
+            MemoryBufferConfiguration first =
+                ParseExtensionFromFixture<MemoryBufferConfiguration>(
+                    "test-memorybuffer-config.xml");
 
             Assert.That(first.Buffers, Has.Count.GreaterThan(0));
             Assert.That(first.Buffers.Count, Is.EqualTo(2));
@@ -106,10 +94,11 @@ namespace Opc.Ua.Server.Tests
             Assert.That(first.Buffers[1].TagCount, Is.EqualTo(200));
             Assert.That(first.Buffers[1].DataType, Is.EqualTo("Double"));
 
-            string xml = EncodeMemoryBufferConfiguration(first, ctx);
-            MemoryBufferConfiguration second =
-                DecodeMemoryBufferConfiguration(xml, ctx);
+            MemoryBufferConfiguration second = RoundTripExtension(
+                first,
+                out string xml);
 
+            Assert.That(xml, Does.Not.Contain("urn:memorybuffer"));
             VerifyMemoryBufferConfiguration(second, first);
         }
 
@@ -123,86 +112,66 @@ namespace Opc.Ua.Server.Tests
                 NextUnusedId = 42
             };
 
-            IServiceMessageContext ctx = CreateMessageContext();
+            TestDataNodeManagerConfiguration decoded = RoundTripExtension(
+                original,
+                out string xml);
 
-            string xml = EncodeTestDataConfig(original, ctx);
-            TestDataNodeManagerConfiguration decoded =
-                DecodeTestDataConfig(xml, ctx);
-
+            Assert.That(xml, Does.Contain("http://test.org/UA/Data/"));
+            Assert.That(xml, Does.Not.Contain("urn:testdata"));
             VerifyTestDataConfig(decoded, original);
         }
 
         [Test]
-        public void TestDataNodeManagerConfigurationXmlRoundTripFromFixture()
+        public void TestDataNodeManagerConfigurationParseExtensionFromFixture()
         {
-            IServiceMessageContext ctx = CreateMessageContext();
-
-            string filePath = Path.Combine(
-                TestContext.CurrentContext.WorkDirectory,
-                "test-testdata-config.xml");
-
-            TestDataNodeManagerConfiguration first;
-            using (var stream = new FileStream(
-                filePath, FileMode.Open, FileAccess.Read))
-            {
-                first = DecodeTestDataConfigFromStream(stream, ctx);
-            }
+            TestDataNodeManagerConfiguration first =
+                ParseExtensionFromFixture<TestDataNodeManagerConfiguration>(
+                    "test-testdata-config.xml");
 
             Assert.That(first.SaveFilePath,
                 Is.EqualTo("C:\\TestData\\state.bin"));
             Assert.That(first.MaxQueueSize, Is.EqualTo(250u));
             Assert.That(first.NextUnusedId, Is.EqualTo(42u));
 
-            string xml = EncodeTestDataConfig(first, ctx);
-            TestDataNodeManagerConfiguration second =
-                DecodeTestDataConfig(xml, ctx);
+            TestDataNodeManagerConfiguration second = RoundTripExtension(
+                first,
+                out string xml);
 
+            Assert.That(xml, Does.Not.Contain("urn:testdata"));
             VerifyTestDataConfig(second, first);
         }
 
-        private static ServiceMessageContext CreateMessageContext()
+        private static T ParseExtensionFromFixture<T>(string fileName)
+            where T : class, IEncodeable, new()
         {
             ITelemetryContext telemetry = NUnitTelemetryContext.Create();
-            return ServiceMessageContext.CreateEmpty(telemetry);
-        }
-
-        private static string EncodeMemoryBufferConfiguration(
-            MemoryBufferConfiguration config,
-            IServiceMessageContext ctx)
-        {
-            using var stream = new MemoryStream();
-            XmlWriterSettings settings = Utils.DefaultXmlWriterSettings();
-            settings.Encoding = new UTF8Encoding(false);
-            using (var writer = XmlWriter.Create(stream, settings))
+            var configuration = new ApplicationConfiguration(telemetry)
             {
-                using var encoder = new XmlEncoder(
-                    typeof(MemoryBufferConfiguration), writer, ctx);
-                config.Encode(encoder);
-                encoder.Close();
-            }
+                Extensions =
+                [
+                    Opc.Ua.XmlElement.From(File.ReadAllText(Path.Combine(
+                        TestContext.CurrentContext.WorkDirectory,
+                        fileName)))
+                ]
+            };
 
-            return Encoding.UTF8.GetString(stream.ToArray());
+            T result = configuration.ParseExtension<T>();
+            Assert.That(result, Is.Not.Null);
+            return result;
         }
 
-        private static MemoryBufferConfiguration
-            DecodeMemoryBufferConfiguration(
-                string xml,
-                IServiceMessageContext ctx)
+        private static T RoundTripExtension<T>(T value, out string xml)
+            where T : class, IEncodeable, new()
         {
-            using var stream = new MemoryStream(
-                Encoding.UTF8.GetBytes(xml));
-            return DecodeMemoryBufferConfigurationFromStream(stream, ctx);
-        }
+            var configuration = new ApplicationConfiguration(
+                NUnitTelemetryContext.Create());
+            configuration.UpdateExtension<T>(null, value);
 
-        private static MemoryBufferConfiguration
-            DecodeMemoryBufferConfigurationFromStream(
-                Stream stream,
-                IServiceMessageContext ctx)
-        {
-            using var parser = new XmlParser(
-                typeof(MemoryBufferConfiguration), stream, ctx);
-            var result = new MemoryBufferConfiguration();
-            result.Decode(parser);
+            Assert.That(configuration.Extensions, Has.Count.EqualTo(1));
+            xml = configuration.Extensions[0].OuterXml;
+
+            T result = configuration.ParseExtension<T>();
+            Assert.That(result, Is.Not.Null);
             return result;
         }
 
@@ -223,46 +192,6 @@ namespace Opc.Ua.Server.Tests
                 Assert.That(actual.Buffers[i].DataType,
                     Is.EqualTo(expected.Buffers[i].DataType));
             }
-        }
-
-        private static string EncodeTestDataConfig(
-            TestDataNodeManagerConfiguration config,
-            IServiceMessageContext ctx)
-        {
-            using var stream = new MemoryStream();
-            XmlWriterSettings settings = Utils.DefaultXmlWriterSettings();
-            settings.Encoding = new UTF8Encoding(false);
-            using (var writer = XmlWriter.Create(stream, settings))
-            {
-                using var encoder = new XmlEncoder(
-                    typeof(TestDataNodeManagerConfiguration), writer, ctx);
-                config.Encode(encoder);
-                encoder.Close();
-            }
-
-            return Encoding.UTF8.GetString(stream.ToArray());
-        }
-
-        private static TestDataNodeManagerConfiguration
-            DecodeTestDataConfig(
-                string xml,
-                IServiceMessageContext ctx)
-        {
-            using var stream = new MemoryStream(
-                Encoding.UTF8.GetBytes(xml));
-            return DecodeTestDataConfigFromStream(stream, ctx);
-        }
-
-        private static TestDataNodeManagerConfiguration
-            DecodeTestDataConfigFromStream(
-                Stream stream,
-                IServiceMessageContext ctx)
-        {
-            using var parser = new XmlParser(
-                typeof(TestDataNodeManagerConfiguration), stream, ctx);
-            var result = new TestDataNodeManagerConfiguration();
-            result.Decode(parser);
-            return result;
         }
 
         private static void VerifyTestDataConfig(

--- a/tests/Opc.Ua.Server.Tests/test-memorybuffer-config.xml
+++ b/tests/Opc.Ua.Server.Tests/test-memorybuffer-config.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <MemoryBufferConfiguration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:uax="http://opcfoundation.org/UA/2008/02/Types.xsd" xmlns="http://samples.org/UA/MemoryBuffer">
-  <Buffers xmlns="urn:memorybuffer">
-    <MemoryBufferInstance xmlns="http://samples.org/UA/MemoryBuffer">
-      <Name xmlns="urn:memorybuffer">UInt32</Name>
-      <TagCount xmlns="urn:memorybuffer">100</TagCount>
-      <DataType xmlns="urn:memorybuffer">UInt32</DataType>
+  <Buffers>
+    <MemoryBufferInstance>
+      <Name>UInt32</Name>
+      <TagCount>100</TagCount>
+      <DataType>UInt32</DataType>
     </MemoryBufferInstance>
-    <MemoryBufferInstance xmlns="http://samples.org/UA/MemoryBuffer">
-      <Name xmlns="urn:memorybuffer">Double</Name>
-      <TagCount xmlns="urn:memorybuffer">200</TagCount>
-      <DataType xmlns="urn:memorybuffer">Double</DataType>
+    <MemoryBufferInstance>
+      <Name>Double</Name>
+      <TagCount>200</TagCount>
+      <DataType>Double</DataType>
     </MemoryBufferInstance>
   </Buffers>
 </MemoryBufferConfiguration>

--- a/tests/Opc.Ua.Server.Tests/test-testdata-config.xml
+++ b/tests/Opc.Ua.Server.Tests/test-testdata-config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <TestDataNodeManagerConfiguration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:uax="http://opcfoundation.org/UA/2008/02/Types.xsd" xmlns="http://test.org/UA/Data/">
-  <SaveFilePath xmlns="urn:testdata">C:\TestData\state.bin</SaveFilePath>
-  <MaxQueueSize xmlns="urn:testdata">250</MaxQueueSize>
-  <NextUnusedId xmlns="urn:testdata">42</NextUnusedId>
+  <SaveFilePath>C:\TestData\state.bin</SaveFilePath>
+  <MaxQueueSize>250</MaxQueueSize>
+  <NextUnusedId>42</NextUnusedId>
 </TestDataNodeManagerConfiguration>

--- a/tests/Opc.Ua.SourceGeneration.Tests/TypeGeneratorTests.cs
+++ b/tests/Opc.Ua.SourceGeneration.Tests/TypeGeneratorTests.cs
@@ -328,6 +328,87 @@ namespace TestApp.CustomId
         }
 
         [Test]
+        public void ClassWithExplicitNamespaceUsesSpecifiedNamespace()
+        {
+            const string source = """
+
+using Opc.Ua;
+
+namespace TestApp.ExplicitNamespace
+{
+    [DataType(
+        Namespace = "urn:test:explicit",
+        DataTypeId = "s=ExplicitConfig",
+        XmlEncodingId = "s=ExplicitConfigXml")]
+    public partial class ExplicitConfig
+    {
+        public string Name { get; set; }
+    }
+}
+""";
+            GeneratorRunResult result = RunGenerator(source);
+
+            Assert.That(result.GeneratedSources, Has.Length.EqualTo(1));
+            string generated = result.GeneratedSources[0].SourceText.ToString();
+            Assert.That(
+                CountOccurrences(generated, "\"urn:test:explicit\""),
+                Is.GreaterThanOrEqualTo(5));
+            Assert.That(generated, Does.Not.Contain("urn:testapp.explicitnamespace"));
+        }
+
+        [Test]
+        public void UnresolvedExplicitNamespaceReportsDiagnostic()
+        {
+            const string source = """
+
+using Opc.Ua;
+
+namespace TestApp.UnresolvedNamespace
+{
+    [DataType(Namespace = Namespaces.GeneratedModel)]
+    public partial class UnresolvedConfig
+    {
+        public string Name { get; set; }
+    }
+}
+""";
+            GeneratorRunResult result = RunGenerator(source, expectErrors: true);
+
+            Assert.That(
+                result.Diagnostics.Any(diagnostic =>
+                    diagnostic.Id == "MODELGEN021" &&
+                    diagnostic.GetMessage(CultureInfo.InvariantCulture)
+                        .Contains("Namespaces.GeneratedModel", StringComparison.Ordinal)),
+                Is.True);
+            Assert.That(result.GeneratedSources, Is.Empty);
+        }
+
+        [Test]
+        public void ExplicitNullNamespaceUsesFallback()
+        {
+            const string source = """
+
+using Opc.Ua;
+
+namespace TestApp.NullNamespace
+{
+    [DataType(Namespace = null)]
+    public partial class NullNamespaceConfig
+    {
+        public string Name { get; set; }
+    }
+}
+""";
+            GeneratorRunResult result = RunGenerator(source);
+
+            Assert.That(result.Diagnostics, Is.Empty);
+            Assert.That(result.GeneratedSources, Has.Length.EqualTo(1));
+            Assert.That(
+                result.GeneratedSources[0].SourceText.ToString(),
+                Does.Contain("\"urn:testapp.nullnamespace\""));
+        }
+
+        [Test]
         public void TwoClassesSameNamespaceSingleExtensionMethod()
         {
             const string source = @"

--- a/tests/Opc.Ua.SourceGeneration.Tests/TypeGeneratorTests.cs
+++ b/tests/Opc.Ua.SourceGeneration.Tests/TypeGeneratorTests.cs
@@ -350,9 +350,18 @@ namespace TestApp.ExplicitNamespace
 
             Assert.That(result.GeneratedSources, Has.Length.EqualTo(1));
             string generated = result.GeneratedSources[0].SourceText.ToString();
-            Assert.That(
-                CountOccurrences(generated, "\"urn:test:explicit\""),
-                Is.GreaterThanOrEqualTo(5));
+            Assert.That(generated, Does.Contain(
+                "new global::Opc.Ua.ExpandedNodeId(" +
+                "global::Opc.Ua.NodeId.Parse(\"s=ExplicitConfig\"), " +
+                "\"urn:test:explicit\")"));
+            Assert.That(generated, Does.Contain(
+                "new global::Opc.Ua.ExpandedNodeId(" +
+                "global::Opc.Ua.NodeId.Parse(\"s=ExplicitConfigXml\"), " +
+                "\"urn:test:explicit\")"));
+            Assert.That(generated, Does.Contain(
+                """encoder.PushNamespace("urn:test:explicit");"""));
+            Assert.That(generated, Does.Contain(
+                """decoder.PushNamespace("urn:test:explicit");"""));
             Assert.That(generated, Does.Not.Contain("urn:testapp.explicitnamespace"));
         }
 

--- a/tools/Opc.Ua.SourceGeneration/AnalyzerReleases.Unshipped.md
+++ b/tools/Opc.Ua.SourceGeneration/AnalyzerReleases.Unshipped.md
@@ -12,3 +12,4 @@ MODELGEN011 | ModelSourceGenerator | Error | [NodeManager] class must be partial
 MODELGEN012 | ModelSourceGenerator | Info | Multiple referenced assemblies expose same model
 MODELGEN013 | ModelSourceGenerator | Info | Model already provided by referenced assembly
 MODELGEN020 | ModelSourceGenerator | Warning | BrowseName requires C# string-literal escaping (UASG_BROWSENAME_UNSAFE)
+MODELGEN021 | ModelSourceGenerator | Error | [DataType] namespace could not be resolved

--- a/tools/Opc.Ua.SourceGeneration/DataTypeCompilation.cs
+++ b/tools/Opc.Ua.SourceGeneration/DataTypeCompilation.cs
@@ -80,6 +80,16 @@ namespace Opc.Ua.SourceGeneration
         public string ErrorMessage { get; }
 
         /// <summary>
+        /// The annotated type name used for diagnostics.
+        /// </summary>
+        public string TypeName { get; }
+
+        /// <summary>
+        /// An explicitly supplied namespace expression that Roslyn could not resolve.
+        /// </summary>
+        public string UnresolvedNamespaceExpression { get; }
+
+        /// <summary>
         /// Check whether the generator can handle the node.
         /// </summary>
         public static bool Handles(SyntaxNode node, CancellationToken ct)
@@ -97,9 +107,23 @@ namespace Opc.Ua.SourceGeneration
             CancellationToken cancellationToken)
         {
             var symbol = (INamedTypeSymbol)context.TargetSymbol;
+            TypeName = symbol.ToDisplayString();
             Location = symbol.Locations.FirstOrDefault();
 
             AttributeData dataTypeAttr = context.Attributes.FirstOrDefault();
+            AttributeArgumentSyntax unresolvedNamespaceArgument =
+                GetUnresolvedNamespaceArgument(dataTypeAttr, cancellationToken);
+            if (unresolvedNamespaceArgument != null)
+            {
+                Location = unresolvedNamespaceArgument.GetLocation();
+                UnresolvedNamespaceExpression =
+                    unresolvedNamespaceArgument.Expression.ToString();
+                HasErrors = true;
+                ValidFields = [];
+                Diagnostics = [];
+                return;
+            }
+
             string dataTypeNamespace =
                 dataTypeAttr.GetValue(nameof(DataTypeAttribute.Namespace));
             string dataTypeId =
@@ -186,6 +210,16 @@ namespace Opc.Ua.SourceGeneration
         {
             foreach (DataTypeCompilation comp in compilations)
             {
+                if (comp.UnresolvedNamespaceExpression != null)
+                {
+                    sourceContext.ReportDiagnostic(
+                        Diagnostic.Create(
+                            SourceGenerator.DataTypeNamespaceUnresolved,
+                            comp.Location,
+                            comp.TypeName,
+                            comp.UnresolvedNamespaceExpression));
+                }
+
                 if (comp.ErrorMessage != null)
                 {
                     sourceContext.ReportDiagnostic(
@@ -645,6 +679,39 @@ namespace Opc.Ua.SourceGeneration
             }
 
             return false;
+        }
+
+        private static AttributeArgumentSyntax GetUnresolvedNamespaceArgument(
+            AttributeData attribute,
+            CancellationToken cancellationToken)
+        {
+            if (attribute?.ApplicationSyntaxReference?.GetSyntax(cancellationToken) is not
+                AttributeSyntax attributeSyntax)
+            {
+                return null;
+            }
+
+            AttributeArgumentSyntax namespaceArgument = attributeSyntax.ArgumentList?.Arguments
+                .FirstOrDefault(argument =>
+                    argument.NameEquals?.Name.Identifier.ValueText ==
+                    nameof(DataTypeAttribute.Namespace));
+            if (namespaceArgument == null)
+            {
+                return null;
+            }
+
+            foreach (KeyValuePair<string, TypedConstant> namedArgument in
+                attribute.NamedArguments)
+            {
+                if (namedArgument.Key == nameof(DataTypeAttribute.Namespace))
+                {
+                    return namedArgument.Value.Kind == TypedConstantKind.Error
+                        ? namespaceArgument
+                        : null;
+                }
+            }
+
+            return namespaceArgument;
         }
 
         private static string ResolveNamespaceUri(

--- a/tools/Opc.Ua.SourceGeneration/DataTypeCompilation.cs
+++ b/tools/Opc.Ua.SourceGeneration/DataTypeCompilation.cs
@@ -87,7 +87,7 @@ namespace Opc.Ua.SourceGeneration
         /// <summary>
         /// An explicitly supplied namespace expression that Roslyn could not resolve.
         /// </summary>
-        public string UnresolvedNamespaceExpression { get; }
+        public string UnresolvedNamespaceExpression { get; } = string.Empty;
 
         /// <summary>
         /// Check whether the generator can handle the node.
@@ -210,7 +210,7 @@ namespace Opc.Ua.SourceGeneration
         {
             foreach (DataTypeCompilation comp in compilations)
             {
-                if (comp.UnresolvedNamespaceExpression != null)
+                if (comp.UnresolvedNamespaceExpression.Length > 0)
                 {
                     sourceContext.ReportDiagnostic(
                         Diagnostic.Create(
@@ -218,6 +218,7 @@ namespace Opc.Ua.SourceGeneration
                             comp.Location,
                             comp.TypeName,
                             comp.UnresolvedNamespaceExpression));
+                    continue;
                 }
 
                 if (comp.ErrorMessage != null)

--- a/tools/Opc.Ua.SourceGeneration/SourceGenerator.cs
+++ b/tools/Opc.Ua.SourceGeneration/SourceGenerator.cs
@@ -144,6 +144,23 @@ namespace Opc.Ua.SourceGeneration
             customTags: ["opcua"]);
 
         /// <summary>
+        /// A <c>[DataType]</c> namespace argument could not be resolved before
+        /// source generation.
+        /// </summary>
+        public static readonly DiagnosticDescriptor DataTypeNamespaceUnresolved = new(
+            id: "MODELGEN021",
+            title: "[DataType] namespace could not be resolved",
+            messageFormat: (LocalizableString)("The Namespace argument '{1}' on [DataType] " +
+                "type '{0}' could not be resolved during source generation. Use a string " +
+                "literal or a const declared in source or a referenced assembly; values " +
+                "generated in the same compilation are unavailable."),
+            category: Name,
+            DiagnosticSeverity.Error,
+            isEnabledByDefault: true,
+            helpLinkUri: "www.opcfoundation.org",
+            customTags: ["opcua"]);
+
+        /// <summary>
         /// Get diagnostic descriptor for event id
         /// </summary>
         public static bool TryGetDiagnostic(


### PR DESCRIPTION
# Description

Fix source-generated configuration types whose explicit namespace references constants emitted by the same generator pass. Roslyn cannot resolve those constants while `[DataType]` attributes are analyzed, so the generated XML codec silently fell back to `urn:memorybuffer` / `urn:testdata` while the shipped configuration uses the model namespace URIs.

This change:

- adds `MODELGEN021` to fail when an explicitly supplied `[DataType.Namespace]` expression cannot be resolved;
- uses compile-time-available model namespace URIs for the MemoryBuffer and TestData configuration types;
- restores production-shaped XML fixtures and exercises the `UpdateExtension<T>()` / `ParseExtension<T>()` path;
- documents the source-generator namespace requirement and migration guidance.

Targeted validation passed:

- `TypeGeneratorTests`: 17 tests on `net10.0` and `net48`;
- `ConfigurationRoundTripTests`: 4 tests on `net10.0` and `net48`.

## Related Issues

- Fixes #4014

## Checklist

- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf) and read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [x] I have added all necessary documentation.
- [x] I have verified that my changes do not introduce (new) build or analyzer warnings.
- [ ] I ran **all** tests locally using the **UA.slnx** solution against at least .net **framework** and .net **10**, and all passed.
- [ ] I fixed **all** failing and flaky tests in the CI pipelines and **all** CodeQL warnings.
- [x] I have addressed **all** PR feedback received.
