### PR TITLE
Ship the OPC Foundation license file from every package and fix the NU5033 pack failure

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -92,9 +92,18 @@
     inherited file, which keeps every new package from having to remember an
     empty `<PackageLicenseFile></PackageLicenseFile>` override.
 
-    Items are evaluated after all properties, so the `LICENSE.txt` `None` item
-    in `common.props` picks up the cleared value and still packs the license
-    text at the package root.
+    Clearing the property does NOT drop the license text from the package. The
+    `LICENSE.txt` in `common.props` is packed by an explicit
+    `<None Include="..." Pack="true" />` item, which is independent of the
+    NuGet license *metadata* this block clears. Its
+    `PackagePath="$(PackageLicenseFile)"` does observe the cleared value even
+    though `Directory.Build.targets` is imported after `common.props`, because
+    MSBuild evaluates every property of every import in an earlier pass than
+    any item: verify with
+    `dotnet msbuild <project> -getItem:None`, which reports an empty
+    `PackagePath` for `LICENSE.txt` (while `logo.jpg` keeps `images/logo.jpg`).
+    An empty `PackagePath` packs the file at the package root, which is where
+    the shared license text lands either way.
   -->
   <PropertyGroup Condition="'$(PackageLicenseExpression)' != ''">
     <PackageLicenseFile />

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -78,6 +78,28 @@
     <Message Importance="high" Text="Skipping $(MSBuildProjectName) for CustomTestTarget=$(CustomTestTarget) (.NET 8+ only)." />
   </Target>
   <!--
+    `common.props` gives every package the shared `LICENSE.txt` as its
+    `<PackageLicenseFile>`. A project that instead declares the SPDX
+    `<PackageLicenseExpression>MIT</PackageLicenseExpression>` must not also
+    carry the inherited license file - NuGet rejects that combination with
+    `NU5033: Cannot specify both a PackageLicenseExpression and a
+    PackageLicenseFile`, which fails `pack` for the whole solution.
+
+    `common.props` cannot decide this itself: it is imported from
+    `Directory.Build.props`, i.e. before the project body, so it never sees a
+    project-level license expression. `Directory.Build.targets` is imported
+    after the project body and is therefore the only place that can drop the
+    inherited file, which keeps every new package from having to remember an
+    empty `<PackageLicenseFile></PackageLicenseFile>` override.
+
+    Items are evaluated after all properties, so the `LICENSE.txt` `None` item
+    in `common.props` picks up the cleared value and still packs the license
+    text at the package root.
+  -->
+  <PropertyGroup Condition="'$(PackageLicenseExpression)' != ''">
+    <PackageLicenseFile />
+  </PropertyGroup>
+  <!--
     On netstandard target frameworks two [LoggerMessage] source generators can be active at once:
     the in-box generator shipped in Microsoft.Extensions.Logging(.Abstractions) and the R9
     Microsoft.Gen.Logging generator that flows in transitively from R9 packages such as

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -78,36 +78,31 @@
     <Message Importance="high" Text="Skipping $(MSBuildProjectName) for CustomTestTarget=$(CustomTestTarget) (.NET 8+ only)." />
   </Target>
   <!--
-    `common.props` gives every package the shared `LICENSE.txt` as its
-    `<PackageLicenseFile>`. A project that instead declares the SPDX
-    `<PackageLicenseExpression>MIT</PackageLicenseExpression>` must not also
-    carry the inherited license file - NuGet rejects that combination with
-    `NU5033: Cannot specify both a PackageLicenseExpression and a
-    PackageLicenseFile`, which fails `pack` for the whole solution.
+    Every package in this repository is licensed under the OPC Foundation MIT
+    License 1.00 and ships the shared `LICENSE.txt` that `common.props` wires
+    up as `<PackageLicenseFile>`. That license is NOT the plain SPDX `MIT`
+    license: it carries the OPC Foundation copyright and preamble, so a package
+    declaring `<PackageLicenseExpression>MIT</PackageLicenseExpression>` would
+    advertise the wrong license on nuget.org (generic MIT plus a
+    `licenses.nuget.org/MIT` URL) instead of the OPC Foundation text.
 
