### PR TITLE
[Server] Bound the server shutdown drain and make request admission an extension

### DIFF
--- a/tests/Opc.Ua.Server.Tests/RequestManagerTests.cs
+++ b/tests/Opc.Ua.Server.Tests/RequestManagerTests.cs
@@ -270,6 +270,64 @@ namespace Opc.Ua.Server.Tests
 
         [Test]
         [Category("NodeManagerLifecycle")]
+        public void RegisterLifecycleExtensionTwiceReturnsSameExtension()
+        {
+            RequestManagerLifecycleExtension first = RegisterLifecycleExtension();
+            RequestManagerLifecycleExtension second = RegisterLifecycleExtension();
+
+            Assert.That(second, Is.SameAs(first));
+        }
+
+        [Test]
+        [Category("NodeManagerLifecycle")]
+        public void RegisterLifecycleExtensionAfterDisposeThrowsObjectDisposedException()
+        {
+            m_requestManager.Dispose();
+
+            Assert.That(
+                () => m_requestManager.RegisterLifecycleExtension(),
+                Throws.TypeOf<ObjectDisposedException>());
+        }
+
+        [Test]
+        [Category("NodeManagerLifecycle")]
+        public void RequestManagerWithoutLifecycleExtensionAdmitsValidationAndRequests()
+        {
+            using var requestLifetime = new RequestLifetime();
+            OperationContext context = CreateOperationContext(15, requestLifetime);
+
+            using (m_requestManager.EnterValidationScope())
+            {
+                Assert.DoesNotThrow(() => m_requestManager.RequestReceived(context));
+            }
+
+            m_requestManager.RequestCompleted(context);
+            Assert.That(requestLifetime.TryCancel(StatusCodes.BadTimeout), Is.False);
+        }
+
+        [Test]
+        [Category("NodeManagerLifecycle")]
+        public async Task RequestManagerWithoutLifecycleExtensionDoesNotRepeatDrainAsync()
+        {
+            using var requestLifetime = new RequestLifetime();
+            OperationContext context = CreateOperationContext(16, requestLifetime);
+            IDisposable validationScope = m_requestManager.EnterValidationScope();
+
+            Task drain = m_requestManager.WaitForCurrentRequestsAsync().AsTask();
+            Assert.That(drain.IsCompleted, Is.False);
+
+            m_requestManager.RequestReceived(context);
+            validationScope.Dispose();
+
+            await AssertCompletesWithinTimeoutAsync(drain).ConfigureAwait(false);
+            Assert.That(
+                requestLifetime.TryCancel(StatusCodes.BadTimeout),
+                Is.True,
+                "Without the lifecycle extension, the drain must not resnapshot promoted requests.");
+        }
+
+        [Test]
+        [Category("NodeManagerLifecycle")]
         public async Task WaitForCurrentRequestsAsyncCompletesAfterAllSnapshotRequestsCompleteAsync()
         {
             using var requestLifetimeA = new RequestLifetime();
@@ -364,6 +422,93 @@ namespace Opc.Ua.Server.Tests
         }
 
         [Test]
