### PR TITLE
Move OpenUSD to 0.6.0-alpha and restore the render smoke job

### DIFF
--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -645,7 +645,7 @@ jobs:
     - name: Install the OpenGL runtime the native payload links against
       run: |
         sudo apt-get update
-        sudo apt-get install -y --no-install-recommends libgl1 libglx0 libegl1 libglvnd0
+        sudo apt-get install -y --no-install-recommends libopengl0 libglx0 libgl1 libegl1 libglvnd0
 
     - name: Render OpenUSD stage with SwiftShader Vulkan
       shell: pwsh

--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -637,6 +637,16 @@ jobs:
       with:
         dotnet-version: 10.0.x
 
+    # The OpenUSD Storm/Silk natives link against the system OpenGL runtime, which a
+    # bare ubuntu-latest image does not carry. Without these the payload publishes
+    # correctly and then fails to load, surfacing as a DllNotFoundException naming
+    # openusd_hdsilk with 'libOpenGL.so.0: cannot open shared object file' buried in
+    # the probe list - which reads as a packaging fault and is not one.
+    - name: Install the OpenGL runtime the native payload links against
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends libgl1 libglx0 libegl1 libglvnd0
+
     - name: Render OpenUSD stage with SwiftShader Vulkan
       shell: pwsh
       run: |
@@ -719,6 +729,18 @@ jobs:
         dotnet publish (Join-Path $sourceRoot 'OpenUsdRenderSmoke.csproj') -c Release -r linux-x64 -o $publishRoot --nologo
         if ($LASTEXITCODE -ne 0) {
           exit $LASTEXITCODE
+        }
+
+        # Report what the publish actually produced. A DllNotFoundException here is
+        # ambiguous between "the native was never published" and "it was published but
+        # a dependency is missing", and telling those apart from the probe list alone
+        # takes forensics. This makes the next failure self-explanatory.
+        $natives = Get-ChildItem $publishRoot -Filter 'libopenusd*' -File -ErrorAction SilentlyContinue
+        Write-Host "OpenUSD natives published: $($natives.Count)"
+        $natives | ForEach-Object { Write-Host "  $($_.Name)" }
+        if ($natives.Count -eq 0) {
+          Write-Host "::error::The publish produced no OpenUSD native libraries."
+          exit 1
         }
 
         Push-Location $publishRoot

--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -617,6 +617,138 @@ jobs:
         }
         Write-Host "UA.slnx built successfully for all target frameworks."
 
