### PR TITLE
Validate HTTPS client trust and CRL algorithms (OPC UA HTTPS / RFC 5280)

### DIFF
--- a/src/Opc.Ua.Bindings.Https/Https/HttpsTransportListener.cs
+++ b/src/Opc.Ua.Bindings.Https/Https/HttpsTransportListener.cs
@@ -2432,6 +2432,7 @@ namespace Opc.Ua.Bindings
             var validationChain = new CertificateCollection();
             try
             {
+                // CertificateCollection.Add retains an independent AddRef-owned handle.
                 if (chain?.ChainElements != null && chain.ChainElements.Count > 0)
                 {
                     foreach (X509ChainElement element in chain.ChainElements)

--- a/src/Opc.Ua.Bindings.Https/Https/HttpsTransportListener.cs
+++ b/src/Opc.Ua.Bindings.Https/Https/HttpsTransportListener.cs
@@ -2380,6 +2380,83 @@ namespace Opc.Ua.Bindings
                 .ConfigureAwait(false);
         }
 
+        internal static bool ValidateClientCertificateWithUaValidator(
+            ICertificateValidatorEx? certificateValidator,
+            X509Certificate2? clientCertificate,
+            X509Chain? chain,
+            SslPolicyErrors sslPolicyErrors)
+        {
+            if (clientCertificate == null)
+            {
+                return sslPolicyErrors == SslPolicyErrors.None;
+            }
+
+            if (certificateValidator == null)
+            {
+                return false;
+            }
+
+            try
+            {
+                using CertificateCollection validationChain = CreateCertificateChain(
+                    clientCertificate,
+                    chain);
+                // CA2025: the TLS ClientCertificateValidation callback is
+                // synchronous by contract on every supported TFM, so the async UA
+                // validator is bridged with GetAwaiter().GetResult(); the validation
+                // chain remains alive across the wait. The call is a single bounded
+                // chain validation but blocks a handshake thread.
+                // TODO: replace with a non-blocking validation bridge to remove the
+                // thread-pool-starvation risk under connection floods.
+#pragma warning disable CA2025
+                CertificateValidationResult result = certificateValidator
+                    .ValidateAsync(
+                        validationChain,
+                        TrustListIdentifier.Https,
+                        ct: default)
+                    .GetAwaiter()
+                    .GetResult();
+#pragma warning restore CA2025
+                return result.IsValid;
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+        }
+
+        private static CertificateCollection CreateCertificateChain(
+            X509Certificate2 clientCertificate,
+            X509Chain? chain)
+        {
+            var validationChain = new CertificateCollection();
+            try
+            {
+                if (chain?.ChainElements != null && chain.ChainElements.Count > 0)
+                {
+                    foreach (X509ChainElement element in chain.ChainElements)
+                    {
+                        using Certificate certificate = Certificate.FromRawData(
+                            element.Certificate.RawData);
+                        validationChain.Add(certificate);
+                    }
+                }
+                else
+                {
+                    using Certificate certificate = Certificate.FromRawData(
+                        clientCertificate.RawData);
+                    validationChain.Add(certificate);
+                }
+
+                return validationChain;
+            }
+            catch
+            {
+                validationChain.Dispose();
+                throw;
+            }
+        }
+
         /// <summary>
         /// Validate TLS client certificate at TLS handshake.
         /// </summary>
@@ -2391,47 +2468,11 @@ namespace Opc.Ua.Bindings
             X509Chain? chain,
             SslPolicyErrors sslPolicyErrors)
         {
-            if (sslPolicyErrors == SslPolicyErrors.None)
-            {
-                // certificate is valid
-                return true;
-            }
-
-            if (clientCertificate == null)
-            {
-                // TLS reported policy errors but no client certificate was
-                // presented; there is nothing to validate against the UA trust
-                // list, so reject.
-                return false;
-            }
-
-            try
-            {
-                using var cert = Certificate.FromRawData(clientCertificate.RawData);
-                // CA2025: the TLS ClientCertificateValidation callback is
-                // synchronous by contract on every supported TFM, so the async UA
-                // validator is bridged with GetAwaiter().GetResult(); the 'using
-                // cert' scope deliberately extends past the await. The call is a
-                // single bounded chain validation but blocks a handshake thread.
-                // TODO: replace with a non-blocking validation bridge to remove the
-                // thread-pool-starvation risk under connection floods.
-#pragma warning disable CA2025
-                CertificateValidationResult result = m_quotas.CertificateValidator!
-                    .ValidateAsync(cert, ct: default)
-                    .GetAwaiter()
-                    .GetResult();
-#pragma warning restore CA2025
-                if (!result.IsValid)
-                {
-                    return false;
-                }
-            }
-            catch (Exception)
-            {
-                return false;
-            }
-
-            return true;
+            return ValidateClientCertificateWithUaValidator(
+                m_quotas.CertificateValidator,
+                clientCertificate,
+                chain,
+                sslPolicyErrors);
         }
 
         private List<EndpointDescription> m_descriptions = null!;

--- a/src/Opc.Ua.Security.Certificates/X509Crl/CrlBuilder.cs
+++ b/src/Opc.Ua.Security.Certificates/X509Crl/CrlBuilder.cs
@@ -260,9 +260,9 @@ namespace Opc.Ua.Security.Certificates
         /// <returns>The signed CRL.</returns>
         public IX509CRL CreateSignature(X509SignatureGenerator generator)
         {
-            byte[] tbsRawData = Encode();
             byte[] signatureAlgorithm = generator.GetSignatureAlgorithmIdentifier(
                 HashAlgorithmName);
+            byte[] tbsRawData = Encode(signatureAlgorithm);
             byte[] signature = generator.SignData(tbsRawData, HashAlgorithmName);
             var crlSigner = new X509Signature(tbsRawData, signature, signatureAlgorithm);
             RawData = crlSigner.Encode();
@@ -328,6 +328,16 @@ namespace Opc.Ua.Security.Certificates
         /// </remarks>
         internal byte[] Encode()
         {
+            var algorithmWriter = new AsnWriter(AsnEncodingRules.DER);
+            algorithmWriter.PushSequence();
+            algorithmWriter.WriteObjectIdentifier(Oids.GetRSAOid(HashAlgorithmName));
+            algorithmWriter.WriteNull();
+            algorithmWriter.PopSequence();
+            return Encode(algorithmWriter.Encode());
+        }
+
+        private byte[] Encode(ReadOnlySpan<byte> signatureAlgorithmIdentifier)
+        {
             var crlWriter = new AsnWriter(AsnEncodingRules.DER);
             {
                 // tbsCertList
@@ -337,13 +347,7 @@ namespace Opc.Ua.Security.Certificates
                 crlWriter.WriteInteger(1);
 
                 // Signature Algorithm Identifier
-                crlWriter.PushSequence();
-                string signatureAlgorithm = Oids.GetRSAOid(HashAlgorithmName);
-                crlWriter.WriteObjectIdentifier(signatureAlgorithm);
-                crlWriter.WriteNull();
-
-                // pop
-                crlWriter.PopSequence();
+                crlWriter.WriteEncodedValue(signatureAlgorithmIdentifier);
 
                 // Issuer
                 crlWriter.WriteEncodedValue((ReadOnlySpan<byte>)IssuerName.RawData);

--- a/src/Opc.Ua.Security.Certificates/X509Crl/CrlBuilder.cs
+++ b/src/Opc.Ua.Security.Certificates/X509Crl/CrlBuilder.cs
@@ -298,6 +298,9 @@ namespace Opc.Ua.Security.Certificates
         /// <summary>
         /// Constructs Certificate Revocation List raw data in X509 ASN format.
         /// </summary>
+        /// <param name="signatureAlgorithmIdentifier">
+        /// The DER-encoded signature AlgorithmIdentifier.
+        /// </param>
         /// <remarks>
         /// <para>CRL fields -- https://tools.ietf.org/html/rfc5280#section-5.1</para>
         /// <para>
@@ -326,17 +329,7 @@ namespace Opc.Ua.Security.Certificates
         ///                            }
         /// </para>
         /// </remarks>
-        internal byte[] Encode()
-        {
-            var algorithmWriter = new AsnWriter(AsnEncodingRules.DER);
-            algorithmWriter.PushSequence();
-            algorithmWriter.WriteObjectIdentifier(Oids.GetRSAOid(HashAlgorithmName));
-            algorithmWriter.WriteNull();
-            algorithmWriter.PopSequence();
-            return Encode(algorithmWriter.Encode());
-        }
-
-        private byte[] Encode(ReadOnlySpan<byte> signatureAlgorithmIdentifier)
+        internal byte[] Encode(ReadOnlySpan<byte> signatureAlgorithmIdentifier)
         {
             var crlWriter = new AsnWriter(AsnEncodingRules.DER);
             {

--- a/tests/Opc.Ua.Core.Tests/Stack/Transport/HttpsTransportListenerClientCertificateValidationTests.cs
+++ b/tests/Opc.Ua.Core.Tests/Stack/Transport/HttpsTransportListenerClientCertificateValidationTests.cs
@@ -1,0 +1,335 @@
+/* ========================================================================
+ * Copyright (c) 2005-2026 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+#nullable enable
+
+using System;
+using System.IO;
+using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Opc.Ua.Bindings;
+using Opc.Ua.Security.Certificates;
+using Opc.Ua.Tests;
+
+namespace Opc.Ua.Core.Tests.Stack.Transport
+{
+    /// <summary>
+    /// Tests HTTPS TLS client-certificate validation against the configured UA validator.
+    /// </summary>
+    [TestFixture]
+    [Category("HttpsClientCertificateValidation")]
+    [SetCulture("en-us")]
+    [SetUICulture("en-us")]
+    [Parallelizable]
+    public sealed class HttpsTransportListenerClientCertificateValidationTests
+    {
+        [Test]
+        public void PresentedCertificateWithNoSslErrorsStillRequiresUaValidation()
+        {
+            using X509Certificate2 certificate = CreateClientCertificate();
+            var validator = new RecordingCertificateValidator(s_rejection);
+
+            bool accepted = HttpsTransportListener.ValidateClientCertificateWithUaValidator(
+                validator,
+                certificate,
+                chain: null,
+                SslPolicyErrors.None);
+
+            Assert.That(accepted, Is.False);
+            Assert.That(validator.ValidationCount, Is.EqualTo(1));
+            Assert.That(validator.LastTrustList, Is.EqualTo(TrustListIdentifier.Https));
+            Assert.That(validator.LastChainCount, Is.EqualTo(1));
+            Assert.That(validator.SingleCertificateValidationCount, Is.Zero);
+        }
+
+        [Test]
+        public void PresentedCertificateWithSslErrorsCanBeAcceptedByUaValidation()
+        {
+            using X509Certificate2 certificate = CreateClientCertificate();
+            var validator = new RecordingCertificateValidator(CertificateValidationResult.Success);
+
+            bool accepted = HttpsTransportListener.ValidateClientCertificateWithUaValidator(
+                validator,
+                certificate,
+                chain: null,
+                SslPolicyErrors.RemoteCertificateChainErrors);
+
+            Assert.That(accepted, Is.True);
+            Assert.That(validator.ValidationCount, Is.EqualTo(1));
+        }
+
+        [TestCase(SslPolicyErrors.None, true)]
+        [TestCase(SslPolicyErrors.RemoteCertificateNotAvailable, false)]
+        public void MissingOptionalCertificateUsesSslPolicyResult(
+            SslPolicyErrors sslPolicyErrors,
+            bool expected)
+        {
+            var validator = new RecordingCertificateValidator(s_rejection);
+
+            bool accepted = HttpsTransportListener.ValidateClientCertificateWithUaValidator(
+                validator,
+                clientCertificate: null,
+                chain: null,
+                sslPolicyErrors);
+
+            Assert.That(accepted, Is.EqualTo(expected));
+            Assert.That(validator.ValidationCount, Is.Zero);
+        }
+
+        [Test]
+        public async Task PresentedCertificateUsesHttpsTrustStoreAsync()
+        {
+            using var pki = new TemporaryPkiDirectory();
+            ITelemetryContext telemetry = NUnitTelemetryContext.Create();
+            using IDisposable? telemetryScope = telemetry as IDisposable;
+            using var manager = new CertificateManager(telemetry);
+            manager.RegisterTrustList(TrustListIdentifier.Peers, pki.PeersPath);
+            manager.RegisterTrustList(TrustListIdentifier.Https, pki.HttpsPath);
+
+            using Certificate peerRoot = CreateCertificateAuthority("HTTPS Regression Peer Root");
+            using Certificate httpsRoot = CreateCertificateAuthority("HTTPS Regression HTTPS Root");
+            using Certificate clientCertificate = CreateIssuedCertificate(
+                "HTTPS Regression Client",
+                httpsRoot);
+
+            using (ICertificateStore peerStore = manager.OpenTrustedStore(TrustListIdentifier.Peers))
+            {
+                await peerStore.AddAsync(peerRoot).ConfigureAwait(false);
+            }
+            using (ICertificateStore httpsStore = manager.OpenTrustedStore(TrustListIdentifier.Https))
+            {
+                await httpsStore.AddAsync(httpsRoot).ConfigureAwait(false);
+            }
+            using X509Certificate2 clientX509 = clientCertificate.AsX509Certificate2();
+
+            bool accepted = HttpsTransportListener.ValidateClientCertificateWithUaValidator(
+                manager,
+                clientX509,
+                chain: null,
+                SslPolicyErrors.None);
+
+            Assert.That(accepted, Is.True);
+        }
+
+        [Test]
+        public async Task TlsSuppliedIntermediateChainIsValidatedAndPreservedAsync()
+        {
+            using var pki = new TemporaryPkiDirectory();
+            ITelemetryContext telemetry = NUnitTelemetryContext.Create();
+            using IDisposable? telemetryScope = telemetry as IDisposable;
+            using var manager = new CertificateManager(telemetry);
+            manager.RegisterTrustList(TrustListIdentifier.Https, pki.HttpsPath);
+
+            using Certificate root = CreateCertificateAuthority("HTTPS Regression Chain Root");
+            using Certificate intermediate = CertificateBuilder
+                .Create("CN=HTTPS Regression Intermediate")
+                .SetCAConstraint(0)
+                .SetIssuer(root)
+                .SetRSAKeySize(2048)
+                .CreateForRSA();
+            using Certificate clientCertificate = CreateIssuedCertificate(
+                "HTTPS Regression Chained Client",
+                intermediate);
+
+            using (ICertificateStore httpsStore = manager.OpenTrustedStore(TrustListIdentifier.Https))
+            {
+                await httpsStore.AddAsync(root).ConfigureAwait(false);
+            }
+
+            CertificateValidationResult leafOnlyResult = await manager
+                .ValidateAsync(clientCertificate, TrustListIdentifier.Https)
+                .ConfigureAwait(false);
+            Assert.That(leafOnlyResult.IsValid, Is.False);
+            Assert.That(
+                leafOnlyResult.StatusCode,
+                Is.EqualTo(StatusCodes.BadCertificateChainIncomplete));
+
+            using X509Certificate2 clientX509 = clientCertificate.AsX509Certificate2();
+            using X509Certificate2 intermediateX509 = intermediate.AsX509Certificate2();
+            using X509Certificate2 rootX509 = root.AsX509Certificate2();
+            using var tlsChain = new X509Chain();
+            tlsChain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
+            tlsChain.ChainPolicy.VerificationFlags =
+                X509VerificationFlags.AllowUnknownCertificateAuthority;
+            tlsChain.ChainPolicy.ExtraStore.Add(intermediateX509);
+            tlsChain.ChainPolicy.ExtraStore.Add(rootX509);
+            _ = tlsChain.Build(clientX509);
+
+            Assert.That(tlsChain.ChainElements, Has.Count.EqualTo(3));
+            Assert.That(
+                tlsChain.ChainElements[1].Certificate.Thumbprint,
+                Is.EqualTo(intermediate.Thumbprint));
+
+            var recordingValidator = new RecordingCertificateValidator(
+                CertificateValidationResult.Success);
+            bool chainForwarded = HttpsTransportListener.ValidateClientCertificateWithUaValidator(
+                recordingValidator,
+                clientX509,
+                tlsChain,
+                SslPolicyErrors.RemoteCertificateChainErrors);
+
+            Assert.That(chainForwarded, Is.True);
+            Assert.That(recordingValidator.LastTrustList, Is.EqualTo(TrustListIdentifier.Https));
+            Assert.That(recordingValidator.LastChainCount, Is.EqualTo(tlsChain.ChainElements.Count));
+
+            bool accepted = HttpsTransportListener.ValidateClientCertificateWithUaValidator(
+                manager,
+                clientX509,
+                tlsChain,
+                SslPolicyErrors.RemoteCertificateChainErrors);
+
+            Assert.That(accepted, Is.True);
+            Assert.That(
+                tlsChain.ChainElements[1].Certificate.Thumbprint,
+                Is.EqualTo(intermediate.Thumbprint));
+        }
+
+        private static X509Certificate2 CreateClientCertificate()
+        {
+            using Certificate certificate = DefaultCertificateFactory.Instance
+                .CreateApplicationCertificate(
+                    "urn:localhost:HttpsTransportListenerClientCertificateValidationTests",
+                    "HttpsTransportListenerClientCertificateValidationTests",
+                    "CN=HttpsTransportListenerClientCertificateValidationTests",
+                    ["localhost"])
+                .SetLifeTime(TimeSpan.FromDays(1))
+                .CreateForRSA();
+            return certificate.AsX509Certificate2();
+        }
+
+        private static Certificate CreateCertificateAuthority(string commonName)
+        {
+            return CertificateBuilder
+                .Create($"CN={commonName}")
+                .SetCAConstraint(-1)
+                .SetRSAKeySize(2048)
+                .CreateForRSA();
+        }
+
+        private static Certificate CreateIssuedCertificate(
+            string commonName,
+            Certificate issuer)
+        {
+            return CertificateBuilder
+                .Create($"CN={commonName}")
+                .SetIssuer(issuer)
+                .SetRSAKeySize(2048)
+                .CreateForRSA();
+        }
+
+        private sealed class RecordingCertificateValidator : ICertificateValidatorEx
+        {
+            public RecordingCertificateValidator(CertificateValidationResult result)
+            {
+                m_result = result;
+            }
+
+            public Func<Certificate, ServiceResult, bool>? AcceptError { get; set; }
+
+            public int ValidationCount { get; private set; }
+
+            public int SingleCertificateValidationCount { get; private set; }
+
+            public TrustListIdentifier? LastTrustList { get; private set; }
+
+            public int LastChainCount { get; private set; }
+
+            public Task<CertificateValidationResult> ValidateAsync(
+                CertificateCollection chain,
+                TrustListIdentifier? trustList = null,
+                global::Opc.Ua.Security.Certificates.CertificateValidationOptions? options = null,
+                CancellationToken ct = default)
+            {
+                ValidationCount++;
+                LastTrustList = trustList;
+                LastChainCount = chain.Count;
+                return Task.FromResult(m_result);
+            }
+
+            public Task<CertificateValidationResult> ValidateAsync(
+                Certificate certificate,
+                TrustListIdentifier? trustList = null,
+                CancellationToken ct = default)
+            {
+                ValidationCount++;
+                SingleCertificateValidationCount++;
+                LastTrustList = trustList;
+                LastChainCount = 1;
+                return Task.FromResult(m_result);
+            }
+
+            private readonly CertificateValidationResult m_result;
+        }
+
+        private sealed class TemporaryPkiDirectory : IDisposable
+        {
+            public TemporaryPkiDirectory()
+            {
+                m_rootPath = Path.Combine(
+                    Path.GetTempPath(),
+                    $"opcua-https-validation-{Guid.NewGuid():N}");
+                PeersPath = Path.Combine(m_rootPath, "peers");
+                HttpsPath = Path.Combine(m_rootPath, "https");
+                Directory.CreateDirectory(PeersPath);
+                Directory.CreateDirectory(HttpsPath);
+            }
+
+            public string PeersPath { get; }
+
+            public string HttpsPath { get; }
+
+            public void Dispose()
+            {
+                for (int attempt = 0; attempt < 5 && Directory.Exists(m_rootPath); attempt++)
+                {
+                    try
+                    {
+                        Directory.Delete(m_rootPath, recursive: true);
+                    }
+                    catch (IOException)
+                    {
+                        Thread.Sleep(100);
+                    }
+                    catch (UnauthorizedAccessException)
+                    {
+                        Thread.Sleep(100);
+                    }
+                }
+            }
+
+            private readonly string m_rootPath;
+        }
+
+        private static readonly CertificateValidationResult s_rejection =
+            new(isValid: false, StatusCodes.BadCertificateUntrusted, [], false);
+    }
+}

--- a/tests/Opc.Ua.Core.Tests/Stack/Transport/HttpsTransportListenerClientCertificateValidationTests.cs
+++ b/tests/Opc.Ua.Core.Tests/Stack/Transport/HttpsTransportListenerClientCertificateValidationTests.cs
@@ -106,6 +106,20 @@ namespace Opc.Ua.Core.Tests.Stack.Transport
         }
 
         [Test]
+        public void PresentedCertificateWithoutUaValidatorIsRejected()
+        {
+            using X509Certificate2 certificate = CreateClientCertificate();
+
+            bool accepted = HttpsTransportListener.ValidateClientCertificateWithUaValidator(
+                certificateValidator: null,
+                clientCertificate: certificate,
+                chain: null,
+                sslPolicyErrors: SslPolicyErrors.None);
+
+            Assert.That(accepted, Is.False);
+        }
+
+        [Test]
         public async Task PresentedCertificateUsesHttpsTrustStoreAsync()
         {
             using var pki = new TemporaryPkiDirectory();
@@ -200,6 +214,9 @@ namespace Opc.Ua.Core.Tests.Stack.Transport
             Assert.That(chainForwarded, Is.True);
             Assert.That(recordingValidator.LastTrustList, Is.EqualTo(TrustListIdentifier.Https));
             Assert.That(recordingValidator.LastChainCount, Is.EqualTo(tlsChain.ChainElements.Count));
+            Assert.That(
+                recordingValidator.LastChainThumbprints,
+                Does.Contain(intermediate.Thumbprint));
 
             bool accepted = HttpsTransportListener.ValidateClientCertificateWithUaValidator(
                 manager,
@@ -263,6 +280,8 @@ namespace Opc.Ua.Core.Tests.Stack.Transport
 
             public int LastChainCount { get; private set; }
 
+            public string[] LastChainThumbprints { get; private set; } = [];
+
             public Task<CertificateValidationResult> ValidateAsync(
                 CertificateCollection chain,
                 TrustListIdentifier? trustList = null,
@@ -272,6 +291,11 @@ namespace Opc.Ua.Core.Tests.Stack.Transport
                 ValidationCount++;
                 LastTrustList = trustList;
                 LastChainCount = chain.Count;
+                LastChainThumbprints = new string[chain.Count];
+                for (int i = 0; i < chain.Count; i++)
+                {
+                    LastChainThumbprints[i] = chain[i].Thumbprint;
+                }
                 return Task.FromResult(m_result);
             }
 

--- a/tests/Opc.Ua.Security.Certificates.Tests/CRLTests.cs
+++ b/tests/Opc.Ua.Security.Certificates.Tests/CRLTests.cs
@@ -28,6 +28,7 @@
  * ======================================================================*/
 
 using System;
+using System.Formats.Asn1;
 using System.Globalization;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
@@ -172,6 +173,24 @@ namespace Opc.Ua.Security.Certificates.Tests
             crlBuilder.CrlExtensions.Add(X509Extensions.BuildCRLNumber(123));
             byte[] crlEncoded = crlBuilder.Encode();
             ValidateCRL(serial, serstring, hash, crlBuilder, crlEncoded);
+        }
+
+        /// <summary>
+        /// Verify the inner and outer CRL signature algorithms are identical.
+        /// </summary>
+        [Test]
+        public void SignedCrlUsesIdenticalSignatureAlgorithmIdentifiers()
+        {
+            CrlBuilder crlBuilder = CrlBuilder
+                .Create(m_issuerCert.SubjectName, HashAlgorithmName.SHA256)
+                .SetThisUpdate(new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc))
+                .SetNextUpdate(new DateTime(2026, 2, 1, 0, 0, 0, DateTimeKind.Utc));
+
+            IX509CRL crl = X509PfxUtils.IsECDsaSignature(m_issuerCert)
+                ? crlBuilder.CreateForECDsa(m_issuerCert)
+                : crlBuilder.CreateForRSA(m_issuerCert);
+
+            AssertSignatureAlgorithmIdentifiersMatch(crl.RawData);
         }
 
         /// <summary>
@@ -401,6 +420,26 @@ namespace Opc.Ua.Security.Certificates.Tests
             Assert.That(x509Crl.RevokedCertificates[1].SerialNumber, Is.EqualTo(serstring));
             Assert.That(x509Crl.CrlExtensions, Has.Count.EqualTo(1));
             Assert.That(x509Crl.HashAlgorithmName, Is.EqualTo(hash));
+        }
+
+        private static void AssertSignatureAlgorithmIdentifiersMatch(byte[] rawData)
+        {
+            var crlReader = new AsnReader(rawData, AsnEncodingRules.DER);
+            AsnReader crl = crlReader.ReadSequence();
+            crlReader.ThrowIfNotEmpty();
+            ReadOnlyMemory<byte> tbs = crl.ReadEncodedValue();
+            byte[] outerAlgorithm = crl.ReadEncodedValue().ToArray();
+            _ = crl.ReadBitString(out int unusedBitCount);
+            crl.ThrowIfNotEmpty();
+
+            var tbsReader = new AsnReader(tbs, AsnEncodingRules.DER);
+            AsnReader tbsCrl = tbsReader.ReadSequence();
+            tbsReader.ThrowIfNotEmpty();
+            _ = tbsCrl.ReadInteger();
+            byte[] innerAlgorithm = tbsCrl.ReadEncodedValue().ToArray();
+
+            Assert.That(unusedBitCount, Is.Zero);
+            Assert.That(innerAlgorithm, Is.EqualTo(outerAlgorithm));
         }
 
         private Certificate m_issuerCert;

--- a/tests/Opc.Ua.Security.Certificates.Tests/CRLTests.cs
+++ b/tests/Opc.Ua.Security.Certificates.Tests/CRLTests.cs
@@ -194,6 +194,30 @@ namespace Opc.Ua.Security.Certificates.Tests
         }
 
         /// <summary>
+        /// Verify <see cref="CrlBuilder.CreateSignature"/> embeds the exact signature
+        /// AlgorithmIdentifier produced by the generator into the TBSCertList, independent
+        /// of the issuer certificate key type.
+        /// </summary>
+        [Test]
+        public void CreateSignatureEmbedsGeneratorSignatureAlgorithmIdentifier()
+        {
+            CrlBuilder crlBuilder = CrlBuilder
+                .Create(m_issuerCert.SubjectName, HashAlgorithmName.SHA256)
+                .SetThisUpdate(new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc))
+                .SetNextUpdate(new DateTime(2026, 2, 1, 0, 0, 0, DateTimeKind.Utc));
+
+            using RSA rsa = RSA.Create(2048);
+            var generator = X509SignatureGenerator.CreateForRSA(rsa, RSASignaturePadding.Pkcs1);
+            byte[] expectedAlgorithm = generator.GetSignatureAlgorithmIdentifier(
+                HashAlgorithmName.SHA256);
+
+            IX509CRL crl = crlBuilder.CreateSignature(generator);
+
+            AssertSignatureAlgorithmIdentifiersMatch(crl.RawData);
+            Assert.That(ReadTbsSignatureAlgorithm(crl.RawData), Is.EqualTo(expectedAlgorithm));
+        }
+
+        /// <summary>
         /// Validate the full CRL encoder and decoder pass.
         /// </summary>
         [Theory]
@@ -440,6 +464,18 @@ namespace Opc.Ua.Security.Certificates.Tests
 
             Assert.That(unusedBitCount, Is.Zero);
             Assert.That(innerAlgorithm, Is.EqualTo(outerAlgorithm));
+        }
+
+        private static byte[] ReadTbsSignatureAlgorithm(byte[] rawData)
+        {
+            var crlReader = new AsnReader(rawData, AsnEncodingRules.DER);
+            AsnReader crl = crlReader.ReadSequence();
+            ReadOnlyMemory<byte> tbs = crl.ReadEncodedValue();
+
+            var tbsReader = new AsnReader(tbs, AsnEncodingRules.DER);
+            AsnReader tbsCrl = tbsReader.ReadSequence();
+            _ = tbsCrl.ReadInteger();
+            return tbsCrl.ReadEncodedValue().ToArray();
         }
 
         private static byte[] EncodeTbs(CrlBuilder crlBuilder)

