### PR TITLE
Complete client subscriptions by identity instead of id

### DIFF
--- a/src/Opc.Ua.Client/Subscription/IMessageAckQueue.cs
+++ b/src/Opc.Ua.Client/Subscription/IMessageAckQueue.cs
@@ -51,10 +51,13 @@ namespace Opc.Ua.Client.Subscriptions
         /// <summary>
         /// Complete subscription
         /// </summary>
-        /// <param name="subscriptionId"></param>
+        /// <param name="subscription">The completing subscription.</param>
+        /// <param name="subscriptionId">The last server-assigned id of the
+        /// subscription (0 when it was never created).</param>
         /// <param name="ct"></param>
         /// <returns></returns>
-        ValueTask CompleteAsync(uint subscriptionId,
+        ValueTask CompleteAsync(IMessageProcessor subscription,
+            uint subscriptionId,
             CancellationToken ct = default);
 
         /// <summary>

--- a/src/Opc.Ua.Client/Subscription/MessageProcessor.cs
+++ b/src/Opc.Ua.Client/Subscription/MessageProcessor.cs
@@ -45,7 +45,19 @@ namespace Opc.Ua.Client.Subscriptions
     internal abstract class MessageProcessor : IMessageProcessor, IAsyncDisposable
     {
         /// <inheritdoc/>
-        public uint Id { get; internal set; }
+        public uint Id
+        {
+            get => m_id;
+            internal set
+            {
+                m_id = value;
+                if (value != 0)
+                {
+                    // Save non-zero server id for completion
+                    m_lastServerId = value;
+                }
+            }
+        }
 
         /// <summary>
         /// Number of notification messages detected as missing during
@@ -275,7 +287,7 @@ namespace Opc.Ua.Client.Subscriptions
                 // to be removed
                 throw;
             }
-            await AckQueue.CompleteAsync(Id, default).ConfigureAwait(false);
+            await AckQueue.CompleteAsync(this, m_lastServerId, default).ConfigureAwait(false);
             OnPublishStateChanged(PublishState.Completed);
         }
 
@@ -645,6 +657,8 @@ namespace Opc.Ua.Client.Subscriptions
         internal long LastNotificationTimestamp;
         internal uint LastSequenceNumberProcessed;
         internal uint LastDataSequenceNumberProcessed;
+        private uint m_id;
+        private uint m_lastServerId;
         internal long m_missingCount;
         internal long m_republishCount;
         internal IReadOnlyList<uint> AvailableInRetransmissionQueue;

--- a/src/Opc.Ua.Client/Subscription/SubscriptionManager.cs
+++ b/src/Opc.Ua.Client/Subscription/SubscriptionManager.cs
@@ -403,21 +403,24 @@ namespace Opc.Ua.Client.Subscriptions
         }
 
         /// <inheritdoc/>
-        public ValueTask CompleteAsync(uint subscriptionId, CancellationToken ct)
+        public ValueTask CompleteAsync(IMessageProcessor completing,
+            uint subscriptionId, CancellationToken ct)
         {
             IManagedSubscription? subscription;
             LogicalSubscription? logical = null;
             lock (m_subscriptionLock)
             {
                 // Drop the partition from the dispatch registry.
-                subscription = m_subscriptions
-                    .FirstOrDefault(s => s.Id == subscriptionId);
+                subscription = completing as IManagedSubscription;
                 if (subscription == null ||
                     !m_subscriptions.Remove(subscription))
                 {
                     return default;
                 }
-                m_subscriptionHistory.Enqueue(subscriptionId);
+                if (subscriptionId != 0)
+                {
+                    m_subscriptionHistory.Enqueue(subscriptionId);
+                }
 
                 // If the removed partition was the primary of any
                 // logical wrapper, the wrapper has no usable
@@ -445,7 +448,7 @@ namespace Opc.Ua.Client.Subscriptions
             {
                 m_subscriptionHistory.TryDequeue(out _);
             }
-            m_logger.SubscriptionRemoved(subscription.Id);
+            m_logger.SubscriptionRemoved(subscriptionId);
             m_publishControl.Set();
             return default;
         }

--- a/tests/Opc.Ua.Client.Tests/Subscription/Fakes/FakeMessageAckQueue.cs
+++ b/tests/Opc.Ua.Client.Tests/Subscription/Fakes/FakeMessageAckQueue.cs
@@ -67,7 +67,8 @@ namespace Opc.Ua.Client.Subscriptions.Fakes
             return OnQueueAsync?.Invoke(ack, ct) ?? default;
         }
 
