### PR TITLE
fix: don't return continuation points on BadNoContinuationPoints

### DIFF
--- a/src/Opc.Ua.Server/NodeManager/MasterNodeManager.cs
+++ b/src/Opc.Ua.Server/NodeManager/MasterNodeManager.cs
@@ -2147,7 +2147,7 @@ namespace Opc.Ua.Server
                 }
 
                 // check for continuation point.
-                if (cp != null)
+                if (cp != null && ServiceResult.IsGood(error))
                 {
                     result.StatusCode = StatusCodes.Good;
                     result.ContinuationPoint = cp.Id.ToByteArray().ToByteString();
@@ -2256,7 +2256,7 @@ namespace Opc.Ua.Server
                 result.References = references;
 
                 // save continuation point.
-                if (cp != null)
+                if (cp != null && ServiceResult.IsGood(error))
                 {
                     result.StatusCode = StatusCodes.Good;
                     result.ContinuationPoint = cp.Id.ToByteArray().ToByteString();
@@ -2343,7 +2343,8 @@ namespace Opc.Ua.Server
                 {
                     if (!assignContinuationPoint)
                     {
-                        return (StatusCodes.BadNoContinuationPoints, currentCp, referenceList);
+                        currentCp.Dispose();
+                        return (StatusCodes.BadNoContinuationPoints, null, referenceList);
                     }
 
                     currentCp.Id = Guid.NewGuid();

--- a/tests/Opc.Ua.Server.Tests/NodeManager/MasterNodeManagerDeterministicTests.cs
+++ b/tests/Opc.Ua.Server.Tests/NodeManager/MasterNodeManagerDeterministicTests.cs
@@ -1127,7 +1127,7 @@ namespace Opc.Ua.Server.Tests
                 .Returns<ByteString>(cpBytes =>
                 {
                     string key = ToContinuationPointKey(cpBytes);
-                    if (continuationPoints.TryGetValue(key, out ContinuationPoint cp))
+                    if (continuationPoints.TryGetValue(key, out ContinuationPoint? cp))
                     {
                         continuationPoints.Remove(key);
                         return cp;
@@ -1152,7 +1152,7 @@ namespace Opc.Ua.Server.Tests
 
         private static string ToContinuationPointKey(ByteString continuationPoint)
         {
-            return System.Convert.ToBase64String(continuationPoint ?? System.Array.Empty<byte>());
+            return System.Convert.ToBase64String(continuationPoint.ToArray());
         }
     }
 }

--- a/tests/Opc.Ua.Server.Tests/NodeManager/MasterNodeManagerDeterministicTests.cs
+++ b/tests/Opc.Ua.Server.Tests/NodeManager/MasterNodeManagerDeterministicTests.cs
@@ -248,6 +248,32 @@ namespace Opc.Ua.Server.Tests
         }
 
         [Test]
+        public async Task BrowseAsync_WhenNoContinuationPointCanBeAssigned_ReturnsBadNoContinuationPointsWithoutContinuationPointAsync()
+        {
+            using MasterNodeManager sut = CreateMasterNodeManager();
+            OperationContext ctx = CreateContextWithContinuationStore();
+
+            SetMaxBrowseContinuationPointsPerBrowse(sut, 0u);
+
+            var nodeToBrowse = new BrowseDescription
+            {
+                NodeId = ObjectIds.RootFolder,
+                BrowseDirection = BrowseDirection.Forward
+            };
+
+            (ArrayOf<BrowseResult> results, _) = await sut.BrowseAsync(
+                ctx,
+                new ViewDescription(),
+                1u,
+                new BrowseDescription[] { nodeToBrowse }.ToArrayOf(),
+                CancellationToken.None).ConfigureAwait(false);
+
+            Assert.That(results.Count, Is.EqualTo(1));
+            Assert.That(results[0].StatusCode, Is.EqualTo(StatusCodes.BadNoContinuationPoints));
+            Assert.That(results[0].ContinuationPoint.IsEmpty, Is.True);
+        }
+
+        [Test]
         public void BrowseNextAsync_NullContext_ThrowsArgumentNullException()
         {
             using MasterNodeManager sut = CreateMasterNodeManager();
@@ -317,6 +343,42 @@ namespace Opc.Ua.Server.Tests
 
             Assert.That(results.Count, Is.EqualTo(1));
             Assert.That(results[0].StatusCode, Is.EqualTo(StatusCodes.Good));
+        }
+
+        [Test]
+        public async Task BrowseNextAsync_WhenNoContinuationPointCanBeAssigned_ReturnsBadNoContinuationPointsWithoutContinuationPointAsync()
+        {
+            using MasterNodeManager sut = CreateMasterNodeManager();
+            OperationContext ctx = CreateContextWithContinuationStore();
+
+            var nodeToBrowse = new BrowseDescription
+            {
+                NodeId = ObjectIds.RootFolder,
+                BrowseDirection = BrowseDirection.Forward
+            };
+
+            (ArrayOf<BrowseResult> firstResults, _) = await sut.BrowseAsync(
+                ctx,
+                new ViewDescription(),
+                1u,
+                new BrowseDescription[] { nodeToBrowse }.ToArrayOf(),
+                CancellationToken.None).ConfigureAwait(false);
+
+            Assert.That(firstResults.Count, Is.EqualTo(1));
+            Assert.That(firstResults[0].StatusCode, Is.EqualTo(StatusCodes.Good));
+            Assert.That(firstResults[0].ContinuationPoint.IsEmpty, Is.False);
+
+            SetMaxBrowseContinuationPointsPerBrowse(sut, 0u);
+
+            (ArrayOf<BrowseResult> nextResults, _) = await sut.BrowseNextAsync(
+                ctx,
+                false,
+                new ByteString[] { firstResults[0].ContinuationPoint }.ToArrayOf(),
+                CancellationToken.None).ConfigureAwait(false);
+
+            Assert.That(nextResults.Count, Is.EqualTo(1));
+            Assert.That(nextResults[0].StatusCode, Is.EqualTo(StatusCodes.BadNoContinuationPoints));
+            Assert.That(nextResults[0].ContinuationPoint.IsEmpty, Is.True);
         }
 
         [Test]
@@ -1046,6 +1108,51 @@ namespace Opc.Ua.Server.Tests
             session.Setup(s => s.PreferredLocales).Returns([]);
             return new OperationContext(
                 new RequestHeader(), null!, RequestType.Read, RequestLifetime.None, session.Object);
+        }
+
+        private static OperationContext CreateContextWithContinuationStore()
+        {
+            var continuationPoints = new Dictionary<string, ContinuationPoint>();
+            var session = new Mock<ISession>();
+            session.Setup(s => s.EffectiveIdentity).Returns(new Mock<IUserIdentity>().Object);
+            session.Setup(s => s.PreferredLocales).Returns([]);
+            session
+                .Setup(s => s.SaveContinuationPoint(It.IsAny<ContinuationPoint>()))
+                .Callback<ContinuationPoint>(cp =>
+                {
+                    continuationPoints[ToContinuationPointKey(cp.Id.ToByteArray().ToByteString())] = cp;
+                });
+            session
+                .Setup(s => s.RestoreContinuationPoint(It.IsAny<ByteString>()))
+                .Returns<ByteString>(cpBytes =>
+                {
+                    string key = ToContinuationPointKey(cpBytes);
+                    if (continuationPoints.TryGetValue(key, out ContinuationPoint cp))
+                    {
+                        continuationPoints.Remove(key);
+                        return cp;
+                    }
+
+                    return null;
+                });
+
+            return new OperationContext(
+                new RequestHeader(), null!, RequestType.Read, RequestLifetime.None, session.Object);
+        }
+
+        private static void SetMaxBrowseContinuationPointsPerBrowse(MasterNodeManager sut, uint value)
+        {
+            var field = typeof(MasterNodeManager).GetField(
+                "m_maxContinuationPointsPerBrowse",
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+
+            Assert.That(field, Is.Not.Null);
+            field!.SetValue(sut, value);
+        }
+
+        private static string ToContinuationPointKey(ByteString continuationPoint)
+        {
+            return System.Convert.ToBase64String(continuationPoint ?? System.Array.Empty<byte>());
         }
     }
 }

--- a/tests/Opc.Ua.Server.Tests/NodeManager/MasterNodeManagerDeterministicTests.cs
+++ b/tests/Opc.Ua.Server.Tests/NodeManager/MasterNodeManagerDeterministicTests.cs
@@ -250,27 +250,35 @@ namespace Opc.Ua.Server.Tests
         [Test]
         public async Task BrowseAsync_WhenNoContinuationPointCanBeAssigned_ReturnsBadNoContinuationPointsWithoutContinuationPointAsync()
         {
-            using MasterNodeManager sut = CreateMasterNodeManager();
+            MasterNodeManager sut = (MasterNodeManager)m_server.CurrentInstance.NodeManager;
             OperationContext ctx = CreateContextWithContinuationStore();
+            uint originalLimit = GetMaxBrowseContinuationPointsPerBrowse(sut);
 
-            SetMaxBrowseContinuationPointsPerBrowse(sut, 0u);
-
-            var nodeToBrowse = new BrowseDescription
+            try
             {
-                NodeId = ObjectIds.RootFolder,
-                BrowseDirection = BrowseDirection.Forward
-            };
+                SetMaxBrowseContinuationPointsPerBrowse(sut, 0u);
 
-            (ArrayOf<BrowseResult> results, _) = await sut.BrowseAsync(
-                ctx,
-                new ViewDescription(),
-                1u,
-                new BrowseDescription[] { nodeToBrowse }.ToArrayOf(),
-                CancellationToken.None).ConfigureAwait(false);
+                var nodeToBrowse = new BrowseDescription
+                {
+                    NodeId = ObjectIds.RootFolder,
+                    BrowseDirection = BrowseDirection.Forward
+                };
 
-            Assert.That(results.Count, Is.EqualTo(1));
-            Assert.That(results[0].StatusCode, Is.EqualTo(StatusCodes.BadNoContinuationPoints));
-            Assert.That(results[0].ContinuationPoint.IsEmpty, Is.True);
+                (ArrayOf<BrowseResult> results, _) = await sut.BrowseAsync(
+                    ctx,
+                    new ViewDescription(),
+                    1u,
+                    new BrowseDescription[] { nodeToBrowse }.ToArrayOf(),
+                    CancellationToken.None).ConfigureAwait(false);
+
+                Assert.That(results.Count, Is.EqualTo(1));
+                Assert.That(results[0].StatusCode, Is.EqualTo(StatusCodes.BadNoContinuationPoints));
+                Assert.That(results[0].ContinuationPoint.IsEmpty, Is.True);
+            }
+            finally
+            {
+                SetMaxBrowseContinuationPointsPerBrowse(sut, originalLimit);
+            }
         }
 
         [Test]
