### PR TITLE
Make Opc.Ua.Mcp.Core trim and Native AOT clean

### DIFF
--- a/tests/Opc.Ua.Aot.Tests/McpAotTests.cs
+++ b/tests/Opc.Ua.Aot.Tests/McpAotTests.cs
@@ -1,0 +1,132 @@
+/* ========================================================================
+ * Copyright (c) 2005-2026 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
+using ModelContextProtocol.Server;
+using Opc.Ua.Mcp;
+using Opc.Ua.Mcp.Serialization;
+
+namespace Opc.Ua.Aot.Tests
+{
+    /// <summary>
+    /// Exercises <c>Opc.Ua.Mcp.Core</c> in the environment Native AOT produces.
+    /// </summary>
+    /// <remarks>
+    /// Publishing ahead of time turns JSON reflection off, so these tests run with
+    /// <c>IsReflectionEnabledByDefault</c> disabled even before the binary is compiled
+    /// natively. That is the condition that matters here: marking an assembly
+    /// <c>IsAotCompatible</c> only proves its own IL is clean, and says nothing about
+    /// whether the library still functions once reflection is unavailable. Tool
+    /// discovery under normal (reflection-enabled) hosting is covered by the NUnit
+    /// suite in <c>Opc.Ua.Tools.Tests</c>.
+    /// </remarks>
+    public class McpAotTests
+    {
+        /// <summary>
+        /// Registering the OPC UA tools does not yet work without JSON reflection.
+        /// </summary>
+        /// <remarks>
+        /// The MCP SDK builds every tool's input schema by asking
+        /// <c>JsonSchemaExporter</c> for a <c>JsonTypeInfo</c> of each parameter type.
+        /// Without a source-generated context covering the tool signatures - and with
+        /// the injected <c>OpcUaSessionManager</c> being described rather than treated
+        /// as a service - that throws. This test pins the limitation so it is stated
+        /// rather than discovered in production, and turns red the moment it is lifted.
+        /// </remarks>
+        [Test]
+        public async Task ToolRegistrationStillNeedsJsonReflectionAsync()
+        {
+            await Assert.That(JsonReflectionIsEnabled()).IsFalse();
+
+            var services = new ServiceCollection();
+            services.AddOpcUaMcpCore();
+            services.AddMcpServer()
+                .WithOpcUaMcpFilters()
+                .WithOpcUaCoreTools(McpToolProfile.Full);
+
+            await Assert.That(() => ResolveTools(services)).Throws<NotSupportedException>();
+        }
+
+        /// <summary>
+        /// Every tool renders its result through this helper, so it has to work without
+        /// reflection. It writes JSON directly with a <c>Utf8JsonWriter</c> rather than
+        /// through <c>JsonSerializer</c> for exactly that reason - the assertion below
+        /// fails outright if that ever regresses.
+        /// </summary>
+        [Test]
+        public async Task ToolResultsSerializeWithoutReflectionAsync()
+        {
+            await Assert.That(JsonReflectionIsEnabled()).IsFalse();
+
+            string json = OpcUaJsonHelper.Serialize(new Dictionary<string, object?>
+            {
+                ["error"] = true,
+                ["statusCode"] = "BadNodeIdUnknown",
+                ["message"] = null,
+                ["values"] = new List<object?> { 1, 2.5, "three", null }
+            });
+
+            using JsonDocument document = JsonDocument.Parse(json);
+            JsonElement root = document.RootElement;
+
+            await Assert.That(root.GetProperty("error").GetBoolean()).IsTrue();
+            await Assert.That(root.GetProperty("statusCode").GetString()).IsEqualTo("BadNodeIdUnknown");
+            await Assert.That(root.GetProperty("message").ValueKind).IsEqualTo(JsonValueKind.Null);
+            await Assert.That(root.GetProperty("values").GetArrayLength()).IsEqualTo(4);
+        }
+
+        /// <summary>
+        /// The diagnostics tools are deliberately absent from this binary. They sit on
+        /// SharpPcap and on reflective service-call dissection, neither of which is trim-
+        /// or AOT-safe, so a host publishing ahead of time takes the core tools alone.
+        /// </summary>
+        [Test]
+        public async Task DiagnosticsToolsAreNotPartOfTheAotSurfaceAsync()
+        {
+            await Assert.That(
+                AppDomain.CurrentDomain.GetAssemblies()
+                    .Any(assembly => assembly.GetName().Name == "Opc.Ua.Mcp.Diagnostics"))
+                .IsFalse();
+        }
+
+        private static bool JsonReflectionIsEnabled()
+        {
+            return AppContext.TryGetSwitch(
+                "System.Text.Json.JsonSerializer.IsReflectionEnabledByDefault",
+                out bool enabled) && enabled;
+        }
+
+        private static IReadOnlyList<McpServerTool> ResolveTools(IServiceCollection services)
+        {
+            using ServiceProvider provider = services.BuildServiceProvider();
+            return [.. provider.GetServices<McpServerTool>()];
+        }
+    }
+}

--- a/tests/Opc.Ua.Aot.Tests/Opc.Ua.Aot.Tests.csproj
+++ b/tests/Opc.Ua.Aot.Tests/Opc.Ua.Aot.Tests.csproj
@@ -38,6 +38,7 @@
     <ProjectReference Include="..\..\src\Opc.Ua.Redundancy.Server\Opc.Ua.Redundancy.Server.csproj" />
     <ProjectReference Include="..\..\src\Opc.Ua.Redundancy.Kubernetes\Opc.Ua.Redundancy.Kubernetes.csproj" />
     <ProjectReference Include="..\..\src\Opc.Ua.Security.Pkcs11\Opc.Ua.Security.Pkcs11.csproj" />
+    <ProjectReference Include="..\..\tools\Opc.Ua.Mcp.Core\Opc.Ua.Mcp.Core.csproj" />
     <ProjectReference Include="..\..\samples\Quickstarts.Servers\Quickstarts.Servers.csproj" />
     <ProjectReference Include="..\..\src\Opc.Ua.Gds.Client.Common\Opc.Ua.Gds.Client.Common.csproj" />
     <ProjectReference Include="..\..\src\Opc.Ua.Gds.Server.Common\Opc.Ua.Gds.Server.Common.csproj" />

--- a/tests/Opc.Ua.Tools.Tests/Mcp/OpcUaJsonHelperTests.cs
+++ b/tests/Opc.Ua.Tools.Tests/Mcp/OpcUaJsonHelperTests.cs
@@ -29,7 +29,9 @@
 
 #if NET10_0
 using System;
+using System.Collections.Generic;
 using System.Globalization;
+using System.Text;
 using System.Text.Json;
 using NUnit.Framework;
 using Opc.Ua.Mcp.Serialization;
@@ -40,16 +42,110 @@ namespace Opc.Ua.Tools.Tests.Mcp
     public sealed class OpcUaJsonHelperTests
     {
         [Test]
-        public void SerializeUsesCamelCaseAndOmitsNulls()
+        public void SerializeWritesDictionaryKeysVerbatimAndKeepsNulls()
         {
-            string json = OpcUaJsonHelper.Serialize(new
+            string json = OpcUaJsonHelper.Serialize(new Dictionary<string, object?>
             {
-                FirstValue = "abc",
-                SecondValue = (string?)null
+                ["firstValue"] = "abc",
+                ["secondValue"] = null
             });
 
             Assert.That(json, Does.Contain("firstValue"));
-            Assert.That(json, Does.Not.Contain("secondValue"));
+            Assert.That(json, Does.Contain("\"secondValue\": null"));
+        }
+
+        [Test]
+        public void SerializeRejectsValuesThatWouldRequireReflection()
+        {
+            // Serialize is trim- and AOT-safe, so it only accepts the JSON-friendly shapes
+            // the conversion helpers in this class produce. Arbitrary object graphs would
+            // need the reflection-based serializer and are refused rather than mangled.
+            Assert.That(
+                () => OpcUaJsonHelper.Serialize(new StringBuilder("nope")),
+                Throws.TypeOf<NotSupportedException>());
+        }
+
+        /// <summary>
+        /// Serialize writes JSON directly with a <see cref="Utf8JsonWriter"/> instead of the
+        /// reflection-based serializer. These cases cover every shape the conversion helpers
+        /// in this class emit and assert the output is byte-for-byte what the reflection-based
+        /// serializer produced, so the AOT change cannot alter any tool's result.
+        /// </summary>
+        private static IEnumerable<TestCaseData> JsonFriendlyValues()
+        {
+            yield return new TestCaseData(new Dictionary<string, object?>
+            {
+                ["error"] = true,
+                ["statusCode"] = "BadNodeIdUnknown",
+                ["message"] = "no such node",
+                ["innerMessage"] = null
+            }).SetName("ErrorResult");
+
+            yield return new TestCaseData(new Dictionary<string, object?>
+            {
+                ["sbyte"] = (sbyte)-1,
+                ["byte"] = (byte)2,
+                ["short"] = (short)-3,
+                ["ushort"] = (ushort)4,
+                ["int"] = 5,
+                ["uint"] = 6u,
+                ["long"] = 7L,
+                ["ulong"] = 8ul,
+                ["float"] = 9.5f,
+                ["double"] = 10.25,
+                ["decimal"] = 11.125m
+            }).SetName("AllNumericScalars");
+
+            yield return new TestCaseData(new Dictionary<string, object?>
+            {
+                ["timestamp"] = new DateTime(2026, 2, 3, 4, 5, 6, DateTimeKind.Utc),
+                ["offset"] = new DateTimeOffset(2026, 2, 3, 4, 5, 6, TimeSpan.Zero),
+                ["guid"] = new Guid("72962b91-fa75-4ae6-8d28-b404dc7daf63"),
+                ["bytes"] = new byte[] { 1, 2, 3 },
+                ["char"] = 'x'
+            }).SetName("ScalarsWithCustomFormatting");
+
+            yield return new TestCaseData(new List<object>
+            {
+                new Dictionary<string, object?> { ["nodeId"] = "ns=2;s=A", ["value"] = 1 },
+                new Dictionary<string, object?> { ["nodeId"] = "ns=2;s=B", ["value"] = null }
+            }).SetName("ListOfDictionaries");
+
+            yield return new TestCaseData(new Dictionary<string, object?>
+            {
+                ["endpoints"] = new List<object?>
+                {
+                    new Dictionary<string, object?>
+                    {
+                        ["endpointUrl"] = "opc.tcp://host:4840",
+                        ["userIdentityTokens"] = new List<object?>
+                        {
+                            new Dictionary<string, object?> { ["tokenType"] = "Anonymous" }
+                        }
+                    }
+                },
+                ["empty"] = new List<object?>()
+            }).SetName("NestedSequences");
+
+            // Strings that force the encoder to escape; proves the writer inherits the
+            // same JavaScriptEncoder the reflection-based serializer used.
+            yield return new TestCaseData(new Dictionary<string, object?>
+            {
+                ["quote"] = "he said \"hi\"",
+                ["angle"] = "<tag>&amp;",
+                ["unicode"] = "grüße \u00b5s",
+                ["newline"] = "line1\nline2"
+            }).SetName("StringsNeedingEscaping");
+        }
+
+        [TestCaseSource(nameof(JsonFriendlyValues))]
+        public void SerializeMatchesTheReflectionBasedSerializer(object value)
+        {
+            string expected = JsonSerializer.Serialize(value, OpcUaJsonHelper.JsonOptions);
+
+            string actual = OpcUaJsonHelper.Serialize(value);
+
+            Assert.That(actual, Is.EqualTo(expected));
         }
 
         [TestCase("i=85")]

--- a/tools/Opc.Ua.Mcp.Core/McpSchemaFilters.cs
+++ b/tools/Opc.Ua.Mcp.Core/McpSchemaFilters.cs
@@ -68,7 +68,14 @@ namespace Opc.Ua.Mcp
                     }
 
                     schema["required"] = new JsonArray();
-                    tool.InputSchema = JsonSerializer.SerializeToElement(schema);
+
+                    // JsonSerializer.SerializeToElement would reflect over JsonObject; parsing
+                    // the node's own text is reflection-free. Clone detaches the element from
+                    // the document so it stays valid after disposal.
+                    using (JsonDocument document = JsonDocument.Parse(schema.ToJsonString()))
+                    {
+                        tool.InputSchema = document.RootElement.Clone();
+                    }
                 }
 
                 return result;

--- a/tools/Opc.Ua.Mcp.Core/NugetREADME.md
+++ b/tools/Opc.Ua.Mcp.Core/NugetREADME.md
@@ -29,6 +29,22 @@ builder.Services.AddMcpServer()
 errors actionable and tool schemas explicit; call it once per server even when
 several OPC UA tool packages are composed.
 
+## Trimming and Native AOT
+
+The assembly is marked `IsAotCompatible` on `net10.0`: its own IL is free of trim
+and AOT warnings, and tool results are written with `Utf8JsonWriter` rather than
+the reflection-based `JsonSerializer`.
+
+That is not yet the same as working in an ahead-of-time published host. Registering
+the tools still requires JSON reflection, because the MCP SDK builds each tool's
+input schema by asking `JsonSchemaExporter` for a `JsonTypeInfo` of every parameter
+type; without a source-generated context covering the tool signatures this throws
+`NotSupportedException`. `Opc.Ua.Aot.Tests.McpAotTests` pins that limitation so it
+is stated rather than discovered at run time.
+
+`OPCFoundation.NetStandard.Opc.Ua.Mcp.Diagnostics` is deliberately *not* marked
+AOT-compatible: it depends on SharpPcap and on reflective service-call dissection.
+
 ## Related packages
 
 | Package | Adds |

--- a/tools/Opc.Ua.Mcp.Core/Opc.Ua.Mcp.Core.csproj
+++ b/tools/Opc.Ua.Mcp.Core/Opc.Ua.Mcp.Core.csproj
@@ -13,6 +13,7 @@
     <TargetFrameworks Condition="'$(TargetFrameworks)' == '' AND ('$(CustomTestTarget)' == 'netstandard2.0' OR '$(CustomTestTarget)' == 'netstandard2.1')">net10.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">$(CustomTestTarget)</TargetFrameworks>
     <RestrictForLegacyTfm>true</RestrictForLegacyTfm>
+    <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))">true</IsAotCompatible>
     <AssemblyName>$(AssemblyPrefix).Mcp.Core</AssemblyName>
     <PackageId>$(PackagePrefix).Opc.Ua.Mcp.Core</PackageId>
     <RootNamespace>Opc.Ua.Mcp</RootNamespace>

--- a/tools/Opc.Ua.Mcp.Core/Serialization/OpcUaJsonHelper.cs
+++ b/tools/Opc.Ua.Mcp.Core/Serialization/OpcUaJsonHelper.cs
@@ -28,10 +28,14 @@
  * ======================================================================*/
 
 using System;
