### PR TITLE
Make fluent sample security settings explicit

### DIFF
--- a/docs/DependencyInjection.md
+++ b/docs/DependencyInjection.md
@@ -157,7 +157,22 @@ IOpcUaBuilder opcUa = services.AddOpcUa()
         options.ApplicationName = "MyApplication";
         options.ApplicationUri = "urn:localhost:MyApplication";
         options.ProductUri = "uri:example.com:MyApplication";
-        options.AutoAcceptUntrustedCertificates = true;
+        options.SubjectName = "CN=MyApplication, O=Example, DC=localhost";
+        options.PkiRoot = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "Example",
+            "MyApplication",
+            "pki");
+        options.AutoAcceptUntrustedCertificates = false;
+        options.RejectSHA1SignedCertificates = true;
+        options.MinimumCertificateKeySize = 2048;
+
+        // Code-only advanced settings, applied after the values above.
+        options.ConfigureSecurity = security => security
+            .SetMaxRejectedCertificates(20)
+            .SetRejectUnknownRevocationStatus(true)
+            .SetUseValidatedCertificates(false)
+            .SetSendCertificateChain(true);
     });
 
 opcUa.AddClient(options =>
@@ -175,6 +190,56 @@ opcUa.AddServer(options =>
 ```
 
 When both features are registered, the shared configuration has `ApplicationType.ClientAndServer` and one application-certificate lifecycle. An explicitly supplied `OpcUaClientOptions.Configuration` still wins for that client registration.
+
+### Application identity and certificate defaults
+
+| Setting | Behavior when omitted |
+|---------|-----------------------|
+| `ApplicationName` | Required after client/server feature defaults are applied. The server feature defaults to `OpcUaServer`; client-only applications should set it explicitly. |
+| `ApplicationUri` | Generated from the host name and application name during validation. Set a stable URI for deployed applications. |
+| `ProductUri` | Uses the contributing feature value. Set a stable product URI for deployed applications. |
+| `SubjectName` | `CN={ApplicationName}, O=OPC Foundation, DC=localhost`; `DC=localhost` is replaced with the host name. |
+| `PkiRoot` | A per-application `OPC Foundation/{ApplicationName}/pki` directory below the process temporary directory. Configure a persistent, access-controlled location in production. |
+| Application certificates and stores | Directory-backed application, trusted peer/issuer, HTTPS, user, and rejected stores are created below `PkiRoot`; default RSA and supported ECC application-certificate identifiers are selected. |
+
+The security builder starts with secure defaults: unknown certificates are not
+auto-accepted, the application certificate is not copied into a shared trusted
+store, SHA-1 certificates and unknown revocation status are rejected, nonce
+validation errors are not suppressed, certificate chains are sent, the minimum
+RSA key size is 2048, and at most five rejected certificates are retained.
+Validated-certificate caching is off unless enabled explicitly.
+
+### Advanced application certificate validation
+
+`OpcUaApplicationOptions.ConfigureSecurity` is an
+`Action<IApplicationConfigurationBuilderSecurityOptions>?`. It is invoked after
+the default application certificates and stores and after the first-class
+`AutoAcceptUntrustedCertificates`, `RejectSHA1SignedCertificates`, and
+`MinimumCertificateKeySize` values. It is the final security customization
+before `CreateAsync`, so it can override those first-class values. The callback
+is code-only and is not bound from `IConfiguration`; exceptions are not
+swallowed and fail application-configuration provider creation.
+
+Prefer the first-class properties for their common settings and use
+`ConfigureSecurity` only for advanced certificate/store behavior:
+
+| Method | Purpose and secure default |
+|--------|----------------------------|
+| `SetApplicationCertificates(...)` | Replaces the generated application-certificate identifiers. Prefer `SubjectName` and `PkiRoot` for the normal generated layout. |
+| `SetMaxRejectedCertificates(...)` | Sets rejected-certificate retention; default `5`, `0` keeps all, and a negative value keeps no history. |
+| `SetAutoAcceptUntrustedCertificates(...)` | Accepts otherwise-valid unknown peer certificates; default `false`. Prefer `AutoAcceptUntrustedCertificates`. Use `true` only in an isolated lab. |
+| `SetAddAppCertToTrustedStore(...)` | Adds a newly created application certificate to a shared trusted store; default `false`. |
+| `SetRejectSHA1SignedCertificates(...)` | Rejects SHA-1-signed certificates; default `true`. Prefer `RejectSHA1SignedCertificates`. |
+| `SetRejectUnknownRevocationStatus(...)` | Rejects chains when CA revocation status cannot be determined; default `true`. |
+| `SetUseValidatedCertificates(...)` | Reuses previously validated certificates without repeating the full validation path; default `false`. Leave disabled unless the reduced revalidation is explicitly acceptable for the deployment. |
+| `SetSuppressNonceValidationErrors(...)` | Suppresses zero/weak nonce errors; default `false`. Enabling it weakens user-token protection and is only for unavoidable legacy interoperability. |
+| `SetSendCertificateChain(...)` | Sends the chain with a CA-signed application certificate; default `true`. |
+| `SetMinimumCertificateKeySize(...)` | Sets the minimum accepted RSA key size; default `2048`. Prefer `MinimumCertificateKeySize`. |
+| `AddCertificatePasswordProvider(...)` | Supplies an `ICertificatePasswordProvider` for protected private keys; no provider is registered by default. |
+
+See [Certificates](Certificates.md) for trust-store deployment and validation,
+and [Certificate Manager](CertificateManager.md) for injectable certificate
+lifecycle management.
 
 Discovery servers expose the same transport and reverse-connect shortcuts as
 the regular server builder:
@@ -259,7 +324,7 @@ builder.Services
         o.ApplicationName = "MyServer";
         o.ApplicationUri = "urn:localhost:MyOrg:MyServer";
         o.ProductUri = "uri:myorg:myserver";
-        o.AutoAcceptUntrustedCertificates = true;
+        o.AutoAcceptUntrustedCertificates = false;
         o.EndpointUrls.Add("opc.tcp://localhost:51210/MyServer");
     })
     .AddNodeManager<MyNodeManagerFactory>()       // IAsyncNodeManagerFactory
@@ -298,23 +363,100 @@ an anonymous authenticator matching its default anonymous user-token policy.
 If a non-anonymous user-token policy is configured without a corresponding
 authenticator, startup logs a warning.
 
-For advanced configuration (custom security policies, custom security
-stores), set `OpcUaServerOptions.ConfigureBuilder` — it receives the
-underlying `IApplicationConfigurationBuilderServerSelected` between the
-default policy/quota steps and `CreateAsync`.
+### Server security and resource controls
+
+The hosted server is secure by default: sign-and-encrypt policies are included,
+`SecurityPolicy#None` is excluded, SHA-1 certificates are rejected, the minimum
+RSA key size is 2048, and unknown certificates are not auto-accepted. Review
+these controls explicitly for every deployment:
+
+- Keep `IncludeSignAndEncryptPolicies = true`. Set
+  `IncludeUnsecurePolicyNone = true` only for an isolated lab endpoint with no
+  sensitive data or credentials.
+- Enable `IncludeEccPolicies` only when the deployment certificates and clients
+  support the advertised ECC policies.
+- Configure `UserTokenPolicies` together with matching authenticators. An empty
+  list advertises `Anonymous`; adding a token policy alone does not authenticate
+  it. See [Identity Providers](IdentityProviders.md) and
+  [Role-Based User Management](RoleBasedUserManagement.md).
+- Keep certificate auto-accept disabled and provision trust lists. For
+  advanced validation, use the shared
+  `ConfigureApplication(...).ConfigureSecurity` callback described above.
+- Bound transport and service work for the deployment. `MaxByteStringLength`,
+  `MaxArrayLength`, `MaxMessageSize`, and `OperationTimeoutMs` control transport
+  quotas; `OperationLimits` bounds nodes processed by individual services.
+- Set deployment-specific channel, session, and failed-authentication ceilings
+  through `ConfigureBuilder` to reduce resource-exhaustion and credential-guessing
+  exposure.
+
+`OpcUaServerOptions.ConfigureBuilder` receives
+`IApplicationConfigurationBuilderServerSelected` after the standard transport
+quotas, policies, user-token policies, and server options are applied, but
+**before** application certificates and security stores are added.
+Use it for server policy and server-runtime options. In contrast,
+`OpcUaApplicationOptions.ConfigureSecurity` runs **after** certificates, stores,
+and first-class certificate-validation values are applied. Use it for
+post-security certificate and validation options.
+
+```csharp
+services.AddOpcUa()
+    .ConfigureApplication(application =>
+    {
+        application.ApplicationName = "MyServer";
+        application.AutoAcceptUntrustedCertificates = false;
+        application.RejectSHA1SignedCertificates = true;
+        application.MinimumCertificateKeySize = 2048;
+        application.ConfigureSecurity = security => security
+            .SetRejectUnknownRevocationStatus(true);
+    })
+    .AddServer(server =>
+    {
+        server.IncludeSignAndEncryptPolicies = true;
+        server.IncludeUnsecurePolicyNone = false;
+        server.IncludeEccPolicies = true;
+        server.ConfigureBuilder = configuration => configuration
+            .SetMaxFailedAuthenticationAttempts(5)
+            .SetMaxSessionCount(100)
+            .SetMaxChannelCount(200)
+            .SetAuditingEnabled(true)
+            .SetHttpsMutualTls(true);
+        server.ConfigureRateLimits = limits =>
+        {
+            limits.ConnectionsPerSecond = 200;
+            limits.ConnectionBurst = 400;
+            limits.MaxConcurrentSessionEstablishment = 64;
+        };
+    });
+```
+
+`SetAuditingEnabled(true)` enables OPC UA audit-event reporting.
+`SetHttpsMutualTls(true)` requests and validates a client certificate when one
+is supplied on HTTPS endpoints; it does not by itself require every client to
+present one. Enforce certificate-only Web API access through the corresponding
+authentication and authorization setup. Server admission rate limiting is
+enabled by default with conservative connection and concurrent
+session-establishment limits. Tune it with `ConfigureRateLimits`, or register a
+custom `IServerRateLimiterProvider`; do not disable it without an equivalent
+upstream control. See [Rate Limiting](RateLimiting.md) rather than duplicating
+the full algorithm and deployment guidance here.
 
 ### First-class server options
 
 In addition to the basic application-identity / endpoint / PKI knobs
 covered above, `OpcUaServerOptions` exposes the following first-class
 properties (bindable from `IConfiguration` or set via the
-`Action<OpcUaServerOptions>` overload). Anything not listed here remains
-reachable through `ConfigureBuilder`.
+`Action<OpcUaServerOptions>` overload). Certificate options added by
+`AddSecurityConfiguration` are instead reached through
+`OpcUaApplicationOptions.ConfigureSecurity`.
 
 | Property | Underlying builder call | Purpose |
 |----------|-------------------------|---------|
+| `IncludeSignAndEncryptPolicies` | `AddSignAndEncryptPolicies()` | Add the standard sign-and-encrypt policies. On by default. |
+| `IncludeUnsecurePolicyNone` | `AddUnsecurePolicyNone()` | Advertise an unsecured endpoint. Off by default; lab use only. |
 | `IncludeEccPolicies` | `AddEccSignAndEncryptPolicies()` | Add ECC sign-and-encrypt security policies. Off by default. |
 | `UserTokenPolicies` | `AddUserTokenPolicy(UserTokenType)` | List of user-token policies advertised on every endpoint. Defaults to `Anonymous` when empty. |
+| `MaxByteStringLength` | `SetMaxByteStringLength(int)` | Transport byte-string quota; defaults to 4 MiB. |
+| `MaxArrayLength` | `SetMaxArrayLength(int)` | Transport array-element quota; defaults to 1 Mi elements. |
 | `MaxMessageSize` | `SetMaxMessageSize(int)` | Transport quota in bytes; `null` keeps the stack default. |
 | `OperationTimeoutMs` | `SetOperationTimeout(int)` | Transport operation timeout in ms; `null` keeps the stack default. |
 | `RejectSHA1Certificates` | `SetRejectSHA1SignedCertificates(bool)` | Security hardening — defaults to `true`. |
@@ -322,6 +464,8 @@ reachable through `ConfigureBuilder`.
 | `RegistrationEndpointUrl` | `SetRegistrationEndpoint(EndpointDescription)` | LDS/GDS endpoint URL the server registers itself with on startup. |
 | `ReverseConnect` | `SetReverseConnect(ReverseConnectServerConfiguration)` | Server-side reverse-connect clients (see below). |
 | `OperationLimits` | `SetOperationLimits(OperationLimits)` | Per-service node limits (max nodes per read/write/browse/...). |
+| `ConfigureBuilder` | Code-only callback | Pre-security server-policy and server-option escape hatch, including max failed authentication attempts, sessions, channels, auditing, and HTTPS mutual TLS. |
+| `ConfigureRateLimits` | Code-only callback | Tunes the default connection and session-establishment admission controls. |
 
 ### Server-side reverse connect
 
@@ -607,6 +751,20 @@ services.AddOpcUa()
         options.SecurityPolicyUri = SecurityPolicies.Basic256Sha256;
     });
 ```
+
+Client security checklist:
+
+- Select `MessageSecurityMode.SignAndEncrypt` and an approved policy such as
+  `Basic256Sha256` (or a supported stronger policy) during discovery. Do not
+  fall back to `SecurityPolicy#None` outside isolated lab environments.
+- Keep `AutoAcceptUntrustedCertificates = false`; provision the server or issuer
+  certificate in the client trust store and retain URI/hostname, chain,
+  revocation, key-size, and nonce validation. See
+  [Certificates](Certificates.md).
+- Register an `IClientIdentityProvider` appropriate for the selected endpoint's
+  user-token policy. Keep passwords and tokens in the secret/provider
+  infrastructure rather than embedding them in configuration. See
+  [Identity Providers](IdentityProviders.md).
 
 ### Identity (client)
 
