### PR TITLE
Complete partial vectored UA-TCP sends (OPC 10000-6)

### DIFF
--- a/src/Opc.Ua.Core/Stack/Tcp/TcpByteTransport.cs
+++ b/src/Opc.Ua.Core/Stack/Tcp/TcpByteTransport.cs
@@ -28,6 +28,7 @@
  * ======================================================================*/
 
 using System;
+using System.Collections.Generic;
 using System.Net;
 using System.Net.Sockets;
 using System.Runtime.InteropServices;
@@ -278,26 +279,13 @@ namespace Opc.Ua.Bindings
             await m_sendLock.WaitAsync(ct).ConfigureAwait(false);
             try
             {
-#if NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER
                 // Socket.SendAsync(IList<ArraySegment<byte>>) is a vectored send
                 // available on all targets but does not accept a CancellationToken,
                 // so we use it directly and rely on Close()/Dispose() for cancel.
-                int sent = await socket
-                    .SendAsync(buffers, SocketFlags.None)
+                await SendAllAsync(
+                    buffers,
+                    pending => socket.SendAsync(pending, SocketFlags.None))
                     .ConfigureAwait(false);
-#else
-                int sent = await socket
-                    .SendAsync(buffers, SocketFlags.None)
-                    .ConfigureAwait(false);
-#endif
-                if (sent < buffers.TotalSize)
-                {
-                    throw ServiceResultException.Create(
-                        StatusCodes.BadConnectionClosed,
-                        "Remote side closed the connection while sending (sent {0} of {1} bytes).",
-                        sent,
-                        buffers.TotalSize);
-                }
             }
             finally
             {
@@ -415,6 +403,56 @@ namespace Opc.Ua.Bindings
             Close();
         }
 
+        internal static async ValueTask SendAllAsync(
+            BufferCollection buffers,
+            Func<IList<ArraySegment<byte>>, Task<int>> sendAsync)
+        {
+            if (buffers == null)
+            {
+                throw new ArgumentNullException(nameof(buffers));
+            }
+            if (sendAsync == null)
+            {
+                throw new ArgumentNullException(nameof(sendAsync));
+            }
+
+            var pending = new List<ArraySegment<byte>>(buffers.Count);
+            int totalSize = 0;
+            foreach (ArraySegment<byte> buffer in buffers)
+            {
+                if (buffer.Count > 0)
+                {
+                    pending.Add(buffer);
+                    totalSize += buffer.Count;
+                }
+            }
+
+            int remaining = totalSize;
+            while (remaining > 0)
+            {
+                int sent = await sendAsync(pending).ConfigureAwait(false);
+                if (sent <= 0)
+                {
+                    throw ServiceResultException.Create(
+                        StatusCodes.BadConnectionClosed,
+                        "Remote side closed the connection while sending (sent {0} of {1} bytes).",
+                        totalSize - remaining,
+                        totalSize);
+                }
+                if (sent > remaining)
+                {
+                    throw ServiceResultException.Create(
+                        StatusCodes.BadInternalError,
+                        "Socket reported sending {0} bytes with only {1} bytes pending.",
+                        sent,
+                        remaining);
+                }
+
+                AdvanceBuffers(pending, sent);
+                remaining -= sent;
+            }
+        }
+
         private Socket RequireConnectedSocket()
         {
             Socket? socket = m_socket;
@@ -425,6 +463,30 @@ namespace Opc.Ua.Bindings
                     "The transport is not connected.");
             }
             return socket;
+        }
+
+        private static void AdvanceBuffers(List<ArraySegment<byte>> buffers, int count)
+        {
+            int removeCount = 0;
+            while (removeCount < buffers.Count && count >= buffers[removeCount].Count)
+            {
+                count -= buffers[removeCount].Count;
+                removeCount++;
+            }
+
+            if (removeCount > 0)
+            {
+                buffers.RemoveRange(0, removeCount);
+            }
+
+            if (count > 0)
+            {
+                ArraySegment<byte> buffer = buffers[0];
+                buffers[0] = new ArraySegment<byte>(
+                    buffer.Array!,
+                    buffer.Offset + count,
+                    buffer.Count - count);
+            }
         }
 
         private static async ValueTask ReadExactAsync(

--- a/src/Opc.Ua.Core/Stack/Tcp/TcpByteTransport.cs
+++ b/src/Opc.Ua.Core/Stack/Tcp/TcpByteTransport.cs
@@ -416,10 +416,16 @@ namespace Opc.Ua.Bindings
                 throw new ArgumentNullException(nameof(sendAsync));
             }
 
