### PR TITLE
fix(di): accept DeviceType subtypes during device discovery

### DIFF
--- a/src/Opc.Ua.Di.Client/DiDiscoveryClient.cs
+++ b/src/Opc.Ua.Di.Client/DiDiscoveryClient.cs
@@ -127,7 +127,11 @@ namespace Opc.Ua.Di.Client
                 var targetId = ExpandedNodeId.ToNodeId(
                     reference.NodeId, session.NamespaceUris);
 
-                if (reference.TypeDefinition == deviceTypeId)
+                if (await IsSubtypeOfAsync(
+                    session,
+                    reference.TypeDefinition,
+                    deviceTypeId,
+                    ct).ConfigureAwait(false))
                 {
                     string displayName =
                         reference.DisplayName.Text ?? string.Empty;
@@ -152,6 +156,18 @@ namespace Opc.Ua.Di.Client
                     }
                 }
             }
+        }
+
+        private static ValueTask<bool> IsSubtypeOfAsync(
+            ISession session,
+            ExpandedNodeId typeDefinition,
+            ExpandedNodeId expectedType,
+            CancellationToken ct)
+        {
+            return session.NodeCache.IsTypeOfAsync(
+                typeDefinition,
+                expectedType,
+                ct);
         }
 
         private static async ValueTask<string> ReadDeviceClassAsync(

--- a/tests/Opc.Ua.Di.Tests/DiDiscoveryClientTests.cs
+++ b/tests/Opc.Ua.Di.Tests/DiDiscoveryClientTests.cs
@@ -105,6 +105,8 @@ namespace Opc.Ua.Di.Tests
         public async Task EnumerateDevicesAsyncReturnsDeviceEntryForMatchingTypeDefinition()
         {
             Mock<ISession> sessionMock = CreateSessionMock();
+            var nodeCacheMock = new Mock<INodeCache>(MockBehavior.Strict);
+            sessionMock.SetupGet(s => s.NodeCache).Returns(nodeCacheMock.Object);
             ExpandedNodeId deviceTypeId = global::Opc.Ua.Di.ObjectTypeIds.DeviceType;
             var deviceNodeId = new NodeId("device-1", 2);
 
@@ -120,6 +122,18 @@ namespace Opc.Ua.Di.Tests
             SetupBrowseSequential(sessionMock,
                 first: [deviceRef, nonDeviceRef],
                 rest: []);
+            nodeCacheMock
+                .Setup(c => c.IsTypeOfAsync(
+                    deviceTypeId,
+                    deviceTypeId,
+                    It.IsAny<CancellationToken>()))
+                .Returns(new ValueTask<bool>(true));
+            nodeCacheMock
+                .Setup(c => c.IsTypeOfAsync(
+                    new ExpandedNodeId("OtherType", 2),
+                    deviceTypeId,
+                    It.IsAny<CancellationToken>()))
+                .Returns(new ValueTask<bool>(false));
 
             // Stub the DeviceClass property lookup so it returns
             // empty (no targets → empty deviceClass).
@@ -133,12 +147,60 @@ namespace Opc.Ua.Di.Tests
             Assert.That(result[0].DeviceId, Is.EqualTo(deviceNodeId));
             Assert.That(result[0].DisplayName, Is.EqualTo("Device 1"));
             Assert.That(result[0].DeviceClass, Is.EqualTo(string.Empty));
+            nodeCacheMock.VerifyAll();
+        }
+
+        [Test]
+        public async Task EnumerateDevicesAsyncReturnsDeviceEntryForSubtypeTypeDefinition()
+        {
+            Mock<ISession> sessionMock = CreateSessionMock();
+            var nodeCacheMock = new Mock<INodeCache>(MockBehavior.Strict);
+            sessionMock.SetupGet(s => s.NodeCache).Returns(nodeCacheMock.Object);
+            ExpandedNodeId deviceTypeId = global::Opc.Ua.Di.ObjectTypeIds.DeviceType;
+            ExpandedNodeId vendorDeviceType = new("VendorDeviceType", 2);
+            var deviceNodeId = new NodeId("device-subtype-1", 2);
+
+            ReferenceDescription deviceRef = MakeReference(
+                deviceNodeId, "Vendor Device", vendorDeviceType);
+            ReferenceDescription nonDeviceRef = MakeReference(
+                new NodeId("other-1", 2), "Other 1",
+                new ExpandedNodeId("OtherType", 2));
+
+            SetupBrowseSequential(sessionMock,
+                first: [deviceRef, nonDeviceRef],
+                rest: []);
+            nodeCacheMock
+                .Setup(c => c.IsTypeOfAsync(
+                    vendorDeviceType,
+                    deviceTypeId,
+                    It.IsAny<CancellationToken>()))
+                .Returns(new ValueTask<bool>(true));
+            nodeCacheMock
+                .Setup(c => c.IsTypeOfAsync(
+                    new ExpandedNodeId("OtherType", 2),
+                    deviceTypeId,
+                    It.IsAny<CancellationToken>()))
+                .Returns(new ValueTask<bool>(false));
+
+            SetupTranslateBrowsePathsEmpty(sessionMock);
+
+            List<DeviceEntry> result = await ToListAsync(
+                DiDiscoveryClient.EnumerateDevicesAsync(
+                    sessionMock.Object, NullTelemetry())).ConfigureAwait(false);
+
+            Assert.That(result, Has.Count.EqualTo(1));
+            Assert.That(result[0].DeviceId, Is.EqualTo(deviceNodeId));
+            Assert.That(result[0].DisplayName, Is.EqualTo("Vendor Device"));
+            Assert.That(result[0].DeviceClass, Is.EqualTo(string.Empty));
+            nodeCacheMock.VerifyAll();
         }
 
         [Test]
         public async Task EnumerateDevicesAsyncFiltersOutNonDeviceTypes()
         {
             Mock<ISession> sessionMock = CreateSessionMock();
+            var nodeCacheMock = new Mock<INodeCache>(MockBehavior.Strict);
+            sessionMock.SetupGet(s => s.NodeCache).Returns(nodeCacheMock.Object);
             ReferenceDescription nonDeviceRef = MakeReference(
                 new NodeId("folder-1", 2), "Folder 1",
                 new ExpandedNodeId("FolderType", 2));
@@ -146,12 +208,19 @@ namespace Opc.Ua.Di.Tests
             SetupBrowseSequential(sessionMock,
                 first: [nonDeviceRef],
                 rest: []);
+            nodeCacheMock
+                .Setup(c => c.IsTypeOfAsync(
+                    new ExpandedNodeId("FolderType", 2),
+                    global::Opc.Ua.Di.ObjectTypeIds.DeviceType,
+                    It.IsAny<CancellationToken>()))
+                .Returns(new ValueTask<bool>(false));
 
             List<DeviceEntry> result = await ToListAsync(
                 DiDiscoveryClient.EnumerateDevicesAsync(
                     sessionMock.Object, NullTelemetry())).ConfigureAwait(false);
 
             Assert.That(result, Is.Empty);
+            nodeCacheMock.VerifyAll();
         }
 
         [Test]
@@ -163,6 +232,8 @@ namespace Opc.Ua.Di.Tests
             // bounded number of browse calls (depth 0..3 inclusive
             // → 4 calls before depth > maxDepth aborts).
             Mock<ISession> sessionMock = CreateSessionMock();
+            var nodeCacheMock = new Mock<INodeCache>(MockBehavior.Strict);
+            sessionMock.SetupGet(s => s.NodeCache).Returns(nodeCacheMock.Object);
             ReferenceDescription nonDeviceRef = MakeReference(
                 new NodeId("nested", 2), "Nested",
                 new ExpandedNodeId("FolderType", 2));
@@ -186,6 +257,12 @@ namespace Opc.Ua.Di.Tests
                         }
                     }.ToArrayOf()
                 });
