### PR TITLE
Add simulation to PumpDeviceIntegrationServer and Event modelling

### DIFF
--- a/samples/PumpDeviceIntegrationServer/PumpNodeManager.Configure.cs
+++ b/samples/PumpDeviceIntegrationServer/PumpNodeManager.Configure.cs
@@ -28,6 +28,7 @@
  * ======================================================================*/
 
 using System;
+using System.Collections.Concurrent;
 using System.Threading;
 using Microsoft.Extensions.Logging;
 using Opc.Ua;
@@ -49,112 +50,209 @@ namespace Pumps
     /// </remarks>
     public partial class PumpNodeManager
     {
-        /// <summary>
-        /// ── Simulation state ────────────────────────────────────────
-        /// </summary>
-        private long m_simulationTicks;
-        private long m_numberOfStarts;
-
-        /// <summary>
-        /// ── Latest simulated values, updated by the simulation tick. ──
-        /// </summary>
-        private double m_currentPressure;
-        private double m_currentTemperature = 313.15;
-        private double m_currentBearingTemp = 333.15;
-        private double m_currentPower;
-        private double m_currentFlow;
-        private double m_currentEfficiency = 75.0;
-        private double m_currentLevel = 2.5;
-        private bool m_cavitation;
-        private bool m_motorOverheat;
-
         partial void Configure(INodeManagerBuilder builder)
         {
             Server.Telemetry.CreateLogger<PumpNodeManager>()
                 .ConfiguringPumpNodeManagerFluentWiring();
 
+            PumpState pump = builder.Node<PumpState>("Pump #1").Node;
             WithIdentification(builder);
-            WithMeasurements(builder);
-            WithSupervision(builder);
+            RegisterPumpSimulation(builder, pump);
 
-            // Single manager-owned simulation tick advances all live
-            // measurements at 250 ms intervals; lets time-based fault
-            // injection work cleanly.
             builder.Simulation(TimeSpan.FromMilliseconds(250))
                 .OnTick((ctx, elapsed) => AdvanceSimulation());
         }
 
         /// <summary>
-        /// ── Identification properties via WithProperty ──────────────
-        /// PumpType.Identification is a mandatory child of PumpType so
-        /// it is materialised by the source-generated factory used in
-        /// CreatePumpAsync. BrowsePathResolver's cross-namespace
-        /// name-only fallback (FB-3 phase 1) resolves the unqualified
-        /// 'Identification' segment to the DI-namespace child without
-        /// requiring an explicit ns= prefix in the path.
+        /// Wires a pump created after the initial fluent configuration into
+        /// the already-running manager simulation.
         /// </summary>
-        /// <param name="builder"></param>
-        private void WithIdentification(INodeManagerBuilder builder)
+        /// <param name="pump">The registered pump instance.</param>
+        private void RegisterPumpSimulation(PumpState pump)
+        {
+            ushort pumpsNs = (ushort)Server.NamespaceUris.GetIndex(
+                Opc.Ua.Pumps.Namespaces.Pumps);
+            NodeManagerBuilder builder = CreateFluentBuilder(pumpsNs);
+            RegisterPumpSimulation(builder, pump);
+            // Seal starts the shared simulation registry; only seal successfully wired builders.
+            builder.Seal();
+        }
+
+        /// <summary>
+        /// Configures the variable updaters, alarms, and phase profile for one
+        /// pump instance.
+        /// </summary>
+        /// <param name="builder">The active fluent builder.</param>
+        /// <param name="pump">The pump to configure.</param>
+        private void RegisterPumpSimulation(
+            INodeManagerBuilder builder,
+            PumpState pump)
+        {
+            lock (m_simulationRegistrationLock)
+            {
+                if (m_pumpSimulations.ContainsKey(pump.NodeId))
+                {
+                    throw ServiceResultException.Create(
+                        StatusCodes.BadConfigurationError,
+                        "Pump '{0}' (id '{1}') already has a simulation registered.",
+                        pump.BrowseName,
+                        pump.NodeId);
+                }
+
+                int profileIndex = m_nextSimulationProfile++;
+                PumpSimulationState simulation = CreatePumpSimulation(
+                    builder,
+                    pump,
+                    profileIndex);
+                simulation.Initialize(Volatile.Read(ref m_simulationTicks));
+                if (!m_pumpSimulations.TryAdd(pump.NodeId, simulation))
+                {
+                    throw ServiceResultException.Create(
+                        StatusCodes.BadConfigurationError,
+                        "Pump '{0}' (id '{1}') already has a simulation registered.",
+                        pump.BrowseName,
+                        pump.NodeId);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Configures the identification values demonstrated by the
+        /// hand-wired first pump.
+        /// </summary>
+        /// <param name="builder">The active fluent builder.</param>
+        private static void WithIdentification(INodeManagerBuilder builder)
         {
             builder.Node("Pump #1/Identification")
                 .WithProperty("Manufacturer", "SimPump Corp")
                 .WithProperty("SerialNumber", "SN-001")
-                .WithProperty("ProductInstanceUri",
+                .WithProperty(
+                    "ProductInstanceUri",
                     "urn:simdevice:SimPump:PumpX-2000:SN-001");
         }
 
-        /// <summary>
-        /// ── Measurements with engineering units ─────────────────────
-        /// All seven analog measurements live under
-        /// PumpType.Operational.Measurements and are materialised by
-        /// CreatePumpAsync via the generator-emitted AddXxx
-        /// helpers. The cross-namespace name-only resolver fallback
-        /// means the unqualified browse path resolves through the
-        /// Pumps -> Machinery (Operational) -> Pumps (Measurements +
-        /// analog states) namespace transitions transparently.
-        /// </summary>
-        /// <param name="builder"></param>
-        private void WithMeasurements(INodeManagerBuilder builder)
+        private PumpSimulationState CreatePumpSimulation(
+            INodeManagerBuilder builder,
+            PumpState pump,
+            int profileIndex)
         {
-            AddMeasurement(builder,
-                "Pump #1/Operational/Measurements/DifferentialPressure",
-                () => m_currentPressure,
-                EngineeringUnits.Pascal, min: 0, max: 1_000_000);
+            MeasurementsState measurements = pump.Operational!.Measurements!;
 
-            AddMeasurement(builder,
-                "Pump #1/Operational/Measurements/FluidTemperature",
-                () => m_currentTemperature,
-                EngineeringUnits.Kelvin, min: 233.15, max: 473.15);
+            AddMeasurement(
+                builder,
+                measurements.DifferentialPressure!.NodeId,
+                EngineeringUnits.Pascal,
+                min: 0,
+                max: 1_000_000,
+                out IValueUpdater<double> pressure);
+            AddMeasurement(
+                builder,
+                measurements.FluidTemperature!.NodeId,
+                EngineeringUnits.Kelvin,
+                min: 233.15,
+                max: 473.15,
+                out IValueUpdater<double> fluidTemperature);
+            AddMeasurement(
+                builder,
+                measurements.BearingTemperature!.NodeId,
+                EngineeringUnits.Kelvin,
+                min: 233.15,
+                max: 473.15,
+                out IValueUpdater<double> bearingTemperature);
+            AddMeasurement(
+                builder,
+                measurements.PumpPowerInput!.NodeId,
+                EngineeringUnits.Watt,
+                min: 0,
+                max: 50_000,
+                out IValueUpdater<double> power);
+            AddMeasurement(
+                builder,
+                measurements.MassFlow!.NodeId,
+                EngineeringUnits.KilogramsPerSecond,
+                min: 0,
+                max: 1.0,
+                out IValueUpdater<double> flow);
+            AddMeasurement(
+                builder,
+                measurements.PumpEfficiency!.NodeId,
+                EngineeringUnits.Percent,
+                min: 0,
+                max: 100,
+                out IValueUpdater<double> efficiency);
+            AddMeasurement(
+                builder,
+                measurements.Level!.NodeId,
+                EngineeringUnits.Metre,
+                min: 0,
+                max: 10,
+                out IValueUpdater<double> level);
 
-            AddMeasurement(builder,
-                "Pump #1/Operational/Measurements/BearingTemperature",
-                () => m_currentBearingTemp,
-                EngineeringUnits.Kelvin, min: 233.15, max: 473.15);
+            builder.Variable<uint>(measurements.NumberOfStarts!.NodeId)
+                .Bind(out IValueUpdater<uint> numberOfStarts);
 
-            AddMeasurement(builder,
-                "Pump #1/Operational/Measurements/PumpPowerInput",
-                () => m_currentPower,
-                EngineeringUnits.Watt, min: 0, max: 50_000);
+            ushort pumpsNs = (ushort)Server.NamespaceUris.GetIndex(
+                Opc.Ua.Pumps.Namespaces.Pumps);
+            INodeBuilder<PumpState> pumpBuilder =
+                builder.Node<PumpState>(pump.NodeId);
+            INodeBuilder<SupervisionState> events =
+                pumpBuilder.Components().Events();
 
-            AddMeasurement(builder,
-                "Pump #1/Operational/Measurements/MassFlow",
-                () => m_currentFlow,
-                EngineeringUnits.KilogramsPerSecond, min: 0, max: 1.0);
+            IAlarmBuilder<NonExclusiveLimitAlarmState> overTempAlarm = events
+                .CreateLimitAlarm(
+                    new QualifiedName("OverTempAlarm", pumpsNs))
+                .WithLimits(
+                    highHigh: 373.15,
+                    high: 363.15,
+                    low: 283.15,
+                    lowLow: 273.15)
+                .OnAcknowledge((ctx, c, eventId, comment) => ServiceResult.Good);
 
-            AddMeasurement(builder,
-                "Pump #1/Operational/Measurements/PumpEfficiency",
-                () => m_currentEfficiency,
-                EngineeringUnits.Percent, min: 0, max: 100);
+            events.Components().SupervisionProcessFluid()
+                .Components().Cavitation()
+                .Bind(out IValueUpdater<bool> cavitation);
+            IVariableBuilder<bool> motorOverheatBuilder = events
+                .Components().SupervisionPumpOperation()
+                .Components().MotorOverheat()
+                .Bind(out IValueUpdater<bool> motorOverheat);
+            overTempAlarm.MonitorVariable(motorOverheatBuilder.Node);
+            motorOverheatBuilder.ActivatesAlarm(overTempAlarm);
 
-            AddMeasurement(builder,
-                "Pump #1/Operational/Measurements/Level",
-                () => m_currentLevel,
-                EngineeringUnits.Metre, min: 0, max: 10);
+            return new PumpSimulationState(
+                profileIndex,
+                pressure,
+                fluidTemperature,
+                bearingTemperature,
+                power,
+                flow,
+                efficiency,
+                level,
+                numberOfStarts,
+                cavitation,
+                motorOverheat);
+        }
 
-            // Discrete count exposed alongside the analog measurements.
-            builder.Variable<uint>(
-                "Pump #1/Operational/Measurements/NumberOfStarts")
-                .OnRead(() => (uint)Interlocked.Read(ref m_numberOfStarts));
+        private static void AddMeasurement(
+            INodeManagerBuilder builder,
+            NodeId nodeId,
+            EUInformation units,
+            double min,
+            double max,
+            out IValueUpdater<double> updater)
+        {
+            builder.Variable<double>(nodeId)
+                .Bind(out updater)
+                .WithEngineeringUnits(units)
+                .WithEURange(min, max);
+        }
+
+        private void AdvanceSimulation()
+        {
+            long tick = Interlocked.Increment(ref m_simulationTicks);
+            foreach (PumpSimulationState simulation in m_pumpSimulations.Values)
+            {
+                simulation.Advance(tick);
+            }
         }
 
         private static class EngineeringUnits
@@ -178,100 +276,108 @@ namespace Pumps
                 new("m", "Metre", "http://www.opcfoundation.org/UA/units/un/cefact");
         }
 
-        /// <summary>
-        /// ── Supervision flags wired to NAMUR alarms ─────────────────
-        /// Demonstrates the FB-3 phase 3 typed accessor API: starting
-        /// from a typed INodeBuilder<PumpState> root, the generator-
-        /// emitted PumpStateComponents.Events extension walks to
-        /// SupervisionState (the type of PumpType.Events), and from
-        /// there the typed SupervisionStateComponents accessor walks
-        /// to SupervisionProcessFluid and SupervisionPumpOperation —
-        /// each step is compile-time checked against the model and
-        /// namespace-aware without forcing the author to spell out
-        /// browse-paths or QualifiedNames.
-        /// </summary>
-        /// <param name="builder"></param>
-        private void WithSupervision(INodeManagerBuilder builder)
+        private sealed class PumpSimulationState
         {
-            ushort pumpsNs = (ushort)Server.NamespaceUris.GetIndex(
-                Opc.Ua.Pumps.Namespaces.Pumps);
-
-            INodeBuilder<PumpState> pump =
-                builder.Node<PumpState>("Pump #1");
-
-            IAlarmBuilder<NonExclusiveLimitAlarmState> tempAlarm = pump
-                .Components().Events()
-                .CreateLimitAlarm(new QualifiedName("OverTempAlarm", pumpsNs))
-                .WithLimits(highHigh: 373.15, high: 363.15, low: 283.15, lowLow: 273.15)
-                .OnAcknowledge((ctx, c, eventId, comment) => ServiceResult.Good);
-
-            pump.Components().Events()
-                .Components().SupervisionProcessFluid()
-                .Components().Cavitation()
-                .OnRead(() => m_cavitation)
-                .ActivatesAlarm(tempAlarm);
-
-            pump.Components().Events()
-                .Components().SupervisionPumpOperation()
-                .Components().MotorOverheat()
-                .OnRead(() => m_motorOverheat);
-        }
-
-        /// <summary>
-        /// Direct measurement wiring — failures now propagate as
-        /// BadNodeIdUnknown ServiceResultException so wiring errors
-        /// surface at configuration time rather than getting silently
-        /// logged. The legacy TryAdd* helpers and their per-method
-        /// try/catch blocks were necessary while the optional pump
-        /// subtree was unmaterialised; CreatePumpAsync now
-        /// materialises every wired leaf so the wiring is unconditional.
-        /// </summary>
-        /// <param name="builder"></param>
-        /// <param name="browsePath"></param>
-        /// <param name="getter"></param>
-        /// <param name="units"></param>
-        /// <param name="min"></param>
-        /// <param name="max"></param>
-        private static void AddMeasurement(
-            INodeManagerBuilder builder,
-            string browsePath,
-            Func<double> getter,
-            EUInformation units,
-            double min,
-            double max)
-        {
-            builder.Variable<double>(browsePath)
-                .OnRead(getter)
-                .WithEngineeringUnits(units)
-                .WithEURange(min, max);
-        }
-
-        /// <summary>
-        /// ── Simulation tick — advances all live measurements ────────
-        /// </summary>
-        private void AdvanceSimulation()
-        {
-            long t = Interlocked.Increment(ref m_simulationTicks);
-
-            m_currentPressure = 200000.0 + (50000.0 * Math.Sin(t * 0.03));
-            m_currentTemperature = 313.15 + (5.0 * Math.Sin(t * 0.01));
-            m_currentBearingTemp = 333.15 + (8.0 * Math.Cos(t * 0.008));
-            m_currentPower = 5000.0 + (500.0 * Math.Sin(t * 0.02));
-            m_currentFlow = 0.05 + (0.005 * Math.Cos(t * 0.04));
-            m_currentEfficiency = 75.0 + (10.0 * Math.Sin(t * 0.015));
-            m_currentLevel = 2.5 + (0.5 * Math.Sin(t * 0.02));
-
-            // Fault injection — supervision flags transition true/false.
-            m_cavitation = (t % 120) > 100;
-            m_motorOverheat = (t % 200) > 190;
-
-            // Periodic restart simulation — every 3600 ticks (~15 min at 250ms).
-            if (t % 3600 == 0)
+            public PumpSimulationState(
+                int profileIndex,
+                IValueUpdater<double> pressure,
+                IValueUpdater<double> fluidTemperature,
+                IValueUpdater<double> bearingTemperature,
+                IValueUpdater<double> power,
+                IValueUpdater<double> flow,
+                IValueUpdater<double> efficiency,
+                IValueUpdater<double> level,
+                IValueUpdater<uint> numberOfStarts,
+                IValueUpdater<bool> cavitation,
+                IValueUpdater<bool> motorOverheat)
             {
-                Interlocked.Increment(ref m_numberOfStarts);
+                m_phaseOffset = profileIndex * 17L;
+                m_pressure = pressure;
+                m_fluidTemperature = fluidTemperature;
+                m_bearingTemperature = bearingTemperature;
+                m_power = power;
+                m_flow = flow;
+                m_efficiency = efficiency;
+                m_level = level;
+                m_numberOfStarts = numberOfStarts;
+                m_cavitation = cavitation;
+                m_motorOverheat = motorOverheat;
             }
+
+            public void Initialize(long tick)
+            {
+                Publish(tick, publishAll: true);
+            }
+
+            public void Advance(long tick)
+            {
+                Publish(tick, publishAll: false);
+            }
+
+            private void Publish(long tick, bool publishAll)
+            {
+                long localTick = tick + m_phaseOffset;
+                m_pressure.SetValue(
+                    200_000.0 + (50_000.0 * Math.Sin(localTick * 0.03)));
+                m_fluidTemperature.SetValue(
+                    313.15 + (5.0 * Math.Sin(localTick * 0.01)));
+                m_bearingTemperature.SetValue(
+                    333.15 + (8.0 * Math.Cos(localTick * 0.008)));
+                m_power.SetValue(
+                    5_000.0 + (500.0 * Math.Sin(localTick * 0.02)));
+                m_flow.SetValue(
+                    0.05 + (0.005 * Math.Cos(localTick * 0.04)));
+                m_efficiency.SetValue(
+                    75.0 + (10.0 * Math.Sin(localTick * 0.015)));
+                m_level.SetValue(
+                    2.5 + (0.5 * Math.Sin(localTick * 0.02)));
+
+                uint numberOfStarts = checked((uint)(localTick / 3_600));
+                if (publishAll || numberOfStarts != m_currentNumberOfStarts)
+                {
+                    m_currentNumberOfStarts = numberOfStarts;
+                    m_numberOfStarts.SetValue(numberOfStarts);
+                }
+
+                long cavitationCycle = localTick % 40;
+                bool cavitation = cavitationCycle >= 32 && cavitationCycle < 36;
+                if (publishAll || cavitation != m_currentCavitation)
+                {
+                    m_currentCavitation = cavitation;
+                    m_cavitation.SetValue(cavitation);
+                }
+
+                long overheatCycle = localTick % 64;
+                bool motorOverheat = overheatCycle >= 56 && overheatCycle < 60;
+                if (publishAll || motorOverheat != m_currentMotorOverheat)
+                {
+                    m_currentMotorOverheat = motorOverheat;
+                    m_motorOverheat.SetValue(motorOverheat);
+                }
+            }
+
+            private readonly long m_phaseOffset;
+            private readonly IValueUpdater<double> m_pressure;
+            private readonly IValueUpdater<double> m_fluidTemperature;
+            private readonly IValueUpdater<double> m_bearingTemperature;
+            private readonly IValueUpdater<double> m_power;
+            private readonly IValueUpdater<double> m_flow;
+            private readonly IValueUpdater<double> m_efficiency;
+            private readonly IValueUpdater<double> m_level;
+            private readonly IValueUpdater<uint> m_numberOfStarts;
+            private readonly IValueUpdater<bool> m_cavitation;
+            private readonly IValueUpdater<bool> m_motorOverheat;
+            private uint m_currentNumberOfStarts;
+            private bool m_currentCavitation;
+            private bool m_currentMotorOverheat;
         }
 
+        // Registration is a compound operation protected by the lock; the concurrent dictionary
+        // allows the 250 ms tick to enumerate fully initialized states without taking that lock.
+        private readonly ConcurrentDictionary<NodeId, PumpSimulationState> m_pumpSimulations = new();
+        private readonly Lock m_simulationRegistrationLock = new();
+        private long m_simulationTicks;
+        private int m_nextSimulationProfile;
     }
 
     internal static partial class PumpNodeManagerLog

--- a/samples/PumpDeviceIntegrationServer/PumpNodeManager.cs
+++ b/samples/PumpDeviceIntegrationServer/PumpNodeManager.cs
@@ -108,7 +108,10 @@ namespace Pumps
             QualifiedName pumpBrowseName,
             CancellationToken cancellationToken = default)
         {
-            return MaterialisePumpInstanceAsync(pumpBrowseName, cancellationToken);
+            return MaterialisePumpInstanceAsync(
+                pumpBrowseName,
+                cancellationToken,
+                RegisterPumpSimulation);
         }
 
         /// <inheritdoc/>
@@ -210,7 +213,8 @@ namespace Pumps
         /// </summary>
         private async ValueTask<PumpState> MaterialisePumpInstanceAsync(
             QualifiedName pumpBrowseName,
-            CancellationToken cancellationToken)
+            CancellationToken cancellationToken,
+            Action<PumpState>? onRegistered = null)
         {
             NodeState? deviceSet = PredefinedNodes.FindById(NodeId.Create(
                 Opc.Ua.Di.Objects.DeviceSet,
@@ -249,6 +253,9 @@ namespace Pumps
 
             await AddPredefinedNodeAsync(SystemContext, pump, cancellationToken)
                 .ConfigureAwait(false);
+            await AddRootNotifierAsync(pump, cancellationToken)
+                .ConfigureAwait(false);
+            onRegistered?.Invoke(pump);
 
             m_logger.MaterialisedPump(pumpBrowseName.Name, pump.NodeId);
             return pump;
@@ -288,6 +295,17 @@ namespace Pumps
             // under SupervisionPumpOperation.
             pump.AddEvents(SystemContext);
             SupervisionState events = pump.Events!;
+            pump.EventNotifier |= EventNotifiers.SubscribeToEvents;
+            events.EventNotifier |= EventNotifiers.SubscribeToEvents;
+            pump.AddReference(
+                Opc.Ua.Types.ReferenceTypeIds.HasNotifier,
+                isInverse: false,
+                events.NodeId);
+            events.AddReference(
+                Opc.Ua.Types.ReferenceTypeIds.HasNotifier,
+                isInverse: true,
+                pump.NodeId);
+
             events.AddSupervisionProcessFluid(SystemContext);
             events.SupervisionProcessFluid!.AddCavitation(SystemContext);
 

--- a/samples/PumpDeviceIntegrationServer/README.md
+++ b/samples/PumpDeviceIntegrationServer/README.md
@@ -37,8 +37,40 @@ info: Opc.Ua.Server.StandardServer
 Browse to `Objects > DeviceSet > Pump #1` in any OPC UA client (e.g.
 UaExpert) to explore the simulated pump. A second declarative pump,
 `Pump #2`, is organized alongside it by the same `DeviceSet` — it
-demonstrates the DI hosting `ConfigureDevicesFor` flow without the
-hand-wired fluent simulation.
+demonstrates the DI hosting `ConfigureDevicesFor` flow and automatically
+joins the same live simulation. Both pumps publish monitored data changes
+every 250 ms, with deterministic phase offsets so their values do not move
+in lockstep.
+
+Subscribe to the `EventNotifier` attribute on either pump to receive alarm
+condition events when its simulated `MotorOverheat` state activates or
+clears. Each pump is also registered as a root notifier, so the same events
+are available from a subscription on the Server object.
+
+## Validating the address space
+
+The
+[`Pump Address Space Validation`](../../.github/workflows/pump-address-space-validation.yml)
+workflow runs nightly and can also be started manually. It builds this sample,
+installs the latest stable
+[`OpcUaAddressSpaceChecker`](https://www.nuget.org/packages/OpcUaAddressSpaceChecker)
+global tool, and validates all `PumpType` instances.
+
+To reproduce the validation locally, start the server and run the following
+commands in another terminal:
+
+```pwsh
+dotnet tool install --global OpcUaAddressSpaceChecker
+opcua-check-address-space `
+    --endpoint opc.tcp://localhost:62542/PumpDeviceIntegrationServer `
+    --type "nsu=http://opcfoundation.org/UA/Pumps/;i=1052" `
+    --severity-threshold warning `
+    --view-completeness complete `
+    --require-complete-view
+```
+
+The nightly check keeps the tool's default `auto` validation-view policy and
+fails on confirmed errors or any checker execution failure.
 
 ## Running in Docker
 
@@ -95,10 +127,11 @@ workflow on every push to `master` and on manual dispatch.
 | Identification properties via `WithProperty(name, value)` | `PumpNodeManager.Configure.cs` `WithIdentification` |
 | Optional-child materialisation via generator-emitted `AddXxx(context)` helpers (Operational / Measurements / Events / SupervisionProcessFluid / SupervisionPumpOperation / Maintenance) | `PumpNodeManager.cs` `MaterialisePumpOptionalChildren` |
 | Engineering units / EURange via `WithEngineeringUnits` / `WithEURange` | `WithMeasurements` |
-| Discrete `NumberOfStarts` counter wired via `Variable<uint>(...).OnRead(...)` | `WithMeasurements` |
-| 250 ms simulation tick via `Simulation(...).OnTick(...)` | `Configure` → `AdvanceSimulation` |
-| Limit alarm with thresholds and acknowledge handler via `CreateLimitAlarm(...).WithLimits(...)` | `WithSupervision` |
-| Boolean supervision (TwoStateDiscreteState) → alarm activation via `.ActivatesAlarm(...)` | `WithSupervision` |
+| Push-style monitored value updates via `Bind(out IValueUpdater<T>)` | `CreatePumpSimulation` |
+| One 250 ms simulation tick for all phase-shifted pumps | `Configure` → `AdvanceSimulation` |
+| Limit alarm with thresholds and acknowledge handler via `CreateLimitAlarm(...).WithLimits(...)` | `CreatePumpSimulation` |
+| Boolean supervision → reported alarm condition events via `.ActivatesAlarm(...)` | `CreatePumpSimulation` |
+| `EventNotifier`, `HasNotifier`, and `HasEventSource` instance wiring | `PumpNodeManager.cs` + fluent alarm builders |
 | Cross-namespace path resolution (Pump #1 in Pumps NS → Operational in Machinery NS → Measurements in Pumps NS, all in one unqualified browse path) | `src/Opc.Ua.Server/Fluent/BrowsePathResolver.cs` |
 | Generated `PumpType` instance + typed Identification group configuration | `Program.cs` (`Pump #2`) |
 
@@ -142,18 +175,22 @@ want to reference Machinery or Pumps the same way they reference
 `Opc.Ua.Di` should source-generate against the model XML inside their
 own assembly using the same `<AdditionalFiles>` pattern.
 
+The sample intentionally does not add `GeneratesEvent` to pump instances.
+OPC 10000-3 restricts that reference to ObjectType, VariableType, and Method
+declarations; runtime delivery is provided by the notifier/event-source
+hierarchy and `ReportEvent`.
+
 ## Extending the sample
 
 - **Add a measurement**: open `PumpNodeManager.Configure.cs`, add a
-  call to `AddMeasurement(builder, browsePath, getter, units, min, max)`
-  inside `WithMeasurements`, then add a field + line to
-  `AdvanceSimulation` that updates the value each tick.
-- **Add an alarm**: inside `WithSupervision`, chain another
-  `builder.Node("Pump #1/Events").CreateLimitAlarm(...).WithLimits(...)`
-  and wire the triggering boolean variable via `.ActivatesAlarm(...)`.
+  bound updater in `CreatePumpSimulation`, store it in
+  `PumpSimulationState`, and publish its value from `Publish`.
+- **Add an alarm**: create it from the typed `Events` builder in
+  `CreatePumpSimulation` and wire the triggering boolean variable via
+  `.ActivatesAlarm(...)`.
 - **Add a second pump**: two patterns are demonstrated in the sample.
   - **Hand-rolled** (used for `Pump #1`): in `PumpNodeManager.CreatePumpAsync`, create the generated `PumpState`, attach it to the DI `DeviceSet` with `Organizes`, and register it. The fluent `Configure.cs` then wires its measurements, alarms, and simulation by browse path.
-  - **DI declarative** (used for `Pump #2`): in `Program.cs`, call `PumpNodeManager.CreatePumpAsync(...)` from a `ConfigureDevicesFor<PumpNodeManager>` block, wrap the generated `PumpState` with `ctx.TopologyElement<PumpState>(...)`, then configure the mandatory `Identification` group. This preserves the `PumpType` type definition while exposing only topology-element operations.
+  - **DI declarative** (used for `Pump #2`): in `Program.cs`, call `PumpNodeManager.CreatePumpAsync(...)` from a `ConfigureDevicesFor<PumpNodeManager>` block, wrap the generated `PumpState` with `ctx.TopologyElement<PumpState>(...)`, then configure the mandatory `Identification` group. `CreatePumpAsync` also registers the new instance with the shared simulation.
 
 ## NativeAOT publishing
 

--- a/src/Opc.Ua.Server/Fluent/AlarmBuilderExtensions.cs
+++ b/src/Opc.Ua.Server/Fluent/AlarmBuilderExtensions.cs
@@ -205,6 +205,14 @@ namespace Opc.Ua.Server.Fluent
             {
                 throw new ArgumentNullException(nameof(factory));
             }
+            if (parent.Node is not BaseObjectState parentObject)
+            {
+                throw ServiceResultException.Create(
+                    StatusCodes.BadTypeMismatch,
+                    "Alarm parent '{0}' must be an Object; resolved node is '{1}'.",
+                    parent.Node.BrowseName,
+                    parent.Node.NodeClass);
+            }
             string symbolicName = browseName.Name ?? string.Empty;
             TState alarm = factory(parent.Node);
             alarm.SymbolicName = symbolicName;
@@ -224,8 +232,20 @@ namespace Opc.Ua.Server.Fluent
                 browseName,
                 displayName: new LocalizedText(symbolicName),
                 assignNodeIds: false);
+            alarm.SetEnableState(parent.Builder.Context, enabled: true);
 
             parent.Node.AddChild(alarm);
+            parentObject.EventNotifier |= EventNotifiers.SubscribeToEvents;
+
+            parent.Node.AddReference(
+                ReferenceTypeIds.HasEventSource,
+                isInverse: false,
+                alarm.NodeId);
+            alarm.AddReference(
+                ReferenceTypeIds.HasEventSource,
+                isInverse: true,
+                parent.Node.NodeId);
+
             return alarm;
         }
     }

--- a/src/Opc.Ua.Server/Fluent/SupervisionBuilderExtensions.cs
+++ b/src/Opc.Ua.Server/Fluent/SupervisionBuilderExtensions.cs
@@ -153,13 +153,43 @@ namespace Opc.Ua.Server.Fluent
             AlarmConditionState alarm,
             bool active)
         {
-            if (alarm.ActiveState?.Id != null)
+            if (!alarm.EnabledState!.Id!.Value)
             {
-                alarm.ActiveState.Id.Value = active;
-                alarm.ActiveState.Value = new LocalizedText(active ? "Active" : "Inactive");
-                alarm.Time?.Value = DateTimeUtc.Now;
-                alarm.ClearChangeMasks(context, includeChildren: true);
+                return;
             }
+
+            DateTimeUtc now = DateTimeUtc.Now;
+            if (active)
+            {
+                alarm.SetAcknowledgedState(context, acknowledged: false);
+                if (alarm.ConfirmedState != null)
+                {
+                    alarm.SetConfirmedState(context, confirmed: false);
+                }
+            }
+            alarm.SetActiveState(context, active);
+            alarm.SetSeverity(
+                context,
+                active ? EventSeverity.High : EventSeverity.Low);
+
+            alarm.EventId!.Value = Uuid.NewUuid().ToByteString();
+            alarm.Time!.Value = now;
+            alarm.ReceiveTime!.Value = now;
+            alarm.Message!.Value = new LocalizedText(
+                string.Format(
+                    System.Globalization.CultureInfo.InvariantCulture,
+                    "Alarm '{0}' {1}.",
+                    alarm.BrowseName.Name,
+                    active ? "active" : "inactive"));
+            alarm.Retain!.Value =
+                active ||
+                !alarm.AckedState!.Id!.Value ||
+                (alarm.ConfirmedState != null && !alarm.ConfirmedState.Id!.Value);
+            alarm.ClearChangeMasks(context, includeChildren: true);
+
+            var eventSnapshot = new InstanceStateSnapshot();
+            eventSnapshot.Initialize(context, alarm);
+            alarm.ReportEvent(context, eventSnapshot);
         }
 
         private static EdgeTracker AttachEdgeTracker(BaseVariableState variable)
@@ -227,7 +257,6 @@ namespace Opc.Ua.Server.Fluent
                 m_last = current;
 
                 if (current && !previous)
-
                 {
                     RisingEdge?.Invoke(context);
                 }

--- a/tests/Opc.Ua.Di.Tests/PumpHostedReferenceTests.cs
+++ b/tests/Opc.Ua.Di.Tests/PumpHostedReferenceTests.cs
@@ -28,6 +28,7 @@
  * ======================================================================*/
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -54,7 +55,7 @@ namespace Opc.Ua.Di.Tests
     public sealed class PumpHostedReferenceTests
     {
         [Test]
-        public async Task MasterBrowseOrganizesBothPumpsAsync()
+        public async Task HostedPumpsBrowseSimulateAndReportEventsAsync()
         {
             CaptureServer.Reset();
             var services = new ServiceCollection();
@@ -131,7 +132,7 @@ namespace Opc.Ua.Di.Tests
                     NUnitTelemetryContext.Create());
                 string clientPkiRoot = System.IO.Path.Combine(
                     TestContext.CurrentContext.WorkDirectory,
-                    nameof(MasterBrowseOrganizesBothPumpsAsync),
+                    nameof(HostedPumpsBrowseSimulateAndReportEventsAsync),
                     "client-pki");
                 await clientFixture.LoadClientConfigurationAsync(clientPkiRoot)
                     .ConfigureAwait(false);
@@ -161,6 +162,156 @@ namespace Opc.Ua.Di.Tests
                         ExpandedNodeId.ToNodeId(
                             reference.ReferenceTypeId,
                             session.NamespaceUris) == Opc.Ua.Types.ReferenceTypeIds.Organizes));
+
+                ushort clientDiNamespaceIndex = (ushort)session.NamespaceUris.GetIndex(
+                    Opc.Ua.Di.Namespaces.OpcUaDi);
+                var pump1PressureId = new NodeId(
+                    "5001_Pump #1_Operational_Measurements_DifferentialPressure",
+                    clientDiNamespaceIndex);
+                var pump2PressureId = new NodeId(
+                    "5001_Pump #2_Operational_Measurements_DifferentialPressure",
+                    clientDiNamespaceIndex);
+                var pump2Id = new NodeId("5001_Pump #2", clientDiNamespaceIndex);
+
+                DataValue initialPump1 = await session.ReadValueAsync(
+                    pump1PressureId,
+                    CancellationToken.None).ConfigureAwait(false);
+                DataValue initialPump2 = await session.ReadValueAsync(
+                    pump2PressureId,
+                    CancellationToken.None).ConfigureAwait(false);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(initialPump1.WrappedValue.TryGetValue(out double pump1Value), Is.True);
+                    Assert.That(initialPump2.WrappedValue.TryGetValue(out double pump2Value), Is.True);
+                    Assert.That(pump1Value, Is.GreaterThan(0));
+                    Assert.That(pump2Value, Is.GreaterThan(0));
+                    Assert.That(pump2Value, Is.Not.EqualTo(pump1Value));
+                });
+
+                using var subscription = new Opc.Ua.Client.Subscription(
+                    session.DefaultSubscription)
+                {
+                    DisplayName = "Pump simulation and events",
+                    PublishingEnabled = true,
+                    PublishingInterval = 250,
+                    KeepAliveCount = 10
+                };
+                session.AddSubscription(subscription);
+                await subscription.CreateAsync(CancellationToken.None)
+                    .ConfigureAwait(false);
+
+                var pump1Values = new ConcurrentDictionary<double, bool>();
+                var pump2Values = new ConcurrentDictionary<double, bool>();
+                var pump1Changed = new TaskCompletionSource<bool>(
+                    TaskCreationOptions.RunContinuationsAsynchronously);
+                var pump2Changed = new TaskCompletionSource<bool>(
+                    TaskCreationOptions.RunContinuationsAsynchronously);
+                var eventReceived = new TaskCompletionSource<EventFieldList>(
+                    TaskCreationOptions.RunContinuationsAsynchronously);
+
+                var pump1Item = new Opc.Ua.Client.MonitoredItem(subscription.DefaultItem)
+                {
+                    StartNodeId = pump1PressureId,
+                    AttributeId = Attributes.Value,
+                    DisplayName = "Pump #1 pressure",
+                    SamplingInterval = 100,
+                    QueueSize = 16
+                };
+                pump1Item.Notification += (item, _) =>
+                {
+                    foreach (DataValue value in item.DequeueValues())
+                    {
+                        if (value.WrappedValue.TryGetValue(out double current))
+                        {
+                            pump1Values.TryAdd(current, !value.SourceTimestamp.IsNull);
+                            if (pump1Values.Count >= 2)
+                            {
+                                pump1Changed.TrySetResult(true);
+                            }
+                        }
+                    }
+                };
+
+                var pump2Item = new Opc.Ua.Client.MonitoredItem(subscription.DefaultItem)
+                {
+                    StartNodeId = pump2PressureId,
+                    AttributeId = Attributes.Value,
+                    DisplayName = "Pump #2 pressure",
+                    SamplingInterval = 100,
+                    QueueSize = 16
+                };
+                pump2Item.Notification += (item, _) =>
+                {
+                    foreach (DataValue value in item.DequeueValues())
+                    {
+                        if (value.WrappedValue.TryGetValue(out double current))
+                        {
+                            pump2Values.TryAdd(current, !value.SourceTimestamp.IsNull);
+                            if (pump2Values.Count >= 2)
+                            {
+                                pump2Changed.TrySetResult(true);
+                            }
+                        }
+                    }
+                };
+
+                var eventFilter = new EventFilter();
+                eventFilter.AddSelectClause(
+                    Opc.Ua.Types.ObjectTypeIds.BaseEventType,
+                    QualifiedName.From("Message"));
+                var eventItem = new Opc.Ua.Client.MonitoredItem(subscription.DefaultItem)
+                {
+                    StartNodeId = pump2Id,
+                    AttributeId = Attributes.EventNotifier,
+                    DisplayName = "Pump #2 events",
+                    Filter = eventFilter,
+                    QueueSize = 16
+                };
+                eventItem.Notification += (_, args) =>
+                {
+                    if (args.NotificationValue is EventFieldList fields)
+                    {
+                        eventReceived.TrySetResult(fields);
+                    }
+                };
+
+                subscription.AddItem(pump1Item);
+                subscription.AddItem(pump2Item);
+                subscription.AddItem(eventItem);
+                await subscription.ApplyChangesAsync(CancellationToken.None)
+                    .ConfigureAwait(false);
+
+                using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+                using (timeout.Token.Register(() =>
+                {
+                    pump1Changed.TrySetCanceled(timeout.Token);
+                    pump2Changed.TrySetCanceled(timeout.Token);
+                    eventReceived.TrySetCanceled(timeout.Token);
+                }))
+                {
+                    await Task.WhenAll(
+                        pump1Changed.Task,
+                        pump2Changed.Task,
+                        eventReceived.Task).ConfigureAwait(false);
+                }
+                EventFieldList observedEvent = await eventReceived.Task.ConfigureAwait(false);
+
+                Assert.Multiple(() =>
+                {
+                    Assert.That(
+                        pump1Values.Values,
+                        Has.All.True);
+                    Assert.That(
+                        pump2Values.Values,
+                        Has.All.True);
+                    Assert.That(observedEvent.EventFields, Has.Count.EqualTo(1));
+                    Assert.That(
+                        observedEvent.EventFields[0].GetLocalizedText().Text,
+                        Does.StartWith("Alarm "));
+                });
+
+                await session.RemoveSubscriptionAsync(subscription)
+                    .ConfigureAwait(false);
             }
             finally
             {

--- a/tests/Opc.Ua.Di.Tests/PumpInstanceNodeIdRegressionTests.cs
+++ b/tests/Opc.Ua.Di.Tests/PumpInstanceNodeIdRegressionTests.cs
@@ -202,40 +202,24 @@ namespace Opc.Ua.Di.Tests
         }
 
         /// <summary>
