### PR TITLE
Watch datasets that appear after the PubSub application starts

### DIFF
--- a/src/Opc.Ua.PubSub/Application/MetaDataPublisher.cs
+++ b/src/Opc.Ua.PubSub/Application/MetaDataPublisher.cs
@@ -220,12 +220,8 @@ namespace Opc.Ua.PubSub.Application
                     m_application.ConfigurationChanged -= OnConfigurationChanged;
                     m_subscribed = false;
                 }
-                foreach (DataSetSubscription subscription in m_dataSetSubscriptions)
-                {
-                    subscription.DataSet.MetaDataChanged -= subscription.Handler;
-                }
-                m_dataSetSubscriptions.Clear();
             }
+            UnsubscribeFromDataSets();
             return default;
         }
 
@@ -241,12 +237,17 @@ namespace Opc.Ua.PubSub.Application
         /// but nothing carried that into the registry this publisher watches,
         /// so the empty announcement was the only one a consumer ever saw.
         ///
-        /// This runs again whenever the configuration changes, so it must be
-        /// idempotent: a dataset already being watched is skipped, compared by
-        /// reference because that is the identity the handler is bound to.
+        /// This runs again whenever the configuration changes. Rather than
+        /// reconcile, it drops every existing subscription and takes them
+        /// afresh: a subscription belongs to a
+        /// (connection, writer group, writer) triple, because that is what the
+        /// handler announces for, and a configuration change can add, remove
+        /// or move writers between groups. Reattaching is cheap and a dropped
+        /// subscription cannot outlive the writer it was taken for.
         /// </remarks>
         private void SubscribeToDataSets()
         {
+            UnsubscribeFromDataSets();
             for (int connectionIndex = 0;
                 connectionIndex < m_application.Connections.Count;
                 connectionIndex++)
@@ -269,6 +270,13 @@ namespace Opc.Ua.PubSub.Application
                         PubSubConnection connection = runtime;
                         IWriterGroup group = writerGroup;
                         IDataSetWriter target = writer;
+                        //
+                        // One handler per writer, not per dataset. Several
+                        // writers may share a PublishedDataSet - the same
+                        // DataSetName used from different groups or
+                        // connections - and each announces to its own
+                        // destination, so each needs its own subscription.
+                        //
                         void Handler(object? sender, DataSetMetaDataChangedEventArgs e)
                         {
                             OnDataSetMetaDataChanged(connection, group, target, e);
@@ -279,17 +287,12 @@ namespace Opc.Ua.PubSub.Application
                             {
                                 return;
                             }
-                            if (IsSubscribedLocked(dataSet))
-                            {
-                                continue;
-                            }
                         }
                         dataSet.MetaDataChanged += Handler;
                         bool keepSubscription;
                         lock (m_gate)
                         {
-                            keepSubscription = Volatile.Read(ref m_disposed) == 0
-                                && !IsSubscribedLocked(dataSet);
+                            keepSubscription = Volatile.Read(ref m_disposed) == 0;
                             if (keepSubscription)
                             {
                                 m_dataSetSubscriptions.Add(
@@ -299,10 +302,7 @@ namespace Opc.Ua.PubSub.Application
                         if (!keepSubscription)
                         {
                             dataSet.MetaDataChanged -= Handler;
-                            if (Volatile.Read(ref m_disposed) != 0)
-                            {
-                                return;
-                            }
+                            return;
                         }
                     }
                 }
@@ -310,22 +310,24 @@ namespace Opc.Ua.PubSub.Application
         }
 
         /// <summary>
-        /// True when this dataset is already being watched. Compared by
-        /// reference, because that is the identity the handler is bound to -
-        /// two datasets can carry equal metadata and still be different
-        /// sources.
+        /// Drops every per-dataset subscription currently held.
         /// </summary>
-        /// <param name="dataSet"></param>
-        private bool IsSubscribedLocked(IPublishedDataSet dataSet)
+        private void UnsubscribeFromDataSets()
         {
-            for (int index = 0; index < m_dataSetSubscriptions.Count; index++)
+            DataSetSubscription[] taken;
+            lock (m_gate)
             {
-                if (ReferenceEquals(m_dataSetSubscriptions[index].DataSet, dataSet))
+                if (m_dataSetSubscriptions.Count == 0)
                 {
-                    return true;
+                    return;
                 }
+                taken = m_dataSetSubscriptions.ToArray();
+                m_dataSetSubscriptions.Clear();
             }
-            return false;
+            for (int index = 0; index < taken.Length; index++)
+            {
+                taken[index].DataSet.MetaDataChanged -= taken[index].Handler;
+            }
         }
 
         private void OnDataSetMetaDataChanged(

--- a/src/Opc.Ua.PubSub/Application/MetaDataPublisher.cs
+++ b/src/Opc.Ua.PubSub/Application/MetaDataPublisher.cs
@@ -33,6 +33,7 @@ using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using Opc.Ua.PubSub.Configuration;
 using Opc.Ua.PubSub.Connections;
 using Opc.Ua.PubSub.DataSets;
 using Opc.Ua.PubSub.Diagnostics;
@@ -174,10 +175,34 @@ namespace Opc.Ua.PubSub.Application
                     return;
                 }
                 m_registry.MetaDataChanged += OnMetaDataChanged;
+                m_application.ConfigurationChanged += OnConfigurationChanged;
                 m_subscribed = true;
             }
             SubscribeToDataSets();
             await PublishInitialAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Re-subscribe when the configuration is replaced.
