### PR TITLE
Use application certificate validation during WSS discovery

### DIFF
--- a/src/Opc.Ua.Client/Session/ChannelManagerSessionFactory.cs
+++ b/src/Opc.Ua.Client/Session/ChannelManagerSessionFactory.cs
@@ -401,7 +401,9 @@ namespace Opc.Ua.Client
 
             if (updateBeforeConnect && connection == null)
             {
-                await endpoint.UpdateFromServerAsync(messageContext.Telemetry, ct).ConfigureAwait(false);
+                await endpoint
+                    .UpdateFromServerAsync(configuration, messageContext.Telemetry, ct)
+                    .ConfigureAwait(false);
             }
 
             if (checkDomain && endpoint.Description.ServerCertificate.Length > 0)

--- a/src/Opc.Ua.Client/Session/DefaultSessionFactory.cs
+++ b/src/Opc.Ua.Client/Session/DefaultSessionFactory.cs
@@ -266,7 +266,9 @@ namespace Opc.Ua.Client
             // update endpoint description using the discovery endpoint.
             if (endpoint.UpdateBeforeConnect && connection == null)
             {
-                await endpoint.UpdateFromServerAsync(messageContext.Telemetry, ct).ConfigureAwait(false);
+                await endpoint
+                    .UpdateFromServerAsync(configuration, messageContext.Telemetry, ct)
+                    .ConfigureAwait(false);
                 endpointDescription = endpoint.Description;
                 // UpdateFromServerAsync re-reads Configuration from the discovery response;
                 // it is set whenever the description was updated successfully.

--- a/src/Opc.Ua.Client/Session/Session.ChannelManager.cs
+++ b/src/Opc.Ua.Client/Session/Session.ChannelManager.cs
@@ -310,7 +310,7 @@ namespace Opc.Ua.Client
             if (updateBeforeConnect)
             {
                 await endpoint
-                    .UpdateFromServerAsync(probeContext.Telemetry, ct)
+                    .UpdateFromServerAsync(configuration, probeContext.Telemetry, ct)
                     .ConfigureAwait(false);
             }
 

--- a/src/Opc.Ua.Core/Stack/Configuration/ConfiguredEndpoints.cs
+++ b/src/Opc.Ua.Core/Stack/Configuration/ConfiguredEndpoints.cs
@@ -1173,13 +1173,59 @@ namespace Opc.Ua
         /// <summary>
         /// Updates an endpoint with information from the server's discovery endpoint.
         /// </summary>
-        public async Task UpdateFromServerAsync(
+        /// <remarks>
+        /// The application configuration supplies the certificate validator required by
+        /// secure discovery transports such as WSS.
+        /// </remarks>
+        public Task UpdateFromServerAsync(
+            ApplicationConfiguration applicationConfiguration,
+            ITelemetryContext? telemetry,
+            CancellationToken ct = default)
+        {
+            if (applicationConfiguration == null)
+            {
+                throw new ArgumentNullException(nameof(applicationConfiguration));
+            }
+
+            return UpdateFromServerCoreAsync(
+                applicationConfiguration,
+                EndpointUrl!,
+                connection: null,
+                m_description.SecurityMode,
+                m_description.SecurityPolicyUri!,
+                telemetry,
+                ct);
+        }
+
+        /// <summary>
+        /// Updates an endpoint with information from the server's discovery endpoint.
+        /// </summary>
+        public Task UpdateFromServerAsync(
             Uri endpointUrl,
             ITransportWaitingConnection? connection,
             MessageSecurityMode securityMode,
             string securityPolicyUri,
             ITelemetryContext? telemetry,
             CancellationToken ct = default)
+        {
+            return UpdateFromServerCoreAsync(
+                applicationConfiguration: null,
+                endpointUrl,
+                connection,
+                securityMode,
+                securityPolicyUri,
+                telemetry,
+                ct);
+        }
+
+        private async Task UpdateFromServerCoreAsync(
+            ApplicationConfiguration? applicationConfiguration,
+            Uri endpointUrl,
+            ITransportWaitingConnection? connection,
+            MessageSecurityMode securityMode,
+            string securityPolicyUri,
+            ITelemetryContext? telemetry,
+            CancellationToken ct)
         {
             // get the a discovery url.
             Uri? discoveryUrl = GetDiscoveryUrl(endpointUrl);
@@ -1188,7 +1234,15 @@ namespace Opc.Ua
             DiscoveryClient? client = null;
             try
             {
-                if (connection != null)
+                if (applicationConfiguration != null)
+                {
+                    client = await DiscoveryClient.CreateAsync(
+                        applicationConfiguration,
+                        discoveryUrl,
+                        m_configuration,
+                        ct: ct).ConfigureAwait(false);
+                }
+                else if (connection != null)
                 {
                     client = await DiscoveryClient.CreateAsync(
                         connection,

--- a/tests/Opc.Ua.Core.Tests/Stack/Client/ConfiguredEndpointTests.cs
+++ b/tests/Opc.Ua.Core.Tests/Stack/Client/ConfiguredEndpointTests.cs
@@ -567,6 +567,23 @@ namespace Opc.Ua.Core.Tests.Stack.Client
         }
 
         [Test]
+        public void UpdateFromServerWithNullApplicationConfigurationThrowsArgumentNullException()
+        {
+            var endpoint = new ConfiguredEndpoint(null, new EndpointDescription
+            {
+                EndpointUrl = "opc.wss://localhost:4840",
+                SecurityMode = MessageSecurityMode.None,
+                SecurityPolicyUri = SecurityPolicies.None
+            });
+
+            ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() =>
+                endpoint.UpdateFromServerAsync(
+                    (ApplicationConfiguration)null!,
+                    telemetry: null));
+            Assert.That(ex.ParamName, Is.EqualTo("applicationConfiguration"));
+        }
+
+        [Test]
         public void GetDiscoveryUrlWithHttpScheme()
         {
             var endpoint = new ConfiguredEndpoint(null, new EndpointDescription

--- a/tests/Opc.Ua.Sessions.Tests/WssTransportIntegrationTests.cs
+++ b/tests/Opc.Ua.Sessions.Tests/WssTransportIntegrationTests.cs
@@ -179,6 +179,29 @@ namespace Opc.Ua.Sessions.Tests
 
             await session.CloseAsync().ConfigureAwait(false);
         }
+
+        [Test]
+        public async Task UpdateBeforeConnectUsesApplicationCertificateValidationAsync()
+        {
+            ConfiguredEndpoint endpoint = await m_clientFixture
+                .GetEndpointAsync(m_endpointUrl, SecurityPolicies.Basic256Sha256)
+                .ConfigureAwait(false);
+
+            using ISession session = await m_clientFixture.SessionFactory
+                .CreateAsync(
+                    m_clientFixture.Config,
+                    endpoint,
+                    updateBeforeConnect: true,
+                    checkDomain: false,
+                    nameof(UpdateBeforeConnectUsesApplicationCertificateValidationAsync),
+                    m_clientFixture.SessionTimeout,
+                    identity: null,
+                    preferredLocales: default)
+                .ConfigureAwait(false);
+
+            Assert.That(session.Connected, Is.True);
+            await session.CloseAsync().ConfigureAwait(false);
+        }
     }
 }
 


### PR DESCRIPTION
ConfiguredEndpoint refreshed endpoint descriptions with a DiscoveryClient created only from EndpointConfiguration. That path did not receive the application certificate manager, so WSS discovery could not validate a server certificate trusted by the application before opening a session.

Add an ApplicationConfiguration-aware endpoint refresh overload and use it from the default and channel-manager session paths. Preserve the existing overloads for compatibility.

The application-aware DiscoveryClient now supplies the configured certificate validation for secure discovery transports while TCP and legacy callers retain their existing behavior.

Specification:
https://reference.opcfoundation.org/Core/Part6/v105/docs/7.5.3

Tests: UpdateFromServerWithNullApplicationConfigurationThrowsArgumentNullException (1 passed, net10.0)

Tests: UpdateBeforeConnectUsesApplicationCertificateValidationAsync (1 passed, net10.0)

# Description

_Describe the changes here to communicate to the maintainers why they should accept this pull request. By default - this will become the Commit message after merging and thus define history._

## Related Issues

_Reference all GitHub issues this PR addresses. If there is no issue yet, open one and link it here._

_If this is a relatively large or complex change, a design must have been discussed in the related tracking issue and signed off (which becomes the Architectural Decision Record (ADR))._

- Fixes #github-issue-number, ...

## Checklist

_Put an `x` in the boxes that apply. You can complete these step by step after opening the PR._

- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf) and read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [x] I have added all necessary documentation.
- [x] I have verified that my changes do not introduce (new) build or analyzer warnings.
- [x] I ran **all** tests locally using the **UA.slnx** solution against at least .net **framework** and .net **10**, and all passed.
- [ ] I fixed **all** failing and flaky tests in the CI pipelines and **all** CodeQL warnings.
- [ ] I have addressed **all** PR feedback received.
