### PR TITLE
DRAFT Avro/Arrow: reject invalid matrix dimensions (B3, stacked on #4007)

### DIFF
--- a/src/Opc.Ua.Types/Encoders/Arrow/A.cs
+++ b/src/Opc.Ua.Types/Encoders/Arrow/A.cs
@@ -1420,7 +1420,7 @@ namespace Opc.Ua
 
             var dims = ReadListAt((null!, s.Fields[0]), i, ReadI32Many);
             var vals = ReadListAt((null!, s.Fields[1]), i, read);
-            return vals.ToMatrix(dims);
+            return vals.ToDecodedMatrix(dims.ToArray() ?? []);
         }
 
         /// <summary>

--- a/src/Opc.Ua.Types/Encoders/Avro/AvroDecoder.cs
+++ b/src/Opc.Ua.Types/Encoders/Avro/AvroDecoder.cs
@@ -601,14 +601,14 @@ namespace Opc.Ua
 
                 ExpectBranch(branch, 1);
                 int[] outerDims = ReadInt32Array(null).ToArray() ?? Array.Empty<int>();
-                return readArray().ToMatrix(outerDims);
+                return readArray().ToDecodedMatrix(outerDims);
             }
 
             // A Variant matrix body: MatrixBody { dimensions: plain array<int>, values: plain array }.
             m_nextArrayPlain = true;
             int[] dims = ReadInt32Array(null).ToArray() ?? Array.Empty<int>();
             m_nextArrayPlain = true;
-            return readArray().ToMatrix(dims);
+            return readArray().ToDecodedMatrix(dims);
         }
 
         /// <inheritdoc/>