+        /// </summary>
+        /// <remarks>
+        /// Per-dataset subscriptions were taken once, from
+        /// <see cref="StartAsync"/>. An application that is configured after it
+        /// starts therefore never subscribed to anything: at start there were
+        /// no writers to walk, and nothing looked again when they arrived. A
+        /// dataset added later was in the same position even on an application
+        /// configured up front.
+        /// </remarks>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void OnConfigurationChanged(object? sender,
+            PubSubConfigurationChangedEventArgs e)
+        {
+            if (Volatile.Read(ref m_disposed) != 0)
+            {
+                return;
+            }
+            SubscribeToDataSets();
         }
 
         /// <inheritdoc/>
@@ -192,6 +217,7 @@ namespace Opc.Ua.PubSub.Application
                 if (m_subscribed)
                 {
                     m_registry.MetaDataChanged -= OnMetaDataChanged;
+                    m_application.ConfigurationChanged -= OnConfigurationChanged;
                     m_subscribed = false;
                 }
                 foreach (DataSetSubscription subscription in m_dataSetSubscriptions)
@@ -214,6 +240,10 @@ namespace Opc.Ua.PubSub.Application
         /// rebuilds and raises <c>MetaDataChanged</c> when the source signals,
         /// but nothing carried that into the registry this publisher watches,
         /// so the empty announcement was the only one a consumer ever saw.
+        ///
+        /// This runs again whenever the configuration changes, so it must be
+        /// idempotent: a dataset already being watched is skipped, compared by
+        /// reference because that is the identity the handler is bound to.
         /// </remarks>
         private void SubscribeToDataSets()
         {
@@ -249,12 +279,17 @@ namespace Opc.Ua.PubSub.Application
                             {
                                 return;
                             }
+                            if (IsSubscribedLocked(dataSet))
+                            {
+                                continue;
+                            }
                         }
                         dataSet.MetaDataChanged += Handler;
                         bool keepSubscription;
                         lock (m_gate)
                         {
-                            keepSubscription = Volatile.Read(ref m_disposed) == 0;
+                            keepSubscription = Volatile.Read(ref m_disposed) == 0
+                                && !IsSubscribedLocked(dataSet);
                             if (keepSubscription)
                             {
                                 m_dataSetSubscriptions.Add(
@@ -264,11 +299,33 @@ namespace Opc.Ua.PubSub.Application
                         if (!keepSubscription)
                         {
                             dataSet.MetaDataChanged -= Handler;
-                            return;
+                            if (Volatile.Read(ref m_disposed) != 0)
+                            {
+                                return;
+                            }
                         }
                     }
                 }
             }
