### PR TITLE
Keep a NodeSet parent that lives outside the import batch

### DIFF
--- a/src/Opc.Ua.Server/EventIds.cs
+++ b/src/Opc.Ua.Server/EventIds.cs
@@ -82,6 +82,7 @@ namespace Opc.Ua
         public const int SubscriptionManager = 500;
         public const int TrustList = 540;
         public const int UserManagementBinding = 550;
+        public const int RuntimeNodeSetNodeManager = 560;
     }
 
     /// <summary>

--- a/src/Opc.Ua.Server/RuntimeNodeSet/RuntimeNodeSetNodeManager.cs
+++ b/src/Opc.Ua.Server/RuntimeNodeSet/RuntimeNodeSetNodeManager.cs
@@ -152,6 +152,8 @@ namespace Opc.Ua.Server.RuntimeNodeSet
             await AddReverseReferencesAsync(externalReferences, cancellationToken)
                 .ConfigureAwait(false);
 
+            ReportUnbackedExternalParents(predefinedNodes);
+
             // Step 6 – Apply the optional fluent configuration.
             if (m_configure is not null || m_configureAsync is not null)
             {
@@ -518,6 +520,60 @@ namespace Opc.Ua.Server.RuntimeNodeSet
         }
 
         /// <summary>
+        /// Reports an imported node whose declared <c>ParentNodeId</c> is
+        /// outside this manager and is not backed by an explicit inverse
+        /// hierarchical Reference.
+        /// </summary>
+        /// <remarks>
+        /// In NodeSet2 the <c>ParentNodeId</c> attribute is a hint; the
+        /// authoritative edge is the entry under <c>&lt;References&gt;</c>,
+        /// which the reverse-reference pass turns into an external reference.
+        /// A node that names an out-of-manager parent but carries no such
+        /// Reference therefore materializes with no path from that parent,
+        /// and no ReferenceType can be inferred to repair it. That is an
+        /// authoring defect, so it is reported rather than guessed at or
+        /// silently accepted.
+        /// </remarks>
+        private void ReportUnbackedExternalParents(NodeStateCollection nodes)
+        {
+            for (int ii = 0; ii < nodes.Count; ii++)
+            {
+                if (nodes[ii] is not BaseInstanceState { Parent: null } instance)
+                {
+                    continue;
+                }
+
+                NodeId? parentNodeId = UANodeSet.GetUnresolvedParentNodeId(instance);
+                if (parentNodeId is null)
+                {
+                    continue;
+                }
+
+                var references = new List<IReference>();
+                instance.GetReferences(SystemContext, references);
+
+                bool backed = false;
+                for (int jj = 0; jj < references.Count; jj++)
+                {
+                    IReference reference = references[jj];
+                    if (reference.IsInverse &&
+                        !reference.TargetId.IsNull &&
+                        !reference.TargetId.IsAbsolute &&
+                        (NodeId)reference.TargetId == parentNodeId.Value)
+                    {
+                        backed = true;
+                        break;
+                    }
+                }
+
+                if (!backed)
+                {
+                    m_logger.UnbackedExternalParent(instance.NodeId, parentNodeId.Value);
+                }
+            }
+        }
+
+        /// <summary>
         /// Scans the imported node collection for duplicate
         /// <see cref="NodeId"/> values and throws
         /// <see cref="InvalidOperationException"/> on the first duplicate
@@ -611,5 +667,15 @@ namespace Opc.Ua.Server.RuntimeNodeSet
         private readonly Dictionary<NodeId, List<IReference>> m_addedReferences = [];
         private IFluentDispatcher? m_dispatcher;
         private IAsyncDisposable? m_generationOwner;
+    }
+
+    internal static partial class RuntimeNodeSetNodeManagerLog
+    {
+        [LoggerMessage(EventId = ServerEventIds.RuntimeNodeSetNodeManager + 0, Level = LogLevel.Warning,
+            Message = "Node {NodeId} declares ParentNodeId {ParentNodeId}, which is outside this " +
+                "NodeManager and is not backed by an inverse hierarchical Reference, so no path to " +
+                "it is created. Add the Reference to the NodeSet.")]
+        public static partial void UnbackedExternalParent(
+            this ILogger logger, NodeId nodeId, NodeId parentNodeId);
     }
 }

