### PR TITLE
fix: return BadInvalidState for unlatched alarm reset

### DIFF
--- a/src/Opc.Ua.Core.Types/State/AlarmConditionState.Methods.cs
+++ b/src/Opc.Ua.Core.Types/State/AlarmConditionState.Methods.cs
@@ -502,8 +502,9 @@ namespace Opc.Ua
 
                     if (!LatchedState.Id!.Value)
                     {
-                        // Not latched — nothing to reset
-                        return StatusCodes.BadConditionNotShelved; // closest standard code for invalid state
+                        // Reset applies to the latched-alarm state machine;
+                        // an unlatched alarm is simply not in a valid reset state.
+                        return StatusCodes.BadInvalidState;
                     }
 
                     if (ActiveState!.Id!.Value)

--- a/tests/Opc.Ua.Features.Tests/AlarmConditionStateMethodTests.cs
+++ b/tests/Opc.Ua.Features.Tests/AlarmConditionStateMethodTests.cs
@@ -870,6 +870,21 @@ namespace Opc.Ua.Features.Tests
             Assert.That(result.StatusCode.Code, Is.EqualTo(StatusCodes.BadNotSupported));
         }
 
+        [Test]
+        [TestCase("v1")]
+        [TestCase("v2")]
+        public void OnResetCalledReturnsBadInvalidStateWhenAlarmIsNotLatched(string variant)
+        {
+            TestableAlarm alarm = CreateTestableAlarm();
+            AddTwoStateChild(alarm, BrowseNames.LatchedState, s => alarm.LatchedState = s);
+
+            ServiceResult result = variant == "v1"
+                ? alarm.CallReset(m_context)
+                : alarm.CallReset2(m_context, new LocalizedText("en", "x"));
+
+            Assert.That(result.StatusCode.Code, Is.EqualTo(StatusCodes.BadInvalidState));
+        }
+
         private TestableAlarm CreateResettableAlarm()
         {
             TestableAlarm alarm = CreateTestableAlarm();


### PR DESCRIPTION
### Summary

This PR fixes the reset status code returned for unlatched alarms and adds a regression test that verifies `Reset` and `Reset2` both report `BadInvalidState` when the alarm is not latched.

### Problem

According to the alarm reset semantics described in OPC UA Part 9, `Reset` is only valid for a latched alarm that is no longer active and has already been acknowledged and confirmed when those states are present. For any other invalid state, the server should return `Bad_InvalidState`.

Previously, `AlarmConditionState.HandleResetCore()` returned `BadConditionNotShelved` when `LatchedState.Id == false`. That status code belongs to the shelving state machine, not the latched alarm reset flow. As a result, clients calling `AlarmClient.ResetAsync()` could receive a shelving-related error for a reset precondition failure, which misrepresents the actual alarm state and breaks the expected Part 9 semantics.

### Changes

- Change the unlatched branch in `AlarmConditionState.HandleResetCore()` to return `BadInvalidState` instead of `BadConditionNotShelved`.
- Add a regression test in `AlarmConditionStateMethodTests` that covers both `Reset` and `Reset2` when `LatchedState` exists but the alarm is not latched.
