### PR TITLE
Source generator: support source-generating compiled companion NodeSets

### DIFF
--- a/src/Opc.Ua.Types/Opc.Ua.Types.csproj
+++ b/src/Opc.Ua.Types/Opc.Ua.Types.csproj
@@ -17,6 +17,7 @@
   <ItemGroup>
     <InternalsVisibleTo Include="Opc.Ua.Core.Types" />
     <InternalsVisibleTo Include="Opc.Ua.Types.Tests" />
+    <InternalsVisibleTo Include="Opc.Ua.Core.Encoders.Tests" />
     <InternalsVisibleTo Include="Opc.Ua.SourceGeneration.Core.Tests" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/Opc.Ua.SourceGeneration.Core.Tests/Schema/StandardMethodStateFallbackTests.cs
+++ b/tests/Opc.Ua.SourceGeneration.Core.Tests/Schema/StandardMethodStateFallbackTests.cs
@@ -1,0 +1,153 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using System.Collections.Immutable;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Xml;
+using NUnit.Framework;
+using Opc.Ua.Schema.Model;
+
+namespace Opc.Ua.SourceGeneration.Tests
+{
+    [TestFixture]
+    [Category("Generator")]
+    [Parallelizable]
+    public sealed class StandardMethodStateFallbackTests
+    {
+        /// <summary>
+        /// Verifies that the fallback scope follows the logical execution
+        /// context when generator work moves to another thread.
+        /// </summary>
+        [Test]
+        public async Task FallbackScopeFlowsToDedicatedThreadAsync()
+        {
+            int sourceThreadId = Environment.CurrentManagedThreadId;
+            using IDisposable scope = StandardMethodStateFallback.Enter(
+                ImmutableHashSet<string>.Empty);
+
+            (bool shouldFallback, int threadId) = await Task.Factory.StartNew(
+                () => (
+                    StandardMethodStateFallback.ShouldFallBackToBase(
+                        "global::Opc.Ua.MissingMethodState"),
+                    Environment.CurrentManagedThreadId),
+                CancellationToken.None,
+                TaskCreationOptions.LongRunning,
+                TaskScheduler.Default).ConfigureAwait(false);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(threadId, Is.Not.EqualTo(sourceThreadId));
+                Assert.That(shouldFallback, Is.True);
+            });
+        }
+
+        /// <summary>
+        /// Verifies that declaration names can opt out of the reference-only
+        /// fallback policy.
+        /// </summary>
+        [Test]
+        public void DeclarationNameDoesNotApplyFallback()
+        {
+            const string namespaceUri = "http://opcfoundation.org/UA/";
+            var method = new MethodDesign
+            {
+                HasArguments = true,
+                SymbolicName = new XmlQualifiedName("Missing", namespaceUri)
+            };
+            Namespace[] namespaces =
+            [
+                new Namespace
+                {
+                    Value = namespaceUri,
+                    Prefix = "Opc.Ua"
+                }
+            ];
+            using IDisposable scope = StandardMethodStateFallback.Enter(
+                ImmutableHashSet<string>.Empty);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(
+                    method.GetNodeStateClassName(namespaceUri, namespaces),
+                    Is.EqualTo("global::Opc.Ua.MethodState"));
+                Assert.That(
+                    method.GetNodeStateClassName(
+                        namespaceUri,
+                        namespaces,
+                        applyStandardFallback: false),
+                    Is.EqualTo("global::Opc.Ua.MissingMethodState"));
+                Assert.That(
+                    method.GetNodeStateClassName(
+                        namespaceUri,
+                        [],
+                        applyStandardFallback: false),
+                    Is.EqualTo("MissingMethodState"));
+            });
+        }
+
+        /// <summary>
+        /// Verifies that disposing a nested fallback scope restores the outer
+        /// immutable availability index.
+        /// </summary>
+        [Test]
+        public void NestedScopeRestoresOuterAvailabilityIndex()
+        {
+            ImmutableHashSet<string> availableStateTypeNames =
+                ImmutableHashSet<string>.Empty.Add("KnownMethodState");
+
+            using (StandardMethodStateFallback.Enter(availableStateTypeNames))
+            {
+                Assert.That(
+                    StandardMethodStateFallback.ShouldFallBackToBase(
+                        "global::Opc.Ua.KnownMethodState"),
+                    Is.False);
+
+                using (StandardMethodStateFallback.Enter(ImmutableHashSet<string>.Empty))
+                {
+                    Assert.That(
+                        StandardMethodStateFallback.ShouldFallBackToBase(
+                            "global::Opc.Ua.KnownMethodState"),
+                        Is.True);
+                }
+
+                Assert.That(
+                    StandardMethodStateFallback.ShouldFallBackToBase(
+                        "global::Opc.Ua.KnownMethodState"),
+                    Is.False);
+            }
+
+            Assert.That(
+                StandardMethodStateFallback.ShouldFallBackToBase(
+                    "global::Opc.Ua.KnownMethodState"),
+                Is.False);
+        }
+    }
+}