-        /// A pump materialised without the fluent configuration must expose the
-        /// same generated model surface as the configured one, minus what the
-        /// fluent wiring adds on top (the alarm and the engineering-unit
-        /// properties). This proves the generated helpers materialise the model
-        /// identically for every instance of the type.
+        /// Every pump created after startup must receive the same fluent
+        /// simulation surface as the initially configured pump.
         /// </summary>
         [Test]
-        public void EveryPumpInstanceExposesTheSameGeneratedModelSurface()
+        public void EveryPumpInstanceExposesTheSameSimulationSurface()
         {
             IEnumerable<string> configured = CollectSubtree(m_configuredPump!)
-                .Select(node => node.Path)
-                .Where(path => !IsAddedByFluentConfiguration(path));
+                .Select(node => node.Path);
             IEnumerable<string> second = CollectSubtree(m_secondPump!)
                 .Select(node => node.Path);
 
             Assert.That(second, Is.EquivalentTo(configured));
             Assert.That(second, Contains.Item("Identification/SerialNumber"));
             Assert.That(second, Contains.Item("Operational/Measurements/PumpEfficiency"));
+            Assert.That(second, Contains.Item("Events/OverTempAlarm"));
             Assert.That(
                 second,
                 Contains.Item("Events/SupervisionPumpOperation/MotorOverheat/TrueState"));
-        }
-
-        /// <summary>
-        /// Paths that the fluent <c>Configure</c> pass adds on top of the
-        /// generated model surface, and which therefore only exist on the
-        /// configured pump.
-        /// </summary>
-        private static bool IsAddedByFluentConfiguration(string path)
-        {
-            return path == "Events/OverTempAlarm" ||
-                path.StartsWith(AlarmSubtreePrefix, StringComparison.Ordinal) ||
-                path.EndsWith("/EURange", StringComparison.Ordinal) ||
-                path.EndsWith("/EngineeringUnits", StringComparison.Ordinal);
         }
 
         /// <summary>
