### PR TITLE
Require exact LDS certificate ApplicationUri registration (OPC 10000-4)

### DIFF
--- a/src/Opc.Ua.Lds.Server/LdsServer.cs
+++ b/src/Opc.Ua.Lds.Server/LdsServer.cs
@@ -30,6 +30,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -503,8 +504,21 @@ namespace Opc.Ua.Lds.Server
             {
                 using var cert = Certificate.FromRawData(certBytes);
                 IReadOnlyList<string> applicationUris = X509Utils.GetApplicationUrisFromCertificate(cert);
-                if (applicationUris.Count != 1 ||
-                    !string.Equals(applicationUris[0], server.ServerUri, StringComparison.Ordinal))
+                if (applicationUris.Count == 0)
+                {
+                    return new ServiceResult(
+                        StatusCodes.BadServerUriInvalid,
+                        new LocalizedText(
+                            "The SecureChannel client certificate has no ApplicationUri."));
+                }
+                if (applicationUris.Count > 1)
+                {
+                    return new ServiceResult(
+                        StatusCodes.BadServerUriInvalid,
+                        new LocalizedText(
+                            "The SecureChannel client certificate has multiple ApplicationUris."));
+                }
+                if (!string.Equals(applicationUris[0], server.ServerUri, StringComparison.Ordinal))
                 {
                     return new ServiceResult(
                         StatusCodes.BadServerUriInvalid,
@@ -512,7 +526,7 @@ namespace Opc.Ua.Lds.Server
                             "ServerUri must exactly match the certificate ApplicationUri."));
                 }
             }
-            catch (Exception ex)
+            catch (CryptographicException ex)
             {
                 m_log?.FailedToInspectClientCertApplicationUri(ex);
                 return new ServiceResult(

--- a/src/Opc.Ua.Lds.Server/LdsServer.cs
+++ b/src/Opc.Ua.Lds.Server/LdsServer.cs
@@ -492,7 +492,7 @@ namespace Opc.Ua.Lds.Server
                     new LocalizedText("ServerType is out of range."));
             }
 
-            byte[] certBytes = secureChannelContext?.ClientChannelCertificate;
+            byte[] certBytes = secureChannelContext.ClientChannelCertificate;
             if (certBytes == null || certBytes.Length == 0)
             {
                 return new ServiceResult(

--- a/src/Opc.Ua.Lds.Server/LdsServer.cs
+++ b/src/Opc.Ua.Lds.Server/LdsServer.cs
@@ -491,24 +491,33 @@ namespace Opc.Ua.Lds.Server
                     new LocalizedText("ServerType is out of range."));
             }
 
-            // Match the client cert ApplicationUri against the ServerUri.
-            if (secureChannelContext?.ClientChannelCertificate is { Length: > 0 } certBytes)
+            byte[] certBytes = secureChannelContext?.ClientChannelCertificate;
+            if (certBytes == null || certBytes.Length == 0)
             {
-                try
+                return new ServiceResult(
+                    StatusCodes.BadSecurityChecksFailed,
+                    new LocalizedText("RegisterServer requires a SecureChannel client certificate."));
+            }
+
+            try
+            {
+                using var cert = Certificate.FromRawData(certBytes);
+                IReadOnlyList<string> applicationUris = X509Utils.GetApplicationUrisFromCertificate(cert);
+                if (applicationUris.Count != 1 ||
+                    !string.Equals(applicationUris[0], server.ServerUri, StringComparison.Ordinal))
                 {
-                    using var cert = Certificate.FromRawData(certBytes);
-                    IReadOnlyList<string> applicationUris = X509Utils.GetApplicationUrisFromCertificate(cert);
-                    if (applicationUris.Count > 0 &&
-                        !applicationUris.Any(uri => string.Equals(uri, server.ServerUri, StringComparison.Ordinal)))
-                    {
-                        return new ServiceResult(StatusCodes.BadServerUriInvalid,
-                            new LocalizedText("ServerUri does not match the certificate ApplicationUri."));
-                    }
+                    return new ServiceResult(
+                        StatusCodes.BadServerUriInvalid,
+                        new LocalizedText(
+                            "ServerUri must exactly match the certificate ApplicationUri."));
                 }
-                catch (Exception ex)
-                {
-                    m_log?.FailedToInspectClientCertApplicationUri(ex);
-                }
+            }
+            catch (Exception ex)
+            {
+                m_log?.FailedToInspectClientCertApplicationUri(ex);
+                return new ServiceResult(
+                    StatusCodes.BadCertificateInvalid,
+                    new LocalizedText("The SecureChannel client certificate is invalid."));
             }
 
             return ServiceResult.Good;

