### PR TITLE
Coordinate the robot cell, and make the twin show what it is actually doing

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -136,10 +136,10 @@
        view option. Published on nuget.org; the runtime packages carry the
        per-RID native payload and the rendering path is win-x64 today. -->
   <ItemGroup>
-    <PackageVersion Include="OpenUsd" Version="0.1.0-alpha" />
-    <PackageVersion Include="OpenUsd.Viewer" Version="0.1.0-alpha" />
-    <PackageVersion Include="OpenUsd.Runtime.Core.win-x64" Version="0.1.0-alpha" />
-    <PackageVersion Include="OpenUsd.Runtime.Imaging.win-x64" Version="0.1.0-alpha" />
+    <PackageVersion Include="OpenUsd" Version="0.3.0-alpha" />
+    <PackageVersion Include="OpenUsd.Viewer" Version="0.3.0-alpha" />
+    <PackageVersion Include="OpenUsd.Runtime.Core.win-x64" Version="0.3.0-alpha" />
+    <PackageVersion Include="OpenUsd.Runtime.Imaging.win-x64" Version="0.3.0-alpha" />
     <PackageVersion Include="Avalonia" Version="12.1.0" />
     <PackageVersion Include="Avalonia.Desktop" Version="12.1.0" />
   </ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -136,10 +136,10 @@
        view option. Published on nuget.org; the runtime packages carry the
        per-RID native payload and the rendering path is win-x64 today. -->
   <ItemGroup>
-    <PackageVersion Include="OpenUsd" Version="0.3.0-alpha" />
-    <PackageVersion Include="OpenUsd.Viewer" Version="0.3.0-alpha" />
-    <PackageVersion Include="OpenUsd.Runtime.Core.win-x64" Version="0.3.0-alpha" />
-    <PackageVersion Include="OpenUsd.Runtime.Imaging.win-x64" Version="0.3.0-alpha" />
+    <PackageVersion Include="OpenUsd" Version="0.4.0-alpha" />
+    <PackageVersion Include="OpenUsd.Viewer" Version="0.4.0-alpha" />
+    <PackageVersion Include="OpenUsd.Runtime.Core.win-x64" Version="0.4.0-alpha" />
+    <PackageVersion Include="OpenUsd.Runtime.Imaging.win-x64" Version="0.4.0-alpha" />
     <PackageVersion Include="Avalonia" Version="12.1.0" />
     <PackageVersion Include="Avalonia.Desktop" Version="12.1.0" />
   </ItemGroup>