+using System.Buffers;
+using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Text;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 
 namespace Opc.Ua.Mcp.Serialization
@@ -49,10 +53,134 @@ namespace Opc.Ua.Mcp.Serialization
         /// <summary>
         /// Serializes an object to a JSON string using the OPC UA JSON options.
         /// </summary>
+        /// <remarks>
+        /// The tool helpers in this assembly reduce every OPC UA value to a closed set of
+        /// JSON-friendly shapes before serializing it (see <see cref="ElementToObject"/>):
+        /// <c>null</c>, the primitive scalars, <see cref="string"/>,
+        /// <see cref="Dictionary{TKey, TValue}"/> of <see cref="string"/> to <see cref="object"/>
+        /// and lists thereof. Because that set is closed, the JSON is written directly with a
+        /// <see cref="Utf8JsonWriter"/> rather than through the reflection-based
+        /// <see cref="JsonSerializer"/>, which keeps the assembly trim- and Native-AOT-safe.
+        /// The output is byte-for-byte identical to the reflection-based serializer configured
+        /// with <see cref="JsonOptions"/>.
+        /// </remarks>
         /// <typeparam name="T"></typeparam>
         public static string Serialize<T>(T value)
         {
-            return JsonSerializer.Serialize(value, JsonOptions);
+            var buffer = new ArrayBufferWriter<byte>();
+            using (var writer = new Utf8JsonWriter(buffer, new JsonWriterOptions
+            {
+                Indented = JsonOptions.WriteIndented,
+                Encoder = JsonOptions.Encoder
+            }))
+            {
+                WriteValue(writer, value);
+            }
+
+            return Encoding.UTF8.GetString(buffer.WrittenSpan);
+        }
+
+        /// <summary>
+        /// Writes a JSON-friendly value produced by the conversion helpers in this class.
+        /// </summary>
+        private static void WriteValue(Utf8JsonWriter writer, object? value)
+        {
+            switch (value)
+            {
+                case null:
+                    writer.WriteNullValue();
+                    break;
+                case string text:
+                    writer.WriteStringValue(text);
+                    break;
+                case bool flag:
+                    writer.WriteBooleanValue(flag);
+                    break;
+                // Utf8JsonWriter has no overloads for the narrow integer types, so widen
+                // them; the rendered digits are the same either way.
+                case sbyte number:
+                    writer.WriteNumberValue(number);
+                    break;
+                case byte number:
+                    writer.WriteNumberValue(number);
+                    break;
+                case short number:
+                    writer.WriteNumberValue(number);
+                    break;
+                case ushort number:
+                    writer.WriteNumberValue(number);
+                    break;
+                case int number:
+                    writer.WriteNumberValue(number);
+                    break;
+                case uint number:
+                    writer.WriteNumberValue(number);
+                    break;
+                case long number:
+                    writer.WriteNumberValue(number);
+                    break;
+                case ulong number:
+                    writer.WriteNumberValue(number);
+                    break;
+                case float number:
+                    writer.WriteNumberValue(number);
+                    break;
+                case double number:
+                    writer.WriteNumberValue(number);
+                    break;
+                case decimal number:
+                    writer.WriteNumberValue(number);
+                    break;
+                case DateTime timestamp:
+                    writer.WriteStringValue(timestamp);
+                    break;
+                case DateTimeOffset timestamp:
+                    writer.WriteStringValue(timestamp);
+                    break;
+                case Guid guid:
+                    writer.WriteStringValue(guid);
+                    break;
+                case byte[] bytes:
+                    writer.WriteBase64StringValue(bytes);
+                    break;
+                case JsonElement element:
+                    element.WriteTo(writer);
+                    break;
+                case JsonNode node:
+                    node.WriteTo(writer);
+                    break;
+                // Must precede IEnumerable: a dictionary is also a sequence of pairs.
+                case IDictionary<string, object?> map:
+                    writer.WriteStartObject();
+                    foreach (KeyValuePair<string, object?> entry in map)
+                    {
+                        writer.WritePropertyName(entry.Key);
+                        WriteValue(writer, entry.Value);
+                    }
+                    writer.WriteEndObject();
+                    break;
+                case IEnumerable sequence:
+                    writer.WriteStartArray();
+                    foreach (object? item in sequence)
+                    {
+                        WriteValue(writer, item);
+                    }
+                    writer.WriteEndArray();
+                    break;
+                case char character:
+                    writer.WriteStringValue(character.ToString());
+                    break;
+                default:
+                    // The conversion helpers in this class reduce every OPC UA value to the
+                    // shapes handled above, so reaching this point means a caller passed a
+                    // type this trim-safe writer cannot model. Fail loudly rather than
+                    // silently emitting a stringified object.
+                    throw new NotSupportedException(
+                        $"'{value.GetType()}' is not a JSON-friendly value. Convert it with the " +
+                        $"{nameof(OpcUaJsonHelper)} helpers before serializing; arbitrary object " +
+                        "graphs are not supported because that would require reflection, which is " +
+                        "unavailable when trimming or publishing ahead of time.");
+            }
         }
 
         /// <summary>