--- a/tools/Opc.Ua.SourceGeneration.Core/Generators/FluentBuilderGenerator.cs
+++ b/tools/Opc.Ua.SourceGeneration.Core/Generators/FluentBuilderGenerator.cs
@@ -580,7 +580,7 @@ namespace Opc.Ua.SourceGeneration
                     continue;
                 }
                 writer.WriteLine("    /// <summary>Resolves the predefined instance <c>{0}</c>.</summary>",
-                    GetBrowseName(root));
+                    EscapeXmlDoc(GetBrowseName(root)));
                 writer.WriteLine("    {0} {1} {{ get; }}", wrapper.ClassName, accessor);
             }
             writer.WriteLine("}");
@@ -1000,7 +1000,7 @@ namespace Opc.Ua.SourceGeneration
                 writer.WriteLine();
                 writer.WriteLine(
                     "{0}/// <summary>Walks the <c>{1}</c> HasProperty child.</summary>",
-                    indent, browseName);
+                    indent, EscapeXmlDoc(browseName));
                 writer.WriteLine(
                     "{0}public static global::Opc.Ua.Server.Fluent.IVariableBuilder<{1}> {2}(",
                     indent, valueType, accessorName);
@@ -1021,7 +1021,7 @@ namespace Opc.Ua.SourceGeneration
                 writer.WriteLine();
                 writer.WriteLine(
                     "{0}/// <summary>Walks the <c>{1}</c> HasComponent variable child.</summary>",
-                    indent, browseName);
+                    indent, EscapeXmlDoc(browseName));
                 writer.WriteLine(
                     "{0}public static global::Opc.Ua.Server.Fluent.IVariableBuilder<{1}> {2}(",
                     indent, valueType, accessorName);
@@ -1041,7 +1041,7 @@ namespace Opc.Ua.SourceGeneration
             writer.WriteLine();
             writer.WriteLine(
                 "{0}/// <summary>Walks the <c>{1}</c> HasComponent child.</summary>",
-                indent, browseName);
+                indent, EscapeXmlDoc(browseName));
             writer.WriteLine(
                 "{0}public static global::Opc.Ua.Server.Fluent.INodeBuilder<{1}> {2}(",
                 indent, childStateClr, accessorName);
@@ -1149,7 +1149,7 @@ namespace Opc.Ua.SourceGeneration
             {
                 case ChildKind.Variable:
                     writer.WriteLine("{0}/// <summary>Typed accessor for variable child <c>{1}</c>.</summary>",
-                        indent, child.BrowseName);
+                        indent, EscapeXmlDoc(child.BrowseName));
                     writer.WriteLine("{0}public global::Opc.Ua.Server.Fluent.IVariableBuilder<{1}> {2}",
                         indent, child.ValueClrType, child.AccessorName);
                     writer.WriteLine("{0}{{", indent);
@@ -1166,7 +1166,7 @@ namespace Opc.Ua.SourceGeneration
                     break;
                 case ChildKind.Method:
                     writer.WriteLine("{0}/// <summary>Typed accessor for method child <c>{1}</c>.</summary>",
-                        indent, child.BrowseName);
+                        indent, EscapeXmlDoc(child.BrowseName));
                     writer.WriteLine("{0}public {1} {2}", indent, child.WrapperClassName, child.AccessorName);
                     writer.WriteLine("{0}{{", indent);
                     writer.WriteLine("{0}get", bodyIndent);
@@ -1182,7 +1182,7 @@ namespace Opc.Ua.SourceGeneration
                     break;
                 case ChildKind.Object:
                     writer.WriteLine("{0}/// <summary>Typed accessor for object child <c>{1}</c>.</summary>",
-                        indent, child.BrowseName);
+                        indent, EscapeXmlDoc(child.BrowseName));
                     writer.WriteLine("{0}public {1} {2}", indent, child.WrapperClassName, child.AccessorName);
                     writer.WriteLine("{0}{{", indent);
                     writer.WriteLine("{0}get", bodyIndent);
@@ -1862,6 +1862,25 @@ namespace Opc.Ua.SourceGeneration
             return value
                 .Replace("\\", "\\\\", StringComparison.Ordinal)
                 .Replace("\"", "\\\"", StringComparison.Ordinal);
+        }
+
+        /// <summary>
+        /// Escapes a value for safe inclusion in a generated XML documentation
+        /// comment. OptionalPlaceholder browse names such as <c>&lt;Binding&gt;</c>
+        /// contain angle brackets that would otherwise produce malformed XML
+        /// (CS1570) when the consuming project enables documentation-file
+        /// generation.
+        /// </summary>
+        private static string EscapeXmlDoc(string value)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                return string.Empty;
+            }
+            return value
+                .Replace("&", "&amp;", StringComparison.Ordinal)
+                .Replace("<", "&lt;", StringComparison.Ordinal)
+                .Replace(">", "&gt;", StringComparison.Ordinal);
         }
 
         /// <summary>