--- a/samples/MinimalRobotServer/Assets/Cell.usda
+++ b/samples/MinimalRobotServer/Assets/Cell.usda
@@ -768,7 +768,7 @@ def Xform "Cell"
 
         def Xform "Part03"
         {
-            matrix4d xformOp:transform = ( (1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0), (-2.38, 1.2, 0.7875, 1) )
+            matrix4d xformOp:transform = ( (1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0), (2.38, 1.2, 0.7875, 1) )
             uniform token[] xformOpOrder = ["xformOp:transform"]
 
             def Cube "Body" (

--- a/samples/MinimalRobotServer/Assets/Cell.usda
+++ b/samples/MinimalRobotServer/Assets/Cell.usda
@@ -516,9 +516,13 @@ def Xform "Cell"
 
     # Shared work table the two arms transfer parts across. Placed clear of the AGV
     # drive lane, which spans |y| <= 0.77 as the platforms trace their figure-eight.
-    def Xform "WorkTable"
+    # Two transfer stations at opposite ends of the cell. R1 carries a part from A to B and
+    # R2 carries it back from B to A, so both have to traverse the aisle and pass each other -
+    # which is what makes the corridor interlock meaningful rather than decorative. Each table
+    # is approached from the aisle in front of it (y ~ 0.35), well inside the 1.61 m arm reach.
+    def Xform "WorkTableA"
     {
-        double3 xformOp:translate = (0, 1.45, 0)
+        double3 xformOp:translate = (-2.4, 1.2, 0)
         uniform token[] xformOpOrder = ["xformOp:translate"]
 
         def Cube "Top" (
@@ -581,27 +585,295 @@ def Xform "Cell"
             uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:scale"]
         }
 
-        def Cube "PartA" (
+        # Painted slot outlines. The server places a part at the matching slot pose, so the
+        # markings and the live part transforms cannot disagree.
+        def Cube "Slot1" (
             prepend apiSchemas = ["MaterialBindingAPI"]
         )
         {
             double size = 1
-            color3f[] primvars:displayColor = [(0.20, 0.42, 0.62)]
-            rel material:binding = </Cell/Materials/PartBlue>
-            double3 xformOp:translate = (-0.22, 0.06, 0.7875)
-            double3 xformOp:scale = (0.070, 0.070, 0.035)
+            color3f[] primvars:displayColor = [(0.85, 0.72, 0.12)]
+            rel material:binding = </Cell/Materials/SafetyYellow>
+            double3 xformOp:translate = (-0.22, 0, 0.7706)
+            double3 xformOp:scale = (0.100, 0.100, 0.001)
             uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:scale"]
         }
 
-        def Cube "PartB" (
+        def Cube "Slot2" (
             prepend apiSchemas = ["MaterialBindingAPI"]
         )
         {
             double size = 1
-            color3f[] primvars:displayColor = [(0.20, 0.42, 0.62)]
-            rel material:binding = </Cell/Materials/PartBlue>
-            double3 xformOp:translate = (0.24, -0.05, 0.7875)
-            double3 xformOp:scale = (0.070, 0.070, 0.035)
+            color3f[] primvars:displayColor = [(0.85, 0.72, 0.12)]
+            rel material:binding = </Cell/Materials/SafetyYellow>
+            double3 xformOp:translate = (0, 0, 0.7706)
+            double3 xformOp:scale = (0.100, 0.100, 0.001)
+            uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:scale"]
+        }
+
+        def Cube "Slot3" (
+            prepend apiSchemas = ["MaterialBindingAPI"]
+        )
+        {
+            double size = 1
+            color3f[] primvars:displayColor = [(0.85, 0.72, 0.12)]
+            rel material:binding = </Cell/Materials/SafetyYellow>
+            double3 xformOp:translate = (0.22, 0, 0.7706)
+            double3 xformOp:scale = (0.100, 0.100, 0.001)
+            uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:scale"]
+        }
+    }
+
+    def Xform "WorkTableB"
+    {
+        double3 xformOp:translate = (2.4, 1.2, 0)
+        uniform token[] xformOpOrder = ["xformOp:translate"]
+
+        def Cube "Top" (
+            prepend apiSchemas = ["MaterialBindingAPI"]
+        )
+        {
+            double size = 1
+            color3f[] primvars:displayColor = [(0.46, 0.47, 0.49)]
+            rel material:binding = </Cell/Materials/Steel>
+            double3 xformOp:translate = (0, 0, 0.760)
+            double3 xformOp:scale = (0.700, 0.450, 0.020)
+            uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:scale"]
+        }
+
+        def Cube "LegA" (
+            prepend apiSchemas = ["MaterialBindingAPI"]
+        )
+        {
+            double size = 1
+            color3f[] primvars:displayColor = [(0.24, 0.25, 0.26)]
+            rel material:binding = </Cell/Materials/Steel>
+            double3 xformOp:translate = (-0.31, -0.185, 0.375)
+            double3 xformOp:scale = (0.030, 0.030, 0.750)
+            uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:scale"]
+        }
+
+        def Cube "LegB" (
+            prepend apiSchemas = ["MaterialBindingAPI"]
+        )
+        {
+            double size = 1
+            color3f[] primvars:displayColor = [(0.24, 0.25, 0.26)]
+            rel material:binding = </Cell/Materials/Steel>
+            double3 xformOp:translate = (0.31, -0.185, 0.375)
+            double3 xformOp:scale = (0.030, 0.030, 0.750)
+            uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:scale"]
+        }
+
+        def Cube "LegC" (
+            prepend apiSchemas = ["MaterialBindingAPI"]
+        )
+        {
+            double size = 1
+            color3f[] primvars:displayColor = [(0.24, 0.25, 0.26)]
+            rel material:binding = </Cell/Materials/Steel>
+            double3 xformOp:translate = (0.31, 0.185, 0.375)
+            double3 xformOp:scale = (0.030, 0.030, 0.750)
+            uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:scale"]
+        }
+
+        def Cube "LegD" (
+            prepend apiSchemas = ["MaterialBindingAPI"]
+        )
+        {
+            double size = 1
+            color3f[] primvars:displayColor = [(0.24, 0.25, 0.26)]
+            rel material:binding = </Cell/Materials/Steel>
+            double3 xformOp:translate = (-0.31, 0.185, 0.375)
+            double3 xformOp:scale = (0.030, 0.030, 0.750)
+            uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:scale"]
+        }
+
+        def Cube "Slot1" (
+            prepend apiSchemas = ["MaterialBindingAPI"]
+        )
+        {
+            double size = 1
+            color3f[] primvars:displayColor = [(0.85, 0.72, 0.12)]
+            rel material:binding = </Cell/Materials/SafetyYellow>
+            double3 xformOp:translate = (-0.22, 0, 0.7706)
+            double3 xformOp:scale = (0.100, 0.100, 0.001)
+            uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:scale"]
+        }
+
+        def Cube "Slot2" (
+            prepend apiSchemas = ["MaterialBindingAPI"]
+        )
+        {
+            double size = 1
+            color3f[] primvars:displayColor = [(0.85, 0.72, 0.12)]
+            rel material:binding = </Cell/Materials/SafetyYellow>
+            double3 xformOp:translate = (0, 0, 0.7706)
+            double3 xformOp:scale = (0.100, 0.100, 0.001)
+            uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:scale"]
+        }
+
+        def Cube "Slot3" (
+            prepend apiSchemas = ["MaterialBindingAPI"]
+        )
+        {
+            double size = 1
+            color3f[] primvars:displayColor = [(0.85, 0.72, 0.12)]
+            rel material:binding = </Cell/Materials/SafetyYellow>
+            double3 xformOp:translate = (0.22, 0, 0.7706)
+            double3 xformOp:scale = (0.100, 0.100, 0.001)
+            uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:scale"]
+        }
+    }
+
+    # Parts in circulation. Each carries a single matrix transform authored live by the
+    # server: the slot pose of whichever table holds it, or the gripper TCP pose while a
+    # robot carries it. The geometry sits on a child prim so the live matrix stays the only
+    # op on the part itself.
+    def Xform "Parts"
+    {
+        def Xform "Part01"
+        {
+            matrix4d xformOp:transform = ( (1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0), (-2.62, 1.2, 0.7875, 1) )
+            uniform token[] xformOpOrder = ["xformOp:transform"]
+
+            def Cube "Body" (
+                prepend apiSchemas = ["MaterialBindingAPI"]
+            )
+            {
+                double size = 1
+                color3f[] primvars:displayColor = [(0.20, 0.42, 0.62)]
+                rel material:binding = </Cell/Materials/PartBlue>
+                double3 xformOp:scale = (0.070, 0.070, 0.035)
+                uniform token[] xformOpOrder = ["xformOp:scale"]
+            }
+        }
+
+        def Xform "Part02"
+        {
+            matrix4d xformOp:transform = ( (1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0), (-2.4, 1.2, 0.7875, 1) )
+            uniform token[] xformOpOrder = ["xformOp:transform"]
+
+            def Cube "Body" (
+                prepend apiSchemas = ["MaterialBindingAPI"]
+            )
+            {
+                double size = 1
+                color3f[] primvars:displayColor = [(0.20, 0.42, 0.62)]
+                rel material:binding = </Cell/Materials/PartBlue>
+                double3 xformOp:scale = (0.070, 0.070, 0.035)
+                uniform token[] xformOpOrder = ["xformOp:scale"]
+            }
+        }
+
+        def Xform "Part03"
+        {
+            matrix4d xformOp:transform = ( (1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0), (-2.18, 1.2, 0.7875, 1) )
+            uniform token[] xformOpOrder = ["xformOp:transform"]
+
+            def Cube "Body" (
+                prepend apiSchemas = ["MaterialBindingAPI"]
+            )
+            {
+                double size = 1
+                color3f[] primvars:displayColor = [(0.20, 0.42, 0.62)]
+                rel material:binding = </Cell/Materials/PartBlue>
+                double3 xformOp:scale = (0.070, 0.070, 0.035)
+                uniform token[] xformOpOrder = ["xformOp:scale"]
+            }
+        }
+    }
+
+    # Charging docks, one in each robot's home corner. A robot whose battery falls below the
+    # threshold routes here before resuming the transfer cycle.
+    def Xform "Docks"
+    {
+        def Xform "D1"
+        {
+            double3 xformOp:translate = (-3.0, -1.6, 0)
+            uniform token[] xformOpOrder = ["xformOp:translate"]
+
+            def Cube "Pad" (
+                prepend apiSchemas = ["MaterialBindingAPI"]
+            )
+            {
+                double size = 1
+                color3f[] primvars:displayColor = [(0.16, 0.17, 0.18)]
+                rel material:binding = </Cell/Materials/CabinetGrey>
+                double3 xformOp:translate = (0, 0, 0.006)
+                double3 xformOp:scale = (0.620, 0.620, 0.012)
+                uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:scale"]
+            }
+
+            def Cube "Contact" (
+                prepend apiSchemas = ["MaterialBindingAPI"]
+            )
+            {
+                double size = 1
+                color3f[] primvars:displayColor = [(0.85, 0.72, 0.12)]
+                rel material:binding = </Cell/Materials/SafetyYellow>
+                double3 xformOp:translate = (0, 0.28, 0.070)
+                double3 xformOp:scale = (0.240, 0.040, 0.140)
+                uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:scale"]
+            }
+        }
+
+        def Xform "D2"
+        {
+            double3 xformOp:translate = (3.0, -1.6, 0)
+            uniform token[] xformOpOrder = ["xformOp:translate"]
+
+            def Cube "Pad" (
+                prepend apiSchemas = ["MaterialBindingAPI"]
+            )
+            {
+                double size = 1
+                color3f[] primvars:displayColor = [(0.16, 0.17, 0.18)]
+                rel material:binding = </Cell/Materials/CabinetGrey>
+                double3 xformOp:translate = (0, 0, 0.006)
+                double3 xformOp:scale = (0.620, 0.620, 0.012)
+                uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:scale"]
+            }
+
+            def Cube "Contact" (
+                prepend apiSchemas = ["MaterialBindingAPI"]
+            )
+            {
+                double size = 1
+                color3f[] primvars:displayColor = [(0.85, 0.72, 0.12)]
+                rel material:binding = </Cell/Materials/SafetyYellow>
+                double3 xformOp:translate = (0, 0.28, 0.070)
+                double3 xformOp:scale = (0.240, 0.040, 0.140)
+                uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:scale"]
+            }
+        }
+    }
+
+    # Painted travel lanes. Outbound traffic keeps to the northern lane and return traffic to
+    # the southern one, so two robots crossing the cell pass on opposite sides of the aisle.
+    def Xform "Lanes"
+    {
+        def Cube "Outbound" (
+            prepend apiSchemas = ["MaterialBindingAPI"]
+        )
+        {
+            double size = 1
+            color3f[] primvars:displayColor = [(0.72, 0.73, 0.74)]
+            rel material:binding = </Cell/Materials/FloorPaint>
+            double3 xformOp:translate = (0, 0.35, -0.0134)
+            double3 xformOp:scale = (5.400, 0.060, 0.002)
+            uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:scale"]
+        }
+
+        def Cube "Return" (
+            prepend apiSchemas = ["MaterialBindingAPI"]
+        )
+        {
+            double size = 1
+            color3f[] primvars:displayColor = [(0.72, 0.73, 0.74)]
+            rel material:binding = </Cell/Materials/FloorPaint>
+            double3 xformOp:translate = (0, -0.75, -0.0134)
+            double3 xformOp:scale = (5.400, 0.060, 0.002)
             uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:scale"]
         }
     }

--- a/samples/MinimalRobotServer/Assets/Cell.usda
+++ b/samples/MinimalRobotServer/Assets/Cell.usda
@@ -903,6 +903,31 @@ def Xform "Cell"
         }
     }
 
+    # The view a host opens on. A cell is a wide, shallow scene sitting inside a fence, so
+    # framing its bounds automatically puts the eye close enough to be inside the cage,
+    # looking at whichever robot happens to be nearest. This is the establishing shot: the
+    # whole floor, both work tables, the docks and the controller cabinet, from the front and
+    # far enough back to keep the fence in frame.
+    #
+    # A UsdGeomCamera looks down its own -Z with +Y up, so the matrix rows are the camera
+    # basis in world: +X right, +Y up-and-tilted-forward, +Z back along the view. The eye
+    # sits 12 m out from the cell centre at 28 degrees of elevation.
+    def Camera "OverviewCamera"
+    {
+        token projection = "perspective"
+        float focalLength = 24
+        float horizontalAperture = 20.955
+        float verticalAperture = 13.97
+        float2 clippingRange = (0.1, 200)
+        matrix4d xformOp:transform = (
+            (1, 0, 0, 0),
+            (0, 0.469472, 0.882948, 0),
+            (0, -0.882948, 0.469472, 0),
+            (0, -10.7954, 6.3837, 1)
+        )
+        uniform token[] xformOpOrder = ["xformOp:transform"]
+    }
+
     # Overhead camera framing the whole cell. Hosts can start on it by prim path.
     def Camera "TopDownCamera"
     {

--- a/samples/MinimalRobotServer/Assets/Cell.usda
+++ b/samples/MinimalRobotServer/Assets/Cell.usda
@@ -522,7 +522,7 @@ def Xform "Cell"
     # is approached from the aisle in front of it (y ~ 0.35), well inside the 1.61 m arm reach.
     def Xform "WorkTableA"
     {
-        double3 xformOp:translate = (-2.4, 1.2, 0)
+        double3 xformOp:translate = (-2.6, 1.2, 0)
         uniform token[] xformOpOrder = ["xformOp:translate"]
 
         def Cube "Top" (
@@ -626,7 +626,7 @@ def Xform "Cell"
 
     def Xform "WorkTableB"
     {
-        double3 xformOp:translate = (2.4, 1.2, 0)
+        double3 xformOp:translate = (2.6, 1.2, 0)
         uniform token[] xformOpOrder = ["xformOp:translate"]
 
         def Cube "Top" (
@@ -734,7 +734,7 @@ def Xform "Cell"
     {
         def Xform "Part01"
         {
-            matrix4d xformOp:transform = ( (1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0), (-2.62, 1.2, 0.7875, 1) )
+            matrix4d xformOp:transform = ( (1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0), (-2.82, 1.2, 0.7875, 1) )
             uniform token[] xformOpOrder = ["xformOp:transform"]
 
             def Cube "Body" (
@@ -751,7 +751,7 @@ def Xform "Cell"
 
         def Xform "Part02"
         {
-            matrix4d xformOp:transform = ( (1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0), (-2.4, 1.2, 0.7875, 1) )
+            matrix4d xformOp:transform = ( (1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0), (-2.6, 1.2, 0.7875, 1) )
             uniform token[] xformOpOrder = ["xformOp:transform"]
 
             def Cube "Body" (
@@ -768,7 +768,7 @@ def Xform "Cell"
 
         def Xform "Part03"
         {
-            matrix4d xformOp:transform = ( (1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0), (-2.18, 1.2, 0.7875, 1) )
+            matrix4d xformOp:transform = ( (1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0), (-2.38, 1.2, 0.7875, 1) )
             uniform token[] xformOpOrder = ["xformOp:transform"]
 
             def Cube "Body" (
@@ -790,7 +790,7 @@ def Xform "Cell"
     {
         def Xform "D1"
         {
-            double3 xformOp:translate = (-3.0, -1.6, 0)
+            double3 xformOp:translate = (-0.8, -2.0, 0)
             uniform token[] xformOpOrder = ["xformOp:translate"]
 
             def Cube "Pad" (
@@ -820,7 +820,7 @@ def Xform "Cell"
 
         def Xform "D2"
         {
-            double3 xformOp:translate = (3.0, -1.6, 0)
+            double3 xformOp:translate = (0.8, -2.0, 0)
             uniform token[] xformOpOrder = ["xformOp:translate"]
 
             def Cube "Pad" (
@@ -872,7 +872,7 @@ def Xform "Cell"
             double size = 1
             color3f[] primvars:displayColor = [(0.72, 0.73, 0.74)]
             rel material:binding = </Cell/Materials/FloorPaint>
-            double3 xformOp:translate = (0, -0.75, -0.0134)
+            double3 xformOp:translate = (0, -1.15, -0.0134)
             double3 xformOp:scale = (5.400, 0.060, 0.002)
             uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:scale"]
         }

--- a/samples/MinimalRobotServer/Assets/tool.usda
+++ b/samples/MinimalRobotServer/Assets/tool.usda
@@ -96,63 +96,81 @@ def Xform "Gripper" (
         uniform token[] xformOpOrder = ["xformOp:translate"]
     }
 
-    # Jaw carriers and the machined gripping fingers.
-    def Cube "CarrierUpper" (
-        prepend apiSchemas = ["MaterialBindingAPI"]
-    )
+    # Jaw carriers and the machined gripping fingers. Each jaw is one Xform so a single
+    # transform strokes the carrier and its finger together - binding the carrier alone
+    # would slide the block out from under the finger it is bolted to. Like every other
+    # live-bound prim it declares one matrix op: this file is referenced onto the flange,
+    # so any op order declared here sits in a layer weaker than the one a connector edits
+    # and could not be cleared from there. The authored pose is the fully open one, with
+    # the finger inner faces at y = +/-0.048, clearing a 70 mm part.
+    def Xform "JawUpper"
     {
-        double size = 1
-        color3f[] primvars:displayColor = [(0.16, 0.17, 0.19)]
-        rel material:binding = </Gripper/Materials/Anodised>
-        double3 xformOp:translate = (0.1080, 0.0420, 0)
-        double3 xformOp:scale = (0.0260, 0.0130, 0.0300)
-        uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:scale"]
+        matrix4d xformOp:transform = ( (1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0), (0, 0.0600, 0, 1) )
+        uniform token[] xformOpOrder = ["xformOp:transform"]
+
+        def Cube "Carrier" (
+            prepend apiSchemas = ["MaterialBindingAPI"]
+        )
+        {
+            double size = 1
+            color3f[] primvars:displayColor = [(0.16, 0.17, 0.19)]
+            rel material:binding = </Gripper/Materials/Anodised>
+            double3 xformOp:translate = (0.1080, 0, 0)
+            double3 xformOp:scale = (0.0260, 0.0130, 0.0300)
+            uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:scale"]
+        }
+
+        def Mesh "Finger" (
+            prepend apiSchemas = ["MaterialBindingAPI"]
+        )
+        {
+            uniform bool doubleSided = true
+            int[] faceVertexCounts = [4, 4, 4, 4, 4, 4]
+            int[] faceVertexIndices = [0, 1, 2, 3, 7, 6, 5, 4, 0, 4, 5, 1, 1, 5, 6, 2, 2, 6, 7, 3, 3, 7, 4, 0]
+            point3f[] points = [
+                (0.1210, -0.0120, -0.0230), (0.1900, -0.0120, -0.0170),
+                (0.1900, 0.0100, -0.0170), (0.1210, 0.0120, -0.0230),
+                (0.1210, -0.0120, 0.0230), (0.1900, -0.0120, 0.0170),
+                (0.1900, 0.0100, 0.0170), (0.1210, 0.0120, 0.0230)
+            ]
+            color3f[] primvars:displayColor = [(0.05, 0.05, 0.06)]
+            rel material:binding = </Gripper/Materials/JawBlack>
+        }
     }
 
-    def Cube "CarrierLower" (
-        prepend apiSchemas = ["MaterialBindingAPI"]
-    )
+    def Xform "JawLower"
     {
-        double size = 1
-        color3f[] primvars:displayColor = [(0.16, 0.17, 0.19)]
-        rel material:binding = </Gripper/Materials/Anodised>
-        double3 xformOp:translate = (0.1080, -0.0420, 0)
-        double3 xformOp:scale = (0.0260, 0.0130, 0.0300)
-        uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:scale"]
-    }
+        matrix4d xformOp:transform = ( (1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0), (0, -0.0600, 0, 1) )
+        uniform token[] xformOpOrder = ["xformOp:transform"]
 
-    def Mesh "FingerUpper" (
-        prepend apiSchemas = ["MaterialBindingAPI"]
-    )
-    {
-        uniform bool doubleSided = true
-        int[] faceVertexCounts = [4, 4, 4, 4, 4, 4]
-        int[] faceVertexIndices = [0, 1, 2, 3, 7, 6, 5, 4, 0, 4, 5, 1, 1, 5, 6, 2, 2, 6, 7, 3, 3, 7, 4, 0]
-        point3f[] points = [
-            (0.1210, 0.0300, -0.0230), (0.1900, 0.0300, -0.0170),
-            (0.1900, 0.0520, -0.0170), (0.1210, 0.0540, -0.0230),
-            (0.1210, 0.0300, 0.0230), (0.1900, 0.0300, 0.0170),
-            (0.1900, 0.0520, 0.0170), (0.1210, 0.0540, 0.0230)
-        ]
-        color3f[] primvars:displayColor = [(0.05, 0.05, 0.06)]
-        rel material:binding = </Gripper/Materials/JawBlack>
-    }
+        def Cube "Carrier" (
+            prepend apiSchemas = ["MaterialBindingAPI"]
+        )
+        {
+            double size = 1
+            color3f[] primvars:displayColor = [(0.16, 0.17, 0.19)]
+            rel material:binding = </Gripper/Materials/Anodised>
+            double3 xformOp:translate = (0.1080, 0, 0)
+            double3 xformOp:scale = (0.0260, 0.0130, 0.0300)
+            uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:scale"]
+        }
 
-    def Mesh "FingerLower" (
-        prepend apiSchemas = ["MaterialBindingAPI"]
-    )
-    {
-        uniform bool doubleSided = true
-        int[] faceVertexCounts = [4, 4, 4, 4, 4, 4]
-        int[] faceVertexIndices = [0, 1, 2, 3, 7, 6, 5, 4, 0, 4, 5, 1, 1, 5, 6, 2, 2, 6, 7, 3, 3, 7, 4, 0]
-        point3f[] points = [
-            (0.1210, -0.0540, -0.0230), (0.1900, -0.0520, -0.0170),
-            (0.1900, -0.0300, -0.0170), (0.1210, -0.0300, -0.0230),
-            (0.1210, -0.0540, 0.0230), (0.1900, -0.0520, 0.0170),
-            (0.1900, -0.0300, 0.0170), (0.1210, -0.0300, 0.0230)
-        ]
-        color3f[] primvars:displayColor = [(0.05, 0.05, 0.06)]
-        rel material:binding = </Gripper/Materials/JawBlack>
+        def Mesh "Finger" (
+            prepend apiSchemas = ["MaterialBindingAPI"]
+        )
+        {
+            uniform bool doubleSided = true
+            int[] faceVertexCounts = [4, 4, 4, 4, 4, 4]
+            int[] faceVertexIndices = [0, 1, 2, 3, 7, 6, 5, 4, 0, 4, 5, 1, 1, 5, 6, 2, 2, 6, 7, 3, 3, 7, 4, 0]
+            point3f[] points = [
+                (0.1210, -0.0120, -0.0230), (0.1900, -0.0100, -0.0170),
+                (0.1900, 0.0120, -0.0170), (0.1210, 0.0120, -0.0230),
+                (0.1210, -0.0120, 0.0230), (0.1900, -0.0100, 0.0170),
+                (0.1900, 0.0120, 0.0170), (0.1210, 0.0120, 0.0230)
+            ]
+            color3f[] primvars:displayColor = [(0.05, 0.05, 0.06)]
+            rel material:binding = </Gripper/Materials/JawBlack>
+        }
     }
 
     # Pneumatic feed to the drive.

--- a/samples/MinimalRobotServer/CellChoreographer.cs
+++ b/samples/MinimalRobotServer/CellChoreographer.cs
@@ -1,0 +1,786 @@
+/* ========================================================================
+ * Copyright (c) 2005-2026 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using System.Collections.Generic;
+
+namespace Robotics
+{
+    /// <summary>
+    /// Drives the two robots through a coordinated transfer cycle without letting them
+    /// collide.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The cell is divided into two end zones and a shared corridor with one lane per
+    /// direction of travel. A robot reserves the zone it is about to enter before it moves
+    /// into it, and releases the zone behind it once it has left. An end zone admits one
+    /// robot, so a deployed arm always has its half of the cell to itself; a corridor lane
+    /// also admits one robot, so two robots travelling opposite ways pass on opposite sides
+    /// of the aisle while two travelling the same way queue instead of overtaking.
+    /// </para>
+    /// <para>
+    /// The arm must be folded into its transport envelope before a corridor lane can be
+    /// reserved, which is what stops the arms sweeping through each other - the failure the
+    /// previous free-running figure-eight paths had, where the platforms cleared by 1.2 m
+    /// but the arms reach 1.61 m.
+    /// </para>
+    /// <para>
+    /// Everything here is deterministic and driven by an explicit time step, so the tests
+    /// can run a full cycle and assert the separation and reservation invariants directly.
+    /// </para>
+    /// </remarks>
+    public sealed class CellChoreographer
+    {
+        private const double CruiseSpeed = 0.85;
+        private const double Acceleration = 0.7;
+        private const double ArrivalTolerance = 0.005;
+        private const double GripSeconds = 0.7;
+        private const double DwellSeconds = 0.4;
+        private const double ProximitySlowdownDistance = 2.0;
+        private const double SlowSpeed = 0.3;
+        private const double BatteryDrainPerMetre = 0.35;
+        private const double BatteryDrainPerSecond = 0.01;
+        private const double ChargeRatePerSecond = 6.0;
+        private const double ChargeThreshold = 25.0;
+        private const double PartHeightOffset = 0.0175;
+
+        private readonly List<RobotAgent> m_robots;
+        private readonly List<CellPart> m_parts;
+        private readonly Dictionary<CellZone, string> m_reservations = [];
+        private readonly Random m_random;
+        private readonly double m_faultProbability;
+        private double m_now;
+
+        /// <summary>
+        /// Creates the choreographer with three parts staged on table A.
+        /// </summary>
+        /// <param name="seed">Seed for the fault injection, so runs are reproducible.</param>
+        /// <param name="faultProbability">
+        /// The chance that a grip slips and drops the part, from 0 to 1.
+        /// </param>
+        public CellChoreographer(int seed = 20260801, double faultProbability = 0.06)
+        {
+            m_random = new Random(seed);
+            m_faultProbability = faultProbability;
+            m_robots =
+            [
+                new RobotAgent("R1", CellStation.TableA, CellStation.TableB,
+                    CellLayout.DockD1X, CellLayout.TableAX),
+                new RobotAgent("R2", CellStation.TableB, CellStation.TableA,
+                    CellLayout.DockD2X, CellLayout.TableBX)
+            ];
+            m_parts =
+            [
+                new CellPart("Part01", CellStation.TableA, 0),
+                new CellPart("Part02", CellStation.TableA, 1),
+                new CellPart("Part03", CellStation.TableA, 2)
+            ];
+            foreach (RobotAgent robot in m_robots)
+            {
+                robot.HeldZone = ZoneAt(robot.X, robot.Y);
+                m_reservations[robot.HeldZone] = robot.Id;
+            }
+        }
+
+        /// <summary>
+        /// The robots in the cell.
+        /// </summary>
+        public IReadOnlyList<RobotAgent> Robots => m_robots;
+
+        /// <summary>
+        /// The parts circulating in the cell.
+        /// </summary>
+        public IReadOnlyList<CellPart> Parts => m_parts;
+
+        /// <summary>
+        /// The cell performance counters.
+        /// </summary>
+        public CellKpis Kpis { get; } = new();
+
+        /// <summary>
+        /// Whether the emergency stop is asserted, which halts all motion.
+        /// </summary>
+        public bool EmergencyStop { get; set; }
+
+        /// <summary>
+        /// The robot holding the eastbound corridor lane, or <c>null</c>.
+        /// </summary>
+        public string? EastboundLaneOwner =>
+            m_reservations.TryGetValue(CellZone.CorridorEastbound, out string? owner)
+                ? owner
+                : null;
+
+        /// <summary>
+        /// The robot holding the westbound corridor lane, or <c>null</c>.
+        /// </summary>
+        public string? WestboundLaneOwner =>
+            m_reservations.TryGetValue(CellZone.CorridorWestbound, out string? owner)
+                ? owner
+                : null;
+
+        /// <summary>
+        /// Advances the whole cell by one time step.
+        /// </summary>
+        /// <param name="deltaSeconds">The step, in seconds.</param>
+        public void Advance(double deltaSeconds)
+        {
+            if (deltaSeconds <= 0.0)
+            {
+                return;
+            }
+            m_now += deltaSeconds;
+            Kpis.ElapsedSeconds += deltaSeconds;
+
+            foreach (RobotAgent robot in m_robots)
+            {
+                if (EmergencyStop)
+                {
+                    robot.Speed = 0.0;
+                    continue;
+                }
+                AdvanceRobot(robot, deltaSeconds);
+                if (robot.State is not (RobotCycleState.Idle or RobotCycleState.Blocked))
+                {
+                    Kpis.BusySeconds += deltaSeconds / m_robots.Count;
+                }
+            }
+
+            Kpis.Utilisation = Kpis.ElapsedSeconds > 0.0
+                ? Kpis.BusySeconds / Kpis.ElapsedSeconds
+                : 0.0;
+            UpdateCarriedParts();
+        }
+
+        /// <summary>
+        /// Returns the pose of a robot's tool centre point.
+        /// </summary>
+        /// <param name="robot">The robot.</param>
+        /// <returns>The tool centre point pose in cell coordinates.</returns>
+        public static RigidTransform ToolCentrePointOf(RobotAgent robot)
+        {
+            if (robot == null)
+            {
+                throw new ArgumentNullException(nameof(robot));
+            }
+            RigidTransform mount = RobotKinematics.CreateMountPose(
+                robot.X, robot.Y, 0.0, robot.HeadingDegrees);
+            return RobotKinematics.ComputeToolCentrePoint(mount, robot.Axes);
+        }
+
+        /// <summary>
+        /// Returns the zone a position belongs to.
+        /// </summary>
+        /// <param name="x">The X position, in metres.</param>
+        /// <param name="y">The Y position, in metres.</param>
+        /// <returns>The zone.</returns>
+        public static CellZone ZoneAt(double x, double y)        {
+            // A dock is its own zone. A robot with no work parks there and releases the end
+            // zone, so the station stays free for the other robot to deliver into - without
+            // that, an idle robot standing next to its table deadlocks the whole cell.
+            if (IsNear(x, y, CellLayout.DockD1X, CellLayout.DockY))
+            {
+                return CellZone.DockA;
+            }
+            if (IsNear(x, y, CellLayout.DockD2X, CellLayout.DockY))
+            {
+                return CellZone.DockB;
+            }
+            if (x < -CellLayout.CorridorHalfWidthX)
+            {
+                return CellZone.EndZoneA;
+            }
+            if (x > CellLayout.CorridorHalfWidthX)
+            {
+                return CellZone.EndZoneB;
+            }
+            return y > (CellLayout.EastboundLaneY + CellLayout.WestboundLaneY) / 2.0
+                ? CellZone.CorridorEastbound
+                : CellZone.CorridorWestbound;
+        }
+
+        private static bool IsNear(double x, double y, double atX, double atY)
+        {
+            const double dockRadius = 0.45;
+            double dx = x - atX;
+            double dy = y - atY;
+            return ((dx * dx) + (dy * dy)) <= (dockRadius * dockRadius);
+        }
+
+        /// <summary>
+        /// Whether two robots' footprints intersect, by the separating axis test over their
+        /// oriented boxes.
+        /// </summary>
+        /// <param name="a">The first robot.</param>
+        /// <param name="b">The second robot.</param>
+        /// <returns><c>true</c> when the footprints overlap.</returns>
+        public static bool FootprintsOverlap(RobotAgent a, RobotAgent b)
+        {
+            if (a == null)
+            {
+                throw new ArgumentNullException(nameof(a));
+            }
+            if (b == null)
+            {
+                throw new ArgumentNullException(nameof(b));
+            }
+
+            (double ax, double ay, double ahl, double ahw, double ah) = a.Footprint;
+            (double bx, double by, double bhl, double bhw, double bh) = b.Footprint;
+            double[] axes =
+            [
+                ah, ah + 90.0, bh, bh + 90.0
+            ];
+
+            foreach (double axisDegrees in axes)
+            {
+                double r = axisDegrees * (Math.PI / 180.0);
+                double nx = Math.Cos(r);
+                double ny = Math.Sin(r);
+                double centreGap = Math.Abs(((bx - ax) * nx) + ((by - ay) * ny));
+                double spread = Project(ahl, ahw, ah, nx, ny) + Project(bhl, bhw, bh, nx, ny);
+                if (centreGap > spread)
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        private static double Project(
+            double halfLength,
+            double halfWidth,
+            double headingDegrees,
+            double nx,
+            double ny)
+        {
+            double r = headingDegrees * (Math.PI / 180.0);
+            double ux = Math.Cos(r);
+            double uy = Math.Sin(r);
+            return (halfLength * Math.Abs((ux * nx) + (uy * ny))) +
+                (halfWidth * Math.Abs((-uy * nx) + (ux * ny)));
+        }
+
+        private void AdvanceRobot(RobotAgent robot, double dt)
+        {
+            DrainBattery(robot, dt);
+
+            if (robot.DwellRemaining > 0.0)
+            {
+                robot.DwellRemaining -= dt;
+                robot.Speed = 0.0;
+                return;
+            }
+
+            switch (robot.State)
+            {
+                case RobotCycleState.Idle:
+                    BeginNextCycle(robot);
+                    break;
+                case RobotCycleState.Blocked:
+                case RobotCycleState.TravelToSource:
+                case RobotCycleState.TravelToTarget:
+                case RobotCycleState.TravelToDock:
+                    Travel(robot, dt);
+                    break;
+                case RobotCycleState.ReachToSource:
+                case RobotCycleState.ReachToTarget:
+                    Reach(robot, dt);
+                    break;
+                case RobotCycleState.Grip:
+                    ActuateGripper(robot, dt, closing: true);
+                    break;
+                case RobotCycleState.Release:
+                    ActuateGripper(robot, dt, closing: false);
+                    break;
+                case RobotCycleState.Lift:
+                case RobotCycleState.Retreat:
+                    Stow(robot, dt);
+                    break;
+                case RobotCycleState.Charging:
+                    Charge(robot, dt);
+                    break;
+                default:
+                    robot.State = RobotCycleState.Idle;
+                    break;
+            }
+        }
+
+        private void BeginNextCycle(RobotAgent robot)
+        {
+            robot.Speed = 0.0;
+            CellPart? part = FindCollectablePart(robot);
+            if (part == null || robot.NeedsCharge)
+            {
+                // Nothing to collect, or the battery is low: park on the dock. This also
+                // releases the end zone, so the other robot can deliver into the station
+                // this robot serves.
+                if (ZoneAt(robot.X, robot.Y) != DockZoneOf(robot))
+                {
+                    RouteTo(robot, robot.DockX, CellLayout.DockY);
+                    robot.State = RobotCycleState.TravelToDock;
+                }
+                return;
+            }
+
+            robot.TargetSlot = part.Slot;
+            robot.CycleStartedAt = m_now;
+            double approachX = StationX(robot.Source);
+            RouteTo(robot, approachX, CellLayout.TableApproachY);
+            robot.State = RobotCycleState.TravelToSource;
+        }
+
+        private static CellZone DockZoneOf(RobotAgent robot)
+        {
+            return robot.DockX < 0.0 ? CellZone.DockA : CellZone.DockB;
+        }
+
+        private CellPart? FindCollectablePart(RobotAgent robot)
+        {
+            CellPart? best = null;
+            foreach (CellPart part in m_parts)
+            {
+                if (!part.IsResting || part.OnFloor || part.Station != robot.Source)
+                {
+                    continue;
+                }
+                if (best == null || part.Slot < best.Slot)
+                {
+                    best = part;
+                }
+            }
+            return best;
+        }
+
+        private void Travel(RobotAgent robot, double dt)
+        {
+            if (robot.Waypoints.Count == 0)
+            {
+                ArriveFromTravel(robot);
+                return;
+            }
+
+            (double targetX, double targetY) = robot.Waypoints.Peek();
+            double dx = targetX - robot.X;
+            double dy = targetY - robot.Y;
+            double distance = Math.Sqrt((dx * dx) + (dy * dy));
+            if (distance <= ArrivalTolerance)
+            {
+                robot.X = targetX;
+                robot.Y = targetY;
+                _ = robot.Waypoints.Dequeue();
+                if (robot.Waypoints.Count == 0)
+                {
+                    robot.Speed = 0.0;
+                    ArriveFromTravel(robot);
+                }
+                return;
+            }
+
+            // Reserve the zone immediately ahead, not the zone of the final waypoint: a robot
+            // travelling from one end of the cell to the other passes through the corridor,
+            // and demanding the far end zone up front would have each robot waiting on the
+            // zone the other is standing in.
+            const double lookahead = 0.35;
+            double nextX = robot.X + (dx / distance * lookahead);
+            double nextY = robot.Y + (dy / distance * lookahead);
+            CellZone next = ZoneAt(nextX, nextY);
+            if (next != robot.HeldZone && !EnsureReservation(robot, next))
+            {
+                robot.Speed = 0.0;
+                if (robot.State != RobotCycleState.Blocked)
+                {
+                    robot.ResumeState = robot.State;
+                    robot.State = RobotCycleState.Blocked;
+                }
+                return;
+            }
+            if (robot.State == RobotCycleState.Blocked)
+            {
+                robot.State = robot.ResumeState;
+            }
+            robot.BlockedBy = null;
+
+            double limit = SpeedLimitFor(robot);
+            double braking = (robot.Speed * robot.Speed) / (2.0 * Acceleration);
+            robot.Speed = distance <= braking
+                ? Math.Max(0.05, robot.Speed - (Acceleration * dt))
+                : Math.Min(limit, robot.Speed + (Acceleration * dt));
+
+            double step = Math.Min(robot.Speed * dt, distance);
+            robot.X += dx / distance * step;
+            robot.Y += dy / distance * step;
+            robot.DistanceTravelled += step;
+            robot.HeadingDegrees = Math.Atan2(dy, dx) * (180.0 / Math.PI);
+
+            CellZone occupied = ZoneAt(robot.X, robot.Y);
+            if (occupied == robot.ReservedZone && occupied != robot.HeldZone)
+            {
+                ReleaseZone(robot.HeldZone, robot.Id);
+                robot.HeldZone = occupied;
+                robot.ReservedZone = CellZone.None;
+            }
+        }
+
+        private void ArriveFromTravel(RobotAgent robot)
+        {
+            robot.Speed = 0.0;
+            robot.HeadingDegrees = 90.0;
+            switch (robot.State)
+            {
+                case RobotCycleState.TravelToSource:
+                    robot.State = RobotCycleState.ReachToSource;
+                    break;
+                case RobotCycleState.TravelToTarget:
+                    robot.State = RobotCycleState.ReachToTarget;
+                    break;
+                case RobotCycleState.TravelToDock:
+                    robot.State = robot.NeedsCharge
+                        ? RobotCycleState.Charging
+                        : RobotCycleState.Idle;
+                    break;
+                default:
+                    robot.State = RobotCycleState.Idle;
+                    break;
+            }
+        }
+
+        private void Reach(RobotAgent robot, double dt)
+        {
+            bool toSource = robot.State == RobotCycleState.ReachToSource;
+            CellStation station = toSource ? robot.Source : robot.Target;
+            int slot = toSource ? robot.TargetSlot : FirstFreeSlot(station);
+            robot.TargetSlot = slot;
+
+            (double slotX, double slotY, double slotZ) = CellLayout.SlotPosition(station, slot);
+            CellPart? floorPart = toSource ? FindFloorPart(robot) : null;
+            if (floorPart != null)
+            {
+                slotX = floorPart.X;
+                slotY = floorPart.Y;
+                slotZ = floorPart.Z;
+            }
+
+            double forward = slotY - robot.Y;
+            double lateral = -(slotX - robot.X);
+            var solved = new double[RobotKinematics.AxisCount];
+            if (!RobotArmSolver.TrySolve(forward, lateral, slotZ, solved))
+            {
+                robot.State = RobotCycleState.Idle;
+                return;
+            }
+
+            robot.ArmStowed = false;
+            if (!StepAxesTowards(robot, solved, dt))
+            {
+                return;
+            }
+            robot.State = toSource ? RobotCycleState.Grip : RobotCycleState.Release;
+            robot.DwellRemaining = DwellSeconds;
+        }
+
+        private void ActuateGripper(RobotAgent robot, double dt, bool closing)
+        {
+            double rate = dt / GripSeconds;
+            robot.GripperOpening = closing
+                ? Math.Max(0.0, robot.GripperOpening - rate)
+                : Math.Min(1.0, robot.GripperOpening + rate);
+
+            if (closing && robot.GripperOpening <= 0.0)
+            {
+                CellPart? part = FindFloorPart(robot) ?? FindCollectablePart(robot);
+                if (part != null)
+                {
+                    part.CarriedBy = robot.Id;
+                    part.OnFloor = false;
+                    robot.HoldingPart = part.Id;
+                }
+                robot.State = RobotCycleState.Lift;
+                robot.DwellRemaining = DwellSeconds;
+                return;
+            }
+            if (!closing && robot.GripperOpening >= 1.0)
+            {
+                CellPart? part = FindCarriedPart(robot);
+                if (part != null)
+                {
+                    part.CarriedBy = null;
+                    part.Station = robot.Target;
+                    part.Slot = robot.TargetSlot;
+                    (part.X, part.Y, part.Z) =
+                        CellLayout.SlotPosition(part.Station, part.Slot);
+                    part.HeadingDegrees = 0.0;
+                    CompleteCycle(robot);
+                }
+                robot.HoldingPart = null;
+                robot.State = RobotCycleState.Retreat;
+                robot.DwellRemaining = DwellSeconds;
+            }
+        }
+
+        private void Stow(RobotAgent robot, double dt)
+        {
+            if (!StepAxesTowards(robot, RobotAgent.TransportPose, dt))
+            {
+                return;
+            }
+            robot.ArmStowed = true;
+
+            if (robot.State == RobotCycleState.Lift)
+            {
+                // A seeded, non-cryptographic generator is exactly what is wanted here: the
+                // injected grip faults have to be reproducible so a test can assert the
+                // recovery path deterministically.
+#pragma warning disable CA5394 // Do not use insecure randomness
+                bool slipped = m_random.NextDouble() < m_faultProbability;
+#pragma warning restore CA5394
+                if (robot.HoldingPart != null && slipped)
+                {
+                    DropPart(robot);
+                    robot.State = RobotCycleState.ReachToSource;
+                    return;
+                }
+                RouteTo(robot, StationX(robot.Target), CellLayout.TableApproachY);
+                robot.State = RobotCycleState.TravelToTarget;
+                return;
+            }
+
+            robot.State = RobotCycleState.Idle;
+        }
+
+        private void DropPart(RobotAgent robot)
+        {
+            CellPart? part = FindCarriedPart(robot);
+            if (part == null)
+            {
+                return;
+            }
+            part.CarriedBy = null;
+            part.OnFloor = true;
+            part.X = robot.X;
+            part.Y = robot.Y + 0.85;
+            part.Z = PartHeightOffset;
+            robot.HoldingPart = null;
+            robot.GripperOpening = 1.0;
+            Kpis.FaultCount++;
+        }
+
+        private void Charge(RobotAgent robot, double dt)
+        {
+            robot.Speed = 0.0;
+            robot.BatteryLevel = Math.Min(100.0, robot.BatteryLevel + (ChargeRatePerSecond * dt));
+            if (robot.BatteryLevel >= 99.9)
+            {
+                robot.NeedsCharge = false;
+                robot.State = RobotCycleState.Idle;
+            }
+        }
+
+        private void CompleteCycle(RobotAgent robot)
+        {
+            double duration = m_now - robot.CycleStartedAt;
+            Kpis.PartsMoved++;
+            Kpis.CycleCount++;
+            Kpis.LastCycleSeconds = duration;
+            Kpis.TotalCycleSeconds += duration;
+            Kpis.AverageCycleSeconds = Kpis.TotalCycleSeconds / Kpis.CycleCount;
+            if (robot.BatteryLevel < ChargeThreshold)
+            {
+                robot.NeedsCharge = true;
+            }
+        }
+
+        private void DrainBattery(RobotAgent robot, double dt)
+        {
+            if (robot.State == RobotCycleState.Charging)
+            {
+                return;
+            }
+            double drain = (BatteryDrainPerSecond * dt) +
+                (BatteryDrainPerMetre * robot.Speed * dt);
+            robot.BatteryLevel = Math.Max(0.0, robot.BatteryLevel - drain);
+        }
+
+        private double SpeedLimitFor(RobotAgent robot)
+        {
+            foreach (RobotAgent other in m_robots)
+            {
+                if (ReferenceEquals(other, robot))
+                {
+                    continue;
+                }
+                double dx = other.X - robot.X;
+                double dy = other.Y - robot.Y;
+                if (Math.Sqrt((dx * dx) + (dy * dy)) < ProximitySlowdownDistance)
+                {
+                    return SlowSpeed;
+                }
+            }
+            return CruiseSpeed;
+        }
+
+        private static bool StepAxesTowards(RobotAgent robot, double[] goal, double dt)
+        {
+            const double axisSpeed = 90.0;
+            bool settled = true;
+            for (int i = 0; i < robot.Axes.Length; i++)
+            {
+                double delta = goal[i] - robot.Axes[i];
+                double step = axisSpeed * dt;
+                if (Math.Abs(delta) <= step)
+                {
+                    robot.Axes[i] = goal[i];
+                    continue;
+                }
+                robot.Axes[i] += Math.Sign(delta) * step;
+                settled = false;
+            }
+            return settled;
+        }
+
+        private void RouteTo(RobotAgent robot, double destinationX, double destinationY)
+        {
+            robot.Waypoints.Clear();
+            bool eastbound = destinationX > robot.X;
+            double laneY = eastbound ? CellLayout.EastboundLaneY : CellLayout.WestboundLaneY;
+
+            if (Math.Abs(robot.Y - laneY) > ArrivalTolerance)
+            {
+                robot.Waypoints.Enqueue((robot.X, laneY));
+            }
+            robot.Waypoints.Enqueue((destinationX, laneY));
+            if (Math.Abs(destinationY - laneY) > ArrivalTolerance)
+            {
+                robot.Waypoints.Enqueue((destinationX, destinationY));
+            }
+        }
+
+        private bool EnsureReservation(RobotAgent robot, CellZone zone)
+        {
+            if (zone == CellZone.None || zone == robot.HeldZone)
+            {
+                return true;
+            }
+            if (robot.ReservedZone == zone)
+            {
+                return true;
+            }
+            bool corridor = zone is CellZone.CorridorEastbound or CellZone.CorridorWestbound;
+            if (corridor && !robot.ArmStowed)
+            {
+                robot.BlockedBy = robot.Id;
+                return false;
+            }
+            if (m_reservations.TryGetValue(zone, out string? owner) && owner != robot.Id)
+            {
+                robot.BlockedBy = owner;
+                return false;
+            }
+            m_reservations[zone] = robot.Id;
+            robot.ReservedZone = zone;
+            return true;
+        }
+
+        private void ReleaseZone(CellZone zone, string robotId)
+        {
+            if (zone != CellZone.None &&
+                m_reservations.TryGetValue(zone, out string? owner) &&
+                owner == robotId)
+            {
+                _ = m_reservations.Remove(zone);
+            }
+        }
+
+        private CellPart? FindCarriedPart(RobotAgent robot)
+        {
+            foreach (CellPart part in m_parts)
+            {
+                if (part.CarriedBy == robot.Id)
+                {
+                    return part;
+                }
+            }
+            return null;
+        }
+
+        private CellPart? FindFloorPart(RobotAgent robot)
+        {
+            foreach (CellPart part in m_parts)
+            {
+                if (part.OnFloor && Math.Abs(part.X - robot.X) < 1.0)
+                {
+                    return part;
+                }
+            }
+            return null;
+        }
+
+        private int FirstFreeSlot(CellStation station)
+        {
+            int count = CellLayout.SlotOffsetsX.Length;
+            var taken = new bool[count];
+            foreach (CellPart part in m_parts)
+            {
+                if (part.IsResting && !part.OnFloor && part.Station == station &&
+                    part.Slot >= 0 && part.Slot < count)
+                {
+                    taken[part.Slot] = true;
+                }
+            }
+            for (int i = 0; i < count; i++)
+            {
+                if (!taken[i])
+                {
+                    return i;
+                }
+            }
+            return 0;
+        }
+
+        private void UpdateCarriedParts()
+        {
+            foreach (RobotAgent robot in m_robots)
+            {
+                CellPart? part = FindCarriedPart(robot);
+                if (part == null)
+                {
+                    continue;
+                }
+                RigidTransform tcp = ToolCentrePointOf(robot);
+                (part.X, part.Y, part.Z) = tcp.Origin;
+                part.HeadingDegrees = robot.HeadingDegrees;
+            }
+        }
+
+        private static double StationX(CellStation station)
+        {
+            return station == CellStation.TableA ? CellLayout.TableAX : CellLayout.TableBX;
+        }
+    }
+}

--- a/samples/MinimalRobotServer/CellChoreographer.cs
+++ b/samples/MinimalRobotServer/CellChoreographer.cs
@@ -77,6 +77,7 @@ namespace Robotics
         private readonly Random m_random;
         private readonly double m_faultProbability;
         private double m_now;
+        private long m_restingSequence;
 
         /// <summary>
         /// Creates the choreographer with the cell staged warm: parts waiting on both
@@ -104,6 +105,10 @@ namespace Robotics
                 new CellPart("Part02", CellStation.TableA, 1),
                 new CellPart("Part03", CellStation.TableB, 0)
             ];
+            foreach (CellPart part in m_parts)
+            {
+                part.RestingSequence = ++m_restingSequence;
+            }
             foreach (RobotAgent robot in m_robots)
             {
                 robot.HeldZone = ZoneAt(robot.X, robot.Y);
@@ -372,7 +377,7 @@ namespace Robotics
                 {
                     continue;
                 }
-                if (best == null || part.Slot < best.Slot)
+                if (best == null || part.RestingSequence < best.RestingSequence)
                 {
                     best = part;
                 }
@@ -535,6 +540,7 @@ namespace Robotics
                     part.CarriedBy = null;
                     part.Station = robot.Target;
                     part.Slot = robot.TargetSlot;
+                    part.RestingSequence = ++m_restingSequence;
                     (part.X, part.Y, part.Z) =
                         CellLayout.SlotPosition(part.Station, part.Slot);
                     part.HeadingDegrees = 0.0;

--- a/samples/MinimalRobotServer/CellChoreographer.cs
+++ b/samples/MinimalRobotServer/CellChoreographer.cs
@@ -79,7 +79,9 @@ namespace Robotics
         private double m_now;
 
         /// <summary>
-        /// Creates the choreographer with three parts staged on table A.
+        /// Creates the choreographer with the cell staged warm: parts waiting on both
+        /// stations, so each robot has work from the first tick instead of one of them idling
+        /// until the other completes a full traverse.
         /// </summary>
         /// <param name="seed">Seed for the fault injection, so runs are reproducible.</param>
         /// <param name="faultProbability">
@@ -100,7 +102,7 @@ namespace Robotics
             [
                 new CellPart("Part01", CellStation.TableA, 0),
                 new CellPart("Part02", CellStation.TableA, 1),
-                new CellPart("Part03", CellStation.TableA, 2)
+                new CellPart("Part03", CellStation.TableB, 0)
             ];
             foreach (RobotAgent robot in m_robots)
             {

--- a/samples/MinimalRobotServer/CellChoreographer.cs
+++ b/samples/MinimalRobotServer/CellChoreographer.cs
@@ -29,6 +29,7 @@
 
 using System;
 using System.Collections.Generic;
+using Opc.Ua;
 
 namespace Robotics
 {
@@ -653,7 +654,7 @@ namespace Robotics
             return CruiseSpeed;
         }
 
-        private static bool StepAxesTowards(RobotAgent robot, double[] goal, double dt)
+        private static bool StepAxesTowards(RobotAgent robot, ArrayOf<double> goal, double dt)
         {
             const double axisSpeed = 90.0;
             bool settled = true;
@@ -751,7 +752,7 @@ namespace Robotics
 
         private int FirstFreeSlot(CellStation station)
         {
-            int count = CellLayout.SlotOffsetsX.Length;
+            int count = CellLayout.SlotOffsetsX.Count;
             var taken = new bool[count];
             foreach (CellPart part in m_parts)
             {

--- a/samples/MinimalRobotServer/CellLayout.cs
+++ b/samples/MinimalRobotServer/CellLayout.cs
@@ -1,0 +1,256 @@
+/* ========================================================================
+ * Copyright (c) 2005-2026 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+namespace Robotics
+{
+    /// <summary>
+    /// Fixed geometry of the sample cell, matching the prims authored in
+    /// <c>Cell.usda</c>.
+    /// </summary>
+    /// <remarks>
+    /// The separations here are what make the cell collision free, so they are stated once
+    /// and asserted by the choreography tests rather than being spread through the code.
+    /// </remarks>
+    public static class CellLayout
+    {
+        /// <summary>
+        /// The X position of the western transfer station, in metres.
+        /// </summary>
+        public const double TableAX = -2.6;
+
+        /// <summary>
+        /// The X position of the eastern transfer station, in metres.
+        /// </summary>
+        public const double TableBX = 2.6;
+
+        /// <summary>
+        /// The Y position of both transfer stations, in metres.
+        /// </summary>
+        public const double TableY = 1.2;
+
+        /// <summary>
+        /// The height of a table top's surface, in metres.
+        /// </summary>
+        public const double TableSurfaceZ = 0.770;
+
+        /// <summary>
+        /// The X offsets of the three part slots on a table, in metres.
+        /// </summary>
+        public static double[] SlotOffsetsX => [-0.22, 0.0, 0.22];
+
+        /// <summary>
+        /// The Y position a robot parks at to work a table, in metres.
+        /// </summary>
+        public const double TableApproachY = 0.35;
+
+        /// <summary>
+        /// The Y position of the eastbound travel lane, in metres.
+        /// </summary>
+        public const double EastboundLaneY = 0.35;
+
+        /// <summary>
+        /// The Y position of the westbound travel lane, in metres.
+        /// </summary>
+        public const double WestboundLaneY = -1.15;
+
+        /// <summary>
+        /// The half width of the shared corridor along X, in metres.
+        /// </summary>
+        /// <remarks>
+        /// Everything beyond this on either side is an end zone, which only one robot may
+        /// occupy. A robot working a table at <see cref="TableAX"/> keeps its arm within
+        /// <see cref="DeployedArmHalfWidthX"/>, so a deployed arm never reaches the corridor.
+        /// </remarks>
+        public const double CorridorHalfWidthX = 1.3;
+
+        /// <summary>
+        /// The bounding radius of the platform with the arm folded for transport, in metres.
+        /// </summary>
+        public const double TransportRadius = 0.65;
+
+        /// <summary>
+        /// The furthest a deployed arm is allowed to reach along X from its platform, in
+        /// metres.
+        /// </summary>
+        public const double DeployedArmHalfWidthX = 0.45;
+
+        /// <summary>
+        /// The X position of the western charging dock, in metres.
+        /// </summary>
+        public const double DockD1X = -0.8;
+
+        /// <summary>
+        /// The X position of the eastern charging dock, in metres.
+        /// </summary>
+        public const double DockD2X = 0.8;
+
+        /// <summary>
+        /// The Y position of both charging docks, in metres.
+        /// </summary>
+        public const double DockY = -2.0;
+
+        /// <summary>
+        /// Returns the cell position of a part resting in a table slot.
+        /// </summary>
+        /// <param name="table">The station the slot belongs to.</param>
+        /// <param name="slot">The zero based slot index.</param>
+        /// <returns>The slot centre, in metres.</returns>
+        public static (double X, double Y, double Z) SlotPosition(CellStation table, int slot)
+        {
+            double[] offsets = SlotOffsetsX;
+            int index = slot < 0 ? 0 : slot % offsets.Length;
+            double tableX = table == CellStation.TableA ? TableAX : TableBX;
+            return (tableX + offsets[index], TableY, TableSurfaceZ + 0.0175);
+        }
+    }
+
+    /// <summary>
+    /// The transfer stations a part can rest on.
+    /// </summary>
+    public enum CellStation
+    {
+        /// <summary>
+        /// The western station.
+        /// </summary>
+        TableA,
+
+        /// <summary>
+        /// The eastern station.
+        /// </summary>
+        TableB
+    }
+
+    /// <summary>
+    /// The exclusive areas of the cell a robot has to reserve before entering.
+    /// </summary>
+    public enum CellZone
+    {
+        /// <summary>
+        /// No reservation held.
+        /// </summary>
+        None,
+
+        /// <summary>
+        /// The western end of the cell, including table A.
+        /// </summary>
+        EndZoneA,
+
+        /// <summary>
+        /// The eastbound lane of the shared corridor.
+        /// </summary>
+        CorridorEastbound,
+
+        /// <summary>
+        /// The westbound lane of the shared corridor.
+        /// </summary>
+        CorridorWestbound,
+
+        /// <summary>
+        /// The eastern end of the cell, including table B.
+        /// </summary>
+        EndZoneB,
+
+        /// <summary>
+        /// The western charging dock, which sits clear of table A's working area so a robot
+        /// waiting for work does not block the station.
+        /// </summary>
+        DockA,
+
+        /// <summary>
+        /// The eastern charging dock, which sits clear of table B's working area.
+        /// </summary>
+        DockB
+    }
+
+    /// <summary>
+    /// The step a robot is currently performing.
+    /// </summary>
+    public enum RobotCycleState
+    {
+        /// <summary>
+        /// Waiting for work.
+        /// </summary>
+        Idle,
+
+        /// <summary>
+        /// Waiting for a zone reservation another robot holds.
+        /// </summary>
+        Blocked,
+
+        /// <summary>
+        /// Driving to the station it collects from.
+        /// </summary>
+        TravelToSource,
+
+        /// <summary>
+        /// Reaching the arm over the source slot.
+        /// </summary>
+        ReachToSource,
+
+        /// <summary>
+        /// Closing the jaws on the part.
+        /// </summary>
+        Grip,
+
+        /// <summary>
+        /// Lifting the part clear and folding the arm for transport.
+        /// </summary>
+        Lift,
+
+        /// <summary>
+        /// Driving to the station it delivers to.
+        /// </summary>
+        TravelToTarget,
+
+        /// <summary>
+        /// Reaching the arm over the target slot.
+        /// </summary>
+        ReachToTarget,
+
+        /// <summary>
+        /// Opening the jaws to release the part.
+        /// </summary>
+        Release,
+
+        /// <summary>
+        /// Folding the arm back for transport.
+        /// </summary>
+        Retreat,
+
+        /// <summary>
+        /// Driving to the charging dock.
+        /// </summary>
+        TravelToDock,
+
+        /// <summary>
+        /// Sitting on the dock taking charge.
+        /// </summary>
+        Charging
+    }
+}

--- a/samples/MinimalRobotServer/CellLayout.cs
+++ b/samples/MinimalRobotServer/CellLayout.cs
@@ -27,6 +27,8 @@
  * http://opcfoundation.org/License/MIT/1.00/
  * ======================================================================*/
 
+using Opc.Ua;
+
 namespace Robotics
 {
     /// <summary>
@@ -62,7 +64,13 @@ namespace Robotics
         /// <summary>
         /// The X offsets of the three part slots on a table, in metres.
         /// </summary>
-        public static double[] SlotOffsetsX => [-0.22, 0.0, 0.22];
+        /// <remarks>
+        /// Held as a single immutable value rather than rebuilt per access: slot positions
+        /// are resolved throughout the simulation, and an <c>ArrayOf</c> can be shared
+        /// safely where a cached <c>double[]</c> would hand every caller a writable
+        /// reference to the one copy.
+        /// </remarks>
+        public static ArrayOf<double> SlotOffsetsX { get; } = new double[] { -0.22, 0.0, 0.22 };
 
         /// <summary>
         /// The Y position a robot parks at to work a table, in metres.
@@ -123,8 +131,8 @@ namespace Robotics
         /// <returns>The slot centre, in metres.</returns>
         public static (double X, double Y, double Z) SlotPosition(CellStation table, int slot)
         {
-            double[] offsets = SlotOffsetsX;
-            int index = slot < 0 ? 0 : slot % offsets.Length;
+            ArrayOf<double> offsets = SlotOffsetsX;
+            int index = slot < 0 ? 0 : slot % offsets.Count;
             double tableX = table == CellStation.TableA ? TableAX : TableBX;
             return (tableX + offsets[index], TableY, TableSurfaceZ + 0.0175);
         }

--- a/samples/MinimalRobotServer/MobileRobotPositionOptions.cs
+++ b/samples/MinimalRobotServer/MobileRobotPositionOptions.cs
@@ -157,6 +157,12 @@ namespace Robotics
         /// <summary>
         /// How often a new position is published, in milliseconds.
         /// </summary>
-        public int UpdateIntervalMilliseconds { get; set; } = 200;
+        /// <remarks>
+        /// This matches the cell's simulation tick on purpose. Publishing the platform
+        /// slower than the arm and the workpieces makes the robot lag its own gripper: at
+        /// 200 ms and cruise speed the platform trails by 170 mm, and a carried part - which
+        /// rides the tool centre point - visibly floats out in front of the jaws.
+        /// </remarks>
+        public int UpdateIntervalMilliseconds { get; set; } = 50;
     }
 }

--- a/samples/MinimalRobotServer/MobileRobotPositionProvider.cs
+++ b/samples/MinimalRobotServer/MobileRobotPositionProvider.cs
@@ -57,9 +57,12 @@ namespace Robotics
 
         public MobileRobotPositionProvider(
             IOptions<MobileRobotPositionOptions> options,
-            RobotPositioningScenario scenario)
+            RobotPositioningScenario scenario,
+            CellChoreographer choreographer)
             : this(options.Value, scenario, TimeProvider.System)
         {
+            Choreographer = choreographer ??
+                throw new ArgumentNullException(nameof(choreographer));
         }
 
         public MobileRobotPositionProvider(
@@ -75,6 +78,11 @@ namespace Robotics
         }
 
         public RobotPositioningScenario Scenario { get; }
+
+        /// <summary>
+        /// The choreographer whose agents own the robot poses, when the provider is hosted.
+        /// </summary>
+        public CellChoreographer? Choreographer { get; }
 
         /// <inheritdoc/>
         public bool SupportsPush => true;
@@ -95,8 +103,7 @@ namespace Robotics
             string sourceId,
             [EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
-            RobotMotionOptions options = GetOptions(sourceId);
-            if (options.Mode == RobotMotionMode.Fixed)
+            if (Choreographer == null && GetOptions(sourceId).Mode == RobotMotionMode.Fixed)
             {
                 yield break;
             }
@@ -124,6 +131,36 @@ namespace Robotics
             string sourceId,
             TimeSpan elapsed)
         {
+            // The choreographer owns the pose whenever the provider is hosted: the two
+            // robots have to agree on where each other is, which independent parametric
+            // paths could never do. The options-driven path below stays for tests that
+            // exercise the provider on its own.
+            if (Choreographer != null)
+            {
+                foreach (RobotAgent agent in Choreographer.Robots)
+                {
+                    if (!string.Equals(agent.Id, sourceId, StringComparison.Ordinal))
+                    {
+                        continue;
+                    }
+                    return new ThreeDFrame
+                    {
+                        CartesianCoordinates = new ThreeDCartesianCoordinates
+                        {
+                            X = agent.X,
+                            Y = agent.Y,
+                            Z = 0.0
+                        },
+                        Orientation = new ThreeDOrientation
+                        {
+                            A = 0.0,
+                            B = 0.0,
+                            C = agent.HeadingDegrees
+                        }
+                    };
+                }
+            }
+
             RobotMotionOptions options = GetOptions(sourceId);
             double period = Math.Max(0.1, options.PeriodSeconds);
             double theta = 2.0 *

--- a/samples/MinimalRobotServer/Program.cs
+++ b/samples/MinimalRobotServer/Program.cs
@@ -54,6 +54,7 @@ string host = builder.Configuration["host"] is { Length: > 0 } h ? h : "0.0.0.0"
 builder.Services.AddOptions<MobileRobotPositionOptions>()
     .Bind(builder.Configuration.GetSection("Robots"));
 builder.Services.AddSingleton<RobotPositioningScenario>();
+builder.Services.AddSingleton<CellChoreographer>();
 
 IPositioningServerBuilder positioning = builder.Services
     .AddOpcUa()

--- a/samples/MinimalRobotServer/README.md
+++ b/samples/MinimalRobotServer/README.md
@@ -24,21 +24,101 @@ A `MotionDeviceSystem` **"RobotCell"** (prim `/Cell`) composed recursively of:
   `Child` `<Component>` binding. Each Axis' `ParameterSet/ActualPosition` (degrees)
   drives one joint `xformOp:rotate{Z|Y|X}` on the (pre-authored) `robot.usda`
   kinematic chain — the live articulation (`RenderTargetKind = Rotation`). The axis
-  limits are those of the reference robot (see below), and the simulation runs an eased
-  pick-and-place cycle rather than a free sweep.
+  limits are those of the reference robot (see below). The axis values come from an arm
+  solver, so the arm genuinely reaches the slot it is working rather than replaying a
+  canned pose list.
 - A cell **EmergencyStop** safety state driving a beacon and per-robot warning halo
   visibility (`UaAlarmToUsd`, `Visibility`).
 - An opt-in **SpeedOverride** command (`UsdToUaCommand`, fail-closed).
-- A **gripper tool** mounted on R1's flange at runtime (`One` / `Reference`,
+- A **gripper tool** on each robot's flange, plus one mounted on R1 at runtime (`One` / `Reference`,
   `Dynamic = true`) via a model-change event.
 - One RSL spatial-object list with a world frame, R1/R2 SpatialObject AddIns,
   each robot's PositionFrame, and R1's ToolFlange AttachPoint.
-- One GPOS Zone with ground-control points and one live GlobalLocation per
-  robot. Each robot independently selects `Fixed`, `FigureEight`, `Circle`, or
-  `Shuttle` motion; the default uses phase-shifted figure-eight paths.
+- One GPOS Zone with ground-control points and one live GlobalLocation per robot. Both
+  poses come from the shared CellChoreographer, so the robots agree on where each other
+  is - see [The transfer cycle](#the-transfer-cycle).
 
 All 15 representations (1 system + 2 robots + 12 axes) are discoverable through the
 well-known `Server/OpenUSD/Representations` registry.
+
+## The transfer cycle
+
+R1 collects a part from the western station (`WorkTableA`) and delivers it to the eastern
+one (`WorkTableB`); R2 collects from the east and returns it to the west. Three parts
+circulate, so both robots usually have work.
+
+### Keeping them apart
+
+The cell is divided into reservable zones:
+
+| Zone | Extent | Occupancy |
+| --- | --- | --- |
+| `EndZoneA` / `EndZoneB` | \|x\| > 1.3 m | one robot — a deployed arm needs the whole end |
+| `CorridorEastbound` | \|x\| ≤ 1.3 m, northern lane (y = 0.35) | one robot |
+| `CorridorWestbound` | \|x\| ≤ 1.3 m, southern lane (y = −1.15) | one robot |
+| `DockA` / `DockB` | around each charging dock (y = −2.0) | one robot |
+
+A robot reserves the zone *immediately ahead* before entering it and releases the one
+behind once it is clear — block signalling, not a global schedule. Three rules follow:
+
+- **Two robots travelling opposite ways pass**, because they are in different lanes 1.5 m
+  apart. Two travelling the same way queue instead of overtaking.
+- **An arm may only leave its transport envelope inside an end zone**, which the robot
+  holds exclusively. This is the rule that fixes the original defect.
+- **A robot with no work parks on its dock**, releasing the end zone so the other robot can
+  deliver into the station it serves. Without this the cell deadlocks on the first
+  handover — an idle robot standing by its table blocks the delivery it is waiting for.
+
+The docks sit in a southern layby rather than beside the stations, because a robot parked
+next to a station is close enough to foul a robot turning into it.
+
+### What else is simulated
+
+- **Trapezoidal travel** — accelerate, cruise, brake into the stop, with the heading
+  following the path.
+- **Speed and separation** — travel speed drops near the other robot, and the cell
+  emergency stop now halts motion rather than only blinking the beacon.
+- **Battery and charging** — charge drains with distance; below the threshold the robot
+  finishes its delivery, docks, charges and resumes.
+- **Grip faults** — a seeded slip occasionally drops a part; the robot re-picks it off the
+  floor. Deterministic, so the recovery path is testable.
+- **KPIs** — parts moved, cycle count, last and average cycle time, utilisation, fault
+  count.
+
+The invariants are asserted rather than assumed: `CellChoreographyTests` runs ten minutes
+of simulated time and checks on every 50 ms step that the oriented footprints never
+overlap, that a zone is never doubly occupied, that arms only deploy in an end zone, that
+parts are conserved, and that a carried part sits exactly on the tool centre point.
+
+### Where the part actually is
+
+A carried part's pose is computed by forward kinematics from the same six axis values the
+server publishes (`RobotKinematics`), not from the script that produced them. That is what
+keeps it welded to the gripper: if the arm and the part were computed independently they
+would drift apart. `RobotArmSolver` is checked against that same forward kinematics, so the
+arm provably reaches each slot to within a micrometre.
+
+## Ideas for more realism
+
+Natural extensions that are deliberately *not* implemented, roughly in order of value:
+
+- **Speed-and-separation monitoring** to ISO 10218 / TS 15066, with a modelled protective
+  field, replacing the simple proximity speed scale.
+- **Sensor cones** on the existing `ScannerFront` / `ScannerRear` prims, with detections
+  driving the slowdown instead of omniscient positions.
+- **A tool changer** — dock the gripper and pick up a different end-effector, which the
+  dynamic-component binding already demonstrates the mechanics for.
+- **An inspection station** that rejects a part, giving the routing a real branch.
+- **Conveyor infeed and outfeed** instead of a fixed part population.
+- **Operator gate interlock** — opening the front gate stops the cell.
+- **Joint torque and current telemetry**, plus thermal drift, so axes carry more than
+  position.
+- **Maintenance counters** (distance travelled, grip cycles) feeding a service alarm.
+- **Time-sampled pose history** so a viewer can scrub the last cycle rather than only
+  following live values.
+- **Traffic priority** — today a blocked robot simply waits; a real fleet manager would
+  weigh deadlines and re-route.
+
 
 ## The USD assets
 
@@ -64,7 +144,8 @@ ROS-Industrial URDF (`ros-industrial/kuka_experimental`, `kuka_kr16_support`):
 `260 + 680 + 670 = 1611 mm`, the robot's published reach. A4, A5 and A6 are coincident,
 which is the real spherical wrist. The livery is KUKA orange over dark cast housings, and
 the cell is scaled around that reach: a 7.2 × 4.8 m floor with the guarding at
-x = ±3.4 m, y = ±2.2 m, plus a controller cabinet, a shared work table and a stack light.
+x = ±3.4 m, y = ±2.2 m, plus a controller cabinet, two transfer stations, two charging
+docks and a stack light.
 
 ### Mobile platform
 
@@ -72,8 +153,12 @@ Each arm rides on an omnidirectional AGV (`/Robot/MobileBase`, 1.10 × 0.72 m, 3
 in the style of a KUKA KMP: orange chassis, dark skirt, four wheels, diagonally opposed
 safety scanners, bumpers and status strips. The RSL scenario drives each robot's spatial
 location across the cell, so the arm has to be carried rather than bolted to the floor.
-The platform footprint and the work-table position are chosen so the two AGVs clear each
-other at their closest approach and never drive through the table.
+
+> **Platform clearance is not enough on its own.** An earlier version of this sample ran
+> the two robots on independent figure-eight paths and claimed the footprints cleared. They
+> did — by 1.2 m at closest approach — but the *arms* reach 1.611 m, so they swept straight
+> through each other. Clearance has to be argued about the deployed arm, not the chassis,
+> which is why the cell is now zoned and the arm must be stowed to travel.
 
 To floor-mount the arm instead, delete `/Robot/MobileBase` and clear the `xformOp:translate`
 on `/Robot/Base`; nothing else depends on it.

--- a/samples/MinimalRobotServer/README.md
+++ b/samples/MinimalRobotServer/README.md
@@ -104,6 +104,13 @@ keeps it welded to the gripper: if the arm and the part were computed independen
 would drift apart. `RobotArmSolver` is checked against that same forward kinematics, so the
 arm provably reaches each slot to within a micrometre.
 
+It is computed from the platform pose that was **last published**, not the one the
+simulation currently holds. The platform and the workpiece leave the server as separate
+bindings, and publishing them from loops running at different rates floated the part a
+quarter of a metre out in front of the jaws while the robot drove — three part widths, and
+the first thing anyone notices in a viewport. `RobotOpenUsdE2eTests` rebuilds the tool
+centre point from the values authored into the scene and asserts a carried part sits on it.
+
 The buffers are worked **first-in-first-out**. Collecting the lowest free slot instead
 starves any part that never lands in it: with two parts seeded on `WorkTableA`, the second
 sat untouched for the life of the process while the robots shuttled the other one past it.
@@ -118,6 +125,14 @@ cleared from there. `RobotAssetContractTests` asserts this for every bound prim.
 
 The gripper jaws are one Xform each, owning their carrier *and* their finger. Driving the
 carrier alone would slide it out from under the finger it is bolted to.
+
+### The opening view
+
+The cell authors `/Cell/OverviewCamera` and a connector opens on it, because framing the
+bounds of an enclosed scene automatically puts the eye inside the fence, looking at whichever
+robot happens to be nearest. The **first** camera in the served root layer wins, so the
+establishing shot is authored before `/Cell/TopDownCamera`; `--camera` overrides the choice
+outright. `RobotAssetContractTests` asserts the ordering.
 
 ## Ideas for more realism
 

--- a/samples/MinimalRobotServer/README.md
+++ b/samples/MinimalRobotServer/README.md
@@ -31,7 +31,8 @@ A `MotionDeviceSystem` **"RobotCell"** (prim `/Cell`) composed recursively of:
   visibility (`UaAlarmToUsd`, `Visibility`).
 - An opt-in **SpeedOverride** command (`UsdToUaCommand`, fail-closed).
 - A **gripper tool** on each robot's flange, plus one mounted on R1 at runtime (`One` / `Reference`,
-  `Dynamic = true`) via a model-change event.
+  `Dynamic = true`) via a model-change event. R1 carries a `NodeVersion` property so that
+  mounting it is reportable at all — see [Dynamic components need a NodeVersion](#dynamic-components-need-a-nodeversion).
 - A **`CellTwin` folder** under `Objects` carrying the state that is neither a device nor
   an axis: a `ThreeDCartesianCoordinates` position and a `ThreeDOrientation` heading per
   workpiece, driving `/Cell/Parts/PartNN` (`Translation` and `Rotation`), and a jaw
@@ -125,6 +126,26 @@ cleared from there. `RobotAssetContractTests` asserts this for every bound prim.
 
 The gripper jaws are one Xform each, owning their carrier *and* their finger. Driving the
 carrier alone would slide it out from under the finger it is bolted to.
+
+### Dynamic components need a NodeVersion
+
+Part 5 §9.32.2 allows only a node that carries a **`NodeVersion`** property to trigger a
+`ModelChangeEvent`, and `AsyncCustomNodeManager` drops entries for nodes that lack one. A
+`Dynamic` component binding is reconciled from those events, so the node whose references
+change — here the robot the tool is mounted on — has to expose `NodeVersion`, via
+`EnableModelChangeTracking`. Without it the mount is filtered out and no client is ever told
+the gripper appeared.
+
+The failure this caused was quietly asymmetric, which is worth knowing about. **Removal**
+kept reporting, because a deleted node is no longer in the manager's index and so takes the
+"not mine, pass it through" branch of the filter; only **addition** was dropped. A connector
+that happened to start while the tool was mounted therefore looked correct and could still
+deactivate it, while one that started in the six-second gap never composed the tool at all
+and never recovered.
+
+`DynamicToolIsComposedAsync` asserts the transition — the prim observed both active and
+inactive across more than one full cycle — rather than a momentary state, so it cannot pass
+on a connector that only ever hears about one direction.
 
 ### The opening view
 

--- a/samples/MinimalRobotServer/README.md
+++ b/samples/MinimalRobotServer/README.md
@@ -32,6 +32,12 @@ A `MotionDeviceSystem` **"RobotCell"** (prim `/Cell`) composed recursively of:
 - An opt-in **SpeedOverride** command (`UsdToUaCommand`, fail-closed).
 - A **gripper tool** on each robot's flange, plus one mounted on R1 at runtime (`One` / `Reference`,
   `Dynamic = true`) via a model-change event.
+- A **`CellTwin` folder** under `Objects` carrying the state that is neither a device nor
+  an axis: a `ThreeDCartesianCoordinates` position and a `ThreeDOrientation` heading per
+  workpiece, driving `/Cell/Parts/PartNN` (`Translation` and `Rotation`), and a jaw
+  position per robot driving `…/Flange/Tool/Jaw{Upper|Lower}`. Without these the
+  choreography is invisible — the robots mime a transfer while the blocks stay wherever
+  the asset authored them.
 - One RSL spatial-object list with a world frame, R1/R2 SpatialObject AddIns,
   each robot's PositionFrame, and R1's ToolFlange AttachPoint.
 - One GPOS Zone with ground-control points and one live GlobalLocation per robot. Both
@@ -97,6 +103,21 @@ server publishes (`RobotKinematics`), not from the script that produced them. Th
 keeps it welded to the gripper: if the arm and the part were computed independently they
 would drift apart. `RobotArmSolver` is checked against that same forward kinematics, so the
 arm provably reaches each slot to within a micrometre.
+
+The buffers are worked **first-in-first-out**. Collecting the lowest free slot instead
+starves any part that never lands in it: with two parts seeded on `WorkTableA`, the second
+sat untouched for the life of the process while the robots shuttled the other one past it.
+
+### Editing a live-bound prim
+
+Every prim the server drives declares **exactly one** `matrix4d xformOp:transform` and
+orders only that op — the parts and the gripper jaws included. A viewer composes the
+translate and rotate ops it receives into that single matrix, and an op order declared in a
+referenced asset sits in a weaker layer than the one a connector edits, so it could not be
+cleared from there. `RobotAssetContractTests` asserts this for every bound prim.
+
+The gripper jaws are one Xform each, owning their carrier *and* their finger. Driving the
+carrier alone would slide it out from under the finger it is bolted to.
 
 ## Ideas for more realism
 
@@ -166,10 +187,11 @@ on `/Robot/Base`; nothing else depends on it.
 ### Editing the assets
 
 The prim paths and rotate ops above are the **binding contract**: `RobotCell.cs` addresses
-them by name, and the connector writes each rotate op as a scalar `double`. Link offsets,
-geometry, materials and lighting are all free to change; the paths, op names,
+them by name, and the connector writes each joint rotate op as a scalar `double`. Link
+offsets, geometry, materials and lighting are all free to change; the paths, op names,
 `xformOpOrder` entries, `/Robot/Base/.../Flange`, `/Robot/Warning`, `/Cell/SafetyBeacon`,
-`/Cell.inputs:speedOverride` and the `R1`/`R2` mount attributes are not.
+`/Cell/Parts/PartNN`, `/Gripper/Jaw{Upper|Lower}`, `/Cell.inputs:speedOverride` and the
+`R1`/`R2` mount attributes are not.
 
 `RobotAssetContractTests` (in `tests/Opc.Ua.OpenUsd.Tests`) parses the shipped assets
 and asserts that contract, so an edit that breaks it fails the build instead of silently

--- a/samples/MinimalRobotServer/RobotAgent.cs
+++ b/samples/MinimalRobotServer/RobotAgent.cs
@@ -100,6 +100,16 @@ namespace Robotics
         /// Whether the part is resting somewhere rather than being carried.
         /// </summary>
         public bool IsResting => CarriedBy == null;
+
+        /// <summary>
+        /// The order in which the part came to rest on its current station.
+        /// </summary>
+        /// <remarks>
+        /// The cell works its buffers first-in-first-out. Picking by slot instead starves
+        /// whichever part never lands in the lowest slot: a spare seeded beside the one the
+        /// robots shuttle would sit untouched for the life of the process.
+        /// </remarks>
+        internal long RestingSequence { get; set; }
     }
 
     /// <summary>

--- a/samples/MinimalRobotServer/RobotAgent.cs
+++ b/samples/MinimalRobotServer/RobotAgent.cs
@@ -29,6 +29,7 @@
 
 using System;
 using System.Collections.Generic;
+using Opc.Ua;
 
 namespace Robotics
 {
@@ -176,14 +177,21 @@ namespace Robotics
             HeadingDegrees = 90.0;
             BatteryLevel = 100.0;
             Axes = new double[RobotKinematics.AxisCount];
-            TransportPose.CopyTo(Axes, 0);
+            TransportPose.Span.CopyTo(Axes);
         }
 
         /// <summary>
         /// The arm pose held while travelling, folded back over the platform so the robot
         /// stays inside <see cref="CellLayout.TransportRadius"/>.
         /// </summary>
-        public static double[] TransportPose => [0.0, -100.0, 125.0, 0.0, 65.0, 0.0];
+        /// <remarks>
+        /// Held as a single immutable value rather than rebuilt per access: the
+        /// choreography reads it on every tick of every robot, and an <c>ArrayOf</c> can be
+        /// shared safely where a cached <c>double[]</c> would hand every caller a writable
+        /// reference to the one copy.
+        /// </remarks>
+        public static ArrayOf<double> TransportPose { get; }
+            = new double[] { 0.0, -100.0, 125.0, 0.0, 65.0, 0.0 };
 
         /// <summary>
         /// The robot identifier, matching its mount prim name.

--- a/samples/MinimalRobotServer/RobotAgent.cs
+++ b/samples/MinimalRobotServer/RobotAgent.cs
@@ -1,0 +1,331 @@
+/* ========================================================================
+ * Copyright (c) 2005-2026 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using System.Collections.Generic;
+
+namespace Robotics
+{
+    /// <summary>
+    /// A part circulating between the two transfer stations.
+    /// </summary>
+    public sealed class CellPart
+    {
+        /// <summary>
+        /// Creates a part resting in a slot.
+        /// </summary>
+        /// <param name="id">The part identifier.</param>
+        /// <param name="station">The station it starts on.</param>
+        /// <param name="slot">The slot it starts in.</param>
+        public CellPart(string id, CellStation station, int slot)
+        {
+            Id = id ?? throw new ArgumentNullException(nameof(id));
+            Station = station;
+            Slot = slot;
+            (X, Y, Z) = CellLayout.SlotPosition(station, slot);
+        }
+
+        /// <summary>
+        /// The part identifier, matching the prim name under <c>/Cell/Parts</c>.
+        /// </summary>
+        public string Id { get; }
+
+        /// <summary>
+        /// The station the part rests on, when it is not being carried.
+        /// </summary>
+        public CellStation Station { get; internal set; }
+
+        /// <summary>
+        /// The slot the part rests in, when it is not being carried.
+        /// </summary>
+        public int Slot { get; internal set; }
+
+        /// <summary>
+        /// The robot carrying the part, or <c>null</c> when it is not being carried.
+        /// </summary>
+        public string? CarriedBy { get; internal set; }
+
+        /// <summary>
+        /// Whether the part has been dropped and is lying on the floor.
+        /// </summary>
+        public bool OnFloor { get; internal set; }
+
+        /// <summary>
+        /// The X position of the part, in metres.
+        /// </summary>
+        public double X { get; internal set; }
+
+        /// <summary>
+        /// The Y position of the part, in metres.
+        /// </summary>
+        public double Y { get; internal set; }
+
+        /// <summary>
+        /// The Z position of the part, in metres.
+        /// </summary>
+        public double Z { get; internal set; }
+
+        /// <summary>
+        /// The orientation of the part about Z, in degrees.
+        /// </summary>
+        public double HeadingDegrees { get; internal set; }
+
+        /// <summary>
+        /// Whether the part is resting somewhere rather than being carried.
+        /// </summary>
+        public bool IsResting => CarriedBy == null;
+    }
+
+    /// <summary>
+    /// Counters describing how the cell is performing.
+    /// </summary>
+    public sealed class CellKpis
+    {
+        /// <summary>
+        /// The number of completed transfers.
+        /// </summary>
+        public int PartsMoved { get; internal set; }
+
+        /// <summary>
+        /// The number of transfers each robot has completed.
+        /// </summary>
+        public int CycleCount { get; internal set; }
+
+        /// <summary>
+        /// The duration of the most recently completed transfer, in seconds.
+        /// </summary>
+        public double LastCycleSeconds { get; internal set; }
+
+        /// <summary>
+        /// The mean transfer duration, in seconds.
+        /// </summary>
+        public double AverageCycleSeconds { get; internal set; }
+
+        /// <summary>
+        /// The fraction of elapsed time a robot has been doing something other than
+        /// waiting, in the range 0 to 1.
+        /// </summary>
+        public double Utilisation { get; internal set; }
+
+        /// <summary>
+        /// The number of grip faults injected.
+        /// </summary>
+        public int FaultCount { get; internal set; }
+
+        internal double BusySeconds { get; set; }
+
+        internal double ElapsedSeconds { get; set; }
+
+        internal double TotalCycleSeconds { get; set; }
+    }
+
+    /// <summary>
+    /// One mobile manipulator in the cell.
+    /// </summary>
+    public sealed class RobotAgent
+    {
+        internal RobotAgent(
+            string id,
+            CellStation source,
+            CellStation target,
+            double dockX,
+            double homeX)
+        {
+            Id = id;
+            Source = source;
+            Target = target;
+            DockX = dockX;
+            HomeX = homeX;
+            X = dockX;
+            Y = CellLayout.DockY;
+            HeadingDegrees = 90.0;
+            BatteryLevel = 100.0;
+            Axes = new double[RobotKinematics.AxisCount];
+            TransportPose.CopyTo(Axes, 0);
+        }
+
+        /// <summary>
+        /// The arm pose held while travelling, folded back over the platform so the robot
+        /// stays inside <see cref="CellLayout.TransportRadius"/>.
+        /// </summary>
+        public static double[] TransportPose => [0.0, -100.0, 125.0, 0.0, 65.0, 0.0];
+
+        /// <summary>
+        /// The robot identifier, matching its mount prim name.
+        /// </summary>
+        public string Id { get; }
+
+        /// <summary>
+        /// The station this robot collects from.
+        /// </summary>
+        public CellStation Source { get; }
+
+        /// <summary>
+        /// The station this robot delivers to.
+        /// </summary>
+        public CellStation Target { get; }
+
+        /// <summary>
+        /// The step the robot is performing.
+        /// </summary>
+        public RobotCycleState State { get; internal set; } = RobotCycleState.Idle;
+
+        /// <summary>
+        /// The X position of the platform, in metres.
+        /// </summary>
+        public double X { get; internal set; }
+
+        /// <summary>
+        /// The Y position of the platform, in metres.
+        /// </summary>
+        public double Y { get; internal set; }
+
+        /// <summary>
+        /// The heading of the platform about Z, in degrees.
+        /// </summary>
+        public double HeadingDegrees { get; internal set; }
+
+        /// <summary>
+        /// The current travel speed, in metres per second.
+        /// </summary>
+        public double Speed { get; internal set; }
+
+        /// <summary>
+        /// The distance the platform has travelled in total, in metres.
+        /// </summary>
+        public double DistanceTravelled { get; internal set; }
+
+        /// <summary>
+        /// The six axis positions, in degrees.
+        /// </summary>
+        public double[] Axes { get; }
+
+        /// <summary>
+        /// How far the jaws are open, from 0 for closed to 1 for fully open.
+        /// </summary>
+        public double GripperOpening { get; internal set; } = 1.0;
+
+        /// <summary>
+        /// The remaining charge, as a percentage.
+        /// </summary>
+        public double BatteryLevel { get; internal set; }
+
+        /// <summary>
+        /// The part the robot is carrying, or <c>null</c>.
+        /// </summary>
+        public string? HoldingPart { get; internal set; }
+
+        /// <summary>
+        /// The robot whose reservation this robot is waiting on, or <c>null</c>.
+        /// </summary>
+        public string? BlockedBy { get; internal set; }
+
+        /// <summary>
+        /// The zone the robot currently occupies.
+        /// </summary>
+        public CellZone HeldZone { get; internal set; } = CellZone.None;
+
+        /// <summary>
+        /// The zone the robot has reserved to move into next.
+        /// </summary>
+        public CellZone ReservedZone { get; internal set; } = CellZone.None;
+
+        /// <summary>
+        /// Whether the arm is folded within the transport envelope.
+        /// </summary>
+        public bool ArmStowed { get; internal set; } = true;
+
+        internal double DockX { get; }
+
+        internal double HomeX { get; }
+
+        internal Queue<(double X, double Y)> Waypoints { get; } = new();
+
+        /// <summary>
+        /// The number of waypoints still to visit.
+        /// </summary>
+        public int WaypointCount => Waypoints.Count;
+
+        internal double DwellRemaining { get; set; }
+
+        internal double CycleStartedAt { get; set; }
+
+        internal RobotCycleState ResumeState { get; set; } = RobotCycleState.Idle;
+
+        internal bool NeedsCharge { get; set; }
+
+        internal int TargetSlot { get; set; }
+
+        /// <summary>
+        /// The bounding radius the robot currently occupies, in metres.
+        /// </summary>
+        /// <remarks>
+        /// A stowed arm keeps the robot inside the platform envelope; a deployed arm claims
+        /// its working width instead. The choreography only lets an arm deploy inside an end
+        /// zone the robot has exclusively reserved.
+        /// </remarks>
+        public double OccupiedRadius => ArmStowed
+            ? CellLayout.TransportRadius
+            : CellLayout.TransportRadius + CellLayout.DeployedArmHalfWidthX;
+
+        /// <summary>
+        /// The oriented footprint the robot occupies, as a centre, a half length along its
+        /// heading, a half width across it and the heading itself.
+        /// </summary>
+        /// <remarks>
+        /// A circle around the platform is far too pessimistic for a machine that is nearly
+        /// twice as long as it is wide, and it would force the cell to be laid out with
+        /// clearances no real installation would need. A deployed arm extends the box
+        /// forwards, since that is where the arm actually reaches.
+        /// </remarks>
+        public (double X, double Y, double HalfLength, double HalfWidth, double HeadingDegrees)
+            Footprint
+        {
+            get
+            {
+                const double halfLength = 0.575;
+                const double halfWidth = 0.300;
+                if (ArmStowed)
+                {
+                    return (X, Y, halfLength, halfWidth, HeadingDegrees);
+                }
+
+                const double reach = 1.200;
+                double centreShift = (reach - halfLength) / 2.0;
+                double radians = HeadingDegrees * (System.Math.PI / 180.0);
+                return (
+                    X + (centreShift * System.Math.Cos(radians)),
+                    Y + (centreShift * System.Math.Sin(radians)),
+                    (reach + halfLength) / 2.0,
+                    CellLayout.DeployedArmHalfWidthX + 0.05,
+                    HeadingDegrees);
+            }
+        }
+    }
+}

--- a/samples/MinimalRobotServer/RobotAgent.cs
+++ b/samples/MinimalRobotServer/RobotAgent.cs
@@ -111,7 +111,6 @@ namespace Robotics
         /// </remarks>
         internal long RestingSequence { get; set; }
     }
-
     /// <summary>
     /// Counters describing how the cell is performing.
     /// </summary>
@@ -270,6 +269,18 @@ namespace Robotics
         /// Whether the arm is folded within the transport envelope.
         /// </summary>
         public bool ArmStowed { get; internal set; } = true;
+
+        /// <summary>
+        /// The platform pose most recently handed to the twin, if any.
+        /// </summary>
+        /// <remarks>
+        /// A carried part has to be drawn relative to the platform the *viewer* has, not
+        /// the one the simulation has. The platform pose and the part pose leave the server
+        /// on different loops, so a part drawn from the newer of the pair visibly runs
+        /// ahead of the gripper holding it - a quarter of a metre of it while driving,
+        /// which is three part widths.
+        /// </remarks>
+        internal (double X, double Y, double HeadingDegrees)? PublishedPose { get; set; }
 
         internal double DockX { get; }
 

--- a/samples/MinimalRobotServer/RobotArmSolver.cs
+++ b/samples/MinimalRobotServer/RobotArmSolver.cs
@@ -1,0 +1,118 @@
+/* ========================================================================
+ * Copyright (c) 2005-2026 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+
+namespace Robotics
+{
+    /// <summary>
+    /// Inverse kinematics for the sample arm, used to place the tool centre point over a
+    /// table slot.
+    /// </summary>
+    /// <remarks>
+    /// Only the shoulder and elbow are solved. The wrist is then set so the tool points
+    /// straight down, which is how a part is picked off and set onto a table. The solution
+    /// is checked against <see cref="RobotKinematics"/> by the tests, so the arm provably
+    /// reaches the slot rather than merely looking as though it does.
+    /// </remarks>
+    public static class RobotArmSolver
+    {
+        private const double UpperArm = 0.6800;
+        private const double ForearmX = 0.6700;
+        private const double ForearmZ = -0.0350;
+
+        /// <summary>
+        /// The distance from the wrist to the tool centre point, in metres.
+        /// </summary>
+        public const double WristToToolCentrePoint = 0.1580 + RobotKinematics.ToolCentrePointOffsetX;
+
+        /// <summary>
+        /// Solves the arm so the tool centre point sits at a target expressed in the robot's
+        /// own frame.
+        /// </summary>
+        /// <param name="forward">
+        /// The horizontal distance ahead of the platform, in metres.
+        /// </param>
+        /// <param name="lateral">The horizontal offset to the left, in metres.</param>
+        /// <param name="height">The height above the platform origin, in metres.</param>
+        /// <param name="axesDegrees">The six axis positions, in degrees.</param>
+        /// <returns><c>true</c> when the target is reachable.</returns>
+        public static bool TrySolve(
+            double forward,
+            double lateral,
+            double height,
+            Span<double> axesDegrees)
+        {
+            if (axesDegrees.Length != RobotKinematics.AxisCount)
+            {
+                throw new ArgumentException(
+                    $"Expected {RobotKinematics.AxisCount} axis positions.",
+                    nameof(axesDegrees));
+            }
+
+            // The shoulder sits above the platform origin; everything below is solved in the
+            // vertical plane the first axis swings to.
+            double azimuth = Math.Atan2(lateral, forward);
+            double planar = Math.Sqrt((forward * forward) + (lateral * lateral));
+
+            const double shoulderHeight = 0.3650 + 0.2900 + 0.3850;
+            const double shoulderForward = 0.2600;
+
+            // The wrist has to sit above the target by the tool length, so the tool points
+            // straight down onto the slot.
+            double u = planar - shoulderForward;
+            double v = shoulderHeight - (height + WristToToolCentrePoint);
+
+            double forearm = Math.Sqrt((ForearmX * ForearmX) + (ForearmZ * ForearmZ));
+            double beta = Math.Atan2(-ForearmZ, ForearmX);
+
+            double distanceSquared = (u * u) + (v * v);
+            double cosGamma = (distanceSquared - (UpperArm * UpperArm) - (forearm * forearm)) /
+                (2.0 * UpperArm * forearm);
+            if (cosGamma is < -1.0 or > 1.0)
+            {
+                return false;
+            }
+
+            double gamma = Math.Acos(cosGamma);
+            double a2 = Math.Atan2(v, u) -
+                Math.Atan2(forearm * Math.Sin(gamma), UpperArm + (forearm * Math.Cos(gamma)));
+            double a3 = gamma - beta;
+
+            const double toDegrees = 180.0 / Math.PI;
+            axesDegrees[0] = azimuth * toDegrees;
+            axesDegrees[1] = a2 * toDegrees;
+            axesDegrees[2] = a3 * toDegrees;
+            axesDegrees[3] = 0.0;
+            axesDegrees[4] = 90.0 - ((a2 + a3) * toDegrees);
+            axesDegrees[5] = 0.0;
+            return true;
+        }
+    }
+}

--- a/samples/MinimalRobotServer/RobotCell.Configure.cs
+++ b/samples/MinimalRobotServer/RobotCell.Configure.cs
@@ -76,6 +76,7 @@ namespace Robotics
             }
             cell.EmergencyStop = estop;
             cell.Advance(TickSeconds);
+            PublishTwinState(cell);
 
             // Publish the axis positions the choreography produced. They come from the arm
             // solver, so the arm genuinely reaches the slot it is working rather than

--- a/samples/MinimalRobotServer/RobotCell.Configure.cs
+++ b/samples/MinimalRobotServer/RobotCell.Configure.cs
@@ -51,27 +51,6 @@ namespace Robotics
         private const int EstopPeriodTicks = 600;
         private const int EstopActiveFromTick = 560;
 
-        /// <summary>
-        /// Key poses of one transfer cycle, in the axis order A1..A6 (degrees). The arm
-        /// swings to the pick station, descends, closes on the part, lifts clear, traverses
-        /// while rotating the part upright, places it, and retracts. Each entry moves from
-        /// the previous pose over <c>MoveSeconds</c> and then holds for <c>DwellSeconds</c>,
-        /// which is what makes the motion read as a real duty cycle instead of a sweep.
-        /// </summary>
-        private static readonly (double[] Pose, double MoveSeconds, double DwellSeconds)[] s_cycle =
-        [
-            ([0.0, -60.0, 75.0, 0.0, 45.0, 0.0], 1.6, 0.4),
-            ([55.0, -45.0, 70.0, 0.0, 45.0, 0.0], 1.8, 0.2),
-            ([55.0, -30.0, 62.0, 0.0, 58.0, 0.0], 1.0, 0.8),
-            ([55.0, -55.0, 78.0, 0.0, 47.0, 0.0], 1.0, 0.2),
-            ([-15.0, -55.0, 78.0, 0.0, 47.0, 90.0], 2.0, 0.2),
-            ([-45.0, -45.0, 70.0, 0.0, 50.0, 90.0], 1.4, 0.2),
-            ([-45.0, -28.0, 60.0, 0.0, 58.0, 90.0], 1.0, 0.8),
-            ([-45.0, -60.0, 80.0, 0.0, 45.0, 0.0], 1.4, 0.3)
-        ];
-
-        private static readonly double s_cycleSeconds = ComputeCycleSeconds();
-
         partial void Configure(INodeManagerBuilder builder)
         {
             // Single manager-owned simulation tick advances every axis position and the
@@ -83,13 +62,32 @@ namespace Robotics
         private void AdvanceSimulation()
         {
             long t = Interlocked.Increment(ref m_simulationTicks);
-            double time = t * TickSeconds;
 
-            // Drive every axis from the shared pick-and-place cycle, offset per robot so
-            // the two arms are not synchronised, and clamp to the axis' own limits.
+            // Emergency-stop pulses active (~2 s) roughly every 30 s so the safety
+            // beacon (cell) and warning zones (robots) toggle live. It now also halts the
+            // choreography rather than only blinking a lamp.
+            bool estop = (t % EstopPeriodTicks) >= EstopActiveFromTick;
+            UpdateBool(m_estopVar, estop);
+
+            CellChoreographer? cell = m_choreographer;
+            if (cell == null)
+            {
+                return;
+            }
+            cell.EmergencyStop = estop;
+            cell.Advance(TickSeconds);
+
+            // Publish the axis positions the choreography produced. They come from the arm
+            // solver, so the arm genuinely reaches the slot it is working rather than
+            // sweeping through a canned pose list.
             foreach (AxisRuntime ax in m_axes)
             {
-                double target = EvaluateCycle(time + ax.PhaseSeconds, ax.Index);
+                RobotAgent? agent = FindAgent(cell, ax.RobotId);
+                if (agent == null || ax.Index >= agent.Axes.Length)
+                {
+                    continue;
+                }
+                double target = agent.Axes[ax.Index];
                 if (target < ax.Min)
                 {
                     target = ax.Min;
@@ -100,54 +98,20 @@ namespace Robotics
                 }
                 UpdateDouble(ax.Position, target);
             }
-
-            // Emergency-stop pulses active (~2 s) roughly every 30 s so the safety
-            // beacon (cell) and warning zones (robots) toggle live.
-            bool estop = (t % EstopPeriodTicks) >= EstopActiveFromTick;
-            UpdateBool(m_estopVar, estop);
         }
 
-        /// <summary>
-        /// Samples the cycle for one axis at a point in time, easing each move so the arm
-        /// accelerates and settles rather than stepping between poses.
-        /// </summary>
-        private static double EvaluateCycle(double time, int axisIndex)
+        private static RobotAgent? FindAgent(CellChoreographer cell, string robotId)
         {
-            double position = time % s_cycleSeconds;
-            if (position < 0.0)
+            foreach (RobotAgent agent in cell.Robots)
             {
-                position += s_cycleSeconds;
-            }
-
-            for (int i = 0; i < s_cycle.Length; i++)
-            {
-                (double[] pose, double move, double dwell) = s_cycle[i];
-                if (position < move)
+                if (string.Equals(agent.Id, robotId, StringComparison.Ordinal))
                 {
-                    double[] previous = s_cycle[(i + s_cycle.Length - 1) % s_cycle.Length].Pose;
-                    double u = position / move;
-                    double eased = u * u * (3.0 - (2.0 * u));
-                    return previous[axisIndex] + ((pose[axisIndex] - previous[axisIndex]) * eased);
+                    return agent;
                 }
-                position -= move;
-                if (position < dwell)
-                {
-                    return pose[axisIndex];
-                }
-                position -= dwell;
             }
-            return s_cycle[^1].Pose[axisIndex];
+            return null;
         }
 
-        private static double ComputeCycleSeconds()
-        {
-            double total = 0.0;
-            foreach ((double[] _, double move, double dwell) in s_cycle)
-            {
-                total += move + dwell;
-            }
-            return total;
-        }
 
         private void UpdateDouble(BaseDataVariableState? v, double value)
         {

--- a/samples/MinimalRobotServer/RobotCell.Configure.cs
+++ b/samples/MinimalRobotServer/RobotCell.Configure.cs
@@ -69,11 +69,7 @@ namespace Robotics
             bool estop = (t % EstopPeriodTicks) >= EstopActiveFromTick;
             UpdateBool(m_estopVar, estop);
 
-            CellChoreographer? cell = m_choreographer;
-            if (cell == null)
-            {
-                return;
-            }
+            CellChoreographer cell = m_choreographer;
             cell.EmergencyStop = estop;
             cell.Advance(TickSeconds);
             PublishTwinState(cell);

--- a/samples/MinimalRobotServer/RobotCell.Twin.cs
+++ b/samples/MinimalRobotServer/RobotCell.Twin.cs
@@ -180,8 +180,9 @@ namespace Robotics
                 {
                     continue;
                 }
-                UpdateCoordinates(twin.Position, part.X, part.Y, part.Z);
-                UpdateOrientation(twin.Heading, part.HeadingDegrees);
+                (double x, double y, double z, double heading) = ResolvePartPose(cell, part);
+                UpdateCoordinates(twin.Position, x, y, z);
+                UpdateOrientation(twin.Heading, heading);
             }
 
             foreach (JawTwin twin in m_jawTwins)
@@ -195,6 +196,35 @@ namespace Robotics
                 UpdateCoordinates(twin.Upper, 0.0, offset, 0.0);
                 UpdateCoordinates(twin.Lower, 0.0, -offset, 0.0);
             }
+        }
+
+        /// <summary>
+        /// The pose to draw a workpiece at.
+        /// </summary>
+        /// <remarks>
+        /// A resting part is simply where it rests. A carried one is recomputed from the
+        /// platform pose that was last published rather than taken from the simulation,
+        /// because the platform and the part reach the twin on different loops: drawing the
+        /// part from the newer of the pair floats it out in front of the jaws by however far
+        /// the robot has driven since the platform was last sent.
+        /// </remarks>
+        private static (double X, double Y, double Z, double Heading) ResolvePartPose(
+            CellChoreographer cell,
+            CellPart part)
+        {
+            if (part.CarriedBy == null)
+            {
+                return (part.X, part.Y, part.Z, part.HeadingDegrees);
+            }
+            RobotAgent? carrier = FindAgent(cell, part.CarriedBy);
+            if (carrier?.PublishedPose is not (double px, double py, double heading))
+            {
+                return (part.X, part.Y, part.Z, part.HeadingDegrees);
+            }
+            RigidTransform mount = RobotKinematics.CreateMountPose(px, py, 0.0, heading);
+            (double x, double y, double z) = RobotKinematics
+                .ComputeToolCentrePoint(mount, carrier.Axes).Origin;
+            return (x, y, z, heading);
         }
 
         /// <summary>

--- a/samples/MinimalRobotServer/RobotCell.Twin.cs
+++ b/samples/MinimalRobotServer/RobotCell.Twin.cs
@@ -1,0 +1,329 @@
+/* ========================================================================
+ * Copyright (c) 2005-2026 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Opc.Ua;
+using Opc.Ua.OpenUsd;
+
+namespace Robotics
+{
+    /// <summary>
+    /// Publishes the workpieces and the gripper jaws, so the transfer cycle is visible.
+    /// </summary>
+    /// <remarks>
+    /// The choreography moved parts between the tables from the first commit, but only
+    /// inside the simulation: the address space exposed the platform poses and the twelve
+    /// axis angles and nothing else. A connector therefore had nothing to subscribe to for
+    /// the parts, the blocks sat where the asset authored them, and the cell looked like
+    /// two robots miming. These are the variables and bindings that were missing.
+    /// </remarks>
+    public sealed partial class RobotCell
+    {
+        private const string PartsScopePrimPath = "/Cell/Parts";
+        private const string JawUpperSuffix = "/JawUpper";
+        private const string JawLowerSuffix = "/JawLower";
+
+        /// <summary>
+        /// Jaw offset from the tool axis with the gripper closed on a part, in metres.
+        /// </summary>
+        /// <remarks>
+        /// The finger inner face sits 12 mm inboard of its jaw origin, so 0.047 puts it on
+        /// the 35 mm half-width of the block: closed means gripping, not intersecting.
+        /// </remarks>
+        private const double JawClosedOffset = 0.047;
+
+        /// <summary>
+        /// Jaw offset with the gripper fully open, in metres - 13 mm of stroke per jaw.
+        /// </summary>
+        private const double JawOpenOffset = 0.060;
+
+        private readonly List<PartTwin> m_partTwins = [];
+        private readonly List<JawTwin> m_jawTwins = [];
+
+        /// <summary>
+        /// Creates the twin variables for the workpieces and the gripper jaws.
+        /// </summary>
+        /// <remarks>
+        /// The variables are registered before the motion device system is built, because
+        /// the bindings that reference them are authored inside the system callback and a
+        /// binding can only carry a SourceNodeId that already exists. They deliberately sit
+        /// outside the robotics subtree: a workpiece is not a device, and the robotics
+        /// builder validates every node below its root as one it allocated itself.
+        /// </remarks>
+        /// <param name="ns">The instance namespace index.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        private async ValueTask MaterialiseTwinNodesAsync(
+            ushort ns,
+            CancellationToken cancellationToken)
+        {
+            if (m_choreographer == null)
+            {
+                return;
+            }
+
+            var folder = new FolderState(null)
+            {
+                SymbolicName = "CellTwin",
+                NodeId = new NodeId("CellTwin", ns),
+                BrowseName = new QualifiedName("CellTwin", ns),
+                DisplayName = new LocalizedText("CellTwin"),
+                TypeDefinitionId = Opc.Ua.ObjectTypeIds.FolderType,
+                ReferenceTypeId = ReferenceTypeIds.Organizes,
+                EventNotifier = EventNotifiers.None
+            };
+            folder.AddReference(ReferenceTypeIds.Organizes, true, Opc.Ua.ObjectIds.ObjectsFolder);
+
+            foreach (CellPart part in m_choreographer.Parts)
+            {
+                m_partTwins.Add(new PartTwin(
+                    part.Id,
+                    CreateCoordinateVariable(folder, ns, part.Id + "Position"),
+                    CreateOrientationVariable(folder, ns, part.Id + "Heading")));
+            }
+
+            foreach (RobotAgent agent in m_choreographer.Robots)
+            {
+                m_jawTwins.Add(new JawTwin(
+                    agent.Id,
+                    CreateCoordinateVariable(folder, ns, agent.Id + "JawUpper"),
+                    CreateCoordinateVariable(folder, ns, agent.Id + "JawLower")));
+            }
+
+            SystemContext.AssignInstanceChildNodeIds(folder);
+            await Manager.AddPredefinedNodeAsync(folder, cancellationToken).ConfigureAwait(false);
+            await Server.NodeManager.AddReferencesAsync(
+                Opc.Ua.ObjectIds.ObjectsFolder,
+                [new NodeStateReference(ReferenceTypeIds.Organizes, false, folder.NodeId)],
+                cancellationToken).ConfigureAwait(false);
+
+            PublishTwinState(m_choreographer);
+        }
+
+        /// <summary>
+        /// Binds the twin variables to the prims they drive.
+        /// </summary>
+        /// <remarks>
+        /// The vector translate and rotate ops are what a connector composes into a prim's
+        /// matrix; the matrix4d profile itself is explicitly left unresolved by the
+        /// reference connector, and a binding it cannot convert is dropped in silence.
+        /// </remarks>
+        /// <param name="cellRep">The cell representation the bindings hang from.</param>
+        /// <param name="usdNs">The OpenUSD namespace index.</param>
+        private void MaterialiseTwinBindings(OpenUsdRepresentationState cellRep, ushort usdNs)
+        {
+            foreach (PartTwin part in m_partTwins)
+            {
+                string primPath = PartsScopePrimPath + "/" + part.Id;
+                CreateBinding(cellRep, usdNs, part.Id + "Position",
+                    GuidFor("part:" + part.Id + ":position"), part.Position.NodeId,
+                    primPath, "xformOp:translate", "double3",
+                    OpenUsdRenderTargetKindEnum.Translation, 1.0);
+                CreateBinding(cellRep, usdNs, part.Id + "Heading",
+                    GuidFor("part:" + part.Id + ":heading"), part.Heading.NodeId,
+                    primPath, "xformOp:rotateXYZ", "double3",
+                    OpenUsdRenderTargetKindEnum.Rotation, 1.0);
+            }
+
+            foreach (JawTwin jaw in m_jawTwins)
+            {
+                string toolPath = PrimPathOf(jaw.RobotId) + ToolSuffix;
+                CreateBinding(cellRep, usdNs, jaw.RobotId + "JawUpper",
+                    GuidFor("jaw:" + jaw.RobotId + ":upper"), jaw.Upper.NodeId,
+                    toolPath + JawUpperSuffix, "xformOp:translate", "double3",
+                    OpenUsdRenderTargetKindEnum.Translation, 1.0);
+                CreateBinding(cellRep, usdNs, jaw.RobotId + "JawLower",
+                    GuidFor("jaw:" + jaw.RobotId + ":lower"), jaw.Lower.NodeId,
+                    toolPath + JawLowerSuffix, "xformOp:translate", "double3",
+                    OpenUsdRenderTargetKindEnum.Translation, 1.0);
+            }
+        }
+
+        /// <summary>
+        /// Pushes the current workpiece poses and jaw positions into their variables.
+        /// </summary>
+        /// <param name="cell">The choreographer holding the state to publish.</param>
+        private void PublishTwinState(CellChoreographer cell)
+        {
+            foreach (PartTwin twin in m_partTwins)
+            {
+                CellPart? part = FindPart(cell, twin.Id);
+                if (part == null)
+                {
+                    continue;
+                }
+                UpdateCoordinates(twin.Position, part.X, part.Y, part.Z);
+                UpdateOrientation(twin.Heading, part.HeadingDegrees);
+            }
+
+            foreach (JawTwin twin in m_jawTwins)
+            {
+                RobotAgent? agent = FindAgent(cell, twin.RobotId);
+                if (agent == null)
+                {
+                    continue;
+                }
+                double offset = JawOffset(agent.GripperOpening);
+                UpdateCoordinates(twin.Upper, 0.0, offset, 0.0);
+                UpdateCoordinates(twin.Lower, 0.0, -offset, 0.0);
+            }
+        }
+
+        /// <summary>
+        /// The jaw offset from the tool axis for a gripper opening.
+        /// </summary>
+        /// <param name="opening">The opening, from 0 for closed to 1 for open.</param>
+        /// <returns>The offset along the jaw stroke axis, in metres.</returns>
+        private static double JawOffset(double opening)
+        {
+            double clamped = Math.Max(0.0, Math.Min(1.0, opening));
+            return JawClosedOffset + ((JawOpenOffset - JawClosedOffset) * clamped);
+        }
+
+        private static CellPart? FindPart(CellChoreographer cell, string partId)
+        {
+            foreach (CellPart part in cell.Parts)
+            {
+                if (string.Equals(part.Id, partId, StringComparison.Ordinal))
+                {
+                    return part;
+                }
+            }
+            return null;
+        }
+
+        private static string PrimPathOf(string robotId)
+        {
+            foreach ((string browseName, string primPath, bool _, double _) in s_robots)
+            {
+                if (string.Equals(browseName, robotId, StringComparison.Ordinal))
+                {
+                    return primPath;
+                }
+            }
+            return RobotsScopePrimPath + "/" + robotId;
+        }
+
+        /// <summary>
+        /// Creates a 3D Cartesian coordinate variable the connector can read as a
+        /// structured translation.
+        /// </summary>
+        /// <remarks>
+        /// The translation profile accepts a ThreeDCartesianCoordinates or a ThreeDFrame
+        /// and nothing else; a bare array of three doubles is not a 3D vector to it and
+        /// would be coerced to a scalar, which authors the wrong arity onto the prim.
+        /// </remarks>
+        private ThreeDCartesianCoordinatesState CreateCoordinateVariable(
+            NodeState parent,
+            ushort ns,
+            string name)
+        {
+            ThreeDCartesianCoordinatesState state = SystemContext
+                .CreateInstanceOfThreeDCartesianCoordinatesType(
+                    parent, new QualifiedName(name, ns));
+            state.ReferenceTypeId = ReferenceTypeIds.HasComponent;
+            state.AccessLevel = AccessLevels.CurrentRead;
+            state.UserAccessLevel = AccessLevels.CurrentRead;
+            parent.AddChild(state);
+            return state;
+        }
+
+        /// <summary>
+        /// Creates a 3D orientation variable the connector can read as a structured
+        /// rotation.
+        /// </summary>
+        /// <remarks>
+        /// The rotation is published as a vector rather than a bare angle because a
+        /// connector composes a prim's matrix from the vector ops; a scalar
+        /// <c>xformOp:rotateZ</c> is authored straight onto the prim instead, which only
+        /// works where the asset declares that op, and a live-bound prim declares the
+        /// matrix op alone.
+        /// </remarks>
+        private ThreeDOrientationState CreateOrientationVariable(
+            NodeState parent,
+            ushort ns,
+            string name)
+        {
+            ThreeDOrientationState state = SystemContext
+                .CreateInstanceOfThreeDOrientationType(parent, new QualifiedName(name, ns));
+            state.ReferenceTypeId = ReferenceTypeIds.HasComponent;
+            state.AccessLevel = AccessLevels.CurrentRead;
+            state.UserAccessLevel = AccessLevels.CurrentRead;
+            parent.AddChild(state);
+            return state;
+        }
+
+        private void UpdateOrientation(ThreeDOrientationState state, double degreesAboutZ)
+        {
+            state.Value = new ThreeDOrientation { A = 0.0, B = 0.0, C = degreesAboutZ };
+            state.Timestamp = DateTime.UtcNow;
+            UpdateDouble(state.A, 0.0);
+            UpdateDouble(state.B, 0.0);
+            UpdateDouble(state.C, degreesAboutZ);
+            state.ClearChangeMasks(SystemContext, includeChildren: false);
+        }
+
+        private void UpdateCoordinates(
+            ThreeDCartesianCoordinatesState state,
+            double x,
+            double y,
+            double z)
+        {
+            state.Value = new ThreeDCartesianCoordinates { X = x, Y = y, Z = z };
+            state.Timestamp = DateTime.UtcNow;
+            UpdateDouble(state.X, x);
+            UpdateDouble(state.Y, y);
+            UpdateDouble(state.Z, z);
+            state.ClearChangeMasks(SystemContext, includeChildren: false);
+        }
+
+        private void UpdateDouble(BaseDataVariableState<double>? variable, double value)
+        {
+            if (variable == null)
+            {
+                return;
+            }
+            variable.Value = value;
+            variable.Timestamp = DateTime.UtcNow;
+            variable.ClearChangeMasks(SystemContext, includeChildren: false);
+        }
+
+        private sealed record PartTwin(
+            string Id,
+            ThreeDCartesianCoordinatesState Position,
+            ThreeDOrientationState Heading);
+
+        private sealed record JawTwin(
+            string RobotId,
+            ThreeDCartesianCoordinatesState Upper,
+            ThreeDCartesianCoordinatesState Lower);
+    }
+}

--- a/samples/MinimalRobotServer/RobotCell.Twin.cs
+++ b/samples/MinimalRobotServer/RobotCell.Twin.cs
@@ -85,11 +85,6 @@ namespace Robotics
             ushort ns,
             CancellationToken cancellationToken)
         {
-            if (m_choreographer == null)
-            {
-                return;
-            }
-
             var folder = new FolderState(null)
             {
                 SymbolicName = "CellTwin",

--- a/samples/MinimalRobotServer/RobotCell.cs
+++ b/samples/MinimalRobotServer/RobotCell.cs
@@ -46,6 +46,7 @@ using Opc.Ua.Robotics.Server.Builders;
 using Opc.Ua.Rsl;
 using Opc.Ua.Server;
 using Opc.Ua.Server.Fluent;
+using Opc.Ua.Server.NodeManager;
 using ReferenceTypeIds = Opc.Ua.ReferenceTypeIds;
 
 namespace Robotics
@@ -344,6 +345,16 @@ namespace Robotics
                         state.ParameterSet!,
                         "SpeedOverride");
                     m_speedOverrideVar.OnReadUserAccessLevel = OnReadCommandTargetUserAccessLevel;
+
+                    // Part 5 §9.32.2: only a node carrying a NodeVersion property may
+                    // trigger a ModelChangeEvent, and the framework drops entries for
+                    // nodes that lack one. Mounting the tool adds a reference to this
+                    // robot, so without this the addition is filtered out and no client
+                    // is ever told the gripper appeared - while the *removal* still
+                    // reports, because a deleted node is no longer in the manager's index
+                    // and takes the "not mine, pass it through" path. A connector that
+                    // starts while the tool is detached would then never compose it.
+                    _ = state.EnableModelChangeTracking(ns);
                 }
 
                 robotRep = AttachRepresentation(state, robot.PrimPath, usdNs);

--- a/samples/MinimalRobotServer/RobotCell.cs
+++ b/samples/MinimalRobotServer/RobotCell.cs
@@ -134,6 +134,8 @@ namespace Robotics
             s_cells.Remove(context.Manager);
             s_cells.Add(context.Manager, this);
             await MaterialiseOpenUsdFacilityAsync(cancellationToken).ConfigureAwait(false);
+            await MaterialiseTwinNodesAsync(context.InstanceNamespaceIndex, cancellationToken)
+                .ConfigureAwait(false);
             await MaterialiseRobotCellAsync(context, cancellationToken).ConfigureAwait(false);
             Configure(context.Nodes);
             m_logger.RoboticsAddressSpaceReady(m_axes.Count + m_robots.Count + 1);
@@ -228,6 +230,8 @@ namespace Robotics
                             OpenUsdRenderTargetKindEnum.Visibility, 1.0,
                             bindingTypeId: Opc.Ua.OpenUsd.ObjectTypes.OpenUsdAlarmBindingType,
                             alarmAspect: OpenUsdAlarmAspectEnum.ActiveState);
+
+                        MaterialiseTwinBindings(cellRep, usdNs);
 
                         CreateBinding(cellRep, usdNs, "SpeedOverrideCommand",
                             new Guid("a1b2c3d4-0003-4a10-9c01-100000000003"),

--- a/samples/MinimalRobotServer/RobotCell.cs
+++ b/samples/MinimalRobotServer/RobotCell.cs
@@ -84,7 +84,7 @@ namespace Robotics
         private static readonly (string BrowseName, string PrimPath, bool HasTool, double PhaseSeconds)[] s_robots =
         [
             ("R1", "/Cell/Robots/R1", true, 0.0),
-            ("R2", "/Cell/Robots/R2", false, 3.0)
+            ("R2", "/Cell/Robots/R2", true, 3.0)
         ];
 
         private static readonly ConditionalWeakTable<AsyncCustomNodeManager, RobotCell> s_cells = new();
@@ -99,6 +99,7 @@ namespace Robotics
         private DiNodeManager? m_manager;
         private NodeId m_r1NodeId;
         private MotionDeviceSystemState? m_robotCell;
+        private readonly CellChoreographer? m_choreographer;
 
         /// <summary>
         /// Creates the sample Robotics configurator.
@@ -106,9 +107,10 @@ namespace Robotics
         /// <param name="logger">
         /// The configurator logger.
         /// </param>
-        public RobotCell(ILogger<RobotCell> logger)
+        public RobotCell(ILogger<RobotCell> logger, CellChoreographer? choreographer = null)
         {
             m_logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            m_choreographer = choreographer;
         }
 
         private DiNodeManager Manager => m_manager ?? throw new InvalidOperationException(
@@ -158,6 +160,7 @@ namespace Robotics
             public double Max;
             public double PhaseSeconds;
             public int Index;
+            public string RobotId = string.Empty;
         }
 
         internal sealed class RobotRuntime
@@ -327,7 +330,10 @@ namespace Robotics
 
             builder.Configure((state, ctx) =>
             {
-                if (robot.HasTool)
+                // Keyed on the robot itself, not on whether it carries a tool: both robots
+                // do now, and the dynamic tool demo and the speed-override command target
+                // are deliberately R1's.
+                if (string.Equals(robot.BrowseName, "R1", StringComparison.Ordinal))
                 {
                     m_r1NodeId = state.NodeId;
                     m_speedOverrideVar = FindRequiredChild<BaseDataVariableState>(
@@ -407,7 +413,8 @@ namespace Robotics
                     Min = axis.Min,
                     Max = axis.Max,
                     PhaseSeconds = robot.PhaseSeconds,
-                    Index = index
+                    Index = index,
+                    RobotId = robot.BrowseName
                 });
             });
         }

--- a/samples/MinimalRobotServer/RobotCell.cs
+++ b/samples/MinimalRobotServer/RobotCell.cs
@@ -100,7 +100,7 @@ namespace Robotics
         private DiNodeManager? m_manager;
         private NodeId m_r1NodeId;
         private MotionDeviceSystemState? m_robotCell;
-        private readonly CellChoreographer? m_choreographer;
+        private readonly CellChoreographer m_choreographer;
 
         /// <summary>
         /// Creates the sample Robotics configurator.
@@ -108,10 +108,20 @@ namespace Robotics
         /// <param name="logger">
         /// The configurator logger.
         /// </param>
-        public RobotCell(ILogger<RobotCell> logger, CellChoreographer? choreographer = null)
+        /// <param name="choreographer">
+        /// The cell choreography every robot, workpiece and twin binding is driven from.
+        /// </param>
+        /// <remarks>
+        /// Required rather than optional: without it the simulation tick has nothing to
+        /// advance and the whole cell silently freezes with its axes at the home pose. A
+        /// missing registration should fail where it is made, not look like a stopped
+        /// robot.
+        /// </remarks>
+        public RobotCell(ILogger<RobotCell> logger, CellChoreographer choreographer)
         {
             m_logger = logger ?? throw new ArgumentNullException(nameof(logger));
-            m_choreographer = choreographer;
+            m_choreographer = choreographer ??
+                throw new ArgumentNullException(nameof(choreographer));
         }
 
         private DiNodeManager Manager => m_manager ?? throw new InvalidOperationException(
@@ -781,10 +791,6 @@ namespace Robotics
             double y,
             double headingDegrees)
         {
-            if (m_choreographer == null)
-            {
-                return;
-            }
             foreach (RobotAgent agent in m_choreographer.Robots)
             {
                 if (string.Equals(agent.Id, robotId, StringComparison.Ordinal))

--- a/samples/MinimalRobotServer/RobotCell.cs
+++ b/samples/MinimalRobotServer/RobotCell.cs
@@ -714,6 +714,8 @@ namespace Robotics
                             },
                             sample.StatusCode,
                             sample.GetEffectiveSourceTimestamp());
+                        RecordPublishedPose(
+                            runtime.SourceId, local.X, local.Y, sampleOrientation.C);
                         return default;
                     },
                     context.CancellationToken).ConfigureAwait(false);
@@ -747,6 +749,38 @@ namespace Robotics
                     runtime.Representation.NodeId,
                     binding,
                     context.CancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
+        /// Records the platform pose that was just written to the twin.
+        /// </summary>
+        /// <remarks>
+        /// Taken here rather than where the sample is produced, so it is the pose that
+        /// actually reached the address space: a carried part is drawn against it, and a
+        /// part drawn against anything newer floats out in front of the jaws holding it.
+        /// </remarks>
+        /// <param name="robotId">The robot the pose belongs to.</param>
+        /// <param name="x">The X position written, in metres.</param>
+        /// <param name="y">The Y position written, in metres.</param>
+        /// <param name="headingDegrees">The heading written, in degrees.</param>
+        private void RecordPublishedPose(
+            string robotId,
+            double x,
+            double y,
+            double headingDegrees)
+        {
+            if (m_choreographer == null)
+            {
+                return;
+            }
+            foreach (RobotAgent agent in m_choreographer.Robots)
+            {
+                if (string.Equals(agent.Id, robotId, StringComparison.Ordinal))
+                {
+                    agent.PublishedPose = (x, y, headingDegrees);
+                    return;
+                }
             }
         }
 

--- a/samples/MinimalRobotServer/RobotKinematics.cs
+++ b/samples/MinimalRobotServer/RobotKinematics.cs
@@ -1,0 +1,330 @@
+/* ========================================================================
+ * Copyright (c) 2005-2026 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+
+namespace Robotics
+{
+    /// <summary>
+    /// A rigid body transform - a rotation followed by a translation.
+    /// </summary>
+    /// <remarks>
+    /// Applied to column vectors, so a point maps as <c>p' = R p + t</c>. USD authors a
+    /// <c>matrix4d</c> in the row vector convention with the translation in the last row,
+    /// which <see cref="ToUsdRowMajor"/> produces.
+    /// </remarks>
+    public readonly struct RigidTransform : IEquatable<RigidTransform>
+    {
+        /// <summary>
+        /// The transform that leaves a point where it is.
+        /// </summary>
+        public static RigidTransform Identity { get; } = new(
+            1.0, 0.0, 0.0,
+            0.0, 1.0, 0.0,
+            0.0, 0.0, 1.0,
+            0.0, 0.0, 0.0);
+
+        /// <summary>
+        /// The translation component, in metres.
+        /// </summary>
+        public (double X, double Y, double Z) Origin => (m_tx, m_ty, m_tz);
+
+        /// <summary>
+        /// Creates a pure translation.
+        /// </summary>
+        /// <param name="x">The X offset, in metres.</param>
+        /// <param name="y">The Y offset, in metres.</param>
+        /// <param name="z">The Z offset, in metres.</param>
+        /// <returns>The transform.</returns>
+        public static RigidTransform Translation(double x, double y, double z)
+        {
+            return new RigidTransform(
+                1.0, 0.0, 0.0,
+                0.0, 1.0, 0.0,
+                0.0, 0.0, 1.0,
+                x, y, z);
+        }
+
+        /// <summary>
+        /// Creates a rotation about the X axis.
+        /// </summary>
+        /// <param name="degrees">The angle, in degrees.</param>
+        /// <returns>The transform.</returns>
+        public static RigidTransform RotationX(double degrees)
+        {
+            double r = degrees * (Math.PI / 180.0);
+            double c = Math.Cos(r);
+            double s = Math.Sin(r);
+            return new RigidTransform(
+                1.0, 0.0, 0.0,
+                0.0, c, -s,
+                0.0, s, c,
+                0.0, 0.0, 0.0);
+        }
+
+        /// <summary>
+        /// Creates a rotation about the Y axis.
+        /// </summary>
+        /// <param name="degrees">The angle, in degrees.</param>
+        /// <returns>The transform.</returns>
+        public static RigidTransform RotationY(double degrees)
+        {
+            double r = degrees * (Math.PI / 180.0);
+            double c = Math.Cos(r);
+            double s = Math.Sin(r);
+            return new RigidTransform(
+                c, 0.0, s,
+                0.0, 1.0, 0.0,
+                -s, 0.0, c,
+                0.0, 0.0, 0.0);
+        }
+
+        /// <summary>
+        /// Creates a rotation about the Z axis.
+        /// </summary>
+        /// <param name="degrees">The angle, in degrees.</param>
+        /// <returns>The transform.</returns>
+        public static RigidTransform RotationZ(double degrees)
+        {
+            double r = degrees * (Math.PI / 180.0);
+            double c = Math.Cos(r);
+            double s = Math.Sin(r);
+            return new RigidTransform(
+                c, -s, 0.0,
+                s, c, 0.0,
+                0.0, 0.0, 1.0,
+                0.0, 0.0, 0.0);
+        }
+
+        /// <summary>
+        /// Applies <paramref name="child"/> in this transform's frame.
+        /// </summary>
+        /// <param name="child">The transform expressed in this frame.</param>
+        /// <returns>The composed transform.</returns>
+        public RigidTransform Compose(in RigidTransform child)
+        {
+            return new RigidTransform(
+                (m_r00 * child.m_r00) + (m_r01 * child.m_r10) + (m_r02 * child.m_r20),
+                (m_r00 * child.m_r01) + (m_r01 * child.m_r11) + (m_r02 * child.m_r21),
+                (m_r00 * child.m_r02) + (m_r01 * child.m_r12) + (m_r02 * child.m_r22),
+                (m_r10 * child.m_r00) + (m_r11 * child.m_r10) + (m_r12 * child.m_r20),
+                (m_r10 * child.m_r01) + (m_r11 * child.m_r11) + (m_r12 * child.m_r21),
+                (m_r10 * child.m_r02) + (m_r11 * child.m_r12) + (m_r12 * child.m_r22),
+                (m_r20 * child.m_r00) + (m_r21 * child.m_r10) + (m_r22 * child.m_r20),
+                (m_r20 * child.m_r01) + (m_r21 * child.m_r11) + (m_r22 * child.m_r21),
+                (m_r20 * child.m_r02) + (m_r21 * child.m_r12) + (m_r22 * child.m_r22),
+                (m_r00 * child.m_tx) + (m_r01 * child.m_ty) + (m_r02 * child.m_tz) + m_tx,
+                (m_r10 * child.m_tx) + (m_r11 * child.m_ty) + (m_r12 * child.m_tz) + m_ty,
+                (m_r20 * child.m_tx) + (m_r21 * child.m_ty) + (m_r22 * child.m_tz) + m_tz);
+        }
+
+        /// <summary>
+        /// Flattens the transform into the 16 row-major doubles a USD
+        /// <c>matrix4d</c> attribute carries, with the translation in the last row.
+        /// </summary>
+        /// <returns>The flattened matrix.</returns>
+        public double[] ToUsdRowMajor()
+        {
+            return
+            [
+                m_r00, m_r10, m_r20, 0.0,
+                m_r01, m_r11, m_r21, 0.0,
+                m_r02, m_r12, m_r22, 0.0,
+                m_tx, m_ty, m_tz, 1.0
+            ];
+        }
+
+        /// <inheritdoc/>
+        public bool Equals(RigidTransform other)
+        {
+            return m_r00.Equals(other.m_r00) && m_r01.Equals(other.m_r01) &&
+                m_r02.Equals(other.m_r02) && m_r10.Equals(other.m_r10) &&
+                m_r11.Equals(other.m_r11) && m_r12.Equals(other.m_r12) &&
+                m_r20.Equals(other.m_r20) && m_r21.Equals(other.m_r21) &&
+                m_r22.Equals(other.m_r22) && m_tx.Equals(other.m_tx) &&
+                m_ty.Equals(other.m_ty) && m_tz.Equals(other.m_tz);
+        }
+
+        /// <inheritdoc/>
+        public override bool Equals(object? obj)
+        {
+            return obj is RigidTransform other && Equals(other);
+        }
+
+        /// <inheritdoc/>
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(m_r00, m_r11, m_r22, m_tx, m_ty, m_tz);
+        }
+
+        /// <summary>
+        /// Compares two transforms.
+        /// </summary>
+        /// <param name="left">The first transform.</param>
+        /// <param name="right">The second transform.</param>
+        /// <returns><c>true</c> when the transforms are equal.</returns>
+        public static bool operator ==(RigidTransform left, RigidTransform right)
+        {
+            return left.Equals(right);
+        }
+
+        /// <summary>
+        /// Compares two transforms.
+        /// </summary>
+        /// <param name="left">The first transform.</param>
+        /// <param name="right">The second transform.</param>
+        /// <returns><c>true</c> when the transforms differ.</returns>
+        public static bool operator !=(RigidTransform left, RigidTransform right)
+        {
+            return !left.Equals(right);
+        }
+
+        private RigidTransform(
+            double r00, double r01, double r02,
+            double r10, double r11, double r12,
+            double r20, double r21, double r22,
+            double tx, double ty, double tz)
+        {
+            m_r00 = r00;
+            m_r01 = r01;
+            m_r02 = r02;
+            m_r10 = r10;
+            m_r11 = r11;
+            m_r12 = r12;
+            m_r20 = r20;
+            m_r21 = r21;
+            m_r22 = r22;
+            m_tx = tx;
+            m_ty = ty;
+            m_tz = tz;
+        }
+
+        private readonly double m_r00;
+        private readonly double m_r01;
+        private readonly double m_r02;
+        private readonly double m_r10;
+        private readonly double m_r11;
+        private readonly double m_r12;
+        private readonly double m_r20;
+        private readonly double m_r21;
+        private readonly double m_r22;
+        private readonly double m_tx;
+        private readonly double m_ty;
+        private readonly double m_tz;
+    }
+
+    /// <summary>
+    /// Forward kinematics of the sample robot, derived from the link offsets authored in
+    /// <c>robot.usda</c>.
+    /// </summary>
+    /// <remarks>
+    /// The server drives the arm by publishing six axis positions, and the connector maps
+    /// each onto the matching <c>xformOp:rotate*</c> in the asset. Computing the tool centre
+    /// point from those same six values - rather than from the choreography that produced
+    /// them - is what keeps a carried part welded to the gripper instead of drifting away
+    /// from it.
+    /// </remarks>
+    public static class RobotKinematics
+    {
+        /// <summary>
+        /// The number of axes the arm has.
+        /// </summary>
+        public const int AxisCount = 6;
+
+        /// <summary>
+        /// The reach of the arm measured along the link offsets, in metres.
+        /// </summary>
+        /// <remarks>
+        /// The sum of the J2, J3, J4 and flange X offsets. The cell layout keeps two robots
+        /// further apart than this whenever both arms are deployed.
+        /// </remarks>
+        public const double MaximumReach = 0.260 + 0.680 + 0.670 + 0.158;
+
+        /// <summary>
+        /// The offset from the flange to the point between the gripper jaws, in metres.
+        /// </summary>
+        public const double ToolCentrePointOffsetX = 0.150;
+
+        /// <summary>
+        /// Computes the pose of the point between the gripper jaws.
+        /// </summary>
+        /// <param name="mount">The pose of the robot mount prim in cell coordinates.</param>
+        /// <param name="axesDegrees">The six axis positions, in degrees.</param>
+        /// <returns>The tool centre point pose in cell coordinates.</returns>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="axesDegrees"/> does not carry <see cref="AxisCount"/> values.
+        /// </exception>
+        public static RigidTransform ComputeToolCentrePoint(
+            in RigidTransform mount,
+            ReadOnlySpan<double> axesDegrees)
+        {
+            if (axesDegrees.Length != AxisCount)
+            {
+                throw new ArgumentException(
+                    $"Expected {AxisCount} axis positions.",
+                    nameof(axesDegrees));
+            }
+
+            RigidTransform pose = mount
+                .Compose(RigidTransform.Translation(0.0, 0.0, 0.3650))
+                .Compose(RigidTransform.Translation(0.0, 0.0, 0.2900))
+                .Compose(RigidTransform.RotationZ(axesDegrees[0]))
+                .Compose(RigidTransform.Translation(0.2600, 0.0, 0.3850))
+                .Compose(RigidTransform.RotationY(axesDegrees[1]))
+                .Compose(RigidTransform.Translation(0.6800, 0.0, 0.0))
+                .Compose(RigidTransform.RotationY(axesDegrees[2]))
+                .Compose(RigidTransform.Translation(0.6700, 0.0, -0.0350))
+                .Compose(RigidTransform.RotationX(axesDegrees[3]))
+                .Compose(RigidTransform.RotationY(axesDegrees[4]))
+                .Compose(RigidTransform.RotationX(axesDegrees[5]))
+                .Compose(RigidTransform.Translation(0.1580, 0.0, 0.0));
+
+            return pose.Compose(
+                RigidTransform.Translation(ToolCentrePointOffsetX, 0.0, 0.0));
+        }
+
+        /// <summary>
+        /// Builds the pose of a robot mount from its cell position and heading.
+        /// </summary>
+        /// <param name="x">The X position, in metres.</param>
+        /// <param name="y">The Y position, in metres.</param>
+        /// <param name="z">The Z position, in metres.</param>
+        /// <param name="headingDegrees">The heading about Z, in degrees.</param>
+        /// <returns>The mount pose.</returns>
+        public static RigidTransform CreateMountPose(
+            double x,
+            double y,
+            double z,
+            double headingDegrees)
+        {
+            return RigidTransform.Translation(x, y, z)
+                .Compose(RigidTransform.RotationZ(headingDegrees));
+        }
+    }
+}

--- a/src/Opc.Ua.OpenUsd.Client/OpenUsdConnector.Composition.cs
+++ b/src/Opc.Ua.OpenUsd.Client/OpenUsdConnector.Composition.cs
@@ -298,18 +298,30 @@ namespace Opc.Ua.OpenUsd.Client
             item.Notification += OnModelChangeEvent;
             subscription.AddItem(item);
             await subscription.ApplyChangesAsync(ct).ConfigureAwait(false);
-
-            // A rejected event item is not a degraded mode, it is a broken one: every
-            // Dynamic component would keep whatever composition it happened to resolve at
-            // start-up and silently never reconcile again. Say so rather than compose a
-            // twin that quietly stops matching the server.
-            if (ServiceResult.IsBad(item.Status.Error))
-            {
-                throw new InvalidOperationException(
-                    "OpenUSD model-change subscription was rejected by the server " +
-                    $"({item.Status.Error}) — Dynamic components could not be reconciled.");
-            }
+            ThrowIfModelChangeRejected(item.Status?.Error, eventSource);
             m_logger.ModelChangeSubscribed(eventSource);
+        }
+
+        /// <summary>
+        /// Throws when the server refused the model-change monitored item.
+        /// </summary>
+        /// <remarks>
+        /// A rejected event item is not a degraded mode, it is a broken one: every Dynamic
+        /// component would keep whatever composition it happened to resolve at start-up and
+        /// silently never reconcile again. Say so rather than compose a twin that quietly
+        /// stops matching the server.
+        /// </remarks>
+        /// <param name="error">The status the server returned for the item.</param>
+        /// <param name="eventSource">The node the item was created on.</param>
+        internal static void ThrowIfModelChangeRejected(ServiceResult? error, NodeId eventSource)
+        {
+            if (!ServiceResult.IsBad(error))
+            {
+                return;
+            }
+            throw new InvalidOperationException(
+                $"OpenUSD model-change subscription on {eventSource} was rejected by the " +
+                $"server ({error}) — Dynamic components could not be reconciled.");
         }
 
         private void OnModelChangeEvent(MonitoredItem item, MonitoredItemNotificationEventArgs e)

--- a/src/Opc.Ua.OpenUsd.Client/OpenUsdConnector.Composition.cs
+++ b/src/Opc.Ua.OpenUsd.Client/OpenUsdConnector.Composition.cs
@@ -298,6 +298,17 @@ namespace Opc.Ua.OpenUsd.Client
             item.Notification += OnModelChangeEvent;
             subscription.AddItem(item);
             await subscription.ApplyChangesAsync(ct).ConfigureAwait(false);
+
+            // A rejected event item is not a degraded mode, it is a broken one: every
+            // Dynamic component would keep whatever composition it happened to resolve at
+            // start-up and silently never reconcile again. Say so rather than compose a
+            // twin that quietly stops matching the server.
+            if (ServiceResult.IsBad(item.Status.Error))
+            {
+                throw new InvalidOperationException(
+                    "OpenUSD model-change subscription was rejected by the server " +
+                    $"({item.Status.Error}) — Dynamic components could not be reconciled.");
+            }
             m_logger.ModelChangeSubscribed(eventSource);
         }
 

--- a/src/Opc.Ua.OpenUsd.Client/OpenUsdConnector.cs
+++ b/src/Opc.Ua.OpenUsd.Client/OpenUsdConnector.cs
@@ -711,6 +711,12 @@ namespace Opc.Ua.OpenUsd.Client
             if (anyDynamic)
             {
                 await SubscribeModelChangesAsync(eventSource, ct).ConfigureAwait(false);
+
+                // The components above were composed from the address space as it stood
+                // *before* this subscription existed, so a change in between was seen by
+                // neither. Re-resolve once now that both are in place. The resolve is
+                // idempotent and serialized with the event-driven ones.
+                await RunRecomposeAsync().ConfigureAwait(false);
             }
         }
 

--- a/tests/Opc.Ua.Di.Tests/CellChoreographyTests.cs
+++ b/tests/Opc.Ua.Di.Tests/CellChoreographyTests.cs
@@ -264,6 +264,47 @@ namespace Opc.Ua.Di.Tests
         }
 
         [Test]
+        public void AStowedArmHoldsThePartAtAConstantOffsetFromThePlatform()
+        {
+            var cell = new CellChoreographer();
+            double minimum = double.MaxValue;
+            double maximum = double.MinValue;
+            int samples = 0;
+
+            for (int i = 0; i < LongRunSteps; i++)
+            {
+                cell.Advance(Step);
+                foreach (RobotAgent robot in cell.Robots)
+                {
+                    if (robot.HoldingPart == null || !robot.ArmStowed)
+                    {
+                        continue;
+                    }
+                    (double x, double y, double _) = CellChoreographer
+                        .ToolCentrePointOf(robot).Origin;
+                    double dx = x - robot.X;
+                    double dy = y - robot.Y;
+                    double distance = Math.Sqrt((dx * dx) + (dy * dy));
+                    minimum = Math.Min(minimum, distance);
+                    maximum = Math.Max(maximum, distance);
+                    samples++;
+                }
+            }
+
+            Assert.That(samples, Is.GreaterThan(0),
+                "The run never carried a part with the arm stowed.");
+
+            // The transport pose is fixed, so a carried part rides at a constant distance
+            // from the platform while the robot drives. The twin has to preserve that: the
+            // part pose and the platform pose leave the server on separate loops, and a
+            // part drawn against a stale platform floats out in front of the jaws by
+            // however far the robot travelled in between - a quarter of a metre at cruise,
+            // which is three part widths.
+            Assert.That(maximum - minimum, Is.LessThan(1e-9),
+                "The stowed transport offset is not constant.");
+        }
+
+        [Test]
         public void EveryPartIsEventuallyCollectedSoNoneStarves()
         {
             var cell = new CellChoreographer();

--- a/tests/Opc.Ua.Di.Tests/CellChoreographyTests.cs
+++ b/tests/Opc.Ua.Di.Tests/CellChoreographyTests.cs
@@ -264,6 +264,32 @@ namespace Opc.Ua.Di.Tests
         }
 
         [Test]
+        public void EveryPartIsEventuallyCollectedSoNoneStarves()
+        {
+            var cell = new CellChoreographer();
+            var moved = new HashSet<string>(StringComparer.Ordinal);
+
+            for (int i = 0; i < LongRunSteps; i++)
+            {
+                cell.Advance(Step);
+                foreach (CellPart part in cell.Parts)
+                {
+                    if (!part.IsResting)
+                    {
+                        _ = moved.Add(part.Id);
+                    }
+                }
+            }
+
+            // The buffers are worked first-in-first-out. Collecting the lowest free slot
+            // instead starves a spare that never lands in it: with two parts seeded on
+            // TableA the second sat untouched for the life of the process, which reads in
+            // the twin as the robots ignoring a block sitting in front of them.
+            Assert.That(moved, Has.Count.EqualTo(cell.Parts.Count),
+                "A part was never collected across the run.");
+        }
+
+        [Test]
         public void KpisAccumulateOverTheRun()
         {
             var cell = new CellChoreographer();

--- a/tests/Opc.Ua.Di.Tests/CellChoreographyTests.cs
+++ b/tests/Opc.Ua.Di.Tests/CellChoreographyTests.cs
@@ -1,0 +1,357 @@
+/* ========================================================================
+ * Copyright (c) 2005-2026 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Robotics;
+
+namespace Opc.Ua.Di.Tests
+{
+    /// <summary>
+    /// Tests for <see cref="CellChoreographer"/>.
+    /// </summary>
+    /// <remarks>
+    /// The sample previously ran the two robots on independent figure-eight paths whose
+    /// platforms cleared by 1.2 m while the arms reach 1.61 m, so the arms swept through
+    /// each other. These tests run the coordinated cycle for several minutes of simulated
+    /// time and assert the separation and reservation invariants on every step, which is the
+    /// regression guard for that.
+    /// </remarks>
+    [TestFixture]
+    [Category("Robotics")]
+    [Parallelizable]
+    public class CellChoreographyTests
+    {
+        private const double Step = 0.05;
+        private const int LongRunSteps = 12000; // ten minutes of simulated time
+
+        [Test]
+        public void RobotsNeverOverlap()
+        {
+            var cell = new CellChoreographer();
+            double worstClearance = double.MaxValue;
+
+            for (int i = 0; i < LongRunSteps; i++)
+            {
+                cell.Advance(Step);
+                RobotAgent a = cell.Robots[0];
+                RobotAgent b = cell.Robots[1];
+                bool overlap = CellChoreographer.FootprintsOverlap(a, b);
+                double dx = a.X - b.X;
+                double dy = a.Y - b.Y;
+                worstClearance = Math.Min(worstClearance, Math.Sqrt((dx * dx) + (dy * dy)));
+
+                Assert.That(overlap, Is.False,
+                    $"Step {i}: {a.Id} at ({a.X:N2},{a.Y:N2}) stowed={a.ArmStowed} and " +
+                    $"{b.Id} at ({b.X:N2},{b.Y:N2}) stowed={b.ArmStowed} overlap.");
+            }
+
+            Assert.That(worstClearance, Is.GreaterThan(0.0));
+        }
+
+        /// <summary>
+        /// The arms are the part that used to collide, so their reach is checked directly
+        /// rather than inferred from the platform separation.
+        /// </summary>
+        [Test]
+        public void ToolCentrePointsNeverMeet()
+        {
+            var cell = new CellChoreographer();
+
+            for (int i = 0; i < LongRunSteps; i++)
+            {
+                cell.Advance(Step);
+                (double ax, double ay, _) = CellChoreographer
+                    .ToolCentrePointOf(cell.Robots[0]).Origin;
+                (double bx, double by, _) = CellChoreographer
+                    .ToolCentrePointOf(cell.Robots[1]).Origin;
+                double distance = Math.Sqrt(((ax - bx) * (ax - bx)) + ((ay - by) * (ay - by)));
+
+                Assert.That(distance, Is.GreaterThan(0.30),
+                    $"Step {i}: the two tool centre points came within {distance:N3} m.");
+            }
+        }
+
+        [Test]
+        public void ACorridorLaneIsNeverSharedByBothRobots()
+        {
+            var cell = new CellChoreographer();
+
+            for (int i = 0; i < LongRunSteps; i++)
+            {
+                cell.Advance(Step);
+                var zones = new List<CellZone>();
+                foreach (RobotAgent robot in cell.Robots)
+                {
+                    zones.Add(CellChoreographer.ZoneAt(robot.X, robot.Y));
+                }
+                bool shared = zones[0] == zones[1] && zones[0] != CellZone.None;
+
+                Assert.That(shared, Is.False,
+                    $"Step {i}: both robots occupied {zones[0]}.");
+            }
+        }
+
+        /// <summary>
+        /// An arm may only leave its transport envelope inside an end zone, because that is
+        /// the reservation that guarantees nothing else is there.
+        /// </summary>
+        [Test]
+        public void ArmsOnlyDeployInsideAnEndZone()
+        {
+            var cell = new CellChoreographer();
+
+            for (int i = 0; i < LongRunSteps; i++)
+            {
+                cell.Advance(Step);
+                foreach (RobotAgent robot in cell.Robots)
+                {
+                    if (robot.ArmStowed)
+                    {
+                        continue;
+                    }
+                    CellZone zone = CellChoreographer.ZoneAt(robot.X, robot.Y);
+                    bool inEndZone = zone is CellZone.EndZoneA or CellZone.EndZoneB;
+                    Assert.That(
+                        inEndZone,
+                        Is.True,
+                        $"Step {i}: {robot.Id} deployed its arm in {zone}.");
+                }
+            }
+        }
+
+        /// <summary>
+        /// Every part must be in exactly one place at all times - resting in a slot, carried
+        /// by one robot, or on the floor after a dropped grip.
+        /// </summary>
+        [Test]
+        public void PartsAreConserved()
+        {
+            var cell = new CellChoreographer();
+            int expected = cell.Parts.Count;
+
+            for (int i = 0; i < LongRunSteps; i++)
+            {
+                cell.Advance(Step);
+                var carriers = new List<string>();
+                foreach (CellPart part in cell.Parts)
+                {
+                    int places = 0;
+                    if (part.CarriedBy != null)
+                    {
+                        places++;
+                        carriers.Add(part.CarriedBy);
+                    }
+                    if (part.IsResting)
+                    {
+                        places++;
+                    }
+                    Assert.That(places, Is.EqualTo(1),
+                        $"Step {i}: {part.Id} is in {places} places.");
+                }
+                Assert.That(cell.Parts, Has.Count.EqualTo(expected));
+                Assert.That(carriers, Is.Unique, $"Step {i}: a part is carried twice.");
+            }
+        }
+
+        /// <summary>
+        /// A carried part has to sit exactly on the tool centre point, which is the whole
+        /// reason the pose is computed from forward kinematics rather than from the script.
+        /// </summary>
+        [Test]
+        public void ACarriedPartTracksTheToolCentrePoint()
+        {
+            var cell = new CellChoreographer();
+            int carriedSamples = 0;
+
+            for (int i = 0; i < LongRunSteps; i++)
+            {
+                cell.Advance(Step);
+                foreach (RobotAgent robot in cell.Robots)
+                {
+                    if (robot.HoldingPart == null)
+                    {
+                        continue;
+                    }
+                    CellPart part = FindPart(cell, robot.HoldingPart);
+                    (double x, double y, double z) = CellChoreographer
+                        .ToolCentrePointOf(robot).Origin;
+                    Assert.That(part.X, Is.EqualTo(x).Within(1e-9));
+                    Assert.That(part.Y, Is.EqualTo(y).Within(1e-9));
+                    Assert.That(part.Z, Is.EqualTo(z).Within(1e-9));
+                    carriedSamples++;
+                }
+            }
+
+            Assert.That(carriedSamples, Is.GreaterThan(0),
+                "The run never carried a part, so the assertion proved nothing.");
+        }
+
+        /// <summary>
+        /// The interlock must not deadlock: parts have to actually make the round trip.
+        /// </summary>
+        [Test]
+        public void PartsAreHandedOverBetweenBothStations()
+        {
+            var cell = new CellChoreographer();
+            var seenOnB = new HashSet<string>(StringComparer.Ordinal);
+            var returnedToA = new HashSet<string>(StringComparer.Ordinal);
+
+            for (int i = 0; i < LongRunSteps; i++)
+            {
+                cell.Advance(Step);
+                foreach (CellPart part in cell.Parts)
+                {
+                    if (!part.IsResting || part.OnFloor)
+                    {
+                        continue;
+                    }
+                    if (part.Station == CellStation.TableB)
+                    {
+                        _ = seenOnB.Add(part.Id);
+                    }
+                    else if (seenOnB.Contains(part.Id))
+                    {
+                        _ = returnedToA.Add(part.Id);
+                    }
+                }
+            }
+
+            Assert.That(seenOnB, Is.Not.Empty,
+                "R1 never delivered a part to the eastern station.");
+            Assert.That(returnedToA, Is.Not.Empty,
+                "R2 never returned a part to the western station.");
+            Assert.That(cell.Kpis.PartsMoved, Is.GreaterThan(1));
+        }
+
+        [Test]
+        public void KpisAccumulateOverTheRun()
+        {
+            var cell = new CellChoreographer();
+
+            for (int i = 0; i < LongRunSteps; i++)
+            {
+                cell.Advance(Step);
+            }
+
+            Assert.That(cell.Kpis.PartsMoved, Is.GreaterThan(0));
+            Assert.That(cell.Kpis.AverageCycleSeconds, Is.GreaterThan(0.0));
+            Assert.That(cell.Kpis.Utilisation, Is.GreaterThan(0.0));
+            Assert.That(cell.Kpis.Utilisation, Is.LessThanOrEqualTo(1.0));
+        }
+
+        [Test]
+        public void EmergencyStopHaltsEveryRobot()
+        {
+            var cell = new CellChoreographer();
+            for (int i = 0; i < 400; i++)
+            {
+                cell.Advance(Step);
+            }
+
+            cell.EmergencyStop = true;
+            for (int i = 0; i < 40; i++)
+            {
+                cell.Advance(Step);
+            }
+
+            double[] x = [cell.Robots[0].X, cell.Robots[1].X];
+            double[] y = [cell.Robots[0].Y, cell.Robots[1].Y];
+            for (int i = 0; i < 40; i++)
+            {
+                cell.Advance(Step);
+            }
+
+            for (int r = 0; r < cell.Robots.Count; r++)
+            {
+                Assert.That(cell.Robots[r].Speed, Is.Zero);
+                Assert.That(cell.Robots[r].X, Is.EqualTo(x[r]).Within(1e-12));
+                Assert.That(cell.Robots[r].Y, Is.EqualTo(y[r]).Within(1e-12));
+            }
+        }
+
+        /// <summary>
+        /// A dropped part must be recovered rather than abandoned, otherwise the cell would
+        /// slowly lose its stock.
+        /// </summary>
+        [Test]
+        public void DroppedPartsAreRecovered()
+        {
+            var cell = new CellChoreographer(seed: 7, faultProbability: 1.0);
+            bool sawDrop = false;
+
+            for (int i = 0; i < 4000; i++)
+            {
+                cell.Advance(Step);
+                foreach (CellPart part in cell.Parts)
+                {
+                    sawDrop |= part.OnFloor;
+                }
+            }
+
+            Assert.That(sawDrop, Is.True, "The forced fault never dropped a part.");
+            Assert.That(cell.Kpis.FaultCount, Is.GreaterThan(0));
+            Assert.That(cell.Parts, Has.Count.EqualTo(3));
+        }
+
+        [Test]
+        public void BatteryDrainsAndRecharges()
+        {
+            var cell = new CellChoreographer();
+            double lowest = 100.0;
+            bool charged = false;
+
+            for (int i = 0; i < LongRunSteps * 2; i++)
+            {
+                cell.Advance(Step);
+                foreach (RobotAgent robot in cell.Robots)
+                {
+                    lowest = Math.Min(lowest, robot.BatteryLevel);
+                    charged |= robot.State == RobotCycleState.Charging;
+                }
+            }
+
+            Assert.That(lowest, Is.LessThan(100.0), "The battery never drained.");
+            Assert.That(charged, Is.True, "No robot ever docked to charge.");
+        }
+
+        private static CellPart FindPart(CellChoreographer cell, string id)
+        {
+            foreach (CellPart part in cell.Parts)
+            {
+                if (string.Equals(part.Id, id, StringComparison.Ordinal))
+                {
+                    return part;
+                }
+            }
+            throw new InvalidOperationException($"Part {id} is missing.");
+        }
+    }
+}

--- a/tests/Opc.Ua.Di.Tests/CellChoreographyTests.cs
+++ b/tests/Opc.Ua.Di.Tests/CellChoreographyTests.cs
@@ -215,13 +215,22 @@ namespace Opc.Ua.Di.Tests
         }
 
         /// <summary>
-        /// The interlock must not deadlock: parts have to actually make the round trip.
+        /// The interlock must not deadlock: a part staged on the western station has to
+        /// reach the eastern one and come back.
         /// </summary>
         [Test]
         public void PartsAreHandedOverBetweenBothStations()
         {
             var cell = new CellChoreographer();
-            var seenOnB = new HashSet<string>(StringComparer.Ordinal);
+            var startedOnA = new HashSet<string>(StringComparer.Ordinal);
+            foreach (CellPart part in cell.Parts)
+            {
+                if (part.Station == CellStation.TableA)
+                {
+                    _ = startedOnA.Add(part.Id);
+                }
+            }
+            var deliveredEast = new HashSet<string>(StringComparer.Ordinal);
             var returnedToA = new HashSet<string>(StringComparer.Ordinal);
 
             for (int i = 0; i < LongRunSteps; i++)
@@ -235,19 +244,22 @@ namespace Opc.Ua.Di.Tests
                     }
                     if (part.Station == CellStation.TableB)
                     {
-                        _ = seenOnB.Add(part.Id);
+                        if (startedOnA.Contains(part.Id))
+                        {
+                            _ = deliveredEast.Add(part.Id);
+                        }
                     }
-                    else if (seenOnB.Contains(part.Id))
+                    else if (deliveredEast.Contains(part.Id))
                     {
                         _ = returnedToA.Add(part.Id);
                     }
                 }
             }
 
-            Assert.That(seenOnB, Is.Not.Empty,
-                "R1 never delivered a part to the eastern station.");
+            Assert.That(deliveredEast, Is.Not.Empty,
+                "R1 never delivered a western part to the eastern station.");
             Assert.That(returnedToA, Is.Not.Empty,
-                "R2 never returned a part to the western station.");
+                "R2 never returned a delivered part to the western station.");
             Assert.That(cell.Kpis.PartsMoved, Is.GreaterThan(1));
         }
 

--- a/tests/Opc.Ua.Di.Tests/Opc.Ua.Di.Tests.csproj
+++ b/tests/Opc.Ua.Di.Tests/Opc.Ua.Di.Tests.csproj
@@ -64,6 +64,8 @@
     <Compile Remove="PumpOpenUsdE2eTests.cs" />
     <Compile Remove="RobotOpenUsdE2eTests.cs" />
     <Compile Remove="RobotMobilityTests.cs" />
+    <Compile Remove="RobotKinematicsTests.cs" />
+    <Compile Remove="CellChoreographyTests.cs" />
     <Compile Remove="TopologyElementBuilderTests.cs" />
   </ItemGroup>
 </Project>

--- a/tests/Opc.Ua.Di.Tests/RobotKinematicsTests.cs
+++ b/tests/Opc.Ua.Di.Tests/RobotKinematicsTests.cs
@@ -1,0 +1,182 @@
+/* ========================================================================
+ * Copyright (c) 2005-2026 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using NUnit.Framework;
+using Robotics;
+
+namespace Opc.Ua.Di.Tests
+{
+    /// <summary>
+    /// Tests for <see cref="RobotKinematics"/>, the forward kinematics the sample uses to
+    /// keep a carried part welded to the gripper.
+    /// </summary>
+    [TestFixture]
+    [Category("Robotics")]
+    [Parallelizable]
+    public class RobotKinematicsTests
+    {
+        private const double Tolerance = 1e-9;
+
+        /// <summary>
+        /// The home pose of the axis template, hand-computed from the link offsets authored
+        /// in robot.usda. If the asset's offsets change this is the test that says so.
+        /// </summary>
+        private static readonly double[] s_homePose = [0.0, -60.0, 75.0, 0.0, 45.0, 0.0];
+
+        [Test]
+        public void IdentityComposesToItself()
+        {
+            RigidTransform composed = RigidTransform.Identity
+                .Compose(RigidTransform.Identity);
+
+            Assert.That(composed, Is.EqualTo(RigidTransform.Identity));
+        }
+
+        [Test]
+        public void TranslationsAccumulate()
+        {
+            RigidTransform composed = RigidTransform.Translation(1.0, 2.0, 3.0)
+                .Compose(RigidTransform.Translation(0.5, -1.0, 0.25));
+
+            (double x, double y, double z) = composed.Origin;
+            Assert.That(x, Is.EqualTo(1.5).Within(Tolerance));
+            Assert.That(y, Is.EqualTo(1.0).Within(Tolerance));
+            Assert.That(z, Is.EqualTo(3.25).Within(Tolerance));
+        }
+
+        /// <summary>
+        /// A child offset is expressed in the parent's rotated frame, which is the property
+        /// the whole arm chain depends on.
+        /// </summary>
+        [Test]
+        public void RotationAppliesToTheChildOffset()
+        {
+            RigidTransform composed = RigidTransform.RotationZ(90.0)
+                .Compose(RigidTransform.Translation(1.0, 0.0, 0.0));
+
+            (double x, double y, double z) = composed.Origin;
+            Assert.That(x, Is.Zero.Within(1e-12));
+            Assert.That(y, Is.EqualTo(1.0).Within(1e-12));
+            Assert.That(z, Is.Zero.Within(1e-12));
+        }
+
+        [Test]
+        public void ToUsdRowMajorPutsTheTranslationInTheLastRow()
+        {
+            double[] m = RigidTransform.Translation(1.0, 2.0, 3.0).ToUsdRowMajor();
+
+            Assert.That(m, Has.Length.EqualTo(16));
+            Assert.That(m[12], Is.EqualTo(1.0).Within(Tolerance));
+            Assert.That(m[13], Is.EqualTo(2.0).Within(Tolerance));
+            Assert.That(m[14], Is.EqualTo(3.0).Within(Tolerance));
+            Assert.That(m[15], Is.EqualTo(1.0).Within(Tolerance));
+        }
+
+        /// <summary>
+        /// The tool centre point of the home pose, computed by hand from the link offsets:
+        /// base 0.365, J1 0.290, J2 (0.260, 0.385) then -60 deg, J3 0.680 then +75 deg,
+        /// J4 (0.670, -0.035), J5 +45 deg, flange 0.158 and the 0.150 jaw offset.
+        /// </summary>
+        [Test]
+        public void HomePoseResolvesToTheHandComputedToolCentrePoint()
+        {
+            RigidTransform mount = RobotKinematics.CreateMountPose(0.0, 0.0, 0.0, 0.0);
+
+            RigidTransform tcp = RobotKinematics.ComputeToolCentrePoint(mount, s_homePose);
+
+            (double x, double y, double z) = tcp.Origin;
+            Assert.That(x, Is.EqualTo(1.3919).Within(0.001));
+            Assert.That(y, Is.Zero.Within(1e-9));
+            Assert.That(z, Is.EqualTo(1.1550).Within(0.001));
+        }
+
+        /// <summary>
+        /// The mount heading has to carry the whole arm round with it, otherwise a robot
+        /// that turns to face a table would reach in the direction it started from.
+        /// </summary>
+        [Test]
+        public void MountHeadingRotatesTheWholeArm()
+        {
+            RigidTransform facingX = RobotKinematics.CreateMountPose(0.0, 0.0, 0.0, 0.0);
+            RigidTransform facingY = RobotKinematics.CreateMountPose(0.0, 0.0, 0.0, 90.0);
+
+            (double x0, double y0, double z0) = RobotKinematics
+                .ComputeToolCentrePoint(facingX, s_homePose).Origin;
+            (double x1, double y1, double z1) = RobotKinematics
+                .ComputeToolCentrePoint(facingY, s_homePose).Origin;
+
+            Assert.That(x1, Is.EqualTo(-y0).Within(1e-9));
+            Assert.That(y1, Is.EqualTo(x0).Within(1e-9));
+            Assert.That(z1, Is.EqualTo(z0).Within(1e-9));
+        }
+
+        [Test]
+        public void MountTranslationOffsetsTheToolCentrePoint()
+        {
+            RigidTransform atOrigin = RobotKinematics.CreateMountPose(0.0, 0.0, 0.0, 0.0);
+            RigidTransform moved = RobotKinematics.CreateMountPose(-2.4, 0.35, 0.0, 0.0);
+
+            (double x0, double y0, _) = RobotKinematics
+                .ComputeToolCentrePoint(atOrigin, s_homePose).Origin;
+            (double x1, double y1, _) = RobotKinematics
+                .ComputeToolCentrePoint(moved, s_homePose).Origin;
+
+            Assert.That(x1 - x0, Is.EqualTo(-2.4).Within(1e-9));
+            Assert.That(y1 - y0, Is.EqualTo(0.35).Within(1e-9));
+        }
+
+        /// <summary>
+        /// The reach constant is what the cell layout is dimensioned against, so it must
+        /// stay consistent with the chain the kinematics actually walks.
+        /// </summary>
+        [Test]
+        public void MaximumReachBoundsTheFullyExtendedArm()
+        {
+            RigidTransform mount = RobotKinematics.CreateMountPose(0.0, 0.0, 0.0, 0.0);
+            double[] extended = [0.0, -90.0, 0.0, 0.0, 0.0, 0.0];
+
+            (double x, double y, _) = RobotKinematics
+                .ComputeToolCentrePoint(mount, extended).Origin;
+
+            double planarReach = Math.Sqrt((x * x) + (y * y));
+            Assert.That(planarReach, Is.LessThanOrEqualTo(RobotKinematics.MaximumReach + 1e-9));
+        }
+
+        [Test]
+        public void WrongAxisCountIsRejected()
+        {
+            RigidTransform mount = RigidTransform.Identity;
+
+            Assert.That(
+                () => RobotKinematics.ComputeToolCentrePoint(mount, [0.0, 0.0]),
+                Throws.ArgumentException);
+        }
+    }
+}

--- a/tests/Opc.Ua.Di.Tests/RobotKinematicsTests.cs
+++ b/tests/Opc.Ua.Di.Tests/RobotKinematicsTests.cs
@@ -178,5 +178,91 @@ namespace Opc.Ua.Di.Tests
                 () => RobotKinematics.ComputeToolCentrePoint(mount, [0.0, 0.0]),
                 Throws.ArgumentException);
         }
+
+        /// <summary>
+        /// The solver is only worth having if the pose it returns actually lands the tool
+        /// where it was asked to, measured by the independent forward kinematics.
+        /// </summary>
+        [TestCase(0.90, 0.00, 0.7875)]
+        [TestCase(0.90, 0.22, 0.7875)]
+        [TestCase(0.90, -0.22, 0.7875)]
+        [TestCase(0.75, 0.10, 0.9500)]
+        [TestCase(1.10, -0.15, 0.8500)]
+        public void SolvedPoseLandsTheToolOnTheTarget(
+            double forward,
+            double lateral,
+            double height)
+        {
+            var axes = new double[RobotKinematics.AxisCount];
+            Assert.That(RobotArmSolver.TrySolve(forward, lateral, height, axes), Is.True,
+                "The target should be inside the arm's working envelope.");
+
+            RigidTransform mount = RobotKinematics.CreateMountPose(0.0, 0.0, 0.0, 0.0);
+            (double x, double y, double z) = RobotKinematics
+                .ComputeToolCentrePoint(mount, axes).Origin;
+
+            Assert.That(x, Is.EqualTo(forward).Within(1e-6));
+            Assert.That(y, Is.EqualTo(lateral).Within(1e-6));
+            Assert.That(z, Is.EqualTo(height).Within(1e-6));
+        }
+
+        /// <summary>
+        /// A robot parked in front of a table must be able to reach every slot on it, or the
+        /// cell layout and the arm disagree.
+        /// </summary>
+        [TestCase(CellStation.TableA, 0)]
+        [TestCase(CellStation.TableA, 1)]
+        [TestCase(CellStation.TableA, 2)]
+        [TestCase(CellStation.TableB, 0)]
+        [TestCase(CellStation.TableB, 1)]
+        [TestCase(CellStation.TableB, 2)]
+        public void EverySlotIsReachableFromTheTableApproach(CellStation table, int slot)
+        {
+            double approachX = table == CellStation.TableA
+                ? CellLayout.TableAX
+                : CellLayout.TableBX;
+            (double slotX, double slotY, double slotZ) = CellLayout.SlotPosition(table, slot);
+
+            // The robot parks facing north, so the arm's forward axis is world +Y.
+            double forward = slotY - CellLayout.TableApproachY;
+            double lateral = -(slotX - approachX);
+
+            var axes = new double[RobotKinematics.AxisCount];
+            Assert.That(RobotArmSolver.TrySolve(forward, lateral, slotZ, axes), Is.True,
+                $"Slot {slot} of {table} is out of reach from the approach pose.");
+
+            RigidTransform mount = RobotKinematics.CreateMountPose(
+                approachX, CellLayout.TableApproachY, 0.0, 90.0);
+            (double x, double y, double z) = RobotKinematics
+                .ComputeToolCentrePoint(mount, axes).Origin;
+
+            Assert.That(x, Is.EqualTo(slotX).Within(1e-6));
+            Assert.That(y, Is.EqualTo(slotY).Within(1e-6));
+            Assert.That(z, Is.EqualTo(slotZ).Within(1e-6));
+        }
+
+        /// <summary>
+        /// A deployed arm must stay inside its own end zone, which is what keeps it clear of
+        /// a robot passing through the corridor.
+        /// </summary>
+        [TestCase(CellStation.TableA, 0)]
+        [TestCase(CellStation.TableA, 2)]
+        [TestCase(CellStation.TableB, 0)]
+        [TestCase(CellStation.TableB, 2)]
+        public void ADeployedArmStaysWithinItsEndZone(CellStation table, int slot)
+        {
+            double approachX = table == CellStation.TableA
+                ? CellLayout.TableAX
+                : CellLayout.TableBX;
+            (double slotX, _, _) = CellLayout.SlotPosition(table, slot);
+
+            Assert.That(
+                Math.Abs(slotX - approachX),
+                Is.LessThanOrEqualTo(CellLayout.DeployedArmHalfWidthX));
+            Assert.That(
+                Math.Abs(slotX),
+                Is.GreaterThan(CellLayout.CorridorHalfWidthX),
+                "A slot must lie outside the shared corridor.");
+        }
     }
 }

--- a/tests/Opc.Ua.Di.Tests/RobotOpenUsdE2eTests.cs
+++ b/tests/Opc.Ua.Di.Tests/RobotOpenUsdE2eTests.cs
@@ -1343,15 +1343,48 @@ namespace Opc.Ua.Di.Tests
             // Dynamic composition (§5.13): the server attaches a gripper tool on R1's
             // flange at runtime (emitting model-change events); the connector reconciles
             // the tool reference prim.
+            //
+            // Asserted as a *transition*, not as a momentary state. The sample cycles the
+            // tool mount(12 s)/detach(6 s) forever, so whether the prim happens to be
+            // active at any instant depends only on the phase the connector started in -
+            // which is near-constant for a given fixture and made this test fail
+            // consistently rather than intermittently. Observing both states across more
+            // than one full cycle is phase-independent, and unlike the momentary check it
+            // actually proves reconciliation runs in both directions: a connector that
+            // never hears about the mount can only ever report one of them.
             var sink = new MockUsdSink();
             var connector = new OpenUsdConnector(m_session!, sink);
             await connector.StartAsync(CancellationToken.None).ConfigureAwait(false);
             try
             {
-                bool appeared = await PollAsync(
-                    () => sink.WasPrimComposed(ToolPrim) && sink.IsPrimActive(ToolPrim),
-                    TimeSpan.FromSeconds(30)).ConfigureAwait(false);
-                Assert.That(appeared, Is.True, "Dynamically attached gripper tool prim was not composed.");
+                bool sawActive = false;
+                bool sawInactive = false;
+                var deadline = System.Diagnostics.Stopwatch.StartNew();
+                while (deadline.Elapsed < TimeSpan.FromSeconds(75) && !(sawActive && sawInactive))
+                {
+                    if (sink.WasPrimComposed(ToolPrim))
+                    {
+                        if (sink.IsPrimActive(ToolPrim))
+                        {
+                            sawActive = true;
+                        }
+                        else
+                        {
+                            sawInactive = true;
+                        }
+                    }
+                    await Task.Delay(250).ConfigureAwait(false);
+                }
+
+                Assert.Multiple(() =>
+                {
+                    Assert.That(sawActive, Is.True,
+                        "The mounted gripper tool prim was never composed active - the connector " +
+                        "was never told the tool was added.");
+                    Assert.That(sawInactive, Is.True,
+                        "The gripper tool prim was never deactivated - the connector was never " +
+                        "told the tool was removed.");
+                });
             }
             finally
             {

--- a/tests/Opc.Ua.Di.Tests/RobotOpenUsdE2eTests.cs
+++ b/tests/Opc.Ua.Di.Tests/RobotOpenUsdE2eTests.cs
@@ -44,6 +44,7 @@ using Opc.Ua.Positioning;
 using Opc.Ua.Positioning.Client;
 using Opc.Ua.Positioning.Server.Hosting;
 using Opc.Ua.Robotics.Server;
+using Robotics;
 using StreamingMonitoredItemOptions =
     Opc.Ua.Client.Subscriptions.MonitoredItems.MonitoredItemOptions;
 
@@ -769,6 +770,195 @@ namespace Opc.Ua.Di.Tests
             }
         }
 
+        /// <summary>
+        /// A carried workpiece has to be authored where the gripper holding it is, not
+        /// where the simulation has since moved it to.
+        /// </summary>
+        /// <remarks>
+        /// The platform pose and the workpiece pose reach a connector as separate bindings.
+        /// Publishing them from different loops let the part run ahead of the jaws by a
+        /// quarter of a metre while the robot drove - three part widths, and plainly wrong
+        /// in a viewport. The tolerance here is deliberately far looser than the defect it
+        /// guards, because the two values land in the sink on separate notifications.
+        /// </remarks>
+        [Test]
+        public async Task ACarriedPartIsAuthoredAtTheGripperItRidesInAsync()
+        {
+            var sink = new MockUsdSink();
+            var connector = new OpenUsdConnector(m_session!, sink);
+            await connector.StartAsync(CancellationToken.None).ConfigureAwait(false);
+            try
+            {
+                bool authored = await PollAsync(
+                    () => sink.WasWritten(R1Prim, "xformOp:translate") &&
+                        sink.WasWritten("/Cell/Parts/Part01", "xformOp:translate"),
+                    TimeSpan.FromSeconds(20)).ConfigureAwait(false);
+                Assert.That(authored, Is.True, "The cell never authored a workpiece pose.");
+
+                double worst = 0.0;
+                var deviations = new List<double>();
+                for (int attempt = 0; attempt < 240; attempt++)
+                {
+                    await Task.Delay(100).ConfigureAwait(false);
+                    foreach (string robotPrim in new[] { R1Prim, R2Prim })
+                    {
+                        // Only judge a stowed arm. The joint angles and the workpiece pose
+                        // land in the sink on separate notifications, and during a fast arm
+                        // sweep a few milliseconds of straddle between them is metres of
+                        // tool travel - an artefact of sampling, not of the server. Stowed
+                        // is also exactly when the platform is driving, which is when the
+                        // defect this guards showed.
+                        if (!TryReadPose(sink, robotPrim, out RigidTransform tcp, out bool stowed) ||
+                            !stowed)
+                        {
+                            continue;
+                        }
+                        (double tx, double ty, double tz) = tcp.Origin;
+                        foreach (string partPrim in s_partPrims)
+                        {
+                            if (!TryReadVector(sink, partPrim, "xformOp:translate",
+                                out double px, out double py, out double pz))
+                            {
+                                continue;
+                            }
+                            // A resting part sits on a table at 0.7875 m, or on the floor
+                            // after a dropped grip. Only a carried one rides up at the tool
+                            // centre point, so the height is what says it is being held -
+                            // proximity alone would match a block on a table the robot
+                            // happens to be parked beside.
+                            if (pz < 0.95)
+                            {
+                                continue;
+                            }
+                            double distance = Math.Sqrt(
+                                ((px - tx) * (px - tx)) +
+                                ((py - ty) * (py - ty)) +
+                                ((pz - tz) * (pz - tz)));
+                            // Attribute the part to the robot holding it; the other robot
+                            // may be carrying one of its own on the far side of the cell.
+                            if (distance > 0.5)
+                            {
+                                continue;
+                            }
+                            deviations.Add(distance);
+                            worst = Math.Max(worst, distance);
+                        }
+                    }
+                }
+
+                Assert.That(deviations, Is.Not.Empty,
+                    "No workpiece was ever authored near a tool centre point.");
+
+                // The median, not the worst case. The platform pose and the workpiece pose
+                // are separate bindings arriving on separate notifications, so a sample read
+                // between the two lands up to one publish period apart - 50 ms at 0.85 m/s
+                // is 43 mm - however coherent the server was. That straddle is occasional
+                // and symmetric, so the median stays well inside it. A server publishing the
+                // two from loops at different rates is wrong in *every* sample while the
+                // robot drives, and was wrong by 0.25 m to 0.49 m, which is what this
+                // catches with an order of magnitude to spare.
+                deviations.Sort();
+                double median = deviations[deviations.Count / 2];
+                Assert.That(median, Is.LessThan(0.05),
+                    $"A carried workpiece sat {median:F3} m from its gripper (worst {worst:F3} m).");
+                Assert.That(worst, Is.LessThan(0.20),
+                    $"A carried workpiece sat {worst:F3} m from its gripper.");
+            }
+            finally
+            {
+                await connector.DisposeAsync().ConfigureAwait(false);
+            }
+        }
+
+        private static readonly string[] s_partPrims =
+        [
+            "/Cell/Parts/Part01",
+            "/Cell/Parts/Part02",
+            "/Cell/Parts/Part03"
+        ];
+
+        /// <summary>
+        /// Rebuilds a robot's tool centre point from the values authored into the scene.
+        /// </summary>
+        private static bool TryReadPose(
+            MockUsdSink sink,
+            string robotPrim,
+            out RigidTransform tcp,
+            out bool stowed)
+        {
+            tcp = RigidTransform.Identity;
+            stowed = false;
+            if (!TryReadVector(sink, robotPrim, "xformOp:translate",
+                    out double x, out double y, out double _) ||
+                !TryReadVector(sink, robotPrim, "xformOp:rotateXYZ",
+                    out double _, out double _, out double heading))
+            {
+                return false;
+            }
+
+            var axes = new double[RobotKinematics.AxisCount];
+            for (int i = 0; i < s_axisPrims.Length; i++)
+            {
+                if (!sink.TryGetWritten(
+                        robotPrim + "/" + s_axisPrims[i].Path,
+                        s_axisPrims[i].Op,
+                        out Variant value) ||
+                    !value.TryGetValue(out double angle))
+                {
+                    return false;
+                }
+                axes[i] = angle;
+            }
+
+            stowed = true;
+            double[] transport = RobotAgent.TransportPose;
+            for (int i = 0; i < axes.Length; i++)
+            {
+                if (Math.Abs(axes[i] - transport[i]) > 1e-6)
+                {
+                    stowed = false;
+                    break;
+                }
+            }
+
+            tcp = RobotKinematics.ComputeToolCentrePoint(
+                RobotKinematics.CreateMountPose(x, y, 0.0, heading), axes);
+            return true;
+        }
+
+        private static readonly (string Path, string Op)[] s_axisPrims =
+        [
+            ("Base/J1", "xformOp:rotateZ"),
+            ("Base/J1/J2", "xformOp:rotateY"),
+            ("Base/J1/J2/J3", "xformOp:rotateY"),
+            ("Base/J1/J2/J3/J4", "xformOp:rotateX"),
+            ("Base/J1/J2/J3/J4/J5", "xformOp:rotateY"),
+            ("Base/J1/J2/J3/J4/J5/J6", "xformOp:rotateX")
+        ];
+
+        private static bool TryReadVector(
+            MockUsdSink sink,
+            string primPath,
+            string propertyName,
+            out double x,
+            out double y,
+            out double z)
+        {
+            x = 0.0;
+            y = 0.0;
+            z = 0.0;
+            if (!sink.TryGetWritten(primPath, propertyName, out Variant value) ||
+                !value.TryGetValue(out ArrayOf<double> vector) ||
+                vector.Count != 3)
+            {
+                return false;
+            }
+            x = vector[0];
+            y = vector[1];
+            z = vector[2];
+            return true;
+        }
+
         [Test]
         public async Task RobotPositionsDriveLiveOpenUsdSceneAsync()
         {
@@ -842,9 +1032,6 @@ namespace Opc.Ua.Di.Tests
                     Is.True);
                 Assert.That(firstR1.TryGetValue(out ArrayOf<double> firstR1Vector), Is.True);
                 Assert.That(firstR2.TryGetValue(out ArrayOf<double> firstR2Vector), Is.True);
-                Assert.That(
-                    Math.Abs(firstR1Vector[0] - firstR2Vector[0]),
-                    Is.GreaterThan(1.0));
 
                 // The robots now follow a coordinated duty cycle rather than a continuous
                 // sine path, so either of them can legitimately be standing still at any
@@ -882,9 +1069,17 @@ namespace Opc.Ua.Di.Tests
                 {
                     Assert.That(r1Moved, Is.GreaterThan(0.001));
                     Assert.That(r2Moved, Is.GreaterThan(0.001));
+
+                    // Separation in the plane, not along X. The robots pass each other in
+                    // opposite corridor lanes, so there are instants where their X is all
+                    // but identical and the 1.5 m between them is entirely in Y. Asserted
+                    // once both have been seen to move, because until the first sample
+                    // arrives each platform sits on the zero frame and the pair coincides.
+                    double dx = secondR1Vector[0] - secondR2Vector[0];
+                    double dy = secondR1Vector[1] - secondR2Vector[1];
                     Assert.That(
-                        Math.Abs(secondR1Vector[0] - secondR2Vector[0]),
-                        Is.GreaterThan(1.0));
+                        Math.Sqrt((dx * dx) + (dy * dy)),
+                        Is.GreaterThan(0.5));
                 });
             }
             finally

--- a/tests/Opc.Ua.Di.Tests/RobotOpenUsdE2eTests.cs
+++ b/tests/Opc.Ua.Di.Tests/RobotOpenUsdE2eTests.cs
@@ -911,7 +911,7 @@ namespace Opc.Ua.Di.Tests
             }
 
             stowed = true;
-            double[] transport = RobotAgent.TransportPose;
+            ArrayOf<double> transport = RobotAgent.TransportPose;
             for (int i = 0; i < axes.Length; i++)
             {
                 if (Math.Abs(axes[i] - transport[i]) > 1e-6)

--- a/tests/Opc.Ua.Di.Tests/RobotOpenUsdE2eTests.cs
+++ b/tests/Opc.Ua.Di.Tests/RobotOpenUsdE2eTests.cs
@@ -139,6 +139,7 @@ namespace Opc.Ua.Di.Tests
             hostBuilder.Logging.SetMinimumLevel(LogLevel.Warning);
             hostBuilder.Services.AddOptions<global::Robotics.MobileRobotPositionOptions>();
             hostBuilder.Services.AddSingleton<global::Robotics.RobotPositioningScenario>();
+        hostBuilder.Services.AddSingleton<global::Robotics.CellChoreographer>();
             IPositioningServerBuilder positioning = hostBuilder.Services
                 .AddOpcUa()
                 .AddServer(o =>
@@ -845,25 +846,42 @@ namespace Opc.Ua.Di.Tests
                     Math.Abs(firstR1Vector[0] - firstR2Vector[0]),
                     Is.GreaterThan(1.0));
 
-                await Task.Delay(1200).ConfigureAwait(false);
-                Assert.That(
-                    sink.TryGetWritten(R1Prim, "xformOp:translate", out Variant secondR1),
-                    Is.True);
-                Assert.That(
-                    sink.TryGetWritten(R2Prim, "xformOp:translate", out Variant secondR2),
-                    Is.True);
-                Assert.That(secondR1.TryGetValue(out ArrayOf<double> secondR1Vector), Is.True);
-                Assert.That(secondR2.TryGetValue(out ArrayOf<double> secondR2Vector), Is.True);
+                // The robots now follow a coordinated duty cycle rather than a continuous
+                // sine path, so either of them can legitimately be standing still at any
+                // instant - gripping, dwelling at a station or charging. Poll until each has
+                // been seen to move instead of assuming it moves within a fixed window; the
+                // point of the assertion is that live positions reach the scene.
+                double r1Moved = 0.0;
+                double r2Moved = 0.0;
+                ArrayOf<double> secondR1Vector = firstR1Vector;
+                ArrayOf<double> secondR2Vector = firstR2Vector;
+                for (int attempt = 0; attempt < 40 && (r1Moved <= 0.001 || r2Moved <= 0.001);
+                    attempt++)
+                {
+                    await Task.Delay(500).ConfigureAwait(false);
+                    if (sink.TryGetWritten(R1Prim, "xformOp:translate", out Variant sampleR1) &&
+                        sampleR1.TryGetValue(out ArrayOf<double> sampleR1Vector))
+                    {
+                        secondR1Vector = sampleR1Vector;
+                        r1Moved = Math.Max(
+                            r1Moved,
+                            Math.Abs(sampleR1Vector[0] - firstR1Vector[0]) +
+                            Math.Abs(sampleR1Vector[1] - firstR1Vector[1]));
+                    }
+                    if (sink.TryGetWritten(R2Prim, "xformOp:translate", out Variant sampleR2) &&
+                        sampleR2.TryGetValue(out ArrayOf<double> sampleR2Vector))
+                    {
+                        secondR2Vector = sampleR2Vector;
+                        r2Moved = Math.Max(
+                            r2Moved,
+                            Math.Abs(sampleR2Vector[0] - firstR2Vector[0]) +
+                            Math.Abs(sampleR2Vector[1] - firstR2Vector[1]));
+                    }
+                }
                 Assert.Multiple(() =>
                 {
-                    Assert.That(
-                        Math.Abs(secondR1Vector[0] - firstR1Vector[0]) +
-                        Math.Abs(secondR1Vector[1] - firstR1Vector[1]),
-                        Is.GreaterThan(0.001));
-                    Assert.That(
-                        Math.Abs(secondR2Vector[0] - firstR2Vector[0]) +
-                        Math.Abs(secondR2Vector[1] - firstR2Vector[1]),
-                        Is.GreaterThan(0.001));
+                    Assert.That(r1Moved, Is.GreaterThan(0.001));
+                    Assert.That(r2Moved, Is.GreaterThan(0.001));
                     Assert.That(
                         Math.Abs(secondR1Vector[0] - secondR2Vector[0]),
                         Is.GreaterThan(1.0));

--- a/tests/Opc.Ua.Di.Tests/RobotOpenUsdE2eTests.cs
+++ b/tests/Opc.Ua.Di.Tests/RobotOpenUsdE2eTests.cs
@@ -855,7 +855,7 @@ namespace Opc.Ua.Di.Tests
                 double r2Moved = 0.0;
                 ArrayOf<double> secondR1Vector = firstR1Vector;
                 ArrayOf<double> secondR2Vector = firstR2Vector;
-                for (int attempt = 0; attempt < 40 && (r1Moved <= 0.001 || r2Moved <= 0.001);
+                for (int attempt = 0; attempt < 90 && (r1Moved <= 0.001 || r2Moved <= 0.001);
                     attempt++)
                 {
                     await Task.Delay(500).ConfigureAwait(false);

--- a/tests/Opc.Ua.OpenUsd.Tests/OpenUsdConnectorModelChangeGuardTests.cs
+++ b/tests/Opc.Ua.OpenUsd.Tests/OpenUsdConnectorModelChangeGuardTests.cs
@@ -1,0 +1,95 @@
+/* ========================================================================
+ * Copyright (c) 2005-2026 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using NUnit.Framework;
+
+namespace Opc.Ua.OpenUsd.Client.Tests
+{
+    /// <summary>
+    /// Covers the guard that refuses to run a twin whose §5.13 reconciliation is dead.
+    /// </summary>
+    /// <remarks>
+    /// A connector whose model-change item was rejected keeps whatever composition it
+    /// happened to resolve at start-up and never reconciles again, so a Dynamic component
+    /// silently stops matching the server. That has to be loud: the same class of silent
+    /// staleness took a long time to find the last time it went unreported.
+    /// </remarks>
+    [TestFixture]
+    [Category("OpenUsd")]
+    public sealed class OpenUsdConnectorModelChangeGuardTests
+    {
+        [Test]
+        public void ARejectedModelChangeItemIsRefused()
+        {
+            var error = new ServiceResult(StatusCodes.BadNodeIdUnknown);
+
+            InvalidOperationException? thrown = Assert.Throws<InvalidOperationException>(
+                () => OpenUsdConnector.ThrowIfModelChangeRejected(error, Opc.Ua.ObjectIds.Server));
+
+            Assert.That(thrown!.Message, Does.Contain("model-change"));
+            Assert.That(thrown.Message, Does.Contain("i=2253"),
+                "The message must name the node the subscription was refused on.");
+        }
+
+        [Test]
+        public void EveryBadStatusIsRefused()
+        {
+            foreach (StatusCode status in new[]
+            {
+                StatusCodes.BadEventFilterInvalid,
+                StatusCodes.BadAttributeIdInvalid,
+                StatusCodes.BadMonitoredItemFilterUnsupported
+            })
+            {
+                Assert.Throws<InvalidOperationException>(
+                    () => OpenUsdConnector.ThrowIfModelChangeRejected(
+                        new ServiceResult(status), Opc.Ua.ObjectIds.Server),
+                    $"{status} should have been refused.");
+            }
+        }
+
+        [Test]
+        public void AnAcceptedModelChangeItemIsAllowedThrough()
+        {
+            Assert.DoesNotThrow(
+                () => OpenUsdConnector.ThrowIfModelChangeRejected(
+                    ServiceResult.Good, Opc.Ua.ObjectIds.Server));
+        }
+
+        [Test]
+        public void AnUnreportedStatusIsAllowedThrough()
+        {
+            // A monitored item that was never given a status is not a rejected one; the
+            // client stack leaves Error null until the server has answered for it.
+            Assert.DoesNotThrow(
+                () => OpenUsdConnector.ThrowIfModelChangeRejected(null, Opc.Ua.ObjectIds.Server));
+        }
+    }
+}

--- a/tests/Opc.Ua.OpenUsd.Tests/RobotAssetContractTests.cs
+++ b/tests/Opc.Ua.OpenUsd.Tests/RobotAssetContractTests.cs
@@ -210,11 +210,16 @@ namespace Opc.Ua.OpenUsdScene.Tests
         }
 
         [Test]
-        [TestCase("/Cell/Robots/R1")]
-        [TestCase("/Cell/Robots/R2")]
-        public void RobotMountPointDeclaresASingleMatrixTransformOp(string primPath)
+        [TestCase("Cell.usda", "/Cell/Robots/R1")]
+        [TestCase("Cell.usda", "/Cell/Robots/R2")]
+        [TestCase("Cell.usda", "/Cell/Parts/Part01")]
+        [TestCase("Cell.usda", "/Cell/Parts/Part02")]
+        [TestCase("Cell.usda", "/Cell/Parts/Part03")]
+        [TestCase("tool.usda", "/Gripper/JawUpper")]
+        [TestCase("tool.usda", "/Gripper/JawLower")]
+        public void LiveBoundPrimDeclaresASingleMatrixTransformOp(string asset, string primPath)
         {
-            UsdStage stage = LoadSample("Cell.usda");
+            UsdStage stage = LoadSample(asset);
 
             UsdPrim? mount = stage.Find(primPath);
             Assert.That(mount, Is.Not.Null);
@@ -232,6 +237,22 @@ namespace Opc.Ua.OpenUsdScene.Tests
             Assert.That(
                 Flatten(order!.Value), Is.EqualTo("xformOp:transform"),
                 $"{primPath} must order exactly the matrix op.");
+        }
+
+        [Test]
+        [TestCase("/Gripper/JawUpper")]
+        [TestCase("/Gripper/JawLower")]
+        public void GripperJawCarriesItsFingerSoTheWholeJawStrokes(string jawPath)
+        {
+            UsdStage stage = LoadSample("tool.usda");
+
+            // The jaw is driven as one prim. If the carrier and the finger were siblings
+            // under the gripper body, stroking the bound prim would slide the carrier out
+            // from under the finger it is bolted to.
+            Assert.That(stage.Find(jawPath + "/Carrier"), Is.Not.Null,
+                $"{jawPath} must own its carrier.");
+            Assert.That(stage.Find(jawPath + "/Finger"), Is.Not.Null,
+                $"{jawPath} must own its finger.");
         }
 
         [Test]

--- a/tests/Opc.Ua.OpenUsd.Tests/RobotAssetContractTests.cs
+++ b/tests/Opc.Ua.OpenUsd.Tests/RobotAssetContractTests.cs
@@ -28,6 +28,7 @@
  * ======================================================================*/
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using NUnit.Framework;
@@ -207,6 +208,22 @@ namespace Opc.Ua.OpenUsdScene.Tests
                     mount!.Attributes.Any(a => a.Name == expected), Is.True,
                     $"{primPath} does not carry {expected}.");
             }
+        }
+
+        [Test]
+        public void TheStageOffersItsEstablishingShotFirst()
+        {
+            UsdStage stage = LoadSample("Cell.usda");
+
+            // A connector opens on the first camera the served root layer authors, because
+            // framing the bounds of an enclosed scene automatically puts the eye inside the
+            // fence. The overview therefore has to come before the overhead camera.
+            List<UsdPrim> cameras = stage.AllPrims()
+                .Where(p => string.Equals(p.TypeName, "Camera", StringComparison.Ordinal))
+                .ToList();
+
+            Assert.That(cameras, Is.Not.Empty, "The cell authors no camera to open on.");
+            Assert.That(cameras[0].Path, Is.EqualTo("/Cell/OverviewCamera"));
         }
 
         [Test]

--- a/tools/Opc.Ua.OpenUsd.Connector/Opc.Ua.OpenUsd.Connector.csproj
+++ b/tools/Opc.Ua.OpenUsd.Connector/Opc.Ua.OpenUsd.Connector.csproj
@@ -19,6 +19,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Opc.Ua.Configuration\Opc.Ua.Configuration.csproj" />
     <ProjectReference Include="..\..\src\Opc.Ua.OpenUsd.Client\Opc.Ua.OpenUsd.Client.csproj" />
+    <ProjectReference Include="..\..\src\Opc.Ua.OpenUsdScene\Opc.Ua.OpenUsdScene.csproj" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" />

--- a/tools/Opc.Ua.OpenUsd.Connector/OpenUsdConnectorRunner.cs
+++ b/tools/Opc.Ua.OpenUsd.Connector/OpenUsdConnectorRunner.cs
@@ -38,6 +38,8 @@ using Microsoft.Extensions.Logging;
 using Opc.Ua;
 using Opc.Ua.Client;
 using Opc.Ua.OpenUsd.Client;
+using Opc.Ua.OpenUsdScene.Conversion;
+using Opc.Ua.OpenUsdScene.Scene;
 
 namespace Opc.Ua.OpenUsd.Connector
 {
@@ -49,7 +51,9 @@ namespace Opc.Ua.OpenUsd.Connector
     /// With <c>--view</c> it additionally opens a viewport on the composed stage and fans
     /// the same values into it, so the twin animates on screen in the same process.
     /// Invoked as <c>Opc.Ua.OpenUsd.Connector [--server &lt;url&gt;] [--out &lt;live.usda&gt;]
-    /// [--seconds N] [--view] [--renderer &lt;Auto|Storm|D3D12|Vulkan&gt;]</c>.
+    /// [--seconds N] [--view] [--camera &lt;primPath&gt;]
+    /// [--renderer &lt;Auto|Storm|D3D12|Vulkan&gt;]</c>. Absent <c>--camera</c>, the
+    /// viewport opens on the first camera the served stage authors.
     /// </summary>
     public static class OpenUsdConnectorRunner
     {
@@ -203,9 +207,14 @@ namespace Opc.Ua.OpenUsd.Connector
                     {
                         WriteStageUsda(cacheDir!, fetched);
                         stagePath ??= Path.Combine(cacheDir!, "stage.usda");
+                        cameraPath ??= FindStageCamera(fetched);
                         Console.WriteLine(
                             $"Fetched {fetched.Count} server-delivered USD layer(s) into {cacheDir}; " +
                             "wrote a self-contained stage.usda.");
+                        if (cameraPath != null)
+                        {
+                            Console.WriteLine($"Opening on the stage camera {cameraPath}.");
+                        }
                     }
                     else
                     {
@@ -434,6 +443,50 @@ namespace Opc.Ua.OpenUsd.Connector
 
         // Writes a self-contained stage.usda that composes the connector's live override
         // layer over the server-delivered root layer (both now local in the cache dir).
+        /// <summary>
+        /// The prim path of the camera a served stage wants a viewer to open on.
+        /// </summary>
+        /// <remarks>
+        /// A stage that authors a camera has an opinion about how it should first be seen,
+        /// and it is a better one than framing the bounds: the eye lands wherever the
+        /// geometry happens to extend, which for an enclosed scene means inside it. The
+        /// first camera in the served root layer wins, so a stage orders its establishing
+        /// shot first; <c>--camera</c> overrides this outright.
+        /// </remarks>
+        /// <param name="fetched">The layers fetched from the server.</param>
+        /// <returns>The camera prim path, or <c>null</c> when the stage authors none.</returns>
+        private static string? FindStageCamera(List<OpenUsdConnector.FetchedAsset> fetched)
+        {
+            OpenUsdConnector.FetchedAsset? root =
+                fetched.Find(a => a.Kind == OpenUsdAssetKind.RootLayer);
+            if (root == null || !File.Exists(root.LocalPath))
+            {
+                return null;
+            }
+
+            try
+            {
+                UsdStage stage = UsdaReader.ParseFile(
+                    root.LocalPath, applyExampleOverlays: false);
+                foreach (UsdPrim prim in stage.AllPrims())
+                {
+                    if (string.Equals(prim.TypeName, "Camera", StringComparison.Ordinal))
+                    {
+                        return prim.Path;
+                    }
+                }
+            }
+            catch (IOException)
+            {
+                // A stage we cannot read is not a reason to refuse to open one: fall back
+                // to letting the host frame the bounds itself.
+            }
+            catch (FormatException)
+            {
+            }
+            return null;
+        }
+
         private static void WriteStageUsda(string cacheDir, List<OpenUsdConnector.FetchedAsset> fetched)
         {
             OpenUsdConnector.FetchedAsset? root = fetched.Find(a => a.Kind == OpenUsdAssetKind.RootLayer);


### PR DESCRIPTION
# Description

`MinimalRobotServer` drove its two mobile manipulators through each other. The platforms *did* clear — R1 and R2 trace figure-eights 1.2 m apart at closest approach, exactly as `README.md` claimed — but each **arm reaches 1.611 m** (link offsets `0.260 + 0.680 + 0.670 + 0.158` from `robot.usda`), so the arms swept straight through one another while the chassis politely missed. Clearance has to be argued about the deployed arm, not the footprint.

Three related gaps sat alongside it: motion was open-loop (two independent sine paths with no awareness of each other), only R1 had a gripper, and nothing was ever actually picked — `PartA`/`PartB` were static children of a single table and the arm replayed a canned eight-pose loop unrelated to where either the robot or the table was.

This replaces all of that with a coordinated transfer cycle.

## Keeping them apart

The cell is divided into reservable zones, and a robot reserves the zone *immediately ahead* before entering it, releasing the one behind once clear — block signalling rather than a global schedule:

| Zone | Extent | Occupancy |
| --- | --- | --- |
| `EndZoneA` / `EndZoneB` | \|x\| > 1.3 m | one robot — a deployed arm needs the whole end |
| `CorridorEastbound` | \|x\| ≤ 1.3 m, northern lane (y = 0.35) | one robot |
| `CorridorWestbound` | \|x\| ≤ 1.3 m, southern lane (y = −1.15) | one robot |
| `DockA` / `DockB` | around each charging dock (y = −2.0) | one robot |

Three rules follow:

- **Opposite-direction traffic passes**, being in lanes 1.5 m apart; same-direction traffic queues rather than overtaking.
- **An arm may only leave its transport envelope inside an exclusively reserved end zone.** This is the rule that actually fixes the reported defect.
- **A robot with no work parks on its dock**, releasing the end zone so the other robot can deliver into the station it serves.

That last rule is not cosmetic. Without it the cell deadlocks permanently on the first handover: an idle robot standing beside its own table blocks the very delivery it is waiting for. A state trace showed R1 blocked at `x = 0.98` forever while R2 sat idle holding `EndZoneB`. The docks are in a southern layby rather than beside the stations, because a robot parked next to a station is close enough to foul one turning into it.

## Where the part actually is

A carried part's pose is computed by forward kinematics (`RobotKinematics`) from **the same six axis values the server publishes**, not from the choreography that produced them — if the arm and the part were computed independently they would visibly drift apart. `RobotArmSolver` solves shoulder and elbow so the tool points down onto a slot, and is checked against that same forward kinematics, landing the tool on every slot of both tables to within 1e-6 m.

## Also simulated

Trapezoidal accel/cruise/decel travel with the heading following the path; speed-and-separation slowdown near the other robot; an emergency stop that now halts motion rather than only blinking the beacon; battery drain with a charging detour; seeded grip-slip faults with floor recovery; and KPIs (parts moved, cycle count, last/average cycle time, utilisation, fault count). Both robots now carry a gripper.

## Two hidden couplings this surfaced

- `m_r1NodeId` was keyed on *"has a tool"*, so giving R2 a gripper silently moved the dynamic-tool demo and the speed-override command target onto R2. Now keyed on R1 explicitly.
- `RobotPositionsDriveLiveOpenUsdSceneAsync` sampled a fixed 1.2 s window and assumed the robot was always moving. Under a duty cycle a robot legitimately stands still while gripping, dwelling or charging, so it now polls until movement is observed — the assertion's intent is that live positions reach the scene, not that the robot never stops.

## Invariants are asserted, not assumed

`CellChoreographyTests` runs ten minutes of simulated time at 50 ms and checks on **every step** that:

- oriented footprints never overlap (an oriented box, not a bounding circle — the circle is so pessimistic for a 1.15 × 0.60 m platform that it demands clearances no real cell would need);
- the two tool centre points never meet;
- a zone is never doubly occupied;
- arms only deploy inside an end zone;
- parts are conserved — never duplicated, lost or carried twice;
- a carried part sits exactly on the tool centre point.

Plus the round trip completing, KPIs accumulating, the emergency stop halting every robot, dropped parts being recovered, and the battery draining and recharging.

The README documents the zoning, traffic rules and cycle, **corrects the misleading clearance claim**, and lists ten further realism extensions that were deliberately not built (ISO 10218 / TS 15066 speed-and-separation monitoring, scanner cones, tool changer, inspection station, conveyor infeed, gate interlock, torque telemetry, maintenance counters, time-sampled pose history, traffic priority).

## Making the cycle visible

Running the sample end to end against the OpenUSD connector showed the robots driving the cycle and the arms reaching the slots while **nothing was picked up or moved**. The choreographer tracked part poses and gripper opening purely in memory: the address space only ever exposed the platform poses and the twelve axis angles, so a connector had nothing to subscribe to for the parts and the blocks stayed wherever the asset authored them.

A `CellTwin` folder now holds a `ThreeDCartesianCoordinates` position and a `ThreeDOrientation` heading per part, plus a jaw position per robot, bound to `/Cell/Parts/PartNN` and to the gripper jaws. The variables are registered before the motion device system is built - a binding can only carry a `SourceNodeId` that already exists - and sit outside the robotics subtree, because a workpiece is not a device and the robotics builder validates every node below its root as one it allocated itself.

**The poses are published as structured vectors, not as a matrix.** A viewer composes a prim's matrix from the vector translate and rotate ops; the `matrix4d` profile is explicitly left unresolved by the reference connector, which drops a binding it cannot convert *in silence*. That is the shape the first attempt took, and it failed without a word in any log.

The jaws needed the asset restructured. A carrier cube and a finger mesh were siblings under the gripper body, so driving the carrier would have slid it out from under the finger it is bolted to. Each jaw is now one `Xform` owning both, declaring the single matrix op every live-bound prim declares, with the finger points rebased onto the jaw origin. Closed puts the finger faces on the 35 mm half-width of the block, so the gripper grips it rather than passing through it.

`RobotAssetContractTests` now holds **every** live-bound prim to the single-matrix contract, not just the two robot mount points.

## No part starves

Collecting the lowest free slot meant a part that never landed in slot 0 was never collected at all: with two parts seeded on `WorkTableA` the second sat untouched for the life of the process while the robots shuttled the other one past it - which reads in the twin as the robots ignoring a block sitting in front of them. Parts are now stamped with the order in which they came to rest and the one that has waited longest is collected, which is what a real cell does with a buffer anyway.

Verified end to end: all three parts circulate between both tables, the heading follows the carrying robot and resets on placement, and the jaws stroke between open (0.060) and closed (0.047) as parts are gripped and released.

The OpenUSD packages move to 0.3.0-alpha.

## The part was not in the gripper

Running it end to end showed a workpiece floating clear of the jaws that were supposed to be holding it.

The platform pose and the workpiece pose leave the server as **separate bindings published by different loops**: positioning at 5 Hz (`UpdateIntervalMilliseconds = 200`), the simulation tick at 20 Hz. A carried part rides the tool centre point, so it was being drawn against a platform up to four ticks stale. Measured against the live scene with the arm stowed — where the part-to-platform distance is fixed by construction — the part sat anywhere between **0.65 m and 0.90 m** from its platform instead of at a single distance. A quarter of a metre of drift, three part widths, in front of a 96 mm jaw opening.

The platform now publishes at the tick rate, and a carried part is derived from the pose that was **actually written to the address space**, recorded at the `SetFrameValue` call site rather than where the sample is produced. Each value was individually correct the whole time; only their relationship was wrong, which is why nothing caught it.

`RobotOpenUsdE2eTests` now rebuilds the tool centre point from the values authored into the scene and asserts a carried part sits on it. It reproduced the defect at 0.49 m before the fix. The tolerance is the sampling straddle of reading two independently delivered bindings — one publish period is 43 mm at cruise — leaving an order of magnitude between it and the defect.

Two assertions in the positioning test wanted the robots a metre apart **in X**. They pass each other in opposite corridor lanes, where X is all but identical and the separation is entirely in Y; and before the first sample arrives both platforms sit on the zero frame and coincide exactly. They now measure separation in the plane, once both have been seen to move — this was failing intermittently on net48 already.

## The opening view

Framing the bounds of an enclosed scene automatically puts the eye *inside* it: the viewport opened on a close-up of whichever robot happened to be nearest, looking through the fence.

The cell now authors `/Cell/OverviewCamera` — the whole floor, both work tables, the docks and the controller cabinet, from 12 m out at 28 degrees of elevation — and the connector opens on the first camera the served root layer declares. It already had the plumbing to honour a camera path; it was simply never given one. `--camera` still overrides the choice outright, and `RobotAssetContractTests` asserts the establishing shot is ordered before `/Cell/TopDownCamera`.

## The mounted gripper was never reported

`DynamicToolIsComposedAsync` was failing on both TFMs, in isolation, and a longer timeout did not help. It predates this branch — I confirmed it at `58fd5e8ca` with a clean worktree. It turned out not to be a flaky test at all.

**Part 5 §9.32.2** lets only a node carrying a `NodeVersion` property trigger a `ModelChangeEvent`, and `AsyncCustomNodeManager` drops entries for nodes that lack one. Neither the mounted tool nor the robot it hangs off had a `NodeVersion`, so **every addition was filtered out**. Removal kept reporting, because a deleted node is no longer in the manager's index and so takes the *"not mine, pass it through"* branch of the same filter.

That asymmetry is what made it look like flakiness. A connector starting while the tool was mounted composed it and could still deactivate it later; one starting in the six-second gap was never told the tool appeared and never composed it **at all, for the life of the process**. Which happened depended only on the phase the fixture reached the test in — near-constant, hence a consistent failure rather than an intermittent one.

Measured directly before the fix: model-change events arrived only on detach, exactly 18 s apart, and every resolve returned zero components:

```
14:00:12.738 SERVER mounted        <- no event
14:00:24.752 SERVER detached
14:00:24.801 model-change event    <- only this
```

After enabling model-change tracking on the robot, the prim tracks the cycle — `A` = composed active (12 s mounted), `i` = inactive (6 s detached):

```
....AAAAAAAAAAAAAAAAAAAAAAAiiiiiiiiiiiiAAAAAAAAAAAAAAAAAAAAAAAAiiiiiiiiiiii
```

**The test now asserts a transition**, not a momentary state: the prim seen both active and inactive across more than one full cycle. Unlike the old check this cannot pass on a connector that only ever hears about one direction — which is exactly what the previous pair of tests could not distinguish, since the sibling `DynamicToolIsDeactivatedWhenDetachedAsync` was satisfied by the *initial* compose and never exercised reconciliation at all.

Two robustness gaps in the connector fell out of this: a rejected model-change monitored item was reported as success, leaving every `Dynamic` component frozen at whatever it resolved at start-up; and the initial compose ran *before* the subscription existed, so a change in between was seen by neither. The first now fails loudly, the second re-resolves once after subscribing.

`Opc.Ua.Di.Tests` is now **402/403 on net48** (was 3 failures) and on net10.0, across three consecutive runs of the dynamic-tool tests on each.

## Related Issues

- Fixes #4161

## Checklist

- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf) and read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [x] I have added all necessary documentation.
- [x] I have verified that my changes do not introduce (new) build or analyzer warnings.
- [x] I ran **all** tests locally using the **UA.slnx** solution against at least .net **framework** and .net **10**, and all passed.
- [ ] I fixed **all** failing and flaky tests in the CI pipelines and **all** CodeQL warnings.
- [ ] I have addressed **all** PR feedback received.

Verification: full `dotnet build UA.slnx -m:1 /p:UseSharedCompilation=false` — 0 errors, no new warnings. `Opc.Ua.Di.Tests` 399/400 on **both net10.0 and net48** (1 pre-existing skip), `Opc.Ua.OpenUsd.Tests` 635, `Opc.Ua.Robotics.Tests` 103.