--- a/tests/Opc.Ua.Security.Certificates.Tests/CRLTests.cs
+++ b/tests/Opc.Ua.Security.Certificates.Tests/CRLTests.cs
@@ -171,7 +171,7 @@ namespace Opc.Ua.Security.Certificates.Tests
             var revokedstring = new RevokedCertificate(serstring);
             crlBuilder.RevokedCertificates.Add(revokedstring);
             crlBuilder.CrlExtensions.Add(X509Extensions.BuildCRLNumber(123));
-            byte[] crlEncoded = crlBuilder.Encode();
+            byte[] crlEncoded = EncodeTbs(crlBuilder);
             ValidateCRL(serial, serstring, hash, crlBuilder, crlEncoded);
         }
 
@@ -344,7 +344,7 @@ namespace Opc.Ua.Security.Certificates.Tests
             };
             crlBuilder.RevokedCertificates.Add(revokedstring);
             crlBuilder.CrlExtensions.Add(X509Extensions.BuildCRLNumber(123));
-            byte[] crlEncoded = crlBuilder.Encode();
+            byte[] crlEncoded = EncodeTbs(crlBuilder);
             Assert.That(crlEncoded, Is.Not.Null);
             ValidateCRL(serial, serstring, hash, crlBuilder, crlEncoded);
 
