### PR TITLE
Add a Roslyn 4.14 analyzer band for Visual Studio 2022

### DIFF
--- a/.agents/skills/opcua-v20-migration/SKILL.md
+++ b/.agents/skills/opcua-v20-migration/SKILL.md
@@ -17,7 +17,8 @@ description: |
   errors after upgrading to v20".
 license: MIT
 compatibility: |
-  Requires .NET SDK 10.0.300+, a C# project, and resolvable access to the
+  Requires .NET SDK 9.0.100+ (10.0.300+ for the `dotnet format analyzers`
+  auto-fix pass), a C# project, and resolvable access to the
   OPCFoundation.NetStandard.Opc.Ua.MigrationAnalyzer NuGet package (v2.0.*-*).
   IDE auto-fixes need a Workspaces-aware host (Visual Studio, Rider, or
   `dotnet format`). Generator + analyzers load in csc.exe too.
@@ -166,9 +167,9 @@ The single `OPCFoundation.NetStandard.Opc.Ua.MigrationAnalyzer` NuGet contains
 
 | Component | Where | Loaded by | Purpose |
 |---|---|---|---|
-| `Opc.Ua.MigrationAnalyzer.dll` | `analyzers/dotnet/roslyn5.0/cs/` | csc.exe and IDE | 19 `DiagnosticAnalyzer`s (UA0001–UA0022). Targets the Roslyn 5.0 API, no `Workspaces` reference, csc-safe. |
-| `Opc.Ua.MigrationAnalyzer.CodeFixer.dll` | `analyzers/dotnet/roslyn5.0/cs/` | Workspaces-aware hosts only (Visual Studio, Rider, `dotnet format analyzers`) | 14 `CodeFixProvider`s. |
-| `Opc.Ua.MigrationAnalyzer.Generator.dll` | `analyzers/dotnet/roslyn5.0/cs/` | csc.exe and IDE | `IIncrementalGenerator` that emits `internal sealed [Obsolete] class <Name>Collection : List<TElement>` shims into the consumer compilation for every `<Type>Collection` reference that fails to bind. |
+| `Opc.Ua.MigrationAnalyzer.dll` | `analyzers/dotnet/roslyn4.14/cs/` and `roslyn5.0/cs/` | csc.exe and IDE | 19 `DiagnosticAnalyzer`s (UA0001–UA0022). No `Workspaces` reference, csc-safe. |
+| `Opc.Ua.MigrationAnalyzer.CodeFixer.dll` | `analyzers/dotnet/roslyn4.14/cs/` and `roslyn5.0/cs/` | Workspaces-aware hosts only (Visual Studio, Rider, `dotnet format analyzers`) | 14 `CodeFixProvider`s. |
+| `Opc.Ua.MigrationAnalyzer.Generator.dll` | `analyzers/dotnet/roslyn4.14/cs/` and `roslyn5.0/cs/` | csc.exe and IDE | `IIncrementalGenerator` that emits `internal sealed [Obsolete] class <Name>Collection : List<TElement>` shims into the consumer compilation for every `<Type>Collection` reference that fails to bind. |
 | `Opc.Ua.MigrationAnalyzer.Core.dll` | `lib/<tfm>/` × 6 TFMs (`net472`, `net48`, `netstandard2.1`, `net8.0`, `net9.0`, `net10.0`) | Runtime | Re-supplies the obsolete extension surface 2.0 moved or removed so 1.5.378 call sites continue to compile with `[Obsolete]` warnings. |
 
 ### The 19 analyzer rules at a glance

--- a/.agents/skills/opcua-v20-migration/references/compatibility-matrix.md
+++ b/.agents/skills/opcua-v20-migration/references/compatibility-matrix.md
@@ -8,8 +8,8 @@ correctly.
 
 | Component | Minimum | Recommended | Notes |
 |---|---|---|---|
