### PR TITLE
Protect certificate and identity secrets in MCP and durable samples (OPC 10000-4 security)

### DIFF
--- a/UA.slnx
+++ b/UA.slnx
@@ -248,6 +248,7 @@
     <Project Path="tests/Opc.Ua.SourceGeneration.Tests/Opc.Ua.SourceGeneration.Tests.csproj" />
     <Project Path="tests/Opc.Ua.MigrationAnalyzer.Core.Tests/Opc.Ua.MigrationAnalyzer.Core.Tests.csproj" />
     <Project Path="tests/Opc.Ua.MigrationAnalyzer.Tests/Opc.Ua.MigrationAnalyzer.Tests.csproj" />
+    <Project Path="tests/Opc.Ua.Tools.Tests/Opc.Ua.Tools.Tests.csproj" />
     <Project Path="tests/Opc.Ua.Types.Tests/Opc.Ua.Types.Tests.csproj" />
     <Project Path="tests/Opc.Ua.WotCon.Tests/Opc.Ua.WotCon.Tests.csproj" />
   </Folder>

--- a/docs/DurableSubscription.md
+++ b/docs/DurableSubscription.md
@@ -34,4 +34,5 @@ Extend the ServerConfiguration
 ## Known limitations and issues
 
 - Subscriptions are only persistet on a gracefuls shutdown. If the server crashes or needs to be shut down forcefully all `Subscriptions` / `MonitoredItems` are lost.
+- The Quickstarts durable-subscription store uses a versioned format and rejects files written by the previous unsafe format. User-name passwords are removed before persistence, and issued-token subscriptions are not persisted because their bearer token is the identity.
 - **Breaking change**: The Interfaces for INodeManager & IMonitoredItem were extended to support durable subscriptions.

--- a/samples/Quickstarts.Servers/DurableSubscription/SubscriptionStore.cs
+++ b/samples/Quickstarts.Servers/DurableSubscription/SubscriptionStore.cs
@@ -77,6 +77,7 @@ namespace Quickstarts.Servers
                 }
 
                 var subs = subscriptions.Cast<StoredSubscription>().ToList();
+                // Validate identities before File.Create can truncate an existing store.
                 foreach (StoredSubscription sub in subs)
                 {
                     _ = SanitizeUserIdentityToken(sub.UserIdentityToken);
@@ -231,7 +232,8 @@ namespace Quickstarts.Servers
             if (magic != kStoreMagic)
             {
                 throw new InvalidDataException(
-                    "The durable subscription store uses the legacy unsafe format.");
+                    "The durable subscription store has an invalid header or uses the " +
+                    "legacy unsafe format.");
             }
 
             uint version = decoder.ReadUInt32(null);

--- a/samples/Quickstarts.Servers/DurableSubscription/SubscriptionStore.cs
+++ b/samples/Quickstarts.Servers/DurableSubscription/SubscriptionStore.cs
@@ -46,6 +46,8 @@ namespace Quickstarts.Servers
             "Durable Subscriptions");
 
         private const string kFilename = "subscriptionsStore.bin";
+        private const uint kStoreMagic = 0x44535541;
+        private const uint kStoreVersion = 1;
         private readonly DurableMonitoredItemQueueFactory? m_durableMonitoredItemQueueFactory;
         private readonly ILogger m_logger;
         private readonly IServiceMessageContext m_messageContext;
@@ -75,11 +77,17 @@ namespace Quickstarts.Servers
                 }
 
                 var subs = subscriptions.Cast<StoredSubscription>().ToList();
