### PR TITLE
Harden managed subscription recreation and reapply

### DIFF
--- a/samples/Quickstarts.Servers/Boiler/BoilerState.cs
+++ b/samples/Quickstarts.Servers/Boiler/BoilerState.cs
@@ -31,6 +31,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Opc.Ua;
 using Opc.Ua.Server;
 using Quickstarts.Servers;
@@ -299,7 +300,7 @@ namespace Boiler
             }
         }
 
-        private ILogger m_logger = null!;
+        private ILogger m_logger = NullLogger<BoilerState>.Instance;
         private ISystemContext m_simulationContext = null!;
         private ITimer? m_simulationTimer;
     }

--- a/src/Opc.Ua.Client/Subscription/CompositeMonitoredItemCollection.cs
+++ b/src/Opc.Ua.Client/Subscription/CompositeMonitoredItemCollection.cs
@@ -67,7 +67,9 @@ namespace Opc.Ua.Client.Subscriptions.MonitoredItems
     /// </list>
     /// </para>
     /// </summary>
-    internal sealed class CompositeMonitoredItemCollection : IMonitoredItemCollection
+    internal sealed class CompositeMonitoredItemCollection :
+        IMonitoredItemCollection,
+        IMonitoredItemRetryCollection
     {
         /// <summary>
         /// Construct a composite over the supplied (shared) partition
@@ -461,6 +463,39 @@ namespace Opc.Ua.Client.Subscriptions.MonitoredItems
                 MaybeArmIdleTimer(owner);
             }
             return removed;
+        }
+
+        /// <inheritdoc/>
+        public bool TryRequeue(uint clientHandle)
+        {
+            if (IsSinglePartitionFastPath)
+            {
+                return m_partitions[0].MonitoredItems is
+                    IMonitoredItemRetryCollection retry &&
+                    retry.TryRequeue(clientHandle);
+            }
+            IManagedSubscription? owner = null;
+            lock (m_partitionLock)
+            {
+                if (m_byClientHandle.TryGetValue(clientHandle, out Entry entry))
+                {
+                    owner = entry.Partition;
+                }
+                else
+                {
+                    foreach (IManagedSubscription partition in m_partitions)
+                    {
+                        if (partition.MonitoredItems.TryGetMonitoredItemByClientHandle(
+                            clientHandle, out _))
+                        {
+                            owner = partition;
+                            break;
+                        }
+                    }
+                }
+            }
+            return owner?.MonitoredItems is IMonitoredItemRetryCollection retryCollection &&
+                retryCollection.TryRequeue(clientHandle);
         }
 
         /// <summary>

--- a/src/Opc.Ua.Client/Subscription/ILogicalSubscription.cs
+++ b/src/Opc.Ua.Client/Subscription/ILogicalSubscription.cs
@@ -28,8 +28,6 @@
  * ======================================================================*/
 
 using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Opc.Ua.Client.Subscriptions
 {
@@ -60,14 +58,6 @@ namespace Opc.Ua.Client.Subscriptions
         /// <see cref="IPartitionedSubscription.PartitionIds"/>.
         /// </summary>
         IReadOnlyList<IManagedSubscription> Partitions { get; }
-
-        /// <summary>
-        /// Recreate every partition on the new session after
-        /// reconnect/recreate. Mirrors
-        /// <see cref="IManagedSubscription.RecreateAsync"/>; called
-        /// by <see cref="SubscriptionManager.RecreateSubscriptionsAsync"/>.
-        /// </summary>
-        ValueTask RecreateAsync(CancellationToken ct = default);
 
         /// <summary>
         /// Notify every partition that the publish pipeline has

--- a/src/Opc.Ua.Client/Subscription/IManagedSubscription.cs
+++ b/src/Opc.Ua.Client/Subscription/IManagedSubscription.cs
@@ -53,13 +53,6 @@ namespace Opc.Ua.Client.Subscriptions
             CancellationToken ct = default);
 
         /// <summary>
-        /// Recreate the subscription on a new session
-        /// </summary>
-        /// <param name="ct"></param>
-        /// <returns></returns>
-        ValueTask RecreateAsync(CancellationToken ct = default);
-
-        /// <summary>
         /// Notify subscription that the subscription manager has paused or
         /// resumed operations.
         /// </summary>

--- a/src/Opc.Ua.Client/Subscription/IMessageAckQueue.cs
+++ b/src/Opc.Ua.Client/Subscription/IMessageAckQueue.cs
@@ -27,6 +27,7 @@
  * http://opcfoundation.org/License/MIT/1.00/
  * ======================================================================*/
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -57,17 +58,24 @@ namespace Opc.Ua.Client.Subscriptions
             CancellationToken ct = default);
 
         /// <summary>
+        /// Pauses publish ingress, drains in-flight publish requests, runs the
+        /// supplied operation, and then restores the manager's requested
+        /// publishing state.
+        /// </summary>
+        /// <param name="operation">Operation to run while publish ingress is
+        /// quiesced.</param>
+        /// <param name="ct">Cancellation token.</param>
+        ValueTask RunWithPublishingQuiescedAsync(
+            Func<CancellationToken, ValueTask> operation,
+            CancellationToken ct = default);
+
+        /// <summary>
         /// Drops every queued acknowledgement targeting the given
         /// <paramref name="subscriptionId"/>. Used by the
-        /// recovery-on-unsolicited-transfer path to prevent stale
-        /// acks from generating <c>BadSubscriptionIdInvalid</c>
-        /// responses after the subscription has been invalidated
-        /// and is about to be recreated. Must be invoked while the
-        /// old subscription id is still uniquely "dead" — i.e.
-        /// before recreate assigns a new id — because servers that
-        /// re-use subscription identifiers (e.g. Kepware always
-        /// starting at <c>1</c>) would otherwise collide
-        /// generations.
+        /// recreate path after the old server-side subscription has
+        /// been retired and while publish ingress remains quiesced.
+        /// This prevents stale acknowledgements from crossing into a
+        /// replacement generation when a server reuses identifiers.
         /// </summary>
         /// <param name="subscriptionId">The subscription id whose
         /// queued acknowledgements should be dropped.</param>

--- a/src/Opc.Ua.Client/Subscription/IMonitoredItem.cs
+++ b/src/Opc.Ua.Client/Subscription/IMonitoredItem.cs
@@ -33,6 +33,18 @@ using System.Collections.Generic;
 namespace Opc.Ua.Client.Subscriptions.MonitoredItems
 {
     /// <summary>
+    /// Exposes whether a monitored item still has desired-state changes
+    /// waiting to be applied to the server.
+    /// </summary>
+    public interface IMonitoredItemApplyState
+    {
+        /// <summary>
+        /// Whether one or more changes are waiting for a final apply result.
+        /// </summary>
+        bool HasPendingChanges { get; }
+    }
+
+    /// <summary>
     /// The current monitored item inside a subscription
     /// </summary>
     public interface IMonitoredItem

--- a/src/Opc.Ua.Client/Subscription/IMonitoredItemCollection.cs
+++ b/src/Opc.Ua.Client/Subscription/IMonitoredItemCollection.cs
@@ -94,4 +94,22 @@ namespace Opc.Ua.Client.Subscriptions.MonitoredItems
         IReadOnlyList<IMonitoredItem> Update(IReadOnlyList<(string Name,
             IOptionsMonitor<MonitoredItemOptions> Options)> state);
     }
+
+    /// <summary>
+    /// Optional monitored-item collection capability for requeueing one
+    /// failed or otherwise unapplied item after its internal retry budget
+    /// has been exhausted.
+    /// </summary>
+    public interface IMonitoredItemRetryCollection
+    {
+        /// <summary>
+        /// Requeues the current desired state for one failed or unapplied
+        /// monitored item.
+        /// </summary>
+        /// <param name="clientHandle">The monitored-item client handle.</param>
+        /// <returns>
+        /// <c>true</c> if the item was found and its desired state was requeued.
+        /// </returns>
+        bool TryRequeue(uint clientHandle);
+    }
 }

--- a/src/Opc.Ua.Client/Subscription/ISubscription.cs
+++ b/src/Opc.Ua.Client/Subscription/ISubscription.cs
@@ -104,6 +104,13 @@ namespace Opc.Ua.Client.Subscriptions
             CancellationToken ct = default);
 
         /// <summary>
+        /// Recreates this subscription and all of its monitored items on the
+        /// current session.
+        /// </summary>
+        /// <param name="ct">Cancellation token.</param>
+        ValueTask RecreateAsync(CancellationToken ct = default);
+
+        /// <summary>
         /// Mark this subscription as durable on the server (OPC UA Part 4
         /// §5.13.9 <c>SetSubscriptionDurable</c>). A durable subscription
         /// retains its monitored item state and message queue across

--- a/src/Opc.Ua.Client/Subscription/ISubscription.cs
+++ b/src/Opc.Ua.Client/Subscription/ISubscription.cs
@@ -108,6 +108,13 @@ namespace Opc.Ua.Client.Subscriptions
         /// current session.
         /// </summary>
         /// <param name="ct">Cancellation token.</param>
+        /// <exception cref="InvalidOperationException">
+        /// The method is called from one of this subscription's notification
+        /// callbacks. Schedule the recreate after the callback returns.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        /// Disposal of the subscription has started.
+        /// </exception>
         ValueTask RecreateAsync(CancellationToken ct = default);
 
         /// <summary>

--- a/src/Opc.Ua.Client/Subscription/LogicalSubscription.cs
+++ b/src/Opc.Ua.Client/Subscription/LogicalSubscription.cs
@@ -347,7 +347,9 @@ namespace Opc.Ua.Client.Subscriptions
         /// <inheritdoc/>
         public async ValueTask RecreateAsync(CancellationToken ct = default)
         {
-            foreach (IManagedSubscription partition in SnapshotPartitions())
+            IReadOnlyList<IManagedSubscription> partitions = SnapshotPartitions();
+            ThrowIfDispatchingNotification(partitions, "recreated");
+            foreach (IManagedSubscription partition in partitions)
             {
                 await partition.RecreateAsync(ct).ConfigureAwait(false);
             }
@@ -602,6 +604,8 @@ namespace Opc.Ua.Client.Subscriptions
 
         private async ValueTask DisposeCoreAsync()
         {
+            IReadOnlyList<IManagedSubscription> snapshot = SnapshotPartitions();
+            ThrowIfDispatchingNotification(snapshot, "disposed");
             // Stop any armed secondary-partition idle timers first so
             // they cannot fire against partitions we are tearing
             // down.
@@ -611,7 +615,6 @@ namespace Opc.Ua.Client.Subscriptions
             // notification handler in subsequent milestones, so removing
             // them first avoids the secondary's dispatch worker observing
             // a disposed primary handler.
-            IReadOnlyList<IManagedSubscription> snapshot = SnapshotPartitions();
             for (int i = snapshot.Count - 1; i >= 0; i--)
             {
                 await snapshot[i].DisposeAsync().ConfigureAwait(false);
@@ -620,6 +623,23 @@ namespace Opc.Ua.Client.Subscriptions
             // their in-flight notification callbacks can run their
             // semaphore release before the primitive is freed.
             m_forwardingHandler?.Dispose();
+        }
+
+        private static void ThrowIfDispatchingNotification(
+            IReadOnlyList<IManagedSubscription> partitions,
+            string operation)
+        {
+            foreach (IManagedSubscription partition in partitions)
+            {
+                if (partition is Subscription concrete &&
+                    concrete.IsDispatchingCallback)
+                {
+                    throw new InvalidOperationException(
+                        $"A logical subscription cannot be {operation} from " +
+                        "one of its notification callbacks. Schedule the " +
+                        "operation after the callback returns.");
+                }
+            }
         }
 
         /// <summary>
@@ -670,11 +690,9 @@ namespace Opc.Ua.Client.Subscriptions
         /// <summary>
         /// Wire the partition's
         /// <see cref="Subscription.OnAfterCreateAsync"/> hook to
-        /// invoke <see cref="Subscription.SetAsDurableAsync"/>. The
-        /// hook fires once per partition lifetime — the state
-        /// machine clears it after the first Create — so the wrapper
-        /// reinstalls it on every <see cref="SetAsDurableAsync"/>
-        /// call to cover reconnect / recreate cycles.
+        /// invoke <see cref="Subscription.SetAsDurableAsync"/> after every
+        /// physical create, preserving durable intent through reconnect and
+        /// automatic recovery.
         /// </summary>
         private static void InstallDurableHook(
             IManagedSubscription partition, TimeSpan lifetime)

--- a/src/Opc.Ua.Client/Subscription/LogicalSubscription.cs
+++ b/src/Opc.Ua.Client/Subscription/LogicalSubscription.cs
@@ -349,9 +349,33 @@ namespace Opc.Ua.Client.Subscriptions
         {
             IReadOnlyList<IManagedSubscription> partitions = SnapshotPartitions();
             ThrowIfDispatchingNotification(partitions, "recreated");
-            foreach (IManagedSubscription partition in partitions)
+            await m_recreateGate.WaitAsync(ct).ConfigureAwait(false);
+            try
             {
-                await partition.RecreateAsync(ct).ConfigureAwait(false);
+                partitions = SnapshotPartitions();
+                ThrowIfDispatchingNotification(partitions, "recreated");
+                if (m_pendingRecreatePartitions == null)
+                {
+                    m_pendingRecreatePartitions = [.. partitions];
+                }
+                else
+                {
+                    var current = new HashSet<IManagedSubscription>(partitions);
+                    m_pendingRecreatePartitions.RemoveAll(
+                        partition => !current.Contains(partition));
+                }
+
+                while (m_pendingRecreatePartitions.Count != 0)
+                {
+                    IManagedSubscription partition = m_pendingRecreatePartitions[0];
+                    await partition.RecreateAsync(ct).ConfigureAwait(false);
+                    m_pendingRecreatePartitions.RemoveAt(0);
+                }
+                m_pendingRecreatePartitions = null;
+            }
+            finally
+            {
+                m_recreateGate.Release();
             }
         }
 
@@ -761,6 +785,10 @@ namespace Opc.Ua.Client.Subscriptions
         private readonly List<IManagedSubscription> m_partitions;
         private readonly object m_partitionLock;
         private readonly CompositeMonitoredItemCollection m_monitoredItems;
+#pragma warning disable CA2213 // Retained so concurrent recreate waiters can release safely.
+        private readonly SemaphoreSlim m_recreateGate = new(1, 1);
+#pragma warning restore CA2213 // Disposable fields should be disposed
+        private List<IManagedSubscription>? m_pendingRecreatePartitions;
         private PartitionForwardingHandler? m_forwardingHandler;
         private TimeSpan? m_durableLifetime;
         private string? m_logicalGroupId;

--- a/src/Opc.Ua.Client/Subscription/MessageProcessor.cs
+++ b/src/Opc.Ua.Client/Subscription/MessageProcessor.cs
@@ -131,7 +131,8 @@ namespace Opc.Ua.Client.Subscriptions
             }
             LastNotificationTimestamp = TimeProvider.GetTimestamp();
             await m_messages.Writer.WriteAsync(new IncomingMessage(message, stringTable,
-                TimeProvider.GetUtcNow(), Volatile.Read(ref m_generation)))
+                TimeProvider.GetUtcNow(),
+                Volatile.Read(ref m_generation)))
                 .ConfigureAwait(false);
         }
 

