### PR TITLE
Treat zero MaxNotificationsPerPublish as unlimited (OPC 10000-4)

### DIFF
--- a/src/Opc.Ua.Server/Subscription/Subscription.cs
+++ b/src/Opc.Ua.Server/Subscription/Subscription.cs
@@ -1152,11 +1152,15 @@ namespace Opc.Ua.Server
                 Diagnostics.NextSequenceNumber = m_messageQueue.NextSequenceNumber;
             }
 
+            uint notificationLimit = m_maxNotificationsPerPublish == 0
+                ? uint.MaxValue
+                : m_maxNotificationsPerPublish;
+
             // add events.
-            if (events.Count > 0 && notificationCount < m_maxNotificationsPerPublish)
+            if (events.Count > 0 && notificationCount < notificationLimit)
             {
                 var eventList = new List<EventFieldList>();
-                while (events.Count > 0 && notificationCount < m_maxNotificationsPerPublish)
+                while (events.Count > 0 && notificationCount < notificationLimit)
                 {
                     eventList.Add(events.Dequeue());
                     notificationCount++;
@@ -1168,13 +1172,13 @@ namespace Opc.Ua.Server
             }
 
             // add datachanges (space permitting).
-            if (datachanges.Count > 0 && notificationCount < m_maxNotificationsPerPublish)
+            if (datachanges.Count > 0 && notificationCount < notificationLimit)
             {
                 bool diagnosticsExist = false;
 
                 var dataChangeList = new List<MonitoredItemNotification>(datachanges.Count);
                 var diagnosticInfos = new List<DiagnosticInfo>(datachanges.Count);
-                while (datachanges.Count > 0 && notificationCount < m_maxNotificationsPerPublish)
+                while (datachanges.Count > 0 && notificationCount < notificationLimit)
                 {
                     MonitoredItemNotification datachange = datachanges.Dequeue();
                     dataChangeList.Add(datachange);

--- a/src/Opc.Ua.Server/Subscription/SubscriptionManager.cs
+++ b/src/Opc.Ua.Server/Subscription/SubscriptionManager.cs
@@ -1977,13 +1977,18 @@ namespace Opc.Ua.Server
         /// </summary>
         protected virtual uint CalculateMaxNotificationsPerPublish(uint maxNotificationsPerPublish)
         {
-            if (maxNotificationsPerPublish == 0 ||
-                maxNotificationsPerPublish > m_maxNotificationsPerPublish)
+            if (maxNotificationsPerPublish == 0)
             {
                 return m_maxNotificationsPerPublish;
             }
 
-            return maxNotificationsPerPublish;
+            if (m_maxNotificationsPerPublish == 0 ||
+                maxNotificationsPerPublish <= m_maxNotificationsPerPublish)
+            {
+                return maxNotificationsPerPublish;
+            }
+
+            return m_maxNotificationsPerPublish;
         }
 
         /// <summary>

--- a/tests/Opc.Ua.Server.Tests/SubscriptionTests.cs
+++ b/tests/Opc.Ua.Server.Tests/SubscriptionTests.cs
@@ -50,7 +50,9 @@ namespace Opc.Ua.Server.Tests
                 .ReturnsAsync(new NodeId(1));
         }
 
-        private Subscription CreateSubscription(double publishingInterval = 1000)
+        private Subscription CreateSubscription(
+            double publishingInterval = 1000,
+            uint maxNotificationsPerPublish = 0)
         {
             return new Subscription(
                 m_serverMock.Object,
@@ -59,7 +61,7 @@ namespace Opc.Ua.Server.Tests
                 publishingInterval: publishingInterval,
                 maxLifetimeCount: 10,
                 maxKeepAliveCount: 5,
-                maxNotificationsPerPublish: 0,
+                maxNotificationsPerPublish: maxNotificationsPerPublish,
                 priority: 0,
                 publishingEnabled: true,
                 maxMessageCount: 10);
@@ -333,7 +335,7 @@ namespace Opc.Ua.Server.Tests
         [Test]
         public void ConstructMessageWithZeroLimitDrainsNotificationQueues()
         {
-            using Subscription subscription = CreateSubscription();
+            using Subscription subscription = CreateSubscription(maxNotificationsPerPublish: 0);
             var events = new Queue<EventFieldList>(
             [
                 new EventFieldList(),
@@ -352,7 +354,15 @@ namespace Opc.Ua.Server.Tests
 
             MethodInfo constructMessage = typeof(Subscription).GetMethod(
                 "ConstructMessage",
-                BindingFlags.NonPublic | BindingFlags.Instance)
+                BindingFlags.NonPublic | BindingFlags.Instance,
+                binder: null,
+                [
+                    typeof(Queue<EventFieldList>),
+                    typeof(Queue<MonitoredItemNotification>),
+                    typeof(Queue<DiagnosticInfo>),
+                    typeof(int).MakeByRefType()
+                ],
+                modifiers: null)
                 ?? throw new InvalidOperationException("ConstructMessage method not found");
             object[] arguments = [events, dataChanges, diagnostics, 0];
 
@@ -372,6 +382,7 @@ namespace Opc.Ua.Server.Tests
         [TestCase(0, 25, 25)]
         [TestCase(10, 0, 10)]
         [TestCase(10, 25, 10)]
+        [TestCase(25, 10, 10)]
         public void CalculateMaxNotificationsTreatsZeroAsUnlimited(
             int serverLimit,
             int requestedLimit,

--- a/tests/Opc.Ua.Server.Tests/SubscriptionTests.cs
+++ b/tests/Opc.Ua.Server.Tests/SubscriptionTests.cs
@@ -1,6 +1,9 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Time.Testing;
 using Moq;
 using NUnit.Framework;
 using Opc.Ua.Tests;
@@ -15,6 +18,7 @@ namespace Opc.Ua.Server.Tests
         private Mock<IServerInternal> m_serverMock;
         private Mock<ISession> m_sessionMock;
         private Mock<IDiagnosticsNodeManager> m_diagnosticsNodeManagerMock;
+        private Mock<IMasterNodeManager> m_nodeManagerMock;
         private Mock<IMonitoredItemQueueFactory> m_queueFactoryMock;
         private ITelemetryContext m_telemetry;
 
@@ -25,11 +29,15 @@ namespace Opc.Ua.Server.Tests
             m_serverMock = new Mock<IServerInternal>();
             m_sessionMock = new Mock<ISession>();
             m_diagnosticsNodeManagerMock = new Mock<IDiagnosticsNodeManager>();
+            m_nodeManagerMock = new Mock<IMasterNodeManager>();
             m_queueFactoryMock = new Mock<IMonitoredItemQueueFactory>();
 
             m_serverMock.Setup(s => s.Telemetry).Returns(m_telemetry);
             m_serverMock.Setup(s => s.DiagnosticsNodeManager).Returns(m_diagnosticsNodeManagerMock.Object);
+            m_serverMock.Setup(s => s.NodeManager).Returns(m_nodeManagerMock.Object);
             m_serverMock.Setup(s => s.MonitoredItemQueueFactory).Returns(m_queueFactoryMock.Object);
+            m_serverMock.Setup(s => s.DiagnosticsWriteLock).Returns(new object());
+            m_serverMock.Setup(s => s.ServerDiagnostics).Returns(new ServerDiagnosticsSummaryDataType());
 
             var namespaceUris = new NamespaceTable();
             m_serverMock.Setup(s => s.NamespaceUris).Returns(namespaceUris);
@@ -41,6 +49,8 @@ namespace Opc.Ua.Server.Tests
             m_serverMock.Setup(s => s.DefaultSystemContext).Returns(new ServerSystemContext(m_serverMock.Object));
 
             m_sessionMock.Setup(s => s.Id).Returns(new NodeId(Guid.NewGuid()));
+            m_sessionMock.Setup(s => s.DiagnosticsLock).Returns(new object());
+            m_sessionMock.Setup(s => s.SessionDiagnostics).Returns(new SessionDiagnosticsDataType());
 
             m_diagnosticsNodeManagerMock
                 .Setup(d => d.CreateSubscriptionDiagnosticsAsync(
@@ -52,7 +62,8 @@ namespace Opc.Ua.Server.Tests
 
         private Subscription CreateSubscription(
             double publishingInterval = 1000,
-            uint maxNotificationsPerPublish = 0)
+            uint maxNotificationsPerPublish = 0,
+            TimeProvider timeProvider = null)
         {
             return new Subscription(
                 m_serverMock.Object,
@@ -64,7 +75,8 @@ namespace Opc.Ua.Server.Tests
                 maxNotificationsPerPublish: maxNotificationsPerPublish,
                 priority: 0,
                 publishingEnabled: true,
-                maxMessageCount: 10);
+                maxMessageCount: 10,
+                timeProvider: timeProvider);
         }
 
         private static void SetExpiryTime(Subscription subscription, long expiryTime)
@@ -333,60 +345,138 @@ namespace Opc.Ua.Server.Tests
         }
 
         [Test]
-        public void ConstructMessageWithZeroLimitDrainsNotificationQueues()
+        public async Task PublishWithZeroLimitDrainsEventAndDataChangeQueuesAsync()
         {
-            using Subscription subscription = CreateSubscription(maxNotificationsPerPublish: 0);
-            var events = new Queue<EventFieldList>(
-            [
-                new EventFieldList(),
-                new EventFieldList()
-            ]);
-            var dataChanges = new Queue<MonitoredItemNotification>(
-            [
-                new MonitoredItemNotification { Value = new DataValue(1) },
-                new MonitoredItemNotification { Value = new DataValue(2) }
-            ]);
-            var diagnostics = new Queue<DiagnosticInfo>(
-            [
-                new DiagnosticInfo(),
-                new DiagnosticInfo()
-            ]);
+            var timeProvider = new FakeTimeProvider(
+                new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
+            using Subscription subscription = CreateSubscription(
+                publishingInterval: 100,
+                maxNotificationsPerPublish: 0,
+                timeProvider);
+            var publishLimits = new List<uint>();
+            Mock<IEventMonitoredItem> eventItem = CreateEventMonitoredItem(
+                id: 1,
+                notificationCount: 2,
+                publishLimits);
+            Mock<IDataChangeMonitoredItem> dataChangeItem = CreateDataChangeMonitoredItem(
+                id: 2,
+                notificationCount: 2,
+                publishLimits);
+            await RegisterMonitoredItemsAsync(
+                subscription,
+                eventItem.Object,
+                dataChangeItem.Object).ConfigureAwait(false);
 
-            MethodInfo constructMessage = typeof(Subscription).GetMethod(
-                "ConstructMessage",
-                BindingFlags.NonPublic | BindingFlags.Instance,
-                binder: null,
-                [
-                    typeof(Queue<EventFieldList>),
-                    typeof(Queue<MonitoredItemNotification>),
-                    typeof(Queue<DiagnosticInfo>),
-                    typeof(int).MakeByRefType()
-                ],
-                modifiers: null)
-                ?? throw new InvalidOperationException("ConstructMessage method not found");
-            object[] arguments = [events, dataChanges, diagnostics, 0];
+            timeProvider.Advance(TimeSpan.FromMilliseconds(101));
+            Assert.That(
+                subscription.PublishTimerExpired(),
+                Is.EqualTo(PublishingState.NotificationsAvailable));
 
-            var message = (NotificationMessage)constructMessage.Invoke(subscription, arguments);
+            var context = new OperationContext(m_sessionMock.Object, new DiagnosticsMasks());
+            NotificationMessage message = subscription.Publish(
+                context,
+                out _,
+                out bool moreNotifications);
 
+            Assert.That(message.NotificationData, Has.Count.EqualTo(2));
+            var eventNotification = (EventNotificationList)ExtensionObject.ToEncodeable(
+                message.NotificationData[0]);
+            var dataChangeNotification = (DataChangeNotification)ExtensionObject.ToEncodeable(
+                message.NotificationData[1]);
             Assert.Multiple(() =>
             {
-                Assert.That(events, Is.Empty);
-                Assert.That(dataChanges, Is.Empty);
-                Assert.That(diagnostics, Is.Empty);
-                Assert.That((int)arguments[3], Is.EqualTo(4));
-                Assert.That(message.NotificationData.Count, Is.EqualTo(2));
+                Assert.That(moreNotifications, Is.False);
+                Assert.That(eventNotification.Events, Has.Count.EqualTo(2));
+                Assert.That(dataChangeNotification.MonitoredItems, Has.Count.EqualTo(2));
+                Assert.That(dataChangeNotification.DiagnosticInfos, Has.Count.EqualTo(2));
+                Assert.That(
+                    publishLimits,
+                    Is.EqualTo(new[] { uint.MaxValue, uint.MaxValue }));
             });
         }
 
-        [TestCase(0, 0, 0)]
-        [TestCase(0, 25, 25)]
-        [TestCase(10, 0, 10)]
-        [TestCase(10, 25, 10)]
-        [TestCase(25, 10, 10)]
-        public void CalculateMaxNotificationsTreatsZeroAsUnlimited(
+        [Test]
+        public async Task PublishWithFiniteLimitBuildsAndDrainsQueuedMessagesAsync()
+        {
+            var timeProvider = new FakeTimeProvider(
+                new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
+            using Subscription subscription = CreateSubscription(
+                publishingInterval: 100,
+                maxNotificationsPerPublish: 2,
+                timeProvider);
+            var publishLimits = new List<uint>();
+            Mock<IEventMonitoredItem> firstEventItem = CreateEventMonitoredItem(
+                id: 1,
+                notificationCount: 3,
+                publishLimits);
+            Mock<IEventMonitoredItem> secondEventItem = CreateEventMonitoredItem(
+                id: 2,
+                notificationCount: 1,
+                publishLimits);
+            Mock<IDataChangeMonitoredItem> dataChangeItem = CreateDataChangeMonitoredItem(
+                id: 3,
+                notificationCount: 2,
+                publishLimits);
+            await RegisterMonitoredItemsAsync(
+                subscription,
+                firstEventItem.Object,
+                secondEventItem.Object,
+                dataChangeItem.Object).ConfigureAwait(false);
+
+            timeProvider.Advance(TimeSpan.FromMilliseconds(101));
+            Assert.That(
+                subscription.PublishTimerExpired(),
+                Is.EqualTo(PublishingState.NotificationsAvailable));
+
+            var context = new OperationContext(m_sessionMock.Object, new DiagnosticsMasks());
+            NotificationMessage firstMessage = subscription.Publish(
+                context,
+                out _,
+                out bool moreAfterFirst);
+            NotificationMessage secondMessage = subscription.Publish(
+                context,
+                out _,
+                out bool moreAfterSecond);
+            NotificationMessage thirdMessage = subscription.Publish(
+                context,
+                out _,
+                out bool moreAfterThird);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(firstMessage.NotificationData, Has.Count.EqualTo(1));
+                Assert.That(secondMessage.NotificationData, Has.Count.EqualTo(1));
+                Assert.That(thirdMessage.NotificationData, Has.Count.EqualTo(1));
+            });
+            var firstEvents = (EventNotificationList)ExtensionObject.ToEncodeable(
+                firstMessage.NotificationData[0]);
+            var secondEvents = (EventNotificationList)ExtensionObject.ToEncodeable(
+                secondMessage.NotificationData[0]);
+            var dataChanges = (DataChangeNotification)ExtensionObject.ToEncodeable(
+                thirdMessage.NotificationData[0]);
+            Assert.Multiple(() =>
+            {
+                Assert.That(moreAfterFirst, Is.True);
+                Assert.That(moreAfterSecond, Is.True);
+                Assert.That(moreAfterThird, Is.False);
+                Assert.That(firstEvents.Events, Has.Count.EqualTo(2));
+                Assert.That(secondEvents.Events, Has.Count.EqualTo(2));
+                Assert.That(dataChanges.MonitoredItems, Has.Count.EqualTo(2));
+                Assert.That(publishLimits, Is.EqualTo(new uint[] { 6, 6, 6 }));
+            });
+        }
+
+        [TestCase(0, 0L, 0L)]
+        [TestCase(0, 25L, 25L)]
+        [TestCase(10, 0L, 10L)]
+        [TestCase(10, 10L, 10L)]
+        [TestCase(10, 25L, 10L)]
+        [TestCase(0, uint.MaxValue, uint.MaxValue)]
+        [TestCase(int.MaxValue, uint.MaxValue, int.MaxValue)]
+        public async Task CreateSubscriptionWithNotificationLimitsUsesEffectiveLimitAsync(
             int serverLimit,
-            int requestedLimit,
-            int expectedLimit)
+            long requestedLimit,
+            long expectedLimit)
         {
             var configuration = new ApplicationConfiguration
             {
@@ -395,30 +485,156 @@ namespace Opc.Ua.Server.Tests
                     MaxNotificationsPerPublish = serverLimit
                 }
             };
-            using var manager = new TestSubscriptionManager(
+            using var manager = new SubscriptionManager(
                 m_serverMock.Object,
                 configuration);
 
-            uint revisedLimit = manager.CalculateMaxNotificationsPerPublish(
-                (uint)requestedLimit);
+            var context = new OperationContext(m_sessionMock.Object, new DiagnosticsMasks());
+            CreateSubscriptionResponse response = await manager.CreateSubscriptionAsync(
+                context,
+                requestedPublishingInterval: 1000,
+                requestedLifetimeCount: 30,
+                requestedMaxKeepAliveCount: 10,
+                maxNotificationsPerPublish: (uint)requestedLimit,
+                publishingEnabled: true,
+                priority: 0).ConfigureAwait(false);
 
-            Assert.That(revisedLimit, Is.EqualTo((uint)expectedLimit));
+            Assert.That(
+                manager.TryGetSubscription(response.SubscriptionId, out ISubscription subscription),
+                Is.True);
+            Assert.That(
+                subscription.Diagnostics.MaxNotificationsPerPublish,
+                Is.EqualTo((uint)expectedLimit));
         }
 
-        private sealed class TestSubscriptionManager : SubscriptionManager
+        private async Task RegisterMonitoredItemsAsync(
+            Subscription subscription,
+            params IMonitoredItem[] monitoredItems)
         {
-            public TestSubscriptionManager(
-                IServerInternal server,
-                ApplicationConfiguration configuration)
-                : base(server, configuration)
-            {
-            }
+            m_nodeManagerMock
+                .Setup(n => n.CreateMonitoredItemsAsync(
+                    It.IsAny<OperationContext>(),
+                    subscription.Id,
+                    It.IsAny<double>(),
+                    It.IsAny<TimestampsToReturn>(),
+                    It.IsAny<ArrayOf<MonitoredItemCreateRequest>>(),
+                    It.IsAny<IList<ServiceResult>>(),
+                    It.IsAny<IList<MonitoringFilterResult>>(),
+                    It.IsAny<IList<IMonitoredItem>>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<CancellationToken>()))
+                .Callback<
+                    OperationContext,
+                    uint,
+                    double,
+                    TimestampsToReturn,
+                    ArrayOf<MonitoredItemCreateRequest>,
+                    IList<ServiceResult>,
+                    IList<MonitoringFilterResult>,
+                    IList<IMonitoredItem>,
+                    bool,
+                    CancellationToken>(
+                    (_, _, _, _, _, _, _, createdItems, _, _) =>
+                    {
+                        for (int ii = 0; ii < monitoredItems.Length; ii++)
+                        {
+                            createdItems[ii] = monitoredItems[ii];
+                        }
+                    })
+                .Returns(default(ValueTask));
 
-            public new uint CalculateMaxNotificationsPerPublish(
-                uint maxNotificationsPerPublish)
+            var requests = new MonitoredItemCreateRequest[monitoredItems.Length];
+            for (int ii = 0; ii < monitoredItems.Length; ii++)
             {
-                return base.CalculateMaxNotificationsPerPublish(maxNotificationsPerPublish);
+                requests[ii] = new MonitoredItemCreateRequest
+                {
+                    MonitoringMode = MonitoringMode.Reporting
+                };
             }
+            ArrayOf<MonitoredItemCreateRequest> itemsToCreate = [.. requests];
+
+            var context = new OperationContext(m_sessionMock.Object, new DiagnosticsMasks());
+            CreateMonitoredItemsResponse response = await subscription.CreateMonitoredItemsAsync(
+                context,
+                TimestampsToReturn.Both,
+                itemsToCreate).ConfigureAwait(false);
+
+            Assert.That(response.Results, Has.Count.EqualTo(monitoredItems.Length));
+        }
+
+        private static Mock<IEventMonitoredItem> CreateEventMonitoredItem(
+            uint id,
+            int notificationCount,
+            List<uint> publishLimits)
+        {
+            var item = new Mock<IEventMonitoredItem>();
+            var createResult = new MonitoredItemCreateResult
+            {
+                StatusCode = StatusCodes.Good,
+                RevisedSamplingInterval = 0,
+                RevisedQueueSize = (uint)notificationCount
+            };
+            item.SetupGet(i => i.Id).Returns(id);
+            item.SetupGet(i => i.IsReadyToPublish).Returns(true);
+            item.SetupGet(i => i.MonitoredItemType).Returns(MonitoredItemTypeMask.Events);
+            item.Setup(i => i.GetCreateResult(out createResult)).Returns(ServiceResult.Good);
+            item.Setup(i => i.Publish(
+                    It.IsAny<OperationContext>(),
+                    It.IsAny<Queue<EventFieldList>>(),
+                    It.IsAny<uint>()))
+                .Returns<OperationContext, Queue<EventFieldList>, uint>(
+                    (_, notifications, maxNotificationsPerPublish) =>
+                    {
+                        publishLimits.Add(maxNotificationsPerPublish);
+                        for (int ii = 0; ii < notificationCount; ii++)
+                        {
+                            notifications.Enqueue(new EventFieldList());
+                        }
+                        return false;
+                    });
+            return item;
+        }
+
+        private static Mock<IDataChangeMonitoredItem> CreateDataChangeMonitoredItem(
+            uint id,
+            int notificationCount,
+            List<uint> publishLimits)
+        {
+            var item = new Mock<IDataChangeMonitoredItem>();
+            var createResult = new MonitoredItemCreateResult
+            {
+                StatusCode = StatusCodes.Good,
+                RevisedSamplingInterval = 0,
+                RevisedQueueSize = (uint)notificationCount
+            };
+            item.SetupGet(i => i.Id).Returns(id);
+            item.SetupGet(i => i.IsReadyToPublish).Returns(true);
+            item.SetupGet(i => i.MonitoredItemType).Returns(MonitoredItemTypeMask.DataChange);
+            item.Setup(i => i.GetCreateResult(out createResult)).Returns(ServiceResult.Good);
+            item.Setup(i => i.Publish(
+                    It.IsAny<OperationContext>(),
+                    It.IsAny<Queue<MonitoredItemNotification>>(),
+                    It.IsAny<Queue<DiagnosticInfo>>(),
+                    It.IsAny<uint>(),
+                    It.IsAny<Microsoft.Extensions.Logging.ILogger>()))
+                .Returns<
+                    OperationContext,
+                    Queue<MonitoredItemNotification>,
+                    Queue<DiagnosticInfo>,
+                    uint,
+                    Microsoft.Extensions.Logging.ILogger>(
+                    (_, notifications, diagnostics, maxNotificationsPerPublish, _) =>
+                    {
+                        publishLimits.Add(maxNotificationsPerPublish);
+                        for (int ii = 0; ii < notificationCount; ii++)
+                        {
+                            notifications.Enqueue(
+                                new MonitoredItemNotification { Value = new DataValue(ii) });
+                            diagnostics.Enqueue(new DiagnosticInfo());
+                        }
+                        return false;
+                    });
+            return item;
         }
     }
 }

--- a/tests/Opc.Ua.Server.Tests/SubscriptionTests.cs
+++ b/tests/Opc.Ua.Server.Tests/SubscriptionTests.cs
@@ -472,6 +472,7 @@ namespace Opc.Ua.Server.Tests
         [TestCase(10, 10L, 10L)]
         [TestCase(10, 25L, 10L)]
         [TestCase(0, uint.MaxValue, uint.MaxValue)]
+        [TestCase(10, uint.MaxValue, 10L)]
         [TestCase(int.MaxValue, uint.MaxValue, int.MaxValue)]
         public async Task CreateSubscriptionWithNotificationLimitsUsesEffectiveLimitAsync(
             int serverLimit,
@@ -498,6 +499,60 @@ namespace Opc.Ua.Server.Tests
                 maxNotificationsPerPublish: (uint)requestedLimit,
                 publishingEnabled: true,
                 priority: 0).ConfigureAwait(false);
+
+            Assert.That(
+                manager.TryGetSubscription(response.SubscriptionId, out ISubscription subscription),
+                Is.True);
+            Assert.That(
+                subscription.Diagnostics.MaxNotificationsPerPublish,
+                Is.EqualTo((uint)expectedLimit));
+        }
+
+        [TestCase(0, 0L, 0L)]
+        [TestCase(0, 25L, 25L)]
+        [TestCase(10, 0L, 10L)]
+        [TestCase(10, 10L, 10L)]
+        [TestCase(10, 25L, 10L)]
+        [TestCase(0, uint.MaxValue, uint.MaxValue)]
+        [TestCase(10, uint.MaxValue, 10L)]
+        [TestCase(int.MaxValue, uint.MaxValue, int.MaxValue)]
+        public async Task ModifySubscriptionWithNotificationLimitsUsesEffectiveLimitAsync(
+            int serverLimit,
+            long requestedLimit,
+            long expectedLimit)
+        {
+            var configuration = new ApplicationConfiguration
+            {
+                ServerConfiguration = new ServerConfiguration
+                {
+                    MaxNotificationsPerPublish = serverLimit
+                }
+            };
+            using var manager = new SubscriptionManager(
+                m_serverMock.Object,
+                configuration);
+
+            var context = new OperationContext(m_sessionMock.Object, new DiagnosticsMasks());
+            CreateSubscriptionResponse response = await manager.CreateSubscriptionAsync(
+                context,
+                requestedPublishingInterval: 1000,
+                requestedLifetimeCount: 30,
+                requestedMaxKeepAliveCount: 10,
+                maxNotificationsPerPublish: 1,
+                publishingEnabled: true,
+                priority: 0).ConfigureAwait(false);
+
+            manager.ModifySubscription(
+                context,
+                response.SubscriptionId,
+                requestedPublishingInterval: 1000,
+                requestedLifetimeCount: 30,
+                requestedMaxKeepAliveCount: 10,
+                maxNotificationsPerPublish: (uint)requestedLimit,
+                priority: 0,
+                revisedPublishingInterval: out _,
+                revisedLifetimeCount: out _,
+                revisedMaxKeepAliveCount: out _);
 
             Assert.That(
                 manager.TryGetSubscription(response.SubscriptionId, out ISubscription subscription),

--- a/tests/Opc.Ua.Server.Tests/SubscriptionTests.cs
+++ b/tests/Opc.Ua.Server.Tests/SubscriptionTests.cs
@@ -329,5 +329,85 @@ namespace Opc.Ua.Server.Tests
             Assert.That(moreNotifications2, Is.True);
             Assert.That(moreNotifications3, Is.False);
         }
+
+        [Test]
+        public void ConstructMessageWithZeroLimitDrainsNotificationQueues()
+        {
+            using Subscription subscription = CreateSubscription();
+            var events = new Queue<EventFieldList>(
+            [
+                new EventFieldList(),
+                new EventFieldList()
+            ]);
+            var dataChanges = new Queue<MonitoredItemNotification>(
+            [
+                new MonitoredItemNotification { Value = new DataValue(1) },
+                new MonitoredItemNotification { Value = new DataValue(2) }
+            ]);
+            var diagnostics = new Queue<DiagnosticInfo>(
+            [
+                new DiagnosticInfo(),
+                new DiagnosticInfo()
+            ]);
+
+            MethodInfo constructMessage = typeof(Subscription).GetMethod(
+                "ConstructMessage",
+                BindingFlags.NonPublic | BindingFlags.Instance)
+                ?? throw new InvalidOperationException("ConstructMessage method not found");
+            object[] arguments = [events, dataChanges, diagnostics, 0];
+
+            var message = (NotificationMessage)constructMessage.Invoke(subscription, arguments);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(events, Is.Empty);
+                Assert.That(dataChanges, Is.Empty);
+                Assert.That(diagnostics, Is.Empty);
+                Assert.That((int)arguments[3], Is.EqualTo(4));
+                Assert.That(message.NotificationData.Count, Is.EqualTo(2));
+            });
+        }
+
+        [TestCase(0, 0, 0)]
+        [TestCase(0, 25, 25)]
+        [TestCase(10, 0, 10)]
+        [TestCase(10, 25, 10)]
+        public void CalculateMaxNotificationsTreatsZeroAsUnlimited(
+            int serverLimit,
+            int requestedLimit,
+            int expectedLimit)
+        {
+            var configuration = new ApplicationConfiguration
+            {
+                ServerConfiguration = new ServerConfiguration
+                {
+                    MaxNotificationsPerPublish = serverLimit
+                }
+            };
+            using var manager = new TestSubscriptionManager(
+                m_serverMock.Object,
+                configuration);
+
+            uint revisedLimit = manager.CalculateMaxNotificationsPerPublish(
+                (uint)requestedLimit);
+
+            Assert.That(revisedLimit, Is.EqualTo((uint)expectedLimit));
+        }
+
+        private sealed class TestSubscriptionManager : SubscriptionManager
+        {
+            public TestSubscriptionManager(
+                IServerInternal server,
+                ApplicationConfiguration configuration)
+                : base(server, configuration)
+            {
+            }
+
+            public new uint CalculateMaxNotificationsPerPublish(
+                uint maxNotificationsPerPublish)
+            {
+                return base.CalculateMaxNotificationsPerPublish(maxNotificationsPerPublish);
+            }
+        }
     }
 }