+        }
+
+        /// <summary>
+        /// True when this dataset is already being watched. Compared by
+        /// reference, because that is the identity the handler is bound to -
+        /// two datasets can carry equal metadata and still be different
+        /// sources.
+        /// </summary>
+        /// <param name="dataSet"></param>
+        private bool IsSubscribedLocked(IPublishedDataSet dataSet)
+        {
+            for (int index = 0; index < m_dataSetSubscriptions.Count; index++)
+            {
+                if (ReferenceEquals(m_dataSetSubscriptions[index].DataSet, dataSet))
+                {
+                    return true;
+                }
+            }
+            return false;
         }
 
         private void OnDataSetMetaDataChanged(

--- a/tests/Opc.Ua.PubSub.Tests/Application/MetaDataPublisherTests.cs
+++ b/tests/Opc.Ua.PubSub.Tests/Application/MetaDataPublisherTests.cs
@@ -270,11 +270,78 @@ namespace Opc.Ua.PubSub.Tests.Application
                 "Disposed publisher must remove the per-dataset metadata subscription.");
         }
 
+        [Test]
+        public async Task EveryWriterSharingADataSetIsAnnouncedAsync()
+        {
+            //
+            // Several writers may publish the same PublishedDataSet - the same
+            // DataSetName referenced from different writers, groups or
+            // connections - and each announces to its own destination. A
+            // subscription taken per dataset rather than per writer would
+            // watch only the first of them, and the rest would never
+            // re-announce.
+            //
+            const ushort secondWriterId = 43;
+            DataSetMetaDataType currentMetaData = NewMeta();
+            var source = new Mock<IPublishedDataSetSource>();
+            source
+                .Setup(s => s.BuildMetaData())
+                .Returns(() => currentMetaData);
+            Mock<IMetaDataChangeNotifier> notifier = source.As<IMetaDataChangeNotifier>();
+            var messages = new ConcurrentQueue<JsonMetaDataMessage>();
+            var encoder = new Mock<INetworkMessageEncoder>();
+            encoder
+                .SetupGet(e => e.TransportProfileUri)
+                .Returns(JsonMqttProfile);
+            encoder
+                .Setup(e => e.EncodeAsync(
+                    It.IsAny<PubSubNetworkMessage>(),
+                    It.IsAny<PubSubNetworkMessageContext>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns((
+                    PubSubNetworkMessage message,
+                    PubSubNetworkMessageContext _,
+                    CancellationToken _) =>
+                {
+                    if (message is JsonMetaDataMessage metaDataMessage)
+                    {
+                        messages.Enqueue(metaDataMessage);
+                    }
+                    return new ValueTask<ReadOnlyMemory<byte>>(new byte[] { 1 });
+                });
+            var factory = new RecordingTransportFactory(JsonMqttProfile, supportsTopics: true);
+            await using IPubSubApplication app = BuildApp(
+                JsonMqttProfile,
+                factory,
+                source.Object,
+                encoder.Object,
+                secondWriterId);
+
+            await app.StartAsync(CancellationToken.None).ConfigureAwait(false);
+            await WaitUntilAsync(
+                () => messages.Count >= 2,
+                TimeSpan.FromSeconds(2)).ConfigureAwait(false);
+            messages.Clear();
+
+            currentMetaData = NewMeta(majorVersion: 2);
+            notifier.Raise(n => n.MetaDataChanged += null, EventArgs.Empty);
+
+            await WaitUntilAsync(
+                () => messages.Count >= 2,
+                TimeSpan.FromSeconds(2)).ConfigureAwait(false);
+
+            Assert.That(
+                messages.Select(m => m.DataSetWriterId).Distinct(),
+                Is.EquivalentTo(new[] { DataSetWriterIdValue, secondWriterId }),
+                "Both writers of a shared data set must re-announce.");
+        }
+
         private static IPubSubApplication BuildApp(
             string transportProfileUri,
             RecordingTransportFactory factory,
             IPublishedDataSetSource? source = null,
-            INetworkMessageEncoder? encoder = null)
+            INetworkMessageEncoder? encoder = null,
+            ushort? secondWriterId = null)
         {
             string addressUrl = transportProfileUri == JsonMqttProfile
                 ? "mqtt://localhost:1883"
@@ -296,15 +363,32 @@ namespace Opc.Ua.PubSub.Tests.Application
                         Name = "wg-1",
                         WriterGroupId = WriterGroupIdValue,
                         PublishingInterval = 600_000,
-                        DataSetWriters = new ArrayOf<DataSetWriterDataType>(new[]
-                        {
-                            new DataSetWriterDataType
+                        DataSetWriters = new ArrayOf<DataSetWriterDataType>(
+                            secondWriterId is null
+                            ? new[]
                             {
-                                Name = "writer-1",
-                                DataSetWriterId = DataSetWriterIdValue,
-                                DataSetName = "pds-1"
+                                new DataSetWriterDataType
+                                {
+                                    Name = "writer-1",
+                                    DataSetWriterId = DataSetWriterIdValue,
+                                    DataSetName = "pds-1"
+                                }
                             }
-                        })
+                            : new[]
+                            {
+                                new DataSetWriterDataType
+                                {
+                                    Name = "writer-1",
+                                    DataSetWriterId = DataSetWriterIdValue,
+                                    DataSetName = "pds-1"
+                                },
+                                new DataSetWriterDataType
+                                {
+                                    Name = "writer-2",
+                                    DataSetWriterId = secondWriterId.Value,
+                                    DataSetName = "pds-1"
+                                }
+                            })
                     }
                 })
             };