-    `common.props` cannot decide this itself: it is imported from
-    `Directory.Build.props`, i.e. before the project body, so it never sees a
-    project-level license expression. `Directory.Build.targets` is imported
-    after the project body and is therefore the only place that can drop the
-    inherited file, which keeps every new package from having to remember an
-    empty `<PackageLicenseFile></PackageLicenseFile>` override.
+    Such a declaration also breaks the build outright: NuGet refuses to pack a
+    project that carries both a license expression and the inherited license
+    file (`NU5033: Cannot specify both a PackageLicenseExpression and a
+    PackageLicenseFile`), which fails `pack` for the whole solution rather than
+    just the offending project.
 
-    Clearing the property does NOT drop the license text from the package. The
-    `LICENSE.txt` in `common.props` is packed by an explicit
-    `<None Include="..." Pack="true" />` item, which is independent of the
-    NuGet license *metadata* this block clears. Its
-    `PackagePath="$(PackageLicenseFile)"` does observe the cleared value even
-    though `Directory.Build.targets` is imported after `common.props`, because
-    MSBuild evaluates every property of every import in an earlier pass than
-    any item: verify with
-    `dotnet msbuild <project> -getItem:None`, which reports an empty
-    `PackagePath` for `LICENSE.txt` (while `logo.jpg` keeps `images/logo.jpg`).
-    An empty `PackagePath` packs the file at the package root, which is where
-    the shared license text lands either way.
+    `common.props` cannot catch this itself - it is imported from
+    `Directory.Build.props`, i.e. before the project body, so it never observes
+    a project-level license expression. `Directory.Build.targets` is imported
+    after the project body, so it is the earliest place that can, and it fails
+    with an actionable message instead of the cryptic NuGet error.
   -->
-  <PropertyGroup Condition="'$(PackageLicenseExpression)' != ''">
-    <PackageLicenseFile />
-  </PropertyGroup>
+  <Target Name="_ValidatePackageLicense" BeforeTargets="Build;Pack"
+          Condition="'$(IsPackable)' != 'false' AND '$(PackageLicenseExpression)' != ''">
+    <Error Code="OPCUA0001"
+           Text="$(MSBuildProjectName) sets PackageLicenseExpression=$(PackageLicenseExpression). Every package must ship the OPC Foundation MIT License 1.00 via the shared LICENSE.txt that common.props sets as PackageLicenseFile, which the SPDX expression neither matches nor is allowed to coexist with (NU5033). Remove the PackageLicenseExpression property." />
+  </Target>
   <!--
     On netstandard target frameworks two [LoggerMessage] source generators can be active at once:
     the in-box generator shipped in Microsoft.Extensions.Logging(.Abstractions) and the R9

--- a/common.props
+++ b/common.props
@@ -46,7 +46,14 @@
     <PackageIcon>images/logo.jpg</PackageIcon>
     <PackageProjectUrl>$(RepositoryUrl)</PackageProjectUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <!--<PackageLicenseExpression>MIT</PackageLicenseExpression>-->
+    <!--
+      Every package ships the OPC Foundation MIT License 1.00 as a license
+      file. Do NOT replace this with
+      <PackageLicenseExpression>MIT</PackageLicenseExpression>: the SPDX `MIT`
+      license is a different text than the OPC Foundation one, and NuGet
+      rejects a project that carries both an expression and a license file
+      (NU5033). `Directory.Build.targets` enforces this.
+    -->
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <PackageReleaseNotes>$(RepositoryUrl)/releases</PackageReleaseNotes>
     <!--

--- a/src/Opc.Ua.Di/Opc.Ua.Di.csproj
+++ b/src/Opc.Ua.Di/Opc.Ua.Di.csproj
@@ -10,7 +10,6 @@
     <IsPackable>true</IsPackable>
     <PackageReadmeFile>NugetREADME.md</PackageReadmeFile>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageLicenseFile></PackageLicenseFile>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))">true</IsAotCompatible>
   </PropertyGroup>

