### PR TITLE
fix(subscription): fail transfer synchronization when deleting stale monitored items

### DIFF
--- a/src/Opc.Ua.Client/Subscription/MonitoredItemManager.cs
+++ b/src/Opc.Ua.Client/Subscription/MonitoredItemManager.cs
@@ -811,8 +811,30 @@ namespace Opc.Ua.Client.Subscriptions.MonitoredItems
             // Ensure all items on the server that are not in the subscription are deleted
             try
             {
-                await m_context.MonitoredItemServiceSet.DeleteMonitoredItemsAsync(null, m_context.Id, itemsToDelete,
-                    ct).ConfigureAwait(false);
+                DeleteMonitoredItemsResponse response =
+                    await m_context.MonitoredItemServiceSet.DeleteMonitoredItemsAsync(
+                        null,
+                        m_context.Id,
+                        itemsToDelete,
+                        ct).ConfigureAwait(false);
+                ClientBase.ValidateResponse(response.Results, itemsToDelete);
+                ClientBase.ValidateDiagnosticInfos(
+                    response.DiagnosticInfos,
+                    itemsToDelete);
+
+                if (StatusCode.IsBad(response.ResponseHeader.ServiceResult))
+                {
+                    return false;
+                }
+
+                for (int i = 0; i < response.Results.Count; i++)
+                {
+                    if (StatusCode.IsBad(response.Results[i]))
+                    {
+                        return false;
+                    }
+                }
+
                 return true;
             }
             catch (Exception ex)

--- a/tests/Opc.Ua.Client.Tests/Subscription/SubscriptionTests.cs
+++ b/tests/Opc.Ua.Client.Tests/Subscription/SubscriptionTests.cs
@@ -1173,6 +1173,61 @@ namespace Opc.Ua.Client.Subscriptions
         }
 
         [Test]
+        public async Task TryCompleteTransferAsyncShouldReturnFalseWhenDeletingExtraneousServerItemFailsAsync()
+        {
+            // Arrange
+            var sut = new TestSubscription(m_session, m_mockNotificationDataHandler.Object,
+                m_completion, m_options, m_telemetry, 2);
+            await using (sut.ConfigureAwait(false))
+            {
+                m_mockMethodServices
+                    .Setup(s => s.CallAsync(
+                        It.IsAny<RequestHeader>(),
+                        It.Is<ArrayOf<CallMethodRequest>>(r =>
+                            r.Count == 1 &&
+                            r[0].InputArguments.Count == 1 &&
+                            r[0].InputArguments[0].AsBoxedObject().Equals(2u) &&
+                            r[0].ObjectId == ObjectIds.Server &&
+                            r[0].MethodId == MethodIds.Server_GetMonitoredItems), It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(new CallResponse
+                    {
+                        Results =
+                        [
+                            new ()
+                            {
+                                StatusCode = StatusCodes.Good,
+                                OutputArguments =
+                                [
+                                    new Variant([19900u]), // serverHandles
+                                    new Variant([300u])  // clientHandles
+                                ]
+                            }
+                        ]
+                    })
+                    .Verifiable(Times.Once);
+
+                m_mockMonitoredItemServices
+                    .Setup(s => s.DeleteMonitoredItemsAsync(It.IsAny<RequestHeader>(), 2,
+                        It.Is<ArrayOf<uint>>(a => a.Count == 1 && a[0] == 19900u), It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(new DeleteMonitoredItemsResponse
+                    {
+                        ResponseHeader = new ResponseHeader
+                        {
+                            ServiceResult = StatusCodes.Good
+                        },
+                        Results = [StatusCodes.BadUnexpectedError]
+                    })
+                    .Verifiable(Times.Once);
+
+                // Act
+                bool success = await sut.TryCompleteTransferAsync([], default).ConfigureAwait(false);
+
+                // Assert
+                Assert.That(success, Is.False);
+            }
+        }
+
+        [Test]
         public async Task TryCompleteTransferAsyncShouldCallGetMonitoredItemsAsyncAndReturnFalseIfFailingAsync()
         {
             // Arrange


### PR DESCRIPTION
### Summary

This PR makes `MonitoredItemManager.TrySynchronizeHandlesAsync()` treat `DeleteMonitoredItems` failures as transfer-synchronization failures and adds a regression test that verifies the client no longer reports success when the server rejects deletion of stale monitored items.

### Problem

OPC UA Part 4 requires clients to evaluate service results at two levels: `ResponseHeader.ServiceResult` reports the outcome of the service call as a whole. `Results[]` reports the outcome of each individual operation in that service. Even when the service-level result is `Good`, the service may still have only partially succeeded. The client therefore still needs to inspect the response payload, especially the per-operation `StatusCode` values, before concluding that the requested work actually completed.

In `TrySynchronizeHandlesAsync()`, the transfer/recovery path deletes monitored items that still exist on the server but no longer exist locally. Previously, this delete path treated `DeleteMonitoredItemsAsync()` as successful as long as the call itself did not throw, and it did not validate `ResponseHeader.ServiceResult`, `Results[]`, or the associated diagnostic information. As a result, the client could report transfer synchronization success even when the server explicitly returned failures for one or more stale monitored items.

### Changes

- Validate the `DeleteMonitoredItemsAsync()` response inside `TrySynchronizeHandlesAsync()` instead of treating any non-throwing call as success.
- Return `false` when the delete operation reports a bad service-level result or any bad per-item result, so synchronization only succeeds after stale server-side items are actually removed.
- Add a regression test that verifies `TryCompleteTransferAsync()` returns `false` when deletion of an extraneous server-side monitored item is rejected.
