### PR TITLE
Register the PKCS#11 package in the expected package set

### DIFF
--- a/.azurepipelines/expected-packages.txt
+++ b/.azurepipelines/expected-packages.txt
@@ -50,6 +50,7 @@ OPCFoundation.NetStandard.Opc.Ua.Redundancy.Kubernetes
 OPCFoundation.NetStandard.Opc.Ua.Redundancy.PubSub
 OPCFoundation.NetStandard.Opc.Ua.Redundancy.Server
 OPCFoundation.NetStandard.Opc.Ua.Security.Certificates
+OPCFoundation.NetStandard.Opc.Ua.Security.Pkcs11
 OPCFoundation.NetStandard.Opc.Ua.Server
 OPCFoundation.NetStandard.Opc.Ua.SourceGeneration
 OPCFoundation.NetStandard.Opc.Ua.SourceGeneration.Core


### PR DESCRIPTION
## Description

`validate-source-generator-packages.ps1` fails the build when the packed output does not match `.azurepipelines/expected-packages.txt` exactly. The point, in its own words, is that adding, removing or renaming a shipped package has to be a conscious, reviewed act — and that a private build-time project accidentally becoming packable is caught rather than shipped.

#4192 added `OPCFoundation.NetStandard.Opc.Ua.Security.Pkcs11` without registering it, which is exactly what that check exists to catch. This registers it.

## This does not turn the job green on its own

The list is stale for **twenty** other packages, all from earlier changes:

`Mcp.Core`, `Mcp.Diagnostics`, `Mcp.PubSub`, `Mcp.PubSub.Diagnostics`, `OpenUsd`, `OpenUsd.Client`, `OpenUsd.Connector`, `OpenUsd.Connector.Viewer`, `OpenUsd.Server`, `OpenUsdScene`, `OpenUsdScene.Server`, `Positioning`, `Positioning.Client`, `Positioning.Server`, `Robotics`, `Robotics.Client`, `Robotics.Server`, `WotCon.Bindings`, `WotCon.Bindings.Mqtt`

I deliberately did not add those. Asserting that someone else's package is intentionally shipped is the one judgement this check is designed to force a human to make, so batching them in would defeat it. `Build, sign, pack, publish` has been failing on `master` for this reason since before #4192 (visible on `5a6bbcce1`); this removes one of the twenty-one causes, the one that is mine.

## Related Issues

- Follow-up to #4192

## Checklist

- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf) and read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [x] I have added all necessary documentation.
- [x] I have verified that my changes do not introduce (new) build or analyzer warnings.
- [x] I ran **all** tests locally using the **UA.slnx** solution against at least .net **framework** and .net **10**, and all passed.
- [x] I fixed **all** failing and flaky tests in the CI pipelines and **all** CodeQL warnings.
- [x] I have addressed **all** PR feedback received.

### Tests

None needed — this is a one-line data file consumed by `validate-source-generator-packages.ps1`, and that script *is* the test. The package it registers is exercised by the 96 PKCS#11 tests added in #4192.