--- a/tools/Opc.Ua.SourceGeneration.Core/Generators/NodeStateGenerator.cs
+++ b/tools/Opc.Ua.SourceGeneration.Core/Generators/NodeStateGenerator.cs
@@ -2042,15 +2042,17 @@ namespace Opc.Ua.SourceGeneration
             IWriteContext context,
             MethodDesign method)
         {
+            string targetNamespace = m_context.ModelDesign.TargetNamespace.Value;
             string declaredClassName = method.GetNodeStateClassName(
-                m_context.ModelDesign.TargetNamespace.Value,
-                []);
-            // Record this pass's declared method-state class (its guard-free,
-            // fully-qualified form) so a later reference to the same standard
-            // Opc.Ua.*MethodState (e.g. GDS emits its own) is not degraded.
+                targetNamespace,
+                [],
+                applyStandardFallback: false);
+            // Declarations require an unqualified identifier, while fallback
+            // tracking requires the fully-qualified name. Neither may apply
+            // the reference-only fallback policy.
             StandardMethodStateFallback.RecordDeclaredMethodState(
                 method.GetNodeStateClassName(
-                    m_context.ModelDesign.TargetNamespace.Value,
+                    targetNamespace,
                     m_context.ModelDesign.Namespaces,
                     applyStandardFallback: false));
             context.Template.AddReplacement(

--- a/tools/Opc.Ua.SourceGeneration.Core/Generators/NodeStateGenerator.cs
+++ b/tools/Opc.Ua.SourceGeneration.Core/Generators/NodeStateGenerator.cs
@@ -2042,16 +2042,23 @@ namespace Opc.Ua.SourceGeneration
             IWriteContext context,
             MethodDesign method)
         {
+            string declaredClassName = method.GetNodeStateClassName(
+                m_context.ModelDesign.TargetNamespace.Value,
+                []);
+            // Record this pass's declared method-state class (its guard-free,
+            // fully-qualified form) so a later reference to the same standard
+            // Opc.Ua.*MethodState (e.g. GDS emits its own) is not degraded.
+            StandardMethodStateFallback.RecordDeclaredMethodState(
+                method.GetNodeStateClassName(
+                    m_context.ModelDesign.TargetNamespace.Value,
+                    m_context.ModelDesign.Namespaces,
+                    applyStandardFallback: false));
             context.Template.AddReplacement(
                 Tokens.ClassName,
-                method.GetNodeStateClassName(
-                    m_context.ModelDesign.TargetNamespace.Value,
-                    []));
+                declaredClassName);
             context.Template.AddReplacement(
                 Tokens.OwnerClassName,
-                method.GetNodeStateClassName(
-                    m_context.ModelDesign.TargetNamespace.Value,
-                    []));
+                declaredClassName);
             context.Template.AddReplacement(
                 Tokens.ListOfInputArguments,
                 method.InputArguments,

--- a/tools/Opc.Ua.SourceGeneration.Core/Schema/ModelDesignExtensions.cs
+++ b/tools/Opc.Ua.SourceGeneration.Core/Schema/ModelDesignExtensions.cs
@@ -116,7 +116,8 @@ namespace Opc.Ua.Schema.Model
             this InstanceDesign instance,
             string targetNamespace,
             Namespace[] namespaces,
-            bool asFactory = false)
+            bool asFactory = false,
+            bool applyStandardFallback = true)
         {
             if (instance is MethodDesign method)
             {
@@ -146,10 +147,24 @@ namespace Opc.Ua.Schema.Model
 
                 if (method.HasArguments)
                 {
-                    return CoreUtils.Format(
+                    string typedClassName = CoreUtils.Format(
                         "{0}{1}MethodState",
                         asFactory ? "new " : string.Empty,
                         className);
+                    // Degrade a reference to a standard global::Opc.Ua.*MethodState
+                    // to the base MethodState when a curated Opc.Ua.Core omits the
+                    // typed class and the current model pass does not declare it
+                    // (e.g. the FileDirectoryType methods on a Robotics Programs
+                    // object). Model-generation-scoped; see
+                    // StandardMethodStateFallback.
+                    if (applyStandardFallback &&
+                        StandardMethodStateFallback.ShouldFallBackToBase(typedClassName))
+                    {
+                        return CoreUtils.Format(
+                            "{0}global::Opc.Ua.MethodState",
+                            asFactory ? "new " : string.Empty);
+                    }
+                    return typedClassName;
                 }
 
                 return CoreUtils.Format(

--- a/tools/Opc.Ua.SourceGeneration.Core/Schema/StandardMethodStateFallback.cs
+++ b/tools/Opc.Ua.SourceGeneration.Core/Schema/StandardMethodStateFallback.cs
@@ -1,0 +1,186 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using System.Collections.Generic;
+
+namespace Opc.Ua.SourceGeneration
+{
+    /// <summary>
+    /// Ambient, thread-scoped policy that lets the companion-model generator
+    /// degrade a reference to a standard (<c>global::Opc.Ua.*</c>) typed
+    /// <c>MethodState</c> class to the base <c>global::Opc.Ua.MethodState</c>
+    /// when that typed class is neither present in the compilation (a curated
+    /// <c>Opc.Ua.Core</c> may omit standard classes such as the
+    /// <c>FileDirectoryType</c> method states) nor declared by the current
+    /// generation pass.
+    /// </summary>
+    /// <remarks>
+    /// The scope is only entered around <b>model</b> generation
+    /// (<c>ModelCompilation</c>); the Stack generator that builds
+    /// <c>Opc.Ua.Core</c> itself never enters it, so it keeps the
+    /// assume-present behaviour. A method-state class is recorded as it is
+    /// <i>declared</i> (the <c>NodeStates.g.cs</c> pass, which runs before the
+    /// <c>NodeStates.ex.g.cs</c> reference pass on the same thread), so a
+    /// model that generates its own standard-namespace method-state classes
+    /// (e.g. GDS) is never wrongly degraded.
+    /// </remarks>
+    internal static class StandardMethodStateFallback
+    {
+        [ThreadStatic]
+        private static bool s_active;
+
+        [ThreadStatic]
+        private static HashSet<string> s_available;
+
+        [ThreadStatic]
+        private static HashSet<string> s_declared;
+
+        /// <summary>
+        /// Enter a fallback scope for the duration of one model compilation.
+        /// The previous scope (if any) is restored on dispose so nested or
+        /// sequential passes on the same thread do not leak state.
+        /// </summary>
+        /// <param name="availableStateTypeNames">
+        /// Simple names of the standard <c>Opc.Ua.*State</c> classes present
+        /// in the compilation (including referenced assemblies).
+        /// </param>
+        public static IDisposable Enter(IEnumerable<string> availableStateTypeNames)
+        {
+            var restore = new Scope(s_active, s_available, s_declared);
+            s_active = true;
+            s_available = availableStateTypeNames == null
+                ? new HashSet<string>(StringComparer.Ordinal)
+                : new HashSet<string>(availableStateTypeNames, StringComparer.Ordinal);
+            s_declared = new HashSet<string>(StringComparer.Ordinal);
+            return restore;
+        }
+
+        /// <summary>
+        /// Record that the current pass declares the given method-state class.
+        /// Only classes that resolve to the standard <c>global::Opc.Ua.*</c>
+        /// namespace (with no further sub-namespace, e.g. a model such as GDS
+        /// that emits its own <c>Opc.Ua.*MethodState</c>) are tracked, so a
+        /// later reference to the same standard class is not degraded.
+        /// </summary>
+        /// <param name="typedClassName">
+        /// The fully-qualified typed class name, e.g.
+        /// <c>global::Opc.Ua.RequestAccessTokenMethodState</c>.
+        /// </param>
+        public static void RecordDeclaredMethodState(string typedClassName)
+        {
+            if (s_active && TryGetStandardSimpleName(typedClassName, out string simpleName))
+            {
+                s_declared?.Add(simpleName);
+            }
+        }
+
+        /// <summary>
+        /// Whether the given fully-qualified typed method-state reference
+        /// should be degraded to the base <c>global::Opc.Ua.MethodState</c>.
+        /// True only when a scope is active, the reference names a standard
+        /// <c>global::Opc.Ua.*MethodState</c> class (no sub-namespace), and
+        /// that class is neither declared by this pass nor present in the
+        /// compilation.
+        /// </summary>
+        public static bool ShouldFallBackToBase(string typedClassName)
+        {
+            if (!s_active)
+            {
+                return false;
+            }
+            if (!TryGetStandardSimpleName(typedClassName, out string simpleName))
+            {
+                return false;
+            }
+            if (s_declared != null && s_declared.Contains(simpleName))
+            {
+                return false;
+            }
+            if (s_available != null && s_available.Contains(simpleName))
+            {
+                return false;
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// Extract the simple class name when <paramref name="typedClassName"/>
+        /// is a reference to a type directly in the standard <c>Opc.Ua</c>
+        /// namespace (i.e. <c>global::Opc.Ua.Name</c> with no further dotted
+        /// sub-namespace such as <c>global::Opc.Ua.Di.Name</c>). An optional
+        /// leading <c>new </c> (factory form) is tolerated.
+        /// </summary>
+        private static bool TryGetStandardSimpleName(string typedClassName, out string simpleName)
+        {
+            simpleName = null;
+            if (string.IsNullOrEmpty(typedClassName))
+            {
+                return false;
+            }
+            const string factoryPrefix = "new ";
+            const string standardPrefix = "global::Opc.Ua.";
+            string candidate = typedClassName.StartsWith(factoryPrefix, StringComparison.Ordinal)
+                ? typedClassName.Substring(factoryPrefix.Length)
+                : typedClassName;
+            if (!candidate.StartsWith(standardPrefix, StringComparison.Ordinal))
+            {
+                return false;
+            }
+            string remainder = candidate.Substring(standardPrefix.Length);
+            if (remainder.Length == 0 || remainder.Contains('.', StringComparison.Ordinal))
+            {
+                return false;
+            }
+            simpleName = remainder;
+            return true;
+        }
+
+        private sealed class Scope : IDisposable
+        {
+            public Scope(bool active, HashSet<string> available, HashSet<string> declared)
+            {
+                m_active = active;
+                m_available = available;
+                m_declared = declared;
+            }
+
+            public void Dispose()
+            {
+                s_active = m_active;
+                s_available = m_available;
+                s_declared = m_declared;
+            }
+
+            private readonly bool m_active;
+            private readonly HashSet<string> m_available;
+            private readonly HashSet<string> m_declared;
+        }
+    }
+}

--- a/tools/Opc.Ua.SourceGeneration.Core/Schema/StandardMethodStateFallback.cs
+++ b/tools/Opc.Ua.SourceGeneration.Core/Schema/StandardMethodStateFallback.cs
@@ -28,18 +28,20 @@
  * ======================================================================*/
 
 using System;
-using System.Collections.Generic;
+using System.Collections.Concurrent;
+using System.Collections.Immutable;
+using System.Threading;
 
 namespace Opc.Ua.SourceGeneration
 {
     /// <summary>
-    /// Ambient, thread-scoped policy that lets the companion-model generator
-    /// degrade a reference to a standard (<c>global::Opc.Ua.*</c>) typed
-    /// <c>MethodState</c> class to the base <c>global::Opc.Ua.MethodState</c>
-    /// when that typed class is neither present in the compilation (a curated
-    /// <c>Opc.Ua.Core</c> may omit standard classes such as the
-    /// <c>FileDirectoryType</c> method states) nor declared by the current
-    /// generation pass.
+    /// Ambient, execution-context-scoped policy that lets the companion-model
+    /// generator degrade a reference to a standard
+    /// (<c>global::Opc.Ua.*</c>) typed <c>MethodState</c> class to the base
+    /// <c>global::Opc.Ua.MethodState</c> when that typed class is neither
+    /// present in the compilation (a curated <c>Opc.Ua.Core</c> may omit
+    /// standard classes such as the <c>FileDirectoryType</c> method states)
+    /// nor declared by the current generation pass.
     /// </summary>
     /// <remarks>
     /// The scope is only entered around <b>model</b> generation
@@ -47,39 +49,27 @@ namespace Opc.Ua.SourceGeneration
     /// <c>Opc.Ua.Core</c> itself never enters it, so it keeps the
     /// assume-present behaviour. A method-state class is recorded as it is
     /// <i>declared</i> (the <c>NodeStates.g.cs</c> pass, which runs before the
-    /// <c>NodeStates.ex.g.cs</c> reference pass on the same thread), so a
-    /// model that generates its own standard-namespace method-state classes
-    /// (e.g. GDS) is never wrongly degraded.
+    /// <c>NodeStates.ex.g.cs</c> reference pass in the same logical execution
+    /// context), so a model that generates its own standard-namespace
+    /// method-state classes (e.g. GDS) is never wrongly degraded.
     /// </remarks>
     internal static class StandardMethodStateFallback
     {
-        [ThreadStatic]
-        private static bool s_active;
-
-        [ThreadStatic]
-        private static HashSet<string> s_available;
-
-        [ThreadStatic]
-        private static HashSet<string> s_declared;
-
         /// <summary>
         /// Enter a fallback scope for the duration of one model compilation.
         /// The previous scope (if any) is restored on dispose so nested or
-        /// sequential passes on the same thread do not leak state.
+        /// sequential passes do not leak state.
         /// </summary>
         /// <param name="availableStateTypeNames">
         /// Simple names of the standard <c>Opc.Ua.*State</c> classes present
         /// in the compilation (including referenced assemblies).
         /// </param>
-        public static IDisposable Enter(IEnumerable<string> availableStateTypeNames)
+        public static IDisposable Enter(ImmutableHashSet<string> availableStateTypeNames)
         {
-            var restore = new Scope(s_active, s_available, s_declared);
-            s_active = true;
-            s_available = availableStateTypeNames == null
-                ? new HashSet<string>(StringComparer.Ordinal)
-                : new HashSet<string>(availableStateTypeNames, StringComparer.Ordinal);
-            s_declared = new HashSet<string>(StringComparer.Ordinal);
-            return restore;
+            FallbackContext previousContext = s_context.Value;
+            s_context.Value = new FallbackContext(
+                availableStateTypeNames ?? ImmutableHashSet<string>.Empty);
+            return new Scope(previousContext);
         }
 
         /// <summary>
@@ -95,9 +85,11 @@ namespace Opc.Ua.SourceGeneration
         /// </param>
         public static void RecordDeclaredMethodState(string typedClassName)
         {
-            if (s_active && TryGetStandardSimpleName(typedClassName, out string simpleName))
+            FallbackContext context = s_context.Value;
+            if (context != null &&
+                TryGetStandardSimpleName(typedClassName, out string simpleName))
             {
-                s_declared?.Add(simpleName);
+                context.DeclaredMethodStateNames.TryAdd(simpleName, 0);
             }
         }
 
@@ -111,7 +103,8 @@ namespace Opc.Ua.SourceGeneration
         /// </summary>
         public static bool ShouldFallBackToBase(string typedClassName)
         {
-            if (!s_active)
+            FallbackContext context = s_context.Value;
+            if (context == null)
             {
                 return false;
             }
@@ -119,11 +112,11 @@ namespace Opc.Ua.SourceGeneration
             {
                 return false;
             }
-            if (s_declared != null && s_declared.Contains(simpleName))
+            if (context.DeclaredMethodStateNames.ContainsKey(simpleName))
             {
                 return false;
             }
-            if (s_available != null && s_available.Contains(simpleName))
+            if (context.AvailableStateTypeNames.Contains(simpleName))
             {
                 return false;
             }
@@ -162,25 +155,35 @@ namespace Opc.Ua.SourceGeneration
             return true;
         }
 
+        private sealed class FallbackContext
+        {
+            public FallbackContext(ImmutableHashSet<string> availableStateTypeNames)
+            {
+                AvailableStateTypeNames = availableStateTypeNames;
+                DeclaredMethodStateNames =
+                    new ConcurrentDictionary<string, byte>(StringComparer.Ordinal);
+            }
+
+            public ImmutableHashSet<string> AvailableStateTypeNames { get; }
+
+            public ConcurrentDictionary<string, byte> DeclaredMethodStateNames { get; }
+        }
+
         private sealed class Scope : IDisposable
         {
-            public Scope(bool active, HashSet<string> available, HashSet<string> declared)
+            public Scope(FallbackContext previousContext)
             {
-                m_active = active;
-                m_available = available;
-                m_declared = declared;
+                m_previousContext = previousContext;
             }
 
             public void Dispose()
             {
-                s_active = m_active;
-                s_available = m_available;
-                s_declared = m_declared;
+                s_context.Value = m_previousContext;
             }
 
-            private readonly bool m_active;
-            private readonly HashSet<string> m_available;
-            private readonly HashSet<string> m_declared;
+            private readonly FallbackContext m_previousContext;
         }
+
+        private static readonly AsyncLocal<FallbackContext> s_context = new();
     }
 }

--- a/tools/Opc.Ua.SourceGeneration/ModelCompilation.cs
+++ b/tools/Opc.Ua.SourceGeneration/ModelCompilation.cs
@@ -62,6 +62,7 @@ namespace Opc.Ua.SourceGeneration
             CompilationOptions compilationOptions,
             ImmutableArray<ModelDependencyReference> referencedModels,
             ImmutableArray<NodeManagerAttributeDiscovery> nodeManagerBindings,
+            ImmutableHashSet<string> availableStateTypeNames,
             ILogger logger)
         {
             m_context = context;
@@ -71,6 +72,7 @@ namespace Opc.Ua.SourceGeneration
             m_compilationOptions = compilationOptions;
             m_nodeManagerBindings = nodeManagerBindings;
             m_referencedModels = referencedModels;
+            m_availableStateTypeNames = availableStateTypeNames;
             m_telemetry = SourceGeneratorTelemetry.Create(logger, m_context);
         }
 
@@ -197,6 +199,15 @@ namespace Opc.Ua.SourceGeneration
                 HashSet<NodeManagerAttributeBinding> usedBindings =
                     bindings.Count > 0 ? [] : null;
                 int totalModelCount = nodesets.ModelUris.Count() + designTargets.Count;
+
+                // Enter the standard method-state fallback scope for the whole
+                // model-generation pass: a reference to a standard
+                // global::Opc.Ua.*MethodState class degrades to the base
+                // MethodState only when the typed class is neither present in
+                // the compilation nor declared by this pass. The Stack
+                // generator (which builds Opc.Ua.Core) never enters this scope.
+                using IDisposable fallbackScope =
+                    StandardMethodStateFallback.Enter(m_availableStateTypeNames);
 
                 nodesets.GenerateCode(
                     sourceFiles.WithFallback(vfs),
@@ -392,6 +403,7 @@ namespace Opc.Ua.SourceGeneration
         private readonly CompilationOptions m_compilationOptions;
         private readonly ImmutableArray<ModelDependencyReference> m_referencedModels;
         private readonly ImmutableArray<NodeManagerAttributeDiscovery> m_nodeManagerBindings;
+        private readonly ImmutableHashSet<string> m_availableStateTypeNames;
         private readonly SourceGeneratorTelemetry m_telemetry;
     }
 }

--- a/tools/Opc.Ua.SourceGeneration/ModelSourceGenerator.cs
+++ b/tools/Opc.Ua.SourceGeneration/ModelSourceGenerator.cs
@@ -61,7 +61,7 @@ namespace Opc.Ua.SourceGeneration
                         pair.Left,
                         pair.Right.GetOptions(pair.Left).ToNodeSetOptions()))
                     .Collect();
-            IncrementalValueProvider<ImmutableArray<AdditionalText>> identiferFile =
+            IncrementalValueProvider<ImmutableArray<AdditionalText>> identifierFiles =
                 context.AdditionalTextsProvider
                     .Where(f => f.IsIdentifierFile())
                     .Collect();
@@ -86,23 +86,57 @@ namespace Opc.Ua.SourceGeneration
                 .Where(static m => m is not null)
                 .Collect();
 
+            var modelFiles = inputFiles
+                .Combine(identifierFiles)
+                .Select(static (pair, _) => (
+                    InputFiles: pair.Left,
+                    IdentifierFiles: pair.Right));
+            var modelSettings = options
+                .Combine(settings)
+                .Select(static (pair, _) => (
+                    Options: pair.Left,
+                    CompilationOptions: pair.Right));
+            var modelReferences = referencedModels
+                .Combine(nodeManagerBindings)
+                .Select(static (pair, _) => (
+                    ReferencedModels: pair.Left,
+                    NodeManagerBindings: pair.Right));
+            var modelDependencies = modelReferences
+                .Combine(stateTypeIndex)
+                .Select(static (pair, _) => (
+                    ReferencedModels: pair.Left.ReferencedModels,
+                    NodeManagerBindings: pair.Left.NodeManagerBindings,
+                    AvailableStateTypeNames: pair.Right));
+            var configuredModel = modelFiles
+                .Combine(modelSettings)
+                .Select(static (pair, _) => (
+                    InputFiles: pair.Left.InputFiles,
+                    IdentifierFiles: pair.Left.IdentifierFiles,
+                    Options: pair.Right.Options,
+                    CompilationOptions: pair.Right.CompilationOptions));
+            IncrementalValueProvider<ModelCompilationInput> modelCompilationInput =
+                configuredModel
+                    .Combine(modelDependencies)
+                    .Select(static (pair, _) => new ModelCompilationInput(
+                        pair.Left.InputFiles,
+                        pair.Left.IdentifierFiles,
+                        pair.Left.Options,
+                        pair.Left.CompilationOptions,
+                        pair.Right.ReferencedModels,
+                        pair.Right.NodeManagerBindings,
+                        pair.Right.AvailableStateTypeNames));
+
             context.RegisterSourceOutput(
-                inputFiles
-                    .Combine(identiferFile)
-                    .Combine(options)
-                    .Combine(settings)
-                    .Combine(referencedModels)
-                    .Combine(nodeManagerBindings)
-                    .Combine(stateTypeIndex),
-                (context, combination) => new ModelCompilation(
+                modelCompilationInput,
+                (context, input) => new ModelCompilation(
                     context,
-                    combination.Left.Left.Left.Left.Left.Left,
-                    combination.Left.Left.Left.Left.Left.Right,
-                    combination.Left.Left.Left.Left.Right,
-                    combination.Left.Left.Left.Right,
-                    combination.Left.Left.Right,
-                    combination.Left.Right,
-                    combination.Right,
+                    input.InputFiles,
+                    input.IdentifierFiles,
+                    input.Options,
+                    input.CompilationOptions,
+                    input.ReferencedModels,
+                    input.NodeManagerBindings,
+                    input.AvailableStateTypeNames,
                     Logger).Emit(context.CancellationToken));
 
             IncrementalValueProvider<bool> publicDataTypeExtensions =
@@ -120,5 +154,14 @@ namespace Opc.Ua.SourceGeneration
                 static (spc, pair) => DataTypeCompilation.EmitBatch(
                     spc, pair.Left, pair.Right));
         }
+
+        private readonly record struct ModelCompilationInput(
+            ImmutableArray<(AdditionalText, NodesetFileOptions)> InputFiles,
+            ImmutableArray<AdditionalText> IdentifierFiles,
+            ModelCompilationOptions Options,
+            CompilationOptions CompilationOptions,
+            ImmutableArray<ModelDependencyReference> ReferencedModels,
+            ImmutableArray<NodeManagerAttributeDiscovery> NodeManagerBindings,
+            ImmutableHashSet<string> AvailableStateTypeNames);
     }
 }