@@ -348,37 +356,45 @@ namespace Opc.Ua.Server.Tests
         [Test]
         public async Task BrowseNextAsync_WhenNoContinuationPointCanBeAssigned_ReturnsBadNoContinuationPointsWithoutContinuationPointAsync()
         {
-            using MasterNodeManager sut = CreateMasterNodeManager();
+            MasterNodeManager sut = (MasterNodeManager)m_server.CurrentInstance.NodeManager;
             OperationContext ctx = CreateContextWithContinuationStore();
+            uint originalLimit = GetMaxBrowseContinuationPointsPerBrowse(sut);
 
-            var nodeToBrowse = new BrowseDescription
+            try
             {
-                NodeId = ObjectIds.RootFolder,
-                BrowseDirection = BrowseDirection.Forward
-            };
+                var nodeToBrowse = new BrowseDescription
+                {
+                    NodeId = ObjectIds.RootFolder,
+                    BrowseDirection = BrowseDirection.Forward
+                };
 
-            (ArrayOf<BrowseResult> firstResults, _) = await sut.BrowseAsync(
-                ctx,
-                new ViewDescription(),
-                1u,
-                new BrowseDescription[] { nodeToBrowse }.ToArrayOf(),
-                CancellationToken.None).ConfigureAwait(false);
+                (ArrayOf<BrowseResult> firstResults, _) = await sut.BrowseAsync(
+                    ctx,
+                    new ViewDescription(),
+                    1u,
+                    new BrowseDescription[] { nodeToBrowse }.ToArrayOf(),
+                    CancellationToken.None).ConfigureAwait(false);
 
-            Assert.That(firstResults.Count, Is.EqualTo(1));
-            Assert.That(firstResults[0].StatusCode, Is.EqualTo(StatusCodes.Good));
-            Assert.That(firstResults[0].ContinuationPoint.IsEmpty, Is.False);
+                Assert.That(firstResults.Count, Is.EqualTo(1));
+                Assert.That(firstResults[0].StatusCode, Is.EqualTo(StatusCodes.Good));
+                Assert.That(firstResults[0].ContinuationPoint.IsEmpty, Is.False);
 
-            SetMaxBrowseContinuationPointsPerBrowse(sut, 0u);
+                SetMaxBrowseContinuationPointsPerBrowse(sut, 0u);
 
-            (ArrayOf<BrowseResult> nextResults, _) = await sut.BrowseNextAsync(
-                ctx,
-                false,
-                new ByteString[] { firstResults[0].ContinuationPoint }.ToArrayOf(),
-                CancellationToken.None).ConfigureAwait(false);
+                (ArrayOf<BrowseResult> nextResults, _) = await sut.BrowseNextAsync(
+                    ctx,
+                    false,
+                    new ByteString[] { firstResults[0].ContinuationPoint }.ToArrayOf(),
+                    CancellationToken.None).ConfigureAwait(false);
 
-            Assert.That(nextResults.Count, Is.EqualTo(1));
-            Assert.That(nextResults[0].StatusCode, Is.EqualTo(StatusCodes.BadNoContinuationPoints));
-            Assert.That(nextResults[0].ContinuationPoint.IsEmpty, Is.True);
+                Assert.That(nextResults.Count, Is.EqualTo(1));
+                Assert.That(nextResults[0].StatusCode, Is.EqualTo(StatusCodes.BadNoContinuationPoints));
+                Assert.That(nextResults[0].ContinuationPoint.IsEmpty, Is.True);
+            }
+            finally
+            {
+                SetMaxBrowseContinuationPointsPerBrowse(sut, originalLimit);
+            }
         }
 
         [Test]