--- a/src/Opc.Ua.Types/Schema/UANodeSetHelpers.cs
+++ b/src/Opc.Ua.Types/Schema/UANodeSetHelpers.cs
@@ -494,6 +494,14 @@ namespace Opc.Ua.Export
         /// <summary>
         /// Links parent-child relationships for imported nodes.
         /// </summary>
+        /// <remarks>
+        /// A node may declare a parent that is not part of this batch, because
+        /// the parent lives in another NodeSet or is owned by another
+        /// NodeManager. That parent cannot be linked in memory here, but it
+        /// must not be discarded either: the caller needs it to wire the node
+        /// as an external reference. Such a parent is recorded through
+        /// <see cref="GetUnresolvedParentNodeId"/> instead of being dropped.
+        /// </remarks>
         /// <param name="nodes">The collection of imported nodes.</param>
         private static void LinkParentChildRelationships(NodeStateCollection nodes)
         {
@@ -512,7 +520,11 @@ namespace Opc.Ua.Export
             {
                 if (node is BaseInstanceState instance && instance.Handle is NodeId parentNodeId)
                 {
-                    // Find the parent node
+                    // The Handle is only a carrier for the authored parent
+                    // between Import and this pass, so it is always cleared;
+                    // an unresolved parent is preserved separately.
+                    instance.Handle = null;
+
                     if (nodeTable.TryGetValue(parentNodeId, out NodeState? parent))
                     {
                         // Set the Parent property to establish the relationship
@@ -520,13 +532,60 @@ namespace Opc.Ua.Export
 
                         // Add the child to the parent's children collection
                         parent.AddChild(instance);
+                        continue;
                     }
 
-                    // Clear the Handle since we've processed it
-                    instance.Handle = null;
+                    s_unresolvedParents.Add(instance, new UnresolvedParent(parentNodeId));
                 }
             }
         }
+
+        /// <summary>
+        /// Gets the parent a node declared at import when that parent was not
+        /// part of the same import batch.
+        /// </summary>
+        /// <remarks>
+        /// The parent of a node owned by another NodeManager cannot be linked
+        /// in memory, so a caller that wants the hierarchical reference has to
+        /// add it as an external reference. This reports the parent for exactly
+        /// those nodes; a node whose parent was linked normally, or that
+        /// declared no parent, returns <c>null</c>.
+        /// <para>
+        /// The record is held in a table keyed by weak reference, so it does
+        /// not keep an imported node alive and does not widen
+        /// <see cref="NodeState"/>'s public surface, whose
+        /// <see cref="NodeState.Handle"/> is a general-purpose slot a caller
+        /// may use for its own purposes.
+        /// </para>
+        /// </remarks>
+        /// <param name="node">The imported node.</param>
+        /// <returns>The unresolved parent NodeId, or <c>null</c>.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="node"/> is <c>null</c>.
+        /// </exception>
+        public static NodeId? GetUnresolvedParentNodeId(NodeState node)
+        {
+            if (node is null)
+            {
+                throw new ArgumentNullException(nameof(node));
+            }
+
+            return s_unresolvedParents.TryGetValue(node, out UnresolvedParent? parent)
+                ? parent.NodeId
+                : null;
+        }
+
+        /// <summary>
+        /// Boxes the unresolved parent so it can live in a weak-keyed table;
+        /// <see cref="NodeId"/> is a value type.
+        /// </summary>
+        private sealed class UnresolvedParent(NodeId nodeId)
+        {
+            public NodeId NodeId { get; } = nodeId;
+        }
+
+        private static readonly System.Runtime.CompilerServices.ConditionalWeakTable<NodeState, UnresolvedParent>
+            s_unresolvedParents = new();
 
         /// <summary>
         /// Adds a node to the set.

--- a/tests/Opc.Ua.Core.Tests/Stack/Schema/UANodeSetHelpersTests.cs
+++ b/tests/Opc.Ua.Core.Tests/Stack/Schema/UANodeSetHelpersTests.cs
@@ -274,6 +274,127 @@ namespace Opc.Ua.Core.Tests.Stack.Schema
         }
 
         /// <summary>
