### PR TITLE
Bump setup-dotnet to v6 and fix UDP fake-time test hang

### DIFF
--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -120,7 +120,7 @@ jobs:
         fetch-depth: 0
 
     - name: Setup .NET ${{ matrix.dotnet-version }}
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@v6
       with:
         dotnet-version: ${{ matrix.dotnet-version }}
 
@@ -203,7 +203,7 @@ jobs:
         fetch-depth: 0
 
     - name: Setup .NET ${{ env.DOTNET_VERSION }}
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@v6
       with:
         dotnet-version: ${{ env.DOTNET_VERSION }}
 
@@ -248,7 +248,7 @@ jobs:
         fetch-depth: 0
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@v6
       with:
         dotnet-version: |
           8.0.x
@@ -293,7 +293,7 @@ jobs:
         fetch-depth: 0
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@v6
       with:
         dotnet-version: |
           8.0.x

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -51,7 +51,7 @@ jobs:
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
     - name: Set up .NET
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@v6
       with:
         dotnet-version: '10.x'
     # https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages#c-compiler-flags-injected-by-codeql-for-manual-builds

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -64,7 +64,7 @@ jobs:
         fetch-depth: 0
 
     - name: Set up .NET 8
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@v6
       with:
         dotnet-version: '8.x'
 

--- a/.github/workflows/preview-publish.yml
+++ b/.github/workflows/preview-publish.yml
@@ -54,7 +54,7 @@ jobs:
           fetch-depth: 0   # nbgv needs full git history
 
       - name: Setup .NET 10.0
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: '10.0.x'
 

--- a/.github/workflows/pump-device-integration-server-docker.yml
+++ b/.github/workflows/pump-device-integration-server-docker.yml
@@ -36,7 +36,7 @@ jobs:
         fetch-depth: 0
 
     - name: Set up .NET
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@v6
       with:
         dotnet-version: '8.x'
 

--- a/.github/workflows/sample-ha-longhaul.yml
+++ b/.github/workflows/sample-ha-longhaul.yml
@@ -44,7 +44,7 @@ jobs:
         fetch-depth: 0
 
     - name: Setup .NET ${{ env.DOTNET_VERSION }}
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@v6
       with:
         dotnet-version: ${{ env.DOTNET_VERSION }}
 

--- a/.github/workflows/stability-test.yml
+++ b/.github/workflows/stability-test.yml
@@ -34,7 +34,7 @@ jobs:
         fetch-depth: 0
 
     - name: Setup .NET ${{ env.DOTNET_VERSION }}
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@v6
       with:
         dotnet-version: ${{ env.DOTNET_VERSION }}
 

--- a/.github/workflows/stress-test.yml
+++ b/.github/workflows/stress-test.yml
@@ -41,7 +41,7 @@ jobs:
         fetch-depth: 0
 
     - name: Setup .NET ${{ env.DOTNET_VERSION }}
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@v6
       with:
         dotnet-version: ${{ env.DOTNET_VERSION }}
 

--- a/tests/Opc.Ua.PubSub.Udp.Tests/UdpMessageRepeaterTests.cs
+++ b/tests/Opc.Ua.PubSub.Udp.Tests/UdpMessageRepeaterTests.cs
@@ -80,11 +80,12 @@ namespace Opc.Ua.PubSub.Udp.Tests
         }
 
         [Test]