@@ -294,6 +278,54 @@ namespace Opc.Ua.Di.Tests
 
             Assert.That(nodeIds, Has.None.Matches<NodeId>(nodeId => nodeId.IsNull));
             Assert.That(nodeIds.Distinct().Count(), Is.EqualTo(nodeIds.Count));
+        }
+
+        [Test]
+        public void EveryPumpExposesTheEventNotifierHierarchy()
+        {
+            foreach (PumpState pump in new[] { m_configuredPump!, m_secondPump! })
+            {
+                SupervisionState events = pump.Events!;
+                Assert.Multiple(() =>
+                {
+                    Assert.That(
+                        pump.EventNotifier & EventNotifiers.SubscribeToEvents,
+                        Is.Not.Zero);
+                    Assert.That(
+                        events.EventNotifier & EventNotifiers.SubscribeToEvents,
+                        Is.Not.Zero);
+                });
+
+                var pumpReferences = new List<IReference>();
+                pump.GetReferences(m_manager!.SystemContext, pumpReferences);
+                Assert.That(
+                    pumpReferences,
+                    Has.Exactly(1).Matches<IReference>(reference =>
+                        reference.ReferenceTypeId == Opc.Ua.Types.ReferenceTypeIds.HasNotifier &&
+                        !reference.IsInverse &&
+                        reference.TargetId == events.NodeId));
+
+                BaseInstanceState alarm = CollectSubtree(pump)
+                    .Single(node => node.Path == "Events/OverTempAlarm")
+                    .State;
+                var eventReferences = new List<IReference>();
+                events.GetReferences(m_manager.SystemContext, eventReferences);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(
+                        eventReferences,
+                        Has.Exactly(1).Matches<IReference>(reference =>
+                            reference.ReferenceTypeId == Opc.Ua.Types.ReferenceTypeIds.HasNotifier &&
+                            reference.IsInverse &&
+                            reference.TargetId == pump.NodeId));
+                    Assert.That(
+                        eventReferences,
+                        Has.Exactly(1).Matches<IReference>(reference =>
+                            reference.ReferenceTypeId == Opc.Ua.Types.ReferenceTypeIds.HasEventSource &&
+                            !reference.IsInverse &&
+                            reference.TargetId == alarm.NodeId));
+                });
+            }
         }
 
         /// <summary>

