### PR TITLE
Contain DI software packages beneath their configured root (OPC 10000-100)

### DIFF
--- a/src/Opc.Ua.Di.Server/SoftwareUpdate/FileSystemPackageStore.cs
+++ b/src/Opc.Ua.Di.Server/SoftwareUpdate/FileSystemPackageStore.cs
@@ -31,6 +31,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Runtime.CompilerServices;
+using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading;
@@ -313,7 +314,7 @@ namespace Opc.Ua.Di.Server.SoftwareUpdate
                 path += $"/{leaf}";
             }
 
-            string canonicalPath = CanonicalizeProviderPath(path, nameof(packageId));
+            string canonicalPath = CanonicalizeProviderPath(path, nameof(path));
             if (canonicalPath.Length <= m_rootPath.Length ||
                 !canonicalPath.StartsWith(m_rootPrefix, StringComparison.Ordinal))
             {
@@ -345,27 +346,45 @@ namespace Opc.Ua.Di.Server.SoftwareUpdate
 
         private static string CanonicalizeProviderPath(string path, string parameterName)
         {
-            string normalized = path.Replace('\\', '/');
-            string[] segments = normalized.Split('/');
-            var canonicalSegments = new List<string>(segments.Length);
-            foreach (string segment in segments)
+            var canonicalPath = new StringBuilder(path.Length + 1);
+            canonicalPath.Append('/');
+            int index = 0;
+            while (index < path.Length)
             {
-                if (segment.Length == 0)
+                while (index < path.Length && path[index] is '/' or '\\')
                 {
-                    continue;
+                    index++;
                 }
-                if (segment is "." or "..")
+
+                int segmentStart = index;
+                while (index < path.Length && path[index] is not ('/' or '\\'))
+                {
+                    index++;
+                }
+
+                int segmentLength = index - segmentStart;
+                if (segmentLength == 0)
+                {
+                    break;
+                }
+                if ((segmentLength == 1 && path[segmentStart] == '.') ||
+                    (segmentLength == 2 &&
+                        path[segmentStart] == '.' &&
+                        path[segmentStart + 1] == '.'))
                 {
                     throw new ArgumentException(
                         "Provider-relative paths must not contain dot segments.",
                         parameterName);
                 }
-                canonicalSegments.Add(segment);
+
+                if (canonicalPath.Length > 1)
+                {
+                    canonicalPath.Append('/');
+                }
+                canonicalPath.Append(path, segmentStart, segmentLength);
             }
 
-            return canonicalSegments.Count == 0
-                ? "/"
-                : "/" + string.Join("/", canonicalSegments);
+            return canonicalPath.ToString();
         }
     }
 

--- a/src/Opc.Ua.Di.Server/SoftwareUpdate/FileSystemPackageStore.cs
+++ b/src/Opc.Ua.Di.Server/SoftwareUpdate/FileSystemPackageStore.cs
@@ -74,6 +74,7 @@ namespace Opc.Ua.Di.Server.SoftwareUpdate
 
         private readonly IFileSystemProvider m_provider;
         private readonly string m_rootPath;
+        private readonly string m_rootPrefix;
         private readonly TimeProvider m_timeProvider;
 
 #if NET8_0_OR_GREATER
@@ -109,7 +110,10 @@ namespace Opc.Ua.Di.Server.SoftwareUpdate
                 throw new ArgumentException(
                     "Root path must be a non-empty string.", nameof(rootPath));
             }
-            m_rootPath = rootPath;
+            m_rootPath = CanonicalizeProviderPath(rootPath, nameof(rootPath));
+            m_rootPrefix = m_rootPath == "/"
+                ? m_rootPath
+                : m_rootPath + "/";
             m_timeProvider = timeProvider ?? TimeProvider.System;
         }
 