--- a/src/Opc.Ua.Lds.Server/LdsServer.cs
+++ b/src/Opc.Ua.Lds.Server/LdsServer.cs
@@ -511,19 +511,13 @@ namespace Opc.Ua.Lds.Server
                         new LocalizedText(
                             "The SecureChannel client certificate has no ApplicationUri."));
                 }
-                if (applicationUris.Count > 1)
+                if (!applicationUris.Any(
+                        uri => string.Equals(uri, server.ServerUri, StringComparison.Ordinal)))
                 {
                     return new ServiceResult(
                         StatusCodes.BadServerUriInvalid,
                         new LocalizedText(
-                            "The SecureChannel client certificate has multiple ApplicationUris."));
-                }
-                if (!string.Equals(applicationUris[0], server.ServerUri, StringComparison.Ordinal))
-                {
-                    return new ServiceResult(
-                        StatusCodes.BadServerUriInvalid,
-                        new LocalizedText(
-                            "ServerUri must exactly match the certificate ApplicationUri."));
+                            "ServerUri must exactly match a certificate ApplicationUri."));
                 }
             }
             catch (CryptographicException ex)

--- a/tests/Opc.Ua.Lds.Tests/RegistrationValidationTests.cs
+++ b/tests/Opc.Ua.Lds.Tests/RegistrationValidationTests.cs
@@ -28,6 +28,7 @@
  * ======================================================================*/
 
 using System;
+using System.Security.Cryptography.X509Certificates;
 using NUnit.Framework;
 using Opc.Ua.Lds.Server;
 using Opc.Ua.Security.Certificates;
@@ -37,7 +38,7 @@ namespace Opc.Ua.Lds.Tests
     [TestFixture]
     [Category("DiscoveryServices")]
     [Parallelizable]
-    public sealed class RegistrationValidationTests
+    public sealed class RegistrationValidationTests : LdsTestFixture
     {
         private const string ServerUri = "urn:localhost:opcfoundation.org:RegistrationValidation";
 
@@ -76,6 +77,37 @@ namespace Opc.Ua.Lds.Tests
                 CreateRegisteredServer(ServerUri));
 
             Assert.That(result.StatusCode, Is.EqualTo(StatusCodes.BadCertificateInvalid));
+        }
+
+        [Test]
+        public void RegisterServerRejectsMalformedSubjectAltNameWithoutMutatingStore()
+        {
+            using Certificate certificate = CreateCertificateWithMalformedSubjectAltName();
+
+            ServiceResultException exception = Assert.ThrowsAsync<ServiceResultException>(async () =>
+                await Lds.RegisterServerAsync(
+                    CreateChannel(certificate.RawData),
+                    new RequestHeader(),
+                    CreateRegisteredServer(ServerUri),
+                    RequestLifetime.None).ConfigureAwait(false));
+
+            Assert.That(exception.StatusCode, Is.EqualTo(StatusCodes.BadCertificateInvalid));
+            Assert.That(Lds.RegistrationStore.Snapshot(), Is.Empty);
+        }
+
+        [Test]
+        public void RegisterServer2RejectsMissingCertificateWithoutMutatingStore()
+        {
+            ServiceResultException exception = Assert.ThrowsAsync<ServiceResultException>(async () =>
+                await Lds.RegisterServer2Async(
+                    CreateChannel(null),
+                    new RequestHeader(),
+                    CreateRegisteredServer(ServerUri),
+                    default,
+                    RequestLifetime.None).ConfigureAwait(false));
+
+            Assert.That(exception.StatusCode, Is.EqualTo(StatusCodes.BadSecurityChecksFailed));
+            Assert.That(Lds.RegistrationStore.Snapshot(), Is.Empty);
         }
 
         [Test]