--- a/tests/Opc.Ua.Server.Tests/Fluent/AlarmBuilderExtensionsTests.cs
+++ b/tests/Opc.Ua.Server.Tests/Fluent/AlarmBuilderExtensionsTests.cs
@@ -115,6 +115,37 @@ namespace Opc.Ua.Server.Tests.Fluent
         }
 
         [Test]
+        public void CreateLimitAlarmAddsEventSourceReferencesAndPromotesNotifier()
+        {
+            (NodeManagerBuilder b, BaseObjectState root, _) = CreateBuilder();
+            INodeBuilder nb = b.Node(new NodeId("Root", kNs));
+
+            IAlarmBuilder<NonExclusiveLimitAlarmState> first = nb.CreateLimitAlarm(
+                new QualifiedName("OverTemp", kNs));
+            _ = nb.CreateLimitAlarm(new QualifiedName("OverPressure", kNs));
+
+            var references = new List<IReference>();
+            root.GetReferences(b.Context, references);
+            Assert.That(
+                root.EventNotifier & EventNotifiers.SubscribeToEvents,
+                Is.Not.Zero);
+            Assert.That(
+                references,
+                Has.Exactly(2).Matches<IReference>(reference =>
+                    reference.ReferenceTypeId == ReferenceTypeIds.HasEventSource &&
+                    !reference.IsInverse));
+
+            references.Clear();
+            first.Alarm.GetReferences(b.Context, references);
+            Assert.That(
+                references,
+                Has.Exactly(1).Matches<IReference>(reference =>
+                    reference.ReferenceTypeId == ReferenceTypeIds.HasEventSource &&
+                    reference.IsInverse &&
+                    reference.TargetId == root.NodeId));
+        }
+
+        [Test]
         public void WithLimitsSetsAllFour()
         {
             (NodeManagerBuilder b, _, _) = CreateBuilder();
@@ -254,6 +285,18 @@ namespace Opc.Ua.Server.Tests.Fluent
                 () => nullBuilder.CreateLimitAlarm(new QualifiedName("X", kNs)));
             Assert.Throws<ArgumentNullException>(
                 () => nb.CreateLimitAlarm(QualifiedName.Null));
