### PR TITLE
Do not fail Docker builds on cache export errors

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -143,7 +143,7 @@ jobs:
         labels: ${{ steps.meta.outputs.labels }}
         provenance: false
         cache-from: type=gha,scope=${{ matrix.image }}
-        cache-to: type=gha,mode=max,scope=${{ matrix.image }}
+        cache-to: type=gha,mode=max,scope=${{ matrix.image }},ignore-error=true
 
     # Sign the resulting Docker image digest except on PRs.
     # https://github.com/sigstore/cosign

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -143,6 +143,7 @@ jobs:
         labels: ${{ steps.meta.outputs.labels }}
         provenance: false
         cache-from: type=gha,scope=${{ matrix.image }}
+        # setup-buildx-action@v4 installs Buildx and BuildKit versions that support ignore-error.
         cache-to: type=gha,mode=max,scope=${{ matrix.image }},ignore-error=true
 
     # Sign the resulting Docker image digest except on PRs.

--- a/.github/workflows/pump-device-integration-server-docker.yml
+++ b/.github/workflows/pump-device-integration-server-docker.yml
@@ -84,4 +84,4 @@ jobs:
         platforms: linux/amd64
         provenance: false
         cache-from: type=gha
-        cache-to: type=gha,mode=max
+        cache-to: type=gha,mode=max,ignore-error=true

--- a/.github/workflows/pump-device-integration-server-docker.yml
+++ b/.github/workflows/pump-device-integration-server-docker.yml
@@ -84,4 +84,5 @@ jobs:
         platforms: linux/amd64
         provenance: false
         cache-from: type=gha
+        # setup-buildx-action@v4 installs Buildx and BuildKit versions that support ignore-error.
         cache-to: type=gha,mode=max,ignore-error=true


### PR DESCRIPTION
## Summary
- keep successful Docker builds from failing when GitHub Actions cache export is unavailable
- apply the non-fatal cache export setting to both Docker image workflows

## Validation
- targeted rerun of the failed MCP server Docker job succeeded
- changed workflow YAML parsed successfully