+        [Category("NodeManagerLifecycle")]
+        public async Task WaitForCurrentRequestsAsyncExcludesEveryLifecycleWaiterAsync()
+        {
+            RequestManagerLifecycleExtension extension = RegisterLifecycleExtension();
+            using var requestLifetimeA = new RequestLifetime();
+            using var requestLifetimeB = new RequestLifetime();
+            using var requestLifetimeC = new RequestLifetime();
+            OperationContext contextA = CreateOperationContext(10, requestLifetimeA);
+            OperationContext contextB = CreateOperationContext(11, requestLifetimeB);
+            OperationContext contextC = CreateOperationContext(12, requestLifetimeC);
+
+            using IDisposable requestScopeA = m_requestManager.EnterRequestScope(contextA);
+            using RequestManagerLifecycleExtension.RequestLifecycleWaiterScope waiterScopeA =
+                extension.EnterLifecycleWaiter();
+            waiterScopeA.MarkSemaphoreWaitStarted();
+            using IDisposable requestScopeB = m_requestManager.EnterRequestScope(contextB);
+            using RequestManagerLifecycleExtension.RequestLifecycleWaiterScope waiterScopeB =
+                extension.EnterLifecycleWaiter();
+            waiterScopeB.MarkSemaphoreWaitStarted();
+            m_requestManager.RequestReceived(contextC);
+
+            Task drain = m_requestManager.WaitForCurrentRequestsAsync().AsTask();
+            Assert.That(drain.IsCompleted, Is.False);
+
+            m_requestManager.RequestCompleted(contextC);
+
+            await AssertCompletesWithinTimeoutAsync(drain).ConfigureAwait(false);
+            Assert.That(
+                requestLifetimeA.TryCancel(StatusCodes.BadTimeout),
+                Is.True,
+                "The first excluded request must still be executing.");
+            Assert.That(
+                requestLifetimeB.TryCancel(StatusCodes.BadTimeout),
+                Is.True,
+                "The second excluded request must still be executing.");
+        }
+
+        [Test]
+        [Category("NodeManagerLifecycle")]
+        public async Task SemaphoreWaitStartReleasesAlreadyActiveDrainAsync()
+        {
+            RequestManagerLifecycleExtension extension = RegisterLifecycleExtension();
+            using var requestLifetime = new RequestLifetime();
+            OperationContext context = CreateOperationContext(13, requestLifetime);
+            using IDisposable requestScope = m_requestManager.EnterRequestScope(context);
+
+            Task drain = m_requestManager.WaitForCurrentRequestsAsync().AsTask();
+            Assert.That(drain.IsCompleted, Is.False);
+
+            using RequestManagerLifecycleExtension.RequestLifecycleWaiterScope waiterScope =
+                extension.EnterLifecycleWaiter();
+
+            Assert.That(
+                drain.IsCompleted,
+                Is.False,
+                "Registration must not release a drain before the semaphore wait is queued.");
+
+            waiterScope.MarkSemaphoreWaitStarted();
+
+            await AssertCompletesWithinTimeoutAsync(drain).ConfigureAwait(false);
+            Assert.That(
+                requestLifetime.TryCancel(StatusCodes.BadTimeout),
+                Is.True,
+                "Waiting for the lifecycle semaphore must not complete the request itself.");
+        }
+
+        [Test]
+        [Category("NodeManagerLifecycle")]
+        public async Task DisposedLifecycleWaiterIsIncludedInNextDrainAsync()
+        {
+            RequestManagerLifecycleExtension extension = RegisterLifecycleExtension();
+            using var requestLifetime = new RequestLifetime();
+            OperationContext context = CreateOperationContext(14, requestLifetime);
+            IDisposable requestScope = m_requestManager.EnterRequestScope(context);
+            using (extension.EnterLifecycleWaiter())
+            {
+            }
+
+            Task drain = m_requestManager.WaitForCurrentRequestsAsync().AsTask();
+            Assert.That(drain.IsCompleted, Is.False);
+
+            requestScope.Dispose();
+
+            await AssertCompletesWithinTimeoutAsync(drain).ConfigureAwait(false);
+        }
+
+        [Test]
         public void RequestReceivedCalledTwiceWithSameContextIsIdempotent()
         {
             using var requestLifetime = new RequestLifetime();
@@ -432,6 +577,58 @@ namespace Opc.Ua.Server.Tests
             {
                 Assert.That(observedInCallee, Is.True);
                 Assert.That(m_requestManager.IsExecutingRequest, Is.False);
+            });
+        }
+
+        [Test]
+        [Category("NodeManagerLifecycle")]
+        public async Task ServiceDispatchScopeReceivesRequestIdentityFromAsyncValidationAsync()
+        {
+            RequestManagerLifecycleExtension extension = RegisterLifecycleExtension();
+            using var requestLifetime = new RequestLifetime();
+            OperationContext context = CreateOperationContext(61, requestLifetime);
+
+            using (m_requestManager.EnterServiceDispatchScope())
+            {
+                await RegisterAsync().ConfigureAwait(false);
+                using RequestManagerLifecycleExtension.RequestLifecycleWaiterScope waiter =
+                    extension.EnterLifecycleWaiter();
+            }
+
+            m_requestManager.RequestCompleted(context);
+            Assert.That(requestLifetime.TryCancel(StatusCodes.BadTimeout), Is.False);
+
+            async Task RegisterAsync()
+            {
+                await Task.Yield();
+                m_requestManager.RequestReceived(context);
+            }
+        }
+
+        [Test]
+        [Category("NodeManagerLifecycle")]
+        public void NestedRequestRegistrationPreservesOuterDispatchIdentity()
+        {
+            RequestManagerLifecycleExtension extension = RegisterLifecycleExtension();
+            using var outerLifetime = new RequestLifetime();
+            using var nestedLifetime = new RequestLifetime();
+            OperationContext outer = CreateOperationContext(62, outerLifetime);
+            OperationContext nested = CreateOperationContext(63, nestedLifetime);
+
+            using (m_requestManager.EnterServiceDispatchScope())
+            using (m_requestManager.EnterRequestScope(outer))
+            {
+                m_requestManager.RequestReceived(nested);
+                m_requestManager.RequestCompleted(nested);
+
+                using RequestManagerLifecycleExtension.RequestLifecycleWaiterScope waiter =
+                    extension.EnterLifecycleWaiter();
+            }
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(outerLifetime.TryCancel(StatusCodes.BadTimeout), Is.False);
+                Assert.That(nestedLifetime.TryCancel(StatusCodes.BadTimeout), Is.False);
             });
         }
 
