### PR TITLE
Use standardized OPC UA WebSocket transport profile URIs

### DIFF
--- a/docs/Profiles.md
+++ b/docs/Profiles.md
@@ -205,12 +205,12 @@ The stack implements the following transport profiles:
   - TLS/SSL encryption only — no UA SecureChannel layer
   - Restricted to `MessageSecurityMode.None`; transport security is provided exclusively by TLS
 
-- **[WebSocket Secure (UA Binary)](http://opcfoundation.org/UA-Profile/Transport/uawss-uasc-uabinary)** (`opc.wss://` and `wss://`) - UA Binary + UASC over secure WebSockets (OPC UA Part 6 §7.5.2, sub-protocol `opcua+uacp`)
+- **[WebSocket Secure (UA Binary)](http://opcfoundation.org/UA-Profile/Transport/wss-uasc-uabinary)** (`opc.wss://` and `wss://`) - UA Binary + UASC over secure WebSockets (OPC UA Part 6 §7.5.2, sub-protocol `opcua+uacp`)
   - Same UASC SecureChannel pipeline as `opc.tcp` carried over WebSocket binary frames (one frame per MessageChunk)
   - Supports all security modes (None / Sign / SignAndEncrypt)
   - TLS/SSL encryption at the WebSocket layer
 
-- **WebSocket Secure (JSON)** (`opc.wss://` and `wss://`) - OPC UA JSON over secure WebSockets (Part 6 §7.5.2, sub-protocol `opcua+uajson`)
+- **[WebSocket Secure (JSON)](http://opcfoundation.org/UA-Profile/Transport/wss-uajson)** (`opc.wss://` and `wss://`) - OPC UA JSON over secure WebSockets (Part 6 §7.5.2, sub-protocol `opcua+uajson`)
   - Compact JSON encoding per WebSocket text frame
   - TLS/SSL encryption only — no UA SecureChannel layer
   - Restricted to `MessageSecurityMode.None`

--- a/docs/Transports.md
+++ b/docs/Transports.md
@@ -15,8 +15,8 @@ to integrate with web-based tooling.
 | `https-uabinary` | `opc.https://`, `https://` | UA Binary in HTTP body (`application/octet-stream`) | yes (one chunk per POST) | `None`, `Sign`, `SignAndEncrypt` |
 | `https-uajson` | `opc.https://`, `https://` | UA JSON in HTTP body (`application/opcua+uajson`) | **no** — TLS only | `None` only |
 | [`https-uajson-openapi`](https://profiles.opcfoundation.org/profile/2338) | `opc.https://`, `https://` | OpenAPI Mapping (Part 6 §G.3): per-service `POST /<service>` with body = `<Service>Request` JSON (`application/json; encoding=compact\|verbose`) | **no** — TLS only | `None` only |
-| `uawss-uasc-uabinary` | `opc.wss://`, `wss://` | UA Binary in WebSocket binary frame (sub-protocol `opcua+uacp`) | yes | `None`, `Sign`, `SignAndEncrypt` |
-| `uawss-uajson` | `opc.wss://`, `wss://` | UA JSON in WebSocket text frame (sub-protocol `opcua+uajson`) | **no** — TLS only | `None` only |
+| `wss-uasc-uabinary` | `opc.wss://`, `wss://` | UA Binary in WebSocket binary frame (sub-protocol `opcua+uacp`) | yes | `None`, `Sign`, `SignAndEncrypt` |
+| `wss-uajson` | `opc.wss://`, `wss://` | UA JSON in WebSocket text frame (sub-protocol `opcua+uajson`) | **no** — TLS only | `None` only |
 | [`wss-uajson-openapi`](https://profiles.opcfoundation.org/profile/2339) | `opc.wss://`, `wss://` | OpenAPI Mapping over WebSocket text frame (sub-protocol `opcua+openapi` / `opcua+openapi+<accesstoken>`) | **no** — TLS only | `None` only |
 
 The JSON / OpenAPI profiles do not negotiate a UA SecureChannel; transport
@@ -191,7 +191,7 @@ A few notes:
 `GetEndpoints` and `FindServers` return the `EndpointDescription` list
 declared by the listener for each base address. For TCP, HTTPS-binary,
 and WSS+uacp the description includes the correct `TransportProfileUri`
-(`uatcp-uasc-uabinary`, `https-uabinary`, `uawss-uasc-uabinary`
+(`uatcp-uasc-uabinary`, `https-uabinary`, `wss-uasc-uabinary`
 respectively). The JSON sub-protocols are reachable on the same URL as
 their binary counterparts and clients select them explicitly via the
 `Content-Type` header (HTTPS) or the `Sec-WebSocket-Protocol` header

--- a/samples/ConsoleReferenceClient/README.md
+++ b/samples/ConsoleReferenceClient/README.md
@@ -19,8 +19,8 @@ on the negotiated endpoint:
 | `opc.tcp://` | `uatcp-uasc-uabinary` | §7.4.2 |
 | `opc.https://` (or `https://`) with binary body | `https-uabinary` | §7.4.4 |
 | `opc.https://` (or `https://`) with `application/opcua+uajson` body | `https-uajson` | §7.4.5 |
-| `opc.wss://` (or `wss://`) with `opcua+uacp` sub-protocol | `uawss-uasc-uabinary` | §7.5.2 |
-| `opc.wss://` (or `wss://`) with `opcua+uajson` sub-protocol | `uawss-uajson` | §7.5.2 |
+| `opc.wss://` (or `wss://`) with `opcua+uacp` sub-protocol | `wss-uasc-uabinary` | §7.5.2 |
+| `opc.wss://` (or `wss://`) with `opcua+uajson` sub-protocol | `wss-uajson` | §7.5.2 |
 
 Examples:
 

--- a/src/Opc.Ua.Core/Security/Constants/SecurityConstants.cs
+++ b/src/Opc.Ua.Core/Security/Constants/SecurityConstants.cs
@@ -129,7 +129,7 @@ namespace Opc.Ua
         /// Communicates with UA TCP over secure Websockets, UA Security and UA Binary.
         /// </summary>
         public const string UaWssTransport
-            = "http://opcfoundation.org/UA-Profile/Transport/uawss-uasc-uabinary";
+            = "http://opcfoundation.org/UA-Profile/Transport/wss-uasc-uabinary";
 
         /// <summary>
         /// Communicates with UA JSON over secure Websockets.
@@ -143,7 +143,7 @@ namespace Opc.Ua
         /// restricted to <see cref="MessageSecurityMode.None"/>.
         /// </remarks>
         public const string UaWssJsonTransport
-            = "http://opcfoundation.org/UA-Profile/Transport/uawss-uajson";
+            = "http://opcfoundation.org/UA-Profile/Transport/wss-uajson";
 
         /// <summary>
         /// Communicates with UA Binary over HTTPS.

--- a/tests/Opc.Ua.Core.Tests/Security/TransportProfileHelpersTests.cs
+++ b/tests/Opc.Ua.Core.Tests/Security/TransportProfileHelpersTests.cs
@@ -65,7 +65,7 @@ namespace Opc.Ua.Core.Tests.Security
         {
             Assert.That(
                 Profiles.UaWssTransport,
-                Is.EqualTo("http://opcfoundation.org/UA-Profile/Transport/uawss-uasc-uabinary"));
+                Is.EqualTo("http://opcfoundation.org/UA-Profile/Transport/wss-uasc-uabinary"));
         }
 
         [Test]
@@ -73,7 +73,7 @@ namespace Opc.Ua.Core.Tests.Security
         {
             Assert.That(
                 Profiles.UaWssJsonTransport,
-                Is.EqualTo("http://opcfoundation.org/UA-Profile/Transport/uawss-uajson"));
+                Is.EqualTo("http://opcfoundation.org/UA-Profile/Transport/wss-uajson"));
         }
 
         [Test]
@@ -94,7 +94,7 @@ namespace Opc.Ua.Core.Tests.Security
         [TestCase("", false)]
         [TestCase("http://opcfoundation.org/UA-Profile/Transport/https-uabinary", true)]
         [TestCase("http://opcfoundation.org/UA-Profile/Transport/https-uajson", false)]
-        [TestCase("http://opcfoundation.org/UA-Profile/Transport/uawss-uasc-uabinary", false)]
+        [TestCase("http://opcfoundation.org/UA-Profile/Transport/wss-uasc-uabinary", false)]
         [TestCase("http://opcfoundation.org/UA-Profile/Transport/uatcp-uasc-uabinary", false)]
         public void IsHttpsBinaryRecognizesExactProfile(string? profileUri, bool expected)
         {
@@ -105,15 +105,15 @@ namespace Opc.Ua.Core.Tests.Security
         [TestCase("", false)]
         [TestCase("http://opcfoundation.org/UA-Profile/Transport/https-uajson", true)]
         [TestCase("http://opcfoundation.org/UA-Profile/Transport/https-uabinary", false)]
-        [TestCase("http://opcfoundation.org/UA-Profile/Transport/uawss-uajson", false)]
+        [TestCase("http://opcfoundation.org/UA-Profile/Transport/wss-uajson", false)]
         public void IsHttpsJsonRecognizesExactProfile(string? profileUri, bool expected)
         {
             Assert.That(Profiles.IsHttpsJson(profileUri), Is.EqualTo(expected));
         }
 
         [TestCase(null, false)]
-        [TestCase("http://opcfoundation.org/UA-Profile/Transport/uawss-uasc-uabinary", true)]
-        [TestCase("http://opcfoundation.org/UA-Profile/Transport/uawss-uajson", false)]
+        [TestCase("http://opcfoundation.org/UA-Profile/Transport/wss-uasc-uabinary", true)]
+        [TestCase("http://opcfoundation.org/UA-Profile/Transport/wss-uajson", false)]
         [TestCase("http://opcfoundation.org/UA-Profile/Transport/uatcp-uasc-uabinary", false)]
         public void IsWssBinaryRecognizesExactProfile(string? profileUri, bool expected)
         {
@@ -121,8 +121,8 @@ namespace Opc.Ua.Core.Tests.Security
         }
 
         [TestCase(null, false)]
-        [TestCase("http://opcfoundation.org/UA-Profile/Transport/uawss-uajson", true)]
-        [TestCase("http://opcfoundation.org/UA-Profile/Transport/uawss-uasc-uabinary", false)]
+        [TestCase("http://opcfoundation.org/UA-Profile/Transport/wss-uajson", true)]
+        [TestCase("http://opcfoundation.org/UA-Profile/Transport/wss-uasc-uabinary", false)]
         [TestCase("http://opcfoundation.org/UA-Profile/Transport/https-uajson", false)]
         public void IsWssJsonRecognizesExactProfile(string? profileUri, bool expected)
         {


### PR DESCRIPTION
The WSS transport constants used the unregistered uawss- prefix for the UA-SecureConversation/UA-Binary and UA-JSON profiles.

Use the profile URIs registered by the OPC Foundation:

https://profiles.opcfoundation.org/profile/254
https://profiles.opcfoundation.org/profile/253

The WebSocket mappings and sub-protocols are specified in OPC UA Part 6 section 7.5.2:

https://reference.opcfoundation.org/Core/Part6/v105/docs/7.5.2

Update the transport-profile helpers, regression tests, and documentation accordingly so endpoint discovery publishes identifiers recognized by conforming OPC UA clients and servers.

Tests: dotnet test tests/Opc.Ua.Core.Tests/Opc.Ua.Core.Tests.csproj -f net10.0 --filter FullyQualifiedName~TransportProfileHelpersTests (39 passed)

# Description

_Describe the changes here to communicate to the maintainers why they should accept this pull request. By default - this will become the Commit message after merging and thus define history._

## Related Issues

_Reference all GitHub issues this PR addresses. If there is no issue yet, open one and link it here._

_If this is a relatively large or complex change, a design must have been discussed in the related tracking issue and signed off (which becomes the Architectural Decision Record (ADR))._

- Fixes #github-issue-number, ...

## Checklist

_Put an `x` in the boxes that apply. You can complete these step by step after opening the PR._

- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf) and read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [x] I have added all necessary documentation.
- [x] I have verified that my changes do not introduce (new) build or analyzer warnings.
- [x] I ran **all** tests locally using the **UA.slnx** solution against at least .net **framework** and .net **10**, and all passed.
- [ ] I fixed **all** failing and flaky tests in the CI pipelines and **all** CodeQL warnings.
- [ ] I have addressed **all** PR feedback received.
