### PR TITLE
Fix AliasName subcategory browse continuation

### DIFF
--- a/src/Opc.Ua.Client/AliasNames/AliasNameClient.cs
+++ b/src/Opc.Ua.Client/AliasNames/AliasNameClient.cs
@@ -32,6 +32,7 @@ using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
+using Opc.Ua.Client;
 
 namespace Opc.Ua.Client.AliasNames
 {
@@ -444,13 +445,7 @@ namespace Opc.Ua.Client.AliasNames
                 throw new ServiceResultException(br.StatusCode);
             }
 
-            int refCount = br.References.Count;
-            var refs = new ReferenceDescription[refCount];
-            for (int i = 0; i < refCount; i++)
-            {
-                refs[i] = br.References[i];
-            }
-            foreach (ReferenceDescription r in refs)
+            foreach (ReferenceDescription r in SnapshotReferences(br.References))
             {
                 if (!r.TypeDefinition.Equals(ObjectTypeIds.AliasNameCategoryType))
                 {
@@ -467,11 +462,52 @@ namespace Opc.Ua.Client.AliasNames
                     r.BrowseName,
                     r.DisplayName);
             }
+
+            ByteString continuationPoint = br.ContinuationPoint;
+            while (!continuationPoint.IsEmpty)
+            {
+                (_, continuationPoint, ArrayOf<ReferenceDescription> nextReferences) =
+                    await Session.BrowseNextAsync(
+                        requestHeader: null,
+                        releaseContinuationPoint: false,
+                        continuationPoint,
+                        ct).ConfigureAwait(false);
+
+                foreach (ReferenceDescription r in SnapshotReferences(nextReferences))
+                {
+                    if (!r.TypeDefinition.Equals(ObjectTypeIds.AliasNameCategoryType))
+                    {
+                        continue;
+                    }
+                    var localId = ExpandedNodeId.ToNodeId(
+                        r.NodeId, Session.NamespaceUris);
+                    if (localId.IsNull)
+                    {
+                        continue;
+                    }
+                    yield return new AliasNameSubCategoryInfo(
+                        localId,
+                        r.BrowseName,
+                        r.DisplayName);
+                }
+            }
         }
 
         // --------------------------------------------------------------
         // Internal helpers
         // --------------------------------------------------------------
+
+        private static ReferenceDescription[] SnapshotReferences(
+            ArrayOf<ReferenceDescription> references)
+        {
+            int refCount = references.Count;
+            var snapshot = new ReferenceDescription[refCount];
+            for (int i = 0; i < refCount; i++)
+            {
+                snapshot[i] = references[i];
+            }
+            return snapshot;
+        }
 
         private async Task<NodeId> ResolveChildAsync(
             string childBrowseName,

--- a/tests/Opc.Ua.Client.Tests/AliasNames/AliasNameClientTests.cs
+++ b/tests/Opc.Ua.Client.Tests/AliasNames/AliasNameClientTests.cs
@@ -228,5 +228,66 @@ namespace Opc.Ua.Client.Tests.AliasNames
                 ]).ConfigureAwait(false);
             }, Throws.TypeOf<System.UnauthorizedAccessException>());
         }
+
+        [Test]
+        public async Task EnumerateSubCategoriesAsyncFollowsBrowseContinuationPointsAsync()
+        {
+            var harness = AliasNameSessionHarness.Create();
+            var continuationPoint = new ByteString([0x01]);
+
+            harness.BrowseHandler = description =>
+            {
+                Assert.That(description.NodeId, Is.EqualTo(ObjectIds.Aliases));
+                return new BrowseResult
+                {
+                    StatusCode = StatusCodes.Good,
+                    ContinuationPoint = continuationPoint,
+                    References = new[]
+                    {
+                        CreateCategoryReference("Page1", "Page1")
+                    }.ToArrayOf()
+                };
+            };
+
+            harness.BrowseNextHandler = cp =>
+            {
+                Assert.That(cp, Is.EqualTo(continuationPoint));
+                return new BrowseResult
+                {
+                    StatusCode = StatusCodes.Good,
+                    ContinuationPoint = ByteString.Empty,
+                    References = new[]
+                    {
+                        CreateCategoryReference("Page2", "Page2")
+                    }.ToArrayOf()
+                };
+            };
+
+            var client = AliasNameClient.OpenStandardAliases(harness.Session);
+            var names = new List<string>();
+
+            await foreach (AliasNameSubCategoryInfo info in
+                client.EnumerateSubCategoriesAsync().ConfigureAwait(false))
+            {
+                names.Add(info.BrowseName.Name);
+            }
+
+            Assert.That(names, Is.EqualTo(new[] { "Page1", "Page2" }));
+            Assert.That(harness.BrowseRequests, Has.Count.EqualTo(1));
+            Assert.That(harness.BrowseNextRequests, Has.Count.EqualTo(1));
+
+            static ReferenceDescription CreateCategoryReference(
+                string browseName,
+                string nodeId)
+            {
+                return new ReferenceDescription
+                {
+                    NodeId = new ExpandedNodeId(new NodeId(nodeId, 2)),
+                    BrowseName = new QualifiedName(browseName, 2),
+                    DisplayName = new LocalizedText(browseName),
+                    TypeDefinition = ObjectTypeIds.AliasNameCategoryType
+                };
+            }
+        }
     }
 }