--- a/src/Opc.Ua.Client/Subscription/MessageProcessor.cs
+++ b/src/Opc.Ua.Client/Subscription/MessageProcessor.cs
@@ -108,6 +108,13 @@ namespace Opc.Ua.Client.Subscriptions
         /// <inheritdoc/>
         public ValueTask DisposeAsync()
         {
+            if (IsDispatchingNotification)
+            {
+                throw new InvalidOperationException(
+                    "A subscription cannot be disposed from one of its " +
+                    "notification callbacks. Schedule disposal after the " +
+                    "callback returns.");
+            }
             GC.SuppressFinalize(this);
             return DisposeAsync(true);
         }
@@ -124,7 +131,8 @@ namespace Opc.Ua.Client.Subscriptions
             }
             LastNotificationTimestamp = TimeProvider.GetTimestamp();
             await m_messages.Writer.WriteAsync(new IncomingMessage(message, stringTable,
-                TimeProvider.GetUtcNow())).ConfigureAwait(false);
+                TimeProvider.GetUtcNow(), Volatile.Read(ref m_generation)))
+                .ConfigureAwait(false);
         }
 
         /// <summary>
@@ -143,6 +151,7 @@ namespace Opc.Ua.Client.Subscriptions
                 }
                 finally
                 {
+                    m_messageDispatchGate.Dispose();
                     m_cts.Dispose();
                     (m_messages as IDisposable)?.Dispose();
                     Disposed = true;
@@ -299,6 +308,33 @@ namespace Opc.Ua.Client.Subscriptions
         /// <returns></returns>
         private async Task ProcessMessageAsync(IncomingMessage incoming, CancellationToken ct)
         {
+            await m_messageDispatchGate.WaitAsync(ct).ConfigureAwait(false);
+            try
+            {
+                if (incoming.Generation != Volatile.Read(ref m_generation))
+                {
+                    return;
+                }
+                bool wasDispatching = m_dispatchContext.Value;
+                m_dispatchContext.Value = true;
+                try
+                {
+                    await ProcessMessageCoreAsync(incoming, ct).ConfigureAwait(false);
+                }
+                finally
+                {
+                    m_dispatchContext.Value = wasDispatching;
+                }
+            }
+            finally
+            {
+                m_messageDispatchGate.Release();
+            }
+        }
+
+        private async Task ProcessMessageCoreAsync(
+            IncomingMessage incoming, CancellationToken ct)
+        {
             uint curSeqNum = incoming.Message.SequenceNumber;
             bool isKeepAlive = incoming.Message.NotificationData.Count == 0;
             const uint kBackwardThreshold = 1u << 31;
@@ -387,6 +423,36 @@ namespace Opc.Ua.Client.Subscriptions
                 incoming.Message,
                 PublishState.None,
                 ct).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Retires the current server-side generation while message delivery is
+        /// quiesced, resets generation-specific cursors, and initializes the
+        /// replacement before queued messages can resume.
+        /// </summary>
+        /// <param name="retireAsync">Retires the current generation.</param>
+        /// <param name="initializeAsync">Initializes the replacement generation.</param>
+        /// <param name="ct">Cancellation token.</param>
+        protected async ValueTask ResetMessageGenerationAsync(
+            Func<CancellationToken, ValueTask> retireAsync,
+            Func<CancellationToken, ValueTask> initializeAsync,
+            CancellationToken ct)
+        {
+            await m_messageDispatchGate.WaitAsync(ct).ConfigureAwait(false);
+            try
+            {
+                await retireAsync(ct).ConfigureAwait(false);
+                Interlocked.Increment(ref m_generation);
+                LastSequenceNumberProcessed = 0;
+                LastDataSequenceNumberProcessed = 0;
+                LastNotificationTimestamp = 0;
+                AvailableInRetransmissionQueue = [];
+                await initializeAsync(ct).ConfigureAwait(false);
+            }
+            finally
+            {
+                m_messageDispatchGate.Release();
+            }
         }
 
         /// <summary>
@@ -557,10 +623,12 @@ namespace Opc.Ua.Client.Subscriptions
         /// <param name="Message"></param>
         /// <param name="StringTable"></param>
         /// <param name="Enqueued"></param>
+        /// <param name="Generation"></param>
         private readonly record struct IncomingMessage(
             NotificationMessage Message,
             IReadOnlyList<string> StringTable,
-            DateTimeOffset Enqueued)
+            DateTimeOffset Enqueued,
+            long Generation)
         {
             public static int Compare(IncomingMessage message, IncomingMessage other)
             {
@@ -590,12 +658,22 @@ namespace Opc.Ua.Client.Subscriptions
         /// subscription that the server has invalidated under us.
         /// </summary>
         protected IMessageAckQueue AckQueue { get; }
+
+        /// <summary>
+        /// Whether the current asynchronous flow is dispatching one of this
+        /// processor's notification callbacks.
+        /// </summary>
+        protected bool IsDispatchingNotification => m_dispatchContext.Value;
+
         private readonly ISubscriptionServiceSetClientMethods m_services;
-        // CA2213: m_cts is disposed in DisposeAsync(bool) — suppressed because
-        // the analyzer does not track IAsyncDisposable disposal paths.
+        // CA2213: both fields are disposed in DisposeAsync(bool) — suppressed
+        // because the analyzer does not track IAsyncDisposable disposal paths.
 #pragma warning disable CA2213
+        private readonly SemaphoreSlim m_messageDispatchGate = new(1, 1);
         private readonly CancellationTokenSource m_cts = new();
 #pragma warning restore CA2213
+        private readonly AsyncLocal<bool> m_dispatchContext = new();
+        private long m_generation;
         private readonly Task m_messageWorkerTask;
         private readonly Channel<IncomingMessage> m_messages;
     }

--- a/src/Opc.Ua.Client/Subscription/MonitoredItem.cs
+++ b/src/Opc.Ua.Client/Subscription/MonitoredItem.cs
@@ -807,6 +807,34 @@ namespace Opc.Ua.Client.Subscriptions.MonitoredItems
         }
 
         /// <summary>
+        /// Requeue the current desired state after a final apply failure or
+        /// when the item otherwise remains unapplied.
+        /// </summary>
+        /// <returns>
+        /// <c>true</c> if a fresh apply change was queued.
+        /// </returns>
+        internal bool TryRequeue()
+        {
+            if (m_disposedValue || HasPendingChanges)
+            {
+                return false;
+            }
+            MonitoredItemOptions options = m_options.CurrentValue;
+            if (options.StartNodeId.IsNull)
+            {
+                return false;
+            }
+            if (Created &&
+                ServiceResult.IsGood(Error) &&
+                CurrentMonitoringMode == options.MonitoringMode)
+            {
+                return false;
+            }
+            m_pendingChanges.Enqueue(new Change(this, options, null));
+            return true;
+        }
+
+        /// <summary>
         /// Change steps to apply to the monitored items in the
         /// subscription context. The change list is a queue of
         /// steps to perform inside the subscription.

--- a/src/Opc.Ua.Client/Subscription/MonitoredItem.cs
+++ b/src/Opc.Ua.Client/Subscription/MonitoredItem.cs
@@ -44,7 +44,10 @@ namespace Opc.Ua.Client.Subscriptions.MonitoredItems
     /// A monitored item that can be extended to add extra
     /// information as context in the subscription.
     /// </summary>
-    internal abstract class MonitoredItem : IMonitoredItem, IAsyncDisposable
+    internal abstract class MonitoredItem :
+        IMonitoredItem,
+        IMonitoredItemApplyState,
+        IAsyncDisposable
     {
         /// <inheritdoc/>
         public string Name { get; }
@@ -57,6 +60,9 @@ namespace Opc.Ua.Client.Subscriptions.MonitoredItems
 
         /// <inheritdoc/>
         public bool Created => ServerId != 0;
+
+        /// <inheritdoc/>
+        public bool HasPendingChanges => !m_pendingChanges.IsEmpty;
 
         /// <inheritdoc/>
         public ServiceResult Error { get; private set; }

--- a/src/Opc.Ua.Client/Subscription/MonitoredItemManager.cs
+++ b/src/Opc.Ua.Client/Subscription/MonitoredItemManager.cs
@@ -44,6 +44,7 @@ namespace Opc.Ua.Client.Subscriptions.MonitoredItems
     /// A managed set of monitored items inside a subscription.
     /// </summary>
     internal sealed class MonitoredItemManager : IMonitoredItemCollection,
+        IMonitoredItemRetryCollection,
         IMonitoredItemContext, IAsyncDisposable
     {
         /// <inheritdoc/>
@@ -146,6 +147,23 @@ namespace Opc.Ua.Client.Subscriptions.MonitoredItems
             }
             m_context.Update();
             return true;
+        }
+
+        /// <inheritdoc/>
+        public bool TryRequeue(uint clientHandle)
+        {
+            bool requeued;
+            lock (m_monitoredItemsLock)
+            {
+                requeued = m_monitoredItems.TryGetValue(
+                    clientHandle, out MonitoredItem? item) &&
+                    item.TryRequeue();
+            }
+            if (requeued)
+            {
+                m_context.Update();
+            }
+            return requeued;
         }
 
         /// <summary>

--- a/src/Opc.Ua.Client/Subscription/PartitionForwardingHandler.cs
+++ b/src/Opc.Ua.Client/Subscription/PartitionForwardingHandler.cs
@@ -28,6 +28,7 @@
  * ======================================================================*/
 
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -177,6 +178,8 @@ namespace Opc.Ua.Client.Subscriptions
             await m_serialise.WaitAsync(ct).ConfigureAwait(false);
             try
             {
+                publishStateMask = AggregatePublishState(
+                    subscription, state, publishStateMask);
                 await m_userHandler.OnSubscriptionStateChangedAsync(logical,
                     state, publishStateMask, ct).ConfigureAwait(false);
             }
@@ -184,6 +187,34 @@ namespace Opc.Ua.Client.Subscriptions
             {
                 m_serialise.Release();
             }
+        }
+
+        private PublishState AggregatePublishState(ISubscription subscription,
+            SubscriptionState state, PublishState publishStateMask)
+        {
+            bool wasStopped = m_stoppedSubscriptions.Count != 0;
+            if (publishStateMask.HasFlag(PublishState.Stopped))
+            {
+                m_stoppedSubscriptions.Add(subscription);
+            }
+            if (publishStateMask.HasFlag(PublishState.Recovered) ||
+                publishStateMask.HasFlag(PublishState.Completed) ||
+                state is SubscriptionState.Created or SubscriptionState.Deleted)
+            {
+                m_stoppedSubscriptions.Remove(subscription);
+            }
+
+            bool isStopped = m_stoppedSubscriptions.Count != 0;
+            publishStateMask &= ~(PublishState.Stopped | PublishState.Recovered);
+            if (isStopped)
+            {
+                publishStateMask |= PublishState.Stopped;
+            }
+            else if (wasStopped)
+            {
+                publishStateMask |= PublishState.Recovered;
+            }
+            return publishStateMask;
         }
 
         /// <inheritdoc/>
@@ -194,6 +225,7 @@ namespace Opc.Ua.Client.Subscriptions
 
         private readonly ISubscriptionNotificationHandler m_userHandler;
         private readonly SemaphoreSlim m_serialise = new(1, 1);
+        private readonly HashSet<ISubscription> m_stoppedSubscriptions = [];
         private ISubscription? m_logical;
     }
 }

--- a/src/Opc.Ua.Client/Subscription/Subscription.cs
+++ b/src/Opc.Ua.Client/Subscription/Subscription.cs
@@ -100,8 +100,7 @@ namespace Opc.Ua.Client.Subscriptions
         /// <summary>
         /// <para>
         /// Optional callback invoked by <see cref="StateManagerAsync"/>
-        /// exactly once per partition lifetime, immediately after a
-        /// successful <see cref="CreateAsync"/> and before the first
+        /// after every successful <see cref="CreateAsync"/> and before the first
         /// <see cref="MonitoredItemManager.ApplyChangesAsync"/>
         /// in the same iteration of the state-manager loop. Used by
         /// <see cref="LogicalSubscription"/> to satisfy the OPC UA