--- a/tools/Opc.Ua.Mcp.Diagnostics/Opc.Ua.Mcp.Diagnostics.csproj
+++ b/tools/Opc.Ua.Mcp.Diagnostics/Opc.Ua.Mcp.Diagnostics.csproj
@@ -6,6 +6,11 @@
     <TargetFrameworks Condition="'$(TargetFrameworks)' == '' AND ('$(CustomTestTarget)' == 'netstandard2.0' OR '$(CustomTestTarget)' == 'netstandard2.1')">net10.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">$(CustomTestTarget)</TargetFrameworks>
     <RestrictForLegacyTfm>true</RestrictForLegacyTfm>
+    <!-- Deliberately NOT IsAotCompatible, unlike Opc.Ua.Mcp.Core. The capture tools sit on
+         Opc.Ua.Core.Diagnostics, which reaches SharpPcap for live capture and reflects over
+         IEncodeable properties when dissecting service calls; neither is trim- or AOT-safe,
+         which is why that package does not opt in either. Hosts publishing ahead of time
+         should take Opc.Ua.Mcp.Core alone. -->
     <AssemblyName>$(AssemblyPrefix).Mcp.Diagnostics</AssemblyName>
     <PackageId>$(PackagePrefix).Opc.Ua.Mcp.Diagnostics</PackageId>
     <RootNamespace>Opc.Ua.Mcp</RootNamespace>