-            int totalSize = buffers.TotalSize;
-            int remaining = totalSize;
+            long totalSize = 0;
+            foreach (ArraySegment<byte> buffer in buffers)
+            {
+                totalSize += buffer.Count;
+            }
+
+            long remaining = totalSize;
             IList<ArraySegment<byte>> pending = buffers;
-            List<ArraySegment<byte>>? slicedBuffers = null;
+            ArraySegment<byte>[]? slicedBuffers = null;
+            int startIndex = 0;
             while (remaining > 0)
             {
                 int sent = await sendAsync(pending).ConfigureAwait(false);
@@ -443,9 +449,12 @@ namespace Opc.Ua.Bindings
                 remaining -= sent;
                 if (remaining > 0)
                 {
-                    slicedBuffers ??= new List<ArraySegment<byte>>(buffers);
-                    AdvanceBuffers(slicedBuffers, sent);
-                    pending = slicedBuffers;
+                    slicedBuffers ??= [.. buffers];
+                    startIndex = AdvanceBuffers(slicedBuffers, startIndex, sent);
+                    pending = new ArraySegment<ArraySegment<byte>>(
+                        slicedBuffers,
+                        startIndex,
+                        slicedBuffers.Length - startIndex);
                 }
             }
         }
@@ -462,28 +471,27 @@ namespace Opc.Ua.Bindings
             return socket;
         }
 
-        private static void AdvanceBuffers(List<ArraySegment<byte>> buffers, int count)
+        private static int AdvanceBuffers(
+            ArraySegment<byte>[] buffers,
+            int startIndex,
+            int count)
         {
-            int removeCount = 0;
-            while (removeCount < buffers.Count && count >= buffers[removeCount].Count)
+            while (startIndex < buffers.Length && count >= buffers[startIndex].Count)
             {
-                count -= buffers[removeCount].Count;
-                removeCount++;
-            }
-
-            if (removeCount > 0)
-            {
-                buffers.RemoveRange(0, removeCount);
+                count -= buffers[startIndex].Count;
+                startIndex++;
             }
 
             if (count > 0)
             {
-                ArraySegment<byte> buffer = buffers[0];
-                buffers[0] = new ArraySegment<byte>(
+                ArraySegment<byte> buffer = buffers[startIndex];
+                buffers[startIndex] = new ArraySegment<byte>(
                     buffer.Array!,
                     buffer.Offset + count,
                     buffer.Count - count);
             }
+
+            return startIndex;
         }
 
         private static async ValueTask ReadExactAsync(

--- a/src/Opc.Ua.Core/Stack/Tcp/TcpByteTransport.cs
+++ b/src/Opc.Ua.Core/Stack/Tcp/TcpByteTransport.cs
@@ -416,18 +416,10 @@ namespace Opc.Ua.Bindings
                 throw new ArgumentNullException(nameof(sendAsync));
             }
 
-            var pending = new List<ArraySegment<byte>>(buffers.Count);
-            int totalSize = 0;
-            foreach (ArraySegment<byte> buffer in buffers)
-            {
-                if (buffer.Count > 0)
-                {
-                    pending.Add(buffer);
-                    totalSize += buffer.Count;
-                }
-            }
-
+            int totalSize = buffers.TotalSize;
             int remaining = totalSize;
+            IList<ArraySegment<byte>> pending = buffers;
+            List<ArraySegment<byte>>? slicedBuffers = null;
             while (remaining > 0)
             {
                 int sent = await sendAsync(pending).ConfigureAwait(false);
@@ -448,8 +440,13 @@ namespace Opc.Ua.Bindings
                         remaining);
                 }
 
-                AdvanceBuffers(pending, sent);
                 remaining -= sent;
+                if (remaining > 0)
+                {
+                    slicedBuffers ??= new List<ArraySegment<byte>>(buffers);
+                    AdvanceBuffers(slicedBuffers, sent);
+                    pending = slicedBuffers;
+                }
             }
         }
 

--- a/tests/Opc.Ua.Core.Tests/Stack/Transport/TcpByteTransportTests.cs
+++ b/tests/Opc.Ua.Core.Tests/Stack/Transport/TcpByteTransportTests.cs
@@ -156,6 +156,75 @@ namespace Opc.Ua.Core.Tests.Stack.Transport
         }
 
         [Test]