-        [CancelAfter(10000)]
+        [CancelAfter(kTestTimeoutMilliseconds)]
         public async Task ThreeRepeats_SendsFourTimes_FakeTimerAdvanced()
         {
-            var fake = new TrackingFakeTimeProvider(3);
-            var repeater = new UdpMessageRepeater(3, TimeSpan.FromMilliseconds(100), fake);
+            TimeSpan repeatDelay = TimeSpan.FromMilliseconds(100);
+            using var fake = new TrackingFakeTimeProvider(repeatDelay);
+            var repeater = new UdpMessageRepeater(3, repeatDelay, fake);
             int count = 0;
 
             Task sendTask = repeater.SendWithRepeatsAsync(_ =>
@@ -96,10 +97,10 @@ namespace Opc.Ua.PubSub.Udp.Tests
             for (int i = 0; i < 3; i++)
             {
                 await WaitForCompletionAsync(
-                    fake.GetTimerCreatedTask(i),
+                    fake.WaitForTimerCreatedAsync(),
                     $"Timed out waiting for repeat timer {i + 1}.")
                     .ConfigureAwait(false);
-                fake.Advance(TimeSpan.FromMilliseconds(100));
+                fake.Advance(repeatDelay);
             }
 
             await WaitForCompletionAsync(
@@ -188,11 +189,12 @@ namespace Opc.Ua.PubSub.Udp.Tests
         }
 
         [Test]
-        [CancelAfter(10000)]
+        [CancelAfter(kTestTimeoutMilliseconds)]
         public async Task CancellationBetweenRepeats_StopsLoop()
         {
-            var fake = new TrackingFakeTimeProvider(1);
-            var repeater = new UdpMessageRepeater(5, TimeSpan.FromMilliseconds(50), fake);
+            TimeSpan repeatDelay = TimeSpan.FromMilliseconds(50);
+            using var fake = new TrackingFakeTimeProvider(repeatDelay);
+            var repeater = new UdpMessageRepeater(5, repeatDelay, fake);
             int count = 0;
             using var cts = new CancellationTokenSource();
 
@@ -207,10 +209,10 @@ namespace Opc.Ua.PubSub.Udp.Tests
             }, cts.Token).AsTask();
 
             await WaitForCompletionAsync(
-                fake.GetTimerCreatedTask(0),
+                fake.WaitForTimerCreatedAsync(),
                 "Timed out waiting for the first repeat timer.")
                 .ConfigureAwait(false);
-            fake.Advance(TimeSpan.FromMilliseconds(50));
+            fake.Advance(repeatDelay);
 
             try
             {
@@ -256,26 +258,21 @@ namespace Opc.Ua.PubSub.Udp.Tests
         {
             Task completed = await Task.WhenAny(
                 completion,
-                Task.Delay(TimeSpan.FromSeconds(5))).ConfigureAwait(false);
+                Task.Delay(s_completionTimeout)).ConfigureAwait(false);
             Assert.That(completed, Is.SameAs(completion), timeoutMessage);
             await completion.ConfigureAwait(false);
         }
 
-        private sealed class TrackingFakeTimeProvider : FakeTimeProvider
+        private sealed class TrackingFakeTimeProvider : FakeTimeProvider, IDisposable
         {
-            public TrackingFakeTimeProvider(int expectedTimerCount)
+            public TrackingFakeTimeProvider(TimeSpan repeatDelay)
             {
-                m_timerCreated = new TaskCompletionSource<bool>[expectedTimerCount];
-                for (int i = 0; i < m_timerCreated.Length; i++)
-                {
-                    m_timerCreated[i] = new TaskCompletionSource<bool>(
-                        TaskCreationOptions.RunContinuationsAsynchronously);
-                }
+                m_repeatDelay = repeatDelay;
             }
 
-            public Task<bool> GetTimerCreatedTask(int index)
+            public Task WaitForTimerCreatedAsync()
             {
-                return m_timerCreated[index].Task;
+                return m_timerCreated.WaitAsync();
             }
 
             public override ITimer CreateTimer(
@@ -285,16 +282,24 @@ namespace Opc.Ua.PubSub.Udp.Tests
                 TimeSpan period)
             {
                 ITimer timer = base.CreateTimer(callback, state, dueTime, period);
-                int timerIndex = Interlocked.Increment(ref m_timerCount) - 1;
-                if ((uint)timerIndex < (uint)m_timerCreated.Length)
+                if (dueTime == m_repeatDelay && period == Timeout.InfiniteTimeSpan)
                 {
-                    m_timerCreated[timerIndex].TrySetResult(true);
+                    m_timerCreated.Release();
                 }
                 return timer;
             }
 
-            private readonly TaskCompletionSource<bool>[] m_timerCreated;
-            private int m_timerCount;
+            public void Dispose()
+            {
+                m_timerCreated.Dispose();
+            }
+
+            private readonly TimeSpan m_repeatDelay;
+            private readonly SemaphoreSlim m_timerCreated = new(0);
         }
+
+        private const int kTestTimeoutMilliseconds = 10000;
+        private static readonly TimeSpan s_completionTimeout =
+            TimeSpan.FromMilliseconds(kTestTimeoutMilliseconds / 2);
     }
 }