--- a/src/Opc.Ua.Di/Opc.Ua.Di.csproj
+++ b/src/Opc.Ua.Di/Opc.Ua.Di.csproj
@@ -9,7 +9,6 @@
     <Description>OPC UA Device Integration (DI, OPC 10000-100) and Package Metadata information models</Description>
     <IsPackable>true</IsPackable>
     <PackageReadmeFile>NugetREADME.md</PackageReadmeFile>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))">true</IsAotCompatible>
   </PropertyGroup>

--- a/src/Opc.Ua.Gds.Common/Opc.Ua.Gds.Common.csproj
+++ b/src/Opc.Ua.Gds.Common/Opc.Ua.Gds.Common.csproj
@@ -10,7 +10,6 @@
     <IsPackable>true</IsPackable>
     <PackageReadmeFile>NugetREADME.md</PackageReadmeFile>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageLicenseFile></PackageLicenseFile>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))">true</IsAotCompatible>
   </PropertyGroup>

--- a/src/Opc.Ua.Gds.Common/Opc.Ua.Gds.Common.csproj
+++ b/src/Opc.Ua.Gds.Common/Opc.Ua.Gds.Common.csproj
@@ -9,7 +9,6 @@
     <Description>OPC UA GDS Class Library</Description>
     <IsPackable>true</IsPackable>
     <PackageReadmeFile>NugetREADME.md</PackageReadmeFile>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))">true</IsAotCompatible>
   </PropertyGroup>

--- a/src/Opc.Ua.ISA95/Opc.Ua.ISA95.csproj
+++ b/src/Opc.Ua.ISA95/Opc.Ua.ISA95.csproj
@@ -10,7 +10,6 @@
     <IsPackable>true</IsPackable>
     <PackageReadmeFile>NugetREADME.md</PackageReadmeFile>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageLicenseFile></PackageLicenseFile>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))">true</IsAotCompatible>
   </PropertyGroup>

--- a/src/Opc.Ua.ISA95/Opc.Ua.ISA95.csproj
+++ b/src/Opc.Ua.ISA95/Opc.Ua.ISA95.csproj
@@ -9,7 +9,6 @@
     <Description>OPC UA ISA-95 Common Model and Job Control V1/V2 information models</Description>
     <IsPackable>true</IsPackable>
     <PackageReadmeFile>NugetREADME.md</PackageReadmeFile>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))">true</IsAotCompatible>
   </PropertyGroup>

--- a/src/Opc.Ua.OpenUsd.Client/Opc.Ua.OpenUsd.Client.csproj
+++ b/src/Opc.Ua.OpenUsd.Client/Opc.Ua.OpenUsd.Client.csproj
@@ -9,7 +9,6 @@
     <Description>Generic, reusable client-side connector for the draft OPC UA - OpenUSD Bindings companion model: discovers a server's representations and live/alarm/history/command bindings, subscribes, applies the conversions, streams the served USD asset closure (Part 5), and writes into a pluggable IUsdSink. Works with any server exposing the OpenUSD binding, independent of the domain model.</Description>
     <IsPackable>true</IsPackable>
     <PackageReadmeFile>NugetREADME.md</PackageReadmeFile>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))">true</IsAotCompatible>
   </PropertyGroup>

--- a/src/Opc.Ua.OpenUsd.Server/Opc.Ua.OpenUsd.Server.csproj
+++ b/src/Opc.Ua.OpenUsd.Server/Opc.Ua.OpenUsd.Server.csproj
@@ -9,7 +9,6 @@
     <Description>Server-side reusable functionality for the draft OPC UA - OpenUSD Bindings companion model: authoring live/alarm/history/command bindings and component compositions on a representation, and serving the artist-authored USD asset closure through a read-only Part 5 FileType (spec §5.15).</Description>
     <IsPackable>true</IsPackable>
     <PackageReadmeFile>NugetREADME.md</PackageReadmeFile>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))">true</IsAotCompatible>
   </PropertyGroup>