+  # Provisional: exercises the OpenUSD render path on Linux via SwiftShader/Vulkan.
+  # It is deliberately NOT part of the required status check below and is allowed
+  # to fail until it has passed unaided on CI at least once.
+  openusd-render-smoke:
+    name: openusd-render-smoke-linux
+    needs: discover
+    if: ${{ needs.discover.outputs.gh_owns_build == 'true' && needs.discover.outputs.relevant_changes == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    continue-on-error: true
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v6
+      with:
+        dotnet-version: 10.0.x
+
+    - name: Render OpenUSD stage with SwiftShader Vulkan
+      shell: pwsh
+      run: |
+        $sourceRoot = 'artifacts/openusd-render-smoke-src'
+        $publishRoot = 'artifacts/openusd-render-smoke'
+        New-Item -ItemType Directory -Path $sourceRoot -Force | Out-Null
+        @'
+        <Project Sdk="Microsoft.NET.Sdk">
+          <PropertyGroup>
+            <OutputType>Exe</OutputType>
+            <TargetFramework>net10.0</TargetFramework>
+            <RuntimeIdentifier>linux-x64</RuntimeIdentifier>
+            <Nullable>enable</Nullable>
+            <InvariantGlobalization>true</InvariantGlobalization>
+            <NoWarn>$(NoWarn);CA1014;CA1859</NoWarn>
+          </PropertyGroup>
+          <ItemGroup>
+            <PackageReference Include="OpenUsd.Rendering.Silk.Vulkan" />
+            <PackageReference Include="OpenUsd.Runtime.Imaging" />
+          </ItemGroup>
+          <ItemGroup>
+            <None Update="minimal.usda" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" />
+          </ItemGroup>
+        </Project>
+        '@ | Set-Content -Path (Join-Path $sourceRoot 'OpenUsdRenderSmoke.csproj') -Encoding UTF8
+        @'
+        #usda 1.0
+        (
+            defaultPrim = "World"
+        )
+
+        def Xform "World"
+        {
+            def Cube "Cube"
+            {
+                double size = 2
+            }
+        }
+        '@ | Set-Content -Path (Join-Path $sourceRoot 'minimal.usda') -Encoding UTF8
+        @'
+        using System;
+        using System.IO;
+        using OpenUsd.Rendering;
+        using OpenUsd.Rendering.Silk;
+        using OpenUsd.Rendering.Silk.Vulkan;
+
+        string pluginPath = Path.Combine(AppContext.BaseDirectory, "plugin", "usd");
+        string stagePath = Path.Combine(AppContext.BaseDirectory, "minimal.usda");
+        using ISilkGraphicsDevice device = VulkanSilkGraphicsDevice.Create();
+        using var sceneResources = new SilkSceneGpuResources(device);
+        var scene = new SilkSceneState();
+        using OpenUsdSilkSession session = OpenUsdSilkRuntime.Create(pluginPath, stagePath);
+        using OpenUsdSilkPage page = session.Sync(640, 360, camera: CameraState.Default);
+        int frames = 0;
+        int upserts = 0;
+        using (SilkCommandEnumerator commands = page.GetEnumerator())
+        {
+            while (commands.MoveNext())
+            {
+                if (commands.Current.Type == SilkCommandType.Frame)
+                {
+                    _ = commands.Current.AsFrame().GetViewElement(0);
+                    frames++;
+                }
+                else if (commands.Current.Type == SilkCommandType.MeshUpsert)
+                {
+                    upserts++;
+                }
+            }
+        }
+        sceneResources.Apply(scene, scene.Apply(page));
+        device.WaitIdle();
+        Console.WriteLine("PACKAGE_IMAGING_EXECUTION_OK");
+        Console.WriteLine($"GPU_BACKEND={(device.Capabilities.IsSoftware ? "VULKAN_SWIFTSHADER" : "VULKAN")}");
+        Console.WriteLine($"SOFTWARE_DEVICE={device.Capabilities.IsSoftware.ToString().ToLowerInvariant()}");
+        Console.WriteLine($"RENDERED_FRAME={(frames > 0 && upserts > 0 && sceneResources.Meshes.Count > 0).ToString().ToLowerInvariant()}");
+        return frames > 0 && upserts > 0 && sceneResources.Meshes.Count > 0 ? 0 : 3;
+        '@ | Set-Content -Path (Join-Path $sourceRoot 'Program.cs') -Encoding UTF8
+
+        dotnet publish (Join-Path $sourceRoot 'OpenUsdRenderSmoke.csproj') -c Release -r linux-x64 -o $publishRoot --nologo
+        if ($LASTEXITCODE -ne 0) {
+          exit $LASTEXITCODE
+        }
+
+        Push-Location $publishRoot
+        try {
+          $publishFullPath = (Get-Location).Path
+          $env:VK_ICD_FILENAMES = Join-Path $publishFullPath 'vk_swiftshader_icd.json'
+          $env:VK_DRIVER_FILES = $env:VK_ICD_FILENAMES
+          $env:LD_LIBRARY_PATH = $publishFullPath
+          $env:LD_PRELOAD = Join-Path $publishFullPath 'libvulkan.so'
+          $output = & ./OpenUsdRenderSmoke 2>&1
+          $exitCode = $LASTEXITCODE
+        }
+        finally {
+          Pop-Location
+        }
+        $output | ForEach-Object { Write-Host $_ }
+        if ($exitCode -ne 0) {
+          exit $exitCode
+        }
+        foreach ($expected in @(
+          'PACKAGE_IMAGING_EXECUTION_OK',
+          'GPU_BACKEND=VULKAN_SWIFTSHADER',
+          'SOFTWARE_DEVICE=true',
+          'RENDERED_FRAME=true')) {
+          if ($output -notcontains $expected) {
+            Write-Host "::error::Missing expected render-smoke output: $expected"
+            exit 1
+          }
+        }
+
   # Single stable status check for branch protection.  The individual jobs above
   # are matrix-generated (their names change with the OS/project fan-out) and
   # they are skipped entirely on master/main while CI_BUILD_BACKEND is 'ado', or

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -138,11 +138,12 @@
        metapackages resolve the correct native asset per RID, so no
        RID-conditional reference is required. -->
   <ItemGroup>
-    <PackageVersion Include="OpenUsd" Version="0.5.0-alpha" />
-    <PackageVersion Include="OpenUsd.Viewer" Version="0.5.0-alpha" />
-    <PackageVersion Include="OpenUsd.Rendering" Version="0.5.0-alpha" />
-    <PackageVersion Include="OpenUsd.Runtime.Core" Version="0.5.0-alpha" />
-    <PackageVersion Include="OpenUsd.Runtime.Imaging" Version="0.5.0-alpha" />
+    <PackageVersion Include="OpenUsd" Version="0.6.0-alpha" />
+    <PackageVersion Include="OpenUsd.Viewer" Version="0.6.0-alpha" />
+    <PackageVersion Include="OpenUsd.Rendering" Version="0.6.0-alpha" />
+    <PackageVersion Include="OpenUsd.Rendering.Silk.Vulkan" Version="0.6.0-alpha" />
+    <PackageVersion Include="OpenUsd.Runtime.Core" Version="0.6.0-alpha" />
+    <PackageVersion Include="OpenUsd.Runtime.Imaging" Version="0.6.0-alpha" />
     <PackageVersion Include="Avalonia" Version="12.1.0" />
     <PackageVersion Include="Avalonia.Desktop" Version="12.1.0" />
   </ItemGroup>

--- a/docs/OpenUsd.md
+++ b/docs/OpenUsd.md
@@ -235,12 +235,14 @@ the command-prim watcher only when renderer picking is unavailable, `Renderer` r
 relationship, string attribute, or token attribute on `UsdViewOptions.CommandPrimPath` (default `/World/IntentCommand`)
 and the callback fires when that target changes.
 The gaps this used to work around were tracked in `marcschier/openusd-dotnet` issues #1, #5, #8, #9, #10 and #11, all
-of which are fixed in `0.5.0-alpha`.
+of which remain fixed in `0.6.0-alpha`.
 
 > The viewport requires .NET 10 and the OpenUSD packages (`OpenUsd`, `OpenUsd.Viewer`, `OpenUsd.Runtime.Imaging`),
 > which are published on nuget.org, so a plain restore is enough. The RID-agnostic runtime metapackages resolve the
-> correct native payload per RID; `win-x64`, `linux-x64` and `osx-arm64` are all supported. Publish the connector and
-> the viewport into the *same* directory, substituting your own RID:
+> correct native payload per RID; `win-x64`, `linux-x64` and `osx-arm64` are all supported. With `0.6.0-alpha`, a
+> RID-less build or publish on a supported host copies that host's OpenUSD native payload. Use an explicit RID when
+> publishing for another platform. Publish the connector and the viewport into the *same* directory, substituting your
+> own RID:
 >
 > ```
 > dotnet publish tools/Opc.Ua.OpenUsd.Connector -c Release -f net10.0 -r win-x64 --self-contained false -o out

--- a/samples/Robotics/README.md
+++ b/samples/Robotics/README.md
@@ -103,8 +103,9 @@ fallback is the supported sample path today, and clicking a target genuinely com
 
 * .NET SDK 10.0.
 * The `--view` option needs the optional viewer assembly and its native OpenUSD payload, which is
-  supported on `win-x64`, `linux-x64`, and `osx-arm64`. Everything else, including both servers and the
-  headless client, runs on every platform the stack supports.
+  supported on `win-x64`, `linux-x64`, and `osx-arm64`. A RID-less build or publish on a supported host
+  uses that host's payload; publish with an explicit RID for another platform. Everything else,
+  including both servers and the headless client, runs on every platform the stack supports.
 
 ## See also
 

--- a/tools/Opc.Ua.OpenUsd.Connector.Viewer/NugetREADME.md
+++ b/tools/Opc.Ua.OpenUsd.Connector.Viewer/NugetREADME.md
@@ -32,7 +32,8 @@ assembly, its dependencies, and the USD plugin tree end up where the connector l
 ## Requirements
 
 - .NET 8 or later.
-- A supported OpenUSD native runtime RID: `win-x64`, `linux-x64`, or `osx-arm64`.
+- A supported OpenUSD native runtime payload: `win-x64`, `linux-x64`, or `osx-arm64`. A RID-less build or publish on a
+  supported host uses that host's payload; use an explicit RID when publishing for another platform.
 - The OpenUSD packages `OpenUsd`, `OpenUsd.Viewer`, and `OpenUsd.Runtime.Imaging`.
 
 See [`docs/OpenUsd.md`](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/docs/OpenUsd.md) for the full

--- a/tools/Opc.Ua.OpenUsd.Connector/NugetREADME.md
+++ b/tools/Opc.Ua.OpenUsd.Connector/NugetREADME.md
@@ -117,8 +117,9 @@ directory first, because a renderer needs geometry it can resolve. `--renderer` 
 and `--plugins` points at the USD plugin tree when it is not beside the connector. Closing the window
 stops the session; `--seconds` closes it automatically. The connector loads the viewport assembly on
 demand, so the package stays small and every other option keeps working without it. The viewport
-requires .NET 8 or later and a supported OpenUSD native runtime RID (`win-x64`, `linux-x64`, or
-`osx-arm64`).
+requires .NET 8 or later and a supported OpenUSD native runtime payload (`win-x64`, `linux-x64`, or
+`osx-arm64`). A RID-less build or publish on a supported host uses that host's payload; use an
+explicit RID when publishing for another platform.
 
 
 Command bindings are **disabled by default** (fail-closed). Add `--enable-commands` and


### PR DESCRIPTION
Follows up [marcschier/openusd-dotnet#12](https://github.com/marcschier/openusd-dotnet/issues/12), now fixed and released in `0.6.0-alpha`.

## What the upstream fix changed

A RID-less build used to succeed and produce a **silently broken** output: the USD plugin tree, `libvulkan.so` and the SwiftShader ICD all landed, and not one `openusd` native library did, so `OpenUsdSilkRuntime.Create` threw `DllNotFoundException` much later. In `0.6.0-alpha` a RID-less build resolves to the **host** RID and copies that host's native payload, and errors clearly on an unsupported host instead.

That was the bug that made us delete the render smoke job, so the job comes back here.

## Package rev

`OpenUsd`, `OpenUsd.Viewer`, `OpenUsd.Rendering`, `OpenUsd.Runtime.Core` and `OpenUsd.Runtime.Imaging` move to `0.6.0-alpha`, and `OpenUsd.Rendering.Silk.Vulkan` is re-added centrally for the restored job. Each was verified present at that version on nuget.org rather than assumed to have moved with the family.

The API surface we depend on was **probed against the shipped assemblies**, not assumed: `ViewerHostOptions.PrimPicked`/`PickTarget`, `ViewerPickEventArgs`, `ViewerStageSession.PickingBackend`/`Camera`/`CurrentRenderState`, and `UsdPrim.SetColor3fArray`/`GetColor3fArray`/`SetMatrix4d` are all unchanged. No code adaptation was needed.

## The restored CI job, with its previous problems fixed

It is worth being explicit about why this job was a poor citizen before, because "restore it" would otherwise repeat the mistakes:

- **It is `continue-on-error` and is not in the required `build-and-test summary` check.** It has never yet passed unaided on CI hardware, and a job in that state does not belong in a gate. Promote it only once it has gone green on its own.
- **It asserts that a frame rendered**, not `INCREMENTAL_GPU_UPLOAD=true`. The old assertion pinned an upstream implementation detail — how the renderer batches GPU uploads — which would have reddened our CI on an upstream change we do not control.
- **It is smaller.** Less of the check needs to be inline C# in YAML now that the RID-less path works.

Verified that the workflow parses and that **no job's `needs:` gates on it**.

## Documentation

Now states that a RID-less build or publish on a supported host uses that host's payload, and that an explicit RID is needed to publish for another platform. The supported RIDs are unchanged — `win-x64`, `linux-x64`, `osx-arm64`, which have shipped since `0.1.0-alpha`. Only the RID-less behaviour is new, and the wording is scoped to "a supported host" because that is what was verified.

## Validation

`dotnet restore` and `dotnet build UA.slnx` clean.

| Suite | Result |
|---|---|
| `Opc.Ua.OpenUsd.Tests` | 902 / 902 |
| `Opc.Ua.Di.Tests` | 424 / 424 |

`Opc.Ua.Di.Tests` is included deliberately: it carries the pump and generator OpenUSD end-to-end coverage, and omitting it is exactly how a CI failure slipped through a previous round.