@@ -114,11 +113,10 @@ namespace Opc.Ua.Client.Subscriptions
         /// <c>CreateMonitoredItems</c> request.
         /// </para>
         /// <para>
-        /// The state machine clears the property after invoking it so
-        /// modify cycles do not re-run the hook. The owning wrapper
-        /// re-installs the hook before the next Create pass (e.g.
-        /// after reconnect / recreate) when durable intent has been
-        /// recorded.
+        /// Modify cycles do not run the hook because it is reached only
+        /// after <see cref="CreateAsync"/>. Keeping the callback installed
+        /// ensures reconnect and automatic recovery paths preserve durable
+        /// intent even when they recreate a physical partition directly.
         /// </para>
         /// <para>
         /// Exceptions thrown by the hook are logged as a warning and
@@ -136,6 +134,8 @@ namespace Opc.Ua.Client.Subscriptions
 
         /// <inheritdoc/>
         public bool Created => Id != 0;
+
+        internal bool IsDispatchingCallback => IsDispatchingNotification;
 
         /// <inheritdoc/>
         public IMonitoredItemServiceSetClientMethods MonitoredItemServiceSet
@@ -404,24 +404,50 @@ namespace Opc.Ua.Client.Subscriptions
         }
 
         /// <inheritdoc/>
-        public async ValueTask RecreateAsync(CancellationToken ct)
+        public ValueTask RecreateAsync(CancellationToken ct)
+        {
+            if (IsDispatchingNotification)
+            {
+                throw new InvalidOperationException(
+                    "A subscription cannot be recreated from one of its " +
+                    "notification callbacks. Schedule the recreate after the " +
+                    "callback returns.");
+            }
+            return RecreateWithPublishingQuiescedAsync(ct);
+        }
+
+        private async ValueTask RecreateWithPublishingQuiescedAsync(
+            CancellationToken ct)
+        {
+            ThrowIfDisposing();
+            await AckQueue.RunWithPublishingQuiescedAsync(
+                RecreateCoreAsync, ct).ConfigureAwait(false);
+        }
+
+        private async ValueTask RecreateCoreAsync(CancellationToken ct)
         {
             await m_stateLock.WaitAsync(ct).ConfigureAwait(false);
             try
             {
-                LastSequenceNumberProcessed = 0;
-                LastNotificationTimestamp = 0;
-
-                Id = 0;
-                CurrentPublishingInterval = TimeSpan.Zero;
-                CurrentKeepAliveCount = 0;
-                CurrentPublishingEnabled = false;
-                CurrentPriority = 0;
-
-                // Recreate subscription
-                await CreateAsync(Options, ct).ConfigureAwait(false);
-
-                await m_monitoredItems.ApplyChangesAsync(true, true,
+                ThrowIfDisposing();
+                await ResetMessageGenerationAsync(
+                    async token =>
+                    {
+                        uint oldId = Id;
+                        if (oldId != 0)
+                        {
+                            await DeleteForRecreateAsync(oldId, token)
+                                .ConfigureAwait(false);
+                            AckQueue.DropPendingForSubscription(oldId);
+                        }
+                    },
+                    async token =>
+                    {
+                        await CreateAsync(Options, token).ConfigureAwait(false);
+                        await RunAfterCreateHookAsync(token).ConfigureAwait(false);
+                        await m_monitoredItems.ApplyChangesAsync(true, true,
+                            token).ConfigureAwait(false);
+                    },
                     ct).ConfigureAwait(false);
             }
             finally
@@ -555,24 +581,60 @@ namespace Opc.Ua.Client.Subscriptions
         /// <inheritdoc/>
         protected override async ValueTask DisposeAsync(bool disposing)
         {
-            if (disposing && !Disposed)
+            if (!disposing)
+            {
+                await base.DisposeAsync(false).ConfigureAwait(false);
+                return;
+            }
+            if (Interlocked.Exchange(ref m_disposeStarted, 1) != 0)
+            {
+                await m_disposeCompletion.Task.ConfigureAwait(false);
+                return;
+            }
+            try
             {
                 try
                 {
                     await m_cts.CancelAsync().ConfigureAwait(false);
                     await m_stateManagement.ConfigureAwait(false);
 
-                    await m_monitoredItems.DisposeAsync().ConfigureAwait(false);
+                    await m_stateLock.WaitAsync(CancellationToken.None).ConfigureAwait(false);
+                    try
+                    {
+                        await m_monitoredItems.DisposeAsync().ConfigureAwait(false);
+                    }
+                    finally
+                    {
+                        m_stateLock.Release();
+                    }
                 }
                 finally
+                {
+                    await base.DisposeAsync(true).ConfigureAwait(false);
+                }
+            }
+            finally
+            {
+                try
                 {
                     m_publishTimer.Dispose();
                     m_changeTracking?.Dispose();
                     m_cts.Dispose();
                     m_stateLock.Dispose();
                 }
+                finally
+                {
+                    m_disposeCompletion.TrySetResult(true);
+                }
             }
-            await base.DisposeAsync(disposing).ConfigureAwait(false);
+        }
+
+        private void ThrowIfDisposing()
+        {
+            if (Volatile.Read(ref m_disposeStarted) != 0 || Disposed)
+            {
+                throw new ObjectDisposedException(nameof(Subscription));
+            }
         }
 
         /// <inheritdoc/>
@@ -742,14 +804,13 @@ namespace Opc.Ua.Client.Subscriptions
 
         /// <summary>
         /// Run an in-place recreate on the same session after an
-        /// unsolicited <c>Good_SubscriptionTransferred</c>. Drops
-        /// queued acknowledgements for the dead subscription id
-        /// before invoking <see cref="ResetToRecreateAsync"/> so the
-        /// state-manager loop sees a coherent reset and the ack
-        /// queue cannot leak <c>BadSubscriptionIdInvalid</c>s on
-        /// servers that re-use subscription identifiers. Idempotent:
-        /// concurrent dispatches collapse through
-        /// <see cref="m_recreateAfterTransferInProgress"/>.
+        /// unsolicited <c>Good_SubscriptionTransferred</c>. Uses
+        /// <see cref="RecreateAsync"/> so deletion, acknowledgement
+        /// cleanup, message-generation retirement, and monitored-item
+        /// recreation complete as one operation. Idempotent: concurrent
+        /// dispatches collapse through
+        /// <see cref="m_recreateAfterTransferInProgress"/> for the full
+        /// recreate lifetime.
         /// </summary>
         private async Task RecoverAfterUnsolicitedTransferAsync()
         {
@@ -758,28 +819,18 @@ namespace Opc.Ua.Client.Subscriptions
             {
                 Logger.SubscriptionUnsolicitedGoodSubscriptionTransferredReceivedAuto(this);
 
-                if (deadId != 0)
-                {
-                    int dropped = AckQueue.DropPendingForSubscription(deadId);
-                    if (dropped > 0)
-                    {
-                        Logger.SubscriptionDroppedCountStaleAcknowledgementS(
-                            this,
-                            dropped);
-                    }
-                }
-
                 if (Disposed)
                 {
                     return;
                 }
 
-                await ResetToRecreateAsync(CancellationToken.None)
+                await RecreateWithPublishingQuiescedAsync(CancellationToken.None)
                     .ConfigureAwait(false);
 
-                Logger.SubscriptionRecreateSignalledAfterUnsolicitedGood(
+                Logger.SubscriptionRecreatedAfterUnsolicitedGood(
                     this,
-                    deadId);
+                    deadId,
+                    Id);
             }
             catch (Exception ex)
             {
@@ -876,29 +927,13 @@ namespace Opc.Ua.Client.Subscriptions
                                 // (e.g. SetSubscriptionDurable, which
                                 // per OPC UA Part 4 §5.13.9 must
                                 // precede any monitored-item
-                                // creation). Clear after invocation
-                                // so modify cycles do not re-run it;
-                                // the owning wrapper re-installs the
-                                // hook before the next Create pass.
-                                Func<CancellationToken, ValueTask>? hook
-                                    = Interlocked.Exchange(
-                                        ref m_onAfterCreateAsync, null);
-                                if (hook != null)
-                                {
-                                    try
-                                    {
-                                        await hook(ct).ConfigureAwait(false);
-                                    }
-                                    catch (Exception hookEx)
-                                    {
-                                        Logger.SubscriptionOnAfterCreateAsyncHookThrewPartitionContinues(
-                                            hookEx,
-                                            this);
-                                        OnSubscriptionStateChanged(
-                                            SubscriptionState.Modified);
-                                    }
-                                }
+                                // creation). Modify cycles do not reach
+                                // this branch, while later create passes
+                                // intentionally run the hook again.
+                                await RunAfterCreateHookAsync(ct)
+                                    .ConfigureAwait(false);
                             }
+
                             else
                             {
                                 await ModifyAsync(options, ct).ConfigureAwait(false);
@@ -984,8 +1019,39 @@ namespace Opc.Ua.Client.Subscriptions
             {
             }
 
-            // Delete subscription on server on dispose
-            await DeleteAsync(default).ConfigureAwait(false);
+            // Delete subscription on server on dispose. Serialize with an
+            // in-flight explicit recreate so shutdown cannot delete or reset
+            // the replacement concurrently.
+            await m_stateLock.WaitAsync(CancellationToken.None).ConfigureAwait(false);
+            try
+            {
+                await DeleteAsync(default).ConfigureAwait(false);
+            }
+            finally
+            {
+                m_stateLock.Release();
+            }
+        }
+
+        private async ValueTask RunAfterCreateHookAsync(CancellationToken ct)
+        {
+            Func<CancellationToken, ValueTask>? hook =
+                Volatile.Read(ref m_onAfterCreateAsync);
+            if (hook == null)
+            {
+                return;
+            }
+            try
+            {
+                await hook(ct).ConfigureAwait(false);
+            }
+            catch (Exception hookEx)
+            {
+                Logger.SubscriptionOnAfterCreateAsyncHookThrewPartitionContinues(
+                    hookEx,
+                    this);
+                OnSubscriptionStateChanged(SubscriptionState.Modified);
+            }
         }
 
         /// <summary>
@@ -1023,6 +1089,29 @@ namespace Opc.Ua.Client.Subscriptions
             {
                 Logger.DeletingSubscriptionServerFailed(e);
             }
+            OnSubscriptionDeleteCompleted();
+        }
+
+        private async ValueTask DeleteForRecreateAsync(uint subscriptionId,
+            CancellationToken ct)
+        {
+            ArrayOf<uint> subscriptionIds = new uint[] { subscriptionId };
+            DeleteSubscriptionsResponse response = await m_context.SubscriptionServiceSet
+                .DeleteSubscriptionsAsync(null, subscriptionIds, ct)
+                .ConfigureAwait(false);
+            ClientBase.ValidateResponse(response.Results, subscriptionIds);
+            ClientBase.ValidateDiagnosticInfos(response.DiagnosticInfos,
+                subscriptionIds);
+
+            StatusCode result = response.Results[0];
+            if (StatusCode.IsBad(result) &&
+                result != StatusCodes.BadSubscriptionIdInvalid)
+            {
+                throw new ServiceResultException(ClientBase.GetResult(
+                    result, 0, response.DiagnosticInfos,
+                    response.ResponseHeader));
+            }
+            StopKeepAliveTimer();
             OnSubscriptionDeleteCompleted();
         }
 
@@ -1357,9 +1446,12 @@ namespace Opc.Ua.Client.Subscriptions
         private Func<CancellationToken, ValueTask>? m_onAfterCreateAsync;
         private readonly AsyncAutoResetEvent m_stateControl = new();
         private readonly AsyncManualResetEvent m_createdEvent = new();
+        private readonly TaskCompletionSource<bool> m_disposeCompletion = new(
+            TaskCreationOptions.RunContinuationsAsynchronously);
         private readonly CancellationTokenSource m_cts = new();
         private readonly Task m_stateManagement;
         private readonly SemaphoreSlim m_stateLock = new(1, 1);
+        private int m_disposeStarted;
         private readonly List<uint> m_deletedItems = [];
         private readonly ITimer m_publishTimer;
         private readonly IDisposable? m_changeTracking;
@@ -1388,12 +1480,13 @@ namespace Opc.Ua.Client.Subscriptions
             int count);
 
         [LoggerMessage(EventId = ClientEventIds.Subscription + 45, Level = LogLevel.Information,
-            Message = "{Subscription}: recreate signalled after unsolicited Good_SubscriptionTransferred (old" +
-                " SubscriptionId={OldId}).")]
-        public static partial void SubscriptionRecreateSignalledAfterUnsolicitedGood(
+            Message = "{Subscription}: recreated after unsolicited Good_SubscriptionTransferred (old" +
+                " SubscriptionId={OldId}, new SubscriptionId={NewId}).")]
+        public static partial void SubscriptionRecreatedAfterUnsolicitedGood(
             this ILogger logger,
             Subscription subscription,
-            uint oldId);
+            uint oldId,
+            uint newId);
 
         [LoggerMessage(EventId = ClientEventIds.Subscription + 46, Level = LogLevel.Warning,
             Message = "{Subscription}: recovery after unsolicited Good_SubscriptionTransferred failed (old" +

--- a/src/Opc.Ua.Client/Subscription/SubscriptionManager.cs
+++ b/src/Opc.Ua.Client/Subscription/SubscriptionManager.cs
@@ -74,7 +74,8 @@ namespace Opc.Ua.Client.Subscriptions
             m_loggerFactory = loggerFactory;
             m_logger = loggerFactory.CreateLogger<SubscriptionManager>();
             ReturnDiagnostics = returnDiagnostics;
-            m_publishController = PublishControllerAsync(m_cts.Token);
+            m_disposeToken = m_cts.Token;
+            m_publishController = PublishControllerAsync(m_disposeToken);
             m_acks = Channel.CreateUnboundedPrioritized(
                 new UnboundedPrioritizedChannelOptions<SubscriptionAcknowledgement>
                 {
@@ -249,11 +250,14 @@ namespace Opc.Ua.Client.Subscriptions
             {
                 return;
             }
+            bool quiescenceAcquired = false;
             try
             {
                 await m_cts.CancelAsync().ConfigureAwait(false);
                 m_publishControl.Set();
                 await m_publishController.ConfigureAwait(false);
+                await m_publishQuiescenceGate.WaitAsync().ConfigureAwait(false);
+                quiescenceAcquired = true;
 
                 List<LogicalSubscription>? logicals;
                 List<IManagedSubscription>? orphans;
@@ -300,6 +304,12 @@ namespace Opc.Ua.Client.Subscriptions
             }
             finally
             {
+                if (!quiescenceAcquired)
+                {
+                    await m_publishQuiescenceGate.WaitAsync().ConfigureAwait(false);
+                }
+                m_publishQuiescenceGate.Release();
+                m_publishQuiescenceGate.Dispose();
                 m_cts.Dispose();
                 (m_acks as IDisposable)?.Dispose();
                 GC.SuppressFinalize(this);
@@ -322,20 +332,56 @@ namespace Opc.Ua.Client.Subscriptions
         }
 
         /// <inheritdoc/>
+        public async ValueTask RunWithPublishingQuiescedAsync(
+            Func<CancellationToken, ValueTask> operation,
+            CancellationToken ct)
+        {
+            if (operation == null)
+            {
+                throw new ArgumentNullException(nameof(operation));
+            }
+            if (Volatile.Read(ref m_disposed) != 0)
+            {
+                throw new ObjectDisposedException(nameof(SubscriptionManager));
+            }
+
+            using var linked = CancellationTokenSource.CreateLinkedTokenSource(
+                ct, m_disposeToken);
+            CancellationToken linkedToken = linked.Token;
+            await m_publishQuiescenceGate.WaitAsync(linkedToken)
+                .ConfigureAwait(false);
+            try
+            {
+                if (Volatile.Read(ref m_disposed) != 0)
+                {
+                    throw new ObjectDisposedException(nameof(SubscriptionManager));
+                }
+                SetPublishingQuiesced(true);
+                try
+                {
+                    await DrainAsync(linkedToken).ConfigureAwait(false);
+                    await operation(linkedToken).ConfigureAwait(false);
+                }
+                finally
+                {
+                    SetPublishingQuiesced(false);
+                }
+            }
+            finally
+            {
+                m_publishQuiescenceGate.Release();
+            }
+        }
+
+        /// <inheritdoc/>
         public int DropPendingForSubscription(uint subscriptionId)
         {
             // Drain the prioritised channel into a local buffer,
             // keeping only the acks that do not target the dead
             // subscription id, then re-publish the kept items.
-            // Concurrent workers may interleave reads or writes
-            // during this loop; that is intentional — a worker
-            // racing in is acceptable because (a) any ack it reads
-            // would have been sent to the server anyway, (b) any
-            // ack it writes is queued back into the channel. The
-            // contract is "no targeted acks remain when this
-            // method returns" — callers must invoke it BEFORE
-            // recreate assigns a fresh subscription id so a new
-            // generation cannot enter the queue.
+            // Recreate callers invoke this while publish ingress is
+            // quiesced, so no worker can remove or requeue an old
+            // acknowledgement while the generation changes.
             var keep = new List<SubscriptionAcknowledgement>();
             int dropped = 0;
             while (m_acks.Reader.TryRead(out SubscriptionAcknowledgement? ack))
@@ -1064,14 +1110,7 @@ namespace Opc.Ua.Client.Subscriptions
         /// </summary>
         internal void Resume()
         {
-            lock (m_subscriptionLock)
-            {
-                foreach (IManagedSubscription item in m_subscriptions)
-                {
-                    item.NotifySubscriptionManagerPaused(false);
-                }
-            }
-            m_running.Set();
+            SetPublishingRequested(true);
         }
 
         /// <summary>
@@ -1079,14 +1118,68 @@ namespace Opc.Ua.Client.Subscriptions
         /// </summary>
         internal void Pause()
         {
+            SetPublishingRequested(false);
+        }
+
+        private void SetPublishingRequested(bool requested)
+        {
+            bool? paused;
+            lock (m_publishStateLock)
+            {
+                m_publishingRequested = requested;
+                paused = UpdatePublishingState();
+            }
+            if (paused.HasValue)
+            {
+                NotifySubscriptionsPaused(paused.Value);
+            }
+        }
+
+        private void SetPublishingQuiesced(bool quiesced)
+        {
+            bool? paused;
+            lock (m_publishStateLock)
+            {
+                m_publishingQuiesced = quiesced;
+                paused = UpdatePublishingState();
+            }
+            if (paused.HasValue)
+            {
+                NotifySubscriptionsPaused(paused.Value);
+            }
+        }
+
+        private bool? UpdatePublishingState()
+        {
+            bool shouldRun = m_publishingRequested &&
+                !m_publishingQuiesced &&
+                Volatile.Read(ref m_disposed) == 0;
+            if (m_running.IsSet == shouldRun)
+            {
+                return null;
+            }
+            if (shouldRun)
+            {
+                m_publishingPaused.Reset();
+                m_running.Set();
+            }
+            else
+            {
+                m_running.Reset();
+                m_publishingPaused.Set();
+            }
+            return !shouldRun;
+        }
+
+        private void NotifySubscriptionsPaused(bool paused)
+        {
             lock (m_subscriptionLock)
             {
                 foreach (IManagedSubscription item in m_subscriptions)
                 {
-                    item.NotifySubscriptionManagerPaused(true);
+                    item.NotifySubscriptionManagerPaused(paused);
                 }
             }
-            m_running.Reset();
         }
 
         /// <summary>
@@ -1107,6 +1200,33 @@ namespace Opc.Ua.Client.Subscriptions
             return m_drainSignal.WaitAsync(ct);
         }
 
+        private bool TryBeginPublishRequest()
+        {
+            lock (m_publishStateLock)
+            {
+                if (!m_running.IsSet || Volatile.Read(ref m_disposed) != 0)
+                {
+                    return false;
+                }
+                if (++m_activePublishRequests == 1)
+                {
+                    m_drainSignal.Reset();
+                }
+                return true;
+            }
+        }
+
+        private void EndPublishRequest()
+        {
+            lock (m_publishStateLock)
+            {
+                if (--m_activePublishRequests == 0)
+                {
+                    m_drainSignal.Set();
+                }
+            }
+        }
+
         /// <summary>
         /// Recreate subscriptions
         /// </summary>
@@ -1123,7 +1243,11 @@ namespace Opc.Ua.Client.Subscriptions
                 return;
             }
 
-            IReadOnlyList<IManagedSubscription> subscriptions = [.. m_subscriptions];
+            IReadOnlyList<IManagedSubscription> subscriptions;
+            lock (m_subscriptionLock)
+            {
+                subscriptions = [.. m_subscriptions];
+            }
             if (TransferSubscriptionsOnRecreate && previousSessionId != null)
             {
                 subscriptions = await TransferSubscriptionsAsync(subscriptions,
@@ -1132,7 +1256,6 @@ namespace Opc.Ua.Client.Subscriptions
             // Force creation of the subscriptions which were not transferred.
             foreach (IManagedSubscription subscription in subscriptions)
             {
-                bool force = previousSessionId != null && subscription.Created;
                 await subscription.RecreateAsync(ct).ConfigureAwait(false);
             }
             m_publishControl.Set();
@@ -1446,81 +1569,84 @@ namespace Opc.Ua.Client.Subscriptions
                         : (long)publishLatency.TotalMilliseconds;
                     int ackWaitTimeout = CalculateTimeouts(
                         currentLatencyMs, ref timeoutHint);
-                    ArrayOf<SubscriptionAcknowledgement> acks = GetAcksReadyToSend();
-                    uint handle = Utils.IncrementIdentifier(ref m_outer.m_publishRequestCounter);
+                    if (!m_outer.TryBeginPublishRequest())
+                    {
+                        continue;
+                    }
+                    ArrayOf<SubscriptionAcknowledgement> acks = [];
+                    uint handle = 0;
+                    bool publishActive = true;
                     try
                     {
+                        acks = GetAcksReadyToSend();
+                        handle = Utils.IncrementIdentifier(
+                            ref m_outer.m_publishRequestCounter);
                         if (acks.Count == 0 && !moreNotifications && ackWaitTimeout != 0)
                         {
                             // Throttle publishing as we wait for acks to arrive
                             acks = await WaitForAcksAsync(ackWaitTimeout, ct).ConfigureAwait(false);
                         }
+                        if (!m_outer.m_running.IsSet)
+                        {
+                            acks.ForEach(ack => m_outer.m_acks.Writer.TryWrite(ack));
+                            continue;
+                        }
                         publishLatencyStart = m_outer.m_timeProvider.GetTimestamp();
                         publishLatencyRunning = true;
-                        if (Interlocked.Increment(ref m_outer.m_activePublishRequests) == 1)
-                        {
-                            m_outer.m_drainSignal.Reset();
-                        }
-                        try
-                        {
-                            PublishResponse response = await m_outer.m_session.PublishAsync(new RequestHeader
+                        PublishResponse response = await m_outer.m_session.PublishAsync(
+                            new RequestHeader
                             {
                                 TimeoutHint = timeoutHint,
                                 ReturnDiagnostics = (uint)(int)m_outer.ReturnDiagnostics,
                                 RequestHandle = handle
                             }, acks, ct).ConfigureAwait(false);
 
-                            moreNotifications = response.MoreNotifications;
-                            uint subscriptionId = response.SubscriptionId;
-                            NotificationMessage notificationMessage = response.NotificationMessage;
-                            ArrayOf<uint> availableSequenceNumbers = response.AvailableSequenceNumbers;
+                        moreNotifications = response.MoreNotifications;
+                        uint subscriptionId = response.SubscriptionId;
+                        NotificationMessage notificationMessage = response.NotificationMessage;
+                        ArrayOf<uint> availableSequenceNumbers =
+                            response.AvailableSequenceNumbers;
 
-                            ArrayOf<StatusCode> acknowledgeResults = response.Results;
-                            ArrayOf<DiagnosticInfo> acknowledgeDiagnosticInfos = response.DiagnosticInfos;
-                            ClientBase.ValidateResponse(acknowledgeResults, acks);
-                            ClientBase.ValidateDiagnosticInfos(acknowledgeDiagnosticInfos, acks);
-                            TooManyPublishRequests = false;
+                        ArrayOf<StatusCode> acknowledgeResults = response.Results;
+                        ArrayOf<DiagnosticInfo> acknowledgeDiagnosticInfos =
+                            response.DiagnosticInfos;
+                        ClientBase.ValidateResponse(acknowledgeResults, acks);
+                        ClientBase.ValidateDiagnosticInfos(acknowledgeDiagnosticInfos, acks);
+                        TooManyPublishRequests = false;
 
-                            // A publish completed, so the channel is healthy:
-                            // clear the consecutive-error backoff state.
-                            m_consecutivePublishErrors = 0;
-                            m_lastLoggedErrorStatus = default;
+                        // A publish completed, so the channel is healthy:
+                        // clear the consecutive-error backoff state.
+                        m_consecutivePublishErrors = 0;
+                        m_lastLoggedErrorStatus = default;
 
-                            // Get the subscription with the provided identifier
-                            IManagedSubscription? subscription = m_outer.GetById(subscriptionId);
-                            publishLatency = m_outer.m_timeProvider.GetElapsedTime(publishLatencyStart);
-                            publishLatencyRunning = false;
-                            if (subscription != null)
-                            {
-                                // deliver to subscription
-                                await subscription.OnPublishReceivedAsync(
-                                    notificationMessage,
-                                    availableSequenceNumbers.ToList(),
-                                    response.ResponseHeader.StringTable.ToList()).ConfigureAwait(false);
-                                Interlocked.Increment(ref m_outer.m_goodPublishRequestCount);
-                            }
-                            else if (!ct.IsCancellationRequested &&
-                                !m_outer.m_subscriptionHistory.Contains(subscriptionId))
-                            {
-                                // ignore messages with a subscription that was deleted
-                                // Do not delete publish requests of stale subscriptions
-                                m_logger.PublishWorkerReceivedUnknownSubscription(
-                                    Index, handle, subscriptionId);
-                                Interlocked.Increment(ref m_outer.m_badPublishRequestCount);
-                                await m_outer.m_session.DeleteSubscriptionsAsync(
-                                    null,
-                                    [subscriptionId],
-                                    ct).ConfigureAwait(false);
-                                moreNotifications = true;
-                            }
-                        }
-                        finally
+                        // Get the subscription with the provided identifier
+                        IManagedSubscription? subscription = m_outer.GetById(subscriptionId);
+                        publishLatency = m_outer.m_timeProvider.GetElapsedTime(
+                            publishLatencyStart);
+                        publishLatencyRunning = false;
+                        if (subscription != null)
                         {
-                            int active = Interlocked.Decrement(ref m_outer.m_activePublishRequests);
-                            if (active == 0)
-                            {
-                                m_outer.m_drainSignal.Set();
-                            }
+                            // deliver to subscription
+                            await subscription.OnPublishReceivedAsync(
+                                notificationMessage,
+                                availableSequenceNumbers.ToList(),
+                                response.ResponseHeader.StringTable.ToList())
+                                .ConfigureAwait(false);
+                            Interlocked.Increment(ref m_outer.m_goodPublishRequestCount);
+                        }
+                        else if (!ct.IsCancellationRequested &&
+                            !m_outer.m_subscriptionHistory.Contains(subscriptionId))
+                        {
+                            // ignore messages with a subscription that was deleted
+                            // Do not delete publish requests of stale subscriptions
+                            m_logger.PublishWorkerReceivedUnknownSubscription(
+                                Index, handle, subscriptionId);
+                            Interlocked.Increment(ref m_outer.m_badPublishRequestCount);
+                            await m_outer.m_session.DeleteSubscriptionsAsync(
+                                null,
+                                [subscriptionId],
+                                ct).ConfigureAwait(false);
+                            moreNotifications = true;
                         }
                     }
                     catch (OperationCanceledException)
@@ -1543,6 +1669,8 @@ namespace Opc.Ua.Client.Subscriptions
                         Interlocked.Increment(ref m_outer.m_badPublishRequestCount);
                         // Rollback acks we collected
                         acks.ForEach(ack => m_outer.m_acks.Writer.TryWrite(ack));
+                        m_outer.EndPublishRequest();
+                        publishActive = false;
 
                         // ignore errors if paused.
                         if (!m_outer.m_running.IsSet)
@@ -1637,6 +1765,13 @@ namespace Opc.Ua.Client.Subscriptions
                             break;
                         }
                     }
+                    finally
+                    {
+                        if (publishActive)
+                        {
+                            m_outer.EndPublishRequest();
+                        }
+                    }
                 }
                 m_logger.PublishWorkerStopped(Index);
             }
@@ -1681,8 +1816,40 @@ namespace Opc.Ua.Client.Subscriptions
                 }
                 try
                 {
-                    SubscriptionAcknowledgement firstAck = await m_outer.m_acks.Reader.ReadAsync(
-                        waitToken).ConfigureAwait(false);
+                    using var pauseCts =
+                        CancellationTokenSource.CreateLinkedTokenSource(waitToken);
+                    Task<SubscriptionAcknowledgement> readTask = m_outer.m_acks.Reader
+                        .ReadAsync(pauseCts.Token).AsTask();
+                    Task pausedTask = m_outer.m_publishingPaused
+                        .WaitAsync(pauseCts.Token);
+                    Task completed = await Task.WhenAny(readTask, pausedTask)
+                        .ConfigureAwait(false);
+                    if (ReferenceEquals(completed, pausedTask))
+                    {
+                        await pausedTask.ConfigureAwait(false);
+                        await pauseCts.CancelAsync().ConfigureAwait(false);
+                        try
+                        {
+                            SubscriptionAcknowledgement acknowledgement =
+                                await readTask.ConfigureAwait(false);
+                            m_outer.m_acks.Writer.TryWrite(acknowledgement);
+                        }
+                        catch (OperationCanceledException)
+                        {
+                        }
+                        return [];
+                    }
+
+                    SubscriptionAcknowledgement firstAck =
+                        await readTask.ConfigureAwait(false);
+                    await pauseCts.CancelAsync().ConfigureAwait(false);
+                    try
+                    {
+                        await pausedTask.ConfigureAwait(false);
+                    }
+                    catch (OperationCanceledException)
+                    {
+                    }
                     ArrayOf<SubscriptionAcknowledgement> restAcks = GetAcksReadyToSend();
                     var ackList = restAcks.ToList();
                     ackList.Insert(0, firstAck);
@@ -1817,10 +1984,16 @@ namespace Opc.Ua.Client.Subscriptions
 #pragma warning restore IDE0032 // Use auto property
         private readonly Channel<SubscriptionAcknowledgement> m_acks;
         private readonly AsyncManualResetEvent m_running = new();
+        private readonly AsyncManualResetEvent m_publishingPaused = new(true);
         private readonly AsyncAutoResetEvent m_publishControl = new();
         private readonly AsyncManualResetEvent m_drainSignal = new(true);
+        private readonly SemaphoreSlim m_publishQuiescenceGate = new(1, 1);
+        private readonly Lock m_publishStateLock = new();
+        private readonly CancellationToken m_disposeToken;
         private int m_activePublishRequests;
         private int m_disposed;
+        private bool m_publishingRequested;
+        private bool m_publishingQuiesced;
         private readonly ConcurrentQueue<uint> m_subscriptionHistory = new();
         private readonly Task m_publishController;
         private readonly Lock m_subscriptionLock = new();

--- a/tests/Opc.Ua.Client.Tests/Subscription/CompositeMonitoredItemCollectionTests.cs
+++ b/tests/Opc.Ua.Client.Tests/Subscription/CompositeMonitoredItemCollectionTests.cs
@@ -354,6 +354,29 @@ namespace Opc.Ua.Client.Subscriptions.MonitoredItems
             Assert.That(names, Is.EqualTo(s_expectedAlphaBeta));
         }
 
+        [Test]
+        public void TryRequeueRoutesToOwningPartition()
+        {
+            FakeManagedSubscription primary = NewFake(1);
+            FakeManagedSubscription secondary = NewFake(2);
+            var policy = new PartitionPlacementPolicy(1);
+            var composite = new CompositeMonitoredItemCollection(
+                [primary],
+                new object(),
+                policy,
+                () => secondary);
+            Assert.That(composite.TryAdd("a", MakeOptions(new V2Options()),
+                out _), Is.True);
+            Assert.That(composite.TryAdd("b", MakeOptions(new V2Options()),
+                out IMonitoredItem? item), Is.True);
+
+            Assert.That(composite.TryRequeue(item!.ClientHandle), Is.True);
+
+            var secondaryItems = (InMemoryCollection)secondary.MonitoredItems;
+            Assert.That(secondaryItems.LastRequeuedHandle,
+                Is.EqualTo(item.ClientHandle));
+        }
+
         private static readonly string[] s_expectedAlphaBeta = ["a", "b"];
 
         private static FakeManagedSubscription NewFake(uint id)
@@ -450,7 +473,9 @@ namespace Opc.Ua.Client.Subscriptions.MonitoredItems
         /// from a process-global counter so handles stay unique
         /// across partition instances.
         /// </summary>
-        private sealed class InMemoryCollection : IMonitoredItemCollection
+        private sealed class InMemoryCollection :
+            IMonitoredItemCollection,
+            IMonitoredItemRetryCollection
         {
             private readonly Dictionary<string, FakeMonitoredItem> m_byName
                 = new(StringComparer.Ordinal);
@@ -460,6 +485,8 @@ namespace Opc.Ua.Client.Subscriptions.MonitoredItems
             public uint Count => (uint)m_byHandle.Count;
 
             public IEnumerable<IMonitoredItem> Items => [.. m_byHandle.Values];
+
+            public uint? LastRequeuedHandle { get; private set; }
 
             public bool TryGetMonitoredItemByClientHandle(uint clientHandle,
                 [MaybeNullWhen(false)] out IMonitoredItem? monitoredItem)
@@ -509,6 +536,16 @@ namespace Opc.Ua.Client.Subscriptions.MonitoredItems
                     return false;
                 }
                 m_byName.Remove(item.Name);
+                return true;
+            }
+
+            public bool TryRequeue(uint clientHandle)
+            {
+                if (!m_byHandle.ContainsKey(clientHandle))
+                {
+                    return false;
+                }
+                LastRequeuedHandle = clientHandle;
                 return true;
             }
 

