### PR TITLE
Prevent stale redundant client Session swaps (OPC UA redundancy)

### DIFF
--- a/src/Opc.Ua.Redundancy.Client/RedundantClientSession.cs
+++ b/src/Opc.Ua.Redundancy.Client/RedundantClientSession.cs
@@ -1294,6 +1294,7 @@ namespace Opc.Ua.Redundancy.Client
 
         private void UpdateActiveSession()
         {
+            // Assign the generation before invoking the accessor so an earlier refresh cannot apply after a later one.
             long refreshGeneration = Interlocked.Increment(ref m_refreshGeneration);
             ISession? s = m_coordinator.IsLeader ? m_currentSessionAccessor() : null;
             TaskCompletionSource<ISession>? release;
@@ -1304,6 +1305,10 @@ namespace Opc.Ua.Redundancy.Client
                     return;
                 }
                 m_appliedRefreshGeneration = refreshGeneration;
+                if (s != null)
+                {
+                    ApplyRememberedValues(s);
+                }
                 if (!ReferenceEquals(s, m_attachedSession))
                 {
                     DetachEvents(m_attachedSession);
@@ -1324,7 +1329,6 @@ namespace Opc.Ua.Redundancy.Client
                 {
                     m_activeSession = CreateSessionCompletionSource();
                 }
-                ApplyRememberedValues(s);
                 release = m_activeSession;
             }
             release.TrySetResult(s);