--- a/src/Opc.Ua.OpenUsd/Opc.Ua.OpenUsd.csproj
+++ b/src/Opc.Ua.OpenUsd/Opc.Ua.OpenUsd.csproj
@@ -9,7 +9,6 @@
     <Description>Draft OPC UA - OpenUSD Bindings companion information model (representation, live/alarm/history/command bindings, composition, content integrity and asset content delivery), source-generated from the shared NodeSet2.xml.</Description>
     <IsPackable>true</IsPackable>
     <PackageReadmeFile>NugetREADME.md</PackageReadmeFile>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))">true</IsAotCompatible>
   </PropertyGroup>

--- a/src/Opc.Ua.OpenUsdScene.Server/Opc.Ua.OpenUsdScene.Server.csproj
+++ b/src/Opc.Ua.OpenUsdScene.Server/Opc.Ua.OpenUsdScene.Server.csproj
@@ -9,7 +9,6 @@
     <Description>Server-side reusable functionality for the draft OPC UA - OpenUSD Scene Materialization companion model: materializes a composed USD stage into the address space as a browsable prim tree with typed prims, attributes, relationships, composition provenance, applied API schemas and georeferencing, and exports it back to .usda.</Description>
     <IsPackable>true</IsPackable>
     <PackageReadmeFile>NugetREADME.md</PackageReadmeFile>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))">true</IsAotCompatible>
   </PropertyGroup>

--- a/src/Opc.Ua.OpenUsdScene/Opc.Ua.OpenUsdScene.csproj
+++ b/src/Opc.Ua.OpenUsdScene/Opc.Ua.OpenUsdScene.csproj
@@ -9,7 +9,6 @@
     <Description>Draft OPC UA - OpenUSD Scene Materialization companion information model (stages, prims, attributes, relationships, composition arcs, variant sets, applied API schemas and georeferencing), source-generated from the shared NodeSet2.xml.</Description>
     <IsPackable>true</IsPackable>
     <PackageReadmeFile>NugetREADME.md</PackageReadmeFile>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))">true</IsAotCompatible>
   </PropertyGroup>

--- a/src/Opc.Ua.Positioning.Client/Opc.Ua.Positioning.Client.csproj
+++ b/src/Opc.Ua.Positioning.Client/Opc.Ua.Positioning.Client.csproj
@@ -10,7 +10,6 @@
     <IsPackable>true</IsPackable>
     <PackageReadmeFile>NugetREADME.md</PackageReadmeFile>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageLicenseFile></PackageLicenseFile>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))">true</IsAotCompatible>
   </PropertyGroup>

--- a/src/Opc.Ua.Positioning.Client/Opc.Ua.Positioning.Client.csproj
+++ b/src/Opc.Ua.Positioning.Client/Opc.Ua.Positioning.Client.csproj
@@ -9,7 +9,6 @@
     <Description>Client APIs for OPC UA Relative Spatial Location and Global Positioning.</Description>
     <IsPackable>true</IsPackable>
     <PackageReadmeFile>NugetREADME.md</PackageReadmeFile>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))">true</IsAotCompatible>
   </PropertyGroup>

--- a/src/Opc.Ua.Positioning.Server/Opc.Ua.Positioning.Server.csproj
+++ b/src/Opc.Ua.Positioning.Server/Opc.Ua.Positioning.Server.csproj
@@ -11,7 +11,6 @@
     <IsPackable>true</IsPackable>
     <PackageReadmeFile>NugetREADME.md</PackageReadmeFile>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageLicenseFile></PackageLicenseFile>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))">true</IsAotCompatible>
   </PropertyGroup>

--- a/src/Opc.Ua.Positioning.Server/Opc.Ua.Positioning.Server.csproj
+++ b/src/Opc.Ua.Positioning.Server/Opc.Ua.Positioning.Server.csproj
@@ -10,7 +10,6 @@
     <Description>Server APIs, providers, builders, and hosting integration for OPC UA Relative Spatial Location and Global Positioning.</Description>
     <IsPackable>true</IsPackable>
     <PackageReadmeFile>NugetREADME.md</PackageReadmeFile>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))">true</IsAotCompatible>
   </PropertyGroup>

