### PR TITLE
fix(di): accept FunctionalGroupType subtypes in BrowseFunctionalGroupsAsync

### DIFF
--- a/src/Opc.Ua.Di.Client/DiDeviceClient.cs
+++ b/src/Opc.Ua.Di.Client/DiDeviceClient.cs
@@ -292,7 +292,10 @@ namespace Opc.Ua.Di.Client
             {
                 ct.ThrowIfCancellationRequested();
 
-                if (!IsSubtypeOf(reference.TypeDefinition, functionalGroupTypeId))
+                if (!await IsSubtypeOfAsync(
+                    reference.TypeDefinition,
+                    functionalGroupTypeId,
+                    ct).ConfigureAwait(false))
                 {
                     continue;
                 }
@@ -394,11 +397,15 @@ namespace Opc.Ua.Di.Client
             return default;
         }
 
-        private static bool IsSubtypeOf(
+        private ValueTask<bool> IsSubtypeOfAsync(
             ExpandedNodeId typeDefinition,
-            ExpandedNodeId expectedType)
+            ExpandedNodeId expectedType,
+            CancellationToken ct)
         {
-            return typeDefinition == expectedType;
+            return Session.NodeCache.IsTypeOfAsync(
+                typeDefinition,
+                expectedType,
+                ct);
         }
 
         private static string? ExtractStringFromWrappedValue(Variant wrapped)

--- a/tests/Opc.Ua.Di.Tests/DiDeviceClientTests.cs
+++ b/tests/Opc.Ua.Di.Tests/DiDeviceClientTests.cs
@@ -239,6 +239,77 @@ namespace Opc.Ua.Di.Tests
         }
 
         [Test]
+        public async Task BrowseFunctionalGroupsAsyncReturnsSubtypeInstancesAsync()
+        {
+            Mock<ISession> sessionMock = CreateSessionMock();
+            var nodeCacheMock = new Mock<INodeCache>(MockBehavior.Strict);
+            sessionMock.SetupGet(s => s.NodeCache).Returns(nodeCacheMock.Object);
+
+            ExpandedNodeId functionalGroupSubtype = new("VendorFunctionalGroupType", 2);
+            ExpandedNodeId unrelatedType = new("FolderType", 2);
+            ReferenceDescription subtypeGroup = new()
+            {
+                NodeId = new ExpandedNodeId(new NodeId("group-1", 2)),
+                DisplayName = new LocalizedText("VendorGroup"),
+                TypeDefinition = functionalGroupSubtype,
+                NodeClass = NodeClass.Object
+            };
+            ReferenceDescription folder = new()
+            {
+                NodeId = new ExpandedNodeId(new NodeId("folder-1", 2)),
+                DisplayName = new LocalizedText("Folder"),
+                TypeDefinition = unrelatedType,
+                NodeClass = NodeClass.Object
+            };
+
+            sessionMock
+                .Setup(s => s.BrowseAsync(
+                    It.IsAny<RequestHeader?>(),
+                    It.IsAny<ViewDescription?>(),
+                    It.IsAny<uint>(),
+                    It.IsAny<ArrayOf<BrowseDescription>>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new BrowseResponse
+                {
+                    Results =
+                    [
+                        new BrowseResult
+                        {
+                            StatusCode = StatusCodes.Good,
+                            References = [subtypeGroup, folder]
+                        }
+                    ]
+                });
+
+            nodeCacheMock
+                .Setup(c => c.IsTypeOfAsync(
+                    functionalGroupSubtype,
+                    Opc.Ua.Di.ObjectTypeIds.FunctionalGroupType,
+                    It.IsAny<CancellationToken>()))
+                .Returns(new ValueTask<bool>(true));
+            nodeCacheMock
+                .Setup(c => c.IsTypeOfAsync(
+                    unrelatedType,
+                    Opc.Ua.Di.ObjectTypeIds.FunctionalGroupType,
+                    It.IsAny<CancellationToken>()))
+                .Returns(new ValueTask<bool>(false));
+
+            var client = new DiDeviceClient(
+                sessionMock.Object, new NodeId("dev-1", 2), NullTelemetry());
+
+            var groups = new System.Collections.Generic.List<FunctionalGroupEntry>();
+            await foreach (FunctionalGroupEntry group in client.BrowseFunctionalGroupsAsync())
+            {
+                groups.Add(group);
+            }
+
+            Assert.That(groups, Has.Count.EqualTo(1));
+            Assert.That(groups[0].NodeId, Is.EqualTo(new NodeId("group-1", 2)));
+            Assert.That(groups[0].DisplayName, Is.EqualTo("VendorGroup"));
+            nodeCacheMock.VerifyAll();
+        }
+
+        [Test]
         public void ForDeviceAsyncThrowsOnNullSession()
         {
             ArgumentNullException ex = Assert.ThrowsAsync<ArgumentNullException>(


### PR DESCRIPTION
### Summary

This PR makes `DiDeviceClient.BrowseFunctionalGroupsAsync()` accept `FunctionalGroupType` subtypes instead of requiring an exact type-definition match and adds a regression test that verifies derived functional groups are included in the returned results.

### Problem

In OPC UA DI, functional groups may be modeled as instances of `FunctionalGroupType` or of any subtype derived from it. A client helper that enumerates functional groups therefore needs to follow the OPC UA type hierarchy instead of requiring the object's `TypeDefinition` to be exactly `FunctionalGroupType`.

Previously, `BrowseFunctionalGroupsAsync()` filtered browse results through a helper named `IsSubtypeOf()`, but that helper only compared `typeDefinition == expectedType`. As a result, any device that exposed functional groups through a legal subtype of `FunctionalGroupType` would have those groups silently filtered out even though they were valid DI functional-group objects.

### Changes

- Replace the exact type-definition comparison in `BrowseFunctionalGroupsAsync()` with a real subtype check based on `Session.NodeCache.IsTypeOfAsync(...)`.
- Preserve the existing filtering behaviour for non-functional-group objects.
- Add a regression test that verifies a derived functional-group type is returned while an unrelated object is still excluded.