--- a/src/Opc.Ua.Redundancy.Client/RedundantClientSession.cs
+++ b/src/Opc.Ua.Redundancy.Client/RedundantClientSession.cs
@@ -1294,28 +1294,35 @@ namespace Opc.Ua.Redundancy.Client
 
         private void UpdateActiveSession()
         {
+            long refreshGeneration = Interlocked.Increment(ref m_refreshGeneration);
             ISession? s = m_coordinator.IsLeader ? m_currentSessionAccessor() : null;
             TaskCompletionSource<ISession>? release;
             lock (m_syncRoot)
             {
-                if (m_disposed)
+                if (m_disposed || refreshGeneration < m_appliedRefreshGeneration)
                 {
                     return;
                 }
+                m_appliedRefreshGeneration = refreshGeneration;
                 if (!ReferenceEquals(s, m_attachedSession))
                 {
                     DetachEvents(m_attachedSession);
                     m_attachedSession = s;
                     AttachEvents(m_attachedSession);
                 }
+                ISession? previousSession = m_currentSession;
                 m_currentSession = s;
                 if (s == null)
                 {
-                    if (m_activeSession.Task.IsCompleted)
+                    if (previousSession != null || m_activeSession.Task.IsCompleted)
                     {
                         m_activeSession = CreateSessionCompletionSource();
                     }
                     return;
+                }
+                if (previousSession != null && !ReferenceEquals(previousSession, s))
+                {
+                    m_activeSession = CreateSessionCompletionSource();
                 }
                 ApplyRememberedValues(s);
                 release = m_activeSession;
@@ -1497,6 +1504,8 @@ namespace Opc.Ua.Redundancy.Client
         private TaskCompletionSource<ISession> m_activeSession;
         private ISession? m_currentSession;
         private ISession? m_attachedSession;
+        private long m_refreshGeneration;
+        private long m_appliedRefreshGeneration;
         private bool m_disposed;
         private bool m_hasHandle;
         private object? m_handle;

--- a/tests/Opc.Ua.Redundancy.Client.Tests/RedundantClientSessionTests.cs
+++ b/tests/Opc.Ua.Redundancy.Client.Tests/RedundantClientSessionTests.cs
@@ -39,6 +39,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -103,6 +104,104 @@ namespace Opc.Ua.Client.Redundancy.Tests
 
             Assert.That(await readTask.ConfigureAwait(false), Is.SameAs(response));
             session.VerifyAll();
+        }
+
+        [Test]
+        public async Task ConcurrentAsyncCallsUseNewSessionAfterLiveSwapAsync()
+        {
+            ISession? current = null;
+            using var store = new InMemorySharedKeyValueStore();
+            var coordinator = new ClientReplicaCoordinator(
+                new ClientReplicaOptions { CreateSessionAsync = _ => default },
+                new StaticLeaderElection(true),
+                store,
+                NullRecordProtector.Instance,
+                m_telemetry);
+            var first = new Mock<ISession>();
+            var second = new Mock<ISession>();
+            var response = new ReadResponse();
+            second
+                .Setup(session => session.ReadAsync(
+                    null,
+                    0,
+                    TimestampsToReturn.Neither,
+                    It.IsAny<ArrayOf<ReadValueId>>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns(new ValueTask<ReadResponse>(response));
+            current = first.Object;
+            await using var facade = new RedundantClientSession(coordinator, () => current);
+
+            current = second.Object;
+            facade.RefreshActiveSessionForTesting();
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            Task<ReadResponse>[] calls = Enumerable.Range(0, 16)
+                .Select(_ => Task.Run(
+                    async () => await facade
+                        .ReadAsync(null, 0, TimestampsToReturn.Neither, [], cts.Token)
+                        .ConfigureAwait(false)))
+                .ToArray();
+            ReadResponse[] results = await Task.WhenAll(calls).ConfigureAwait(false);
+
+            Assert.That(results, Is.All.SameAs(response));
+            second.Verify(
+                session => session.ReadAsync(
+                    null,
+                    0,
+                    TimestampsToReturn.Neither,
+                    It.IsAny<ArrayOf<ReadValueId>>(),
+                    It.IsAny<CancellationToken>()),
+                Times.Exactly(calls.Length));
+            first.Verify(
+                session => session.ReadAsync(
+                    It.IsAny<RequestHeader>(),
+                    It.IsAny<double>(),
+                    It.IsAny<TimestampsToReturn>(),
+                    It.IsAny<ArrayOf<ReadValueId>>(),
+                    It.IsAny<CancellationToken>()),
+                Times.Never);
+        }
+
+        [Test]
+        public async Task OlderConcurrentRefreshCannotReplaceNewerObservedSessionAsync()
+        {
+            using var store = new InMemorySharedKeyValueStore();
+            var coordinator = new ClientReplicaCoordinator(
+                new ClientReplicaOptions { CreateSessionAsync = _ => default },
+                new StaticLeaderElection(true),
+                store,
+                NullRecordProtector.Instance,
+                m_telemetry);
+            var first = new Mock<ISession>();
+            var second = new Mock<ISession>();
+            ISession? current = first.Object;
+            using var staleObserved = new ManualResetEventSlim();
+            using var releaseStale = new ManualResetEventSlim();
+            int blockNextRefresh = 0;
+            ISession? AccessCurrent()
+            {
+                ISession? observed = current;
+                if (Interlocked.Exchange(ref blockNextRefresh, 0) == 1)
+                {
+                    staleObserved.Set();
+                    if (!releaseStale.Wait(TimeSpan.FromSeconds(10)))
+                    {
+                        throw new TimeoutException("The stale refresh was not released.");
+                    }
+                }
+                return observed;
+            }
+
+            await using var facade = new RedundantClientSession(coordinator, AccessCurrent);
+            Volatile.Write(ref blockNextRefresh, 1);
+            Task staleRefresh = Task.Run(facade.RefreshActiveSessionForTesting);
+            Assert.That(staleObserved.Wait(TimeSpan.FromSeconds(10)), Is.True);
+
+            current = second.Object;
+            facade.RefreshActiveSessionForTesting();
+            releaseStale.Set();
+            await staleRefresh.ConfigureAwait(false);
+
+            Assert.That(facade.Current, Is.SameAs(second.Object));
         }
 
         [Test]

--- a/tests/Opc.Ua.Redundancy.Client.Tests/RedundantClientSessionTests.cs
+++ b/tests/Opc.Ua.Redundancy.Client.Tests/RedundantClientSessionTests.cs
@@ -162,7 +162,47 @@ namespace Opc.Ua.Client.Redundancy.Tests
         }
 
         [Test]
-        public async Task OlderConcurrentRefreshCannotReplaceNewerObservedSessionAsync()
+        public async Task FailedRememberedValueApplicationKeepsPreviousSessionAsync()
+        {
+            using var store = new InMemorySharedKeyValueStore();
+            var coordinator = new ClientReplicaCoordinator(
+                new ClientReplicaOptions { CreateSessionAsync = _ => default },
+                new StaticLeaderElection(true),
+                store,
+                NullRecordProtector.Instance,
+                m_telemetry);
+            var first = new Mock<ISession>();
+            var second = new Mock<ISession>();
+            var response = new ReadResponse();
+            first
+                .Setup(session => session.ReadAsync(
+                    null,
+                    0,
+                    TimestampsToReturn.Neither,
+                    It.IsAny<ArrayOf<ReadValueId>>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns(new ValueTask<ReadResponse>(response));
+            second
+                .SetupSet(session => session.DeleteSubscriptionsOnClose = true)
+                .Throws(new InvalidOperationException("remembered value failed"));
+            ISession? current = first.Object;
+            await using var facade = new RedundantClientSession(coordinator, () => current);
+            facade.DeleteSubscriptionsOnClose = true;
+
+            current = second.Object;
+            InvalidOperationException? exception = Assert.Throws<InvalidOperationException>(
+                facade.RefreshActiveSessionForTesting);
+            ReadResponse result = await facade
+                .ReadAsync(null, 0, TimestampsToReturn.Neither, [], CancellationToken.None)
+                .ConfigureAwait(false);
+
+            Assert.That(exception!.Message, Is.EqualTo("remembered value failed"));
+            Assert.That(facade.Current, Is.SameAs(first.Object));
+            Assert.That(result, Is.SameAs(response));
+        }
+
+        [Test]
+        public async Task EarlierConcurrentRefreshCannotReplaceLaterAppliedSessionAsync()
         {
             using var store = new InMemorySharedKeyValueStore();
             var coordinator = new ClientReplicaCoordinator(


### PR DESCRIPTION
## Failure

Concurrent active-Session refreshes observed the coordinator outside the facade lock and then applied results in completion order. An older refresh could overwrite a newer Session, while a non-null to non-null swap retained the already-completed waiter and routed later async calls to the stale Session.

## Fix

- Assign every refresh invocation a generation before accessing the Session and reject earlier-started refreshes after a later refresh has applied.
- Reset the active-Session completion source for live Session replacements.
- Cover concurrent stale refreshes and async calls immediately after a live swap.

## Standard

OPC 10000-4 §6.6 redundant-client continuity requires the stable facade to route service calls through the current active Session during replica and Session transitions.

## Tests

- `dotnet test tests\Opc.Ua.Redundancy.Client.Tests\Opc.Ua.Redundancy.Client.Tests.csproj -f net10.0 --no-restore --nologo --verbosity minimal` — 122 passed
- `CustomTestTarget=net48 dotnet test tests\Opc.Ua.Redundancy.Client.Tests\Opc.Ua.Redundancy.Client.Tests.csproj --no-restore --nologo --verbosity minimal -m:1` — 122 passed

- Review follow-up: `RedundantClientSessionTests` — 7 passed on net10.0 and 7 passed on net48.

## Split

Split from #4021.