--- a/tools/Opc.Ua.Mcp.Diagnostics/Serialization/PcapMcpJsonContext.cs
+++ b/tools/Opc.Ua.Mcp.Diagnostics/Serialization/PcapMcpJsonContext.cs
@@ -1,0 +1,44 @@
+/* ========================================================================
+ * Copyright (c) 2005-2026 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System.Text.Json.Serialization;
+using Opc.Ua.Pcap.Dissection;
+
+namespace Opc.Ua.Mcp.Serialization
+{
+    /// <summary>
+    /// Source-generated serialization metadata for the types the packet diagnostics
+    /// tools render as JSON. Using a generated context instead of the reflection-based
+    /// serializer keeps this assembly trim- and Native-AOT-safe.
+    /// </summary>
+    [JsonSerializable(typeof(DecodedServiceCall))]
+    internal sealed partial class PcapMcpJsonContext : JsonSerializerContext
+    {
+    }
+}

--- a/tools/Opc.Ua.Mcp.Diagnostics/Tools/PacketCaptureTools.cs
+++ b/tools/Opc.Ua.Mcp.Diagnostics/Tools/PacketCaptureTools.cs
@@ -59,9 +59,18 @@ namespace Opc.Ua.Mcp.Tools
         /// <summary>
         /// Lists local network interfaces that can be captured from.
         /// </summary>
+        /// <remarks>
+        /// Enumerating interfaces goes through SharpPcap, which loads native libpcap/Npcap
+        /// dynamically and is therefore neither trim- nor Native-AOT-safe. The constraint is
+        /// annotated rather than suppressed so that hosts publishing ahead of time see it.
+        /// </remarks>
         [McpServerTool(Name = "list_interfaces")]
         [Description("Lists local network interfaces that can be used as the 'interfaceName' parameter to " +
             "start_capture with source='nic'. Requires libpcap (Linux/macOS) or Npcap (Windows).")]
+        [RequiresUnreferencedCode(
+            "SharpPcap requires dynamic native libpcap/Npcap loading and is not NativeAOT/trimming safe.")]
+        [RequiresDynamicCode(
+            "SharpPcap requires dynamic native libpcap/Npcap loading and is not NativeAOT/trimming safe.")]
         public static IReadOnlyList<NetworkInterfaceInfo> ListInterfaces()
         {
             return NetworkInterfaceEnumerator.ListLocalInterfaces();

--- a/tools/Opc.Ua.Mcp.Diagnostics/Tools/PacketDecodeTools.cs
+++ b/tools/Opc.Ua.Mcp.Diagnostics/Tools/PacketDecodeTools.cs
@@ -41,6 +41,7 @@ using Microsoft.Extensions.DependencyInjection;
 using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
 using Opc.Ua.Bindings;
+using Opc.Ua.Mcp.Serialization;
 using Opc.Ua.Pcap.Audit;
 using Opc.Ua.Pcap.Capture;
 using Opc.Ua.Pcap.Capture.Sources;
@@ -398,7 +399,8 @@ namespace Opc.Ua.Mcp.Tools
             var builder = new StringBuilder();
             foreach (DecodedServiceCall call in calls)
             {
-                builder.AppendLine(JsonSerializer.Serialize(call));
+                builder.AppendLine(JsonSerializer.Serialize(
+                    call, PcapMcpJsonContext.Default.DecodedServiceCall));
             }
 
             return builder.ToString();


### PR DESCRIPTION
## What this does

Marks `Opc.Ua.Mcp.Core` `IsAotCompatible` on `net10.0` and removes the reflection the analysers then reported. Turning the analysers on is the point: until now they were not running on these libraries at all.

### `Opc.Ua.Mcp.Core`

- **`OpcUaJsonHelper.Serialize`** went through `JsonSerializer` (IL2026 / IL3050). The conversion helpers in that class already reduce every OPC UA value to a closed set — `null`, the primitive scalars, `string`, `Dictionary<string, object?>` and lists thereof — so the JSON is now written directly with a `Utf8JsonWriter`.

  Output is unchanged, and that is asserted rather than assumed: `OpcUaJsonHelperTests.SerializeMatchesTheReflectionBasedSerializer` compares the new writer byte for byte against `JsonSerializer` for every shape the helpers emit, including all numeric widths, the custom-formatted scalars, nested sequences and strings that force the encoder to escape.

  One deliberate contract change: arbitrary object graphs are no longer accepted. Serializing them needs reflection, so `Serialize` now throws `NotSupportedException` naming the type instead of silently stringifying it. No call site in the repository passes anything outside the closed set.

- **`McpSchemaFilters`** used `JsonSerializer.SerializeToElement` on a `JsonObject`; it now parses the node's own text, which needs no reflection.

### `Opc.Ua.Mcp.Diagnostics`

Deliberately **not** marked. It depends on SharpPcap and on the reflective service-call dissection in `Opc.Ua.Core.Diagnostics`, neither of which is trim safe — which is why that package does not opt in either. Two improvements are kept regardless:

- `PacketDecodeTools` serializes `DecodedServiceCall` through a source-generated `JsonSerializerContext`.
- `PacketCaptureTools.ListInterfaces` now carries the `RequiresUnreferencedCode` / `RequiresDynamicCode` annotations that `NetworkInterfaceEnumerator.ListLocalInterfaces` already declares, so the constraint is visible to callers instead of implicit. Nothing is suppressed.

### `Opc.Ua.Aot.Tests`

References `Opc.Ua.Mcp.Core` and exercises it with JSON reflection disabled.

Marking an assembly `IsAotCompatible` only proves its own IL is clean; it says nothing about whether the library still functions once reflection is gone. So `McpAotTests` states what is and is not true today:

- tool **results** serialize without reflection — this would fail outright if the `Utf8JsonWriter` change regressed;
- tool **registration** still requires reflection, because the MCP SDK builds each tool's input schema by asking `JsonSchemaExporter` for a `JsonTypeInfo` of every parameter type. Without a source-generated context covering the tool signatures — and with the injected `OpcUaSessionManager` being described rather than treated as a service — that throws `NotSupportedException`.

The second test asserts the throw. It documents the remaining gap and turns red the moment someone closes it, rather than leaving it to be found in a published binary. The package README says the same thing in prose.

## Verification

- `Opc.Ua.Mcp.Core` and `Opc.Ua.Mcp.Diagnostics`: **0 warnings, 0 errors** with the analysers enabled.
- ILCompiler trim and AOT **analysis** over `Opc.Ua.Aot.Tests` with `Opc.Ua.Mcp.Core` referenced: **no IL warnings**. (The native link step could not be completed on my machine — no Windows SDK link libraries — so the `aot-test` CI job is the check that matters for the compiled binary.)
- `Opc.Ua.Tools.Tests`: **338 passed, 0 failed** on `net10.0`.
- `McpAotTests`: 3 passed.

## Note on a pre-existing issue found on the way

Pulling `Opc.Ua.Mcp.Diagnostics` into an AOT publish surfaces two problems in `Opc.Ua.Core.Diagnostics` that are outside this PR:

- `IL2046` / `IL3051`: `NicCaptureSource.StartAsync` is annotated `RequiresUnreferencedCode` / `RequiresDynamicCode` but the `ICaptureSource.StartAsync` it implements is not. Those annotations must match across overrides.
- `IL2075`: `ServiceCallReassembler.GetCollectionCount` / `GetPropertyString` call `Type.GetProperty` on the result of `GetType()`.

Happy to file these separately if useful.