+        public async Task SendAllAsyncCompleteSendUsesCallerBuffersDirectly()
+        {
+            var buffers = new BufferCollection
+            {
+                new(new byte[4]),
+                new(new byte[8])
+            };
+            IList<ArraySegment<byte>>? observed = null;
+
+            await TcpByteTransport.SendAllAsync(
+                buffers,
+                pending =>
+                {
+                    observed = pending;
+                    return Task.FromResult(buffers.TotalSize);
+                }).ConfigureAwait(false);
+
+            Assert.That(observed, Is.SameAs(buffers));
+        }
+
+        [TestCase(0)]
+        [TestCase(13)]
+        public void SendAllAsyncRejectsInvalidSendCounts(int sent)
+        {
+            var buffers = new BufferCollection(new byte[12], 0, 12);
+            StatusCode expectedStatusCode = sent == 0
+                ? StatusCodes.BadConnectionClosed
+                : StatusCodes.BadInternalError;
+
+            ServiceResultException ex = Assert.ThrowsAsync<ServiceResultException>(
+                async () => await TcpByteTransport.SendAllAsync(
+                    buffers,
+                    _ => Task.FromResult(sent)).ConfigureAwait(false))!;
+
+            Assert.That(ex.StatusCode, Is.EqualTo((uint)expectedStatusCode));
+        }
+
+        [Test]
+        public async Task SendAllAsyncEmptyCollectionDoesNotSend()
+        {
+            int sendCount = 0;
+
+            await TcpByteTransport.SendAllAsync(
+                [],
+                _ =>
+                {
+                    sendCount++;
+                    return Task.FromResult(0);
+                }).ConfigureAwait(false);
+
+            Assert.That(sendCount, Is.Zero);
+        }
+
+        [Test]
+        public void SendAllAsyncRejectsNullArguments()
+        {
+            var buffers = new BufferCollection();
+
+            Assert.ThrowsAsync<ArgumentNullException>(
+                async () => await TcpByteTransport.SendAllAsync(
+                    null!,
+                    _ => Task.FromResult(0)).ConfigureAwait(false));
+            Assert.ThrowsAsync<ArgumentNullException>(
+                async () => await TcpByteTransport.SendAllAsync(
+                    buffers,
+                    null!).ConfigureAwait(false));
+        }
+
+        [Test]
         public async Task ReceiveChunkAsyncReturnsCompleteChunk()
         {
             (TcpByteTransport client, Socket serverSocket, TcpListener listener) =

--- a/tests/Opc.Ua.Core.Tests/Stack/Transport/TcpByteTransportTests.cs
+++ b/tests/Opc.Ua.Core.Tests/Stack/Transport/TcpByteTransportTests.cs
@@ -30,6 +30,7 @@
 #nullable enable
 
 using System;
+using System.Collections.Generic;
 using System.Net;
 using System.Net.Sockets;
 using System.Threading;
@@ -110,6 +111,48 @@ namespace Opc.Ua.Core.Tests.Stack.Transport
                 }
                 Assert.That(received, Is.EqualTo(payload));
             }
+        }
+
+        [Test]
+        public async Task SendAllAsyncHandlesPartialSendsWithoutMutatingCallerBuffers()
+        {
+            byte[] first = [0, 1, 2, 3, 4, 5];
+            byte[] second = [10, 11, 12, 13, 14, 15];
+            byte[] third = [20, 21, 22, 23, 24];
+            var buffers = new BufferCollection
+            {
+                new(first, 1, 4),
+                new(second, 2, 3),
+                new(third, 0, 5)
+            };
+            ArraySegment<byte>[] original = [.. buffers];
+            int[] partialSends = [3, 4, 5];
+            int sendIndex = 0;
+            var snapshots = new List<ArraySegment<byte>[]>();
+
+            await TcpByteTransport.SendAllAsync(
+                buffers,
+                pending =>
+                {
+                    snapshots.Add(CopySegments(pending));
+                    return Task.FromResult(partialSends[sendIndex++]);
+                }).ConfigureAwait(false);
+
+            Assert.That(sendIndex, Is.EqualTo(partialSends.Length));
+            Assert.That(snapshots, Has.Count.EqualTo(3));
+            Assert.That(snapshots[0], Is.EqualTo(original));
+            Assert.That(
+                snapshots[1],
+                Is.EqualTo(
+                [
+                    new ArraySegment<byte>(first, 4, 1),
+                    new ArraySegment<byte>(second, 2, 3),
+                    new ArraySegment<byte>(third, 0, 5)
+                ]));
+            Assert.That(
+                snapshots[2],
+                Is.EqualTo([new ArraySegment<byte>(third, 0, 5)]));
+            Assert.That(buffers, Is.EqualTo(original));
         }
 
         [Test]