-| .NET SDK | 10.0.300 | latest 10.x | Earlier SDKs ship older Roslyn that has known incremental-generator bugs |
-| `dotnet format` | bundled with SDK 10.0.300+ | latest 10.x | The `analyzers` subcommand is what applies UA0002…UA0022 fixes |
+| .NET SDK | 9.0.100 | latest 10.x | 9.0.100 ships Roslyn 4.14, which the package's `roslyn4.14` band targets. Earlier SDKs ship older Roslyn that has known incremental-generator bugs |
+| `dotnet format` | bundled with SDK 10.0.300+ | latest 10.x | The `analyzers` subcommand is what applies UA0002…UA0022 fixes. Diagnostics alone need only SDK 9.0.100; the auto-fix pass needs 10.0.300+ |
 | C# language version | 13 | 14 (default in SDK 10) | Required for `extension` keyword the runtime shim uses |
 | Consumer project SDK | `Microsoft.NET.Sdk` (SDK-style) | same | Pre-SDK MSBuild XML projects (`xmlns="…/2003"`) cannot install the analyzer — see [`known-gaps.md` G1](known-gaps.md#g1--legacy-net-framework-winforms-projects-in-pre-sdk-msbuild-xml) |
 
@@ -37,19 +37,27 @@ and SDK-style csproj rewrites.
 
 ## Roslyn API targeting (internal)
 
-The migration package's Roslyn components are built against the **stable
-analyzer API surface**:
+Every Roslyn component ships twice, once per band, under
+`analyzers/dotnet/<band>/cs/`. The .NET SDK picks the highest band its compiler
+supports and ignores the rest, so a single package serves both hosts:
 
-| DLL | Roslyn API target | Why |
+| Band | Built against | Loaded by |
 |---|---|---|
-| `Opc.Ua.MigrationAnalyzer.dll` | `Microsoft.CodeAnalysis.CSharp 4.14.0` | csc-safe (loads in `csc.exe`); Workspaces-free |
-| `Opc.Ua.MigrationAnalyzer.Generator.dll` | `Microsoft.CodeAnalysis.CSharp 4.14.0` | csc-safe; needed for `IIncrementalGenerator` |
-| `Opc.Ua.MigrationAnalyzer.CodeFixer.dll` | `Microsoft.CodeAnalysis.CSharp 4.14.0` + `Microsoft.CodeAnalysis.CSharp.Workspaces 4.14.0` | Loaded only in Workspaces-aware hosts (Visual Studio, `dotnet format`) |
+| `roslyn4.14` | `Microsoft.CodeAnalysis.CSharp 4.14.0` | Visual Studio 2022 17.14+ / .NET 9 SDK |
+| `roslyn5.0` | `Microsoft.CodeAnalysis.CSharp 5.0.0` | Visual Studio 2026 18.0+ / .NET 10 SDK |
 
-> The repo's `Directory.Packages.props` pins all `Microsoft.CodeAnalysis.*`
-> packages to `4.14.0`. This is the **stable analyzer API**, not the
-> csc-internal version that the .NET SDK ships (which is `5.x` in SDK 10).
-> Analyzers built against 5.x silently fail to load in csc.exe — see
+Within a band, the three components differ only in what else they reference:
+
+| DLL | Extra reference | Why |
+|---|---|---|
+| `Opc.Ua.MigrationAnalyzer.dll` | none | csc-safe (loads in `csc.exe`); Workspaces-free |
+| `Opc.Ua.MigrationAnalyzer.Generator.dll` | none | csc-safe; needed for `IIncrementalGenerator` |
+| `Opc.Ua.MigrationAnalyzer.CodeFixer.dll` | `Microsoft.CodeAnalysis.CSharp.Workspaces` | Loaded only in Workspaces-aware hosts (Visual Studio, `dotnet format`) |
+
+> An analyzer built against a **newer** Roslyn than the host is skipped silently
+> with warning `CS9057` — the consumer simply gets no diagnostics and no
+> generated shims. That is why the package ships a band per supported host
+> rather than a single `analyzers/dotnet/cs/` folder; see
 > [`known-gaps.md` G9](known-gaps.md#g9--analyzer-silently-doesnt-load-under-cscexe-historical-fixed).
 
 ## Verifying analyzer + generator loaded under csc.exe

--- a/.agents/skills/opcua-v20-migration/references/known-gaps.md
+++ b/.agents/skills/opcua-v20-migration/references/known-gaps.md
@@ -148,8 +148,10 @@ code-fixers in one assembly, which transitively referenced
 swallowed the Workspaces load failure → zero diagnostics across all samples
 even though `/analyzer:` was on the csc command line.
 
-**Status:** fixed (commit `861fa6ee1`). Analyzer split into two DLLs; analyzer
-DLL is Workspaces-free + targets stable Roslyn 4.14 API.
+**Status:** fixed (commit `861fa6ee1`). Analyzer split into two DLLs; the analyzer
+DLL is Workspaces-free. Each DLL now ships once per Roslyn band (`roslyn4.14`,
+`roslyn5.0`) so the host always loads a build it can run — see
+[`compatibility-matrix.md`](compatibility-matrix.md#roslyn-api-targeting-internal).
 
 **Verification:** if you ever suspect the analyzer isn't firing, run with
 `/p:ReportAnalyzer=true` and confirm `Opc.Ua.MigrationAnalyzer` and

--- a/.azurepipelines/validate-source-generator-packages.ps1
+++ b/.azurepipelines/validate-source-generator-packages.ps1
@@ -113,8 +113,9 @@ function Test-PackageContents
         ForEach-Object { $_.Substring($analyzerRoot.Length).Split("/")[0] } |
         Sort-Object -Unique)
     Assert-Condition (
-        $roslynFolders.Count -ge 1
-    ) "Package '$($Package.Id)' ships no analyzer folder."
+        $roslynFolders.Count -ge 2
+    ) ("Package '$($Package.Id)' must ship one analyzer folder per supported Roslyn " +
+        "band; found: $($roslynFolders -join ', ').")
     Assert-Condition (
         @($roslynFolders | Where-Object { $_ -notmatch "^roslyn[0-9]+\.[0-9]+$" }).Count -eq 0
     ) ("Package '$($Package.Id)' analyzer folders must be named 'roslyn<major>.<minor>'; " +
@@ -162,6 +163,54 @@ function Test-PackageContents
     Assert-Condition (
         $Package.Dependencies.Count -eq 0
     ) "Package '$($Package.Id)' must carry its analyzer runtime closure privately."
+}
+
+function Test-AnalyzerBands
+{
+    <#
+    .SYNOPSIS
+        Asserts a package ships the expected analyzer assemblies in every Roslyn band.
+
+    .DESCRIPTION
+        For packages that Test-PackageContents cannot check because they also ship lib/
+        assemblies and carry dependencies - the migration analyzer, whose payload comes
+        from a hand-written nuspec rather than SourceGeneratorPack.targets. A band added
+        to one half of that nuspec and not the other is invisible at pack time.
+    #>
+    param(
+        [Parameter(Mandatory = $true)]
+        [PSCustomObject] $Package,
+
+        [Parameter(Mandatory = $true)]
+        [string[]] $ExpectedFolders,
+
+        [Parameter(Mandatory = $true)]
+        [string[]] $ExpectedAssemblies
+    )
+
+    $analyzerRoot = "analyzers/dotnet/"
+    foreach ($folder in $ExpectedFolders)
+    {
+        foreach ($assembly in $ExpectedAssemblies)
+        {
+            $path = "$analyzerRoot$folder/cs/$assembly"
+            Assert-Condition (
+                $Package.Entries -contains $path
+            ) "Package '$($Package.Id)' is missing '$path'."
+        }
+    }
+
+    $actualFolders = @($Package.Entries |
+        Where-Object {
+            $_.StartsWith($analyzerRoot, [StringComparison]::OrdinalIgnoreCase) -and
+            $_.EndsWith(".dll", [StringComparison]::OrdinalIgnoreCase)
+        } |
+        ForEach-Object { $_.Substring($analyzerRoot.Length).Split("/")[0] } |
+        Sort-Object -Unique)
+    Assert-Condition (
+        @(Compare-Object $actualFolders @($ExpectedFolders | Sort-Object -Unique)).Count -eq 0
+    ) ("Package '$($Package.Id)' analyzer bands are '$($actualFolders -join ', ')' but " +
+        "'$(($ExpectedFolders | Sort-Object -Unique) -join ', ')' was expected.")
 }
 
 function Test-PackageBuildProps
@@ -358,6 +407,147 @@ public static class GeneratedModelProbe
         "standalone NodeSet consumer.")
 }
 
