### PR TITLE
Fix MCP startup failure and respect session name

### DIFF
--- a/tools/Opc.Ua.Mcp/OpcUaSessionManager.cs
+++ b/tools/Opc.Ua.Mcp/OpcUaSessionManager.cs
@@ -278,7 +278,7 @@ namespace Opc.Ua.Mcp
                     var endpoint = new ConfiguredEndpoint(null, selectedEndpoint, endpointConfiguration);
                     ManagedSessionBuilder builder = new ManagedSessionBuilder(configuration, Telemetry)
                         .UseEndpoint(endpoint)
-                        .WithSessionName(configuration.ApplicationName ?? kApplicationName)
+                        .WithSessionName(name)
                         .WithSessionTimeout(TimeSpan.FromMilliseconds(60_000))
                         .WithUserIdentity(identity);
 

--- a/tools/Opc.Ua.Mcp/Program.cs
+++ b/tools/Opc.Ua.Mcp/Program.cs
@@ -134,7 +134,7 @@ static async Task RunSseServerAsync(int port, CancellationToken ct)
 
 static void ConfigureServices(IServiceCollection services, PcapOptions pcapOptions)
 {
-    services.AddOpcUa().AddClient(options => { });
+    services.AddOpcUa().AddClient(options => options.Configuration = new Opc.Ua.ApplicationConfiguration());
     services.AddSingleton<OpcUaSessionManager>();
     services.AddSingleton<PubSubRuntimeManager>();
     services.AddSingleton(_ => CreateMcpServerOptions());


### PR DESCRIPTION
# Description

Fixes a Microsoft.Extensions.Options.OptionsValidationException when starting the MCP server and fixes the Connection tools to return and use the correct session name.

## Related Issues

- Fixes #4076 

## Checklist

_Put an `x` in the boxes that apply. You can complete these step by step after opening the PR._

- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf) and read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added all necessary documentation.
- [ ] I have verified that my changes do not introduce (new) build or analyzer warnings.
- [ ] I ran **all** tests locally using the **UA.slnx** solution against at least .net **framework** and .net **10**, and all passed.
- [ ] I fixed **all** failing and flaky tests in the CI pipelines and **all** CodeQL warnings.
- [ ] I have addressed **all** PR feedback received.