### PR DESCRIPTION
### Problem

`MetaDataPublisher` takes its per-dataset subscriptions once, from `StartAsync`, by walking the connections that exist at that moment:

```csharp
m_registry.MetaDataChanged += OnMetaDataChanged;
m_subscribed = true;
...
SubscribeToDataSets();
```

An application that is **configured after it starts** therefore never subscribes to anything — at start there are no writers to walk, and nothing looks again when they arrive. The same gap applies to a dataset added to an already-configured application.

The visible effect is that `PublishedDataSet.MetaDataChanged` is never observed for those datasets. A source whose fields are only known once data has flowed — one fed by a live subscription — announces its empty metadata and never corrects it, so a consumer that relies on the announcement to decode the payload never sees a usable one.

This is not hypothetical: it is how a host that starts with an empty `PubSubConfigurationDataType` and calls `ReplaceConfigurationAsync` later behaves, which is a reasonable way to drive the application when the configuration is not known at construction time.

### Change

`SubscribeToDataSets()` now also runs on `IPubSubApplication.ConfigurationChanged`.

Running it more than once means it has to be idempotent, so a dataset that is already being watched is skipped. The comparison is by **reference**, because that is the identity the handler is bound to — two datasets can carry equal metadata and still be different sources. The new subscription is removed again on dispose alongside the registry handler.

The re-entrancy check is done twice under the lock: once before attaching the handler to avoid the work, and once after, because the handler is attached outside the lock and a concurrent configuration change could have added the same dataset in between.

### Scope

**This does not on its own change the order in which the first announcement and the first data message are published.** It only ensures the announcement happens at all for datasets the publisher was never watching. Relates to #4152, which is about that ordering; this is a prerequisite, not a fix for it.

### Verification

- `Opc.Ua.PubSub` builds with **0 warnings, 0 errors** across all six target frameworks (net10.0, net9.0, net8.0, netstandard2.1, net48, net472).
- `Opc.Ua.PubSub.Tests` on net10.0: **1341 passed, 1 skipped, 0 failed**.