+        /// A node whose declared parent is not part of the same import batch —
+        /// because it lives in another NodeSet or another NodeManager — must
+        /// not have that parent silently discarded. The caller needs it so it
+        /// can be wired as an external reference.
+        /// </summary>
+        [Test]
+        public void ImportKeepsAParentThatIsNotInTheSameBatch()
+        {
+            ITelemetryContext telemetry = NUnitTelemetryContext.Create();
+
+            const string importBuffer =
+                @"<?xml version='1.0' encoding='utf-8'?>
+                <UANodeSet xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'
+                           xmlns:xsd='http://www.w3.org/2001/XMLSchema'
+                           LastModified='2024-01-01T00:00:00.000Z'
+                           xmlns='http://opcfoundation.org/UA/2011/03/UANodeSet.xsd'>
+                  <NamespaceUris>
+                    <Uri>http://opcfoundation.org/UA/Test</Uri>
+                    <Uri>http://opcfoundation.org/UA/Elsewhere</Uri>
+                  </NamespaceUris>
+                  <Aliases>
+                    <Alias Alias='HasComponent'>i=47</Alias>
+                    <Alias Alias='HasTypeDefinition'>i=40</Alias>
+                  </Aliases>
+                  <UAObject ParentNodeId='ns=2;i=5001' NodeId='ns=1;i=1001' BrowseName='1:Orphan'>
+                    <DisplayName>Orphan</DisplayName>
+                    <References>
+                      <Reference ReferenceType='HasTypeDefinition'>i=58</Reference>
+                      <Reference ReferenceType='HasComponent' IsForward='false'>ns=2;i=5001</Reference>
+                    </References>
+                  </UAObject>
+                </UANodeSet>";
+
+            using var importStream = new MemoryStream(Encoding.UTF8.GetBytes(importBuffer));
+            Export.UANodeSet importedNodeSet = Export.UANodeSet.Read(importStream);
+
+            var importedNodeStates = new NodeStateCollection();
+            var localContext = new SystemContext(telemetry) { NamespaceUris = new NamespaceTable() };
+            foreach (string namespaceUri in importedNodeSet.NamespaceUris)
+            {
+                localContext.NamespaceUris.Append(namespaceUri);
+            }
+
+            importedNodeSet.Import(localContext, importedNodeStates, linkParentChild: true);
+
+            Assert.That(importedNodeStates, Has.Count.EqualTo(1));
+            var orphan = (BaseInstanceState)importedNodeStates[0];
+
+            Assert.That(orphan.Parent, Is.Null,
+                "The parent is not in this batch, so it cannot be linked as an in-memory parent.");
+
+            NodeId expectedParent = new(5001u, (ushort)localContext.NamespaceUris.GetIndex(
+                "http://opcfoundation.org/UA/Elsewhere"));
+
+            Assert.That(
+                Export.UANodeSet.GetUnresolvedParentNodeId(orphan),
+                Is.EqualTo(expectedParent),
+                "The declared parent must survive the import so a caller can wire it " +
+                "as an external reference.");
+        }
+
+        /// <summary>
+        /// The record must be precise: a parent that was linked normally is not
+        /// an unresolved parent, or a caller would wire references that already
+        /// exist.
+        /// </summary>
+        [Test]
+        public void ImportRecordsNoUnresolvedParentWhenTheParentIsInTheBatch()
+        {
+            ITelemetryContext telemetry = NUnitTelemetryContext.Create();
+
+            const string importBuffer =
+                @"<?xml version='1.0' encoding='utf-8'?>
+                <UANodeSet xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'
+                           xmlns:xsd='http://www.w3.org/2001/XMLSchema'
+                           LastModified='2024-01-01T00:00:00.000Z'
+                           xmlns='http://opcfoundation.org/UA/2011/03/UANodeSet.xsd'>
+                  <NamespaceUris>
+                    <Uri>http://opcfoundation.org/UA/Test</Uri>
+                  </NamespaceUris>
+                  <Aliases>
+                    <Alias Alias='HasComponent'>i=47</Alias>
+                    <Alias Alias='HasTypeDefinition'>i=40</Alias>
+                  </Aliases>
+                  <UAObject NodeId='ns=1;i=1000' BrowseName='1:ParentObject'>
+                    <DisplayName>ParentObject</DisplayName>
+                    <References>
+                      <Reference ReferenceType='HasTypeDefinition'>i=58</Reference>
+                    </References>
+                  </UAObject>
+                  <UAObject ParentNodeId='ns=1;i=1000' NodeId='ns=1;i=1002' BrowseName='1:ChildObject'>
+                    <DisplayName>ChildObject</DisplayName>
+                    <References>
+                      <Reference ReferenceType='HasTypeDefinition'>i=58</Reference>
+                      <Reference ReferenceType='HasComponent' IsForward='false'>ns=1;i=1000</Reference>
+                    </References>
+                  </UAObject>
+                </UANodeSet>";
+
+            using var importStream = new MemoryStream(Encoding.UTF8.GetBytes(importBuffer));
+            Export.UANodeSet importedNodeSet = Export.UANodeSet.Read(importStream);
+
+            var importedNodeStates = new NodeStateCollection();
+            var localContext = new SystemContext(telemetry) { NamespaceUris = new NamespaceTable() };
+            foreach (string namespaceUri in importedNodeSet.NamespaceUris)
+            {
+                localContext.NamespaceUris.Append(namespaceUri);
+            }
+
+            importedNodeSet.Import(localContext, importedNodeStates, linkParentChild: true);
+
+            foreach (NodeState node in importedNodeStates)
+            {
+                Assert.That(
+                    Export.UANodeSet.GetUnresolvedParentNodeId(node),
+                    Is.Null,
+                    $"'{node.BrowseName.Name}' resolved inside the batch, so nothing is unresolved.");
+            }
+        }
+
+        /// <summary>
         /// Test that parent-child references are NOT established by default (backward compatibility).
         /// </summary>
         [Test]


