### PR TITLE
Seal BinaryEncoder for consistency with Xml/Json encoders

### DIFF
--- a/docs/migrate/2.0.x/encoders.md
+++ b/docs/migrate/2.0.x/encoders.md
@@ -56,11 +56,17 @@ In addition to the generic Write/ReadEnumerated, the non-generic `EnumValue` var
 
 Custom encoder/decoder implementations must adjust to comply with the new interfaces.
 
+`BinaryEncoder`, `XmlEncoder` and `JsonEncoder` are now `sealed`. They were never designed as
+inheritance points, and deriving from them was not a supported extension mechanism. `BinaryEncoder`
+additionally no longer exposes the `protected virtual void Dispose(bool)` overload; its `Dispose()`
+behaviour is unchanged. Implement `IEncoder` directly instead of deriving from a built-in encoder.
+
 **Change code as follows:**
 
 - Change all `ReadEncodeable`/`WriteEncodeable` calls to use the type as part of the generic expression. E.g. `ReadEncodeable("field", typeof(T))` to `ReadEncodeable<T>("field")` and `WriteEncodeable("field", value, typeof(T))` to `WriteEncodeable("field", value)`. If value is a type that cannot be created using a parameterless constructor, pass the type id as last argument.
 - Change all `ReadEnumerated` calls to use the enumeration type as part of the generic expression. E.g. `ReadEnumerated("field", typeof(T))` to `ReadEnumerated<T>("field")`.
 - Change calls to `ReadArray`/`WriteArray` to use `ReadVariantValue` and `WriteVariantValue` and extract the value from the returned `Variant` based on the type you intended to read. A good example can be found in `BaseComplexType` `EncodeProperty` and `DecodeProperty`.
+- Replace any type deriving from `BinaryEncoder`, `XmlEncoder` or `JsonEncoder` with a direct `IEncoder` implementation, and move any `Dispose(bool)` override into that implementation's own `Dispose()`.
 
 ## Complex Types
 

--- a/src/Opc.Ua.Types/Encoders/BinaryEncoder.cs
+++ b/src/Opc.Ua.Types/Encoders/BinaryEncoder.cs
@@ -45,7 +45,7 @@ namespace Opc.Ua
     /// <summary>
     /// Encodes objects in a stream using the UA Binary encoding.
     /// </summary>
-    public class BinaryEncoder : IEncoder
+    public sealed class BinaryEncoder : IEncoder
     {
         /// <summary>
         /// Creates an encoder that writes to a memory buffer.
@@ -122,34 +122,22 @@ namespace Opc.Ua
         /// </summary>
         public void Dispose()
         {
-            Dispose(true);
-            GC.SuppressFinalize(this);
-        }
-
-        /// <summary>
-        /// An overrideable version of the Dispose.
-        /// </summary>
-        protected virtual void Dispose(bool disposing)
-        {
-            if (disposing)
+            if (m_writer != null)
             {
-                if (m_writer != null)
-                {
-                    m_writer.Flush();
-                    m_writer.Dispose();
-                    m_writer = null!;
-                }
-
-                if (!m_leaveOpen)
-                {
-                    m_ostrm?.Dispose();
-                    m_ostrm = null!;
-                }
-
-                m_ownedBufferWriter?.Dispose();
-                m_ownedBufferWriter = null;
-                m_bufferWriter = null;
+                m_writer.Flush();
+                m_writer.Dispose();
+                m_writer = null!;
             }
+
+            if (!m_leaveOpen)
+            {
+                m_ostrm?.Dispose();
+                m_ostrm = null!;
+            }
+
+            m_ownedBufferWriter?.Dispose();
+            m_ownedBufferWriter = null;
+            m_bufferWriter = null;
         }
 
         /// <summary>


### PR DESCRIPTION
# Description

`XmlEncoder` and `JsonEncoder` are both `sealed` in 2.0, but `BinaryEncoder` was left as `public class`. On `master378` (1.5.378) **all three** were unsealed, so this is not a new restriction — it completes a decision that was already made and shipped for the other two encoders, and brings `BinaryEncoder` in line with the repo's sealed-by-default guidance in [`docs/DeveloperGuide.md`](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/docs/DeveloperGuide.md).

Changes:

- `BinaryEncoder` is now `public sealed class`.
- The now-unreachable `protected virtual void Dispose(bool disposing)` overload is removed and its body moved inline into `Dispose()`. The type has no finalizer, so the `GC.SuppressFinalize(this)` call is dropped too. **Disposal behaviour is unchanged** — this mirrors the pattern already used by the sealed `XmlEncoder`.
- The break is documented in `docs/migrate/2.0.x/encoders.md`, which also closes a pre-existing documentation gap: the earlier sealing of `XmlEncoder` and `JsonEncoder` had never been recorded in the migration guide.

No type in the repository derives from `BinaryEncoder`, so nothing in-tree required changes.

### Migration impact

External code that derived from `BinaryEncoder` (or overrode `Dispose(bool)`) must implement `IEncoder` directly instead. This is called out in the migration guide with the other encoder changes.

## Related Issues

_No tracking issue — this is a small consistency fix that completes the existing 2.0 encoder sealing work rather than a new feature or behavioural change. Happy to open one if maintainers prefer it tracked._

## Checklist

_Put an `x` in the boxes that apply. You can complete these step by step after opening the PR._

- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf) and read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage. — _No new tests: this changes type accessibility only, with no behavioural change. Existing coverage exercises it (2,959 tests in `Opc.Ua.Types.Tests` `Encoders` pass unchanged)._
- [x] I have added all necessary documentation.
- [x] I have verified that my changes do not introduce (new) build or analyzer warnings.
- [ ] I ran **all** tests locally using the **UA.slnx** solution against at least .net **framework** and .net **10**, and all passed. — _Partially: full `UA.slnx` build succeeds with 0 errors, and `Opc.Ua.Types` builds clean across all 6 TFMs (incl. net48/net472). Targeted encoder tests were run on net10.0 only; the full suite has not been run on .NET Framework locally. Relying on CI for the remainder._
- [ ] I fixed **all** failing and flaky tests in the CI pipelines and **all** CodeQL warnings.
- [ ] I have addressed **all** PR feedback received.

## Verification performed

| Check | Result |
| --- | --- |
| `dotnet build UA.slnx` | Build succeeded — 0 errors (33 pre-existing warnings, none from this change) |
| `dotnet build src/Opc.Ua.Types` (all TFMs) | 0 warnings, 0 errors |
| `Opc.Ua.Types.Tests` filter `Encoders` (net10.0) | 2,959 passed, 0 failed |
| Derived types of `BinaryEncoder` in repo | none found |
| `master378` baseline | all three encoders unsealed there — no regression vs 1.5.378 |