@@ -148,10 +180,7 @@ namespace Opc.Ua.Lds.Tests
             string[] applicationUris,
             bool includeSubjectAltName = false)
         {
-            ICertificateBuilder builder = CertificateBuilder
-                .Create("CN=RegistrationValidation")
-                .SetNotBefore(DateTime.UtcNow.AddDays(-1))
-                .SetNotAfter(DateTime.UtcNow.AddDays(30));
+            ICertificateBuilder builder = CreateCertificateBuilder();
             if (applicationUris.Length > 0 || includeSubjectAltName)
             {
                 builder = builder.AddExtension(
@@ -159,6 +188,26 @@ namespace Opc.Ua.Lds.Tests
             }
 
             return builder.SetRSAKeySize(2048).CreateForRSA();
+        }
+
+        private static Certificate CreateCertificateWithMalformedSubjectAltName()
+        {
+            return CreateCertificateBuilder()
+                .AddExtension(
+                    new X509Extension(
+                        X509SubjectAltNameExtension.SubjectAltName2Oid,
+                        [0x30, 0x01, 0x86],
+                        critical: false))
+                .SetRSAKeySize(2048)
+                .CreateForRSA();
+        }
+
+        private static ICertificateBuilder CreateCertificateBuilder()
+        {
+            return CertificateBuilder
+                .Create("CN=RegistrationValidation")
+                .SetNotBefore(DateTime.UtcNow.AddDays(-1))
+                .SetNotAfter(DateTime.UtcNow.AddDays(30));
         }
 
         private static SecureChannelContext CreateChannel(byte[]? clientCertificate)

--- a/tests/Opc.Ua.Lds.Tests/RegistrationValidationTests.cs
+++ b/tests/Opc.Ua.Lds.Tests/RegistrationValidationTests.cs
@@ -1,0 +1,170 @@
+/* ========================================================================
+ * Copyright (c) 2005-2026 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using NUnit.Framework;
+using Opc.Ua.Lds.Server;
+using Opc.Ua.Security.Certificates;
+
+namespace Opc.Ua.Lds.Tests
+{
+    [TestFixture]
+    [Category("DiscoveryServices")]
+    [Parallelizable]
+    public sealed class RegistrationValidationTests
+    {
+        private const string ServerUri = "urn:localhost:opcfoundation.org:RegistrationValidation";
+
+        [Test]
+        public void RegistrationAcceptsOneExactCertificateApplicationUri()
+        {
+            using Certificate certificate = CreateCertificate([ServerUri]);
+            using var server = new TestLdsServer();
+
+            ServiceResult result = server.Validate(
+                CreateChannel(certificate.RawData),
+                CreateRegisteredServer(ServerUri));
+
+            Assert.That(ServiceResult.IsGood(result), Is.True);
+        }
+
+        [Test]
+        public void RegistrationRejectsMissingClientCertificate()
+        {
+            using var server = new TestLdsServer();
+
+            ServiceResult result = server.Validate(
+                CreateChannel(null),
+                CreateRegisteredServer(ServerUri));
+
+            Assert.That(result.StatusCode, Is.EqualTo(StatusCodes.BadSecurityChecksFailed));
+        }
+
+        [Test]
+        public void RegistrationRejectsMalformedClientCertificate()
+        {
+            using var server = new TestLdsServer();
+
+            ServiceResult result = server.Validate(
+                CreateChannel([1, 2, 3, 4]),
+                CreateRegisteredServer(ServerUri));
+
+            Assert.That(result.StatusCode, Is.EqualTo(StatusCodes.BadCertificateInvalid));
+        }
+
+        [Test]
+        public void RegistrationRejectsCertificateWithoutApplicationUri()
+        {
+            using Certificate certificate = CreateCertificate([]);
+            using var server = new TestLdsServer();
+
+            ServiceResult result = server.Validate(
+                CreateChannel(certificate.RawData),
+                CreateRegisteredServer(ServerUri));
+
+            Assert.That(result.StatusCode, Is.EqualTo(StatusCodes.BadServerUriInvalid));
+        }
+
+        [Test]
+        public void RegistrationRejectsCertificateWithMultipleApplicationUris()
+        {
+            using Certificate certificate = CreateCertificate([ServerUri, "urn:test:other"]);
+            using var server = new TestLdsServer();
+
+            ServiceResult result = server.Validate(
+                CreateChannel(certificate.RawData),
+                CreateRegisteredServer(ServerUri));
+
+            Assert.That(result.StatusCode, Is.EqualTo(StatusCodes.BadServerUriInvalid));
+        }
+
+        [Test]
+        public void RegistrationRequiresOrdinalApplicationUriMatch()
+        {
+            using Certificate certificate = CreateCertificate([ServerUri]);
+            using var server = new TestLdsServer();
+
+            ServiceResult result = server.Validate(
+                CreateChannel(certificate.RawData),
+                CreateRegisteredServer(ServerUri.ToUpperInvariant()));
+
+            Assert.That(result.StatusCode, Is.EqualTo(StatusCodes.BadServerUriInvalid));
+        }
+
+        private static Certificate CreateCertificate(string[] applicationUris)
+        {
+            ICertificateBuilder builder = CertificateBuilder
+                .Create("CN=RegistrationValidation")
+                .SetNotBefore(DateTime.UtcNow.AddDays(-1))
+                .SetNotAfter(DateTime.UtcNow.AddDays(30));
+            if (applicationUris.Length > 0)
+            {
+                builder = builder.AddExtension(
+                    new X509SubjectAltNameExtension(applicationUris, ["localhost"]));
+            }
+
+            return builder.SetRSAKeySize(2048).CreateForRSA();
+        }
+
+        private static SecureChannelContext CreateChannel(byte[] clientCertificate)
+        {
+            return new SecureChannelContext(
+                "registration-validation",
+                new EndpointDescription
+                {
+                    SecurityMode = MessageSecurityMode.SignAndEncrypt
+                },
+                RequestEncoding.Binary,
+                clientCertificate);
+        }
+
+        private static RegisteredServer CreateRegisteredServer(string serverUri)
+        {
+            return new RegisteredServer
+            {
+                ServerUri = serverUri,
+                ProductUri = "urn:test:product",
+                ServerNames = [new LocalizedText("en-US", "Registration Validation")],
+                ServerType = ApplicationType.Server,
+                DiscoveryUrls = ["opc.tcp://localhost:4840"],
+                IsOnline = true
+            };
+        }
+
+        private sealed class TestLdsServer : LdsServer
+        {
+            public ServiceResult Validate(
+                SecureChannelContext secureChannelContext,
+                RegisteredServer registeredServer)
+            {
+                return ValidateRegistration(secureChannelContext, registeredServer);
+            }
+        }
+    }
+}

--- a/tests/Opc.Ua.Lds.Tests/RegistrationValidationTests.cs
+++ b/tests/Opc.Ua.Lds.Tests/RegistrationValidationTests.cs
@@ -92,6 +92,19 @@ namespace Opc.Ua.Lds.Tests
         }
 
         [Test]
+        public void RegistrationRejectsSubjectAltNameWithoutApplicationUri()
+        {
+            using Certificate certificate = CreateCertificate([], includeSubjectAltName: true);
+            using var server = new TestLdsServer();
+
+            ServiceResult result = server.Validate(
+                CreateChannel(certificate.RawData),
+                CreateRegisteredServer(ServerUri));
+
+            Assert.That(result.StatusCode, Is.EqualTo(StatusCodes.BadServerUriInvalid));
+        }
+
+        [Test]
         public void RegistrationRejectsCertificateWithMultipleApplicationUris()
         {
             using Certificate certificate = CreateCertificate([ServerUri, "urn:test:other"]);
@@ -117,13 +130,15 @@ namespace Opc.Ua.Lds.Tests
             Assert.That(result.StatusCode, Is.EqualTo(StatusCodes.BadServerUriInvalid));
         }
 
-        private static Certificate CreateCertificate(string[] applicationUris)
+        private static Certificate CreateCertificate(
+            string[] applicationUris,
+            bool includeSubjectAltName = false)
         {
             ICertificateBuilder builder = CertificateBuilder
                 .Create("CN=RegistrationValidation")
                 .SetNotBefore(DateTime.UtcNow.AddDays(-1))
                 .SetNotAfter(DateTime.UtcNow.AddDays(30));
-            if (applicationUris.Length > 0)
+            if (applicationUris.Length > 0 || includeSubjectAltName)
             {
                 builder = builder.AddExtension(
                     new X509SubjectAltNameExtension(applicationUris, ["localhost"]));
@@ -132,7 +147,7 @@ namespace Opc.Ua.Lds.Tests
             return builder.SetRSAKeySize(2048).CreateForRSA();
         }
 
-        private static SecureChannelContext CreateChannel(byte[] clientCertificate)
+        private static SecureChannelContext CreateChannel(byte[]? clientCertificate)
         {
             return new SecureChannelContext(
                 "registration-validation",

--- a/tests/Opc.Ua.Lds.Tests/RegistrationValidationTests.cs
+++ b/tests/Opc.Ua.Lds.Tests/RegistrationValidationTests.cs
@@ -105,9 +105,23 @@ namespace Opc.Ua.Lds.Tests
         }
 
         [Test]
-        public void RegistrationRejectsCertificateWithMultipleApplicationUris()
+        public void RegistrationAcceptsExactApplicationUriAmongMultipleUris()
         {
-            using Certificate certificate = CreateCertificate([ServerUri, "urn:test:other"]);
+            using Certificate certificate = CreateCertificate(["urn:test:other", ServerUri]);
+            using var server = new TestLdsServer();
+
+            ServiceResult result = server.Validate(
+                CreateChannel(certificate.RawData),
+                CreateRegisteredServer(ServerUri));
+
+            Assert.That(ServiceResult.IsGood(result), Is.True);
+        }
+
+        [Test]
+        public void RegistrationRejectsMultipleApplicationUrisWithoutExactMatch()
+        {
+            using Certificate certificate = CreateCertificate(
+                ["urn:test:other", "urn:test:another"]);
             using var server = new TestLdsServer();
 
             ServiceResult result = server.Validate(


### PR DESCRIPTION
# Description

This PR splits the LDS registration-validation changes from #4021.

## Specification

[OPC 10000-4 v1.05.07 §5.5.5.1](https://reference.opcfoundation.org/specs/OPC-10000-4/v1.05.07/5.5.5.1) requires `RegisterServer` to use a SecureChannel that supports Client authentication and requires a Discovery Server to reject a registration when `serverUri` does not match the `applicationUri` in the Server Certificate used for that SecureChannel.

## Failure

LDS registration validation previously skipped the ApplicationUri check when the SecureChannel had no Client certificate, accepted a certificate with no ApplicationUri, and logged malformed-certificate parsing errors before continuing with a successful registration.

## Fix

- Require a SecureChannel Client certificate for registration.
- Parse the certificate fail closed and return `BadCertificateInvalid` when it is malformed.
- Require at least one certificate ApplicationUri and compare every URI entry to `ServerUri` with ordinal equality.
- Return `BadServerUriInvalid` when no certificate ApplicationUri exactly matches `ServerUri`.

## Validation

- Full `Opc.Ua.Lds.Tests`: net10.0 (171 passed, 3 skipped), net48 (171 passed, 3 skipped).
- `git diff --check` passed.

## Related Issues

- Split from #4021.

## Checklist

_Only verified claims are checked._

- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf) and read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added all necessary documentation.
- [x] I have verified that my changes do not introduce (new) build or analyzer warnings.
- [ ] I ran **all** tests locally using the **UA.slnx** solution against at least .net **framework** and .net **10**, and all passed.
- [ ] I fixed **all** failing and flaky tests in the CI pipelines and **all** CodeQL warnings.
- [ ] I have addressed **all** PR feedback received.