### PR DESCRIPTION
# Description

`UANodeSetHelpers.LinkParentChildRelationships` builds its lookup table from
**only the nodes in the current import batch**, links a child when the parent is
found — and then clears `instance.Handle` **unconditionally**, which is exactly
where `Import` stashed the authored `ParentNodeId`.

So a node whose parent lives in another NodeSet, or is owned by another
NodeManager, lost that parent **silently** at import, and nothing downstream
could recover it. `RuntimeNodeSetNodeManager.CreateAddressSpaceAsync` already
has a step that wires references to external node managers; the parent link
never reached it.

## What changes

Such a parent is now recorded rather than discarded, and exposed through
`UANodeSet.GetUnresolvedParentNodeId`. A parent that resolved normally inside
the batch is **not** recorded, so a caller does not re-wire references that
already exist.

The record lives in a `ConditionalWeakTable`, so it does not keep an imported
node alive and does not widen `NodeState` — whose `Handle` is a
general-purpose slot a caller may legitimately use for its own purposes, and so
is not a safe place to leave the value.

`RuntimeNodeSetNodeManager` consumes it to report the one case that cannot be
repaired automatically. In NodeSet2 the `ParentNodeId` attribute is a *hint*;
the authoritative edge is the entry under `<References>`, which the
reverse-reference pass already turns into an external reference. A node that
names an out-of-manager parent but carries **no such Reference** materializes
with no path from that parent, and no ReferenceType can be inferred to
synthesise one — so it is reported as an authoring defect rather than guessed
at or silently accepted.

## Scope note

This is deliberately **not** a fix for a specific address-space symptom. It
removes a silent loss of authored information and gives callers the means to act
on it. Whether any particular orphaned-node report is caused by this path, or by
namespace-index translation elsewhere, still needs separate diagnosis — I did not
want to claim a fix I had not reproduced.

## Related Issues

No tracking issue; this came out of reading the import path while planning WoT
placement work (Connectivity §7.3 needs to resolve a parent to an existing
AddressSpace node, which this unblocks).

## Checklist

- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf) and read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [x] I have added all necessary documentation.
- [x] I have verified that my changes do not introduce (new) build or analyzer warnings.
- [x] I ran **all** tests locally using the **UA.slnx** solution against at least .net **framework** and .net **10**, and all passed.
- [ ] I fixed **all** failing and flaky tests in the CI pipelines and **all** CodeQL warnings.
- [ ] I have addressed **all** PR feedback received.

### Verification

| | Result |
|---|---|
| `Opc.Ua.Core.Tests` (net10.0) | 4243 / 4243, 86 skipped |
| `Opc.Ua.Core.Tests` — `UANodeSetHelpers` (net48) | 5 / 5 |
| `Opc.Ua.Server.Tests` — `RuntimeNodeSet` (net10.0) | 94 / 94 |
| Full `UA.slnx` build | **0 errors, 0 warnings** |

Both new tests were mutation-verified: removing the record makes the
out-of-batch test fail, and recording resolved parents too makes the precision
test fail.

The reporting in `RuntimeNodeSetNodeManager` is thin glue over those tested
primitives; exercising the log line itself would need a full server harness,
which seemed disproportionate for a warning.
