### PR TITLE
fix(server): enforce browse continuation point limit at capacity

### DIFF
--- a/src/Opc.Ua.Server/Session/SessionContinuationPoints.cs
+++ b/src/Opc.Ua.Server/Session/SessionContinuationPoints.cs
@@ -85,7 +85,7 @@ namespace Opc.Ua.Server
                 m_browse ??= [];
 
                 // remove the first continuation point if too many points.
-                while (m_browse.Count > MaxBrowse)
+                while (m_browse.Count >= MaxBrowse)
                 {
                     ContinuationPoint cp = m_browse[0];
                     m_browse.RemoveAt(0);

--- a/tests/Opc.Ua.Server.Tests/SessionContinuationPointsTests.cs
+++ b/tests/Opc.Ua.Server.Tests/SessionContinuationPointsTests.cs
@@ -111,10 +111,13 @@ namespace Opc.Ua.Server.Tests
 
             Assert.That(evicted.Disposed, Is.True);
             Assert.That(holder.RestoreBrowse(ToByteString(cp1.Id)), Is.Null);
-            Assert.That(holder.RestoreBrowse(ToByteString(cp2.Id)), Is.SameAs(cp2));
+            Assert.That(holder.RestoreBrowse(ToByteString(cp2.Id)), Is.Null);
             Assert.That(holder.RestoreBrowse(ToByteString(cp3.Id)), Is.SameAs(cp3));
             store.Verify(
                 s => s.RemoveContinuationPoint(s_sessionId, ContinuationPointKind.Browse, cp1.Id),
+                Times.Once);
+            store.Verify(
+                s => s.RemoveContinuationPoint(s_sessionId, ContinuationPointKind.Browse, cp2.Id),
                 Times.Once);
         }
 

--- a/tests/Opc.Ua.Server.Tests/SessionContinuationPointsTests.cs
+++ b/tests/Opc.Ua.Server.Tests/SessionContinuationPointsTests.cs
@@ -119,6 +119,30 @@ namespace Opc.Ua.Server.Tests
         }
 
         [Test]
+        public void SaveBrowseEvictsWhenCountReachesConfiguredLimit()
+        {
+            var store = new Mock<IContinuationPointStore>(MockBehavior.Loose);
+            SessionContinuationPoints holder = NewHolder(maxBrowse: 2, store: store.Object);
+
+            var evicted = new TrackingDisposable();
+            ContinuationPoint cp1 = NewBrowsePoint(data: evicted);
+            ContinuationPoint cp2 = NewBrowsePoint();
+            ContinuationPoint cp3 = NewBrowsePoint();
+
+            holder.SaveBrowse(cp1);
+            holder.SaveBrowse(cp2);
+            holder.SaveBrowse(cp3);
+
+            Assert.That(evicted.Disposed, Is.True);
+            Assert.That(holder.RestoreBrowse(ToByteString(cp1.Id)), Is.Null);
+            Assert.That(holder.RestoreBrowse(ToByteString(cp2.Id)), Is.SameAs(cp2));
+            Assert.That(holder.RestoreBrowse(ToByteString(cp3.Id)), Is.SameAs(cp3));
+            store.Verify(
+                s => s.RemoveContinuationPoint(s_sessionId, ContinuationPointKind.Browse, cp1.Id),
+                Times.Once);
+        }
+
+        [Test]
         public void SaveBrowseStoresEnvelopeWithNormalizedNodeIds()
         {
             var store = new Mock<IContinuationPointStore>(MockBehavior.Loose);


### PR DESCRIPTION
Fixes an off-by-one error in browse continuation-point retention by evicting the oldest point as soon as the session reaches `MaxBrowseContinuationPoints`, and adds a regression test covering the exact-limit case that previously allowed one extra browse continuation point to remain active.