### PR DESCRIPTION
# Description

This focused change extracts the `MaxNotificationsPerPublish` conformance fix from #4021. It contains only `Subscription.cs`, `SubscriptionManager.cs`, and focused `SubscriptionTests`.

## Failure

OPC UA defines zero as no notification limit. The message builder compared the queued count directly with zero, so an effective zero limit emitted no event or data-change notifications and left the queues pending. Separately, the revision logic treated a configured Server maximum of zero as a numeric cap, revising a non-zero Client request to zero and silently removing the Client's requested limit.

## Fix

- Treat an effective zero limit as unlimited while draining event and data-change queues.
- When the Client requests zero, use the Server's configured maximum, which may itself remain zero/unlimited.
- When the Server maximum is zero, preserve a non-zero Client request, including `uint.MaxValue`.
- When the Server maximum is finite, cap zero, `uint.MaxValue`, and larger finite Client requests to that maximum.
- Cover the same revision matrix through both CreateSubscription and ModifySubscription.

This implements the zero-means-unlimited semantics in OPC 10000-4 v1.05.07 Sections 5.14.2.2 and 5.14.3.2. Those Service responses do not contain a `revisedMaxNotificationsPerPublish` field; the effective value is retained by the Server-side Subscription and its diagnostics.

## Tests

- `dotnet test tests\Opc.Ua.Server.Tests\Opc.Ua.Server.Tests.csproj -f net10.0 --filter "FullyQualifiedName~Opc.Ua.Server.Tests.SubscriptionTests" --no-restore`: 25 passed.
- `dotnet test tests\Opc.Ua.Server.Tests\Opc.Ua.Server.Tests.csproj -f net48 --filter "FullyQualifiedName~Opc.Ua.Server.Tests.SubscriptionTests" --no-restore`: 25 passed.

The regression tests cover zero, finite, and `uint.MaxValue` Client requests against unlimited and finite Server limits for both CreateSubscription and ModifySubscription. They also verify that zero drains both event and data-change queues.

## Related Issues

- Focused split from #4021 (closed umbrella draft); no separate issue.

## Checklist

- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf) and read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [x] I have added all necessary documentation.
- [x] I have verified that my changes do not introduce (new) build or analyzer warnings.
- [ ] I ran **all** tests locally using the **UA.slnx** solution against at least .net **framework** and .net **10**, and all passed.
- [ ] I fixed **all** failing and flaky tests in the CI pipelines and **all** CodeQL warnings.
- [x] I have addressed **all** PR feedback received.
