### PR TITLE
fix(server): enforce published HistoryUpdate operation limits

### DIFF
--- a/src/Opc.Ua.Server/Server/StandardServer.cs
+++ b/src/Opc.Ua.Server/Server/StandardServer.cs
@@ -1877,10 +1877,10 @@ namespace Opc.Ua.Server
 
             try
             {
-                // check only for BadNothingToDo here
-                // MaxNodesPerHistoryUpdateEvents & MaxNodesPerHistoryUpdateData
-                // must be checked in NodeManager (TODO)
                 ValidateOperationLimits(historyUpdateDetails);
+                ValidateOperationLimits(
+                    historyUpdateDetails.Count,
+                    GetHistoryUpdateOperationLimit(historyUpdateDetails));
 
                 (ArrayOf<HistoryUpdateResult> results, ArrayOf<DiagnosticInfo> diagnosticInfos) =
                     await ServerInternal.NodeManager.HistoryUpdateAsync(
@@ -1913,6 +1913,37 @@ namespace Opc.Ua.Server
             {
                 OnRequestComplete(context);
             }
+        }
+
+        private PropertyState<uint>? GetHistoryUpdateOperationLimit(
+            ArrayOf<ExtensionObject> historyUpdateDetails)
+        {
+            foreach (ExtensionObject details in historyUpdateDetails)
+            {
+                if (details.IsNull || !details.TryGetValue(out HistoryUpdateDetails? historyUpdateDetail))
+                {
+                    continue;
+                }
+
+                Type detailsType = historyUpdateDetail!.GetType();
+                if (detailsType == typeof(UpdateEventDetails) ||
+                    detailsType == typeof(DeleteEventDetails))
+                {
+                    return OperationLimits.MaxNodesPerHistoryUpdateEvents;
+                }
+
+                if (detailsType == typeof(UpdateDataDetails) ||
+                    detailsType == typeof(UpdateStructureDataDetails) ||
+                    detailsType == typeof(DeleteRawModifiedDetails) ||
+                    detailsType == typeof(DeleteAtTimeDetails))
+                {
+                    return OperationLimits.MaxNodesPerHistoryUpdateData;
+                }
+
+                break;
+            }
+
+            return null;
         }
 
         /// <inheritdoc/>

--- a/tests/Opc.Ua.History.Tests/HistoricalAccessTests.cs
+++ b/tests/Opc.Ua.History.Tests/HistoricalAccessTests.cs
@@ -870,7 +870,7 @@ namespace Opc.Ua.History.Tests
         }
 
         [Test]
-        public void HistoryUpdateRejectsTooManyDataOperationsAsync()
+        public async Task HistoryUpdateRejectsTooManyDataOperationsAsync()
         {
             NodeId nodeId = ToNodeId(Constants.ScalarStaticDouble);
             var details = new ExtensionObject[1001];
@@ -891,17 +891,33 @@ namespace Opc.Ua.History.Tests
                 });
             }
 
-            ServiceResultException ex = Assert.ThrowsAsync<ServiceResultException>(
-                async () => await Session.HistoryUpdateAsync(
-                    null,
-                    details.ToArrayOf(),
-                    CancellationToken.None).ConfigureAwait(false));
+            uint originalDataLimit = Session.OperationLimits.MaxNodesPerHistoryUpdateData;
+            uint originalEventLimit = Session.OperationLimits.MaxNodesPerHistoryUpdateEvents;
 
-            Assert.That(ex.StatusCode, Is.EqualTo(StatusCodes.BadTooManyOperations));
+            try
+            {
+                // Disable client-side batching so the oversized request reaches
+                // the server as a single HistoryUpdate call.
+                Session.OperationLimits.MaxNodesPerHistoryUpdateData = 0;
+                Session.OperationLimits.MaxNodesPerHistoryUpdateEvents = 0;
+
+                ServiceResultException ex = Assert.ThrowsAsync<ServiceResultException>(
+                    async () => await Session.HistoryUpdateAsync(
+                        null,
+                        details.ToArrayOf(),
+                        CancellationToken.None).ConfigureAwait(false));
+
+                Assert.That(ex.StatusCode, Is.EqualTo(StatusCodes.BadTooManyOperations));
+            }
+            finally
+            {
+                Session.OperationLimits.MaxNodesPerHistoryUpdateData = originalDataLimit;
+                Session.OperationLimits.MaxNodesPerHistoryUpdateEvents = originalEventLimit;
+            }
         }
 
         [Test]
-        public void HistoryUpdateRejectsTooManyEventOperationsAsync()
+        public async Task HistoryUpdateRejectsTooManyEventOperationsAsync()
         {
             var details = new ExtensionObject[1001];
 
@@ -914,13 +930,29 @@ namespace Opc.Ua.History.Tests
                 });
             }
 
-            ServiceResultException ex = Assert.ThrowsAsync<ServiceResultException>(
-                async () => await Session.HistoryUpdateAsync(
-                    null,
-                    details.ToArrayOf(),
-                    CancellationToken.None).ConfigureAwait(false));
+            uint originalDataLimit = Session.OperationLimits.MaxNodesPerHistoryUpdateData;
+            uint originalEventLimit = Session.OperationLimits.MaxNodesPerHistoryUpdateEvents;
 