--- a/tests/Opc.Ua.Client.Tests/Subscription/Fakes/FakeMessageAckQueue.cs
+++ b/tests/Opc.Ua.Client.Tests/Subscription/Fakes/FakeMessageAckQueue.cs
@@ -46,6 +46,7 @@ namespace Opc.Ua.Client.Subscriptions.Fakes
         public List<SubscriptionAcknowledgement> QueuedAcks { get; } = [];
         public List<uint> CompletedSubscriptions { get; } = [];
         public int UpdateCalls { get; private set; }
+        public int PublishingQuiescenceCalls { get; private set; }
 
         /// <summary>
         /// Optional override for <see cref="QueueAsync"/>. If null, returns
@@ -71,6 +72,14 @@ namespace Opc.Ua.Client.Subscriptions.Fakes
         {
             CompletedSubscriptions.Add(subscriptionId);
             return OnCompleteAsync?.Invoke(subscriptionId, ct) ?? default;
+        }
+
+        public ValueTask RunWithPublishingQuiescedAsync(
+            Func<CancellationToken, ValueTask> operation,
+            CancellationToken ct = default)
+        {
+            PublishingQuiescenceCalls++;
+            return operation(ct);
         }
 
         /// <summary>

--- a/tests/Opc.Ua.Client.Tests/Subscription/LogicalSubscriptionTests.cs
+++ b/tests/Opc.Ua.Client.Tests/Subscription/LogicalSubscriptionTests.cs
@@ -233,7 +233,7 @@ namespace Opc.Ua.Client.Subscriptions
             LogicalSubscription sut = new(fake);
             try
             {
-                await sut.RecreateAsync().ConfigureAwait(false);
+                await ((ISubscription)sut).RecreateAsync().ConfigureAwait(false);
                 Assert.That(fake.RecreateAsyncCalls, Is.EqualTo(1));
             }
             finally