+            nodeCacheMock
+                .Setup(c => c.IsTypeOfAsync(
+                    new ExpandedNodeId("FolderType", 2),
+                    global::Opc.Ua.Di.ObjectTypeIds.DeviceType,
+                    It.IsAny<CancellationToken>()))
+                .Returns(new ValueTask<bool>(false));
 
             List<DeviceEntry> result = await ToListAsync(
                 DiDiscoveryClient.EnumerateDevicesAsync(
@@ -196,6 +273,12 @@ namespace Opc.Ua.Di.Tests
             // depth > 3 guard stops further recursion.
             Assert.That(browseCalls, Is.EqualTo(4),
                 "Recursion must stop at maxDepth=3 (4 invocations).");
+            nodeCacheMock.Verify(
+                c => c.IsTypeOfAsync(
+                    new ExpandedNodeId("FolderType", 2),
+                    global::Opc.Ua.Di.ObjectTypeIds.DeviceType,
+                    It.IsAny<CancellationToken>()),
+                Times.Exactly(4));
         }
 
         private static async Task<List<DeviceEntry>> ToListAsync(
@@ -228,6 +311,8 @@ namespace Opc.Ua.Di.Tests
             var nsTable = new NamespaceTable();
             nsTable.GetIndexOrAppend(global::Opc.Ua.Di.Namespaces.OpcUaDi);
             mock.SetupGet(s => s.NamespaceUris).Returns(nsTable);
+            mock.SetupGet(s => s.NodeCache)
+                .Returns(new Mock<INodeCache>(MockBehavior.Loose).Object);
             return mock;
         }
 


### PR DESCRIPTION
### Summary

This PR makes `DiDiscoveryClient.EnumerateDevicesAsync()` accept `DeviceType` subtypes instead of requiring an exact type-definition match and adds regression tests that verify derived device types are discovered while non-device objects remain filtered out.

### Problem

In OPC UA DI, device instances may be modeled directly as `DeviceType` or as instances of any subtype derived from `DeviceType`. A discovery helper that claims to enumerate `DeviceType` devices therefore needs to follow the OPC UA type hierarchy instead of requiring an exact `TypeDefinition` match.

Previously, `DiDiscoveryClient.BrowseForDevicesAsync()` identified devices with a direct comparison against `DeviceType`. As a result, any server that exposed devices through a legal subtype of `DeviceType` would have those devices treated as non-device objects, causing them to be skipped or only used as recursion points instead of being returned as discovered devices.

### Changes

- Replace the exact `DeviceType` comparison in `BrowseForDevicesAsync()` with a real subtype check based on `session.NodeCache.IsTypeOfAsync(...)`.
- Preserve the existing recursive browse behaviour for non-device objects.
- Add regression coverage that verifies exact `DeviceType` instances still work, derived device types are now discovered, and non-device objects are still excluded.