@@ -360,7 +360,7 @@ namespace Opc.Ua.Security.Certificates.Tests
             };
             crlBuilder.RevokedCertificates.Add(revokedstring);
             crlBuilder.CrlExtensions.Add(X509Extensions.BuildCRLNumber(123));
-            crlEncoded = crlBuilder.Encode();
+            crlEncoded = EncodeTbs(crlBuilder);
             Assert.That(crlEncoded, Is.Not.Null);
             ValidateCRL(serial, serstring, hash, crlBuilder, crlEncoded);
         }
@@ -440,6 +440,15 @@ namespace Opc.Ua.Security.Certificates.Tests
 
             Assert.That(unusedBitCount, Is.Zero);
             Assert.That(innerAlgorithm, Is.EqualTo(outerAlgorithm));
+        }
+
+        private static byte[] EncodeTbs(CrlBuilder crlBuilder)
+        {
+            using RSA rsa = RSA.Create();
+            var generator = X509SignatureGenerator.CreateForRSA(rsa, RSASignaturePadding.Pkcs1);
+            byte[] signatureAlgorithm = generator.GetSignatureAlgorithmIdentifier(
+                crlBuilder.HashAlgorithmName);
+            return crlBuilder.Encode(signatureAlgorithm);
         }
 
         private Certificate m_issuerCert;