--- a/tests/Opc.Ua.PubSub.Udp.Tests/UdpMessageRepeaterTests.cs
+++ b/tests/Opc.Ua.PubSub.Udp.Tests/UdpMessageRepeaterTests.cs
@@ -80,25 +80,32 @@ namespace Opc.Ua.PubSub.Udp.Tests
         }
 
         [Test]
+        [CancelAfter(10000)]
         public async Task ThreeRepeats_SendsFourTimes_FakeTimerAdvanced()
         {
-            var fake = new FakeTimeProvider();
+            var fake = new TrackingFakeTimeProvider(3);
             var repeater = new UdpMessageRepeater(3, TimeSpan.FromMilliseconds(100), fake);
             int count = 0;
 
-            ValueTask sendTask = repeater.SendWithRepeatsAsync(_ =>
+            Task sendTask = repeater.SendWithRepeatsAsync(_ =>
             {
-                count++;
+                Interlocked.Increment(ref count);
                 return default;
-            });
+            }).AsTask();
 
-            for (int i = 0; i < 3 && !sendTask.IsCompleted; i++)
+            for (int i = 0; i < 3; i++)
             {
+                await WaitForCompletionAsync(
+                    fake.GetTimerCreatedTask(i),
+                    $"Timed out waiting for repeat timer {i + 1}.")
+                    .ConfigureAwait(false);
                 fake.Advance(TimeSpan.FromMilliseconds(100));
-                await Task.Yield();
             }
 
-            await sendTask.ConfigureAwait(false);
+            await WaitForCompletionAsync(
+                sendTask,
+                "Timed out waiting for the repeated sends to complete.")
+                .ConfigureAwait(false);
 
             Assert.That(count, Is.EqualTo(4));
         }
@@ -181,39 +188,42 @@ namespace Opc.Ua.PubSub.Udp.Tests
         }
 
         [Test]
+        [CancelAfter(10000)]
         public async Task CancellationBetweenRepeats_StopsLoop()
         {
-            var fake = new FakeTimeProvider();
+            var fake = new TrackingFakeTimeProvider(1);
             var repeater = new UdpMessageRepeater(5, TimeSpan.FromMilliseconds(50), fake);
             int count = 0;
             using var cts = new CancellationTokenSource();
 
-            ValueTask sendTask = repeater.SendWithRepeatsAsync(_ =>
+            Task sendTask = repeater.SendWithRepeatsAsync(_ =>
             {
-                count++;
-                if (count == 2)
+                int sendNumber = Interlocked.Increment(ref count);
+                if (sendNumber == 2)
                 {
                     cts.Cancel();
                 }
                 return default;
-            }, cts.Token);
+            }, cts.Token).AsTask();
 
-            for (int i = 0; i < 6 && !sendTask.IsCompleted; i++)
-            {
-                fake.Advance(TimeSpan.FromMilliseconds(50));
-                await Task.Yield();
-            }
+            await WaitForCompletionAsync(
+                fake.GetTimerCreatedTask(0),
+                "Timed out waiting for the first repeat timer.")
+                .ConfigureAwait(false);
+            fake.Advance(TimeSpan.FromMilliseconds(50));
 
             try
             {
-                await sendTask.ConfigureAwait(false);
+                await WaitForCompletionAsync(
+                    sendTask,
+                    "Timed out waiting for cancellation to stop the repeater.")
+                    .ConfigureAwait(false);
             }
             catch (OperationCanceledException)
             {
             }
 
