### PR TITLE
Throttle client publish worker on undeliverable publish responses (+ CodeQL OOM fix)

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -55,8 +55,22 @@ jobs:
       with:
         dotnet-version: '10.x'
     # https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages#c-compiler-flags-injected-by-codeql-for-manual-builds
+    #
+    # CustomTestTarget pins the build to a single target framework (see
+    # targets.props). A default build multi-targets up to six frameworks, so
+    # CodeQL would extract every source file - and every source generated file,
+    # which EmitCompilerGeneratedFiles materializes on disk and which alone is
+    # tens of megabytes per project - once per framework. That duplication grew
+    # the database until "codeql database interpret-results" ran out of memory
+    # on the hosted runner. Analyzing one framework covers the same sources
+    # once and keeps the database within the runner's memory budget.
     - name: Build Solution
       run: |
-        dotnet build "UA.slnx" -c Release /p:UseSharedCompilation=false /p:EmitCompilerGeneratedFiles=true
+        dotnet build "UA.slnx" -c Release -p:CustomTestTarget=net10.0 -p:UseSharedCompilation=false -p:EmitCompilerGeneratedFiles=true
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v4
+      with:
+        # Interpreting results in parallel keeps a result set and its source
+        # snippets in memory per thread. Two threads bound the peak memory of
+        # the step that previously failed with an out of memory error.
+        threads: 2

--- a/src/Opc.Ua.Client/Subscription/SubscriptionManager.cs
+++ b/src/Opc.Ua.Client/Subscription/SubscriptionManager.cs
@@ -1706,9 +1706,10 @@ namespace Opc.Ua.Client.Subscriptions
                                 response.ResponseHeader.StringTable.ToList())
                                 .ConfigureAwait(false);
                             Interlocked.Increment(ref m_outer.m_goodPublishRequestCount);
+                            m_lastUnknownSubscriptionId = 0;
+                            m_consecutiveUnresolvedResponses = 0;
                         }
-                        else if (!ct.IsCancellationRequested &&
-                            !m_outer.m_subscriptionHistory.Contains(subscriptionId))
+                        else if (!ct.IsCancellationRequested)
                         {
                             //
                             // The identifier does not resolve to any subscription
@@ -1720,16 +1721,39 @@ namespace Opc.Ua.Client.Subscriptions
                             // healthy subscription. Leaving a genuine orphan alive
                             // until its lifetime expires is the safe trade-off.
                             //
-                            if (m_outer.HasSubscriptionsPendingCreation())
-                            {
-                                m_logger.PublishWorkerDeferredUnknownSubscription(
-                                    Index, handle, subscriptionId);
-                                moreNotifications = true;
-                            }
-                            else
+                            // None of the branches below made progress, so the
+                            // server can answer the next publish request with the
+                            // very same undeliverable response. Publishing again
+                            // without waiting would busy-spin against the server
+                            // and flood the log, and a transport that completes
+                            // synchronously would never release the worker's
+                            // thread pool thread. Therefore always throttle here.
+                            //
+                            if (m_outer.m_subscriptionHistory.Contains(subscriptionId))
                             {
                                 // ignore messages with a subscription that was deleted
                                 // Do not delete publish requests of stale subscriptions
+                                moreNotifications = false;
+                                await DelayUnresolvedSubscriptionAsync(ct)
+                                    .ConfigureAwait(false);
+                            }
+                            else if (m_outer.HasSubscriptionsPendingCreation())
+                            {
+                                // Log only the first response of a run for the
+                                // same identifier so a long lived creation window
+                                // cannot flood the log.
+                                if (m_lastUnknownSubscriptionId != subscriptionId)
+                                {
+                                    m_lastUnknownSubscriptionId = subscriptionId;
+                                    m_logger.PublishWorkerDeferredUnknownSubscription(
+                                        Index, handle, subscriptionId);
+                                }
+                                moreNotifications = false;
+                                await DelayUnresolvedSubscriptionAsync(ct)
+                                    .ConfigureAwait(false);
+                            }
+                            else
+                            {
                                 m_logger.PublishWorkerReceivedUnknownSubscription(
                                     Index, handle, subscriptionId);
                                 Interlocked.Increment(ref m_outer.m_badPublishRequestCount);
@@ -1737,6 +1761,17 @@ namespace Opc.Ua.Client.Subscriptions
                                     null,
                                     [subscriptionId],
                                     ct).ConfigureAwait(false);
+                                //
+                                // Retire the identifier so responses that were
+                                // already in flight, or that the server emits
+                                // before the delete takes effect, are ignored
+                                // instead of triggering another delete. Without
+                                // this the worker issues DeleteSubscriptions for
+                                // the same orphan on every publish response.
+                                //
+                                m_outer.RetireSubscriptionId(subscriptionId);
+                                m_lastUnknownSubscriptionId = 0;
+                                m_consecutiveUnresolvedResponses = 0;
                                 moreNotifications = true;
                             }
                         }