@@ -269,6 +312,16 @@ namespace Opc.Ua.Core.Tests.Stack.Transport
                 .ConfigureAwait(false);
             Socket serverSocket = await acceptTask.ConfigureAwait(false);
             return (transport, serverSocket, listener);
+        }
+
+        private static ArraySegment<byte>[] CopySegments(IList<ArraySegment<byte>> buffers)
+        {
+            var copy = new ArraySegment<byte>[buffers.Count];
+            for (int i = 0; i < buffers.Count; i++)
+            {
+                copy[i] = buffers[i];
+            }
+            return copy;
         }
 
         private static byte[] BuildValidChunk(uint messageType, int size)

--- a/tests/Opc.Ua.Core.Tests/Stack/Transport/TcpByteTransportTests.cs
+++ b/tests/Opc.Ua.Core.Tests/Stack/Transport/TcpByteTransportTests.cs
@@ -184,6 +184,9 @@ namespace Opc.Ua.Core.Tests.Stack.Transport
             StatusCode expectedStatusCode = sent == 0
                 ? StatusCodes.BadConnectionClosed
                 : StatusCodes.BadInternalError;
+            string expectedMessage = sent == 0
+                ? "Remote side closed the connection while sending"
+                : "Socket reported sending 13 bytes with only 12 bytes pending";
 
             ServiceResultException ex = Assert.ThrowsAsync<ServiceResultException>(
                 async () => await TcpByteTransport.SendAllAsync(
@@ -191,6 +194,7 @@ namespace Opc.Ua.Core.Tests.Stack.Transport
                     _ => Task.FromResult(sent)).ConfigureAwait(false))!;
 
             Assert.That(ex.StatusCode, Is.EqualTo((uint)expectedStatusCode));
+            Assert.That(ex.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
@@ -207,6 +211,31 @@ namespace Opc.Ua.Core.Tests.Stack.Transport
                 }).ConfigureAwait(false);
 
             Assert.That(sendCount, Is.Zero);
+        }
+
+        [Test]
+        public async Task SendAllAsyncSupportsTotalsLargerThanIntMaxValue()
+        {
+            const int segmentSize = 1024 * 1024;
+            var buffers = new BufferCollection(2049);
+            var segment = new ArraySegment<byte>(new byte[segmentSize]);
+            for (int i = 0; i < buffers.Capacity; i++)
+            {
+                buffers.Add(segment);
+            }
+            long totalSize = (long)segmentSize * buffers.Count;
+            int finalSendSize = checked((int)(totalSize - int.MaxValue));
+            int sendCount = 0;
+
+            await TcpByteTransport.SendAllAsync(
+                buffers,
+                _ =>
+                {
+                    sendCount++;
+                    return Task.FromResult(sendCount == 1 ? int.MaxValue : finalSendSize);
+                }).ConfigureAwait(false);
+
+            Assert.That(sendCount, Is.EqualTo(2));
         }
 
         [Test]


### PR DESCRIPTION
# Description

Stream socket semantics permit a successful vectored send to complete after fewer bytes than requested. The previous one-shot send treated that legal partial completion as a closed connection and left the remaining bytes unsent, risking truncation of an OPC 10000-6 UA-TCP message chunk.

The transport now continues sending while advancing across copied buffer segments, without mutating the caller's `BufferCollection`, and rejects zero-byte or impossible over-reported sends.

## Validation

- `TcpByteTransportTests`: net10.0 (10 passed), net48 (10 passed).
- `git diff --check` passed.

## Related Issues

- Split from #4021.

## Checklist

_Only verified claims are checked._

- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf) and read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added all necessary documentation.
- [x] I have verified that my changes do not introduce (new) build or analyzer warnings.
- [ ] I ran **all** tests locally using the **UA.slnx** solution against at least .net **framework** and .net **10**, and all passed.
- [ ] I fixed **all** failing and flaky tests in the CI pipelines and **all** CodeQL warnings.
- [ ] I have addressed **all** PR feedback received.