--- a/tests/Opc.Ua.Client.Tests/AliasNames/AliasNameClientTests.cs
+++ b/tests/Opc.Ua.Client.Tests/AliasNames/AliasNameClientTests.cs
@@ -233,7 +233,7 @@ namespace Opc.Ua.Client.Tests.AliasNames
         public async Task EnumerateSubCategoriesAsyncFollowsBrowseContinuationPointsAsync()
         {
             var harness = AliasNameSessionHarness.Create();
-            var continuationPoint = new ByteString([0x01]);
+            var continuationPoint = new ByteString(new byte[] { 0x01 });
 
             harness.BrowseHandler = description =>
             {
@@ -272,7 +272,8 @@ namespace Opc.Ua.Client.Tests.AliasNames
                 names.Add(info.BrowseName.Name);
             }
 
-            Assert.That(names, Is.EqualTo(new[] { "Page1", "Page2" }));
+            var expectedNames = new[] { "Page1", "Page2" };
+            Assert.That(names, Is.EqualTo(expectedNames));
             Assert.That(harness.BrowseRequests, Has.Count.EqualTo(1));
             Assert.That(harness.BrowseNextRequests, Has.Count.EqualTo(1));
 

--- a/tests/Opc.Ua.Client.Tests/AliasNames/AliasNameSessionHarness.cs
+++ b/tests/Opc.Ua.Client.Tests/AliasNames/AliasNameSessionHarness.cs
@@ -49,8 +49,12 @@ namespace Opc.Ua.Client.Tests.AliasNames
         public IServiceMessageContext MessageContext { get; }
         public List<CallMethodRequest> CallRequests { get; } = [];
         public List<ReadValueId> ReadRequests { get; } = [];
+        public List<BrowseDescription> BrowseRequests { get; } = [];
+        public List<ByteString> BrowseNextRequests { get; } = [];
         public Func<CallMethodRequest, CallMethodResult> CallHandler { get; set; }
         public Func<ReadValueId, DataValue> ReadHandler { get; set; }
+        public Func<BrowseDescription, BrowseResult> BrowseHandler { get; set; }
+        public Func<ByteString, BrowseResult> BrowseNextHandler { get; set; }
 
         public Func<BrowsePath, BrowsePathResult> BrowsePathHandler { get; set; }
 
@@ -164,15 +168,39 @@ namespace Opc.Ua.Client.Tests.AliasNames
                         var results = new BrowseResult[descriptions.Count];
                         for (int i = 0; i < descriptions.Count; i++)
                         {
-                            results[i] = new BrowseResult
-                            {
-                                StatusCode = StatusCodes.Good,
-                                References = Array
-                                    .Empty<ReferenceDescription>()
-                                    .ToArrayOf()
-                            };
+                            BrowseDescription description = descriptions[i];
+                            harness.BrowseRequests.Add(description);
+                            results[i] = harness.BrowseHandler != null
+                                ? harness.BrowseHandler(description)
+                                : DefaultBrowseResult();
                         }
                         return new ValueTask<BrowseResponse>(new BrowseResponse
+                        {
+                            ResponseHeader = new ResponseHeader(),
+                            Results = results.ToArrayOf(),
+                            DiagnosticInfos = default
+                        });
+                    });
+
+            sessionMock
+                .Setup(s => s.BrowseNextAsync(
+                    It.IsAny<RequestHeader>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<ArrayOf<ByteString>>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns<RequestHeader, bool, ArrayOf<ByteString>, CancellationToken>(
+                    (_, _, continuationPoints, _) =>
+                    {
+                        var results = new BrowseResult[continuationPoints.Count];
+                        for (int i = 0; i < continuationPoints.Count; i++)
+                        {
+                            ByteString continuationPoint = continuationPoints[i];
+                            harness.BrowseNextRequests.Add(continuationPoint);
+                            results[i] = harness.BrowseNextHandler != null
+                                ? harness.BrowseNextHandler(continuationPoint)
+                                : DefaultBrowseResult();
+                        }
+                        return new ValueTask<BrowseNextResponse>(new BrowseNextResponse
                         {
                             ResponseHeader = new ResponseHeader(),
                             Results = results.ToArrayOf(),
@@ -189,6 +217,15 @@ namespace Opc.Ua.Client.Tests.AliasNames
             {
                 StatusCode = StatusCodes.Good,
                 OutputArguments = Array.Empty<Variant>().ToArrayOf()
+            };
+        }
+
+        private static BrowseResult DefaultBrowseResult()
+        {
+            return new BrowseResult
+            {
+                StatusCode = StatusCodes.Good,
+                References = Array.Empty<ReferenceDescription>().ToArrayOf()
             };
         }
 


### PR DESCRIPTION
### Summary

This PR fixes `AliasNameClient.EnumerateSubCategoriesAsync()` so it follows OPC UA `Browse` continuation points until the server has returned every `SubAliasNameCategories` reference, and adds a regression test covering the paged browse case that was previously truncated after the first page.

### Problem

`EnumerateSubCategoriesAsync()` is intended to expose the full set of sub-categories organized beneath an `AliasNameCategoryType` node. However, the previous implementation only issued a single `BrowseAsync()` call and immediately enumerated `BrowseResult.References` from that first response.

Under OPC UA, servers are allowed to split browse results across multiple pages and return a `ContinuationPoint` when the first response does not contain the full reference set. In that situation, the client must continue with `BrowseNext` until the continuation point is exhausted. Because this helper never consumed the returned continuation point, it silently dropped every sub-category that appeared after the first page.

### Changes

- Continue sub-category enumeration with `BrowseNextAsync()` whenever the initial `BrowseAsync()` response contains a non-empty continuation point.
- Keep the existing filtering behavior so the helper still returns only `AliasNameCategoryType` references that can be resolved to local `NodeId` values.
- Add scriptable `Browse` / `BrowseNext` support to the alias-name session test harness so paged browse behavior can be covered with a focused unit test.
- Add a regression test that verifies `EnumerateSubCategoriesAsync()` returns sub-categories from both the initial browse response and the follow-up `BrowseNext` response.
