### PR TITLE
fix(alias): compare PortableNodeId identifiers by NodeId semantics

### DIFF
--- a/src/Opc.Ua.Client/AliasNames/PubSub/AliasNamePubSubRefreshStrategy.cs
+++ b/src/Opc.Ua.Client/AliasNames/PubSub/AliasNamePubSubRefreshStrategy.cs
@@ -143,23 +143,10 @@ namespace Opc.Ua.Client.AliasNames.PubSub
 
         private static bool CompareIdentifiers(NodeId publisherId, NodeId localId)
         {
-            // Both NodeIds carry the same identifier-shape (numeric /
-            // string / guid / opaque). Comparing identifier text after
-            // dropping the namespace prefix is the simplest robust path.
-            string a = StripNamespacePrefix(publisherId.ToString());
-            string b = StripNamespacePrefix(localId.ToString());
-            return string.Equals(a, b, StringComparison.Ordinal);
-        }
-
-        private static string StripNamespacePrefix(string? text)
-        {
-            if (string.IsNullOrEmpty(text))
-            {
-                return string.Empty;
-            }
-            string value = text!;
-            int idx = value.IndexOf(';', StringComparison.Ordinal);
-            return idx < 0 ? value : value[(idx + 1)..];
+            // PortableNodeId strips the namespace index but preserves
+            // the underlying identifier type and value.
+            return publisherId.WithNamespaceIndex(0) ==
+                localId.WithNamespaceIndex(0);
         }
 
         private readonly AliasNamePubSubReader m_reader;

--- a/tests/Opc.Ua.Client.Tests/AliasNames/PubSub/AliasNamePubSubBridgeTests.cs
+++ b/tests/Opc.Ua.Client.Tests/AliasNames/PubSub/AliasNamePubSubBridgeTests.cs
@@ -176,6 +176,48 @@ namespace Opc.Ua.Client.Tests.AliasNames.PubSub
             }
         }
 
+        [Test]
+        public async Task StrategyMatchesStringIdentifiersContainingSemicolonsAsync()
+        {
+            var reader = new AliasNamePubSubReader();
+            var strategy = new AliasNamePubSubRefreshStrategy(reader);
+            var harness = AliasNameSessionHarness.Create();
+            harness.SessionMock.SetupGet(s => s.NamespaceUris)
+                .Returns(BuildNamespaceTable());
+
+            var categoryId = new NodeId("A;B", 1);
+            var client = new AliasNameClient(harness.Session, categoryId);
+
+            int invalidations = 0;
+            await strategy.StartAsync(
+                client, () => invalidations++, CancellationToken.None).ConfigureAwait(false);
+            try
+            {
+                reader.Submit(new AliasUpdateDataType
+                {
+                    ApplicationUri = "urn:p",
+                    Categories = new[]
+                    {
+                        new AliasCategoryUpdateDataType
+                        {
+                            Category = new PortableNodeId
+                            {
+                                NamespaceUri = "http://test.example/",
+                                Identifier = NodeId.Parse("s=A;B")
+                            },
+                            LastChange = 7
+                        }
+                    }.ToArrayOf()
+                });
+
+                Assert.That(invalidations, Is.EqualTo(1));
+            }
+            finally
+            {
+                await strategy.DisposeAsync().ConfigureAwait(false);
+            }
+        }
+
         private static NamespaceTable BuildNamespaceTable()
         {
             var ns = new NamespaceTable();


### PR DESCRIPTION
### Summary

This PR fixes `AliasNamePubSubRefreshStrategy` category matching for string NodeIds whose identifier contains semicolons and adds a regression test covering that scenario.

### Problem

`AliasNamePubSubRefreshStrategy` is supposed to match the publisher's `PortableNodeId.Identifier` against the local alias category `NodeId` while ignoring namespace index differences. However, the previous implementation did that by converting both NodeIds to text and stripping everything before the first `;`.

That happened to work for simple identifiers such as `ns=1;s=MyCategory`, but it broke for valid string NodeIds whose identifier itself contains semicolons. For example, when the local category is `ns=1;s=A;B`, the previous logic transformed the local value into `s=A;B` but transformed the already namespace-free portable form `s=A;B` into just `B`. As a result, both sides represented the same identifier semantically, yet the refresh strategy could never match them and would silently ignore legitimate alias update messages for that category.

### Changes

- Replace the string-prefix stripping comparison in `AliasNamePubSubRefreshStrategy` with namespace-insensitive `NodeId` equality, preserving the original identifier type and value.
- Add a regression test that verifies a PubSub alias update for a category such as `s=A;B` still invalidates the local cache.
