### PR TITLE
Stabilize FakeTimeProvider UDP repeater test

### DIFF
--- a/tests/Opc.Ua.PubSub.Udp.Tests/UdpMessageRepeaterTests.cs
+++ b/tests/Opc.Ua.PubSub.Udp.Tests/UdpMessageRepeaterTests.cs
@@ -82,8 +82,10 @@ namespace Opc.Ua.PubSub.Udp.Tests
         [Test]
         public async Task ThreeRepeats_SendsFourTimes_FakeTimerAdvanced()
         {
-            var fake = new FakeTimeProvider();
-            var repeater = new UdpMessageRepeater(3, TimeSpan.FromMilliseconds(100), fake);
+            const int repeatCount = 3;
+            var repeatDelay = TimeSpan.FromMilliseconds(100);
+            var fake = new ObservableFakeTimeProvider();
+            var repeater = new UdpMessageRepeater(repeatCount, repeatDelay, fake);
             int count = 0;
 
             ValueTask sendTask = repeater.SendWithRepeatsAsync(_ =>
@@ -92,15 +94,19 @@ namespace Opc.Ua.PubSub.Udp.Tests
                 return default;
             });
 
-            for (int i = 0; i < 3 && !sendTask.IsCompleted; i++)
+            for (int timerNumber = 1; timerNumber <= repeatCount; timerNumber++)
             {
-                fake.Advance(TimeSpan.FromMilliseconds(100));
-                await Task.Yield();
+                await fake.WaitForTimerCreatedAsync(timerNumber)
+                    .WaitAsync(TimeSpan.FromSeconds(5))
+                    .ConfigureAwait(false);
+                fake.Advance(repeatDelay);
             }
 
-            await sendTask.ConfigureAwait(false);
+            await sendTask.AsTask()
+                .WaitAsync(TimeSpan.FromSeconds(5))
+                .ConfigureAwait(false);
 
-            Assert.That(count, Is.EqualTo(4));
+            Assert.That(count, Is.EqualTo(repeatCount + 1));
         }
 
         [Test]
@@ -240,6 +246,54 @@ namespace Opc.Ua.PubSub.Udp.Tests
             }
 
             Assert.That(count, Is.EqualTo(3));
+        }
+
+        private sealed class ObservableFakeTimeProvider : FakeTimeProvider
+        {
+            public override ITimer CreateTimer(
+                TimerCallback callback,
+                object? state,
+                TimeSpan dueTime,
+                TimeSpan period)
+            {
+                ITimer timer = base.CreateTimer(callback, state, dueTime, period);
+                int timerNumber = Interlocked.Increment(ref m_timerCount);
+                if (timerNumber == 1)
+                {
+                    m_firstTimerCreated.TrySetResult(true);
+                }
+                else if (timerNumber == 2)
+                {
+                    m_secondTimerCreated.TrySetResult(true);
+                }
+                else if (timerNumber == 3)
+                {
+                    m_thirdTimerCreated.TrySetResult(true);
+                }
+                return timer;
+            }
+
+            public Task<bool> WaitForTimerCreatedAsync(int timerNumber)
+            {
+                return timerNumber switch
+                {
+                    1 => m_firstTimerCreated.Task,
+                    2 => m_secondTimerCreated.Task,
+                    3 => m_thirdTimerCreated.Task,
+                    _ => throw new ArgumentOutOfRangeException(nameof(timerNumber))
+                };
+            }
+
+            private readonly TaskCompletionSource<bool> m_firstTimerCreated = new(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+
+            private readonly TaskCompletionSource<bool> m_secondTimerCreated = new(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+
+            private readonly TaskCompletionSource<bool> m_thirdTimerCreated = new(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+
+            private int m_timerCount;
         }
     }
 }


### PR DESCRIPTION
# Description

Stabilizes
`UdpMessageRepeaterTests.ThreeRepeats_SendsFourTimes_FakeTimerAdvanced`,
which caused the .NET Framework test host in ADO build 15853 to hang until
blame terminated it after ten minutes.

The original test advanced `FakeTimeProvider` three times and used
`Task.Yield()` between advances. The delay continuation runs asynchronously,
so `Task.Yield()` did not guarantee that the repeater had registered its next
timer before the following advance. A captured hang showed fake time at
300 ms with three sends completed while the final timer had only just been
registered for 400 ms.

The original test reproduced as follows:

- PR merge commit `d301b4dc`: 23 hangs in 100 isolated net48 test hosts.
- PR merge commit `d301b4dc`: 8 hangs in 30 isolated net10 test hosts.
- Pre-PR base `7b5fd1f`: 10 hangs in 30 isolated net48 test hosts.

This change adds an observable test-only `FakeTimeProvider` that signals after
`CreateTimer` has registered each timer. The test waits for that signal before
every synthetic-time advance and uses bounded waits so a regression fails
instead of hanging the test host. Production code is unchanged.

## Related Issues

No GitHub issue. This addresses the test hang observed in ADO build 15853.

## Validation

- Exact test in 100 fresh net48 test hosts: 100 passed, 0 failed.
- Exact test in 100 fresh net10 test hosts: 100 passed, 0 failed.
- Full `Opc.Ua.PubSub.Udp.Tests` net48: 176 passed, 4 skipped, 0 failed.
- Full `Opc.Ua.PubSub.Udp.Tests` net10: 233 passed, 0 failed.
- `dotnet format` verification for the changed test file at info severity: clean.

## Checklist

- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf) and read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [x] I have added all necessary documentation.
- [x] I have verified that my changes do not introduce (new) build or analyzer warnings.
- [ ] I ran **all** tests locally using the **UA.slnx** solution against at least .net **framework** and .net **10**, and all passed.
- [ ] I fixed **all** failing and flaky tests in the CI pipelines and **all** CodeQL warnings.
- [ ] I have addressed **all** PR feedback received.