+                foreach (StoredSubscription sub in subs)
+                {
+                    _ = SanitizeUserIdentityToken(sub.UserIdentityToken);
+                }
+
                 using (FileStream fileStream = File.Create(
                     Path.Combine(s_storage_path, kFilename)))
                 using (var encoder = new BinaryEncoder(
                     fileStream, m_messageContext, true))
                 {
+                    WriteStoreHeader(encoder);
                     encoder.WriteStringArray(
                         null, m_messageContext.NamespaceUris.ToArrayOf());
                     encoder.WriteStringArray(
@@ -126,6 +134,7 @@ namespace Quickstarts.Servers
                     using (var decoder = new BinaryDecoder(
                         fileStream, m_messageContext, true))
                     {
+                        ValidateStoreHeader(decoder);
                         ArrayOf<string> nsUris = decoder.ReadStringArray(null)!;
                         ArrayOf<string> serverUris = decoder.ReadStringArray(null)!;
                         decoder.SetMappingTables(
@@ -210,6 +219,29 @@ namespace Quickstarts.Servers
             return default;
         }
 
+        internal static void WriteStoreHeader(BinaryEncoder encoder)
+        {
+            encoder.WriteUInt32(null, kStoreMagic);
+            encoder.WriteUInt32(null, kStoreVersion);
+        }
+
+        internal static void ValidateStoreHeader(BinaryDecoder decoder)
+        {
+            uint magic = decoder.ReadUInt32(null);
+            if (magic != kStoreMagic)
+            {
+                throw new InvalidDataException(
+                    "The durable subscription store uses the legacy unsafe format.");
+            }
+
+            uint version = decoder.ReadUInt32(null);
+            if (version != kStoreVersion)
+            {
+                throw new InvalidDataException(
+                    $"Unsupported durable subscription store version {version}.");
+            }
+        }
+
         public static void EncodeSubscription(
             BinaryEncoder encoder, StoredSubscription subscription)
         {
@@ -225,9 +257,11 @@ namespace Quickstarts.Servers
             encoder.WriteInt32(null, subscription.LastSentMessage);
             encoder.WriteUInt32(null, subscription.SequenceNumber);
 
+            UserIdentityToken? sanitizedIdentityToken =
+                SanitizeUserIdentityToken(subscription.UserIdentityToken);
             encoder.WriteExtensionObject(null,
-                subscription.UserIdentityToken != null
-                    ? new ExtensionObject(subscription.UserIdentityToken)
+                sanitizedIdentityToken != null
+                    ? new ExtensionObject(sanitizedIdentityToken)
                     : ExtensionObject.Null);
 
             ExtensionObject[] sentMsgs = subscription.SentMessages?
@@ -330,6 +364,37 @@ namespace Quickstarts.Servers
             }
             subscription.MonitoredItems = items;
             return subscription;
+        }
+
+        internal static UserIdentityToken? SanitizeUserIdentityToken(
+            UserIdentityToken? identityToken)
+        {
+            return identityToken switch
+            {
+                null => null,
+                AnonymousIdentityToken anonymous => new AnonymousIdentityToken
+                {
+                    PolicyId = anonymous.PolicyId
+                },
+                UserNameIdentityToken userName => new UserNameIdentityToken
+                {
+                    PolicyId = userName.PolicyId,
+                    UserName = userName.UserName,
+                    Password = default,
+                    EncryptionAlgorithm = null
+                },
+                X509IdentityToken x509 => new X509IdentityToken
+                {
+                    PolicyId = x509.PolicyId,
+                    CertificateData = x509.CertificateData
+                },
+                IssuedIdentityToken => throw new NotSupportedException(
+                    "Durable subscriptions owned by issued-token identities cannot be " +
+                    "persisted without storing bearer credentials."),
+                _ => throw new NotSupportedException(
+                    $"User identity token type '{identityToken.GetType().Name}' is not safe " +
+                    "for durable subscription persistence.")
+            };
         }
 
         internal static StoredMonitoredItem DecodeMonitoredItem(BinaryDecoder decoder)

--- a/samples/Quickstarts.Servers/Quickstarts.Servers.csproj
+++ b/samples/Quickstarts.Servers/Quickstarts.Servers.csproj
@@ -31,6 +31,9 @@
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <InternalsVisibleTo Include="Opc.Ua.Tools.Tests" />
+  </ItemGroup>
   <Import Project="..\..\tools\Opc.Ua.SourceGeneration\OPCFoundation.Opc.Ua.SourceGeneration.props" />
   <PropertyGroup>
     <ModelSourceGeneratorUseAllowSubtypes>true</ModelSourceGeneratorUseAllowSubtypes>

--- a/tests/Opc.Ua.Tools.Tests/Opc.Ua.Tools.Tests.csproj
+++ b/tests/Opc.Ua.Tools.Tests/Opc.Ua.Tools.Tests.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>$(TestsTargetFrameworks)</TargetFrameworks>
+    <RootNamespace>Opc.Ua.Tools.Tests</RootNamespace>
+    <Nullable>enable</Nullable>
+    <IsTestProject>true</IsTestProject>
+    <NoWarn>$(NoWarn);CS1591;CA1014</NoWarn>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit.Console" />
+    <PackageReference Include="NUnit.Analyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="NUnit3TestAdapter">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\samples\Quickstarts.Servers\Quickstarts.Servers.csproj" />
+    <ProjectReference Include="..\..\tools\Opc.Ua.Mcp\Opc.Ua.Mcp.csproj"
+                      Condition="'$(TargetFramework)' == 'net10.0'" />
+  </ItemGroup>
+</Project>

--- a/tests/Opc.Ua.Tools.Tests/OpcUaSessionManagerTests.cs
+++ b/tests/Opc.Ua.Tools.Tests/OpcUaSessionManagerTests.cs
@@ -1,0 +1,184 @@
+/* ========================================================================
+ * Copyright (c) 2005-2026 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+#if NET10_0
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Opc.Ua.Mcp;
+using Opc.Ua.Security.Certificates;
+
+namespace Opc.Ua.Tools.Tests
+{
+    [TestFixture]
+    public class OpcUaSessionManagerTests
+    {
+        [Test]
+        public async Task ConcurrentAutoAcceptContextsUseIndependentCertificateManagersAsync()
+        {
+            using var telemetry = (DefaultTelemetry)DefaultTelemetry.Create(static _ => { });
+            ApplicationConfiguration configuration = CreateConfiguration(
+                telemetry,
+                out CertificateManager sharedCertificateManager);
+            using (sharedCertificateManager)
+            {
+                Func<Certificate, ServiceResult, bool> sharedCallback = static (_, _) => false;
+                sharedCertificateManager.AcceptError = sharedCallback;
+
+                Task<OpcUaSessionManager.ConnectionValidationContext>[] tasks = Enumerable
+                    .Range(0, 4)
+                    .Select(_ => OpcUaSessionManager.CreateConnectionValidationContextAsync(
+                        configuration,
+                        telemetry,
+                        true,
+                        CancellationToken.None))
+                    .ToArray();
+                OpcUaSessionManager.ConnectionValidationContext[] contexts =
+                    await Task.WhenAll(tasks).ConfigureAwait(false);
+                try
+                {
+                    Assert.That(configuration.CertificateManager, Is.SameAs(sharedCertificateManager));
+                    Assert.That(sharedCertificateManager.AcceptError, Is.SameAs(sharedCallback));
+                    Assert.That(
+                        contexts.Select(context => context.Configuration.CertificateManager)
+                            .Distinct()
+                            .Count(),
+                        Is.EqualTo(contexts.Length));
+
+                    foreach (OpcUaSessionManager.ConnectionValidationContext context in contexts)
+                    {
+                        Assert.That(context.IsIsolated, Is.True);
+                        Assert.That(context.UseSharedChannelManager, Is.False);
+                        Assert.That(context.Configuration, Is.Not.SameAs(configuration));
+                        Assert.That(
+                            context.Configuration.CertificateManager,
+                            Is.Not.SameAs(sharedCertificateManager));
+                    }
+
+                    contexts[0].Dispose();
+                    Assert.That(
+                        contexts[1].Configuration.CertificateManager.AcceptError,
+                        Is.Not.Null);
+                    Assert.That(sharedCertificateManager.AcceptError, Is.SameAs(sharedCallback));
+                }
+                finally
+                {
+                    foreach (OpcUaSessionManager.ConnectionValidationContext context in contexts)
+                    {
+                        context.Dispose();
+                    }
+                }
+            }
+        }
+
+        [Test]
+        public async Task AutoAcceptContextRetainsValidationPolicyForReconnectAsync()
+        {
+            using var telemetry = (DefaultTelemetry)DefaultTelemetry.Create(static _ => { });
+            ApplicationConfiguration configuration = CreateConfiguration(
+                telemetry,
+                out CertificateManager sharedCertificateManager);
+            using (sharedCertificateManager)
+            using (OpcUaSessionManager.ConnectionValidationContext context =
+                await OpcUaSessionManager.CreateConnectionValidationContextAsync(
+                    configuration,
+                    telemetry,
+                    true,
+                    CancellationToken.None).ConfigureAwait(false))
+            {
+                ApplicationConfiguration initialConfiguration = context.Configuration;
+                ICertificateManager initialManager = initialConfiguration.CertificateManager;
+                Func<Certificate, ServiceResult, bool>? acceptError = initialManager.AcceptError;
+
+                Assert.That(acceptError, Is.Not.Null);
+                Assert.That(
+                    acceptError!(null!, new ServiceResult(StatusCodes.BadCertificateUntrusted)),
+                    Is.True);
+                Assert.That(
+                    acceptError(null!, new ServiceResult(StatusCodes.BadCertificateTimeInvalid)),
+                    Is.False);
+
+                await Task.Yield();
+
+                Assert.That(context.Configuration, Is.SameAs(initialConfiguration));
+                Assert.That(context.Configuration.CertificateManager, Is.SameAs(initialManager));
+                Assert.That(context.Configuration.CertificateManager.AcceptError, Is.SameAs(acceptError));
+                Assert.That(configuration.CertificateManager, Is.SameAs(sharedCertificateManager));
+                Assert.That(sharedCertificateManager.AcceptError, Is.Null);
+            }
+        }
+
+        [Test]
+        public async Task StrictContextUsesSharedValidationAndChannelManagerAsync()
+        {
+            using var telemetry = (DefaultTelemetry)DefaultTelemetry.Create(static _ => { });
+            ApplicationConfiguration configuration = CreateConfiguration(
+                telemetry,
+                out CertificateManager sharedCertificateManager);
+            using (sharedCertificateManager)
+            using (OpcUaSessionManager.ConnectionValidationContext context =
+                await OpcUaSessionManager.CreateConnectionValidationContextAsync(
+                    configuration,
+                    telemetry,
+                    false,
+                    CancellationToken.None).ConfigureAwait(false))
+            {
+                Assert.That(context.IsIsolated, Is.False);
+                Assert.That(context.UseSharedChannelManager, Is.True);
+                Assert.That(context.Configuration, Is.SameAs(configuration));
+                Assert.That(
+                    context.Configuration.CertificateManager,
+                    Is.SameAs(sharedCertificateManager));
+            }
+        }
+
+        private static ApplicationConfiguration CreateConfiguration(
+            ITelemetryContext telemetry,
+            out CertificateManager certificateManager)
+        {
+            var securityConfiguration = new SecurityConfiguration();
+            certificateManager = CertificateManagerFactory.Create(
+                securityConfiguration,
+                telemetry);
+            return new ApplicationConfiguration(telemetry)
+            {
+                ApplicationName = "MCP Session Manager Tests",
+                ApplicationUri = "urn:localhost:opcua:mcp-tests",
+                ApplicationType = ApplicationType.Client,
+                SecurityConfiguration = securityConfiguration,
+                ClientConfiguration = new ClientConfiguration(),
+                CertificateManager = certificateManager
+            };
+        }
+    }
+}
+#endif

--- a/tests/Opc.Ua.Tools.Tests/SubscriptionStoreTests.cs
+++ b/tests/Opc.Ua.Tools.Tests/SubscriptionStoreTests.cs
@@ -1,0 +1,137 @@
+/* ========================================================================
+ * Copyright (c) 2005-2026 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using System.IO;
+using System.Text;
+using NUnit.Framework;
+using Opc.Ua.Server;
+using Quickstarts.Servers;
+
+namespace Opc.Ua.Tools.Tests
+{
+    [TestFixture]
+    public class SubscriptionStoreTests
+    {
+        [SetUp]
+        public void SetUp()
+        {
+            m_telemetry = (DefaultTelemetry)DefaultTelemetry.Create(static _ => { });
+            m_messageContext = ServiceMessageContext.Create(m_telemetry);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            m_telemetry.Dispose();
+        }
+
+        [Test]
+        public void EncodeSubscriptionRemovesUserNamePassword()
+        {
+            var identityToken = new UserNameIdentityToken
+            {
+                PolicyId = "username",
+                UserName = "operator",
+                Password = new ByteString(Encoding.UTF8.GetBytes("secret")),
+                EncryptionAlgorithm = SecurityPolicies.Basic256Sha256
+            };
+            var subscription = new StoredSubscription
+            {
+                UserIdentityToken = identityToken
+            };
+
+            using var encoder = new BinaryEncoder(m_messageContext);
+            SubscriptionStore.EncodeSubscription(encoder, subscription);
+            byte[] encoded = encoder.CloseAndReturnBuffer()!;
+
+            using var decoder = new BinaryDecoder(encoded, m_messageContext);
+            StoredSubscription decoded = SubscriptionStore.DecodeSubscription(decoder);
+
+            Assert.That(decoded.UserIdentityToken, Is.TypeOf<UserNameIdentityToken>());
+            var decodedToken = (UserNameIdentityToken)decoded.UserIdentityToken!;
+            Assert.That(decodedToken.PolicyId, Is.EqualTo(identityToken.PolicyId));
+            Assert.That(decodedToken.UserName, Is.EqualTo(identityToken.UserName));
+            Assert.That(decodedToken.Password.IsNull, Is.True);
+            Assert.That(decodedToken.EncryptionAlgorithm, Is.Null);
+            Assert.That(identityToken.Password.IsNull, Is.False);
+        }
+
+        [Test]
+        public void EncodeSubscriptionRejectsIssuedBearerToken()
+        {
+            var subscription = new StoredSubscription
+            {
+                UserIdentityToken = new IssuedIdentityToken
+                {
+                    PolicyId = Profiles.JwtUserToken,
+                    TokenData = new ByteString(Encoding.UTF8.GetBytes("bearer-token"))
+                }
+            };
+
+            using var encoder = new BinaryEncoder(m_messageContext);
+
+            Assert.That(
+                () => SubscriptionStore.EncodeSubscription(encoder, subscription),
+                Throws.TypeOf<NotSupportedException>());
+        }
+
+        [Test]
+        public void StoreHeaderAcceptsCurrentVersion()
+        {
+            using var encoder = new BinaryEncoder(m_messageContext);
+            SubscriptionStore.WriteStoreHeader(encoder);
+            byte[] encoded = encoder.CloseAndReturnBuffer()!;
+
+            using var decoder = new BinaryDecoder(encoded, m_messageContext);
+
+            Assert.That(
+                () => SubscriptionStore.ValidateStoreHeader(decoder),
+                Throws.Nothing);
+        }
+
+        [Test]
+        public void StoreHeaderRejectsLegacyUnsafeFormat()
+        {
+            using var encoder = new BinaryEncoder(m_messageContext);
+            encoder.WriteStringArray(null, ["http://opcfoundation.org/UA/"]);
+            byte[] encoded = encoder.CloseAndReturnBuffer()!;
+
+            using var decoder = new BinaryDecoder(encoded, m_messageContext);
+
+            Assert.That(
+                () => SubscriptionStore.ValidateStoreHeader(decoder),
+                Throws.TypeOf<InvalidDataException>());
+        }
+
+        private ServiceMessageContext m_messageContext = null!;
+        private DefaultTelemetry m_telemetry = null!;
+    }
+}

--- a/tools/Opc.Ua.Mcp/Opc.Ua.Mcp.csproj
+++ b/tools/Opc.Ua.Mcp/Opc.Ua.Mcp.csproj
@@ -39,6 +39,9 @@
     <ProjectReference Include="..\..\src\Opc.Ua.PubSub.Diagnostics\Opc.Ua.PubSub.Diagnostics.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <InternalsVisibleTo Include="Opc.Ua.Tools.Tests" />
+  </ItemGroup>
+  <ItemGroup>
     <None Update="Opc.Ua.Mcp.Config.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/tools/Opc.Ua.Mcp/OpcUaSessionManager.cs
+++ b/tools/Opc.Ua.Mcp/OpcUaSessionManager.cs
@@ -205,19 +205,12 @@ namespace Opc.Ua.Mcp
         {
             ObjectDisposedException.ThrowIf(m_disposed, this);
 
-            await m_lock.WaitAsync(ct).ConfigureAwait(false);
-            try
-            {
-                await EnsureConfigurationInternalAsync(ct).ConfigureAwait(false);
-                return await DiscoverEndpointsInternalAsync(
-                    m_configuration!,
-                    discoveryUrl,
-                    ct).ConfigureAwait(false);
-            }
-            finally
-            {
-                m_lock.Release();
-            }
+            ApplicationConfiguration configuration =
+                await EnsureConfigurationAsync(ct).ConfigureAwait(false);
+            return await DiscoverEndpointsInternalAsync(
+                configuration,
+                discoveryUrl,
+                ct).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/tools/Opc.Ua.Mcp/OpcUaSessionManager.cs
+++ b/tools/Opc.Ua.Mcp/OpcUaSessionManager.cs
@@ -83,6 +83,7 @@ namespace Opc.Ua.Mcp
             public required string AuthType { get; init; }
             public DateTime ConnectedAt { get; init; } = DateTime.UtcNow;
             public bool IsConnected => Session.Connected;
+            internal ConnectionValidationContext? ValidationContext { get; init; }
         }
 
         /// <summary>
@@ -124,7 +125,7 @@ namespace Opc.Ua.Mcp
             await m_lock.WaitAsync(ct).ConfigureAwait(false);
             try
             {
-                await EnsureConfigurationInternalAsync(false, ct).ConfigureAwait(false);
+                await EnsureConfigurationInternalAsync(ct).ConfigureAwait(false);
                 return m_configuration!;
             }
             finally
@@ -204,18 +205,19 @@ namespace Opc.Ua.Mcp
         {
             ObjectDisposedException.ThrowIf(m_disposed, this);
 
-            await EnsureConfigurationInternalAsync(false, ct).ConfigureAwait(false);
-
-            var uri = new Uri(discoveryUrl);
-            var endpointConfiguration = EndpointConfiguration.Create(m_configuration!);
-
-            using DiscoveryClient client = await DiscoveryClient.CreateAsync(
-                m_configuration!,
-                uri,
-                endpointConfiguration,
-                ct: ct).ConfigureAwait(false);
-
-            return await client.GetEndpointsAsync(default, ct).ConfigureAwait(false);
+            await m_lock.WaitAsync(ct).ConfigureAwait(false);
+            try
+            {
+                await EnsureConfigurationInternalAsync(ct).ConfigureAwait(false);
+                return await DiscoverEndpointsInternalAsync(
+                    m_configuration!,
+                    discoveryUrl,
+                    ct).ConfigureAwait(false);
+            }
+            finally
+            {
+                m_lock.Release();
+            }
         }
 
         /// <summary>
@@ -256,60 +258,80 @@ namespace Opc.Ua.Mcp
                     m_sessions.TryRemove(name, out _);
                 }
 
-                await EnsureConfigurationInternalAsync(autoAcceptCerts, ct).ConfigureAwait(false);
-
-                if (autoAcceptCerts)
+                await EnsureConfigurationInternalAsync(ct).ConfigureAwait(false);
+                ConnectionValidationContext? validationContext =
+                    await CreateConnectionValidationContextAsync(
+                        m_configuration!,
+                        Telemetry,
+                        autoAcceptCerts,
+                        ct).ConfigureAwait(false);
+                try
                 {
-                    m_configuration!.CertificateManager.AcceptError = AutoAcceptError;
+                    ApplicationConfiguration configuration = validationContext.Configuration;
+
+                    m_logger.Connecting(endpointUrl, name);
+
+                    EndpointDescription selectedEndpoint = await SelectEndpointAsync(
+                        configuration,
+                        endpointUrl,
+                        securityMode,
+                        securityPolicy,
+                        authType,
+                        ct).ConfigureAwait(false);
+
+                    UserIdentity identity = BuildUserIdentity(authType, username, password);
+
+                    var endpointConfiguration = EndpointConfiguration.Create(configuration);
+                    var endpoint = new ConfiguredEndpoint(null, selectedEndpoint, endpointConfiguration);
+                    ManagedSessionBuilder builder = new ManagedSessionBuilder(configuration, Telemetry)
+                        .UseEndpoint(endpoint)
+                        .WithSessionName(configuration.ApplicationName ?? kApplicationName)
+                        .WithSessionTimeout(TimeSpan.FromMilliseconds(60_000))
+                        .WithUserIdentity(identity);
+
+                    if (validationContext.UseSharedChannelManager)
+                    {
+                        builder.WithChannelManager(
+                            m_serviceProvider.GetRequiredService<IClientChannelManager>());
+                    }
+
+                    ManagedSession session = await builder
+                        .ConnectAsync(ct)
+                        .ConfigureAwait(false);
+
+                    session.KeepAliveInterval = 5000;
+                    session.ConnectionStateChanged += (_, e) => SessionConnectionStateChanged(name, e);
+                    session.ChannelStateChanged += (_, e) => SessionChannelStateChanged(name, e);
+
+                    m_sessions[name] = new SessionInfo
+                    {
+                        Name = name,
+                        Session = session,
+                        Endpoint = selectedEndpoint,
+                        AuthType = authType,
+                        ConnectedAt = DateTime.UtcNow,
+                        ValidationContext = validationContext
+                    };
+                    validationContext = null;
+
+                    m_logger.Connected(name, session.SessionName, session.SessionId);
+
+                    return string.Format(
+                        CultureInfo.InvariantCulture,
+                        "Connected to {0} as '{1}'. SecurityMode={2}, SecurityPolicy={3}, Auth={4}, " +
+                        "SessionName={5}, SessionId={6}",
+                        endpointUrl,
+                        name,
+                        selectedEndpoint.SecurityMode,
+                        selectedEndpoint.SecurityPolicyUri,
+                        authType,
+                        session.SessionName,
+                        session.SessionId);
                 }
-
-                m_logger.Connecting(endpointUrl, name);
-
-                EndpointDescription selectedEndpoint = await SelectEndpointAsync(
-                    endpointUrl, securityMode, securityPolicy, authType, ct).ConfigureAwait(false);
-
-                UserIdentity identity = BuildUserIdentity(authType, username, password);
-
-                ApplicationConfiguration configuration = m_configuration!;
-                var endpointConfiguration = EndpointConfiguration.Create(configuration);
-                var endpoint = new ConfiguredEndpoint(null, selectedEndpoint, endpointConfiguration);
-                IClientChannelManager channelManager = m_serviceProvider.GetRequiredService<IClientChannelManager>();
-
-                ManagedSession session = await new ManagedSessionBuilder(configuration, Telemetry)
-                    .UseEndpoint(endpoint)
-                    .WithChannelManager(channelManager)
-                    .WithSessionName(configuration.ApplicationName ?? kApplicationName)
-                    .WithSessionTimeout(TimeSpan.FromMilliseconds(60_000))
-                    .WithUserIdentity(identity)
-                    .ConnectAsync(ct)
-                    .ConfigureAwait(false);
-
-                session.KeepAliveInterval = 5000;
-                session.ConnectionStateChanged += (_, e) => SessionConnectionStateChanged(name, e);
-                session.ChannelStateChanged += (_, e) => SessionChannelStateChanged(name, e);
-
-                m_sessions[name] = new SessionInfo
+                finally
                 {
-                    Name = name,
-                    Session = session,
-                    Endpoint = selectedEndpoint,
-                    AuthType = authType,
-                    ConnectedAt = DateTime.UtcNow
-                };
-
-                m_logger.Connected(name, session.SessionName, session.SessionId);
-
-                return string.Format(
-                    CultureInfo.InvariantCulture,
-                    "Connected to {0} as '{1}'. SecurityMode={2}, SecurityPolicy={3}, Auth={4}, " +
-                    "SessionName={5}, SessionId={6}",
-                    endpointUrl,
-                    name,
-                    selectedEndpoint.SecurityMode,
-                    selectedEndpoint.SecurityPolicyUri,
-                    authType,
-                    session.SessionName,
-                    session.SessionId);
+                    validationContext?.Dispose();
+                }
             }
             finally
             {
@@ -399,7 +421,14 @@ namespace Opc.Ua.Mcp
             m_disposed = true;
             foreach (SessionInfo info in m_sessions.Values)
             {
-                info.Session.Dispose();
+                try
+                {
+                    info.Session.Dispose();
+                }
+                finally
+                {
+                    info.ValidationContext?.Dispose();
+                }
             }
 
             m_sessions.Clear();
@@ -408,11 +437,64 @@ namespace Opc.Ua.Mcp
 
         private static async Task DisconnectInternalAsync(SessionInfo info, CancellationToken ct)
         {
-            await info.Session.CloseAsync(ct).ConfigureAwait(false);
-            info.Session.Dispose();
+            try
+            {
+                await info.Session.CloseAsync(ct).ConfigureAwait(false);
+            }
+            finally
+            {
+                try
+                {
+                    info.Session.Dispose();
+                }
+                finally
+                {
+                    info.ValidationContext?.Dispose();
+                }
+            }
         }
 
-        private async Task EnsureConfigurationInternalAsync(bool autoAcceptCerts, CancellationToken ct)
+        internal static async Task<ConnectionValidationContext>
+            CreateConnectionValidationContextAsync(
+                ApplicationConfiguration configuration,
+                ITelemetryContext telemetry,
+                bool autoAcceptCertificates,
+                CancellationToken ct)
+        {
+            if (!autoAcceptCertificates)
+            {
+                return new ConnectionValidationContext(configuration, null);
+            }
+
+            CertificateManager? certificateManager = null;
+            try
+            {
+                certificateManager = CertificateManagerFactory.Create(
+                    configuration.SecurityConfiguration,
+                    telemetry);
+                certificateManager.AcceptError = AutoAcceptError;
+                await certificateManager.LoadApplicationCertificatesAsync(
+                    configuration.SecurityConfiguration,
+                    configuration.ApplicationUri,
+                    ct).ConfigureAwait(false);
+
+                var isolatedConfiguration = new ApplicationConfiguration(configuration)
+                {
+                    CertificateManager = certificateManager
+                };
+                var result = new ConnectionValidationContext(
+                    isolatedConfiguration,
+                    certificateManager);
+                certificateManager = null;
+                return result;
+            }
+            finally
+            {
+                certificateManager?.Dispose();
+            }
+        }
+
+        private async Task EnsureConfigurationInternalAsync(CancellationToken ct)
         {
             if (m_configuration != null)
             {
@@ -448,16 +530,29 @@ namespace Opc.Ua.Mcp
                 m_logger.ApplicationCertificateNotFound();
             }
 
-            if (autoAcceptCerts)
-            {
-                config.CertificateManager.AcceptError = AutoAcceptError;
-            }
-
             m_clientOptions.Configuration = config;
             m_configuration = config;
         }
 
+        private async Task<ArrayOf<EndpointDescription>> DiscoverEndpointsInternalAsync(
+            ApplicationConfiguration configuration,
+            string discoveryUrl,
+            CancellationToken ct)
+        {
+            var uri = new Uri(discoveryUrl);
+            var endpointConfiguration = EndpointConfiguration.Create(configuration);
+
+            using DiscoveryClient client = await DiscoveryClient.CreateAsync(
+                configuration,
+                uri,
+                endpointConfiguration,
+                ct: ct).ConfigureAwait(false);
+
+            return await client.GetEndpointsAsync(default, ct).ConfigureAwait(false);
+        }
+
         private async Task<EndpointDescription> SelectEndpointAsync(
+            ApplicationConfiguration configuration,
             string endpointUrl,
             string? securityMode,
             string? securityPolicy,
@@ -470,13 +565,13 @@ namespace Opc.Ua.Mcp
             {
                 // Auto-select most secure, fall back to no-security
                 return (await CoreClientUtils.SelectEndpointAsync(
-                    m_configuration!,
+                    configuration,
                     endpointUrl,
                     true,
                     Telemetry,
                     ct: ct).ConfigureAwait(false) ??
                     await CoreClientUtils.SelectEndpointAsync(
-                        m_configuration!,
+                        configuration,
                         endpointUrl,
                         false,
                         Telemetry,
@@ -487,7 +582,10 @@ namespace Opc.Ua.Mcp
             }
 
             ArrayOf<EndpointDescription> allEndpoints =
-                await DiscoverEndpointsAsync(endpointUrl, ct).ConfigureAwait(false);
+                await DiscoverEndpointsInternalAsync(
+                    configuration,
+                    endpointUrl,
+                    ct).ConfigureAwait(false);
 
             IEnumerable<EndpointDescription> candidates = allEndpoints.ToArray() ??
                 [];
@@ -655,11 +753,37 @@ namespace Opc.Ua.Mcp
                 info.Session.ServerUris?.ToArray().FirstOrDefault() ?? "unknown");
         }
 
-        private static bool AutoAcceptError(
-            Certificate certificate,
-            ServiceResult error)
+        private static bool AutoAcceptError(Certificate _, ServiceResult error)
         {
-            return true;
+            return error.StatusCode == StatusCodes.BadCertificateUntrusted;
+        }
+
+        internal sealed class ConnectionValidationContext : IDisposable
+        {
+            public ConnectionValidationContext(
+                ApplicationConfiguration configuration,
+                CertificateManager? ownedCertificateManager)
+            {
+                Configuration = configuration ??
+                    throw new ArgumentNullException(nameof(configuration));
+                m_ownedCertificateManager = ownedCertificateManager;
+            }
+
+            public ApplicationConfiguration Configuration { get; }
+
+            public bool IsIsolated => m_ownedCertificateManager != null;
+
+            public bool UseSharedChannelManager => !IsIsolated;
+
+            public void Dispose()
+            {
+                CertificateManager? certificateManager = Interlocked.Exchange(
+                    ref m_ownedCertificateManager,
+                    null);
+                certificateManager?.Dispose();
+            }
+
+            private CertificateManager? m_ownedCertificateManager;
         }
     }
 


### PR DESCRIPTION
## Failure

MCP auto-accept mutated the shared application certificate manager and accepted
every certificate error, so one permissive connection could affect concurrent or
later strict sessions. The durable-subscription sample also serialized complete
user identity tokens, including user-name passwords and issued bearer tokens.

## Fix

- Isolate auto-accept certificate managers/configurations per connection and keep
  their lifetime with the managed session.
- Auto-accept only `BadCertificateUntrusted`; retain strict validation for all
  other certificate errors and shared sessions.
- Version the durable store and reject the previous unsafe format.
- Remove user-name passwords before persistence and reject issued-token
  subscriptions rather than storing bearer credentials.
- Add focused tools tests plus solution, project, and durable-subscription docs.

## Reference

- OPC 10000-4 Session identity-token and application-certificate security.
- Split from #4021.

## Tests

- `Opc.Ua.Tools.Tests` Release: 7 passed on net10.0; 4 passed on net48.
- `Quickstarts.Servers` Release builds passed on net10.0 and net48 with zero warnings/errors.
- `Opc.Ua.Mcp` Release net10.0 build passed with zero warnings/errors.
