### PR TITLE
Fix managed session failover target selection

### DIFF
--- a/src/Opc.Ua.Client/Session/ManagedSession.cs
+++ b/src/Opc.Ua.Client/Session/ManagedSession.cs
@@ -1321,9 +1321,11 @@ namespace Opc.Ua.Client
 
             try
             {
+                ConfiguredEndpoint currentEndpoint = m_session?.ConfiguredEndpoint
+                    ?? ConfiguredEndpoint;
                 ConfiguredEndpoint? failoverEndpoint =
                     m_redundancyHandler.SelectFailoverTarget(
-                        m_redundancyInfo, ConfiguredEndpoint);
+                        m_redundancyInfo, currentEndpoint);
 
                 if (failoverEndpoint == null)
                 {

--- a/tests/Opc.Ua.Client.Tests/Session/ManagedSessionTests.cs
+++ b/tests/Opc.Ua.Client.Tests/Session/ManagedSessionTests.cs
@@ -322,6 +322,61 @@ namespace Opc.Ua.Client.Tests.ManagedSession
         }
 
         [Test]
+        public async Task HandleFailoverAsyncUsesInnerSessionCurrentEndpointForTargetSelectionAsync()
+        {
+            ITelemetryContext telemetry = NUnitTelemetryContext.Create();
+            ApplicationConfiguration configuration = CreateClientConfiguration(telemetry);
+            ConfiguredEndpoint initialEndpoint = CreateEndpoint();
+            initialEndpoint.Description.EndpointUrl = "opc.tcp://initial:4840";
+            ConfiguredEndpoint activeEndpoint = CreateEndpoint();
+            activeEndpoint.Description.EndpointUrl = "opc.tcp://active:4840";
+            IServiceMessageContext messageContext = configuration.CreateMessageContext();
+
+            var managedChannel = new Mock<IManagedTransportChannel>();
+            managedChannel.SetupGet(c => c.MessageContext).Returns(messageContext);
+
+            ConfiguredEndpoint? capturedCurrentEndpoint = null;
+            var redundancyHandler = new Mock<IServerRedundancyHandler>(MockBehavior.Strict);
+            redundancyHandler.Setup(h => h.SelectFailoverTarget(
+                    It.IsAny<ServerRedundancyInfo>(),
+                    It.IsAny<ConfiguredEndpoint>()))
+                .Callback<ServerRedundancyInfo, ConfiguredEndpoint>(
+                    (_, currentEndpoint) => capturedCurrentEndpoint = currentEndpoint)
+                .Returns((ConfiguredEndpoint?)null);
+
+            using var innerSession = new Session(
+                managedChannel.Object,
+                configuration,
+                activeEndpoint,
+                engineFactory: DefaultSubscriptionEngineFactory.Instance);
+
+            using Client.ManagedSession managedSession = CreateManagedSessionWithInner(
+                configuration,
+                initialEndpoint,
+                innerSession,
+                telemetry,
+                redundancyHandler: redundancyHandler.Object);
+
+            typeof(Client.ManagedSession)
+                .GetField(
+                    "m_redundancyInfo",
+                    BindingFlags.NonPublic | BindingFlags.Instance)!
+                .SetValue(managedSession, new ServerRedundancyInfo());
+
+            ServiceResult result = await InvokeHandleFailoverAsync(
+                    managedSession,
+                    new RetryBudget(TimeSpan.FromSeconds(30)))
+                .ConfigureAwait(false);
+
+            Assert.That(result.StatusCode, Is.EqualTo(StatusCodes.BadNothingToDo));
+            Assert.That(capturedCurrentEndpoint, Is.SameAs(activeEndpoint));
+            redundancyHandler.Verify(h => h.SelectFailoverTarget(
+                    It.IsAny<ServerRedundancyInfo>(),
+                    It.IsAny<ConfiguredEndpoint>()),
+                Times.Once);
+        }
+
+        [Test]
         public void ConnectionStateChangedEventArgsHasCorrectProperties()
         {
             var error = new ServiceResult(StatusCodes.BadCommunicationError);
@@ -625,13 +680,37 @@ namespace Opc.Ua.Client.Tests.ManagedSession
         }
 #pragma warning restore IDE0051, RCS1213
 
+#pragma warning disable IDE0051, RCS1213 // Test scaffold kept for failover-path tests that need the private handler.
+        private static Task<ServiceResult> InvokeHandleFailoverAsync(
+            Client.ManagedSession managedSession,
+            IRetryBudget budget)
+        {
+            MethodInfo? method = typeof(Client.ManagedSession).GetMethod(
+                "HandleFailoverAsync",
+                BindingFlags.NonPublic | BindingFlags.Instance,
+                null,
+                [typeof(IRetryBudget), typeof(CancellationToken)],
+                null);
+
+            Assert.That(method, Is.Not.Null);
+
+            var task = (Task<ServiceResult>?)method!.Invoke(
+                managedSession,
+                [budget, CancellationToken.None]);
+
+            Assert.That(task, Is.Not.Null);
+            return task!;
+        }
+#pragma warning restore IDE0051, RCS1213
+
 #pragma warning disable IDE0051, RCS1213 // Test scaffold kept for tests that inject an already-created inner Session.
         private static Client.ManagedSession CreateManagedSessionWithInner(
             ApplicationConfiguration configuration,
             ConfiguredEndpoint endpoint,
             Session innerSession,
             ITelemetryContext telemetry,
-            NetworkRedundancyOptions? networkRedundancy = null)
+            NetworkRedundancyOptions? networkRedundancy = null,
+            IServerRedundancyHandler? redundancyHandler = null)
         {
             ILogger<Client.ManagedSession> logger = telemetry.CreateLogger<Client.ManagedSession>();
             var sessionFactory = new Mock<ISessionFactory>();
@@ -675,7 +754,7 @@ namespace Opc.Ua.Client.Tests.ManagedSession
                 endpoint,
                 sessionFactory.Object,
                 reconnectPolicy,
-                null,
+                redundancyHandler,
                 logger,
                 null,
                 null,


### PR DESCRIPTION
### Summary

This PR makes `ManagedSession` select failover targets relative to the currently active endpoint after a successful failover and adds a regression test that verifies subsequent failover decisions no longer use the original connection target as the current server.

### Problem

According to OPC UA Part 4 redundancy semantics, once a client has failed over to a different redundant server, subsequent target selection must be based on the server that is currently hosting the active session. The current server is not permanently tied to the endpoint that was used for the initial connection.

Previously, `ManagedSession` stored the constructor-supplied `ConfiguredEndpoint` in a read-only property and always passed that outer value into `IServerRedundancyHandler.SelectFailoverTarget()`. However, the inner `Session` updates its own `ConfiguredEndpoint` during `RecreateInPlaceAsync()` when failover succeeds. After the first failover, the outer `ManagedSession` and inner `Session` could therefore disagree about which redundant member was currently active, causing later failover decisions to be evaluated against the original endpoint instead of the active one.

### Changes

- Make `ManagedSession.HandleFailoverAsync()` prefer the inner session's current `ConfiguredEndpoint` when selecting a failover target, while keeping the outer endpoint as a fallback before the session is available.
- Preserve the existing failover flow and scope the fix to target selection only.
- Add a regression test that verifies `HandleFailoverAsync()` passes the inner session's current endpoint to `IServerRedundancyHandler.SelectFailoverTarget()`.