@@ -568,11 +765,95 @@ namespace Opc.Ua.Server.Tests
             m_requestManager.RequestCompleted(innerContext);
         }
 
+        [Test]
+        public void CloseAdmissionRejectsNewValidationAndDirectRequests()
+        {
+            RequestManagerLifecycleExtension extension = RegisterLifecycleExtension();
+            using var requestLifetime = new RequestLifetime();
+            OperationContext context = CreateOperationContext(90, requestLifetime);
+
+            extension.CloseAdmission();
+
+            ServiceResultException validationException =
+                Assert.Throws<ServiceResultException>(
+                    () => m_requestManager.EnterValidationScope());
+            ServiceResultException requestException =
+                Assert.Throws<ServiceResultException>(
+                    () => m_requestManager.RequestReceived(context));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(
+                    validationException.StatusCode,
+                    Is.EqualTo(StatusCodes.BadServerHalted));
+                Assert.That(
+                    requestException.StatusCode,
+                    Is.EqualTo(StatusCodes.BadServerHalted));
+                Assert.That(
+                    requestLifetime.TryCancel(StatusCodes.BadTimeout),
+                    Is.True);
+            });
+        }
+
+        [Test]
+        public void PreAdmittedValidationCanPromoteRequestAfterAdmissionCloses()
+        {
+            RequestManagerLifecycleExtension extension = RegisterLifecycleExtension();
+            using var requestLifetime = new RequestLifetime();
+            OperationContext context = CreateOperationContext(91, requestLifetime);
+            IDisposable validationScope = m_requestManager.EnterValidationScope();
+
+            extension.CloseAdmission();
+
+            using (m_requestManager.EnterServiceDispatchScope())
+            using (m_requestManager.EnterRequestScope(context))
+            {
+                validationScope.Dispose();
+                Assert.That(m_requestManager.IsExecutingRequest, Is.True);
+            }
+
+            Assert.That(requestLifetime.TryCancel(StatusCodes.BadTimeout), Is.False);
+        }
+
+        [Test]
+        [Category("NodeManagerLifecycle")]
+        public async Task ClosedAdmissionDrainTracksRequestRegisteredAfterInitialSnapshotAsync()
+        {
+            RequestManagerLifecycleExtension extension = RegisterLifecycleExtension();
+            using var requestLifetime = new RequestLifetime();
+            OperationContext context = CreateOperationContext(92, requestLifetime);
+            IDisposable validationScope = m_requestManager.EnterValidationScope();
+            extension.CloseAdmission();
+
+            Task drain = m_requestManager.WaitForCurrentRequestsAsync().AsTask();
+            Assert.That(drain.IsCompleted, Is.False);
+            m_requestManager.RequestReceived(context);
+            m_requestManager.RequestReceived(context);
+            validationScope.Dispose();
+
+            Task completed = await Task.WhenAny(
+                drain,
+                Task.Delay(TimeSpan.FromMilliseconds(250))).ConfigureAwait(false);
+            Assert.That(
+                completed,
+                Is.Not.SameAs(drain),
+                "The closed-admission drain must resnapshot the request promoted by validation.");
+
+            m_requestManager.RequestCompleted(context);
+            await AssertCompletesWithinTimeoutAsync(drain).ConfigureAwait(false);
+            Assert.That(requestLifetime.TryCancel(StatusCodes.BadTimeout), Is.False);
+        }
+
         private static OperationContext CreateOperationContext(
             uint requestHandle,
             RequestLifetime requestLifetime)
         {
             return CreateOperationContext(requestHandle, requestLifetime, 0);
+        }
+
+        private RequestManagerLifecycleExtension RegisterLifecycleExtension()
+        {
+            return m_requestManager.RegisterLifecycleExtension();
         }
 
         private static OperationContext CreateOperationContext(

--- a/tests/Opc.Ua.Server.Tests/StandardServerCoverageTests.cs
+++ b/tests/Opc.Ua.Server.Tests/StandardServerCoverageTests.cs
@@ -112,6 +112,16 @@ namespace Opc.Ua.Server.Tests
         }
 
         [Test]