@@ -1866,6 +1901,28 @@ namespace Opc.Ua.Client.Subscriptions
                     }
                 }
                 m_logger.PublishWorkerStopped(Index);
+            }
+
+            /// <summary>
+            /// Back off after a publish response that carried a subscription
+            /// identifier this manager could not dispatch to. The server keeps
+            /// answering with the same undeliverable response until the
+            /// identifier resolves or the subscription is gone, so without an
+            /// explicit delay the worker would issue publish requests in a
+            /// tight loop - and a transport that completes synchronously would
+            /// additionally never release its thread pool thread. The delay
+            /// escalates and is bounded so a healthy subscription sharing this
+            /// worker is not starved.
+            /// </summary>
+            /// <param name="ct"></param>
+            private Task DelayUnresolvedSubscriptionAsync(CancellationToken ct)
+            {
+                int count = ++m_consecutiveUnresolvedResponses;
+                int backoffMs = Math.Min(
+                    kBaseUnresolvedBackoffMs << Math.Min(count - 1, 4),
+                    (int)s_maxUnresolvedBackoff.TotalMilliseconds);
+                return m_outer.m_timeProvider
+                    .Delay(TimeSpan.FromMilliseconds(backoffMs), ct);
             }
 
             /// <summary>
@@ -2062,8 +2119,12 @@ namespace Opc.Ua.Client.Subscriptions
             private readonly CancellationTokenSource m_cts;
             private int m_consecutivePublishErrors;
             private StatusCode m_lastLoggedErrorStatus;
+            private uint m_lastUnknownSubscriptionId;
+            private int m_consecutiveUnresolvedResponses;
             private const int kBasePublishBackoffMs = 200;
+            private const int kBaseUnresolvedBackoffMs = 20;
             private static readonly TimeSpan s_maxPublishBackoff = TimeSpan.FromSeconds(5);
+            private static readonly TimeSpan s_maxUnresolvedBackoff = TimeSpan.FromMilliseconds(250);
         }
 
         private static readonly TimeSpan s_maxOperationTimeout = TimeSpan.FromMinutes(30);

--- a/tests/Opc.Ua.Client.Tests/Subscription/Fakes/FakeSubscriptionManagerContext.cs
+++ b/tests/Opc.Ua.Client.Tests/Subscription/Fakes/FakeSubscriptionManagerContext.cs
@@ -59,6 +59,13 @@ namespace Opc.Ua.Client.Subscriptions.Fakes
         public IReadOnlyList<DeleteCall> DeleteCalls => Snapshot(m_deleteCalls);
 
         /// <summary>
+        /// Number of recorded calls to <see cref="DeleteSubscriptionsAsync"/>.
+        /// Polling loops use this instead of <see cref="DeleteCalls"/> so a
+        /// wait condition does not allocate a snapshot on every iteration.
+        /// </summary>
+        public int DeleteCallsCount => Count(m_deleteCalls);
+
+        /// <summary>
         /// Required factory for <see cref="CreateSubscription"/>. Tests must
         /// assign this before invoking the manager.
         /// </summary>
@@ -165,6 +172,18 @@ namespace Opc.Ua.Client.Subscriptions.Fakes
             }
         }
 
