### PR TITLE
Fix BadContinuationPointInvalid that occurred due to incorrect Browser.BrowseAsync

### DIFF
--- a/Libraries/Opc.Ua.Client/Browser.cs
+++ b/Libraries/Opc.Ua.Client/Browser.cs
@@ -303,7 +303,7 @@ namespace Opc.Ua.Client
             try
             {
                 // process any continuation point.
-                while (continuationPoint != null)
+                while (continuationPoint?.Length > 0)
                 {
                     ReferenceDescriptionCollection additionalReferences;
 


### PR DESCRIPTION
Fix BadContinuationPointInvalid that occurred due to incorrect handling of an empty continuation point byte array in Browser.BrowseAsync

# Description
Temporary hotfix of BadContinuationPointInvalid when calling Browser.BrowseAsync with servers 1.6.0 and higher.

## Related Issues

- Fixes #3698

## Checklist

- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf) and read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added all necessary documentation.
- [ ] I have verified that my changes do not introduce (new) build or analyzer warnings.
- [ ] I ran **all** tests locally using the **UA.slnx** solution against at least .net **framework** and .net **10**, and all passed.
- [ ] I fixed **all** failing and flaky tests in the CI pipelines and **all** CodeQL warnings.
- [ ] I have addressed **all** PR feedback received.

## Further comments

The issue seems to be fixed by a refactoring in the master branch (adding the ByteString type), but I'm proposing a temporary spot hotfix for latest 1.5.378 version