@@ -897,7 +1055,7 @@ services
         o.ApplicationName = "MyGds";
         o.ApplicationUri = "urn:localhost:MyOrg:MyGds";
         o.ProductUri = "uri:myorg:mygds";
-        o.AutoAcceptUntrustedCertificates = true;
+        o.AutoAcceptUntrustedCertificates = false;
         o.EndpointUrls.Add("opc.tcp://localhost:58810/GlobalDiscoveryServer");
         o.AuthoritiesStorePath = "%LocalApplicationData%/OPC Foundation/pki/CA";
     })
@@ -1106,7 +1264,7 @@ services.AddOpcUa()
         o.ApplicationName = "AotServer";
         o.ApplicationUri = "urn:host:AotServer";
         o.EndpointUrls.Add("opc.tcp://localhost:51210/AotServer");
-        o.AutoAcceptUntrustedCertificates = true;
+        o.AutoAcceptUntrustedCertificates = false;
     })
     .AddNodeManager<MyAotNodeManagerFactory>();
 ```

--- a/samples/MinimalBoilerServer/Program.cs
+++ b/samples/MinimalBoilerServer/Program.cs
@@ -27,11 +27,13 @@
  * http://opcfoundation.org/License/MIT/1.00/
  * ======================================================================*/
 
+using System.IO;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
 HostApplicationBuilder builder = Host.CreateApplicationBuilder(args);
+const string applicationName = "MinimalBoilerServer";
 
 builder.Logging.ClearProviders();
 builder.Logging.AddConsole();
@@ -42,10 +44,18 @@ builder.Services
     .AddOpcUa()
     .AddServer(o =>
     {
-        o.ApplicationName = "MinimalBoilerServer";
+        o.ApplicationName = applicationName;
         o.ApplicationUri = "urn:localhost:OPCFoundation:MinimalBoilerServer";
         o.ProductUri = "uri:opcfoundation.org:MinimalBoilerServer";
+        // Sample convenience only; never auto-accept untrusted certificates in production.
         o.AutoAcceptUntrustedCertificates = true;
+        o.PkiRoot = Path.Combine(
+            Path.GetTempPath(),
+            "OPC Foundation",
+            applicationName,
+            "pki");
+        o.RejectSHA1Certificates = true;
+        o.MinCertificateKeySize = 2048;
         o.EndpointUrls.Add($"opc.tcp://localhost:{port}/MinimalBoilerServer");
     })
     .AddNodeManager<Boiler.BoilerNodeManagerFactory>();

--- a/samples/MinimalCalcServer/Program.cs
+++ b/samples/MinimalCalcServer/Program.cs
@@ -27,11 +27,15 @@
  * http://opcfoundation.org/License/MIT/1.00/
  * ======================================================================*/
 
+using System.IO;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Opc.Ua;
+using Opc.Ua.Server.Hosting;
 
 HostApplicationBuilder builder = Host.CreateApplicationBuilder(args);
+const string applicationName = "MinimalCalcServer";
 
 builder.Logging.ClearProviders();
 builder.Logging.AddConsole();
@@ -42,11 +46,34 @@ builder.Services
     .AddOpcUa()
     .AddServer(o =>
     {
-        o.ApplicationName = "MinimalCalcServer";
+        o.ApplicationName = applicationName;
         o.ApplicationUri = "urn:localhost:OPCFoundation:MinimalCalcServer";
         o.ProductUri = "uri:opcfoundation.org:MinimalCalcServer";
+        o.SubjectName = "CN=MinimalCalcServer, O=OPC Foundation, DC=localhost";
+        // Sample convenience only; never auto-accept untrusted certificates in production.
         o.AutoAcceptUntrustedCertificates = true;
+        o.PkiRoot = Path.Combine(
+            Path.GetTempPath(),
+            "OPC Foundation",
+            applicationName,
+            "pki");
+        o.RejectSHA1Certificates = true;
+        o.MinCertificateKeySize = 2048;
+        o.IncludeSignAndEncryptPolicies = true;
+        o.IncludeUnsecurePolicyNone = false;
+        o.IncludeEccPolicies = false;
+        o.UserTokenPolicies.Add(new OpcUaUserTokenPolicy
+        {
+            TokenType = UserTokenType.Anonymous,
+        });
         o.EndpointUrls.Add($"opc.tcp://localhost:{port}/MinimalCalcServer");
+    })
+    .AddDefaultIdentityAuthenticators(o =>
+    {
+        o.EnableAnonymous = true;
+        o.EnableUserNamePassword = false;
+        o.EnableX509 = false;
+        o.EnableJwt = false;
     })
     .AddNodeManager<Calc.CalcNodeManagerFactory>();
 

--- a/samples/MinimalClient/Program.cs
+++ b/samples/MinimalClient/Program.cs
@@ -29,6 +29,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
@@ -67,10 +68,18 @@ try
         .AddOpcUa()
         .AddClient(options =>
         {
-            options.ApplicationName = "MinimalClient";
+            const string applicationName = "MinimalClient";
+            options.ApplicationName = applicationName;
             options.ApplicationUri = "urn:localhost:OPCFoundation:MinimalClient";
             options.ProductUri = "uri:opcfoundation.org:MinimalClient";
+            options.PkiRoot = Path.Combine(
+                Path.GetTempPath(),
+                "OPC Foundation",
+                applicationName,
+                "pki");
             options.AutoAcceptUntrustedCertificates = autoAccept;
+            options.RejectSHA1SignedCertificates = true;
+            options.MinimumCertificateKeySize = 2048;
             options.Session = new ManagedSessionOptions
             {
                 SessionName = "MinimalClient",

--- a/samples/PumpDeviceIntegrationServer/Program.cs
+++ b/samples/PumpDeviceIntegrationServer/Program.cs
@@ -28,6 +28,7 @@
  * ======================================================================*/
 
 using System;
+using System.IO;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -57,7 +58,11 @@ builder.Services
         o.ApplicationName = "PumpDeviceIntegrationServer";
         o.ApplicationUri = "urn:localhost:OPCFoundation:PumpDeviceIntegrationServer";
         o.ProductUri = "uri:opcfoundation.org:PumpDeviceIntegrationServer";
+        // Sample convenience only; never auto-accept untrusted certificates in production.
         o.AutoAcceptUntrustedCertificates = true;
+        o.PkiRoot = Path.Combine(AppContext.BaseDirectory, "pki");
+        o.RejectSHA1Certificates = true;
+        o.MinCertificateKeySize = 2048;
         o.EndpointUrls.Add($"opc.tcp://{host}:{port}/PumpDeviceIntegrationServer");
     })
     .AddNodeManager<PumpNodeManagerFactory>()

--- a/src/Opc.Ua.Configuration/OpcUaApplicationConfigurationProvider.cs
+++ b/src/Opc.Ua.Configuration/OpcUaApplicationConfigurationProvider.cs
@@ -143,6 +143,7 @@ namespace Opc.Ua.Configuration
             {
                 securityOptions = securityOptions.SetMinimumCertificateKeySize(minimumKeySize);
             }
+            effectiveOptions.ConfigureSecurity?.Invoke(securityOptions);
 
             Configuration = configuration;
             m_certificateManager = certificateManager;

--- a/src/Opc.Ua.Configuration/OpcUaApplicationOptions.cs
+++ b/src/Opc.Ua.Configuration/OpcUaApplicationOptions.cs
@@ -27,6 +27,8 @@
  * http://opcfoundation.org/License/MIT/1.00/
  * ======================================================================*/
 
+using System;
+
 namespace Opc.Ua.Configuration
 {
     /// <summary>
@@ -78,6 +80,17 @@ namespace Opc.Ua.Configuration
         /// </summary>
         public ushort? MinimumCertificateKeySize { get; set; }
 
+        /// <summary>
+        /// Configures advanced application security options after the default
+        /// certificates, stores, and first-class validation settings are applied.
+        /// </summary>
+        /// <remarks>
+        /// This code-only callback is the final security customization before
+        /// <c>CreateAsync</c>. It may override the first-class security
+        /// properties on this options instance.
+        /// </remarks>
+        public Action<IApplicationConfigurationBuilderSecurityOptions>? ConfigureSecurity { get; set; }
+
         internal OpcUaApplicationOptions Clone()
         {
             return new OpcUaApplicationOptions
@@ -89,7 +102,8 @@ namespace Opc.Ua.Configuration
                 PkiRoot = PkiRoot,
                 AutoAcceptUntrustedCertificates = AutoAcceptUntrustedCertificates,
                 RejectSHA1SignedCertificates = RejectSHA1SignedCertificates,
-                MinimumCertificateKeySize = MinimumCertificateKeySize
+                MinimumCertificateKeySize = MinimumCertificateKeySize,
+                ConfigureSecurity = ConfigureSecurity
             };
         }
     }

--- a/src/Opc.Ua.Server/Hosting/OpcUaServerOptions.cs
+++ b/src/Opc.Ua.Server/Hosting/OpcUaServerOptions.cs
@@ -40,8 +40,10 @@ namespace Opc.Ua.Server.Hosting
     /// <remarks>
     /// Only the most common knobs are exposed directly. Use
     /// <see cref="ConfigureBuilder"/> for full control of the underlying
-    /// <see cref="IApplicationConfigurationBuilder"/> chain (security policies,
-    /// transport quotas, custom security stores, etc.).
+    /// server-policy and server-option builder stages. Use
+    /// <see cref="OpcUaApplicationOptions.ConfigureSecurity"/> through
+    /// <c>ConfigureApplication(...)</c> for post-security certificate and
+    /// validation settings.
     /// </remarks>
     public sealed class OpcUaServerOptions
     {
@@ -192,10 +194,13 @@ namespace Opc.Ua.Server.Hosting
         public OperationLimitsOptions? OperationLimits { get; set; }
 
         /// <summary>
-        /// Optional escape hatch invoked after the standard configuration steps
-        /// (transport quotas, server policies, security configuration) but
-        /// before <c>CreateAsync</c>. Use it to add bespoke security policies,
-        /// override quotas, or add custom security stores.
+        /// Optional escape hatch invoked after the standard transport-quota,
+        /// server-policy, and server-option steps, but before the application
+        /// security configuration is added. Use it to add bespoke server
+        /// policies or override server options. Use
+        /// <see cref="OpcUaApplicationOptions.ConfigureSecurity"/> through
+        /// <c>ConfigureApplication(...)</c> for post-security certificate and
+        /// validation settings.
         /// </summary>
         public Action<IApplicationConfigurationBuilderServerSelected>? ConfigureBuilder { get; set; }
 

--- a/tests/Opc.Ua.Configuration.Tests/OpcUaApplicationConfigurationProviderTests.cs
+++ b/tests/Opc.Ua.Configuration.Tests/OpcUaApplicationConfigurationProviderTests.cs
@@ -365,6 +365,69 @@ namespace Opc.Ua.Configuration.Tests
             }
         }
 
+        [Test]
+        public async Task ConfigureSecurityRunsOnceAfterFirstClassOptionsForCombinedConfigurationAsync()
+        {
+            string pkiRoot = CreatePkiRoot();
+            int invocationCount = 0;
+            var provider = new OpcUaApplicationConfigurationProvider(
+                new OpcUaApplicationOptions
+                {
+                    ApplicationName = "AdvancedSecurityOptions",
+                    ApplicationUri = "urn:localhost:AdvancedSecurityOptions",
+                    ProductUri = "uri:opcfoundation.org:AdvancedSecurityOptions",
+                    PkiRoot = pkiRoot,
+                    AutoAcceptUntrustedCertificates = true,
+                    RejectSHA1SignedCertificates = true,
+                    MinimumCertificateKeySize = 2048,
+                    ConfigureSecurity = security =>
+                    {
+                        invocationCount++;
+                        security
+                            .SetMaxRejectedCertificates(17)
+                            .SetAutoAcceptUntrustedCertificates(false)
+                            .SetAddAppCertToTrustedStore(true)
+                            .SetRejectSHA1SignedCertificates(false)
+                            .SetRejectUnknownRevocationStatus(false)
+                            .SetUseValidatedCertificates(true)
+                            .SetSuppressNonceValidationErrors(true)
+                            .SetSendCertificateChain(false)
+                            .SetMinimumCertificateKeySize(3072);
+                    }
+                },
+                new TestApplicationInstanceFactory(),
+                NUnitTelemetryContext.Create(),
+                [new ClientFeature(), new ServerFeature()]);
+
+            try
+            {
+                ApplicationConfiguration configuration = await provider
+                    .GetAsync()
+                    .ConfigureAwait(false);
+
+                Assert.That(invocationCount, Is.EqualTo(1));
+                Assert.That(configuration.ApplicationType, Is.EqualTo(ApplicationType.ClientAndServer));
+                Assert.That(configuration.SecurityConfiguration.MaxRejectedCertificates, Is.EqualTo(17));
+                Assert.That(
+                    configuration.SecurityConfiguration.AutoAcceptUntrustedCertificates,
+                    Is.False);
+                Assert.That(configuration.SecurityConfiguration.AddAppCertToTrustedStore, Is.True);
+                Assert.That(configuration.SecurityConfiguration.RejectSHA1SignedCertificates, Is.False);
+                Assert.That(configuration.SecurityConfiguration.RejectUnknownRevocationStatus, Is.False);
+                Assert.That(configuration.SecurityConfiguration.UseValidatedCertificates, Is.True);
+                Assert.That(configuration.SecurityConfiguration.SuppressNonceValidationErrors, Is.True);
+                Assert.That(configuration.SecurityConfiguration.SendCertificateChain, Is.False);
+                Assert.That(
+                    configuration.SecurityConfiguration.MinimumCertificateKeySize,
+                    Is.EqualTo(3072));
+            }
+            finally
+            {
+                await provider.DisposeAsync().ConfigureAwait(false);
+                DeletePkiRoot(pkiRoot);
+            }
+        }
+
         private static string CreatePkiRoot()
         {
             return Path.Combine(


### PR DESCRIPTION
# Description

Makes security-critical configuration explicit in the modern fluent client and server samples instead of relying on hidden defaults.

- Adds an application-wide `ConfigureSecurity` DI callback for advanced certificate validation settings.
- Makes PKI roots and certificate validation settings explicit in the Pump, Boiler, Calculator, and Minimal Client samples.
- Makes the Calculator sample's endpoint policies and anonymous authentication choice explicit.
- Adds consolidated developer guidance for application certificates, endpoint security, identity, resource controls, and every advanced security-builder setting.
- Preserves the samples' existing automatic-trust behavior while clearly marking it as sample-only.

## Related Issues

- Fixes #4085

## Checklist

- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf) and read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [x] I have added all necessary documentation.
- [x] I have verified that my changes do not introduce (new) build or analyzer warnings.
- [ ] I ran **all** tests locally using the **UA.slnx** solution against at least .net **framework** and .net **10**, and all passed.
- [ ] I fixed **all** failing and flaky tests in the CI pipelines and **all** CodeQL warnings.
- [ ] I have addressed **all** PR feedback received.