+        public void DisposeCanBeCalledMoreThanOnce()
+        {
+            TestableStandardServer server = CreateServer();
+
+            server.Dispose();
+
+            Assert.DoesNotThrow(server.Dispose);
+        }
+
+        [Test]
         public void LoadComplexTypesDefaultsToTrue()
         {
             using TestableStandardServer server = CreateServer();


### PR DESCRIPTION
## Summary
- PR 6 of the stacked split of integration PR #4093.
- Adds coverage for the RequestManager lifecycle extension, request-admission closure, closed-admission drain retry behavior, AsyncLocal request-scope nesting, and StandardServer double dispose.
- Leaves subscription transfer and publish-queue lifecycle coverage for PR 7.

## Stack context
This PR is stacked on #4147 (`marcschier/wot-05-lifecycle`) and intentionally needs its shutdown-progress members: `MasterNodeManager.ShutdownCompletedNodeManagerCount` and `NodeManagerLifecycle.ShutdownCleanupProgress`.

The shutdown hardening remains minimal and in-place because the maintainer chose that over extracting a shutdown coordinator. The `AsyncLocal` scope nesting is retained deliberately as a correctness fix; removing `AsyncLocal` is tracked separately.

## Validation
- `dotnet build src\Opc.Ua.Server\Opc.Ua.Server.csproj -c Release -f net10.0 -v:m`
- `dotnet build tests\Opc.Ua.Server.Tests\Opc.Ua.Server.Tests.csproj -c Release -p:CustomTestTarget=net10.0 -v:m`
- `dotnet test tests\Opc.Ua.Server.Tests\Opc.Ua.Server.Tests.csproj -c Release -p:CustomTestTarget=net10.0 --no-build` — 3927 passed, 9 skipped
- `dotnet build tests\Opc.Ua.Server.Tests\Opc.Ua.Server.Tests.csproj -c Release -p:CustomTestTarget=net48 -v:m`
- `dotnet test tests\Opc.Ua.Server.Tests\Opc.Ua.Server.Tests.csproj -c Release -p:CustomTestTarget=net48 --no-build` — 3926 passed, 9 skipped, 1 known local-only failure (`DurableDataValueQueueVerifyReferenceBatchingAsync`)
- `dotnet test tests\Opc.Ua.Server.Tests\Opc.Ua.Server.Tests.csproj -c Release -p:CustomTestTarget=net48 --no-build --filter FullyQualifiedName~DurableDataValueQueueVerifyReferenceBatchingAsync` — isolated known flake passed