-        public ValueTask CompleteAsync(uint subscriptionId,
+        public ValueTask CompleteAsync(IMessageProcessor subscription,
+            uint subscriptionId,
             CancellationToken ct = default)
         {
             CompletedSubscriptions.Add(subscriptionId);

--- a/tests/Opc.Ua.Client.Tests/Subscription/SubscriptionManagerTests.cs
+++ b/tests/Opc.Ua.Client.Tests/Subscription/SubscriptionManagerTests.cs
@@ -180,6 +180,44 @@ namespace Opc.Ua.Client.Subscriptions
         }
 
         [Test]
+        public async Task CompleteForUncreatedIdDoesNotEvictPendingSubscriptionAsync()
+        {
+            ILoggerFactory loggerFactory = m_telemetry.LoggerFactory;
+            var session = new FakeSubscriptionManagerContext();
+            OptionsMonitor<SubscriptionOptions> so1 = OptionsFactory.Create<SubscriptionOptions>();
+
+            // Subscription awaiting CreateSubscription
+            var ms1 = new FakeManagedSubscription();
+
+            var sut = new SubscriptionManager(session,
+                loggerFactory, DiagnosticsMasks.None);
+
+            session.CreateSubscriptionFactory = (handler, options, queue) =>
+            {
+                Assert.That(queue, Is.SameAs(sut));
+                if (ReferenceEquals(options, so1))
+                {
+                    return ms1;
+                }
+                throw new InvalidOperationException("unexpected options");
+            };
+
+            ISubscription s1 = sut.Add(m_mockNotificationDataHandler.Object, so1);
+            Assert.That(sut.Count, Is.EqualTo(1));
+
+            // A deleted subscription acknowledges completion with an id already reset to 0
+            await sut.CompleteAsync(0, default).ConfigureAwait(false);
+
+            // Verify that the pending subscription still exists
+            Assert.That(sut.Count, Is.EqualTo(1));
+            Assert.That(sut.Items, Does.Contain(s1));
+
+            await sut.DisposeAsync().ConfigureAwait(false);
+            Assert.That(sut.Count, Is.Zero);
+            Assert.That(sut.PublishWorkerCount, Is.Zero);
+        }
+
+        [Test]
         public async Task ScaleOutAndInOfPublishWorkersAsync()
         {
             ILoggerFactory loggerFactory = m_telemetry.LoggerFactory;

--- a/tests/Opc.Ua.Client.Tests/Subscription/SubscriptionManagerTests.cs
+++ b/tests/Opc.Ua.Client.Tests/Subscription/SubscriptionManagerTests.cs
@@ -106,7 +106,7 @@ namespace Opc.Ua.Client.Subscriptions
             Assert.That(ex.StatusCode, Is.EqualTo(StatusCodes.BadAlreadyExists));
             await Task.Delay(100).ConfigureAwait(false); // Give time to workers to start
             Assert.That(sut.PublishWorkerCount, Is.Zero);
-            await sut.CompleteAsync(1, default).ConfigureAwait(false);
+            await sut.CompleteAsync(ms1, 1, default).ConfigureAwait(false);
             Assert.That(sut.Count, Is.EqualTo(1));
             Assert.That(sut.Items, Does.Contain(s2));
 
@@ -160,7 +160,7 @@ namespace Opc.Ua.Client.Subscriptions
             // but MinPublishWorkerCount defaults to 2, so the desired count is 2.
             await WaitForPublishWorkerCountAsync(sut, 2).ConfigureAwait(false);
 
-            await sut.CompleteAsync(2, default).ConfigureAwait(false); // Remove s2
+            await sut.CompleteAsync(ms2, 2, default).ConfigureAwait(false); // Remove s2
             Assert.That(sut.Count, Is.EqualTo(1));
             Assert.That(sut.Items, Does.Not.Contain(s2));
 
@@ -168,7 +168,7 @@ namespace Opc.Ua.Client.Subscriptions
             Assert.That(sut.PublishWorkerCount, Is.EqualTo(2));
             Assert.That(sut.PublishControlCycles, Is.GreaterThan(0));
 
-            await sut.CompleteAsync(1, default).ConfigureAwait(false); // Remove s1
+            await sut.CompleteAsync(ms1, 1, default).ConfigureAwait(false); // Remove s1
             Assert.That(sut.Count, Is.Zero);
             Assert.That(sut.Items, Does.Not.Contain(s1));
 
@@ -206,7 +206,7 @@ namespace Opc.Ua.Client.Subscriptions
             Assert.That(sut.Count, Is.EqualTo(1));
 
             // A deleted subscription acknowledges completion with an id already reset to 0
-            await sut.CompleteAsync(0, default).ConfigureAwait(false);
+            await sut.CompleteAsync(new FakeManagedSubscription(), 0, default).ConfigureAwait(false);
 
             // Verify that the pending subscription still exists
             Assert.That(sut.Count, Is.EqualTo(1));
@@ -449,7 +449,8 @@ namespace Opc.Ua.Client.Subscriptions
 
             m_subscriptionManager.Add(m_mockNotificationDataHandler.Object,
                 Mock.Of<IOptionsMonitor<SubscriptionOptions>>());
-            await m_subscriptionManager.CompleteAsync(1, CancellationToken.None).ConfigureAwait(false);
+            await m_subscriptionManager.CompleteAsync(mockSubscription, 1, CancellationToken.None)
+                .ConfigureAwait(false);
             Assert.That(m_subscriptionManager.Items, Is.Empty);
         }
 

--- a/tests/Opc.Ua.Subscriptions.Tests/SubscriptionManagerCoverageTests.cs
+++ b/tests/Opc.Ua.Subscriptions.Tests/SubscriptionManagerCoverageTests.cs
@@ -265,7 +265,8 @@ namespace Opc.Ua.Subscriptions.Tests
             SubscriptionManager manager = CreateManager(context);
             await using (manager.ConfigureAwait(false))
             {
-                await manager.CompleteAsync(999u, CancellationToken.None).ConfigureAwait(false);
+                await manager.CompleteAsync(new StubManagedSubscription { Id = 999u }, 999u,
+                    CancellationToken.None).ConfigureAwait(false);
                 Assert.That(manager.Count, Is.Zero);
             }
             Assert.That(context.PublishCallCount, Is.Zero);
@@ -500,7 +501,7 @@ namespace Opc.Ua.Subscriptions.Tests
                 manager.Add(handler, SinglePartitionOptions());
                 Assert.That(manager.Count, Is.EqualTo(1));
 
-                await manager.CompleteAsync(1u, CancellationToken.None).ConfigureAwait(false);
+                await manager.CompleteAsync(subscription, 1u, CancellationToken.None).ConfigureAwait(false);
 
                 Assert.That(manager.Count, Is.Zero);
                 Assert.That(manager.Items, Is.Empty);


### PR DESCRIPTION
# Description

Completes subscriptions by passing `IMessageProcessor` and last known server subscription id to prevent incorrect subscription removal when multiple subscriptions with id 0 exist.

## Issue

During calls to `SubscriptionManager.CompleteAsync`, the subscription manager looked up the subscription entry to remove by the passed subscription id. But newly created subscriptions not yet having received an id from the server have their id set to 0, meaning that disposing an unrelated subscription also with id set to 0 could remove the wrong one (as there can exist multiple subscriptions with the same zero-id), which in turn could lead to the id no longer being resolved, and the publish worker treating it as unknown. Deleted subscriptions also have their id reset to zero, which could potentially clash as well.

## Fix

- Internal interface `IMessageAckQueue` is changed so that `CompleteAsync` also takes `IMessageProcessor` as an argument.
- `MessageProcessor` stores the known server id (if set) and passes itself along with that id to `CompleteAsync`.
- With the `IMessageProcessor` argument, `SubscriptionManager` no longer needs to look up subscription by id and therefore removes the correct subscription.
- Additionally, `SubscriptionManager` receives the non-zeroed server id and no longer enqueues zero-value ids to the subscription history.

## Related Issues

- Fixes #4113 

## Checklist

- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf) and read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added all necessary documentation.
- [x] I have verified that my changes do not introduce (new) build or analyzer warnings.
- [ ] I ran **all** tests locally using the **UA.slnx** solution against at least .net **framework** and .net **10**, and all passed.
- [ ] I fixed **all** failing and flaky tests in the CI pipelines and **all** CodeQL warnings.
- [ ] I have addressed **all** PR feedback received.