+        }
+
+        [Test]
+        public void CreateLimitAlarmOnVariableThrowsBadTypeMismatch()
+        {
+            (NodeManagerBuilder b, _, BaseDataVariableState src) = CreateBuilder();
+            IVariableBuilder<double> variable = b.Variable<double>(src.NodeId);
+
+            ServiceResultException ex = Assert.Throws<ServiceResultException>(
+                () => variable.CreateLimitAlarm(new QualifiedName("OverTemp", kNs)));
+
+            Assert.That(ex.StatusCode, Is.EqualTo(StatusCodes.BadTypeMismatch));
         }
     }
 }

--- a/tests/Opc.Ua.Server.Tests/Fluent/SupervisionBuilderExtensionsTests.cs
+++ b/tests/Opc.Ua.Server.Tests/Fluent/SupervisionBuilderExtensionsTests.cs
@@ -152,7 +152,8 @@ namespace Opc.Ua.Server.Tests.Fluent
         [Test]
         public void ActivatesAlarmFlipsAlarmActiveState()
         {
-            (NodeManagerBuilder b, _, BaseDataVariableState<bool> v) = CreateBuilder();
+            (NodeManagerBuilder b, BaseObjectState root, BaseDataVariableState<bool> v) =
+                CreateBuilder();
             INodeBuilder nb = b.Node(new NodeId("Root", kNs));
             IAlarmBuilder<NonExclusiveLimitAlarmState> ab = nb.CreateLimitAlarm(
                 new QualifiedName("CavitationAlarm", kNs));
@@ -160,17 +161,49 @@ namespace Opc.Ua.Server.Tests.Fluent
             IVariableBuilder<bool> vb = b.Variable<bool>(new NodeId("Root.Flag", kNs));
             vb.ActivatesAlarm(ab);
 
+            var reported = new List<IFilterTarget>();
+            root.OnReportEvent = (_, _, e) => reported.Add(e);
+
             // Transition false -> true: should activate alarm
             v.Value = true;
             v.ClearChangeMasks(null!, includeChildren: false);
 
             Assert.That(ab.Alarm.ActiveState!.Id!.Value, Is.True);
+            Assert.That(reported, Has.Count.EqualTo(1));
+            Assert.That(ab.Alarm.EventId!.Value.IsNull, Is.False);
+            Assert.That(ab.Alarm.Retain!.Value, Is.True);
+            Assert.That(ab.Alarm.Severity!.Value, Is.EqualTo((ushort)EventSeverity.High));
+            Assert.That(ab.Alarm.AckedState!.Id!.Value, Is.False);
 
-            // Transition true -> false: should deactivate
+            // Re-publishing the same value must not report another event.
+            v.Value = true;
+            v.ClearChangeMasks(null!, includeChildren: false);
+            Assert.That(reported, Has.Count.EqualTo(1));
+
+            // Clearing an unacknowledged alarm keeps it retained.
             v.Value = false;
             v.ClearChangeMasks(null!, includeChildren: false);
 
             Assert.That(ab.Alarm.ActiveState.Id.Value, Is.False);
+            Assert.That(reported, Has.Count.EqualTo(2));
+            Assert.That(ab.Alarm.Retain.Value, Is.True);
+            Assert.That(ab.Alarm.Severity.Value, Is.EqualTo((ushort)EventSeverity.Low));
+
+            // A subsequent activation is a new unacknowledged occurrence.
+            ab.Alarm.SetAcknowledgedState(b.Context, acknowledged: true);
+            ab.Alarm.Retain.Value = false;
+            v.Value = true;
+            v.ClearChangeMasks(null!, includeChildren: false);
+            Assert.That(ab.Alarm.AckedState.Id.Value, Is.False);
+            Assert.That(ab.Alarm.Retain.Value, Is.True);
+            Assert.That(reported, Has.Count.EqualTo(3));
+
+            // Disabled conditions ignore source transitions.
+            ab.Alarm.SetEnableState(b.Context, enabled: false);
+            v.Value = false;
+            v.ClearChangeMasks(null!, includeChildren: false);
+            Assert.That(ab.Alarm.ActiveState.Id.Value, Is.True);
+            Assert.That(reported, Has.Count.EqualTo(3));
         }
 
         [Test]

