### PR TITLE
Do not return NodeId.Null from GetRandomNodeId unless boundary values are requested

### DIFF
--- a/src/Opc.Ua.Core/Types/Utils/DataGenerator.cs
+++ b/src/Opc.Ua.Core/Types/Utils/DataGenerator.cs
@@ -822,27 +822,40 @@ namespace Opc.Ua.Test
         /// <inheritdoc/>
         public NodeId GetRandomNodeId(bool useBoundaryValues = false)
         {
-            ushort ns = (ushort)m_random.NextInt32(NamespaceUris.Count - 1);
-
             NodeId nodeId;
-            switch ((IdType)m_random.NextInt32(3))
+            //
+            // NodeId.Null is one of the boundary values offered below, so a
+            // caller passing useBoundaryValues: false is entitled not to get it.
+            // The random draw can produce it by accident: an opaque identifier
+            // in namespace 0 is null when the byte string is empty, and
+            // GetRandomByteString draws its length from [0, MaxStringLength]
+            // inclusive. A numeric identifier of 0 in namespace 0 is null too,
+            // though far less likely. Draw again rather than return one.
+            //
+            do
             {
-                case IdType.Numeric:
-                    nodeId = new NodeId(GetRandomUInt32(), ns);
-                    break;
-                case IdType.String:
-                    nodeId = new NodeId(CreateString(GetRandomLocale(), true), ns);
-                    break;
-                case IdType.Guid:
-                    nodeId = new NodeId(GetRandomGuid(), ns);
-                    break;
-                case IdType.Opaque:
-                    nodeId = new NodeId(GetRandomByteString(), ns);
-                    break;
-                default:
-                    throw ServiceResultException.Unexpected(
-                        "Unexpected IdType value");
+                ushort ns = (ushort)m_random.NextInt32(NamespaceUris.Count - 1);
+                switch ((IdType)m_random.NextInt32(3))
+                {
+                    case IdType.Numeric:
+                        nodeId = new NodeId(GetRandomUInt32(), ns);
+                        break;
+                    case IdType.String:
+                        nodeId = new NodeId(CreateString(GetRandomLocale(), true), ns);
+                        break;
+                    case IdType.Guid:
+                        nodeId = new NodeId(GetRandomGuid(), ns);
+                        break;
+                    case IdType.Opaque:
+                        nodeId = new NodeId(GetRandomByteString(), ns);
+                        break;
+                    default:
+                        throw ServiceResultException.Unexpected(
+                            "Unexpected IdType value");
+                }
             }
+            while (!useBoundaryValues && nodeId.IsNull);
+
             return GetBoundaryValue(
                 useBoundaryValues,
                 nodeId,

--- a/tests/Opc.Ua.Core.Tests/Types/DataGeneratorTests.cs
+++ b/tests/Opc.Ua.Core.Tests/Types/DataGeneratorTests.cs
@@ -1,0 +1,140 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+#nullable enable
+
+using System.Collections.Generic;
+using NUnit.Framework;
+using Opc.Ua.Test;
+using Opc.Ua.Tests;
+
+namespace Opc.Ua.Core.Tests.Types
+{
+    /// <summary>
+    /// Tests for <see cref="DataGenerator"/>.
+    /// </summary>
+    [TestFixture]
+    [Category("Utils")]
+    [Parallelizable]
+    public class DataGeneratorTests
+    {
+        /// <summary>
+        /// A caller that asks for no boundary values must not be handed one.
+        /// <see cref="NodeId.Null"/> is itself listed among the boundary values
+        /// the generator offers, yet the random draw could produce it directly:
+        /// an opaque identifier in namespace 0 is null when its byte string is
+        /// empty, and the length is drawn from a range that includes zero.
+        /// </summary>
+        /// <remarks>
+        /// The failure this guards against is rare per call, so a single draw
+        /// proves nothing. The loop is sized to make the pre-fix behaviour
+        /// practically certain to appear: with roughly one draw in 130 landing
+        /// on the empty opaque identifier, 20 000 draws would have produced
+        /// well over a hundred null node ids.
+        /// </remarks>
+        [Test]
+        public void GetRandomNodeIdWithoutBoundaryValuesIsNeverNull()
+        {
+            var generator = new DataGenerator(null, NUnitTelemetryContext.Create());
+
+            for (int ii = 0; ii < 20000; ii++)
+            {
+                NodeId nodeId = generator.GetRandomNodeId();
+
+                Assert.That(nodeId.IsNull, Is.False,
+                    $"GetRandomNodeId returned NodeId.Null on draw {ii}, " +
+                    "although boundary values were not requested.");
+            }
+        }
+
+        /// <summary>
+        /// <see cref="DataGenerator.GetRandomExpandedNodeId"/> builds on
+        /// <see cref="DataGenerator.GetRandomNodeId"/>, so it inherits the same
+        /// guarantee.
+        /// </summary>
+        [Test]
+        public void GetRandomExpandedNodeIdWithoutBoundaryValuesIsNeverNull()
+        {
+            var generator = new DataGenerator(null, NUnitTelemetryContext.Create());
+
+            for (int ii = 0; ii < 20000; ii++)
+            {
+                ExpandedNodeId nodeId = generator.GetRandomExpandedNodeId();
+
+                Assert.That(nodeId.IsNull, Is.False,
+                    $"GetRandomExpandedNodeId returned ExpandedNodeId.Null on draw {ii}, " +
+                    "although boundary values were not requested.");
+            }
+        }
+
+        /// <summary>
+        /// The guarantee above must not cost the generator its variety: every
+        /// identifier type should still appear. Without this a fix that simply
+        /// stopped emitting opaque identifiers would pass the tests above while
+        /// silently narrowing what the generator produces.
+        /// </summary>
+        [Test]
+        public void GetRandomNodeIdStillProducesEveryIdentifierType()
+        {
+            var generator = new DataGenerator(null, NUnitTelemetryContext.Create());
+            var seen = new HashSet<IdType>();
+
+            for (int ii = 0; ii < 20000; ii++)
+            {
+                seen.Add(generator.GetRandomNodeId().IdType);
+            }
+
+            Assert.That(seen, Does.Contain(IdType.Numeric));
+            Assert.That(seen, Does.Contain(IdType.String));
+            Assert.That(seen, Does.Contain(IdType.Guid));
+            Assert.That(seen, Does.Contain(IdType.Opaque));
+        }
+
+        /// <summary>
+        /// Asking for boundary values must still offer them, otherwise the fix
+        /// would have removed the feature rather than corrected its leak into
+        /// the non-boundary path.
+        /// </summary>
+        [Test]
+        public void GetRandomNodeIdWithBoundaryValuesStillYieldsThem()
+        {
+            var generator = new DataGenerator(null, NUnitTelemetryContext.Create());
+            bool sawNull = false;
+
+            for (int ii = 0; ii < 20000 && !sawNull; ii++)
+            {
+                sawNull = generator.GetRandomNodeId(true).IsNull;
+            }
+
+            Assert.That(sawNull, Is.True,
+                "GetRandomNodeId(useBoundaryValues: true) never returned a null " +
+                "node id, so the boundary values are no longer reachable.");
+        }
+    }
+}

--- a/tests/Opc.Ua.Core.Tests/Types/DataGeneratorTests.cs
+++ b/tests/Opc.Ua.Core.Tests/Types/DataGeneratorTests.cs
@@ -61,7 +61,7 @@ namespace Opc.Ua.Core.Tests.Types
         [Test]
         public void GetRandomNodeIdWithoutBoundaryValuesIsNeverNull()
         {
-            var generator = new DataGenerator(null, NUnitTelemetryContext.Create());
+            var generator = new DataGenerator(new RandomSource(42), NUnitTelemetryContext.Create());
 
             for (int ii = 0; ii < 20000; ii++)
             {


### PR DESCRIPTION
Fixes #4226.

## The problem

`GetRandomNodeId(useBoundaryValues: false)` can return `NodeId.Null` — one of the boundary values the same method offers when boundary values *are* requested. A caller that opted out should not receive one. `GetRandomExpandedNodeId` builds on it and inherits the same behaviour.

The `IdType.Opaque` branch is the practical path: `GetRandomByteString()` draws its length with `NextInt32(MaxStringLength)`, which is inclusive of zero, and a zero-length opaque identifier in namespace 0 satisfies `NodeId.IsNull`. With three namespaces and `MaxStringLength` at 10 that is roughly **one call in 130**. A numeric identifier of `0` in namespace 0 is null too, at around one in four billion.

## The change

Redraw while the result is null and boundary values were not requested:

```csharp
do
{
    ushort ns = (ushort)m_random.NextInt32(NamespaceUris.Count - 1);
    switch ((IdType)m_random.NextInt32(3))
    {
        ...
    }
}
while (!useBoundaryValues && nodeId.IsNull);
```

Guarding the result rather than the individual branches covers every identifier type, including the numeric case, rather than only the one that happens to be reachable today. The `useBoundaryValues: true` path is untouched, so boundary values remain available when they are asked for.

## Tests

Four tests in `tests/Opc.Ua.Core.Tests/Types/DataGeneratorTests.cs`.

They loop 20,000 draws, because at one call in 130 a single draw proves nothing. Against the **unmodified** generator they fail on **draw 93** and **draw 1346**:

```
Failed GetRandomNodeIdWithoutBoundaryValuesIsNeverNull
   GetRandomNodeId returned NodeId.Null on draw 93, although boundary values were not requested.
Failed GetRandomExpandedNodeIdWithoutBoundaryValuesIsNeverNull
   GetRandomExpandedNodeId returned ExpandedNodeId.Null on draw 1346, although boundary values were not requested.
```

With the fix: `Passed! - Failed: 0, Passed: 168`. The full `Opc.Ua.Core.Tests` project is green — 4,245 passed, 86 skipped.

Two of the four tests exist to keep the fix honest rather than to test the bug:

- **`GetRandomNodeIdStillProducesEveryIdentifierType`** — a "fix" that simply stopped emitting opaque identifiers would satisfy the null assertions while silently narrowing the generator. This catches that.
- **`GetRandomNodeIdWithBoundaryValuesStillYieldsThem`** — confirms boundary values are still reachable when requested, so the leak was closed rather than the feature removed.

## How it was found

An intermittent downstream test failure. A test server initialising a static `NodeId`-valued variable via `TestDataSystem.ReadValue` occasionally stored `NodeId.Null`; the encoder correctly writes that as JSON `null`, and a consumer asserting a value was present failed about one run in five — never reproducibly in isolation.

It only surfaced under load because `UnsecureRandom.Shared` is a fixed-seed, process-global generator shared between `DataGenerator` and OPC UA transport jitter, so the number of draws preceding address-space initialisation depends on what else is running in the process.
