### PR TITLE
Jpfr/fix wss session discovery

### DIFF
--- a/src/Opc.Ua.Bindings.Https/Https/HttpsServiceHost.cs
+++ b/src/Opc.Ua.Bindings.Https/Https/HttpsServiceHost.cs
@@ -226,8 +226,11 @@ namespace Opc.Ua.Bindings
                     description);
                 description.TransportProfileUri = TransportProfileUri;
 
-                // if no mutual TLS authentication is used, anonymous user tokens are not allowed
-                if (!httpsMutualTls)
+                // Keep the HTTPS authentication policy that requires an
+                // authenticated user when mutual TLS is disabled. WSS carries
+                // normal UASC sessions, so it uses the server's configured OPC UA
+                // user-token policies just like UA TCP, including Anonymous.
+                if (!httpsMutualTls && !Profiles.IsWssBinary(TransportProfileUri))
                 {
                     description.UserIdentityTokens = description.UserIdentityTokens
                         .Filter(token => token.TokenType != UserTokenType.Anonymous);

--- a/src/Opc.Ua.Client/Session/ChannelManagerSessionFactory.cs
+++ b/src/Opc.Ua.Client/Session/ChannelManagerSessionFactory.cs
@@ -401,7 +401,9 @@ namespace Opc.Ua.Client
 
             if (updateBeforeConnect && connection == null)
             {
-                await endpoint.UpdateFromServerAsync(messageContext.Telemetry, ct).ConfigureAwait(false);
+                await endpoint
+                    .UpdateFromServerAsync(configuration, messageContext.Telemetry, ct)
+                    .ConfigureAwait(false);
             }
 
             if (checkDomain && endpoint.Description.ServerCertificate.Length > 0)

--- a/src/Opc.Ua.Client/Session/DefaultSessionFactory.cs
+++ b/src/Opc.Ua.Client/Session/DefaultSessionFactory.cs
@@ -266,7 +266,9 @@ namespace Opc.Ua.Client
             // update endpoint description using the discovery endpoint.
             if (endpoint.UpdateBeforeConnect && connection == null)
             {
-                await endpoint.UpdateFromServerAsync(messageContext.Telemetry, ct).ConfigureAwait(false);
+                await endpoint
+                    .UpdateFromServerAsync(configuration, messageContext.Telemetry, ct)
+                    .ConfigureAwait(false);
                 endpointDescription = endpoint.Description;
                 // UpdateFromServerAsync re-reads Configuration from the discovery response;
                 // it is set whenever the description was updated successfully.

--- a/src/Opc.Ua.Client/Session/Session.ChannelManager.cs
+++ b/src/Opc.Ua.Client/Session/Session.ChannelManager.cs
@@ -310,7 +310,7 @@ namespace Opc.Ua.Client
             if (updateBeforeConnect)
             {
                 await endpoint
-                    .UpdateFromServerAsync(probeContext.Telemetry, ct)
+                    .UpdateFromServerAsync(configuration, probeContext.Telemetry, ct)
                     .ConfigureAwait(false);
             }
 

--- a/src/Opc.Ua.Core/Stack/Configuration/ConfiguredEndpoints.cs
+++ b/src/Opc.Ua.Core/Stack/Configuration/ConfiguredEndpoints.cs
@@ -1173,13 +1173,59 @@ namespace Opc.Ua
         /// <summary>
         /// Updates an endpoint with information from the server's discovery endpoint.
         /// </summary>
-        public async Task UpdateFromServerAsync(
+        /// <remarks>
+        /// The application configuration supplies the certificate validator required by
+        /// secure discovery transports such as WSS.
+        /// </remarks>
+        public Task UpdateFromServerAsync(
+            ApplicationConfiguration applicationConfiguration,
+            ITelemetryContext? telemetry,
+            CancellationToken ct = default)
+        {
+            if (applicationConfiguration == null)
+            {
+                throw new ArgumentNullException(nameof(applicationConfiguration));
+            }
+
+            return UpdateFromServerCoreAsync(
+                applicationConfiguration,
+                EndpointUrl!,
+                connection: null,
+                m_description.SecurityMode,
+                m_description.SecurityPolicyUri!,
+                telemetry,
+                ct);
+        }
+
+        /// <summary>
+        /// Updates an endpoint with information from the server's discovery endpoint.
+        /// </summary>
+        public Task UpdateFromServerAsync(
             Uri endpointUrl,
             ITransportWaitingConnection? connection,
             MessageSecurityMode securityMode,
             string securityPolicyUri,
             ITelemetryContext? telemetry,
             CancellationToken ct = default)
+        {
+            return UpdateFromServerCoreAsync(
+                applicationConfiguration: null,
+                endpointUrl,
+                connection,
+                securityMode,
+                securityPolicyUri,
+                telemetry,
+                ct);
+        }
+
+        private async Task UpdateFromServerCoreAsync(
+            ApplicationConfiguration? applicationConfiguration,
+            Uri endpointUrl,
+            ITransportWaitingConnection? connection,
+            MessageSecurityMode securityMode,
+            string securityPolicyUri,
+            ITelemetryContext? telemetry,
+            CancellationToken ct)
         {
             // get the a discovery url.
             Uri? discoveryUrl = GetDiscoveryUrl(endpointUrl);
@@ -1188,7 +1234,15 @@ namespace Opc.Ua
             DiscoveryClient? client = null;
             try
             {
-                if (connection != null)
+                if (applicationConfiguration != null)
+                {
+                    client = await DiscoveryClient.CreateAsync(
+                        applicationConfiguration,
+                        discoveryUrl,
+                        m_configuration,
+                        ct: ct).ConfigureAwait(false);
+                }
+                else if (connection != null)
                 {
                     client = await DiscoveryClient.CreateAsync(
                         connection,

--- a/tests/Opc.Ua.Core.Tests/Stack/Client/ConfiguredEndpointTests.cs
+++ b/tests/Opc.Ua.Core.Tests/Stack/Client/ConfiguredEndpointTests.cs
@@ -567,6 +567,23 @@ namespace Opc.Ua.Core.Tests.Stack.Client
         }
 
         [Test]
+        public void UpdateFromServerWithNullApplicationConfigurationThrowsArgumentNullException()
+        {
+            var endpoint = new ConfiguredEndpoint(null, new EndpointDescription
+            {
+                EndpointUrl = "opc.wss://localhost:4840",
+                SecurityMode = MessageSecurityMode.None,
+                SecurityPolicyUri = SecurityPolicies.None
+            });
+
+            ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() =>
+                endpoint.UpdateFromServerAsync(
+                    (ApplicationConfiguration)null!,
+                    telemetry: null));
+            Assert.That(ex.ParamName, Is.EqualTo("applicationConfiguration"));
+        }
+
+        [Test]
         public void GetDiscoveryUrlWithHttpScheme()
         {
             var endpoint = new ConfiguredEndpoint(null, new EndpointDescription

--- a/tests/Opc.Ua.Sessions.Tests/WssJsonTransportIntegrationTests.cs
+++ b/tests/Opc.Ua.Sessions.Tests/WssJsonTransportIntegrationTests.cs
@@ -135,6 +135,25 @@ namespace Opc.Ua.Sessions.Tests
         }
 
         [Test]
+        public async Task AnonymousSessionOverWssBinaryOpensWithoutMutualTlsAsync()
+        {
+            EndpointDescription wss = m_server.GetEndpoints()
+                .ToArray()
+                .First(ep =>
+                    string.Equals(ep.TransportProfileUri, Profiles.UaWssTransport, StringComparison.Ordinal) &&
+                    ep.SecurityMode == MessageSecurityMode.None);
+            Assert.That(
+                wss.UserIdentityTokens.ToArray(),
+                Has.Some.Matches<UserTokenPolicy>(token => token.TokenType == UserTokenType.Anonymous));
+
+            using var session = await m_clientFixture
+                .ConnectAsync(m_endpointUrl.ToString())
+                .ConfigureAwait(false);
+            Assert.That(session.Connected, Is.True);
+            await session.CloseAsync().ConfigureAwait(false);
+        }
+
+        [Test]
         public async Task GetEndpointsOverWssJsonReturnsServerEndpointsAsync()
         {
             // Discovery does not yet advertise the JSON sub-protocol explicitly

--- a/tests/Opc.Ua.Sessions.Tests/WssTransportIntegrationTests.cs
+++ b/tests/Opc.Ua.Sessions.Tests/WssTransportIntegrationTests.cs
@@ -179,6 +179,29 @@ namespace Opc.Ua.Sessions.Tests
 
             await session.CloseAsync().ConfigureAwait(false);
         }
+
+        [Test]
+        public async Task UpdateBeforeConnectUsesApplicationCertificateValidationAsync()
+        {
+            ConfiguredEndpoint endpoint = await m_clientFixture
+                .GetEndpointAsync(m_endpointUrl, SecurityPolicies.Basic256Sha256)
+                .ConfigureAwait(false);
+
+            using ISession session = await m_clientFixture.SessionFactory
+                .CreateAsync(
+                    m_clientFixture.Config,
+                    endpoint,
+                    updateBeforeConnect: true,
+                    checkDomain: false,
+                    nameof(UpdateBeforeConnectUsesApplicationCertificateValidationAsync),
+                    m_clientFixture.SessionTimeout,
+                    identity: null,
+                    preferredLocales: default)
+                .ConfigureAwait(false);
+
+            Assert.That(session.Connected, Is.True);
+            await session.CloseAsync().ConfigureAwait(false);
+        }
     }
 }
 


### PR DESCRIPTION
# Description

WSS binary endpoints use the `opcua+uacp` sub-protocol and carry the normal OPC UA Connection Protocol, SecureChannel, and Session layers. User authentication should therefore behave like `opc.tcp`, independently of whether mutual TLS is enabled for the WebSocket connection.

`HttpsServiceHost` previously shared an HTTPS-specific rule with WSS: when `HttpsMutualTls` was disabled, it removed the `Anonymous` user-token policy from the endpoint description. This prevented an anonymous OPC UA session even when anonymous access was explicitly configured by the server.

This PR:

- Preserves the server’s configured OPC UA user-token policies for WSS UA-SC UA-Binary endpoints.
- Retains the existing anonymous-token filtering for HTTPS transports.
- Adds an integration test that disables mutual TLS, verifies that the WSS endpoint advertises `Anonymous`, and opens a complete anonymous OPC UA session.
- Passes `ApplicationConfiguration` into endpoint discovery performed by `updateBeforeConnect`, allowing WSS discovery to use the application’s certificate manager.
- Applies certificate-aware discovery to both the default and channel-manager session paths while preserving the existing endpoint-refresh APIs.

## Verification

- Anonymous WSS binary session with `HttpsMutualTls = false`: passed.
- WSS `updateBeforeConnect` using application certificate validation: passed.
- Null application-configuration validation: passed.
- Affected projects build without new warnings.

## Related Issues

_Reference all GitHub issues this PR addresses. If there is no issue yet, open one and link it here._

_If this is a relatively large or complex change, a design must have been discussed in the related tracking issue and signed off (which becomes the Architectural Decision Record (ADR))._

- Fixes #github-issue-number, ...

## Checklist

_Put an `x` in the boxes that apply. You can complete these step by step after opening the PR._

- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf) and read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [x] I have added all necessary documentation.
- [x] I have verified that my changes do not introduce (new) build or analyzer warnings.
- [x] I ran **all** tests locally using the **UA.slnx** solution against at least .net **framework** and .net **10**, and all passed.
- [ ] I fixed **all** failing and flaky tests in the CI pipelines and **all** CodeQL warnings.
- [ ] I have addressed **all** PR feedback received.