--- a/tests/Opc.Ua.Server.Tests/Hosting/OpcUaServerHostedServiceCoverageTests.cs
+++ b/tests/Opc.Ua.Server.Tests/Hosting/OpcUaServerHostedServiceCoverageTests.cs
@@ -146,17 +146,33 @@ namespace Opc.Ua.Server.Tests.Hosting
                 await WaitForAsync(
                     () => RegistryCaptureServer.StartedServer != null,
                     TimeSpan.FromSeconds(60)).ConfigureAwait(false),
-                Is.True);
+                Is.True,
+                "Hosted service post-start registry wiring did not complete.");
 
             IServerInternal server = RegistryCaptureServer.StartedServer ??
                 throw new InvalidOperationException("The server did not start.");
 
             var historianRegistryProvider = (IHistorianRegistryProvider)server;
+            var aliasRegistryProvider = (IAliasNameStoreRegistryProvider)server;
+
+            // OnServerStarted publishes StartedServer before the hosted service completes
+            // RegisterPostStartRegistries. Wait for all post-start registrations to become visible.
+            Assert.That(
+                await WaitForAsync(
+                    () =>
+                        historianRegistryProvider.HistorianRegistry.Providers.Contains(
+                            historian.Object) &&
+                        aliasRegistryProvider.AliasNameStoreRegistry.Stores.Contains(
+                            directStore.Object) &&
+                        aliasRegistryProvider.AliasNameStoreRegistry.Stores.Contains(
+                            registrySourcedStore.Object),
+                    TimeSpan.FromSeconds(60)).ConfigureAwait(false),
+                Is.True);
+
             Assert.That(
                 historianRegistryProvider.HistorianRegistry.Providers,
                 Has.Member(historian.Object));
 