@@ -1148,6 +1164,16 @@ namespace Opc.Ua.Server.Tests
 
             Assert.That(field, Is.Not.Null);
             field!.SetValue(sut, value);
+        }
+
+        private static uint GetMaxBrowseContinuationPointsPerBrowse(MasterNodeManager sut)
+        {
+            var field = typeof(MasterNodeManager).GetField(
+                "m_maxContinuationPointsPerBrowse",
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+
+            Assert.That(field, Is.Not.Null);
+            return (uint)field!.GetValue(sut)!;
         }
 
         private static string ToContinuationPointKey(ByteString continuationPoint)

--- a/tests/Opc.Ua.Server.Tests/NodeManager/MasterNodeManagerDeterministicTests.cs
+++ b/tests/Opc.Ua.Server.Tests/NodeManager/MasterNodeManagerDeterministicTests.cs
@@ -379,8 +379,6 @@ namespace Opc.Ua.Server.Tests
                 Assert.That(firstResults[0].StatusCode, Is.EqualTo(StatusCodes.Good));
                 Assert.That(firstResults[0].ContinuationPoint.IsEmpty, Is.False);
 
-                SetMaxBrowseContinuationPointsPerBrowse(sut, 0u);
-
                 (ArrayOf<BrowseResult> nextResults, _) = await sut.BrowseNextAsync(
                     ctx,
                     false,
@@ -388,8 +386,20 @@ namespace Opc.Ua.Server.Tests
                     CancellationToken.None).ConfigureAwait(false);
 
                 Assert.That(nextResults.Count, Is.EqualTo(1));
-                Assert.That(nextResults[0].StatusCode, Is.EqualTo(StatusCodes.BadNoContinuationPoints));
-                Assert.That(nextResults[0].ContinuationPoint.IsEmpty, Is.True);
+                Assert.That(nextResults[0].StatusCode, Is.EqualTo(StatusCodes.Good));
+                Assert.That(nextResults[0].ContinuationPoint.IsEmpty, Is.False);
+
+                SetMaxBrowseContinuationPointsPerBrowse(sut, 0u);
+
+                (ArrayOf<BrowseResult> finalResults, _) = await sut.BrowseNextAsync(
+                    ctx,
+                    false,
+                    new ByteString[] { nextResults[0].ContinuationPoint }.ToArrayOf(),
+                    CancellationToken.None).ConfigureAwait(false);
+
+                Assert.That(finalResults.Count, Is.EqualTo(1));
+                Assert.That(finalResults[0].StatusCode, Is.EqualTo(StatusCodes.BadNoContinuationPoints));
+                Assert.That(finalResults[0].ContinuationPoint.IsEmpty, Is.True);
             }
             finally
             {


### PR DESCRIPTION
### Summary

This PR fixes `Browse` and `BrowseNext` so they do not return a usable continuation point when the server reports `BadNoContinuationPoints`, and adds regression tests that cover both code paths.

### Problem

According to OPC UA Part 4, if the server cannot allocate another continuation point for a `Browse` or `BrowseNext` operation, the result should be `Bad_NoContinuationPoints`. In that case, the server must not also return a continuation point that the client can continue to use.

Previously, `MasterNodeManager.FetchReferencesAsync()` could return `BadNoContinuationPoints` while still passing a live continuation point object back to its callers. `BrowseAsync()` then copied that continuation point into the result, producing a contradictory response with `StatusCode = BadNoContinuationPoints` and a non-empty `ContinuationPoint`. `BrowseNextAsync()` went further and overwrote the error with `Good` whenever a continuation point object was still present. That behavior hides continuation-point quota exhaustion and breaks the expected paging semantics.

### Changes

- Dispose and clear the continuation point when `FetchReferencesAsync()` hits the no-continuation-points path.
- Only copy a continuation point into `Browse` and `BrowseNext` results when the operation completed successfully.
- Add deterministic regression tests that verify both `Browse` and `BrowseNext` return `BadNoContinuationPoints` without a continuation point when the continuation-point quota is exhausted.