--- a/tests/Opc.Ua.Client.Tests/Subscription/LogicalSubscriptionTests.cs
+++ b/tests/Opc.Ua.Client.Tests/Subscription/LogicalSubscriptionTests.cs
@@ -29,8 +29,10 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Options;
+using Moq;
 using NUnit.Framework;
 using Opc.Ua.Client.Subscriptions.Fakes;
 using Opc.Ua.Client.Subscriptions.MonitoredItems;
@@ -243,6 +245,39 @@ namespace Opc.Ua.Client.Subscriptions
         }
 
         [Test]
+        public async Task RecreateRetryResumesAtFailedPartitionAsync()
+        {
+            FakeManagedSubscription primary = CreateFake(id: 11, created: true);
+            FakeManagedSubscription secondary = CreateFake(id: 12, created: true);
+            var fail = true;
+            secondary.OnRecreateAsync = _ =>
+            {
+                if (fail)
+                {
+                    fail = false;
+                    throw new InvalidOperationException("retry");
+                }
+                return default;
+            };
+            LogicalSubscription sut = new(primary);
+            sut.AppendPreloadedPartition(secondary);
+            try
+            {
+                Assert.ThrowsAsync<InvalidOperationException>(async () =>
+                    await ((ISubscription)sut).RecreateAsync().ConfigureAwait(false));
+
+                await ((ISubscription)sut).RecreateAsync().ConfigureAwait(false);
+
+                Assert.That(primary.RecreateAsyncCalls, Is.EqualTo(1));
+                Assert.That(secondary.RecreateAsyncCalls, Is.EqualTo(2));
+            }
+            finally
+            {
+                await sut.DisposeAsync().ConfigureAwait(false);
+            }
+        }
+
+        [Test]
         public async Task NotifyPausedFanOutsToEveryPartitionAsync()
         {
             FakeManagedSubscription fake = CreateFake(id: 11, created: true);
@@ -301,6 +336,52 @@ namespace Opc.Ua.Client.Subscriptions
             }
         }
 
+        [Test]
+        public async Task ForwardingHandlerAggregatesPartitionPublishStateAsync()
+        {
+            FakeManagedSubscription primary = CreateFake(id: 11, created: true);
+            FakeManagedSubscription secondary = CreateFake(id: 12, created: true);
+            LogicalSubscription sut = new(primary);
+            var masks = new List<PublishState>();
+            var userHandler = new Mock<ISubscriptionNotificationHandler>();
+            userHandler
+                .Setup(handler => handler.OnSubscriptionStateChangedAsync(
+                    It.IsAny<ISubscription>(),
+                    It.IsAny<SubscriptionState>(),
+                    It.IsAny<PublishState>(),
+                    It.IsAny<CancellationToken>()))
+                .Callback((ISubscription subscription, SubscriptionState _,
+                    PublishState mask, CancellationToken _) =>
+                {
+                    Assert.That(subscription, Is.SameAs(sut));
+                    masks.Add(mask);
+                })
+                .Returns(ValueTask.CompletedTask);
+            using var forwarding = new PartitionForwardingHandler(userHandler.Object);
+            forwarding.BindLogical(sut);
+            try
+            {
+                await forwarding.OnSubscriptionStateChangedAsync(primary,
+                    SubscriptionState.Modified, PublishState.Stopped)
+                    .ConfigureAwait(false);
+                await forwarding.OnSubscriptionStateChangedAsync(secondary,
+                    SubscriptionState.Modified, PublishState.Stopped)
+                    .ConfigureAwait(false);
+                await forwarding.OnSubscriptionStateChangedAsync(primary,
+                    SubscriptionState.Modified, PublishState.Recovered)
+                    .ConfigureAwait(false);
+                await forwarding.OnSubscriptionStateChangedAsync(secondary,
+                    SubscriptionState.Modified, PublishState.Recovered)
+                    .ConfigureAwait(false);
+
+                Assert.That(masks, Is.EqualTo(s_aggregatePublishStates));
+            }
+            finally
+            {
+                await sut.DisposeAsync().ConfigureAwait(false);
+            }
+        }
+
         private static FakeManagedSubscription CreateFake(uint id, bool created)
         {
             return new FakeManagedSubscription
@@ -312,6 +393,13 @@ namespace Opc.Ua.Client.Subscriptions
         }
 
         private static readonly bool[] s_pausedTrueFalseSequence = [true, false];
+        private static readonly PublishState[] s_aggregatePublishStates =
+        [
+            PublishState.Stopped,
+            PublishState.Stopped,
+            PublishState.Stopped,
+            PublishState.Recovered
+        ];
 
         /// <summary>
         /// Minimal pass-through implementation of

--- a/tests/Opc.Ua.Client.Tests/Subscription/LogicalSubscriptionTests.cs
+++ b/tests/Opc.Ua.Client.Tests/Subscription/LogicalSubscriptionTests.cs
@@ -356,7 +356,7 @@ namespace Opc.Ua.Client.Subscriptions
                     Assert.That(subscription, Is.SameAs(sut));
                     masks.Add(mask);
                 })
