### PR TITLE
Initialize encoder fuzz ServiceMessageContext (OPC 10000-6)

### DIFF
--- a/fuzzing/Opc.Ua.Encoders.Fuzz.Tests/EncoderTests.cs
+++ b/fuzzing/Opc.Ua.Encoders.Fuzz.Tests/EncoderTests.cs
@@ -45,9 +45,12 @@ namespace Opc.Ua.Fuzzing
         [Test]
         public void MessageContextIsInitializedWithoutTestSetup()
         {
-            Assert.That(FuzzableCode.MessageContext, Is.Not.Null);
-            Assert.That(FuzzableCode.MessageContext, Is.SameAs(FuzzableCode.MessageContext));
-            Assert.That(FuzzableCode.MessageContext.Factory, Is.Not.Null);
+            ServiceMessageContext firstContext = FuzzableCode.MessageContext;
+            ServiceMessageContext secondContext = FuzzableCode.MessageContext;
+
+            Assert.That(firstContext, Is.Not.Null);
+            Assert.That(firstContext, Is.SameAs(secondContext));
+            Assert.That(firstContext.Factory, Is.Not.Null);
         }
     }
 }

--- a/fuzzing/Opc.Ua.Encoders.Fuzz.Tests/EncoderTests.cs
+++ b/fuzzing/Opc.Ua.Encoders.Fuzz.Tests/EncoderTests.cs
@@ -42,9 +42,12 @@ namespace Opc.Ua.Fuzzing
 
         protected override Type FuzzableCodeType => typeof(FuzzableCode);
 
-        protected override void OnFuzzTargetSetup(ITelemetryContext telemetry)
+        [Test]
+        public void MessageContextIsInitializedWithoutTestSetup()
         {
-            FuzzableCode.MessageContext = ServiceMessageContext.Create(telemetry);
+            Assert.That(FuzzableCode.MessageContext, Is.Not.Null);
+            Assert.That(FuzzableCode.MessageContext, Is.SameAs(FuzzableCode.MessageContext));
+            Assert.That(FuzzableCode.MessageContext.Factory, Is.Not.Null);
         }
     }
 }

--- a/fuzzing/Opc.Ua.Encoders.Fuzz.Tests/Issue3546RoundTripTests.cs
+++ b/fuzzing/Opc.Ua.Encoders.Fuzz.Tests/Issue3546RoundTripTests.cs
@@ -29,7 +29,6 @@
 
 using System.IO;
 using NUnit.Framework;
-using Opc.Ua.Tests;
 
 namespace Opc.Ua.Fuzzing
 {
@@ -57,13 +56,6 @@ namespace Opc.Ua.Fuzzing
     public class Issue3546RoundTripTests
     {
         private static readonly uint[] s_arrayDimensions = [1u, 2u];
-
-        [SetUp]
-        public void Setup()
-        {
-            ITelemetryContext telemetry = NUnitTelemetryContext.Create();
-            FuzzableCode.MessageContext = ServiceMessageContext.Create(telemetry);
-        }
 
         [Test]
         public void DataTypeNodeWithReferencesRoundTripsCleanly()

--- a/fuzzing/Opc.Ua.Encoders.Fuzz.Tools/Encoders.Testcases.cs
+++ b/fuzzing/Opc.Ua.Encoders.Fuzz.Tools/Encoders.Testcases.cs
@@ -47,11 +47,10 @@ namespace Opc.Ua.Fuzzing
         /// Run the encoder test cases
         /// </summary>
         /// <param name="workPath"></param>
-        /// <param name="telemetry">The telemetry context to use to create obvservability instruments</param>
+        /// <param name="telemetry">Unused; retained for the common fuzz-tool signature.</param>
         public static void Run(string workPath, ITelemetryContext telemetry)
         {
-            // Create the Testcases for the binary decoder.
-            FuzzableCode.MessageContext = ServiceMessageContext.Create(telemetry);
+            _ = telemetry;
             string pathSuffix = GetTestcaseEncoderSuffix(TestCaseEncoders.Binary);
             string pathTarget = workPath + pathSuffix + Path.DirectorySeparatorChar;
             Directory.CreateDirectory(pathTarget);

--- a/fuzzing/Opc.Ua.Encoders.Fuzz/FuzzableCode.cs
+++ b/fuzzing/Opc.Ua.Encoders.Fuzz/FuzzableCode.cs
@@ -29,13 +29,15 @@
 
 using System;
 using System.IO;
+using Microsoft.Extensions.Logging.Abstractions;
 using Opc.Ua.Bindings;
 
 namespace Opc.Ua.Fuzzing
 {
     public static partial class FuzzableCode
     {
-        public static ServiceMessageContext MessageContext { get; set; }
+        public static ServiceMessageContext MessageContext { get; } =
+            ServiceMessageContext.Create(new FuzzTelemetryContext());
 
         /// <summary>
         /// Print information about the fuzzer target.
@@ -69,6 +71,14 @@ namespace Opc.Ua.Fuzzing
             }
 
             return memoryStream;
+        }
+
+        private sealed class FuzzTelemetryContext : TelemetryContextBase
+        {
+            public FuzzTelemetryContext()
+                : base(NullLoggerFactory.Instance)
+            {
+            }
         }
     }
 }


### PR DESCRIPTION
## Failure

The encoder fuzz host relied on NUnit or corpus-tool setup to assign
`FuzzableCode.MessageContext`. Direct afl-fuzz/libFuzzer startup could therefore
reach encoder targets without an initialized OPC UA message context.

## Fix

- Initialize one process-lifetime `ServiceMessageContext` with null logging.
- Make the context immutable and remove test/tool reassignment.
- Exercise the same context from regression tests and the standalone fuzz host.

## Reference

- OPC 10000-6 encoding validation.
- Split from #4021.

## Tests

- `dotnet test fuzzing\Opc.Ua.Encoders.Fuzz.Tests\Opc.Ua.Encoders.Fuzz.Tests.csproj -c Release -f net10.0 --nologo` (4,569 passed)
- `dotnet run --project fuzzing\Opc.Ua.Encoders.Fuzz\Opc.Ua.Encoders.Fuzz.csproj -c Release --` (standalone smoke passed)