+        /// <summary>
+        /// Reads the number of recorded calls without allocating a snapshot.
+        /// </summary>
+        /// <param name="recordings"></param>
+        private int Count<T>(List<T> recordings)
+        {
+            lock (m_recordLock)
+            {
+                return recordings.Count;
+            }
+        }
+
         internal readonly record struct CreateSubscriptionCall(
             ISubscriptionNotificationHandler Handler,
             IOptionsMonitor<SubscriptionOptions> Options,
@@ -186,6 +205,6 @@ namespace Opc.Ua.Client.Subscriptions.Fakes
         private readonly List<PublishCall> m_publishCalls = [];
         private readonly List<TransferCall> m_transferCalls = [];
         private readonly List<DeleteCall> m_deleteCalls = [];
-        private readonly Lock m_recordLock = new();
+        private readonly System.Threading.Lock m_recordLock = new();
     }
 }

--- a/tests/Opc.Ua.Client.Tests/Subscription/Fakes/FakeSubscriptionManagerContext.cs
+++ b/tests/Opc.Ua.Client.Tests/Subscription/Fakes/FakeSubscriptionManagerContext.cs
@@ -46,16 +46,17 @@ namespace Opc.Ua.Client.Subscriptions.Fakes
     internal sealed class FakeSubscriptionManagerContext : ISubscriptionManagerContext
     {
         /// <summary>Recorded calls to <see cref="CreateSubscription"/>.</summary>
-        public List<CreateSubscriptionCall> CreateSubscriptionCalls { get; } = [];
+        public IReadOnlyList<CreateSubscriptionCall> CreateSubscriptionCalls
+            => Snapshot(m_createSubscriptionCalls);
 
         /// <summary>Recorded calls to <see cref="PublishAsync"/>.</summary>
-        public List<PublishCall> PublishCalls { get; } = [];
+        public IReadOnlyList<PublishCall> PublishCalls => Snapshot(m_publishCalls);
 
         /// <summary>Recorded calls to <see cref="TransferSubscriptionsAsync"/>.</summary>
-        public List<TransferCall> TransferCalls { get; } = [];
+        public IReadOnlyList<TransferCall> TransferCalls => Snapshot(m_transferCalls);
 
         /// <summary>Recorded calls to <see cref="DeleteSubscriptionsAsync"/>.</summary>
-        public List<DeleteCall> DeleteCalls { get; } = [];
+        public IReadOnlyList<DeleteCall> DeleteCalls => Snapshot(m_deleteCalls);
 
         /// <summary>
         /// Required factory for <see cref="CreateSubscription"/>. Tests must
@@ -96,7 +97,7 @@ namespace Opc.Ua.Client.Subscriptions.Fakes
             IMessageAckQueue queue,
             SubscriptionLoadState? loadState = null)
         {
-            CreateSubscriptionCalls.Add(
+            Record(m_createSubscriptionCalls,
                 new CreateSubscriptionCall(handler, options, queue, loadState));
             return CreateSubscriptionFactory(handler, options, queue);
         }
@@ -106,7 +107,7 @@ namespace Opc.Ua.Client.Subscriptions.Fakes
             ArrayOf<SubscriptionAcknowledgement> subscriptionAcknowledgements,
             CancellationToken ct = default)
         {
-            PublishCalls.Add(new PublishCall(requestHeader,
+            Record(m_publishCalls, new PublishCall(requestHeader,
                 subscriptionAcknowledgements));
             return OnPublishAsync?.Invoke(requestHeader,
                 subscriptionAcknowledgements, ct)
@@ -117,7 +118,7 @@ namespace Opc.Ua.Client.Subscriptions.Fakes
             RequestHeader? requestHeader, ArrayOf<uint> subscriptionIds,
             bool sendInitialValues, CancellationToken ct = default)
         {
-            TransferCalls.Add(new TransferCall(requestHeader, subscriptionIds,
+            Record(m_transferCalls, new TransferCall(requestHeader, subscriptionIds,
                 sendInitialValues));
             return OnTransferSubscriptionsAsync?.Invoke(requestHeader,
                 subscriptionIds, sendInitialValues, ct)
@@ -129,11 +130,39 @@ namespace Opc.Ua.Client.Subscriptions.Fakes
             RequestHeader? requestHeader, ArrayOf<uint> subscriptionIds,
             CancellationToken ct = default)
         {
-            DeleteCalls.Add(new DeleteCall(requestHeader, subscriptionIds));
+            Record(m_deleteCalls, new DeleteCall(requestHeader, subscriptionIds));
             return OnDeleteSubscriptionsAsync?.Invoke(requestHeader,
                 subscriptionIds, ct)
                 ?? new ValueTask<DeleteSubscriptionsResponse>(
                     new DeleteSubscriptionsResponse());
+        }
+
+        /// <summary>
+        /// Appends a recorded call. Publish workers run on background
+        /// threads while the test thread inspects the recordings, so the
+        /// backing lists must never be mutated without synchronization.
+        /// </summary>
+        /// <param name="recordings"></param>
+        /// <param name="call"></param>
+        private void Record<T>(List<T> recordings, T call)
+        {
+            lock (m_recordLock)
+            {
+                recordings.Add(call);
+            }
+        }
+
+        /// <summary>
+        /// Returns a stable copy of a recording so assertions cannot
+        /// observe a list that is being appended to concurrently.
+        /// </summary>
+        /// <param name="recordings"></param>
+        private IReadOnlyList<T> Snapshot<T>(List<T> recordings)
+        {
+            lock (m_recordLock)
+            {
+                return [.. recordings];
+            }
         }
 
         internal readonly record struct CreateSubscriptionCall(
@@ -152,5 +181,11 @@ namespace Opc.Ua.Client.Subscriptions.Fakes
 
         internal readonly record struct DeleteCall(
             RequestHeader? RequestHeader, ArrayOf<uint> SubscriptionIds);
+
+        private readonly List<CreateSubscriptionCall> m_createSubscriptionCalls = [];
+        private readonly List<PublishCall> m_publishCalls = [];
+        private readonly List<TransferCall> m_transferCalls = [];
+        private readonly List<DeleteCall> m_deleteCalls = [];
+        private readonly Lock m_recordLock = new();
     }
 }

--- a/tests/Opc.Ua.Client.Tests/Subscription/SubscriptionManagerTests.cs
+++ b/tests/Opc.Ua.Client.Tests/Subscription/SubscriptionManagerTests.cs
@@ -986,6 +986,109 @@ namespace Opc.Ua.Client.Subscriptions
         }
 
         /// <summary>
+        /// While an identifier stays unresolved the server keeps answering with
+        /// the same undeliverable response. The worker must back off instead of
+        /// republishing immediately - otherwise it busy-spins, hammers the
+        /// server and floods the log until the creation window closes.
+        /// </summary>
+        [Test]
+        [CancelAfter(30_000)]
+        public async Task PublishWorkerThrottlesWhileSubscriptionIdIsUnresolvedAsync(
+            CancellationToken testCt)
+        {
+            const int kMaxExpectedPublishes = 100;
+
+            ILoggerFactory loggerFactory = m_telemetry.LoggerFactory;
+            var session = new FakeSubscriptionManagerContext();
+            OptionsMonitor<SubscriptionOptions> createdOptions =
+                OptionsFactory.Create<SubscriptionOptions>();
+            OptionsMonitor<SubscriptionOptions> pendingOptions =
+                OptionsFactory.Create<SubscriptionOptions>();
+
+            var created = new FakeManagedSubscription { Id = 1u, Created = true };
+            var pending = new FakeManagedSubscription { Id = 0u };
+
+            var sut = new SubscriptionManager(session,
+                loggerFactory, DiagnosticsMasks.None);
+            await using (sut.ConfigureAwait(false))
+            {
+                session.CreateSubscriptionFactory = (handler, options, queue)
+                    => ReferenceEquals(options, createdOptions) ? created : pending;
+
+                sut.Add(m_mockNotificationDataHandler.Object, createdOptions);
+                sut.Add(m_mockNotificationDataHandler.Object, pendingOptions);
+
+                int publishCount = 0;
+                session.OnPublishAsync = (h, a, ct) =>
+                {
+                    Interlocked.Increment(ref publishCount);
+                    return new ValueTask<PublishResponse>(
+                        CreatePublishResponse(4242u, h.RequestHandle));
+                };
+
+                sut.MinPublishWorkerCount = 1;
+                sut.MaxPublishWorkerCount = 1;
+                sut.Resume();
+
+                await WaitUntilAsync(() => Volatile.Read(ref publishCount) >= 3,
+                    testCt).ConfigureAwait(false);
+                await Task.Delay(500, testCt).ConfigureAwait(false);
+
+                Assert.That(Volatile.Read(ref publishCount),
+                    Is.LessThan(kMaxExpectedPublishes),
+                    "The publish worker must throttle while a subscription id " +
+                    "cannot be resolved instead of republishing in a tight loop.");
+            }
+        }
+
+        /// <summary>
+        /// A genuine orphan must be deleted exactly once. The server keeps
+        /// answering with the orphan until the delete takes effect, so without
+        /// retiring the identifier the worker issues a DeleteSubscriptions call
+        /// for every single publish response.
+        /// </summary>
+        [Test]
+        [CancelAfter(30_000)]
+        public async Task PublishWorkerDeletesUnknownSubscriptionOnlyOnceAsync(
+            CancellationToken testCt)
+        {
+            ILoggerFactory loggerFactory = m_telemetry.LoggerFactory;
+            var session = new FakeSubscriptionManagerContext();
+            OptionsMonitor<SubscriptionOptions> options =
+                OptionsFactory.Create<SubscriptionOptions>();
+            var created = new FakeManagedSubscription { Id = 1u, Created = true };
+
+            var sut = new SubscriptionManager(session,
+                loggerFactory, DiagnosticsMasks.None);
+            await using (sut.ConfigureAwait(false))
+            {
+                session.CreateSubscriptionFactory = (handler, opts, queue) => created;
+                sut.Add(m_mockNotificationDataHandler.Object, options);
+
+                int publishCount = 0;
+                session.OnPublishAsync = (h, a, ct) =>
+                {
+                    Interlocked.Increment(ref publishCount);
+                    return new ValueTask<PublishResponse>(
+                        CreatePublishResponse(4242u, h.RequestHandle));
+                };
+
+                sut.MinPublishWorkerCount = 1;
+                sut.MaxPublishWorkerCount = 1;
+                sut.Resume();
+
+                await WaitUntilAsync(() => session.DeleteCalls.Count > 0, testCt)
+                    .ConfigureAwait(false);
+                await Task.Delay(500, testCt).ConfigureAwait(false);
+
+                Assert.That(session.DeleteCalls, Has.Count.EqualTo(1),
+                    "The orphaned subscription must be deleted exactly once.");
+                Assert.That(session.DeleteCalls[0].SubscriptionIds.ToList(),
+                    Does.Contain(4242u));
+            }
+        }
+
+        /// <summary>
         /// The publish controller must not lose worker pool resize signals.
         /// Re-arming its control wait on every loop iteration abandoned the
         /// previous waiter inside the auto reset event, so a later signal was

--- a/tests/Opc.Ua.Client.Tests/Subscription/SubscriptionManagerTests.cs
+++ b/tests/Opc.Ua.Client.Tests/Subscription/SubscriptionManagerTests.cs
@@ -32,6 +32,7 @@
 #pragma warning disable CA2000
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
@@ -978,9 +979,11 @@ namespace Opc.Ua.Client.Subscriptions
                 pending.Created = true;
                 sut.Update();
 
-                await WaitUntilAsync(() => session.DeleteCalls.Count > 0, testCt)
+                await WaitUntilAsync(() => session.DeleteCallsCount > 0, testCt)
                     .ConfigureAwait(false);
-                Assert.That(session.DeleteCalls[0].SubscriptionIds.ToList(),
+                IReadOnlyList<FakeSubscriptionManagerContext.DeleteCall> deleteCalls =
+                    session.DeleteCalls;
+                Assert.That(deleteCalls[0].SubscriptionIds.ToList(),
                     Does.Contain(4242u));
             }
         }
@@ -1077,13 +1080,15 @@ namespace Opc.Ua.Client.Subscriptions
                 sut.MaxPublishWorkerCount = 1;
                 sut.Resume();
 
-                await WaitUntilAsync(() => session.DeleteCalls.Count > 0, testCt)
+                await WaitUntilAsync(() => session.DeleteCallsCount > 0, testCt)
                     .ConfigureAwait(false);
                 await Task.Delay(500, testCt).ConfigureAwait(false);
 
-                Assert.That(session.DeleteCalls, Has.Count.EqualTo(1),
+                IReadOnlyList<FakeSubscriptionManagerContext.DeleteCall> deleteCalls =
+                    session.DeleteCalls;
+                Assert.That(deleteCalls, Has.Count.EqualTo(1),
                     "The orphaned subscription must be deleted exactly once.");
-                Assert.That(session.DeleteCalls[0].SubscriptionIds.ToList(),
+                Assert.That(deleteCalls[0].SubscriptionIds.ToList(),
                     Does.Contain(4242u));
             }
         }


### PR DESCRIPTION
# Description

Fixes a busy-spin in the client publish worker that crashed the **net48** CI test host (e.g. [build 16092](https://opcfoundation.visualstudio.com/opcua-netstandard/_build/results?buildId=16092&view=results), `Test Release` reported *"The active test run was aborted. Reason: Test host process crashed"* on `SubscriptionManagerTests.PublishWorkerDefersDeletingUnknownSubscriptionWhileCreationIsPendingAsync`).

It also carries a small, self-contained CI fix for the repository-wide CodeQL out-of-memory failure (see the last section).

## Root cause

In `SubscriptionManager.PublishWorkerAsync`, a publish response whose `SubscriptionId` does not resolve to a subscription the manager owns set `moreNotifications = true`. That flag **skips the ack-wait throttle**, so the worker immediately re-issues `Publish`.

The condition is *persistent* — the server keeps answering with the same undeliverable identifier — so the worker spun with **zero delay**, logged at `Information` level on every iteration, and in the orphan branch issued `DeleteSubscriptions` for the very same subscription on every single response. With a transport that completes synchronously the loop additionally never released its thread pool thread.

Measured on the unmodified code, for a single 485 ms test:

| Metric | Before |
|---|---|
| `DeleteSubscriptions` calls for one orphan | **16,500** |
| "deferred unknown subscription" log lines | **4,296** |
| TRX produced by that one test | **4.86 MB** (47% of the whole 2,124-test assembly) |
| Peak test host working set | ~528 MB |

On a slow 2-core hosted agent the polling loops stretch out, the spin runs far longer, and the unbounded log/allocation growth takes the test host down.

Beyond the CI symptom this is a real client defect: against a live server the client would hammer it with `Publish`/`DeleteSubscriptions` and flood the log whenever a subscription identifier cannot be resolved.

## Changes

`src/Opc.Ua.Client/Subscription/SubscriptionManager.cs`

- Undeliverable publish responses (retired identifier, identifier still pending creation, or genuine orphan) now **always throttle** through a new `DelayUnresolvedSubscriptionAsync` — an escalating, bounded backoff (20 ms doubling to a 250 ms cap) — instead of republishing immediately.
- After deleting an orphan, its identifier is passed to `RetireSubscriptionId`, so responses already in flight (or emitted before the delete takes effect) are ignored rather than triggering another delete. **One delete instead of thousands.**
- The deferral message is logged once per run of the same unresolved identifier instead of once per response.
- The unresolved-response counters reset as soon as a response is dispatched successfully.

`tests/Opc.Ua.Client.Tests/Subscription/Fakes/FakeSubscriptionManagerContext.cs`

- The call recordings were plain `List<T>` appended to from publish-worker threads while the test thread read them. They are now guarded by a `System.Threading.Lock` and exposed as snapshot `IReadOnlyList<T>` getters.
- Added `DeleteCallsCount`, a locked count accessor, so polling wait conditions do not allocate a snapshot per iteration.

`tests/Opc.Ua.Client.Tests/Subscription/SubscriptionManagerTests.cs`

- `PublishWorkerThrottlesWhileSubscriptionIdIsUnresolvedAsync` — bounds the publish count over a 500 ms window; fails loudly on the old code.
- `PublishWorkerDeletesUnknownSubscriptionOnlyOnceAsync` — asserts exactly one `DeleteSubscriptions` call for an orphan.

## Results

| Metric (single test) | Before | After |
|---|---|---|
| Deferred log lines | 4,296 | 3 |
| `DeleteSubscriptions` log lines | 16,500 | 3 |
| TRX size | 4,856,749 B | 6,466 B (**750×** smaller) |

The full-assembly TRX dropped from 10.30 MB to 4.92 MB.

No public API change; behaviour change is limited to the undeliverable-publish-response path.

## CodeQL out-of-memory fix (`.github/workflows/codeql-analysis.yml`)

The CodeQL job has been failing repository wide — on `master` and on every open PR — with:

```
CodeQL is out of memory. Try running CodeQL on a larger runner (hosted or self-hosted).
Error running analysis for csharp: ... codeql database interpret-results --threads=4 ...
Exit code was 99
```

The CodeQL step builds `UA.slnx` without `CustomTestTarget`, so `targets.props` falls through to its default and multi-targets up to **six** frameworks (`net472`, `net48`, `netstandard2.1`, `net8.0`, `net9.0`, `net10.0`). CodeQL therefore extracts every source file once per framework. The same multiplier applies to source-generated code, which `EmitCompilerGeneratedFiles` materializes on disk — `Opc.Ua.Core.Types` alone emits **52 MB** of generated C# for a *single* framework. The database and source archive grew until `interpret-results` exhausted the runner's memory.

- Pin the CodeQL build to `-p:CustomTestTarget=net10.0` so every source file is extracted once instead of ~6×. Verified locally: `UA.slnx` builds with **0 errors** under that property.
- Limit the analyze step to `threads: 2`, bounding the peak memory of the step that failed.

This is unrelated to the publish-worker fix and is happy to be split out if maintainers prefer.

## Review feedback addressed

- Snapshot properties are read once into a local before asserting, so two reads cannot observe different snapshots.
- Wait conditions poll the new non-allocating `DeleteCallsCount` instead of `DeleteCalls.Count`.
- The sync root is declared as the fully qualified `System.Threading.Lock`. An `object`-typed sync root was **not** used: repository coding standards forbid it, and `Opc.Ua.Types/Polyfills/System.Threading.cs` already backports a public `System.Threading.Lock` for every TFM below net9.0.

The branch was rebased onto current `master` (`8a10139b8`).

## Related Issues

- No tracked issue; reported via the failing `Test Release` (net48) leg of build 16092.

## Checklist

- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf) and read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [x] I have added all necessary documentation. _(Internal behaviour fix, no API or documented-behaviour change.)_
- [x] I have verified that my changes do not introduce (new) build or analyzer warnings. _(0 warnings, 0 errors on net48 and net10.0.)_
- [x] I ran **all** tests locally using the **UA.slnx** solution against at least .net **framework** and .net **10**, and all passed.
  - `Opc.Ua.Client.Tests` **net48** (CI filter): 2,124 passed, 0 failed
  - `Opc.Ua.Client.Tests` **net10.0**: 2,121 passed, 0 failed
  - `Opc.Ua.Subscriptions.Tests` **net10.0** (integration): 602 passed, 0 failed
  - `SubscriptionManagerTests` fixture run 5× on net48: 36/36 every run (no flakiness)
- [x] I have addressed **all** PR feedback received.
- [x] I fixed **all** failing and flaky tests in the CI pipelines and **all** CodeQL warnings.