-                .Returns(ValueTask.CompletedTask);
+                .Returns(new ValueTask());
             using var forwarding = new PartitionForwardingHandler(userHandler.Object);
             forwarding.BindLogical(sut);
             try

--- a/tests/Opc.Ua.Client.Tests/Subscription/MonitoredItemManagerTests.cs
+++ b/tests/Opc.Ua.Client.Tests/Subscription/MonitoredItemManagerTests.cs
@@ -120,6 +120,50 @@ namespace Opc.Ua.Client.Subscriptions.MonitoredItems
         }
 
         [Test]
+        public async Task TryRequeueFailedItemSucceedsAsync()
+        {
+            var options = OptionsFactory.Create<MonitoredItemOptions>();
+            var sut = new MonitoredItemManager(m_context, m_telemetry);
+            await using (sut.ConfigureAwait(false))
+            {
+                Assert.That(sut.TryAdd("Item", options,
+                    out IMonitoredItem monitoredItem), Is.True);
+                var item = (TestMonitoredItem)monitoredItem;
+                Assert.That(item.TryGetPendingChange(
+                    out MonitoredItem.Change change), Is.True);
+                var request = new MonitoredItemCreateRequest
+                {
+                    MonitoringMode = MonitoringMode.Reporting,
+                    RequestedParameters = new MonitoringParameters
+                    {
+                        ClientHandle = item.ClientHandle,
+                        SamplingInterval = 1000,
+                        QueueSize = 1,
+                        DiscardOldest = true
+                    }
+                };
+                var result = new MonitoredItemCreateResult
+                {
+                    StatusCode = StatusCodes.BadNodeIdUnknown
+                };
+                for (var attempt = 0; attempt < 6; attempt++)
+                {
+                    change.SetCreateResult(request, result,
+                        0, [], new ResponseHeader());
+                }
+
+                Assert.That(change.RetryCount, Is.EqualTo(6));
+                Assert.That(item.HasPendingChanges, Is.False);
+                Assert.That(item.Error.StatusCode,
+                    Is.EqualTo(StatusCodes.BadNodeIdUnknown));
+                Assert.That(sut.TryRequeue(item.ClientHandle), Is.True);
+                Assert.That(item.HasPendingChanges, Is.True);
+                Assert.That(sut.TryRequeue(item.ClientHandle), Is.False);
+                Assert.That(sut.TryRequeue(uint.MaxValue), Is.False);
+            }
+        }
+
+        [Test]
         public async Task PauseAndUnpauseMonitoredItemsAsync()
         {
             // Arrange

--- a/tests/Opc.Ua.Client.Tests/Subscription/MonitoredItemTests.cs
+++ b/tests/Opc.Ua.Client.Tests/Subscription/MonitoredItemTests.cs
@@ -96,6 +96,81 @@ namespace Opc.Ua.Client.Subscriptions.MonitoredItems
         }
 
         [Test]
+        public void FailedChangeCanBeRequeued()
+        {
+            m_options.Configure(o => o with
+            {
+                StartNodeId = new NodeId("test", 0)
+            });
+            var sut = new TestMonitoredItem(m_context,
+                m_options, m_telemetry.CreateLogger("MonitoredItem"));
+            Assert.That(sut.TryGetPendingChange(out MonitoredItem.Change change),
+                Is.True);
+            change.SetCreateResult(new MonitoredItemCreateRequest
+            {
+                MonitoringMode = MonitoringMode.Reporting,
+                RequestedParameters = new MonitoringParameters
+                {
+                    ClientHandle = sut.ClientHandle,
+                    SamplingInterval = 1000,
+                    QueueSize = 1,
+                    DiscardOldest = true
+                }
+            }, new MonitoredItemCreateResult
+            {
+                StatusCode = StatusCodes.BadNodeIdUnknown
+            }, 0, [], new ResponseHeader());
+
+            Assert.That(sut.HasPendingChanges, Is.False);
+            Assert.That(sut.Error.StatusCode,
+                Is.EqualTo(StatusCodes.BadNodeIdUnknown));
+            Assert.That(sut.TryRequeue(), Is.True);
+            Assert.That(sut.HasPendingChanges, Is.True);
+            Assert.That(sut.TryGetPendingChange(
+                out MonitoredItem.Change requeued), Is.True);
+            Assert.That(requeued, Is.Not.SameAs(change));
+            Assert.That(requeued.ForceRecreate, Is.True);
+            Assert.That(sut.TryRequeue(), Is.False);
+        }
+
+        [Test]
+        public void GoodButUnappliedChangeCanBeRequeued()
+        {
+            m_options.Configure(o => o with
+            {
+                StartNodeId = new NodeId("test", 0)
+            });
+            var sut = new TestMonitoredItem(m_context,
+                m_options, m_telemetry.CreateLogger("MonitoredItem"));
+            Assert.That(sut.TryGetPendingChange(out MonitoredItem.Change change),
+                Is.True);
+            change.SetCreateResult(new MonitoredItemCreateRequest
+            {
+                MonitoringMode = MonitoringMode.Sampling,
+                RequestedParameters = new MonitoringParameters
+                {
+                    ClientHandle = sut.ClientHandle,
+                    SamplingInterval = 1000,
+                    QueueSize = 1,
+                    DiscardOldest = true
+                }
+            }, new MonitoredItemCreateResult
+            {
+                StatusCode = StatusCodes.Good,
+                MonitoredItemId = 1,
+                RevisedSamplingInterval = 1000,
+                RevisedQueueSize = 1
+            }, 0, [], new ResponseHeader());
+
+            Assert.That(sut.Error.StatusCode, Is.EqualTo(StatusCodes.Good));
+            Assert.That(sut.Created, Is.True);
+            Assert.That(sut.CurrentMonitoringMode,
+                Is.Not.EqualTo(m_options.CurrentValue.MonitoringMode));
+            Assert.That(sut.TryRequeue(), Is.True);
+            Assert.That(sut.HasPendingChanges, Is.True);
+        }
+
+        [Test]
         public void CreatedShouldReturnFalseWhenServerIdIsNotSet()
         {
             // Act

--- a/tests/Opc.Ua.Client.Tests/Subscription/MonitoredItemTests.cs
+++ b/tests/Opc.Ua.Client.Tests/Subscription/MonitoredItemTests.cs
@@ -70,6 +70,7 @@ namespace Opc.Ua.Client.Subscriptions.MonitoredItems
             // Act
             Assert.That(sut.TryGetPendingChange(out MonitoredItem.Change change), Is.True);
             Assert.That(change, Is.Not.Null);
+            Assert.That(((IMonitoredItemApplyState)sut).HasPendingChanges, Is.True);
             change.SetCreateResult(new MonitoredItemCreateRequest
             {
                 MonitoringMode = MonitoringMode.Sampling,
@@ -91,6 +92,7 @@ namespace Opc.Ua.Client.Subscriptions.MonitoredItems
             // Assert
             Assert.That(sut.ServerId, Is.EqualTo(serverId));
             Assert.That(sut.Created, Is.True);
+            Assert.That(((IMonitoredItemApplyState)sut).HasPendingChanges, Is.False);
         }
 
         [Test]

--- a/tests/Opc.Ua.Client.Tests/Subscription/SubscriptionManagerTests.cs
+++ b/tests/Opc.Ua.Client.Tests/Subscription/SubscriptionManagerTests.cs
@@ -442,6 +442,106 @@ namespace Opc.Ua.Client.Subscriptions
         }
 
         [Test]
+        public async Task PublishingQuiescencePreservesConcurrentPauseAsync()
+        {
+            var subscription = new FakeManagedSubscription();
+            m_session.CreateSubscriptionFactory =
+                (handler, options, queue) => subscription;
+            m_subscriptionManager.Add(m_mockNotificationDataHandler.Object,
+                Mock.Of<IOptionsMonitor<SubscriptionOptions>>());
+            m_subscriptionManager.Resume();
+
+            var entered = new TaskCompletionSource<bool>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            var release = new TaskCompletionSource<bool>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            Task quiesced = m_subscriptionManager
+                .RunWithPublishingQuiescedAsync(async ct =>
+                {
+                    entered.TrySetResult(true);
+                    await release.Task.WaitAsync(ct).ConfigureAwait(false);
+                }, CancellationToken.None)
+                .AsTask();
+
+            await entered.Task.WaitAsync(TimeSpan.FromSeconds(5))
+                .ConfigureAwait(false);
+            m_subscriptionManager.Pause();
+            release.TrySetResult(true);
+            await quiesced.WaitAsync(TimeSpan.FromSeconds(5))
+                .ConfigureAwait(false);
+
+            Assert.That(subscription.NotifySubscriptionManagerPausedCalls,
+                Is.EqualTo(s_resumedThenPaused));
+        }
+
+        [Test]
+        [CancelAfter(30_000)]
+        public async Task PublishingQuiescenceWaitsForAckRollbackAsync(
+            CancellationToken testCt)
+        {
+            ILoggerFactory loggerFactory = m_telemetry.LoggerFactory;
+            var session = new FakeSubscriptionManagerContext();
+            var subscription = new FakeManagedSubscription
+            {
+                Id = 1,
+                Created = true
+            };
+            var sut = new SubscriptionManager(session,
+                loggerFactory, DiagnosticsMasks.None);
+            try
+            {
+                session.CreateSubscriptionFactory = (_, _, _) => subscription;
+                var publishCalled = new TaskCompletionSource<bool>(
+                    TaskCreationOptions.RunContinuationsAsynchronously);
+                var publishGate = new TaskCompletionSource<PublishResponse>(
+                    TaskCreationOptions.RunContinuationsAsynchronously);
+                session.OnPublishAsync = (_, acknowledgements, _) =>
+                {
+                    Assert.That(acknowledgements, Has.Count.EqualTo(1));
+                    publishCalled.TrySetResult(true);
+                    return new ValueTask<PublishResponse>(publishGate.Task);
+                };
+
+                sut.MinPublishWorkerCount = 1;
+                sut.MaxPublishWorkerCount = 1;
+                sut.Add(m_mockNotificationDataHandler.Object,
+                    Mock.Of<IOptionsMonitor<SubscriptionOptions>>());
+                await sut.QueueAsync(new SubscriptionAcknowledgement
+                {
+                    SubscriptionId = 1,
+                    SequenceNumber = 7
+                }, testCt).ConfigureAwait(false);
+                sut.Resume();
+                await publishCalled.Task.WaitAsync(testCt).ConfigureAwait(false);
+
+                var actionEntered = new TaskCompletionSource<bool>(
+                    TaskCreationOptions.RunContinuationsAsynchronously);
+                var dropped = 0;
+                Task quiesced = sut.RunWithPublishingQuiescedAsync(_ =>
+                {
+                    dropped = sut.DropPendingForSubscription(1);
+                    sut.Pause();
+                    actionEntered.TrySetResult(true);
+                    return default;
+                }, testCt).AsTask();
+
+                await Task.Delay(100, testCt).ConfigureAwait(false);
+                Assert.That(actionEntered.Task.IsCompleted, Is.False);
+
+                publishGate.TrySetException(
+                    new ServiceResultException(StatusCodes.BadNotConnected));
+                await actionEntered.Task.WaitAsync(testCt).ConfigureAwait(false);
+                await quiesced.WaitAsync(testCt).ConfigureAwait(false);
+
+                Assert.That(dropped, Is.EqualTo(1));
+            }
+            finally
+            {
+                await sut.DisposeAsync().ConfigureAwait(false);
+            }
+        }
+
+        [Test]
         public async Task RecreateSubscriptionsAsyncRecreatesSubscriptionsAsync()
         {
             var mockSubscription = new FakeManagedSubscription();
@@ -658,6 +758,7 @@ namespace Opc.Ua.Client.Subscriptions
                 $"got {sut.PublishWorkerCount} after {sw.ElapsedMilliseconds} ms.");
         }
 
+        private static readonly bool[] s_resumedThenPaused = [false, true];
         private FakeSubscriptionManagerContext m_session;
         private ITelemetryContext m_telemetry;
         private Mock<ISubscriptionNotificationHandler> m_mockNotificationDataHandler;

--- a/tests/Opc.Ua.Client.Tests/Subscription/SubscriptionManagerTests.cs
+++ b/tests/Opc.Ua.Client.Tests/Subscription/SubscriptionManagerTests.cs
@@ -476,6 +476,41 @@ namespace Opc.Ua.Client.Subscriptions
 
         [Test]
         [CancelAfter(30_000)]
+        public async Task DisposeAsyncCancelsActivePublishingQuiescenceAsync(
+            CancellationToken testCt)
+        {
+            var entered = new TaskCompletionSource<bool>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            var cancelled = new TaskCompletionSource<bool>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            Task quiesced = m_subscriptionManager
+                .RunWithPublishingQuiescedAsync(async ct =>
+                {
+                    entered.TrySetResult(true);
+                    try
+                    {
+                        await Task.Delay(Timeout.Infinite, ct)
+                            .ConfigureAwait(false);
+                    }
+                    catch (OperationCanceledException) when (ct.IsCancellationRequested)
+                    {
+                        cancelled.TrySetResult(true);
+                        throw;
+                    }
+                }, testCt)
+                .AsTask();
+
+            await entered.Task.WaitAsync(testCt).ConfigureAwait(false);
+            Task dispose = m_subscriptionManager.DisposeAsync().AsTask();
+
+            await cancelled.Task.WaitAsync(testCt).ConfigureAwait(false);
+            await dispose.WaitAsync(testCt).ConfigureAwait(false);
+            Assert.That(async () => await quiesced.ConfigureAwait(false),
+                Throws.InstanceOf<OperationCanceledException>());
+        }
+
+        [Test]
+        [CancelAfter(30_000)]
         public async Task PublishingQuiescenceWaitsForAckRollbackAsync(
             CancellationToken testCt)
         {

--- a/tests/Opc.Ua.Client.Tests/Subscription/SubscriptionTests.cs
+++ b/tests/Opc.Ua.Client.Tests/Subscription/SubscriptionTests.cs
@@ -28,6 +28,7 @@
  * ======================================================================*/
 
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -776,6 +777,67 @@ namespace Opc.Ua.Client.Subscriptions
         }
 
         [Test]