--- a/src/Opc.Ua.Positioning/Opc.Ua.Positioning.csproj
+++ b/src/Opc.Ua.Positioning/Opc.Ua.Positioning.csproj
@@ -10,7 +10,6 @@
     <IsPackable>true</IsPackable>
     <PackageReadmeFile>NugetREADME.md</PackageReadmeFile>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageLicenseFile></PackageLicenseFile>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))">true</IsAotCompatible>
   </PropertyGroup>

--- a/src/Opc.Ua.Positioning/Opc.Ua.Positioning.csproj
+++ b/src/Opc.Ua.Positioning/Opc.Ua.Positioning.csproj
@@ -9,7 +9,6 @@
     <Description>OPC UA Relative Spatial Location (OPC 10000-210) and Global Positioning (OPC 10000-211) information models and transformation primitives.</Description>
     <IsPackable>true</IsPackable>
     <PackageReadmeFile>NugetREADME.md</PackageReadmeFile>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))">true</IsAotCompatible>
   </PropertyGroup>

--- a/src/Opc.Ua.Robotics.Client/Opc.Ua.Robotics.Client.csproj
+++ b/src/Opc.Ua.Robotics.Client/Opc.Ua.Robotics.Client.csproj
@@ -9,7 +9,6 @@
     <Description>Client-side helpers for the OPC 40010 Robotics companion model: discover MotionDeviceSystem instances over a session and identify Robotics types (MotionDeviceSystem / MotionDevice / Axis / Controller) from a node's TypeDefinition, so a generic OpenUSD connector or viewer can label and drive a robot-cell twin.</Description>
     <IsPackable>true</IsPackable>
     <PackageReadmeFile>NugetREADME.md</PackageReadmeFile>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))">true</IsAotCompatible>
   </PropertyGroup>

--- a/src/Opc.Ua.Robotics.Server/Opc.Ua.Robotics.Server.csproj
+++ b/src/Opc.Ua.Robotics.Server/Opc.Ua.Robotics.Server.csproj
@@ -9,7 +9,6 @@
     <Description>Server hosting for the source-generated OPC 40010 Robotics model, including compiled model providers, a stock DI-based node manager and factory, and fluent application configuration APIs.</Description>
     <IsPackable>true</IsPackable>
     <PackageReadmeFile>NugetREADME.md</PackageReadmeFile>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))">true</IsAotCompatible>
   </PropertyGroup>

--- a/src/Opc.Ua.Robotics/Opc.Ua.Robotics.csproj
+++ b/src/Opc.Ua.Robotics/Opc.Ua.Robotics.csproj
@@ -9,7 +9,6 @@
     <Description>Server/client-independent OPC 40010 Robotics contracts and source-generated Robotics and Industrial Automation models over OPC UA DI, including model identifiers, typed states and proxies, model loaders, and focused topology read-projection contracts.</Description>
     <IsPackable>true</IsPackable>
     <PackageReadmeFile>NugetREADME.md</PackageReadmeFile>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))">true</IsAotCompatible>
   </PropertyGroup>

--- a/src/Opc.Ua.WotCon/Opc.Ua.WotCon.csproj
+++ b/src/Opc.Ua.WotCon/Opc.Ua.WotCon.csproj
@@ -10,7 +10,6 @@
     <IsPackable>true</IsPackable>
     <PackageReadmeFile>NugetREADME.md</PackageReadmeFile>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageLicenseFile></PackageLicenseFile>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))">true</IsAotCompatible>
   </PropertyGroup>

--- a/src/Opc.Ua.WotCon/Opc.Ua.WotCon.csproj
+++ b/src/Opc.Ua.WotCon/Opc.Ua.WotCon.csproj
@@ -9,7 +9,6 @@
     <Description>OPC UA WoT Connectivity (OPC 10100-1) information model</Description>
     <IsPackable>true</IsPackable>
     <PackageReadmeFile>NugetREADME.md</PackageReadmeFile>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))">true</IsAotCompatible>
   </PropertyGroup>