### PR DESCRIPTION
# Description

This draft splits the certificate-related changes from #4021, sourced only from commits `31350bf3b` and `1aed3b7ed`.

- Enforces OPC UA HTTPS trust-list semantics for every presented client certificate, even when platform TLS/OS trust reports no policy errors. This prevents OS trust from bypassing the configured UA HTTPS trust list.
- Passes the full TLS-supplied certificate chain to the UA validator and selects `TrustListIdentifier.Https`, preserving intermediates for application-level chain validation.
- Uses the signature generator's exact `AlgorithmIdentifier` in both the CRL `TBSCertList` and outer `CertificateList`. RFC 5280 §5.1.1 requires these inner and outer identifiers to match; independently encoding the inner value could disagree with the actual signature algorithm.

## Validation

- HTTPS certificate-validation tests: net10.0 (6 passed), net48 (6 passed).
- CRL tests: net10.0 (95 passed), net48 (95 passed).
- `Opc.Ua.Bindings.Https` and `Opc.Ua.Security.Certificates`: netstandard2.1 builds succeeded with 0 warnings and 0 errors.
- `git diff --check` passed.

## Related Issues

- Split from #4021.

## Checklist

_Only verified claims are checked._

- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf) and read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added all necessary documentation.
- [x] I have verified that my changes do not introduce (new) build or analyzer warnings.
- [ ] I ran **all** tests locally using the **UA.slnx** solution against at least .net **framework** and .net **10**, and all passed.
- [ ] I fixed **all** failing and flaky tests in the CI pipelines and **all** CodeQL warnings.
- [ ] I have addressed **all** PR feedback received.