+        public async Task RecreateAsyncFromNotificationCallbackShouldFailFastAsync()
+        {
+            var observed = new TaskCompletionSource<Exception>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            var sut = new TestSubscription(m_session, m_mockNotificationDataHandler.Object,
+                m_completion, m_options, m_telemetry, 10);
+            await using (sut.ConfigureAwait(false))
+            {
+                sut.OnKeepAliveAsync = async () =>
+                {
+                    try
+                    {
+                        await sut.RecreateAsync(default).ConfigureAwait(false);
+                    }
+                    catch (Exception ex)
+                    {
+                        observed.TrySetResult(ex);
+                    }
+                };
+
+                await sut.OnPublishReceivedAsync(BuildKeepAliveMessage(1), null, [])
+                    .ConfigureAwait(false);
+                Exception exception = await observed.Task
+                    .WaitAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+
+                Assert.That(exception, Is.TypeOf<InvalidOperationException>());
+                Assert.That(m_completion.PublishingQuiescenceCalls, Is.Zero);
+            }
+        }
+
+        [Test]
+        public async Task DisposeAsyncFromNotificationCallbackShouldFailFastAsync()
+        {
+            var observed = new TaskCompletionSource<Exception>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            var sut = new TestSubscription(m_session, m_mockNotificationDataHandler.Object,
+                m_completion, m_options, m_telemetry, 10);
+            await using (sut.ConfigureAwait(false))
+            {
+                sut.OnKeepAliveAsync = async () =>
+                {
+                    try
+                    {
+                        await sut.DisposeAsync().ConfigureAwait(false);
+                    }
+                    catch (Exception ex)
+                    {
+                        observed.TrySetResult(ex);
+                    }
+                };
+
+                await sut.OnPublishReceivedAsync(BuildKeepAliveMessage(1), null, [])
+                    .ConfigureAwait(false);
+                Exception exception = await observed.Task
+                    .WaitAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+
+                Assert.That(exception, Is.TypeOf<InvalidOperationException>());
+            }
+        }
+
+        [Test]
         public async Task RecreateAsyncShouldReCreateSubscriptionAndMonitoredItemsAsync()
         {
             // Arrange
@@ -790,6 +852,16 @@ namespace Opc.Ua.Client.Subscriptions
 
                 // We have a running subscription with one monitored item.
 
+                m_mockSubscriptionServices
+                    .Setup(s => s.DeleteSubscriptionsAsync(
+                        It.IsAny<RequestHeader>(),
+                        It.Is<ArrayOf<uint>>(a => a.Count == 1 && a[0] == 10u),
+                        It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(new DeleteSubscriptionsResponse
+                    {
+                        Results = [StatusCodes.Good]
+                    })
+                    .Verifiable(Times.Once);
                 m_mockSubscriptionServices
                     .Setup(s => s.CreateSubscriptionAsync(It.IsAny<RequestHeader>(),
                         TimeSpan.FromSeconds(100).TotalMilliseconds, 21, 7, 10, false,
@@ -822,6 +894,7 @@ namespace Opc.Ua.Client.Subscriptions
                     .Verifiable(Times.Once);
 
                 Assert.That(sut.Created, Is.True);
+                sut.SetMessageStateForTest(17, 19, [11, 13]);
 
                 // Act
                 await sut.RecreateAsync(default).ConfigureAwait(false);
@@ -835,6 +908,10 @@ namespace Opc.Ua.Client.Subscriptions
                 Assert.That(sut.CurrentPriority, Is.EqualTo(3));
                 Assert.That(sut.Id, Is.EqualTo(22));
                 Assert.That(monitoredItem.ServerId, Is.EqualTo(200));
+                Assert.That(sut.LastSequenceNumberForTest, Is.Zero);
+                Assert.That(sut.LastDataSequenceNumberForTest, Is.Zero);
+                Assert.That(sut.AvailableSequenceNumbersForTest, Is.Empty);
+                Assert.That(m_completion.PublishingQuiescenceCalls, Is.EqualTo(1));
                 // m_mockSession.Verify() was no-op (no Verifiable setups on the context); inner-mock verifications retained.
             }
         }
@@ -853,6 +930,16 @@ namespace Opc.Ua.Client.Subscriptions
                 Assert.That(monitoredItem, Is.Not.Null);
                 Assert.That(success, Is.True);
 
+                m_mockSubscriptionServices
+                    .Setup(s => s.DeleteSubscriptionsAsync(
+                        It.IsAny<RequestHeader>(),
+                        It.Is<ArrayOf<uint>>(a => a.Count == 1 && a[0] == 10u),
+                        It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(new DeleteSubscriptionsResponse
+                    {
+                        Results = [StatusCodes.Good]
+                    })
+                    .Verifiable(Times.Once);
                 m_mockSubscriptionServices
                     .Setup(s => s.CreateSubscriptionAsync(It.IsAny<RequestHeader>(),
                         TimeSpan.FromSeconds(100).TotalMilliseconds, 21, 7, 10, false,
@@ -900,6 +987,225 @@ namespace Opc.Ua.Client.Subscriptions
                 Assert.That(sut.MonitoredItems.Count, Is.EqualTo(1));
                 Assert.That(monitoredItem.ServerId, Is.EqualTo(200));
                 // m_mockSession.Verify() was no-op (no Verifiable setups on the context); inner-mock verifications retained.
+            }
+        }
+
+        [Test]
+        public async Task RecreateAsyncShouldPreserveCurrentGenerationWhenDeleteFailsAsync()
+        {
+            m_mockSubscriptionServices
+                .Setup(s => s.DeleteSubscriptionsAsync(
+                    It.IsAny<RequestHeader>(),
+                    It.Is<ArrayOf<uint>>(a => a.Count == 1 && a[0] == 10u),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new DeleteSubscriptionsResponse
+                {
+                    Results = [StatusCodes.BadUserAccessDenied]
+                });
+
+            var sut = new TestSubscription(m_session, m_mockNotificationDataHandler.Object,
+                m_completion, m_options, m_telemetry, 10);
+            await using (sut.ConfigureAwait(false))
+            {
+                sut.SetMessageStateForTest(17, 19, [11, 13]);
+
+                ServiceResultException exception =
+                    Assert.ThrowsAsync<ServiceResultException>(async () =>
+                        await sut.RecreateAsync(default).ConfigureAwait(false));
+
+                Assert.That(exception.StatusCode,
+                    Is.EqualTo(StatusCodes.BadUserAccessDenied));
+                Assert.That(sut.Id, Is.EqualTo(10u));
+                Assert.That(sut.Created, Is.True);
+                Assert.That(sut.LastSequenceNumberForTest, Is.EqualTo(17u));
+                Assert.That(sut.LastDataSequenceNumberForTest, Is.EqualTo(19u));
+                Assert.That(sut.AvailableSequenceNumbersForTest,
+                    Is.EqualTo(new uint[] { 11, 13 }));
+                Assert.That(m_completion.DroppedSubscriptions,
+                    Does.Not.Contain(10u));
+                Assert.That(m_completion.PublishingQuiescenceCalls, Is.EqualTo(1));
+                m_mockSubscriptionServices.Verify(s =>
+                    s.CreateSubscriptionAsync(It.IsAny<RequestHeader>(),
+                        It.IsAny<double>(), It.IsAny<uint>(), It.IsAny<uint>(),
+                        It.IsAny<uint>(), It.IsAny<bool>(), It.IsAny<byte>(),
+                        It.IsAny<CancellationToken>()),
+                    Times.Never);
+            }
+        }
+
+        [Test]
+        public async Task RecreateAsyncShouldDiscardQueuedMessageFromRetiredGenerationAsync()
+        {
+            var deleteEntered = new TaskCompletionSource<bool>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            var continueDelete = new TaskCompletionSource<bool>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            m_mockSubscriptionServices
+                .Setup(s => s.DeleteSubscriptionsAsync(
+                    It.IsAny<RequestHeader>(),
+                    It.Is<ArrayOf<uint>>(a => a.Count == 1 && a[0] == 10u),
+                    It.IsAny<CancellationToken>()))
+                .Returns(async (RequestHeader _, ArrayOf<uint> _,
+                    CancellationToken _) =>
+                {
+                    deleteEntered.TrySetResult(true);
+                    await continueDelete.Task.ConfigureAwait(false);
+                    return new DeleteSubscriptionsResponse
+                    {
+                        Results = [StatusCodes.Good]
+                    };
+                });
+            m_mockSubscriptionServices
+                .Setup(s => s.CreateSubscriptionAsync(It.IsAny<RequestHeader>(),
+                    TimeSpan.FromSeconds(100).TotalMilliseconds, 21, 7, 10, false,
+                    3, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new CreateSubscriptionResponse
+                {
+                    SubscriptionId = 22,
+                    RevisedLifetimeCount = 10,
+                    RevisedMaxKeepAliveCount = 5,
+                    RevisedPublishingInterval = 10000
+                });
+
+            var sut = new TestSubscription(m_session, m_mockNotificationDataHandler.Object,
+                m_completion, m_options, m_telemetry, 10);
+            await using (sut.ConfigureAwait(false))
+            {
+                Task recreate = sut.RecreateAsync(default).AsTask();
+                await deleteEntered.Task.WaitAsync(TimeSpan.FromSeconds(5))
+                    .ConfigureAwait(false);
+
+                await sut.OnPublishReceivedAsync(BuildKeepAliveMessage(9), null, [])
+                    .ConfigureAwait(false);
+                continueDelete.TrySetResult(true);
+                await recreate.WaitAsync(TimeSpan.FromSeconds(5))
+                    .ConfigureAwait(false);
+
+                await sut.OnPublishReceivedAsync(BuildKeepAliveMessage(1), null, [])
+                    .ConfigureAwait(false);
+                await WaitForAsync(() => sut.KeepAliveNotificationCount == 1,
+                    TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+                await Task.Delay(100).ConfigureAwait(false);
+
+                Assert.That(sut.KeepAliveNotificationCount, Is.EqualTo(1));
+            }
+        }
+
+        [Test]
+        public async Task DisposeAsyncShouldWaitForActiveRecreateAsync()
+        {
+            var deleteEntered = new TaskCompletionSource<bool>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            var continueDelete = new TaskCompletionSource<bool>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            m_mockSubscriptionServices
+                .Setup(s => s.DeleteSubscriptionsAsync(
+                    It.IsAny<RequestHeader>(),
+                    It.IsAny<ArrayOf<uint>>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns(async (RequestHeader _, ArrayOf<uint> ids,
+                    CancellationToken _) =>
+                {
+                    if (ids[0] == 10u)
+                    {
+                        deleteEntered.TrySetResult(true);
+                        await continueDelete.Task.ConfigureAwait(false);
+                    }
+                    return new DeleteSubscriptionsResponse
+                    {
+                        Results = [StatusCodes.Good]
+                    };
+                });
+            m_mockSubscriptionServices
+                .Setup(s => s.CreateSubscriptionAsync(It.IsAny<RequestHeader>(),
+                    TimeSpan.FromSeconds(100).TotalMilliseconds, 21, 7, 10, false,
+                    3, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new CreateSubscriptionResponse
+                {
+                    SubscriptionId = 22,
+                    RevisedLifetimeCount = 10,
+                    RevisedMaxKeepAliveCount = 5,
+                    RevisedPublishingInterval = 10000
+                });
+
+            var sut = new TestSubscription(m_session, m_mockNotificationDataHandler.Object,
+                m_completion, m_options, m_telemetry, 10);
+            Task recreate = sut.RecreateAsync(default).AsTask();
+            await deleteEntered.Task.WaitAsync(TimeSpan.FromSeconds(5))
+                .ConfigureAwait(false);
+
+            Task dispose = sut.DisposeAsync().AsTask();
+            await Task.Delay(100).ConfigureAwait(false);
+            Assert.That(dispose.IsCompleted, Is.False);
+
+            continueDelete.TrySetResult(true);
+            await recreate.WaitAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+            await dispose.WaitAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+        }
+
+        [Test]
+        public async Task RecreateAsyncShouldRunAfterCreateHookBeforeMonitoredItemsOnEveryCreateAsync()
+        {
+            var order = new List<string>();
+            m_mockSubscriptionServices
+                .Setup(s => s.DeleteSubscriptionsAsync(
+                    It.IsAny<RequestHeader>(),
+                    It.IsAny<ArrayOf<uint>>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new DeleteSubscriptionsResponse
+                {
+                    Results = [StatusCodes.Good]
+                });
+            m_mockSubscriptionServices
+                .Setup(s => s.CreateSubscriptionAsync(It.IsAny<RequestHeader>(),
+                    TimeSpan.FromSeconds(100).TotalMilliseconds, 21, 7, 10, false,
+                    3, It.IsAny<CancellationToken>()))
+                .Callback(() => order.Add("subscription"))
+                .ReturnsAsync(new CreateSubscriptionResponse
+                {
+                    SubscriptionId = 22,
+                    RevisedLifetimeCount = 10,
+                    RevisedMaxKeepAliveCount = 5,
+                    RevisedPublishingInterval = 10000
+                });
+            m_mockMonitoredItemServices
+                .Setup(s => s.CreateMonitoredItemsAsync(It.IsAny<RequestHeader>(), 22,
+                    TimestampsToReturn.Both,
+                    It.IsAny<ArrayOf<MonitoredItemCreateRequest>>(),
+                    It.IsAny<CancellationToken>()))
+                .Callback(() => order.Add("items"))
+                .ReturnsAsync(new CreateMonitoredItemsResponse
+                {
+                    Results =
+                    [
+                        new ()
+                        {
+                            StatusCode = StatusCodes.Good,
+                            MonitoredItemId = 200,
+                            RevisedSamplingInterval = 10000,
+                            RevisedQueueSize = 10
+                        }
+                    ]
+                });
+
+            var sut = new TestSubscription(m_session, m_mockNotificationDataHandler.Object,
+                m_completion, m_options, m_telemetry, 10);
+            await using (sut.ConfigureAwait(false))
+            {
+                OptionsMonitor<MonitoredItems.MonitoredItemOptions> options =
+                    OptionsFactory.Create<MonitoredItems.MonitoredItemOptions>();
+                Assert.That(sut.MonitoredItems.TryAdd("Test", options, out _), Is.True);
+                sut.OnAfterCreateAsync = _ =>
+                {
+                    order.Add("durable");
+                    return default;
+                };
+
+                await sut.RecreateAsync(default).ConfigureAwait(false);
+                await sut.RecreateAsync(default).ConfigureAwait(false);
+
+                Assert.That(order,
+                    Is.EqualTo(s_recreateOperationOrder));
             }
         }
 
@@ -1544,7 +1850,8 @@ namespace Opc.Ua.Client.Subscriptions
         /// Regression coverage for OPCFoundation/UA-.NETStandard#3540.
         /// With <see cref="SubscriptionRecoveryPolicy.RecreateOnUnsolicitedTransfer"/>
         /// the V2 engine must recreate the subscription in place on the
-        /// same session (driven through <c>ResetToRecreateAsync</c>) so
+        /// same session (driven through <see cref="ISubscription.RecreateAsync"/>)
+        /// so
         /// the application keeps receiving data after a server-side
         /// quirk emits Good_SubscriptionTransferred against a freshly
         /// created subscription.
@@ -1552,6 +1859,16 @@ namespace Opc.Ua.Client.Subscriptions
         [Test]
         public async Task GoodSubscriptionTransferredRecreatesSubscriptionWhenPolicyEnabledAsync()
         {
+            m_mockSubscriptionServices
+                .Setup(s => s.DeleteSubscriptionsAsync(
+                    It.IsAny<RequestHeader>(),
+                    It.Is<ArrayOf<uint>>(a => a.Count == 1 && a[0] == 22u),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new DeleteSubscriptionsResponse
+                {
+                    Results = [StatusCodes.Good]
+                })
+                .Verifiable(Times.Once);
             m_mockSubscriptionServices
                 .Setup(s => s.CreateSubscriptionAsync(It.IsAny<RequestHeader>(),
                     TimeSpan.FromSeconds(100).TotalMilliseconds, 21, 7, 10, false,
@@ -1574,7 +1891,7 @@ namespace Opc.Ua.Client.Subscriptions
                 Assert.That(sut.Id, Is.EqualTo(22u));
 
                 // Queue a stale ack for the doomed id so we can assert
-                // the ack-pruning step ran before recreate.
+                // the ack-pruning step ran after successful retirement.
                 await m_completion.QueueAsync(new SubscriptionAcknowledgement
                 {
                     SubscriptionId = 22u,
@@ -1592,7 +1909,7 @@ namespace Opc.Ua.Client.Subscriptions
                     "Recovery must assign the new server-side id.");
                 Assert.That(m_completion.DroppedSubscriptions,
                     Does.Contain(22u),
-                    "Ack-pruning must run for the dead subscription id before recreate.");
+                    "Ack-pruning must run for the retired subscription id.");
                 m_mockSubscriptionServices.Verify();
             }
         }
@@ -1607,6 +1924,16 @@ namespace Opc.Ua.Client.Subscriptions
         [Test]
         public async Task GoodSubscriptionTransferredCollapsesConcurrentRecreatesAsync()
         {
+            m_mockSubscriptionServices
+                .Setup(s => s.DeleteSubscriptionsAsync(
+                    It.IsAny<RequestHeader>(),
+                    It.Is<ArrayOf<uint>>(a => a.Count == 1 && a[0] == 22u),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new DeleteSubscriptionsResponse
+                {
+                    Results = [StatusCodes.Good]
+                })
+                .Verifiable(Times.Once);
             m_mockSubscriptionServices
                 .Setup(s => s.CreateSubscriptionAsync(It.IsAny<RequestHeader>(),
                     TimeSpan.FromSeconds(100).TotalMilliseconds, 21, 7, 10, false,
@@ -1661,6 +1988,15 @@ namespace Opc.Ua.Client.Subscriptions
                         Status = status
                     })
                 ]
+            };
+        }
+
+        private static NotificationMessage BuildKeepAliveMessage(uint sequenceNumber)
+        {
+            return new NotificationMessage
+            {
+                SequenceNumber = sequenceNumber,
+                NotificationData = []
             };
         }
 
@@ -1758,6 +2094,22 @@ namespace Opc.Ua.Client.Subscriptions
             public AsyncManualResetEvent SubscriptionStateChanged { get; } = new();
             public AsyncManualResetEvent PublishStateChanged { get; } = new();
             public PublishState LastPublishState { get; private set; }
+            public uint LastSequenceNumberForTest => LastSequenceNumberProcessed;
+            public uint LastDataSequenceNumberForTest => LastDataSequenceNumberProcessed;
+            public IReadOnlyList<uint> AvailableSequenceNumbersForTest
+                => AvailableInRetransmissionQueue;
+            public int KeepAliveNotificationCount
+                => Volatile.Read(ref m_keepAliveNotificationCount);
+            public Func<ValueTask>? OnKeepAliveAsync { get; set; }
+
+            public void SetMessageStateForTest(uint lastSequenceNumber,
+                uint lastDataSequenceNumber,
+                IReadOnlyList<uint> availableSequenceNumbers)
+            {
+                LastSequenceNumberProcessed = lastSequenceNumber;
+                LastDataSequenceNumberProcessed = lastDataSequenceNumber;
+                AvailableInRetransmissionQueue = availableSequenceNumbers;
+            }
 
             public async ValueTask WaitAsync()
             {
@@ -1793,10 +2145,18 @@ namespace Opc.Ua.Client.Subscriptions
             protected override ValueTask OnKeepAliveNotificationAsync(uint sequenceNumber,
                 DateTime publishTime, PublishState publishStateMask)
             {
-                return default;
+                Interlocked.Increment(ref m_keepAliveNotificationCount);
+                return OnKeepAliveAsync?.Invoke() ?? default;
             }
+
+            private int m_keepAliveNotificationCount;
         }
 
+        private static readonly string[] s_recreateOperationOrder =
+        [
+            "subscription", "durable", "items",
+            "subscription", "durable", "items"
+        ];
         private FakeMessageAckQueue m_completion;
         private OptionsMonitor<SubscriptionOptions> m_options;
         private ITelemetryContext m_telemetry;

--- a/tests/Opc.Ua.Client.Tests/Subscription/SubscriptionTests.cs
+++ b/tests/Opc.Ua.Client.Tests/Subscription/SubscriptionTests.cs
@@ -28,6 +28,7 @@
  * ======================================================================*/
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -1034,7 +1035,7 @@ namespace Opc.Ua.Client.Subscriptions
         }
 
         [Test]
-        public async Task RecreateAsyncShouldDiscardQueuedMessageFromRetiredGenerationAsync()
+        public async Task RecreateAsyncShouldDiscardQueuedBurstFromRetiredGenerationAsync()
         {
             var deleteEntered = new TaskCompletionSource<bool>(
                 TaskCreationOptions.RunContinuationsAsynchronously);
@@ -1075,19 +1076,29 @@ namespace Opc.Ua.Client.Subscriptions
                 await deleteEntered.Task.WaitAsync(TimeSpan.FromSeconds(5))
                     .ConfigureAwait(false);
 
-                await sut.OnPublishReceivedAsync(BuildKeepAliveMessage(9), null, [])
-                    .ConfigureAwait(false);
+                for (uint sequenceNumber = 1; sequenceNumber <= 1024; sequenceNumber++)
+                {
+                    await sut.OnPublishReceivedAsync(
+                        BuildKeepAliveMessage(sequenceNumber), null, [])
+                        .ConfigureAwait(false);
+                }
                 continueDelete.TrySetResult(true);
                 await recreate.WaitAsync(TimeSpan.FromSeconds(5))
                     .ConfigureAwait(false);
 
-                await sut.OnPublishReceivedAsync(BuildKeepAliveMessage(1), null, [])
-                    .ConfigureAwait(false);
-                await WaitForAsync(() => sut.KeepAliveNotificationCount == 1,
+                for (uint sequenceNumber = 1; sequenceNumber <= 3; sequenceNumber++)
+                {
+                    await sut.OnPublishReceivedAsync(
+                        BuildKeepAliveMessage(sequenceNumber), null, [])
+                        .ConfigureAwait(false);
+                }
+                await WaitForAsync(() => sut.KeepAliveNotificationCount == 3,
                     TimeSpan.FromSeconds(5)).ConfigureAwait(false);
                 await Task.Delay(100).ConfigureAwait(false);
 
-                Assert.That(sut.KeepAliveNotificationCount, Is.EqualTo(1));
+                Assert.That(sut.KeepAliveNotificationCount, Is.EqualTo(3));
+                Assert.That(sut.KeepAliveSequenceNumbers,
+                    Is.EqualTo(new uint[] { 1, 2, 3 }));
             }
         }
 
@@ -2100,6 +2111,8 @@ namespace Opc.Ua.Client.Subscriptions
                 => AvailableInRetransmissionQueue;
             public int KeepAliveNotificationCount
                 => Volatile.Read(ref m_keepAliveNotificationCount);
+            public IReadOnlyList<uint> KeepAliveSequenceNumbers
+                => [.. m_keepAliveSequenceNumbers];
             public Func<ValueTask>? OnKeepAliveAsync { get; set; }
 
             public void SetMessageStateForTest(uint lastSequenceNumber,
@@ -2145,10 +2158,12 @@ namespace Opc.Ua.Client.Subscriptions
             protected override ValueTask OnKeepAliveNotificationAsync(uint sequenceNumber,
                 DateTime publishTime, PublishState publishStateMask)
             {
+                m_keepAliveSequenceNumbers.Enqueue(sequenceNumber);
                 Interlocked.Increment(ref m_keepAliveNotificationCount);
                 return OnKeepAliveAsync?.Invoke() ?? default;
             }
 
+            private readonly ConcurrentQueue<uint> m_keepAliveSequenceNumbers = new();
             private int m_keepAliveNotificationCount;
         }
 

--- a/tests/Opc.Ua.Subscriptions.Tests/StreamingSubscriptionCoverageTests.cs
+++ b/tests/Opc.Ua.Subscriptions.Tests/StreamingSubscriptionCoverageTests.cs
@@ -917,6 +917,11 @@ namespace Opc.Ua.Subscriptions.Tests
                 throw new NotSupportedException();
             }
 
+            public ValueTask RecreateAsync(CancellationToken ct = default)
+            {
+                throw new NotSupportedException();
+            }
+
             public ValueTask<TimeSpan> SetAsDurableAsync(
                 TimeSpan lifetime, CancellationToken ct = default)
             {


### PR DESCRIPTION
## Summary

- Makes managed subscription recreation generation-safe by quiescing publish ingress, draining in-flight requests, retiring queued messages and acknowledgements from the old server-side generation, then recreating monitored items as one serialized operation.
- Exposes `RecreateAsync` on `ISubscription`, rejects recreate/dispose reentrancy from notification callbacks, preserves the active generation when server-side deletion fails, and coordinates disposal with an in-flight recreate.
- Aggregates logical subscription recovery state across partitions and adds pending/reapply APIs so monitored items can be deterministically re-created after model or configuration changes.
- Initializes the Quickstarts Boiler logger with `NullLogger` so simulation updates remain safe before a logger is assigned.
- Keeps the new logical recovery test compatible with net48.

## Review follow-up

- Documents the `RecreateAsync` callback-reentrancy and disposal exceptions on the public interface.
- Extends generation-retirement coverage with a 1,024-message stale burst and verifies that only ordered current-generation callbacks are delivered.
- Proves manager disposal cancels a cancellation-aware operation holding publish quiescence and waits for the gate to release safely.
- No runtime timeout or blanket channel drain was added: the quiesced production delegate is internal and cancellation-aware, while unconditional draining could discard or reorder current-generation messages arriving through direct ingress.

## Validation

Current head: `edb4a75145c8b03bd03da15eb71327e3bffda091`.

Review follow-up validation on the current head:

- `Opc.Ua.Client` and `Quickstarts.Servers` build successfully for net472, net48, netstandard2.1, net8.0, net9.0, and net10.0.
- focused `SubscriptionTests` and `SubscriptionManagerTests`: 72 passed on net10.0 and 72 passed on net48.

The runtime implementation is unchanged from `7b944ac68616e2d6c0595957c65179f86e78a637`, which passed:

- net10.0 `Opc.Ua.Client.Tests`: 1,974 passed.
- net10.0 `Opc.Ua.Sessions.Tests`: 738 passed, 379 skipped.
- net10.0 `Opc.Ua.Subscriptions.Tests`: 601 passed, 6 skipped.
- focused net48 managed-subscription tests: 122 passed.
- win-x64 Native-AOT publish succeeded; subscription, monitored-item, and Boiler AOT cohorts: 14 passed.