-            Assert.That(count, Is.LessThan(6));
-            Assert.That(count, Is.GreaterThanOrEqualTo(2));
+            Assert.That(count, Is.EqualTo(2));
         }
 
         [Test]
@@ -240,6 +250,51 @@ namespace Opc.Ua.PubSub.Udp.Tests
             }
 
             Assert.That(count, Is.EqualTo(3));
+        }
+
+        private static async Task WaitForCompletionAsync(Task completion, string timeoutMessage)
+        {
+            Task completed = await Task.WhenAny(
+                completion,
+                Task.Delay(TimeSpan.FromSeconds(5))).ConfigureAwait(false);
+            Assert.That(completed, Is.SameAs(completion), timeoutMessage);
+            await completion.ConfigureAwait(false);
+        }
+
+        private sealed class TrackingFakeTimeProvider : FakeTimeProvider
+        {
+            public TrackingFakeTimeProvider(int expectedTimerCount)
+            {
+                m_timerCreated = new TaskCompletionSource<bool>[expectedTimerCount];
+                for (int i = 0; i < m_timerCreated.Length; i++)
+                {
+                    m_timerCreated[i] = new TaskCompletionSource<bool>(
+                        TaskCreationOptions.RunContinuationsAsynchronously);
+                }
+            }
+
+            public Task<bool> GetTimerCreatedTask(int index)
+            {
+                return m_timerCreated[index].Task;
+            }
+
+            public override ITimer CreateTimer(
+                TimerCallback callback,
+                object? state,
+                TimeSpan dueTime,
+                TimeSpan period)
+            {
+                ITimer timer = base.CreateTimer(callback, state, dueTime, period);
+                int timerIndex = Interlocked.Increment(ref m_timerCount) - 1;
+                if ((uint)timerIndex < (uint)m_timerCreated.Length)
+                {
+                    m_timerCreated[timerIndex].TrySetResult(true);
+                }
+                return timer;
+            }
+
+            private readonly TaskCompletionSource<bool>[] m_timerCreated;
+            private int m_timerCount;
         }
     }
 }


### PR DESCRIPTION
# Description

Updates every GitHub Actions workflow from `actions/setup-dotnet@v5` to `actions/setup-dotnet@v6` and fixes the net48 `UdpMessageRepeaterTests` hang observed in Azure build 15773.

The hang dump showed NUnit blocked in `AsyncToSyncAdapter` waiting for an unfinished async test after virtual time advanced before the repeater registered its next delay timer. The tests now wait for each timer registration before advancing `FakeTimeProvider`, apply the same synchronization to cancellation coverage, and use real-time deadlines so regressions fail instead of hanging the test host.

## Related Issues

- Replaces #4064
- Fixes the PubSub UDP net48 hang in [Azure build 15773](https://opcfoundation.visualstudio.com/865bd736-d0a6-4260-a336-d09d3eb39375/_build/results?buildId=15773)

## Testing

- Exact PubSub UDP net48 pipeline selection: 175 passed, 4 skipped.
- `UdpMessageRepeaterTests`: 30 consecutive net48 runs passed.
- `UdpMessageRepeaterTests`: 10 passed on net10.0.

## Checklist

- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf) and read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [x] I have added all necessary documentation.
- [x] I have verified that my changes do not introduce (new) build or analyzer warnings.
- [ ] I ran **all** tests locally using the **UA.slnx** solution against at least .net **framework** and .net **10**, and all passed.
- [ ] I fixed **all** failing and flaky tests in the CI pipelines and **all** CodeQL warnings.
- [x] I have addressed **all** PR feedback received.