### PR TITLE
Fix #4061: invalidate component cache on runtime node add/remove

### DIFF
--- a/docs/ModelChangeTracking.md
+++ b/docs/ModelChangeTracking.md
@@ -67,6 +67,13 @@ public class MyNodeManager : AsyncCustomNodeManager
 }
 ```
 
+> **Browse consistency.** `CreateNodeAsync` / `AddNodeAsync` /
+> `DeleteNodeAsync` also keep the node manager's internal component
+> cache in sync with the change — the affected node (and its parent)
+> are refreshed or evicted — so a Browse, Read or Call issued after
+> the change reflects the committed address space instead of a stale,
+> cached view.
+
 If your node manager mutates the address space without going through
 `CreateNodeAsync` / `DeleteNodeAsync` (for example by editing an
 in-memory `NodeStateCollection`), you can either:

--- a/docs/ModelChangeTracking.md
+++ b/docs/ModelChangeTracking.md
@@ -67,12 +67,9 @@ public class MyNodeManager : AsyncCustomNodeManager
 }
 ```
 
-> **Browse consistency.** `CreateNodeAsync` / `AddNodeAsync` /
-> `DeleteNodeAsync` also keep the node manager's internal component
-> cache in sync with the change — the affected node (and its parent)
-> are refreshed or evicted — so a Browse, Read or Call issued after
-> the change reflects the committed address space instead of a stale,
-> cached view.
+> **Browse consistency.** `CreateNodeAsync`, `AddNodeAsync` and `DeleteNodeAsync` also keep the node manager's internal component cache in sync with the change.
+> A deleted node is evicted from the cache, and the parent's cached view is refreshed after a runtime add or remove, so a Browse, Read or Call issued afterwards reflects the committed child set instead of a stale, cached view.
+> Re-registering or replacing a node id (for example swapping a passive child for a typed proxy) refreshes the cached instance only when that node is already cached.
 
 If your node manager mutates the address space without going through
 `CreateNodeAsync` / `DeleteNodeAsync` (for example by editing an

--- a/src/Opc.Ua.Server/NodeManager/AsyncCustomNodeManager.cs
+++ b/src/Opc.Ua.Server/NodeManager/AsyncCustomNodeManager.cs
@@ -484,8 +484,8 @@ namespace Opc.Ua.Server
             await AddPredefinedNodeAsync(contextToUse, instance, cancellationToken).ConfigureAwait(false);
 
             // Refresh the parent's cached component view so a Browse issued
-            // after this runtime add reflects the new child (see issue #4061).
-            RefreshParentComponentCache(parentId);
+            // after this runtime add reflects the new child.
+            await RefreshParentComponentCacheAsync(parentId, cancellationToken).ConfigureAwait(false);
 
             NodeId resultId = instance.NodeId;
 
@@ -539,8 +539,8 @@ namespace Opc.Ua.Server
             await AddPredefinedNodeAsync(contextToUse, instance, cancellationToken).ConfigureAwait(false);
 
             // Refresh the parent's cached component view so a Browse issued
-            // after this runtime add reflects the new child (see issue #4061).
-            RefreshParentComponentCache(parentId);
+            // after this runtime add reflects the new child.
+            await RefreshParentComponentCacheAsync(parentId, cancellationToken).ConfigureAwait(false);
 
             NodeId resultId = instance.NodeId;
 
@@ -827,9 +827,8 @@ namespace Opc.Ua.Server
             await RemoveRootNotifierAsync(node!, cancellationToken).ConfigureAwait(false);
 
             // Refresh the parent's cached component view so a Browse issued
-            // after this runtime delete no longer reflects the removed child
-            // (see issue #4061).
-            RefreshParentComponentCache(parentId);
+            // after this runtime delete no longer reflects the removed child.
+            await RefreshParentComponentCacheAsync(parentId, cancellationToken).ConfigureAwait(false);
 
             if (referencesToRemove.Count > 0)
             {
@@ -991,8 +990,8 @@ namespace Opc.Ua.Server
             }
 
             // Refresh the parent's cached component view so a Browse issued
-            // after this runtime add reflects the new child (see issue #4061).
-            RefreshParentComponentCache(parentNodeId);
+            // after this runtime add reflects the new child.
+            await RefreshParentComponentCacheAsync(parentNodeId, cancellationToken).ConfigureAwait(false);
 
             if (ModelChangeEmissionEnabled)
             {
@@ -1036,9 +1035,8 @@ namespace Opc.Ua.Server
             await RemoveRootNotifierAsync(node!, cancellationToken).ConfigureAwait(false);
 
             // Refresh the parent's cached component view so a Browse issued
-            // after this runtime delete no longer reflects the removed child
-            // (see issue #4061).
-            RefreshParentComponentCache(parentId);
+            // after this runtime delete no longer reflects the removed child.
+            await RefreshParentComponentCacheAsync(parentId, cancellationToken).ConfigureAwait(false);
 
             if (item.DeleteTargetReferences && referencesToRemove.Count > 0)
             {
@@ -1574,7 +1572,7 @@ namespace Opc.Ua.Server
             PredefinedNodes.AddOrUpdate(activeNode.NodeId, activeNode, (key, _) => activeNode);
 
             // Keep any cached component view pointing at the current instance
-            // when a node is re-registered/replaced at runtime (see issue #4061).
+            // when a node is re-registered/replaced at runtime.
             RefreshComponentCache(activeNode.NodeId, activeNode);
 
             if (activeNode is BaseTypeState type)
@@ -1624,8 +1622,8 @@ namespace Opc.Ua.Server
             }
 
             // Drop any cached component view so a later resolution does not
-            // return the removed node (see issue #4061).
-            InvalidateComponentCache(node.NodeId);
+            // return the removed node.
+            await InvalidateComponentCacheAsync(node.NodeId, cancellationToken).ConfigureAwait(false);
 
             node.UpdateChangeMasks(NodeStateChangeMasks.Deleted);
             await node.ClearChangeMasksAsync(context, false, cancellationToken).ConfigureAwait(false);
@@ -6851,18 +6849,20 @@ namespace Opc.Ua.Server
         /// Forcibly evicts the component-cache entry for a node id, ignoring
         /// its reference count. Used when a node is deleted at runtime so a
         /// subsequent Browse/Read/Call re-validates against the current
-        /// address space instead of resolving the stale, removed node
-        /// (see issue #4061).
+        /// address space instead of resolving the stale, removed node.
         /// </summary>
         /// <param name="nodeId">The node id whose cached view to evict.</param>
-        protected void InvalidateComponentCache(NodeId nodeId)
+        /// <param name="cancellationToken">The token used to cancel the operation.</param>
+        private async ValueTask InvalidateComponentCacheAsync(
+            NodeId nodeId,
+            CancellationToken cancellationToken = default)
         {
             if (nodeId.IsNull || m_componentCache == null)
             {
                 return;
             }
 
-            m_componentCacheSemaphore.Wait();
+            await m_componentCacheSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
             try
             {
                 m_componentCache.Remove(nodeId);
@@ -6877,11 +6877,16 @@ namespace Opc.Ua.Server
         /// Updates the cached instance for a node id when the address-space
         /// entry has been replaced at runtime, preserving the existing
         /// reference count. No-op when the node is not cached or the cached
-        /// instance is already current (see issue #4061).
+        /// instance is already current.
         /// </summary>
+        /// <remarks>
+        /// Invoked from the synchronous registration and upgrade paths, so it
+        /// uses the same synchronous cache synchronization as the other
+        /// synchronous component-cache helpers on this type.
+        /// </remarks>
         /// <param name="nodeId">The node id whose cached instance to refresh.</param>
         /// <param name="node">The current node state instance.</param>
-        protected void RefreshComponentCache(NodeId nodeId, NodeState node)
+        private void RefreshComponentCache(NodeId nodeId, NodeState node)
         {
             if (nodeId.IsNull || node == null || m_componentCache == null)
             {
@@ -6906,19 +6911,33 @@ namespace Opc.Ua.Server
         /// <summary>
         /// Refreshes the cached component view of a parent node after one of
         /// its children was added or removed at runtime, so a Browse issued
-        /// after the change reflects the committed child set (see issue #4061).
+        /// after the change reflects the committed child set.
         /// </summary>
         /// <param name="parentId">The parent node id.</param>
-        private void RefreshParentComponentCache(NodeId parentId)
+        /// <param name="cancellationToken">The token used to cancel the operation.</param>
+        private async ValueTask RefreshParentComponentCacheAsync(
+            NodeId parentId,
+            CancellationToken cancellationToken = default)
         {
-            if (parentId.IsNull)
+            if (parentId.IsNull ||
+                m_componentCache == null ||
+                !PredefinedNodes.TryGetValue(parentId, out NodeState? parent))
             {
                 return;
             }
 
-            if (PredefinedNodes.TryGetValue(parentId, out NodeState? parent))
+            await m_componentCacheSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+            try
             {
-                RefreshComponentCache(parentId, parent);
+                if (m_componentCache.TryGetValue(parentId, out CacheEntry? entry) &&
+                    !ReferenceEquals(entry.Entry, parent))
+                {
+                    entry.Entry = parent;
+                }
+            }
+            finally
+            {
+                m_componentCacheSemaphore.Release();
             }
         }
 

--- a/src/Opc.Ua.Server/NodeManager/AsyncCustomNodeManager.cs
+++ b/src/Opc.Ua.Server/NodeManager/AsyncCustomNodeManager.cs
@@ -483,6 +483,10 @@ namespace Opc.Ua.Server
             instance.Create(contextToUse, default, browseName, default, true);
             await AddPredefinedNodeAsync(contextToUse, instance, cancellationToken).ConfigureAwait(false);
 
+            // Refresh the parent's cached component view so a Browse issued
+            // after this runtime add reflects the new child (see issue #4061).
+            RefreshParentComponentCache(parentId);
+
             NodeId resultId = instance.NodeId;
 
             if (ModelChangeEmissionEnabled)
@@ -533,6 +537,10 @@ namespace Opc.Ua.Server
             instance.UpdateReferenceTargets(context, mappingTable);
 
             await AddPredefinedNodeAsync(contextToUse, instance, cancellationToken).ConfigureAwait(false);
+
+            // Refresh the parent's cached component view so a Browse issued
+            // after this runtime add reflects the new child (see issue #4061).
+            RefreshParentComponentCache(parentId);
 
             NodeId resultId = instance.NodeId;
 
@@ -610,6 +618,7 @@ namespace Opc.Ua.Server
                 return false;
             }
             PredefinedNodes[nodeId] = node;
+            RefreshComponentCache(nodeId, node);
             return true;
         }
 
@@ -812,9 +821,15 @@ namespace Opc.Ua.Server
             }
 
             NodeId? deletedTypeDefinition = (node as BaseInstanceState)?.TypeDefinitionId;
+            NodeId parentId = (node as BaseInstanceState)?.Parent?.NodeId ?? default;
 
             await RemovePredefinedNodeAsync(contextToUse, node!, referencesToRemove, cancellationToken).ConfigureAwait(false);
             await RemoveRootNotifierAsync(node!, cancellationToken).ConfigureAwait(false);
+
+            // Refresh the parent's cached component view so a Browse issued
+            // after this runtime delete no longer reflects the removed child
+            // (see issue #4061).
+            RefreshParentComponentCache(parentId);
 
             if (referencesToRemove.Count > 0)
             {
@@ -975,6 +990,10 @@ namespace Opc.Ua.Server
                 return (new ServiceResult(ex), NodeId.Null);
             }
 
+            // Refresh the parent's cached component view so a Browse issued
+            // after this runtime add reflects the new child (see issue #4061).
+            RefreshParentComponentCache(parentNodeId);
+
             if (ModelChangeEmissionEnabled)
             {
                 ModelChangeAggregator.RecordNodeAdded(instance.NodeId, instance.TypeDefinitionId);
@@ -1009,11 +1028,17 @@ namespace Opc.Ua.Server
             }
 
             NodeId? deletedTypeDefinition = (node as BaseInstanceState)?.TypeDefinitionId;
+            NodeId parentId = (node as BaseInstanceState)?.Parent?.NodeId ?? default;
 
             var referencesToRemove = new List<LocalReference>();
             await RemovePredefinedNodeAsync(systemContext, node!, referencesToRemove, cancellationToken)
                 .ConfigureAwait(false);
             await RemoveRootNotifierAsync(node!, cancellationToken).ConfigureAwait(false);
+
+            // Refresh the parent's cached component view so a Browse issued
+            // after this runtime delete no longer reflects the removed child
+            // (see issue #4061).
+            RefreshParentComponentCache(parentId);
 
             if (item.DeleteTargetReferences && referencesToRemove.Count > 0)
             {
@@ -1548,6 +1573,10 @@ namespace Opc.Ua.Server
 
             PredefinedNodes.AddOrUpdate(activeNode.NodeId, activeNode, (key, _) => activeNode);
 
+            // Keep any cached component view pointing at the current instance
+            // when a node is re-registered/replaced at runtime (see issue #4061).
+            RefreshComponentCache(activeNode.NodeId, activeNode);
+
             if (activeNode is BaseTypeState type)
             {
                 AddTypesToTypeTree(type);
@@ -1593,6 +1622,11 @@ namespace Opc.Ua.Server
             {
                 return;
             }
+
+            // Drop any cached component view so a later resolution does not
+            // return the removed node (see issue #4061).
+            InvalidateComponentCache(node.NodeId);
+
             node.UpdateChangeMasks(NodeStateChangeMasks.Deleted);
             await node.ClearChangeMasksAsync(context, false, cancellationToken).ConfigureAwait(false);
             await OnNodeRemovedAsync(node, cancellationToken).ConfigureAwait(false);
@@ -6810,6 +6844,81 @@ namespace Opc.Ua.Server
             finally
             {
                 m_componentCacheSemaphore.Release();
+            }
+        }
+
+        /// <summary>
+        /// Forcibly evicts the component-cache entry for a node id, ignoring
+        /// its reference count. Used when a node is deleted at runtime so a
+        /// subsequent Browse/Read/Call re-validates against the current
+        /// address space instead of resolving the stale, removed node
+        /// (see issue #4061).
+        /// </summary>
+        /// <param name="nodeId">The node id whose cached view to evict.</param>
+        protected void InvalidateComponentCache(NodeId nodeId)
+        {
+            if (nodeId.IsNull || m_componentCache == null)
+            {
+                return;
+            }
+
+            m_componentCacheSemaphore.Wait();
+            try
+            {
+                m_componentCache.Remove(nodeId);
+            }
+            finally
+            {
+                m_componentCacheSemaphore.Release();
+            }
+        }
+
+        /// <summary>
+        /// Updates the cached instance for a node id when the address-space
+        /// entry has been replaced at runtime, preserving the existing
+        /// reference count. No-op when the node is not cached or the cached
+        /// instance is already current (see issue #4061).
+        /// </summary>
+        /// <param name="nodeId">The node id whose cached instance to refresh.</param>
+        /// <param name="node">The current node state instance.</param>
+        protected void RefreshComponentCache(NodeId nodeId, NodeState node)
+        {
+            if (nodeId.IsNull || node == null || m_componentCache == null)
+            {
+                return;
+            }
+
+            m_componentCacheSemaphore.Wait();
+            try
+            {
+                if (m_componentCache.TryGetValue(nodeId, out CacheEntry? entry) &&
+                    !ReferenceEquals(entry.Entry, node))
+                {
+                    entry.Entry = node;
+                }
+            }
+            finally
+            {
+                m_componentCacheSemaphore.Release();
+            }
+        }
+
+        /// <summary>
+        /// Refreshes the cached component view of a parent node after one of
+        /// its children was added or removed at runtime, so a Browse issued
+        /// after the change reflects the committed child set (see issue #4061).
+        /// </summary>
+        /// <param name="parentId">The parent node id.</param>
+        private void RefreshParentComponentCache(NodeId parentId)
+        {
+            if (parentId.IsNull)
+            {
+                return;
+            }
+
+            if (PredefinedNodes.TryGetValue(parentId, out NodeState? parent))
+            {
+                RefreshComponentCache(parentId, parent);
             }
         }
 

--- a/src/Opc.Ua.Types/State/NodeState.cs
+++ b/src/Opc.Ua.Types/State/NodeState.cs
@@ -4729,9 +4729,8 @@ namespace Opc.Ua
             lock (m_childrenLock)
             {
                 (m_children ??= []).Add(child);
+                m_changeMasks |= NodeStateChangeMasks.Children;
             }
-
-            m_changeMasks |= NodeStateChangeMasks.Children;
         }
 
         /// <summary>

--- a/tests/Opc.Ua.Server.Tests/AsyncCustomNodeManagerTests.cs
+++ b/tests/Opc.Ua.Server.Tests/AsyncCustomNodeManagerTests.cs
@@ -1020,6 +1020,133 @@ namespace Opc.Ua.Server.Tests
             Assert.That(references[0].NodeId, Is.EqualTo(new ExpandedNodeId(child.NodeId)));
         }
 
+        /// <summary>
+        /// Regression for issue #4061: when a node that has been cached (e.g.
+        /// because it was subscribed/registered) is deleted at runtime, it must
+        /// no longer be resolvable through the component cache, otherwise a
+        /// later Browse/Read/Call can be served the stale, removed node.
+        /// </summary>
+        [Test]
+        public async Task DeleteNodeAsync_EvictsDeletedNodeFromComponentCacheAsync()
+        {
+            using ITestNodeManager manager = CreateManager();
+            Assume.That(manager is TestableAsyncCustomNodeManager, "Requires AsyncCustomNodeManager features");
+
+            ServerSystemContext context = manager.SystemContext;
+            ushort ns = manager.NamespaceIndexes[0];
+
+            var node = new BaseObjectState(null);
+            node.CreateAsPredefinedNode(context);
+            node.NodeId = new NodeId("CachedDeleteNode", ns);
+            node.BrowseName = new QualifiedName("CachedDeleteNode", ns);
+            await manager.AddNodeAsync(context, default, node).ConfigureAwait(false);
+
+            // simulate a subscription/registration that caches the node.
+            manager.AddNodeToComponentCachePublic(context, new NodeHandle(node.NodeId, node), node);
+            Assume.That(
+                manager.LookupNodeInComponentCachePublic(context, new NodeHandle { NodeId = node.NodeId }),
+                Is.Not.Null);
+
+            await manager.DeleteNodeAsync(context, node.NodeId).ConfigureAwait(false);
+
+            Assert.That(manager.Find(node.NodeId), Is.Null);
+            Assert.That(
+                manager.LookupNodeInComponentCachePublic(context, new NodeHandle { NodeId = node.NodeId }),
+                Is.Null,
+                "deleted node must not remain resolvable through the component cache");
+        }
+
+        /// <summary>
+        /// Regression for issue #4061: re-registering a node id with a new
+        /// instance at runtime must refresh any cached component view so a
+        /// later resolution returns the current instance rather than the stale
+        /// one captured when the node was first cached.
+        /// </summary>
+        [Test]
+        public async Task AddPredefinedNodeAsync_RefreshesReplacedInstanceInComponentCacheAsync()
+        {
+            using ITestNodeManager manager = CreateManager();
+            Assume.That(manager is TestableAsyncCustomNodeManager, "Requires AsyncCustomNodeManager features");
+
+            ServerSystemContext context = manager.SystemContext;
+            ushort ns = manager.NamespaceIndexes[0];
+
+            var original = new BaseObjectState(null);
+            original.CreateAsPredefinedNode(context);
+            original.NodeId = new NodeId("SwapNode", ns);
+            original.BrowseName = new QualifiedName("SwapNode", ns);
+            await manager.AddNodeAsync(context, default, original).ConfigureAwait(false);
+
+            manager.AddNodeToComponentCachePublic(context, new NodeHandle(original.NodeId, original), original);
+
+            var replacement = new BaseObjectState(null);
+            replacement.CreateAsPredefinedNode(context);
+            replacement.NodeId = new NodeId("SwapNode", ns);
+            replacement.BrowseName = new QualifiedName("SwapNode", ns);
+            await manager.AddPredefinedNodeAsync(context, replacement).ConfigureAwait(false);
+
+            NodeState cached = manager.LookupNodeInComponentCachePublic(
+                context, new NodeHandle { NodeId = original.NodeId });
+            Assert.That(
+                cached,
+                Is.SameAs(replacement),
+                "component cache must resolve the current instance after re-registration");
+        }
+
+        /// <summary>
+        /// Regression for issue #4061: a Browse of a parent that was already
+        /// browsed/subscribed (and therefore cached) must reflect a child added
+        /// to it at runtime via CreateNodeAsync.
+        /// </summary>
+        [Test]
+        public async Task BrowseAsync_AfterRuntimeAddWithCachedParent_IncludesNewChildAsync()
+        {
+            using ITestNodeManager manager = CreateManager();
+            Assume.That(manager is TestableAsyncCustomNodeManager, "Requires AsyncCustomNodeManager features");
+
+            ServerSystemContext context = manager.SystemContext;
+            ushort ns = manager.NamespaceIndexes[0];
+
+            var parent = new BaseObjectState(null);
+            parent.CreateAsPredefinedNode(context);
+            parent.NodeId = new NodeId("BrowseCachedParent", ns);
+            parent.BrowseName = new QualifiedName("BrowseCachedParent", ns);
+            await manager.AddNodeAsync(context, default, parent).ConfigureAwait(false);
+
+            // parent is subscribed/browsed -> cached.
+            manager.AddNodeToComponentCachePublic(context, new NodeHandle(parent.NodeId, parent), parent);
+
+            var child = new BaseObjectState(null);
+            NodeId childId = await manager.CreateNodeAsync(
+                context,
+                parent.NodeId,
+                ReferenceTypeIds.Organizes,
+                new QualifiedName("RuntimeChild", ns),
+                child).ConfigureAwait(false);
+
+            object handle = await manager.GetManagerHandleAsync(parent.NodeId).ConfigureAwait(false);
+            var continuationPoint = new ContinuationPoint
+            {
+                NodeToBrowse = handle,
+                Manager = manager,
+                View = new ViewDescription(),
+                BrowseDirection = BrowseDirection.Forward,
+                IncludeSubtypes = true,
+                ResultMask = BrowseResultMask.All
+            };
+
+            var references = new List<ReferenceDescription>();
+            await manager.BrowseAsync(
+                new OperationContext(new RequestHeader(), null, RequestType.Browse, RequestLifetime.None),
+                continuationPoint,
+                references).ConfigureAwait(false);
+
+            Assert.That(
+                references,
+                Has.Some.Property(nameof(ReferenceDescription.NodeId)).EqualTo(new ExpandedNodeId(childId)),
+                "runtime-added child must be visible when browsing an already-cached parent");
+        }
+
         [Test]
         public async Task WriteAsync_WritesValueToNodeAsync()
         {

--- a/tests/Opc.Ua.Server.Tests/NodeManager/MasterNodeManagerNodeManagementTests.cs
+++ b/tests/Opc.Ua.Server.Tests/NodeManager/MasterNodeManagerNodeManagementTests.cs
@@ -55,6 +55,7 @@ namespace Opc.Ua.Server.Tests
     public class MasterNodeManagerNodeManagementTests
     {
         private const string TestNamespaceUri = "http://test.org/UA/MasterNodeManagement/";
+        private const string E2eNamespaceUri = "http://test.org/UA/MasterNodeManagement/E2E/";
 
         private ServerFixture<StandardServer> m_fixture = null!;
         private StandardServer m_server = null!;
@@ -639,6 +640,103 @@ namespace Opc.Ua.Server.Tests
                     System.Array.Empty<DeleteReferencesItem>().ToArrayOf(),
                     CancellationToken.None).ConfigureAwait(false),
                 Throws.TypeOf<System.ArgumentNullException>());
+        }
+
+        /// <summary>
+        /// End-to-end regression for issue #4061: a child added to an
+        /// already-subscribed (cached) parent at runtime via CreateNodeAsync
+        /// must be visible when the parent is browsed through the full
+        /// MasterNodeManager dispatch pipeline, and must disappear again once
+        /// the child is deleted.
+        /// </summary>
+        [Test]
+        public async Task BrowseThroughMaster_ReflectsRuntimeAddAndDeleteOnCachedParentAsync()
+        {
+            // Ownership of the manager transfers to the MasterNodeManager,
+            // which disposes its registered node managers; do not dispose it
+            // a second time here.
+#pragma warning disable CA2000
+            var manager = new TestableAsyncCustomNodeManager(
+                m_server.CurrentInstance,
+                m_fixture.Config,
+                Microsoft.Extensions.Logging.Abstractions.NullLogger.Instance,
+                E2eNamespaceUri);
+#pragma warning restore CA2000
+            using MasterNodeManager sut = new MasterNodeManager(
+                m_server.CurrentInstance, m_fixture.Config, null, manager);
+
+            ServerSystemContext ctx = manager.SystemContext;
+            ushort ns = manager.NamespaceIndexes[0];
+
+            var parent = new BaseObjectState(null);
+            parent.CreateAsPredefinedNode(ctx);
+            parent.NodeId = new NodeId("E2eParent", ns);
+            parent.BrowseName = new QualifiedName("E2eParent", ns);
+            await manager.AddNodeAsync(ctx, default, parent).ConfigureAwait(false);
+
+            // parent is subscribed/browsed -> cached in the component cache.
+            manager.AddNodeToComponentCachePublic(ctx, new NodeHandle(parent.NodeId, parent), parent);
+
+            // runtime-add a child.
+            var child = new BaseObjectState(null);
+            NodeId childId = await manager.CreateNodeAsync(
+                ctx,
+                parent.NodeId,
+                ReferenceTypeIds.Organizes,
+                new QualifiedName("E2eRuntimeChild", ns),
+                child).ConfigureAwait(false);
+
+            (ArrayOf<BrowseResult> afterAdd, _) =
+                await BrowseChildrenAsync(sut, parent.NodeId).ConfigureAwait(false);
+
+            Assert.That(afterAdd[0].StatusCode, Is.EqualTo(StatusCodes.Good));
+            Assert.That(
+                ChildNodeIds(afterAdd[0]),
+                Has.Member(new ExpandedNodeId(childId)),
+                "runtime-added child must be visible when browsing the cached parent through the master");
+
+            // delete the child and re-browse -> gone.
+            await manager.DeleteNodeAsync(ctx, childId).ConfigureAwait(false);
+
+            (ArrayOf<BrowseResult> afterDelete, _) =
+                await BrowseChildrenAsync(sut, parent.NodeId).ConfigureAwait(false);
+
+            Assert.That(afterDelete[0].StatusCode, Is.EqualTo(StatusCodes.Good));
+            Assert.That(
+                ChildNodeIds(afterDelete[0]),
+                Has.No.Member(new ExpandedNodeId(childId)),
+                "deleted child must no longer be visible when browsing the parent through the master");
+        }
+
+        private static List<ExpandedNodeId> ChildNodeIds(BrowseResult result)
+        {
+            var ids = new List<ExpandedNodeId>();
+            foreach (ReferenceDescription reference in result.References)
+            {
+                ids.Add(reference.NodeId);
+            }
+            return ids;
+        }
+
+        private async Task<(ArrayOf<BrowseResult> results, ArrayOf<DiagnosticInfo> diagnostics)> BrowseChildrenAsync(
+            MasterNodeManager sut,
+            NodeId parentId)
+        {
+            var browseDescription = new BrowseDescription
+            {
+                NodeId = parentId,
+                BrowseDirection = BrowseDirection.Forward,
+                ReferenceTypeId = ReferenceTypeIds.HierarchicalReferences,
+                IncludeSubtypes = true,
+                ResultMask = (uint)BrowseResultMask.All
+            };
+
+            return await sut.BrowseAsync(
+                CreateContext(),
+                new ViewDescription(),
+                0u,
+                new[] { browseDescription }.ToArrayOf(),
+                CancellationToken.None).ConfigureAwait(false);
         }
 
         private MasterNodeManager CreateMasterNodeManager(params INodeManager[] additional)


### PR DESCRIPTION
## Summary

Fixes #4061.

`AsyncCustomNodeManager` kept its component cache (`m_componentCache`, populated when monitored items / registered nodes resolve through the manager) out of sync with runtime address-space changes:

- `RemovePredefinedNodeAsync` (the delete path) never evicted the removed node, so a deleted node stayed resolvable through the cache.
- A re-registered / replaced `NodeId` kept pointing at the stale instance.

For a dynamic-composition consumer (recompose = delete + re-add) this surfaced as a Browse/Read/Call served a stale, pre-change view — the runtime-added child intermittently missing while the pre-add set (or a removed node) lingered.

## Fix

- `RemovePredefinedNodeAsync` force-evicts the removed node from the component cache.
- `IndexPredefinedNode` / `ReplacePredefinedNode` refresh the cached instance on re-registration (reference count preserved).
- `CreateNodeAsync` / `AddNodeAsync` / `DeleteNodeAsync` (both convenience and service overloads) refresh the parent's cached view after a runtime child add/remove — covering both the runtime and predefined-node registration paths.
- `NodeState.AddChild` now sets the `Children` change mask inside the children lock so the mask is published together with the mutation.

The component-cache helpers are additive and NativeAOT-safe. The runtime async paths use async waits — `RefreshParentComponentCacheAsync` / `InvalidateComponentCacheAsync` (`await m_componentCacheSemaphore.WaitAsync(cancellationToken)`) — while the genuinely synchronous registration/upgrade paths (`IndexPredefinedNode` via `AddPredefinedNodeSynchronously`, `ReplacePredefinedNode`) keep a synchronous `RefreshComponentCache` that matches the existing synchronous cache helpers on the type. All are `private`.

## Tests

- Manager-level regression tests (`AsyncCustomNodeManagerTests.cs`): delete-eviction, replace-refresh, and browse-of-a-runtime-added-child-from-an-already-cached-parent (the reporter's explicitly requested framework coverage).
- End-to-end test (`MasterNodeManagerNodeManagementTests.cs`): registers a real `AsyncCustomNodeManager` in a `MasterNodeManager` over the `StandardServer` fixture, caches a parent, runtime-adds a child, and browses through the full master dispatch (Forward / HierarchicalReferences / IncludeSubtypes), asserting the child is visible and then gone after delete.

## Validation

- `net10.0` and `net48`: full `AsyncCustomNodeManager` suite + `MasterNodeManagerNodeManagement` suite green, no regressions.

## Docs

- Browse-consistency note added to `docs/ModelChangeTracking.md`.