@@ -299,9 +303,25 @@ namespace Opc.Ua.Di.Server.SoftwareUpdate
 
         private string BuildPath(string packageId, string? leaf = null)
         {
-            string root = m_rootPath.TrimEnd('/');
-            string path = $"{root}/{packageId}";
-            return leaf == null ? path : $"{path}/{leaf}";
+            ValidateId(packageId);
+
+            string path = m_rootPath == "/"
+                ? $"/{packageId}"
+                : $"{m_rootPath}/{packageId}";
+            if (leaf != null)
+            {
+                path += $"/{leaf}";
+            }
+
+            string canonicalPath = CanonicalizeProviderPath(path, nameof(packageId));
+            if (canonicalPath.Length <= m_rootPath.Length ||
+                !canonicalPath.StartsWith(m_rootPrefix, StringComparison.Ordinal))
+            {
+                throw new UnauthorizedAccessException(
+                    "The package path escapes the configured package-store root.");
+            }
+
+            return canonicalPath;
         }
 
         private static void ValidateId(string packageId)
@@ -316,6 +336,36 @@ namespace Opc.Ua.Di.Server.SoftwareUpdate
                 throw new ArgumentException(
                     "Package id must not contain path separators.", nameof(packageId));
             }
+            if (packageId is "." or "..")
+            {
+                throw new ArgumentException(
+                    "Package id must not be a dot segment.", nameof(packageId));
+            }
+        }
+
+        private static string CanonicalizeProviderPath(string path, string parameterName)
+        {
+            string normalized = path.Replace('\\', '/');
+            string[] segments = normalized.Split('/');
+            var canonicalSegments = new List<string>(segments.Length);
+            foreach (string segment in segments)
+            {
+                if (segment.Length == 0)
+                {
+                    continue;
+                }
+                if (segment is "." or "..")
+                {
+                    throw new ArgumentException(
+                        "Provider-relative paths must not contain dot segments.",
+                        parameterName);
+                }
+                canonicalSegments.Add(segment);
+            }
+
+            return canonicalSegments.Count == 0
+                ? "/"
+                : "/" + string.Join("/", canonicalSegments);
         }
     }
 

--- a/tests/Opc.Ua.Di.Tests/PackageStoreTests.cs
+++ b/tests/Opc.Ua.Di.Tests/PackageStoreTests.cs
@@ -258,6 +258,98 @@ namespace Opc.Ua.Di.Tests
             }
         }
 