-            Assert.That(ex.StatusCode, Is.EqualTo(StatusCodes.BadTooManyOperations));
+            try
+            {
+                // Disable client-side batching so the oversized request reaches
+                // the server as a single HistoryUpdate call.
+                Session.OperationLimits.MaxNodesPerHistoryUpdateData = 0;
+                Session.OperationLimits.MaxNodesPerHistoryUpdateEvents = 0;
+
+                ServiceResultException ex = Assert.ThrowsAsync<ServiceResultException>(
+                    async () => await Session.HistoryUpdateAsync(
+                        null,
+                        details.ToArrayOf(),
+                        CancellationToken.None).ConfigureAwait(false));
+
+                Assert.That(ex.StatusCode, Is.EqualTo(StatusCodes.BadTooManyOperations));
+            }
+            finally
+            {
+                Session.OperationLimits.MaxNodesPerHistoryUpdateData = originalDataLimit;
+                Session.OperationLimits.MaxNodesPerHistoryUpdateEvents = originalEventLimit;
+            }
         }
 
         [Description("Verify that HistoryRead can read history for multiple nodes in a single request and returns one result per node.")]

--- a/tests/Opc.Ua.History.Tests/HistoricalAccessTests.cs
+++ b/tests/Opc.Ua.History.Tests/HistoricalAccessTests.cs
@@ -869,6 +869,60 @@ namespace Opc.Ua.History.Tests
             }
         }
 
+        [Test]
+        public void HistoryUpdateRejectsTooManyDataOperationsAsync()
+        {
+            NodeId nodeId = ToNodeId(Constants.ScalarStaticDouble);
+            var details = new ExtensionObject[1001];
+
+            for (int i = 0; i < details.Length; i++)
+            {
+                details[i] = new ExtensionObject(new UpdateDataDetails
+                {
+                    NodeId = nodeId,
+                    PerformInsertReplace = PerformUpdateType.Insert,
+                    UpdateValues =
+                    [
+                        new DataValue(
+                            new Variant((double)i),
+                            StatusCodes.Good,
+                            DateTime.UtcNow.AddSeconds(i))
+                    ]
+                });
+            }
+
+            ServiceResultException ex = Assert.ThrowsAsync<ServiceResultException>(
+                async () => await Session.HistoryUpdateAsync(
+                    null,
+                    details.ToArrayOf(),
+                    CancellationToken.None).ConfigureAwait(false));
+
+            Assert.That(ex.StatusCode, Is.EqualTo(StatusCodes.BadTooManyOperations));
+        }
+
+        [Test]
+        public void HistoryUpdateRejectsTooManyEventOperationsAsync()
+        {
+            var details = new ExtensionObject[1001];
+
+            for (int i = 0; i < details.Length; i++)
+            {
+                details[i] = new ExtensionObject(new DeleteEventDetails
+                {
+                    NodeId = ObjectIds.Server,
+                    EventIds = [ByteString.From([(byte)(i & 0xff)])]
+                });
+            }
+
+            ServiceResultException ex = Assert.ThrowsAsync<ServiceResultException>(
+                async () => await Session.HistoryUpdateAsync(
+                    null,
+                    details.ToArrayOf(),
+                    CancellationToken.None).ConfigureAwait(false));
+
+            Assert.That(ex.StatusCode, Is.EqualTo(StatusCodes.BadTooManyOperations));
+        }
+
         [Description("Verify that HistoryRead can read history for multiple nodes in a single request and returns one result per node.")]
         [Test]
         public async Task HistoryReadMultipleNodesAtOnceAsync()


### PR DESCRIPTION
### Summary

This PR enforces the published `HistoryUpdate` operation limits in the server service entry point and adds regression coverage that verifies requests exceeding `MaxNodesPerHistoryUpdateData` or `MaxNodesPerHistoryUpdateEvents` are rejected with `BadTooManyOperations`.

### Problem

The server already publishes `MaxNodesPerHistoryUpdateData` and `MaxNodesPerHistoryUpdateEvents` through `ServerCapabilities.OperationLimits`, but `StandardServer.HistoryUpdateAsync()` did not actually enforce either limit. The method only called the generic `ValidateOperationLimits(historyUpdateDetails)` overload without passing a concrete limit, which meant it only rejected empty requests with `BadNothingToDo` and never returned `BadTooManyOperations` for oversized `HistoryUpdate` requests.

The existing code already acknowledged this gap: `HistoryUpdateAsync()` contained a TODO comment stating that the history-update operation limits still needed to be checked elsewhere. In practice, neither `StandardServer`, `MasterNodeManager`, nor the downstream node-manager paths consumed `MaxNodesPerHistoryUpdateData` or `MaxNodesPerHistoryUpdateEvents`, so the advertised limits were never enforced at runtime.

### Changes

- Enforce `HistoryUpdate` operation limits in `StandardServer.HistoryUpdateAsync()` after the existing non-empty request validation.
- Classify `HistoryUpdateDetails` into data-oriented vs event-oriented requests and apply `MaxNodesPerHistoryUpdateData` or `MaxNodesPerHistoryUpdateEvents` accordingly.
- Add integration-style regression tests that verify oversized data-update and event-update requests are both rejected with `BadTooManyOperations`.
