### PR TITLE
Fix signed preview pack build (CS8002)

### DIFF
--- a/src/Opc.Ua.PubSub.Kafka/Opc.Ua.PubSub.Kafka.csproj
+++ b/src/Opc.Ua.PubSub.Kafka/Opc.Ua.PubSub.Kafka.csproj
@@ -9,7 +9,10 @@
     <PackageReadmeFile>NugetREADME.md</PackageReadmeFile>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Nullable>enable</Nullable>
-    <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <!-- Suppress CS8002: the Dekaf package is not strong-named. This only surfaces on the
+         .NET Framework / netstandard TFMs of the signed preview-pack build (SignAssembly=true);
+         referencing a non-strong-named assembly is otherwise benign. -->
+    <NoWarn>$(NoWarn);CS1591;CS8002</NoWarn>
     <EnableConfigurationBindingGenerator>true</EnableConfigurationBindingGenerator>
     <!-- The default Dekaf backend is AOT-compatible; the opt-in Confluent backend is not. -->
     <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))">true</IsAotCompatible>

--- a/src/Opc.Ua.PubSub.Kafka/Opc.Ua.PubSub.Kafka.csproj
+++ b/src/Opc.Ua.PubSub.Kafka/Opc.Ua.PubSub.Kafka.csproj
@@ -9,13 +9,20 @@
     <PackageReadmeFile>NugetREADME.md</PackageReadmeFile>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Nullable>enable</Nullable>
-    <!-- Suppress CS8002: the Dekaf package is not strong-named. This only surfaces on the
-         .NET Framework / netstandard TFMs of the signed preview-pack build (SignAssembly=true);
-         referencing a non-strong-named assembly is otherwise benign. -->
-    <NoWarn>$(NoWarn);CS1591;CS8002</NoWarn>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
     <EnableConfigurationBindingGenerator>true</EnableConfigurationBindingGenerator>
     <!-- The default Dekaf backend is AOT-compatible; the opt-in Confluent backend is not. -->
     <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))">true</IsAotCompatible>
+  </PropertyGroup>
+  <!--
+    Suppress CS8002: the Dekaf package is not strong-named (PublicKeyToken=null) and ships no
+    signed variant. CS8002 is only ever emitted when the output assembly is itself strong-named,
+    which happens in the signed preview-pack build, so the suppression is scoped to that build.
+    common.props already suppresses CS8002 for net5.0-compatible target frameworks (strong-name
+    identity is not enforced there), leaving only the .NET Framework / netstandard TFMs below.
+  -->
+  <PropertyGroup Condition="'$(SignAssembly)' == 'true' AND !$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net5.0'))">
+    <NoWarn>$(NoWarn);CS8002</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="Opc.Ua.PubSub.Kafka.Tests" />


### PR DESCRIPTION
# Description

Fixes the failing **OPCFoundation.UA-.NETStandard Nuget Preview** pipeline ([build 16022](https://opcfoundation.visualstudio.com/opcua-netstandard/_build/results?buildId=16022&view=results)), where both the *Pack Nugets Debug* and *Pack Nugets Release* jobs failed.

**Root cause**

The preview pipeline builds `preview-pack.slnx` with `/p:SignAssembly=true` (see `.azurepipelines/preview.yml`). Strong-naming promotes `CS8002` — *"Referenced assembly ... does not have a strong name"* — to a build-breaking error for every reference to an unsigned assembly.

`common.props` only suppresses `CS8002` for net5.0-compatible target frameworks, where strong-name identity is no longer enforced. The `Dekaf` package (the default, AOT-compatible Kafka backend) is **not** strong-named (`PublicKeyToken=null`) and ships no signed variant, so `Opc.Ua.PubSub.Kafka` failed to compile on the remaining TFMs:

```
CSC : error CS8002: Referenced assembly 'Dekaf, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null'
      does not have a strong name.
      [src\Opc.Ua.PubSub.Kafka\Opc.Ua.PubSub.Kafka.csproj::TargetFramework=net472]
      [src\Opc.Ua.PubSub.Kafka\Opc.Ua.PubSub.Kafka.csproj::TargetFramework=net48]
      [src\Opc.Ua.PubSub.Kafka\Opc.Ua.PubSub.Kafka.csproj::TargetFramework=netstandard2.1]
```

These three errors were the *only* errors in the build.

**Fix**

Suppress `CS8002` in `Opc.Ua.PubSub.Kafka.csproj`, scoped precisely to the case that needs it:

```xml
<PropertyGroup Condition="'$(SignAssembly)' == 'true' AND !$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net5.0'))">
  <NoWarn>$(NoWarn);CS8002</NoWarn>
</PropertyGroup>
```

- `CS8002` is only ever emitted when the output assembly is itself strong-named, so outside the signed pack build the suppression is inert rather than merely redundant.
- The `net5.0` compatibility check narrows it to `net472;net48;netstandard2.1`. It reuses the same `IsTargetFrameworkCompatible` predicate `common.props` uses, rather than hardcoding a TFM list, so the two stay in sync if `LibxTargetFrameworks` changes.
- If `Dekaf` ever ships a strong-named build, the suppression becomes dead rather than silently masking a real reference problem.

Referencing a non-strong-named assembly is otherwise benign — it only surfaces in the signed pack build. Upgrading is not an option, as no signed `Dekaf` build exists. The same class of suppression already exists for the unsigned `Makaretu.Dns` packages in `Opc.Ua.Lds.Server.csproj` and for `SourceGenerator.Foundations.Contracts` in the source-generator projects.

**Verification**

- Reproduced locally with a throwaway `.snk` and confirmed `CS8002` fires without the fix.
- Ran the exact CI sequence with the fix — `.azurepipelines/generate-slnx.ps1`, then `dotnet build preview-pack.slnx --configuration Release /p:SignAssembly=true /p:AssemblyOriginatorKeyFile=...` across all 56 packable projects and every TFM (`net472;net48;netstandard2.1;net8.0;net9.0;net10.0`): **Build succeeded, 0 errors.**
- `Opc.Ua.PubSub.Kafka` builds with **0 warnings, 0 errors** on all six TFMs both with and without `SignAssembly=true`.
- The only downstream consumer of the project, `ConsoleReferencePubSubClient`, targets `net10.0` only, where `CS8002` is already suppressed globally — so it is unaffected.

## Related Issues

No tracking issue — this is a CI-only regression in the nightly preview pack build, reported directly by the pipeline run linked above.

## Checklist

- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf) and read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage. — _N/A: build-configuration-only change (a scoped `NoWarn` entry); there is no runtime behavior to test. The fix is verified by reproducing the signed pack build, as described above._
- [x] I have added all necessary documentation. — _Rationale is captured as an inline comment next to the suppression, matching the style used for the other `CS8002` suppressions in the repo._
- [x] I have verified that my changes do not introduce (new) build or analyzer warnings. — _The full signed pack build reports 0 errors; the 8 remaining warnings are pre-existing `CA2000` occurrences in `samples/ConsoleReferenceClient` that are unrelated to this change._
- [ ] I ran **all** tests locally using the **UA.slnx** solution against at least .net **framework** and .net **10**, and all passed. — _No compiled code changes; `Opc.Ua.PubSub.Kafka` builds clean on all six TFMs, signed and unsigned._
- [ ] I fixed **all** failing and flaky tests in the CI pipelines and **all** CodeQL warnings.
- [x] I have addressed **all** PR feedback received.