--- a/src/Opc.Ua.Types/Encoders/MatrixDecodingExtensions.cs
+++ b/src/Opc.Ua.Types/Encoders/MatrixDecodingExtensions.cs
@@ -1,0 +1,75 @@
+/* ========================================================================
+ * Copyright (c) 2005-2026 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using Opc.Ua.Types;
+
+namespace Opc.Ua
+{    /// <summary>
+    /// Shared helpers for reconstructing a <see cref="MatrixOf{T}"/> from decoded
+    /// wire data. Used by the experimental Avro and Arrow decoders so that an
+    /// attacker- or corruption-controlled dimension set is rejected consistently
+    /// as <see cref="StatusCodes.BadDecodingError"/> rather than leaking the
+    /// <see cref="ArgumentException"/> thrown by the <see cref="MatrixOf{T}"/>
+    /// constructor.
+    /// </summary>
+    internal static class MatrixDecodingExtensions
+    {
+        /// <summary>
+        /// Builds a matrix from decoded values and wire dimensions, enforcing the
+        /// OPC UA matrix contract: a matrix has at least two dimensions and the
+        /// product of the dimensions equals the number of decoded elements. Any
+        /// violation is surfaced as <see cref="StatusCodes.BadDecodingError"/>.
+        /// </summary>
+        /// <typeparam name="T">The element type of the matrix.</typeparam>
+        /// <param name="values">The decoded, flattened element array.</param>
+        /// <param name="dimensions">The dimensions read from the wire.</param>
+        public static MatrixOf<T> ToDecodedMatrix<T>(this ArrayOf<T> values, int[] dimensions)
+        {
+            if (dimensions is not { Length: >= 2 })
+            {
+                throw ServiceResultException.Create(
+                    StatusCodes.BadDecodingError,
+                    "A matrix must have at least two dimensions.");
+            }
+
+            try
+            {
+                return values.ToMatrix(dimensions);
+            }
+            catch (ArgumentException ex)
+            {
+                throw ServiceResultException.Create(
+                    StatusCodes.BadDecodingError,
+                    "The encoded matrix dimensions are invalid: {0}",
+                    ex.Message);
+            }
+        }
+    }
+}

--- a/tests/Opc.Ua.Core.Encoders.Tests/VariantMatrixConformanceTests.cs
+++ b/tests/Opc.Ua.Core.Encoders.Tests/VariantMatrixConformanceTests.cs
@@ -39,6 +39,9 @@ using System.Xml.Linq;
 using NUnit.Framework;
 using Opc.Ua.Core.TestFramework;
 
+#pragma warning disable UA_NETStandard_Avro // experimental encoder surface under test
+#pragma warning disable UA_NETStandard_Arrow // experimental encoder surface under test
+
 namespace Opc.Ua.Core.Encoders.Tests
 {
     /// <summary>
@@ -199,6 +202,8 @@ namespace Opc.Ua.Core.Encoders.Tests
                 EncodingType.Binary => ReplaceBinaryDimensions(payload, dimensions),
                 EncodingType.Json => ReplaceJsonDimensions(payload, dimensions),
                 EncodingType.Xml => ReplaceXmlDimensions(payload, dimensions),
+                EncodingType.Avro => ReplaceAvroDimensions(payload, dimensions),
+                EncodingType.Arrow => ReplaceArrowDimensions(payload, dimensions),
                 _ => throw new ArgumentOutOfRangeException(nameof(encodingType), encodingType, null)
             };
         }
@@ -287,6 +292,152 @@ namespace Opc.Ua.Core.Encoders.Tests
             }
             dimensionsElement.ReplaceNodes(elements);
             return Encoding.UTF8.GetBytes(document.ToString(SaveOptions.DisableFormatting));
+        }
+
+        // The value under test is a 2x3 Int32 matrix {1,2,3,4,5,6}. On the Avro wire the
+        // Variant matrix body is a MatrixBody record { dimensions: plain int array, values:
+        // plain int array }. The dimensions plain array is located by the unique byte
+        // signature formed by the original dimensions immediately followed by the values
+        // plain array, and only that dimensions prefix is rewritten.
+        private static byte[] ReplaceAvroDimensions(byte[] payload, int[] dimensions)
+        {
+            byte[] originalDimensions = EncodeAvroIntArray([2, 3]);
+            byte[] values = EncodeAvroIntArray([1, 2, 3, 4, 5, 6]);
+            byte[] signature = new byte[originalDimensions.Length + values.Length];
+            originalDimensions.CopyTo(signature, 0);
+            values.CopyTo(signature, originalDimensions.Length);
+
+            int at = IndexOf(payload, signature);
+            Assert.That(
+                at,
+                Is.GreaterThanOrEqualTo(0),
+                "The encoded Avro payload does not contain the expected matrix body.");
+
+            byte[] newDimensions = EncodeAvroIntArray(dimensions);
+            int remainderStart = at + originalDimensions.Length;
+            byte[] result = new byte[payload.Length - originalDimensions.Length + newDimensions.Length];
+            Array.Copy(payload, 0, result, 0, at);
+            newDimensions.CopyTo(result, at);
+            Array.Copy(
+                payload,
+                remainderStart,
+                result,
+                at + newDimensions.Length,
+                payload.Length - remainderStart);
+            return result;
+        }
+
+        // The Arrow matrix Struct stores dimensions as a List&lt;int32&gt; child: an offsets
+        // buffer [0, 2] followed by a values buffer [2, 3] for the 2x3 matrix under test.
+        // The dimensions are corrupted in place (never changing any buffer size, so the
+        // IPC record-batch metadata stays valid): a two-dimension replacement rewrites the
+        // values, and a rank-one replacement shrinks the list to a single element via its
+        // offset and rewrites the first value.
+        private static byte[] ReplaceArrowDimensions(byte[] payload, int[] dimensions)
+        {
+            byte[] result = (byte[])payload.Clone();
+            byte[] originalValues = [0x02, 0, 0, 0, 0x03, 0, 0, 0];
+
+            int valuesOffset = -1;
+            for (int i = 4; i + originalValues.Length <= result.Length; i++)
+            {
+                if (BytesMatch(result, i, originalValues) &&
+                    BinaryPrimitives.ReadInt32LittleEndian(result.AsSpan(i - 4)) == 0)
+                {
+                    valuesOffset = i;
+                    break;
+                }
+            }
+            Assert.That(
+                valuesOffset,
+                Is.GreaterThanOrEqualTo(0),
+                "The encoded Arrow payload does not contain the expected dimensions values buffer.");
+
+            // The list length lives in the offsets buffer as the last non-zero int32 that
+            // precedes the (padding-separated) values buffer.
+            int lengthOffset = valuesOffset - 4;
+            while (lengthOffset >= 4 &&
+                BinaryPrimitives.ReadInt32LittleEndian(result.AsSpan(lengthOffset)) == 0)
+            {
+                lengthOffset -= sizeof(int);
+            }
+            Assert.That(
+                BinaryPrimitives.ReadInt32LittleEndian(result.AsSpan(lengthOffset)),
+                Is.EqualTo(2),
+                "Unexpected Arrow dimensions offsets layout.");
+
+            if (dimensions.Length == 1)
+            {
+                BinaryPrimitives.WriteInt32LittleEndian(result.AsSpan(lengthOffset), 1);
+                BinaryPrimitives.WriteInt32LittleEndian(result.AsSpan(valuesOffset), dimensions[0]);
+            }
+            else
+            {
+                for (int i = 0; i < dimensions.Length; i++)
+                {
+                    BinaryPrimitives.WriteInt32LittleEndian(
+                        result.AsSpan(valuesOffset + (i * sizeof(int))),
+                        dimensions[i]);
+                }
+            }
+            return result;
+        }
+
+        private static bool BytesMatch(byte[] data, int offset, byte[] pattern)
+        {
+            for (int i = 0; i < pattern.Length; i++)
+            {
+                if (data[offset + i] != pattern[i])
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        // Encodes an Avro plain array&lt;int&gt;: zig-zag block count, zig-zag items, 0 terminator.
+        private static byte[] EncodeAvroIntArray(int[] values)
+        {
+            var buffer = new List<byte>();
+            WriteAvroLong(buffer, values.Length);
+            foreach (int value in values)
+            {
+                WriteAvroLong(buffer, value);
+            }
+            buffer.Add(0x00);
+            return buffer.ToArray();
+        }
+
+        private static void WriteAvroLong(List<byte> buffer, long value)
+        {
+            ulong zig = (ulong)((value << 1) ^ (value >> 63));
+            while ((zig & ~0x7FUL) != 0)
+            {
+                buffer.Add((byte)((zig & 0x7F) | 0x80));
+                zig >>= 7;
+            }
+            buffer.Add((byte)zig);
+        }
+
+        private static int IndexOf(byte[] haystack, byte[] needle)
+        {
+            for (int i = 0; i <= haystack.Length - needle.Length; i++)
+            {
+                bool match = true;
+                for (int j = 0; j < needle.Length; j++)
+                {
+                    if (haystack[i + j] != needle[j])
+                    {
+                        match = false;
+                        break;
+                    }
+                }
+                if (match)
+                {
+                    return i;
+                }
+            }
+            return -1;
         }
     }
 }


### PR DESCRIPTION
**Stacked on #4007** (base `marcschier/experimental-dataencodings`).

Addresses the six `VariantMatrixConformanceTests` failures that the master merge (upstream #4002 CTT model-validation) surfaced on the experimental encoders: the Avro and Arrow decoders accepted rank-1, zero-sized and product-mismatched matrix dimensions, and the cross-codec negative-test helper only supported Binary/Json/Xml.

### Production
- New `MatrixDecodingExtensions.ToDecodedMatrix` enforces the OPC UA matrix contract (at least two dimensions; product of dimensions equals element count) and raises `BadDecodingError` instead of the `MatrixOf` constructor's `ArgumentException`. Wired into `AvroDecoder.ReadMatrix` (both branches) and the Arrow `A.ReadMatrix` path.

### Test helper
- `VariantMatrixConformanceTests.ReplaceDimensions` extended to **Avro** (plain int-array varint splice of the MatrixBody dimensions) and **Arrow** (in-place, metadata-safe edit of the dimensions `List` offsets/values buffers in the IPC body).

### Result
- `Opc.Ua.Core.Encoders.Tests` (net8.0): **3976 passed / 0 failed / 1 skipped**. The one skip remains the registry-coupled ExtensionObject executable spec (finding #15), addressed in a later B3b change.