+function Test-DownlevelAnalyzerHost
+{
+    <#
+    .SYNOPSIS
+        Loads the down-level analyzer payload in a real compiler of that Roslyn band.
+
+    .DESCRIPTION
+        The repository builds against the newest band, so nothing else here ever executes
+        the down-level payload. Every way it can be wrong is reported by the compiler as a
+        *warning*, which means a broken band ships silently and the consumer simply gets no
+        generated code:
+
+          CS9057 - built against a newer compiler than the host, so it is skipped entirely.
+          CS8784 - loaded but failed to initialize, e.g. MissingMethodException because a
+                   shipped System.Collections.Immutable bound a second ImmutableArray<T>.
+          CS8032 - the analyzer instance could not be created at all.
+
+        So run the matching csc over the packed payload and fail on any of them. Absence of
+        diagnostics is necessary but not sufficient - a generator that is never handed to
+        the compiler also produces none - so /reportanalyzer is used to additionally assert
+        that the generator positively executed.
+    #>
+    param(
+        [Parameter(Mandatory = $true)]
+        [PSCustomObject] $Package,
+
+        [Parameter(Mandatory = $true)]
+        [string] $ValidationRoot,
+
+        [Parameter(Mandatory = $true)]
+        [string] $RoslynFolder,
+
+        [Parameter(Mandatory = $true)]
+        [string] $CompilerToolsetVersion,
+
+        [Parameter(Mandatory = $true)]
+        [string] $GeneratorAssembly
+    )
+
+    $root = Join-Path $ValidationRoot "downlevel-$RoslynFolder-$($Package.Id)"
+    $analyzerDirectory = Join-Path $root "analyzers"
+    # Per package, and emptied first: a shared directory would leak the previous
+    # package's assemblies into this compilation and the assertion below would pass on
+    # someone else's generator.
+    Remove-Item -Path $analyzerDirectory -Recurse -Force -ErrorAction SilentlyContinue
+    New-Item -ItemType Directory -Path $analyzerDirectory -Force | Out-Null
+
+    $archive = [IO.Compression.ZipFile]::OpenRead($Package.Path)
+    try
+    {
+        $prefix = "analyzers/dotnet/$RoslynFolder/cs/"
+        $entries = @($archive.Entries |
+            Where-Object { $_.FullName.StartsWith($prefix, [StringComparison]::OrdinalIgnoreCase) } |
+            Where-Object { $_.FullName.EndsWith(".dll", [StringComparison]::OrdinalIgnoreCase) })
+        Assert-Condition (
+            $entries.Count -gt 0
+        ) "Package '$($Package.Id)' has no assemblies under '$prefix'."
+        foreach ($entry in $entries)
+        {
+            [IO.Compression.ZipFileExtensions]::ExtractToFile(
+                $entry, (Join-Path $analyzerDirectory ([IO.Path]::GetFileName($entry.FullName))), $true)
+        }
+    }
+    finally
+    {
+        $archive.Dispose()
+    }
+
+    # `dotnet tool`-free way to get a specific csc: restore the toolset package.
+    $toolsetProject = Join-Path $root "toolset.csproj"
+    @"
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Net.Compilers.Toolset"
+                      Version="$CompilerToolsetVersion" PrivateAssets="all" />
+  </ItemGroup>
+</Project>
+"@ | Set-Content -Path $toolsetProject -Encoding utf8
+
+    $packagesPath = Join-Path $ValidationRoot "packages"
+    Invoke-DotNet @(
+        "restore",
+        $toolsetProject,
+        "--configfile",
+        (Join-Path $ValidationRoot "NuGet.WithUpstream.Config"),
+        "--packages",
+        $packagesPath,
+        "--nologo"
+    )
+
+    $csc = Join-Path $packagesPath `
+        "microsoft.net.compilers.toolset/$CompilerToolsetVersion/tasks/netcore/bincore/csc.dll"
+    Assert-Condition (Test-Path $csc) "csc from Microsoft.Net.Compilers.Toolset $CompilerToolsetVersion not found at '$csc'."
+
+    $sourceFile = Join-Path $root "Probe.cs"
+    "namespace DownlevelProbe { public class Marker { } }" | Set-Content -Path $sourceFile -Encoding utf8
+
+    $referenceDirectory = @(Get-ChildItem -Path (
+        Join-Path $env:ProgramFiles "dotnet\packs\Microsoft.NETCore.App.Ref") -Directory -ErrorAction SilentlyContinue |
+        Sort-Object Name -Descending |
+        ForEach-Object { Get-ChildItem -Path (Join-Path $_.FullName "ref") -Directory -ErrorAction SilentlyContinue } |
+        Select-Object -First 1)
+    Assert-Condition (
+        $referenceDirectory.Count -eq 1
+    ) "Could not locate a Microsoft.NETCore.App reference assembly directory."
+
+    $arguments = @(
+        $csc, "/noconfig", "/nostdlib+", "/target:library",
+        "/out:$(Join-Path $root 'probe.dll')", "/reportanalyzer"
+    )
+    $arguments += @(Get-ChildItem (Join-Path $referenceDirectory[0].FullName "*.dll") |
+        ForEach-Object { "/r:$($_.FullName)" })
+    $arguments += @(Get-ChildItem (Join-Path $analyzerDirectory "*.dll") |
+        ForEach-Object { "/analyzer:$($_.FullName)" })
+    $arguments += $sourceFile
+
+    $output = & dotnet @arguments 2>&1
+    $loadDiagnostics = @($output | Where-Object { $_ -match "CS9057|CS8784|CS8032|CS8034" })
+    Assert-Condition (
+        $loadDiagnostics.Count -eq 0
+    ) ("Package '$($Package.Id)' analyzer folder '$RoslynFolder' does not load in " +
+        "Microsoft.Net.Compilers.Toolset $CompilerToolsetVersion. A consumer on that " +
+        "compiler silently gets no generated code:`n" + ($loadDiagnostics -join "`n"))
+
+    # /reportanalyzer lists every generator the compiler actually ran, so this turns
+    # "nothing complained" into "the generator executed".
+    $ran = @($output | Where-Object { $_ -match "(^|\s)$([Regex]::Escape($GeneratorAssembly)), Version=" })
+    Assert-Condition (
+        $ran.Count -gt 0
+    ) ("Package '$($Package.Id)' analyzer folder '$RoslynFolder' reported no execution of " +
+        "'$GeneratorAssembly' under Microsoft.Net.Compilers.Toolset $CompilerToolsetVersion. " +
+        "The payload loaded without complaint but the generator never ran:`n" +
+        ($output -join "`n"))
+
+    Write-Host "Analyzer folder '$RoslynFolder' of '$($Package.Id)' runs in csc $CompilerToolsetVersion."
+}
+
 function Invoke-DotNet
 {
     param(
@@ -493,9 +683,14 @@ Test-ConfigurationPackageIds (
     Join-Path $repoRoot "tools\Opc.Ua.SourceGeneration.Stack.Pack\Opc.Ua.SourceGeneration.Stack.Pack.csproj")
 $modelPackage = Get-PackageInfo "OPCFoundation.NetStandard.Opc.Ua.SourceGeneration"
 $stackPackage = Get-PackageInfo "OPCFoundation.NetStandard.Opc.Ua.SourceGeneration.Stack"
+$migrationPackage = Get-PackageInfo "OPCFoundation.NetStandard.Opc.Ua.MigrationAnalyzer"
 
 Test-PackageContents $modelPackage "Opc.Ua.SourceGeneration.dll"
 Test-PackageContents $stackPackage "Opc.Ua.SourceGeneration.Stack.dll"
+Test-AnalyzerBands $migrationPackage @("roslyn4.14", "roslyn5.0") @(
+    "Opc.Ua.MigrationAnalyzer.dll",
+    "Opc.Ua.MigrationAnalyzer.CodeFixer.dll",
+    "Opc.Ua.MigrationAnalyzer.Generator.dll")
 
 # Only the model generator exposes MSBuild settings to consumers, so only it ships a
 # build/<PackageId>.props; the stack generator must not smuggle in stray build/ content.
@@ -545,6 +740,15 @@ try
     Test-CleanConsumer $modelPackage $validationRoot
     Test-CleanConsumer $stackPackage $validationRoot
     Test-SourceGeneratingConsumer $modelPackage $validationRoot $repoRoot
+    # The repository builds against the newest band, so the down-level payload is only
+    # ever exercised here. Every failure mode is a compiler *warning*, so without this
+    # a broken band ships silently.
+    Test-DownlevelAnalyzerHost $modelPackage $validationRoot "roslyn4.14" "4.14.0" "Opc.Ua.SourceGeneration"
+    Test-DownlevelAnalyzerHost $stackPackage $validationRoot "roslyn4.14" "4.14.0" "Opc.Ua.SourceGeneration.Stack"
+    # The migration analyzer ships the same two bands from a hand-written nuspec rather
+    # than SourceGeneratorPack.targets, so its down-level payload has its own way to rot.
+    Test-DownlevelAnalyzerHost $migrationPackage $validationRoot "roslyn4.14" "4.14.0" `
+        "Opc.Ua.MigrationAnalyzer.Generator"
 }
 finally
 {

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -121,8 +121,8 @@
          - System.Text.RegularExpressions 4.3.1 fixes GHSA-cmhx-cq75-c4mj -->
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
     <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />
-    <PackageVersion Include="System.Collections.Immutable" Version="$(RoslynRuntimeVersionVS2026)" />
-    <PackageVersion Include="System.Reflection.Metadata" Version="$(RoslynRuntimeVersionVS2026)" />
+    <PackageVersion Include="System.Collections.Immutable" Version="$(RoslynRuntimeVersion)" />
+    <PackageVersion Include="System.Reflection.Metadata" Version="$(RoslynRuntimeVersion)" />
     <PackageVersion Include="System.Text.Json" Version="10.0.9" />
     <PackageVersion Include="System.Private.Uri" Version="4.3.2" />
     <PackageVersion Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />

--- a/UA.slnx
+++ b/UA.slnx
@@ -277,6 +277,9 @@
     <Project Path="tools/Opc.Ua.MigrationAnalyzer.Core/Opc.Ua.MigrationAnalyzer.Core.csproj" />
     <Project Path="tools/Opc.Ua.MigrationAnalyzer.Generator/Opc.Ua.MigrationAnalyzer.Generator.csproj" />
     <Project Path="tools/Opc.Ua.MigrationAnalyzer/Opc.Ua.MigrationAnalyzer.csproj" />
+    <Project Path="tools/Opc.Ua.MigrationAnalyzer.Roslyn4_14/Opc.Ua.MigrationAnalyzer.Roslyn4_14.csproj" />
+    <Project Path="tools/Opc.Ua.MigrationAnalyzer.CodeFixer.Roslyn4_14/Opc.Ua.MigrationAnalyzer.CodeFixer.Roslyn4_14.csproj" />
+    <Project Path="tools/Opc.Ua.MigrationAnalyzer.Generator.Roslyn4_14/Opc.Ua.MigrationAnalyzer.Generator.Roslyn4_14.csproj" />
   </Folder>
   <Folder Name="/tools/SourceGeneration/">
     <Project Path="tools/Opc.Ua.SourceGeneration.Core/Opc.Ua.SourceGeneration.Core.csproj" />
@@ -285,5 +288,7 @@
     <Project Path="tools/Opc.Ua.SourceGeneration.Stack.Pack/Opc.Ua.SourceGeneration.Stack.Pack.csproj" />
     <Project Path="tools/Opc.Ua.SourceGeneration.Tester/Opc.Ua.SourceGeneration.Tester.csproj" />
     <Project Path="tools/Opc.Ua.SourceGeneration/Opc.Ua.SourceGeneration.csproj" />
+    <Project Path="tools/Opc.Ua.SourceGeneration.Roslyn4_14/Opc.Ua.SourceGeneration.Roslyn4_14.csproj" />
+    <Project Path="tools/Opc.Ua.SourceGeneration.Stack.Roslyn4_14/Opc.Ua.SourceGeneration.Stack.Roslyn4_14.csproj" />
   </Folder>
 </Solution>

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -239,11 +239,14 @@ The analyzer and source generator packages ship under `analyzers/dotnet/roslyn<m
 
 | Roslyn API | Package folder | Minimum host |
 | --- | --- | --- |
+| 4.14 | `analyzers/dotnet/roslyn4.14/cs` | Visual Studio 2022 17.14 / .NET 9 SDK |
 | 5.0 | `analyzers/dotnet/roslyn5.0/cs` | Visual Studio 2026 18.0 / .NET 10 SDK |
 
 The version is declared once in `roslyn.props`.
 
-> **Adding a down-level band is not just another entry in that file.** The analyzer closure — the generator, `Opc.Ua.SourceGeneration.Core` **and** `Opc.Ua.Types` — must bind against the Roslyn host's own `System.Collections.Immutable` and `System.Reflection.Metadata`, whose assembly versions are fixed per band (4.8 → 7.0.0.0, 4.14 → 8.0.0.0, 5.0 → 9.0.0.0). `Directory.Packages.props` pins both centrally with transitive pinning on, so today the whole closure references 10.0.0.0. On an older band the compiler cannot satisfy that: the generator either fails to load (`FileNotFoundException`) or, if a copy is shipped alongside, binds a second `ImmutableArray<T>` identity and dies with `MissingMethodException` on its first Roslyn call. Both surface only as warning `CS8784`, so the consumer silently gets no generated code. A down-level band therefore requires building that entire closure against the band's package versions, which is why `validate-source-generator-packages.ps1` fails any package that ships `Microsoft.CodeAnalysis*`, `System.Collections.Immutable` or `System.Reflection.Metadata`.
+> **Adding a band below 4.14 is not just another entry in that file.** The analyzer closure — the generator, `Opc.Ua.SourceGeneration.Core` **and** `Opc.Ua.Types` — must bind against the Roslyn host's own `System.Collections.Immutable` and `System.Reflection.Metadata`. .NET satisfies a reference from a *higher* assembly version but never from a lower one, and those assemblies are supplied by the compiler, so the closure must reference the lowest version across every supported band and must never ship a copy of its own. Roslyn 4.14 and 5.0 both depend on 9.0.0, which is why `$(RoslynRuntimeVersion)` in `roslyn.props` drives the central pin and one build of the non-Roslyn closure serves both bands. Going lower — Roslyn 4.8 wants 7.x — would mean building that whole closure, `Opc.Ua.Types` included, a second time.
+>
+> Get it wrong and the failure is silent: the generator is skipped (`CS9057`), fails to load (`CS8032`) or throws `MissingMethodException` while initializing (`CS8784`) — all *warnings*, so the consumer just gets no generated code. `validate-source-generator-packages.ps1` therefore refuses any package that ships `Microsoft.CodeAnalysis*`, `System.Collections.Immutable` or `System.Reflection.Metadata`, and runs the packed down-level payload through a real compiler of that band.
 
 ### Versioning
 

--- a/roslyn.props
+++ b/roslyn.props
@@ -18,29 +18,40 @@
 
     RoslynRuntimeVersion is the critical part. The compiler supplies
     System.Collections.Immutable and System.Reflection.Metadata itself, and the version it
-    supplies is fixed by its Roslyn band (4.8 -> 7.x, 4.14 -> 8.x, 5.0 -> 9.x). An analyzer
+    supplies is fixed by its Roslyn band (4.8 -> 7.x, 4.14 -> 9.x, 5.0 -> 9.x). An analyzer
     must therefore reference a version at or BELOW its band's - .NET satisfies a reference
     from a higher assembly version but never from a lower one - and must never ship a copy
     of its own, because a second copy binds a separate ImmutableArray<T> identity and the
     generator dies with MissingMethodException on its first Roslyn call. Either failure
     surfaces only as warning CS8784, so the consumer silently gets no generated code.
 
-    Directory.Packages.props pins both packages to RoslynRuntimeVersion and central
+    Directory.Packages.props pins both packages to $(RoslynRuntimeVersion) and central
     transitive pinning propagates that through the whole analyzer closure - the generator,
     Opc.Ua.SourceGeneration.Core and Opc.Ua.Types. Keeping the pin here rather than as a
     loose version literal is what stops the closure drifting above the band again.
 
-    Adding a down-level band is therefore not just another entry in this file: the whole
-    closure, Opc.Ua.Types included, has to be built against that band's runtime version.
+    Adding a band below the current floor is therefore not just another entry in this
+    file. It only stays cheap while the new band shares $(RoslynRuntimeVersion): Roslyn
+    4.14 and 5.0 both depend on System.Collections.Immutable 9.0.0, so one build of the
+    non-Roslyn part of the closure serves both. Going lower - Roslyn 4.8 wants 7.x -
+    would require building that whole closure, Opc.Ua.Types included, a second time
+    against the older runtime.
   -->
   <PropertyGroup>
     <!-- Visual Studio 2026 18.0+ / .NET 10 SDK. -->
     <RoslynApiVersionVS2026>5.0.0</RoslynApiVersionVS2026>
-    <!-- System.Collections.Immutable / System.Reflection.Metadata that
-         Microsoft.CodeAnalysis $(RoslynApiVersionVS2026) itself depends on. -->
-    <RoslynRuntimeVersionVS2026>9.0.0</RoslynRuntimeVersionVS2026>
+    <!-- Visual Studio 2022 17.14+ / .NET 9 SDK. -->
+    <RoslynApiVersionVS2022>4.14.0</RoslynApiVersionVS2022>
+    <!-- System.Collections.Immutable / System.Reflection.Metadata that both
+         Microsoft.CodeAnalysis $(RoslynApiVersionVS2022) and $(RoslynApiVersionVS2026)
+         depend on. The two bands share it, so a single build of the non-Roslyn part of
+         the closure (Opc.Ua.SourceGeneration.Core, Opc.Ua.Types) serves both. Roslyn
+         4.14's csc runs on net9.0 and takes these from the shared framework, which is
+         9.0.0.0 - matching this pin exactly. -->
+    <RoslynRuntimeVersion>9.0.0</RoslynRuntimeVersion>
   </PropertyGroup>
   <PropertyGroup>
     <RoslynAnalyzerFolderVS2026>roslyn$(RoslynApiVersionVS2026.Substring(0, $(RoslynApiVersionVS2026.LastIndexOf('.'))))</RoslynAnalyzerFolderVS2026>
+    <RoslynAnalyzerFolderVS2022>roslyn$(RoslynApiVersionVS2022.Substring(0, $(RoslynApiVersionVS2022.LastIndexOf('.'))))</RoslynAnalyzerFolderVS2022>
   </PropertyGroup>
 </Project>

--- a/tools/MigrationAnalyzer.slnx
+++ b/tools/MigrationAnalyzer.slnx
@@ -3,15 +3,20 @@
     <Project Path="../tests/Opc.Ua.MigrationAnalyzer.Core.Tests/Opc.Ua.MigrationAnalyzer.Core.Tests.csproj" />
     <Project Path="../tests/Opc.Ua.MigrationAnalyzer.Tests/Opc.Ua.MigrationAnalyzer.Tests.csproj" />
     <Project Path="Opc.Ua.MigrationAnalyzer/Opc.Ua.MigrationAnalyzer.csproj" />
+    <Project Path="Opc.Ua.MigrationAnalyzer.Roslyn4_14/Opc.Ua.MigrationAnalyzer.Roslyn4_14.csproj" />
     <Project Path="Opc.Ua.MigrationAnalyzer.CodeFixer/Opc.Ua.MigrationAnalyzer.CodeFixer.csproj" />
+    <Project Path="Opc.Ua.MigrationAnalyzer.CodeFixer.Roslyn4_14/Opc.Ua.MigrationAnalyzer.CodeFixer.Roslyn4_14.csproj" />
     <Project Path="Opc.Ua.MigrationAnalyzer.Core/Opc.Ua.MigrationAnalyzer.Core.csproj" />
     <Project Path="Opc.Ua.MigrationAnalyzer.Generator/Opc.Ua.MigrationAnalyzer.Generator.csproj" />
+    <Project Path="Opc.Ua.MigrationAnalyzer.Generator.Roslyn4_14/Opc.Ua.MigrationAnalyzer.Generator.Roslyn4_14.csproj" />
   </Folder>
   <Folder Name="/Generators/">
     <Project Path="Opc.Ua.SourceGeneration/Opc.Ua.SourceGeneration.csproj" />
+    <Project Path="Opc.Ua.SourceGeneration.Roslyn4_14/Opc.Ua.SourceGeneration.Roslyn4_14.csproj" />
     <Project Path="Opc.Ua.SourceGeneration.Pack/Opc.Ua.SourceGeneration.Pack.csproj" />
     <Project Path="Opc.Ua.SourceGeneration.Core/Opc.Ua.SourceGeneration.Core.csproj" />
     <Project Path="Opc.Ua.SourceGeneration.Stack/Opc.Ua.SourceGeneration.Stack.csproj" />
+    <Project Path="Opc.Ua.SourceGeneration.Stack.Roslyn4_14/Opc.Ua.SourceGeneration.Stack.Roslyn4_14.csproj" />
     <Project Path="Opc.Ua.SourceGeneration.Stack.Pack/Opc.Ua.SourceGeneration.Stack.Pack.csproj" />
   </Folder>
   <Folder Name="/src/">

--- a/tools/Opc.Ua.MigrationAnalyzer.CodeFixer.Roslyn4_14/Opc.Ua.MigrationAnalyzer.CodeFixer.Roslyn4_14.csproj
+++ b/tools/Opc.Ua.MigrationAnalyzer.CodeFixer.Roslyn4_14/Opc.Ua.MigrationAnalyzer.CodeFixer.Roslyn4_14.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <!--
+    Visual Studio 2022 build of the OPC UA migration code-fix providers. Shares every source file with
+    ..\Opc.Ua.MigrationAnalyzer.CodeFixer through a glob-link, so only the Roslyn API version differs.
+  -->
+  <Import Project="..\..\roslyn.props" Condition="'$(RoslynApiVersionVS2026)' == ''" />
+  <PropertyGroup>
+    <RoslynApiVersion>$(RoslynApiVersionVS2022)</RoslynApiVersion>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <Import Project="..\Opc.Ua.MigrationAnalyzer.CodeFixer\Opc.Ua.MigrationAnalyzer.CodeFixer.Sources.targets" />
+</Project>

--- a/tools/Opc.Ua.MigrationAnalyzer.Generator.Roslyn4_14/Opc.Ua.MigrationAnalyzer.Generator.Roslyn4_14.csproj
+++ b/tools/Opc.Ua.MigrationAnalyzer.Generator.Roslyn4_14/Opc.Ua.MigrationAnalyzer.Generator.Roslyn4_14.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <!--
+    Visual Studio 2022 build of the OPC UA migration source generator. Shares every source file with
+    ..\Opc.Ua.MigrationAnalyzer.Generator through a glob-link, so only the Roslyn API version differs.
+  -->
+  <Import Project="..\..\roslyn.props" Condition="'$(RoslynApiVersionVS2026)' == ''" />
+  <PropertyGroup>
+    <RoslynApiVersion>$(RoslynApiVersionVS2022)</RoslynApiVersion>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <Import Project="..\Opc.Ua.MigrationAnalyzer.Generator\Opc.Ua.MigrationAnalyzer.Generator.Sources.targets" />
+</Project>

--- a/tools/Opc.Ua.MigrationAnalyzer.Roslyn4_14/Opc.Ua.MigrationAnalyzer.Roslyn4_14.csproj
+++ b/tools/Opc.Ua.MigrationAnalyzer.Roslyn4_14/Opc.Ua.MigrationAnalyzer.Roslyn4_14.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <!--
+    Visual Studio 2022 build of the OPC UA migration analyzer. Shares every source file with
+    ..\Opc.Ua.MigrationAnalyzer through a glob-link, so only the Roslyn API version differs.
+  -->
+  <Import Project="..\..\roslyn.props" Condition="'$(RoslynApiVersionVS2026)' == ''" />
+  <PropertyGroup>
+    <RoslynApiVersion>$(RoslynApiVersionVS2022)</RoslynApiVersion>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <Import Project="..\Opc.Ua.MigrationAnalyzer\Opc.Ua.MigrationAnalyzer.Sources.targets" />
+</Project>

--- a/tools/Opc.Ua.MigrationAnalyzer/NugetREADME.md
+++ b/tools/Opc.Ua.MigrationAnalyzer/NugetREADME.md
@@ -144,6 +144,7 @@ skips the analyzer rather than failing to load it:
 
 | Roslyn API | Minimum host |
 | --- | --- |
+| 4.14 | Visual Studio 2022 17.14 / .NET 9 SDK |
 | 5.0 | Visual Studio 2026 18.0 / .NET 10 SDK |
 
 - `Opc.Ua.MigrationAnalyzer.dll` — the analyzer assembly. References **only**

--- a/tools/Opc.Ua.MigrationAnalyzer/Opc.Ua.MigrationAnalyzer.csproj
+++ b/tools/Opc.Ua.MigrationAnalyzer/Opc.Ua.MigrationAnalyzer.csproj
@@ -73,8 +73,11 @@
   <!-- Every Roslyn variant of every analyzer assembly that the nuspec ships.
        Building them here keeps the pack step independent of solution ordering. -->
   <ItemGroup>
+    <MigrationAnalyzerVariantProject Include="..\Opc.Ua.MigrationAnalyzer.Roslyn4_14\Opc.Ua.MigrationAnalyzer.Roslyn4_14.csproj" />
     <MigrationAnalyzerVariantProject Include="..\Opc.Ua.MigrationAnalyzer.CodeFixer\Opc.Ua.MigrationAnalyzer.CodeFixer.csproj" />
+    <MigrationAnalyzerVariantProject Include="..\Opc.Ua.MigrationAnalyzer.CodeFixer.Roslyn4_14\Opc.Ua.MigrationAnalyzer.CodeFixer.Roslyn4_14.csproj" />
     <MigrationAnalyzerVariantProject Include="..\Opc.Ua.MigrationAnalyzer.Generator\Opc.Ua.MigrationAnalyzer.Generator.csproj" />
+    <MigrationAnalyzerVariantProject Include="..\Opc.Ua.MigrationAnalyzer.Generator.Roslyn4_14\Opc.Ua.MigrationAnalyzer.Generator.Roslyn4_14.csproj" />
   </ItemGroup>
   <!-- Ensure the multi-TFM Core (shim) DLL AND every analyzer variant are built
        before pack consumes them. The Core ProjectReference above only triggers
@@ -107,11 +110,14 @@
     <PropertyGroup>
       <_MigrationAnalyzerToolsDir>$(MSBuildThisFileDirectory)..</_MigrationAnalyzerToolsDir>
       <_MigrationAnalyzerBin50>$(MSBuildThisFileDirectory)bin\$(Configuration)\netstandard2.0</_MigrationAnalyzerBin50>
+      <_MigrationAnalyzerBin414>$(_MigrationAnalyzerToolsDir)\Opc.Ua.MigrationAnalyzer.Roslyn4_14\bin\$(Configuration)\netstandard2.0</_MigrationAnalyzerBin414>
       <_MigrationCodeFixerBin50>$(_MigrationAnalyzerToolsDir)\Opc.Ua.MigrationAnalyzer.CodeFixer\bin\$(Configuration)\netstandard2.0</_MigrationCodeFixerBin50>
+      <_MigrationCodeFixerBin414>$(_MigrationAnalyzerToolsDir)\Opc.Ua.MigrationAnalyzer.CodeFixer.Roslyn4_14\bin\$(Configuration)\netstandard2.0</_MigrationCodeFixerBin414>
       <_MigrationGeneratorBin50>$(_MigrationAnalyzerToolsDir)\Opc.Ua.MigrationAnalyzer.Generator\bin\$(Configuration)\netstandard2.0</_MigrationGeneratorBin50>
+      <_MigrationGeneratorBin414>$(_MigrationAnalyzerToolsDir)\Opc.Ua.MigrationAnalyzer.Generator.Roslyn4_14\bin\$(Configuration)\netstandard2.0</_MigrationGeneratorBin414>
     </PropertyGroup>
     <PropertyGroup>
-      <NuspecProperties>version=$(PackageVersion);configuration=$(Configuration);repoRoot=$(MSBuildThisFileDirectory)..\..;roslynFolderVS2026=$(RoslynAnalyzerFolderVS2026);analyzerDllVS2026=$(_MigrationAnalyzerBin50)\Opc.Ua.MigrationAnalyzer.dll;codeFixesDllVS2026=$(_MigrationCodeFixerBin50)\Opc.Ua.MigrationAnalyzer.CodeFixer.dll;generatorDllVS2026=$(_MigrationGeneratorBin50)\Opc.Ua.MigrationAnalyzer.Generator.dll;shimBin=$(MSBuildThisFileDirectory)..\Opc.Ua.MigrationAnalyzer.Core\bin\$(Configuration);readme=$(MSBuildThisFileDirectory)NugetREADME.md;propsFile=$(MSBuildThisFileDirectory)OPCFoundation.NetStandard.Opc.Ua.MigrationAnalyzer.props</NuspecProperties>
+      <NuspecProperties>version=$(PackageVersion);configuration=$(Configuration);repoRoot=$(MSBuildThisFileDirectory)..\..;roslynFolderVS2026=$(RoslynAnalyzerFolderVS2026);roslynFolderVS2022=$(RoslynAnalyzerFolderVS2022);analyzerDllVS2026=$(_MigrationAnalyzerBin50)\Opc.Ua.MigrationAnalyzer.dll;analyzerDllVS2022=$(_MigrationAnalyzerBin414)\Opc.Ua.MigrationAnalyzer.dll;codeFixesDllVS2026=$(_MigrationCodeFixerBin50)\Opc.Ua.MigrationAnalyzer.CodeFixer.dll;codeFixesDllVS2022=$(_MigrationCodeFixerBin414)\Opc.Ua.MigrationAnalyzer.CodeFixer.dll;generatorDllVS2026=$(_MigrationGeneratorBin50)\Opc.Ua.MigrationAnalyzer.Generator.dll;generatorDllVS2022=$(_MigrationGeneratorBin414)\Opc.Ua.MigrationAnalyzer.Generator.dll;shimBin=$(MSBuildThisFileDirectory)..\Opc.Ua.MigrationAnalyzer.Core\bin\$(Configuration);readme=$(MSBuildThisFileDirectory)NugetREADME.md;propsFile=$(MSBuildThisFileDirectory)OPCFoundation.NetStandard.Opc.Ua.MigrationAnalyzer.props</NuspecProperties>
     </PropertyGroup>
   </Target>
   <Import Project="Opc.Ua.MigrationAnalyzer.Sources.targets" />

--- a/tools/Opc.Ua.MigrationAnalyzer/Opc.Ua.MigrationAnalyzer.nuspec
+++ b/tools/Opc.Ua.MigrationAnalyzer/Opc.Ua.MigrationAnalyzer.nuspec
@@ -71,6 +71,9 @@
     <file src="$analyzerDllVS2026$" target="analyzers\dotnet\$roslynFolderVS2026$\cs\Opc.Ua.MigrationAnalyzer.dll" />
     <file src="$codeFixesDllVS2026$" target="analyzers\dotnet\$roslynFolderVS2026$\cs\Opc.Ua.MigrationAnalyzer.CodeFixer.dll" />
     <file src="$generatorDllVS2026$" target="analyzers\dotnet\$roslynFolderVS2026$\cs\Opc.Ua.MigrationAnalyzer.Generator.dll" />
+    <file src="$analyzerDllVS2022$" target="analyzers\dotnet\$roslynFolderVS2022$\cs\Opc.Ua.MigrationAnalyzer.dll" />
+    <file src="$codeFixesDllVS2022$" target="analyzers\dotnet\$roslynFolderVS2022$\cs\Opc.Ua.MigrationAnalyzer.CodeFixer.dll" />
+    <file src="$generatorDllVS2022$" target="analyzers\dotnet\$roslynFolderVS2022$\cs\Opc.Ua.MigrationAnalyzer.Generator.dll" />
     <file src="$shimBin$\net472\Opc.Ua.MigrationAnalyzer.Core.dll" target="lib\net472\Opc.Ua.MigrationAnalyzer.Core.dll" />
     <file src="$shimBin$\net48\Opc.Ua.MigrationAnalyzer.Core.dll" target="lib\net48\Opc.Ua.MigrationAnalyzer.Core.dll" />
     <file src="$shimBin$\netstandard2.1\Opc.Ua.MigrationAnalyzer.Core.dll" target="lib\netstandard2.1\Opc.Ua.MigrationAnalyzer.Core.dll" />

--- a/tools/Opc.Ua.SourceGeneration.Pack/NugetREADME.md
+++ b/tools/Opc.Ua.SourceGeneration.Pack/NugetREADME.md
@@ -22,6 +22,7 @@ ignores it otherwise, so an older host cleanly skips the generator.
 
 | Roslyn API | Minimum host |
 | --- | --- |
+| 4.14 | Visual Studio 2022 17.14 / .NET 9 SDK |
 | 5.0 | Visual Studio 2026 18.0 / .NET 10 SDK |
 
 ## Getting started

--- a/tools/Opc.Ua.SourceGeneration.Pack/Opc.Ua.SourceGeneration.Pack.csproj
+++ b/tools/Opc.Ua.SourceGeneration.Pack/Opc.Ua.SourceGeneration.Pack.csproj
@@ -16,6 +16,8 @@
   <ItemGroup>
     <SourceGeneratorVariant Include="..\Opc.Ua.SourceGeneration\Opc.Ua.SourceGeneration.csproj"
                             RoslynAnalyzerFolder="$(RoslynAnalyzerFolderVS2026)" />
+    <SourceGeneratorVariant Include="..\Opc.Ua.SourceGeneration.Roslyn4_14\Opc.Ua.SourceGeneration.Roslyn4_14.csproj"
+                            RoslynAnalyzerFolder="$(RoslynAnalyzerFolderVS2022)" />
   </ItemGroup>
   <ItemGroup>
     <!-- NuGet only auto-imports build\<PackageId>.props, so the file has to be

--- a/tools/Opc.Ua.SourceGeneration.Roslyn4_14/Opc.Ua.SourceGeneration.Roslyn4_14.csproj
+++ b/tools/Opc.Ua.SourceGeneration.Roslyn4_14/Opc.Ua.SourceGeneration.Roslyn4_14.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <!--
+    Visual Studio 2022 build of the OPC UA model source generator. Shares every source
+    file with ..\Opc.Ua.SourceGeneration through a glob-link, so only the Roslyn API
+    version differs. A separate build is required because an analyzer that references a
+    newer compiler than the host is skipped with warning CS9057 - the host does not fall
+    back to it.
+  -->
+  <Import Project="..\..\roslyn.props" Condition="'$(RoslynApiVersionVS2026)' == ''" />
+  <PropertyGroup>
+    <RoslynApiVersion>$(RoslynApiVersionVS2022)</RoslynApiVersion>
+  </PropertyGroup>
+  <Import Project="..\Opc.Ua.SourceGeneration\Opc.Ua.SourceGeneration.Sources.targets" />
+</Project>

--- a/tools/Opc.Ua.SourceGeneration.Stack.Pack/NugetREADME.md
+++ b/tools/Opc.Ua.SourceGeneration.Stack.Pack/NugetREADME.md
@@ -27,6 +27,7 @@ ignores it otherwise, so an older host cleanly skips the generator.
 
 | Roslyn API | Minimum host |
 | --- | --- |
+| 4.14 | Visual Studio 2022 17.14 / .NET 9 SDK |
 | 5.0 | Visual Studio 2026 18.0 / .NET 10 SDK |
 
 ## Additional documentation

--- a/tools/Opc.Ua.SourceGeneration.Stack.Pack/Opc.Ua.SourceGeneration.Stack.Pack.csproj
+++ b/tools/Opc.Ua.SourceGeneration.Stack.Pack/Opc.Ua.SourceGeneration.Stack.Pack.csproj
@@ -16,6 +16,8 @@
   <ItemGroup>
     <SourceGeneratorVariant Include="..\Opc.Ua.SourceGeneration.Stack\Opc.Ua.SourceGeneration.Stack.csproj"
                             RoslynAnalyzerFolder="$(RoslynAnalyzerFolderVS2026)" />
+    <SourceGeneratorVariant Include="..\Opc.Ua.SourceGeneration.Stack.Roslyn4_14\Opc.Ua.SourceGeneration.Stack.Roslyn4_14.csproj"
+                            RoslynAnalyzerFolder="$(RoslynAnalyzerFolderVS2022)" />
   </ItemGroup>
   <Import Project="..\SourceGeneratorPack.targets" />
 </Project>

--- a/tools/Opc.Ua.SourceGeneration.Stack.Roslyn4_14/Opc.Ua.SourceGeneration.Stack.Roslyn4_14.csproj
+++ b/tools/Opc.Ua.SourceGeneration.Stack.Roslyn4_14/Opc.Ua.SourceGeneration.Stack.Roslyn4_14.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <!--
+    Visual Studio 2022 build of the OPC UA stack source generator. Shares every source
+    file with ..\Opc.Ua.SourceGeneration.Stack through a glob-link, so only the Roslyn
+    API version differs.
+  -->
+  <Import Project="..\..\roslyn.props" Condition="'$(RoslynApiVersionVS2026)' == ''" />
+  <PropertyGroup>
+    <RoslynApiVersion>$(RoslynApiVersionVS2022)</RoslynApiVersion>
+  </PropertyGroup>
+  <Import Project="..\Opc.Ua.SourceGeneration.Stack\Opc.Ua.SourceGeneration.Stack.Sources.targets" />
+</Project>

--- a/tools/SourceGeneration.slnx
+++ b/tools/SourceGeneration.slnx
@@ -3,8 +3,10 @@
     <Project Path="../tests/Opc.Ua.SourceGeneration.Stack.Tests/Opc.Ua.SourceGeneration.Stack.Tests.csproj" />
     <Project Path="../tests/Opc.Ua.SourceGeneration.Tests/Opc.Ua.SourceGeneration.Tests.csproj" />
     <Project Path="Opc.Ua.SourceGeneration.Stack/Opc.Ua.SourceGeneration.Stack.csproj" />
+    <Project Path="Opc.Ua.SourceGeneration.Stack.Roslyn4_14/Opc.Ua.SourceGeneration.Stack.Roslyn4_14.csproj" />
     <Project Path="Opc.Ua.SourceGeneration.Stack.Pack/Opc.Ua.SourceGeneration.Stack.Pack.csproj" />
     <Project Path="Opc.Ua.SourceGeneration/Opc.Ua.SourceGeneration.csproj" />
+    <Project Path="Opc.Ua.SourceGeneration.Roslyn4_14/Opc.Ua.SourceGeneration.Roslyn4_14.csproj" />
     <Project Path="Opc.Ua.SourceGeneration.Pack/Opc.Ua.SourceGeneration.Pack.csproj" />
   </Folder>
   <Folder Name="/Solution Items/">


### PR DESCRIPTION
> **Stacked on #4120.** Base is `marcschier/remove-source-generator-foundations`, so this reads as a stack and retargets onto `master` automatically once #4120 merges. Draft until then.

## Problem

#4120 ships the generators and the migration analyzer under `analyzers/dotnet/roslyn5.0/cs` only.

The .NET SDK loads the **highest** analyzer band its compiler supports and **silently skips** anything above it. So every consumer on Visual Studio 2022 / .NET 9 SDK currently gets no diagnostics and no generated code — with only warning `CS9057` to show for it.

## Fix

Ship a second band built against `Microsoft.CodeAnalysis 4.14`.

This turned out to be nearly free. The original plan targeted Roslyn **4.8**, but two findings redirected it:

1. `System.Collections.Immutable 7.0.0` does not resolve in this repo (`NU1603`, 8.0.0 substituted), so a 4.8 band cannot be built at all.
2. `Microsoft.CodeAnalysis 4.14` depends on S.C.I **9.0.0** — exactly what `5.0.0` depends on — and its `csc` runs on `net9.0`.

So both bands share `$(RoslynRuntimeVersion)`, and only the five Roslyn-referencing assemblies need a second build. `Opc.Ua.Types` and `Opc.Ua.SourceGeneration.Core` are compiled once and serve both.

| Assembly | 4.14 band | 5.0 band |
| --- | --- | --- |
| `Opc.Ua.SourceGeneration[.Stack]` | Roslyn 4.14 | Roslyn 5.0 |
| `Opc.Ua.MigrationAnalyzer[.CodeFixer/.Generator]` | Roslyn 4.14 | Roslyn 5.0 |
| `Opc.Ua.SourceGeneration.Core`, `Opc.Ua.Types` | one build, S.C.I 9.0.0 | same build |
| S.C.I / S.R.M shipped | never | never |

Each `*.Roslyn4_14` project is 12 lines: it glob-links the primary project''s sources via the existing `*.Sources.targets` and overrides `RoslynApiVersion`. No source is duplicated. No new package IDs — the manifest stays at 47.

### The rule this encodes

> An analyzer must reference the **lowest** `System.Collections.Immutable` / `System.Reflection.Metadata` across all hosts it claims to support, and must never ship them. .NET binds *upward* (a 9.0.0.0 reference is satisfied by a 10.x host) but never downward.

## Why the CI check is the important part of this PR

Nothing else in the repository exercises the down-level payload — the repo builds on the newest band. And **every** way the band can be wrong is a compiler *warning*, so a broken band ships silently:

| Diagnostic | Cause |
| --- | --- |
| `CS9057` | Built against a newer Roslyn than the host, so it is skipped entirely |
| `CS8784` | Loaded, then `MissingMethodException` — a shipped S.C.I bound a second `ImmutableArray<T>` |
| `CS8032` | Analyzer instance could not be created |

This is not hypothetical: it is exactly how #4120''s original `roslyn4.8` band shipped broken until it was caught and removed.

So `validate-source-generator-packages.ps1` now restores a real `Microsoft.Net.Compilers.Toolset 4.14.0`, runs its `csc.dll` with `/analyzer:` over the extracted `roslyn4.14` payload, and asserts:

- none of `CS9057` / `CS8784` / `CS8032` / `CS8034`, **and**
- `/reportanalyzer` lists the generator as having executed.

The second assertion matters: absence of complaints alone would also pass if the generator were never handed to the compiler.

The migration analyzer gets the same treatment plus a band/assembly manifest check (`Test-AnalyzerBands`), because its payload comes from a hand-written nuspec rather than `SourceGeneratorPack.targets`, where a band added to one half and not the other is invisible at pack time.

## Validation

| Check | Result |
| --- | --- |
| `dotnet build UA.slnx` | 0 errors, 18 pre-existing `CA1873` |
| Generator / Stack / Core / MigrationAnalyzer suites, net8/9/10 + net472/48 | all pass |
| `dotnet pack preview-pack.slnx` | 47 packages, matches `expected-packages.txt` |
| Payload contents | both `roslyn4.14` and `roslyn5.0`, no host-provided assemblies |
| `Test-SourceGeneratingConsumer` (5.0 band, E2E) | 8 files emitted |
| `Test-DownlevelAnalyzerHost` | all three packages **run** under csc 4.14.0 |

Each new assertion was negative-tested rather than just observed to pass:

- 5.0 build placed into the `roslyn4.14` folder → fails with the real `CS9057`.
- Generator name that never runs → fails the execution assertion.
- Expecting a `roslyn4.8` band → fails the band manifest check.

Fixing one defect found along the way: `Test-DownlevelAnalyzerHost` originally used a single scratch directory for all packages, so payloads accumulated across calls and each run could have been satisfied by a previous package''s generator. It is now per-package and cleared first.

## Docs

4.14 row added to the support tables in `docs/DeveloperGuide.md` and the three `NugetREADME.md` files; the "adding a band" note rewritten around the binding rule above. Migration-skill docs (`SKILL.md`, `compatibility-matrix.md`, `known-gaps.md` G9) updated for two bands and a 9.0.100 SDK floor.