--- a/tools/Opc.Ua.OpenUsd.Connector.Viewer/Opc.Ua.OpenUsd.Connector.Viewer.csproj
+++ b/tools/Opc.Ua.OpenUsd.Connector.Viewer/Opc.Ua.OpenUsd.Connector.Viewer.csproj
@@ -10,7 +10,6 @@
     <AssemblyName>Opc.Ua.OpenUsd.Connector.Viewer</AssemblyName>
     <PackageId>$(PackagePrefix).Opc.Ua.OpenUsd.Connector.Viewer</PackageId>
     <PackageReadmeFile>NugetREADME.md</PackageReadmeFile>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Description>Optional viewport for the OPC UA - OpenUSD connector. Renders the composed stage with the OpenUSD Avalonia viewer and exposes it as an IUsdSink, so the connector's --view option streams live OPC UA values into the picture on screen. Install alongside Opc.Ua.OpenUsd.Connector; the connector loads it on demand and works without it.</Description>
     <RootNamespace>Opc.Ua.OpenUsd.Connector.Viewer</RootNamespace>
     <Nullable>enable</Nullable>

--- a/tools/Opc.Ua.SourceGeneration.Core/Opc.Ua.SourceGeneration.Core.csproj
+++ b/tools/Opc.Ua.SourceGeneration.Core/Opc.Ua.SourceGeneration.Core.csproj
@@ -7,7 +7,6 @@
     <Description>OPC UA source generation common Library</Description>
     <IsPackable>true</IsPackable>
     <PackageReadmeFile>NugetREADME.md</PackageReadmeFile>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>

--- a/tools/Opc.Ua.SourceGeneration.Core/Opc.Ua.SourceGeneration.Core.csproj
+++ b/tools/Opc.Ua.SourceGeneration.Core/Opc.Ua.SourceGeneration.Core.csproj
@@ -8,7 +8,6 @@
     <IsPackable>true</IsPackable>
     <PackageReadmeFile>NugetREADME.md</PackageReadmeFile>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageLicenseFile></PackageLicenseFile>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>

--- a/tools/SourceGeneratorPack.targets
+++ b/tools/SourceGeneratorPack.targets
@@ -34,13 +34,6 @@
     <DevelopmentDependency>true</DevelopmentDependency>
     <NoPackageAnalysis>true</NoPackageAnalysis>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <!-- Must stay empty: common.props sets PackageLicenseFile=LICENSE.txt for every
-         packable project, and NuGet rejects a package that declares both a license
-         expression and a license file (NU5035). Clearing it also makes common.props
-         pack LICENSE.txt at the package root as plain content, which is what the
-         other OPC UA packages do. -->
-    <PackageLicenseFile></PackageLicenseFile>
     <PackageReadmeFile>NugetREADME.md</PackageReadmeFile>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <ProduceReferenceAssembly>false</ProduceReferenceAssembly>


### PR DESCRIPTION
# Description

The `preview-pack` stage of the Azure DevOps pipeline fails with nine `NU5033` errors, which fails the whole build:

```
NuGet.Build.Tasks.Pack.targets(222,5): error NU5033: Invalid metadata.
Cannot specify both a PackageLicenseExpression and a PackageLicenseFile.
[src\Opc.Ua.Robotics\Opc.Ua.Robotics.csproj]
```

`common.props` gives every package the shared `LICENSE.txt` as its `<PackageLicenseFile>`, but **19** packages also declared `<PackageLicenseExpression>MIT</PackageLicenseExpression>`. Nine of them hit `NU5033`; the other ten only avoided it by carrying an empty `<PackageLicenseFile></PackageLicenseFile>` workaround.

That declaration was wrong on two counts.

**It advertised the wrong license.** `LICENSE.txt` is the **OPC Foundation MIT License 1.00**, which carries the OPC Foundation copyright and preamble — it is a different text than the plain SPDX `MIT` license. The affected packages therefore published `<license type="expression">MIT</license>` plus a `licenses.nuget.org/MIT` URL on nuget.org, instead of the OPC Foundation text that every other package in the stack ships.

**It also broke the build,** because NuGet refuses to pack a project carrying both a license expression and a license file, failing `pack` solution-wide rather than just for the offending projects.

## Changes

The expression is dropped from all 19 packages so every one uses the shared OPC Foundation license file uniformly, like the rest of the stack:

* `src/Opc.Ua.OpenUsd`, `.Client`, `.Server`
* `src/Opc.Ua.OpenUsdScene`, `.Server`
* `src/Opc.Ua.Robotics`, `.Client`, `.Server`
* `src/Opc.Ua.Positioning`, `.Client`, `.Server`
* `src/Opc.Ua.Di`, `src/Opc.Ua.ISA95`, `src/Opc.Ua.WotCon`, `src/Opc.Ua.Gds.Common`
* `tools/Opc.Ua.OpenUsd.Connector.Viewer`, `tools/Opc.Ua.SourceGeneration.Core`
* `tools/Opc.Ua.SourceGeneration.Pack`, `tools/Opc.Ua.SourceGeneration.Stack.Pack` — these two set the license not in their own `.csproj` but in the shared `tools/SourceGeneratorPack.targets`, so they were only caught once the new guard ran in CI.

The eight per-project empty `<PackageLicenseFile></PackageLicenseFile>` workarounds go away with it.

To stop the whole class of failure from recurring, `Directory.Build.targets` now *enforces* the rule rather than papering over it. Silently clearing the inherited license file would have fixed the build while still publishing the wrong license metadata, so instead a violation fails fast with an actionable error naming the project:

```
error OPCUA0001: Opc.Ua.Foo sets PackageLicenseExpression=MIT. Every package must
ship the OPC Foundation MIT License 1.00 via the shared LICENSE.txt that
common.props sets as PackageLicenseFile, which the SPDX expression neither
matches nor is allowed to coexist with (NU5033). Remove the
PackageLicenseExpression property.
```

`common.props` cannot catch this itself: it is imported from `Directory.Build.props`, i.e. **before** the project body, so it never observes a project-level license expression. `Directory.Build.targets` is imported **after** the project body and is the earliest place that can. The `common.props` comment that previously hinted the expression was an option now points at this rule.

### Verification

* Every packable project evaluates to `PackageLicenseFile=LICENSE.txt` with an empty `PackageLicenseExpression`; file-licensed packages such as `Opc.Ua.Client` are unchanged.
* `dotnet pack -c Release` succeeds for `Opc.Ua.Robotics` (previously failing) and `Opc.Ua.SourceGeneration.Core` (previously relying on the removed workaround).
* Replicated the CI build commands locally — `dotnet build` of `UA.slnx` (net48/Debug), `tools/SourceGeneration.slnx` (net472/Release) and `tools/MigrationAnalyzer.slnx` (net48/Debug) all succeed with 0 errors.
* Inspected the produced `.nupkg`: now `<license type="file">LICENSE.txt</license>` with the license text at the package root, matching the rest of the stack (it was `<license type="expression">MIT</license>` before).
* Confirmed the guard fires on a simulated violation (`-p:PackageLicenseExpression=MIT`) and is inert otherwise.

## Related Issues

No tracking issue — this fixes the `NU5033` failure in the OPC Foundation Azure DevOps pipeline (build 16247, `preview-pack` stage) and corrects the license metadata published for the affected packages. No product code or public API changes.

## Checklist

_Put an `x` in the boxes that apply. You can complete these step by step after opening the PR._

- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf) and read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have added tests that prove my fix is effective or that my feature works and increased code coverage. _(Build-infrastructure change with no code surface. Validated by `dotnet pack` of the affected projects, by inspecting the resulting package metadata, and by confirming the new `OPCUA0001` guard fires on a simulated violation. The pipeline `preview-pack` stage is the regression test.)_
- [x] I have added all necessary documentation. _(The rule is documented in place, on the new `Directory.Build.targets` guard and at the `PackageLicenseFile` definition in `common.props`.)_
- [x] I have verified that my changes do not introduce (new) build or analyzer warnings.
- [ ] I ran **all** tests locally using the **UA.slnx** solution against at least .net **framework** and .net **10**, and all passed.
- [ ] I fixed **all** failing and flaky tests in the CI pipelines and **all** CodeQL warnings.
- [ ] I have addressed **all** PR feedback received.