+        [TestCase(".")]
+        [TestCase("..")]
+        public void FileSystemStoreRejectsDotSegmentId(string packageId)
+        {
+            string tempRoot = Path.Combine(
+                Path.GetTempPath(),
+                "di-pkg-tests-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(tempRoot);
+            try
+            {
+                var provider = new PhysicalFileSystemProvider(
+                    rootDirectory: tempRoot,
+                    mountName: "Packages",
+                    isWritable: true);
+                var store = new FileSystemPackageStore(provider, rootPath: "/Pkgs");
+
+                Assert.ThrowsAsync<ArgumentException>(
+                    async () => await store.GetAsync(packageId).ConfigureAwait(false));
+            }
+            finally
+            {
+                if (Directory.Exists(tempRoot))
+                {
+                    Directory.Delete(tempRoot, recursive: true);
+                }
+            }
+        }
+
+        [TestCase("/Pkgs/./Nested")]
+        [TestCase("/Pkgs/../Outside")]
+        [TestCase("\\Pkgs\\..\\Outside")]
+        public void FileSystemStoreRejectsRootWithDotSegment(string rootPath)
+        {
+            string tempRoot = Path.Combine(
+                Path.GetTempPath(),
+                "di-pkg-tests-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(tempRoot);
+            try
+            {
+                var provider = new PhysicalFileSystemProvider(
+                    rootDirectory: tempRoot,
+                    mountName: "Packages",
+                    isWritable: true);
+
+                Assert.That(
+                    () => new FileSystemPackageStore(provider, rootPath),
+                    Throws.TypeOf<ArgumentException>());
+            }
+            finally
+            {
+                if (Directory.Exists(tempRoot))
+                {
+                    Directory.Delete(tempRoot, recursive: true);
+                }
+            }
+        }
+
+        [Test]
+        public async Task FileSystemStoreCanonicalizesProviderRelativeRootAsync()
+        {
+            string tempRoot = Path.Combine(
+                Path.GetTempPath(),
+                "di-pkg-tests-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(tempRoot);
+            try
+            {
+                var provider = new PhysicalFileSystemProvider(
+                    rootDirectory: tempRoot,
+                    mountName: "Packages",
+                    isWritable: true);
+                var store = new FileSystemPackageStore(
+                    provider,
+                    rootPath: "\\Pkgs\\\\Nested\\");
+
+                await store.AddAsync(
+                    NewMetadata("firmware"),
+                    new MemoryStream([1, 2, 3])).ConfigureAwait(false);
+
+                string packageRoot = Path.Combine(tempRoot, "Pkgs", "Nested", "firmware");
+                Assert.That(File.Exists(Path.Combine(packageRoot, "payload.bin")), Is.True);
+                Assert.That(File.Exists(Path.Combine(packageRoot, "metadata.json")), Is.True);
+                Assert.That(File.Exists(Path.Combine(tempRoot, "payload.bin")), Is.False);
+            }
+            finally
+            {
+                if (Directory.Exists(tempRoot))
+                {
+                    Directory.Delete(tempRoot, recursive: true);
+                }
+            }
+        }
+
         private static SoftwarePackage NewMetadata(string id)
         {
             return new(

--- a/tests/Opc.Ua.Di.Tests/PackageStoreTests.cs
+++ b/tests/Opc.Ua.Di.Tests/PackageStoreTests.cs
@@ -331,10 +331,11 @@ namespace Opc.Ua.Di.Tests
                 var store = new FileSystemPackageStore(
                     provider,
                     rootPath: "\\Pkgs\\\\Nested\\");
+                using var payload = new MemoryStream([1, 2, 3]);
 
                 await store.AddAsync(
                     NewMetadata("firmware"),
-                    new MemoryStream([1, 2, 3])).ConfigureAwait(false);
+                    payload).ConfigureAwait(false);
 
                 string packageRoot = Path.Combine(tempRoot, "Pkgs", "Nested", "firmware");
                 Assert.That(File.Exists(Path.Combine(packageRoot, "payload.bin")), Is.True);


### PR DESCRIPTION
# Description

This PR splits the DI software-package containment changes from #4021.

## Specification

- [OPC 10000-100 v1.05.0 §3.1.14](https://reference.opcfoundation.org/specs/OPC-10000-100/v1.05.0/3.1.14) defines a Software Package as a single file containing the software-update data.
- [OPC 10000-100 v1.05.0 §8.7.1](https://reference.opcfoundation.org/specs/OPC-10000-100/v1.05.0/8.7.1) defines the standard Software Package as one ZIP file.
- [OPC 10000-100 v1.05.0 §8.7.3](https://reference.opcfoundation.org/specs/OPC-10000-100/v1.05.0/8.7.3) defines package metadata as the identity of that Software Package.

The provider-backed package cache must therefore keep each package payload and its metadata together beneath the configured store root.

## Failure

`FileSystemPackageStore` rejected path separators in package identifiers but accepted `.` and `..`. It also accepted configured roots containing dot segments. Provider path normalization could therefore resolve a package operation outside the configured package-store root.

## Fix

- Canonicalize configured provider-relative roots to forward-slash absolute provider paths.
- Reject dot segments in both package identifiers and configured roots.
- Re-canonicalize every constructed package path and require it to be a strict descendant of the configured root before calling the file-system provider.
- Preserve valid mixed-separator roots by normalizing them deterministically.

## Validation

- Full `Opc.Ua.Di.Tests`: net10.0 (288 passed), net48 (288 passed).
- Review follow-up `PackageStoreTests`: net10.0 (15 passed), net48 (15 passed).
- `git diff --check` passed.

## Related Issues

- Split from #4021.

## Checklist

_Only verified claims are checked._

- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf) and read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added all necessary documentation.
- [x] I have verified that my changes do not introduce (new) build or analyzer warnings.
- [ ] I ran **all** tests locally using the **UA.slnx** solution against at least .net **framework** and .net **10**, and all passed.
- [ ] I fixed **all** failing and flaky tests in the CI pipelines and **all** CodeQL warnings.
- [x] I have addressed **all** PR feedback received.