-            var aliasRegistryProvider = (IAliasNameStoreRegistryProvider)server;
             Assert.That(
                 aliasRegistryProvider.AliasNameStoreRegistry.Stores,
                 Has.Member(directStore.Object));


### PR DESCRIPTION
This pull request introduces significant improvements to the Pump Device Integration Server sample, focusing on robust event/alarm integration, simulation enhancements, and comprehensive test coverage. The changes ensure that pump objects and their events are correctly wired for OPC UA eventing, improve alarm state management and reporting, and update documentation and tests to validate these behaviors.

**Event and Alarm Integration Improvements:**

* Pump objects and their event sub-objects now have `EventNotifier` flags and are linked via `HasNotifier` references, ensuring they properly participate in the OPC UA event hierarchy. Each pump is also registered as a root notifier. [[1]](diffhunk://#diff-6d01bd352b39d1bd0a96e8c0c11d27c066ae33a64a552bdabe023535ca833fc2R297-R307) [[2]](diffhunk://#diff-6d01bd352b39d1bd0a96e8c0c11d27c066ae33a64a552bdabe023535ca833fc2R256-R257)
* The alarm builder now enforces that alarms are attached only to valid object nodes, enables alarms by default, and wires `HasEventSource` references and `EventNotifier` flags for both parent and alarm nodes. [[1]](diffhunk://#diff-2d10b87cac23754d35da8632e9b1a23ec0c1e706689c7241da36dbc934b2666aR208-R215) [[2]](diffhunk://#diff-2d10b87cac23754d35da8632e9b1a23ec0c1e706689c7241da36dbc934b2666aR235-R248)

**Alarm State and Reporting Enhancements:**

* Alarm state transitions now check that the alarm is enabled before updating state, set acknowledged/confirmed flags, assign new event IDs, update timestamps, and report events using OPC UA mechanisms.
* Alarm severity and message are set dynamically based on the active state, and the `Retain` flag is managed according to OPC UA alarm state requirements.

**Simulation and API Changes:**

* `CreatePumpAsync` now registers new pump instances with the simulation, ensuring all pumps participate in the live simulation loop.
* Simulation ticks and monitored value publishing are unified and described in the documentation, with deterministic phase offsets for each pump. [[1]](diffhunk://#diff-e2a596af01b60e5bf0559e8c4307604ca80889523b67221fb999ce8a7ad2bb2cL98-R134) [[2]](diffhunk://#diff-e2a596af01b60e5bf0559e8c4307604ca80889523b67221fb999ce8a7ad2bb2cR178-R193)

**Documentation Updates:**

* The README is updated to reflect the new event/alarm integration, simulation details, and instructions for validating the address space with automated and manual workflows. [[1]](diffhunk://#diff-e2a596af01b60e5bf0559e8c4307604ca80889523b67221fb999ce8a7ad2bb2cL40-R73) [[2]](diffhunk://#diff-e2a596af01b60e5bf0559e8c4307604ca80889523b67221fb999ce8a7ad2bb2cL98-R134) [[3]](diffhunk://#diff-e2a596af01b60e5bf0559e8c4307604ca80889523b67221fb999ce8a7ad2bb2cR178-R193)

**Test Coverage Expansion:**

* The main integration test is expanded to verify that both pumps publish unique, changing monitored values and that alarm events are reported and observable via OPC UA subscriptions. [[1]](diffhunk://#diff-818e6fe65e5a28c2405bb287d9e40fcb74f1275c90755da56c60343528e17ee5L57-R58) [[2]](diffhunk://#diff-818e6fe65e5a28c2405bb287d9e40fcb74f1275c90755da56c60343528e17ee5R165-R314)

These changes ensure the sample is a robust reference for OPC UA eventing, simulation, and alarm integration, and that its correctness is validated both automatically and through enhanced documentation.# Description

_Describe the changes here to communicate to the maintainers why they should accept this pull request. By default - this will become the Commit message after merging and thus define history._

## Related Issues

_Reference all GitHub issues this PR addresses. If there is no issue yet, open one and link it here._

_If this is a relatively large or complex change, a design must have been discussed in the related tracking issue and signed off (which becomes the Architectural Decision Record (ADR))._

- Fixes #github-issue-number, ...

## Checklist

_Put an `x` in the boxes that apply. You can complete these step by step after opening the PR._

- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf) and read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added all necessary documentation.
- [ ] I have verified that my changes do not introduce (new) build or analyzer warnings.
- [ ] I ran **all** tests locally using the **UA.slnx** solution against at least .net **framework** and .net **10**, and all passed.
- [ ] I fixed **all** failing and flaky tests in the CI pipelines and **all** CodeQL warnings.
- [ ] I have addressed **all** PR feedback received.