--- a/tools/Opc.Ua.SourceGeneration/ModelSourceGenerator.cs
+++ b/tools/Opc.Ua.SourceGeneration/ModelSourceGenerator.cs
@@ -74,6 +74,9 @@ namespace Opc.Ua.SourceGeneration
             IncrementalValueProvider<ImmutableArray<ModelDependencyReference>> referencedModels =
                 context.CompilationProvider
                     .Select((c, _) => ReferencedModelDependencyScanner.Scan(c));
+            IncrementalValueProvider<ImmutableHashSet<string>> stateTypeIndex =
+                context.CompilationProvider
+                    .Select((c, _) => OpcUaStateTypeIndex.Build(c));
 
             IncrementalValueProvider<ImmutableArray<NodeManagerAttributeDiscovery>> nodeManagerBindings =
                 context.SyntaxProvider.ForAttributeWithMetadataName(
@@ -89,10 +92,12 @@ namespace Opc.Ua.SourceGeneration
                     .Combine(options)
                     .Combine(settings)
                     .Combine(referencedModels)
-                    .Combine(nodeManagerBindings),
+                    .Combine(nodeManagerBindings)
+                    .Combine(stateTypeIndex),
                 (context, combination) => new ModelCompilation(
                     context,
-                    combination.Left.Left.Left.Left.Left,
+                    combination.Left.Left.Left.Left.Left.Left,
+                    combination.Left.Left.Left.Left.Left.Right,
                     combination.Left.Left.Left.Left.Right,
                     combination.Left.Left.Left.Right,
                     combination.Left.Left.Right,

--- a/tools/Opc.Ua.SourceGeneration/OpcUaStateTypeIndex.cs
+++ b/tools/Opc.Ua.SourceGeneration/OpcUaStateTypeIndex.cs
@@ -1,0 +1,97 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+
+namespace Opc.Ua.SourceGeneration
+{
+    /// <summary>
+    /// Builds the set of simple names of the standard <c>Opc.Ua.*State</c>
+    /// classes (node-state and method-state) available in a compilation,
+    /// including referenced assemblies such as <c>Opc.Ua.Core</c>. The model
+    /// generator consults this set (together with the classes declared in the
+    /// current pass) to decide whether a reference to a standard typed
+    /// <c>MethodState</c> can be emitted, or must degrade to the base
+    /// <c>MethodState</c> because a curated Core omits the typed class.
+    /// </summary>
+    internal static class OpcUaStateTypeIndex
+    {
+        /// <summary>
+        /// Enumerate the immediate type members of the <c>Opc.Ua</c> namespace
+        /// whose name ends with <c>State</c>.
+        /// </summary>
+        public static ImmutableHashSet<string> Build(Compilation compilation)
+        {
+            ImmutableHashSet<string>.Builder builder =
+                ImmutableHashSet.CreateBuilder<string>(StringComparer.Ordinal);
+            if (compilation == null)
+            {
+                return builder.ToImmutable();
+            }
+            INamespaceSymbol opcUa = ResolveNamespace(compilation.GlobalNamespace, "Opc", "Ua");
+            if (opcUa != null)
+            {
+                foreach (INamedTypeSymbol type in opcUa.GetTypeMembers())
+                {
+                    if (type.Name.EndsWith("State", StringComparison.Ordinal))
+                    {
+                        builder.Add(type.Name);
+                    }
+                }
+            }
+            return builder.ToImmutable();
+        }
+
+        private static INamespaceSymbol ResolveNamespace(
+            INamespaceSymbol root, params string[] path)
+        {
+            INamespaceSymbol current = root;
+            foreach (string segment in path)
+            {
+                if (current == null)
+                {
+                    return null;
+                }
+                INamespaceSymbol next = null;
+                foreach (INamespaceSymbol child in current.GetNamespaceMembers())
+                {
+                    if (string.Equals(child.Name, segment, StringComparison.Ordinal))
+                    {
+                        next = child;
+                        break;
+                    }
+                }
+                current = next;
+            }
+            return current;
+        }
+    }
+}


### PR DESCRIPTION
## What

Enhancements to the model **source generator** so that a *compiled* companion `NodeSet2` (an OPC companion spec such as Robotics/IA, or an application companion model such as an OpenUSD binding) can be source-generated:

- Add `OpcUaStateTypeIndex` and wire it through `ModelCompilation` / `ModelSourceGenerator` so standard (`ns=0`) node-state / method-state class names are resolved from the referenced `Opc.Ua.Core(.Types)` metadata during the model pass.
- Add `StandardMethodStateFallback`: when a compiled NodeSet instantiates a standard type that carries methods (e.g. a `FileDirectoryType` object whose `Delete` method is modelled as a plain instance method), the default naming can compute a `global::Opc.Ua.*MethodState` class name that `Opc.Ua.Core.Types` never emits under that name (Core emits the curated name derived from the method **type**, e.g. `DeleteFileMethodState`). This degrades an **unresolved** standard `global::Opc.Ua.*MethodState` reference to the base `global::Opc.Ua.MethodState` — **only** when that typed class is neither declared by the current pass nor present in the compilation. It is keyed on the exact `Opc.Ua` namespace, records declared method-state classes at their declaration site (so a model that legitimately emits its own `Opc.Ua.*MethodState`, e.g. GDS, is never degraded), and the Stack pass that builds `Opc.Ua.Core.Types` never enters the scope.
- Supporting changes in `NodeStateGenerator`, `ModelDesignExtensions`, and `FluentBuilderGenerator`.
- `Opc.Ua.Types`: expose internals to `Opc.Ua.Core.Encoders.Tests`.

## Why

Today a companion model that (a) is consumed as a compiled `NodeSet2` and (b) instantiates a standard type that carries methods or state-machine members cannot be source-generated without this fallback. This is the scoped, model-generation-only interim workaround tracked by #4060; the proper long-term fix is an upstream name-resolution step in the generator (also described in #4060), which would make the fallback unnecessary.

## Validation

- Generator builds (`netstandard2.0`).
- `Opc.Ua.Core.Types` generates and builds.
- Full `Opc.Ua.SourceGeneration.Core` test suite passes: **3718 passed / 8 skipped / 0 failed**.
- Full `Opc.Ua.SourceGeneration` test suite passes: **68 passed / 0 skipped / 0 failed**.

## Context

This is the generic, upstream-worthy prerequisite extracted from a larger OpenUSD/Robotics integration. The full integration lives on the stacked branch `marcschier/openusd-integration` (this branch is a clean prefix of it) and is not part of this PR.

