### PR TITLE
Honour the format in DateTimeUtc.TryFormat and verify ECDSA CSRs on netstandard2.1

### DIFF
--- a/src/Opc.Ua.Security.Certificates/PKCS10/Pkcs10CertificationRequest.cs
+++ b/src/Opc.Ua.Security.Certificates/PKCS10/Pkcs10CertificationRequest.cs
@@ -146,7 +146,7 @@ namespace Opc.Ua.Security.Certificates
                 }
                 else if (keyAlgorithmOid == Oids.ECPublicKey)
                 {
-                    return VerifyEcdsaSignature(publicKeyBytes, hashAlgorithm);
+                    return VerifyEcdsaSignature(hashAlgorithm);
                 }
                 else
                 {
@@ -258,11 +258,15 @@ namespace Opc.Ua.Security.Certificates
                 RSASignaturePadding.Pkcs1);
         }
 
-        private bool VerifyEcdsaSignature(byte[] publicKeyBytes, HashAlgorithmName hashAlgorithm)
+        private bool VerifyEcdsaSignature(HashAlgorithmName hashAlgorithm)
         {
 #if NET6_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
-            // ImportSubjectPublicKeyInfo is .NET Core 3.0 API and is part of the
-            // netstandard2.1 surface, so this path is not limited to net6.0+.
+            // Unlike the RSA path this does not take the parsed public key bit
+            // string: ImportSubjectPublicKeyInfo wants the whole
+            // SubjectPublicKeyInfo, because for EC the curve lives in the
+            // algorithm parameters rather than in the key itself.
+            // That API is .NET Core 3.0 and part of the netstandard2.1 surface,
+            // so this path is not limited to net6.0+.
             using var ecdsa = ECDsa.Create();
             try
             {

--- a/src/Opc.Ua.Security.Certificates/PKCS10/Pkcs10CertificationRequest.cs
+++ b/src/Opc.Ua.Security.Certificates/PKCS10/Pkcs10CertificationRequest.cs
@@ -260,8 +260,9 @@ namespace Opc.Ua.Security.Certificates
 
         private bool VerifyEcdsaSignature(byte[] publicKeyBytes, HashAlgorithmName hashAlgorithm)
         {
-#if NET6_0_OR_GREATER
-            // .NET 6+ has ImportSubjectPublicKeyInfo
+#if NET6_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+            // ImportSubjectPublicKeyInfo is .NET Core 3.0 API and is part of the
+            // netstandard2.1 surface, so this path is not limited to net6.0+.
             using var ecdsa = ECDsa.Create();
             try
             {
@@ -283,15 +284,15 @@ namespace Opc.Ua.Security.Certificates
                 return false;
             }
 #else
-            // For .NET Framework 4.8 and .NET Standard 2.x, ECDSA CSR verification is not supported
-            // This is acceptable as the GDS Server primarily uses RSA certificates
+            // .NET Framework and netstandard2.0 have no ImportSubjectPublicKeyInfo,
+            // so an ECDSA CSR cannot be verified there.
             throw new NotSupportedException(
                 "ECDSA certificate signing request verification is not supported on this platform. " +
-                "Please use .NET 6.0 or later.");
+                "Please use .NET Standard 2.1, .NET 6.0 or later.");
 #endif
         }
 
-#if NET6_0_OR_GREATER
+#if NET6_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
         /// <summary>
         /// Converts ECDSA signature from DER format to IEEE P1363 format.
         /// </summary>

--- a/src/Opc.Ua.Types/BuiltIn/DateTimeUtc.cs
+++ b/src/Opc.Ua.Types/BuiltIn/DateTimeUtc.cs
@@ -422,10 +422,14 @@ namespace Opc.Ua
                     bytesWritten = 0;
                     return false;
                 }
-                encoded.CopyTo(utf8Destination);
+                encoded.AsSpan().CopyTo(utf8Destination);
                 bytesWritten = encoded.Length;
                 return true;
             }
+            // ToString throws FormatException for an invalid format string and
+            // ArgumentException for an unusable provider. EncoderFallbackException
+            // derives from ArgumentException, so an unencodable character is covered
+            // too - Encoding.UTF8 replaces rather than throws in any case.
             catch (Exception ex) when (ex is FormatException or ArgumentException)
             {
                 bytesWritten = 0;

--- a/src/Opc.Ua.Types/BuiltIn/DateTimeUtc.cs
+++ b/src/Opc.Ua.Types/BuiltIn/DateTimeUtc.cs
@@ -408,17 +408,27 @@ namespace Opc.Ua
 #else
             try
             {
-                string formatted = ToDateTime().ToString(provider);
+                // Honour the format specifier. ToString(provider) ignores it and
+                // always emits the general format, so a caller asking for "O" got
+                // "1/1/2023 12:30:45 PM" instead of the round trip form - the
+                // fractional seconds and the UTC designator were silently lost.
+                string formatted = ToDateTime()
+                    .ToString(format.IsEmpty ? null : format.ToString(), provider);
                 byte[] encoded = System.Text.Encoding.UTF8.GetBytes(formatted);
-                bytesWritten = encoded.Length > utf8Destination.Length ?
-                    utf8Destination.Length :
-                    encoded.Length;
-                encoded.AsSpan(0, bytesWritten).CopyTo(utf8Destination);
+                if (encoded.Length > utf8Destination.Length)
+                {
+                    // All or nothing: reporting success for a truncated timestamp
+                    // would hand the caller a corrupt value it believes is complete.
+                    bytesWritten = 0;
+                    return false;
+                }
+                encoded.CopyTo(utf8Destination);
+                bytesWritten = encoded.Length;
                 return true;
             }
-            catch
+            catch (Exception ex) when (ex is FormatException or ArgumentException)
             {
-                bytesWritten = default;
+                bytesWritten = 0;
                 return false;
             }
 #endif

--- a/tests/Opc.Ua.Types.Tests/BuiltIn/DateTimeUtcTests.cs
+++ b/tests/Opc.Ua.Types.Tests/BuiltIn/DateTimeUtcTests.cs
@@ -356,6 +356,55 @@ namespace Opc.Ua.Types.Tests.BuiltIn
 #endif
         }
 
+        /// <summary>
+        /// The format specifier must be honoured on every target framework. The
+        /// pre-net8 fallback used to call ToString(provider), which ignores it and
+        /// emits the general format, so "O" silently lost the fractional seconds
+        /// and the UTC designator.
+        /// </summary>
+        [Test]
+        public void TryFormatShouldHonourTheFormatSpecifier()
+        {
+            var date = new DateTimeUtc(new DateTime(2023, 1, 1, 12, 30, 45, DateTimeKind.Utc));
+            byte[] buffer = new byte[100];
+
+            bool success = date.TryFormat(
+                buffer,
+                out int bytesWritten,
+                "O".AsSpan(),
+                CultureInfo.InvariantCulture);
+
+            Assert.That(success, Is.True);
+            Assert.That(
+                Encoding.UTF8.GetString(buffer, 0, bytesWritten),
+                Is.EqualTo("2023-01-01T12:30:45.0000000Z"));
+        }
+
+        /// <summary>
+        /// A destination too small to hold the value must be reported as a failure
+        /// and must not be written to. Reporting success for a truncated timestamp
+        /// hands the caller a corrupt value it believes is complete.
+        /// </summary>
+        [Test]
+        public void TryFormatShouldFailRatherThanTruncate()
+        {
+            var date = new DateTimeUtc(new DateTime(2023, 1, 1, 12, 30, 45, DateTimeKind.Utc));
+            byte[] buffer = new byte[8];
+
+            bool success = date.TryFormat(
+                buffer,
+                out int bytesWritten,
+                "O".AsSpan(),
+                CultureInfo.InvariantCulture);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(success, Is.False);
+                Assert.That(bytesWritten, Is.Zero);
+                Assert.That(buffer, Is.All.EqualTo((byte)0), "nothing may be written on failure");
+            });
+        }
+
         [TestCase(null)]
         [TestCase("d")]
         [TestCase("D")]


### PR DESCRIPTION
# Description

Fixes two real defects in the pre-net8.0 code paths, both surfaced by the nightly scheduled build ([16786](https://opcfoundation.visualstudio.com/opcua-netstandard/_build/results?buildId=16786&view=results)).

The nightly runs a **"Test .NETStandard 2.1"** stage that builds the libraries as `netstandard2.1` while the test assemblies build and run as `net8.0`. That combination exercises the `#else` branches of the stack while the tests assert the net8.0 contract — which is exactly how these two got found. Regular CI never covers it: the PR pipeline only runs `net10.0` and `net48`.

## 1. `DateTimeUtc.TryFormat` ignored its format argument

On every framework below net8.0 the fallback called `ToString(provider)` instead of `ToString(format, provider)`. A caller asking for the round-trip form `"O"` got the **general** format back:

| | |
|---|---|
| asked for | `2023-01-01T12:30:45.0000000Z` |
| actually got | `1/1/2023 12:30:45 PM` |

The fractional seconds and the UTC designator were silently dropped. That matters because this is the wire representation of a Part 6 `DateTime`.

The same fallback also **truncated to the destination length and still returned `true`**. A caller that trusts the result emits a cut-off timestamp believing it is complete. It now returns `false` and writes nothing when the value does not fit, which is what `IUtf8SpanFormattable` requires.

## 2. ECDSA CSR verification was disabled on netstandard2.1

`Pkcs10CertificationRequest.VerifyEcdsaSignature` was gated on `NET6_0_OR_GREATER` and threw `NotSupportedException` otherwise. But `ImportSubjectPublicKeyInfo` is .NET Core 3.0 API and **is part of the netstandard2.1 surface** — that band was refusing to verify signatures it is perfectly capable of verifying.

The guard now admits `netstandard2.1`. `net472`/`net48`/`netstandard2.0` still throw, and the message now names the lowest band that actually works instead of claiming .NET 6 is required.

Both changes are consumer-visible: they change what the `netstandard2.1` and `net48` builds of the stack do, not just what the tests observe.

## Not fixed here, and why

The same nightly stage has ~50 further failing tests, and it has been red for at least a month (builds 15464, 15980, 16363 all failed the same way) — so this is not a regression from any recent commit. The bulk of the remainder are **genuine platform limitations rather than bugs**, e.g. `DtlsRecordProtection` throws `AEAD DTLS record protection requires .NET 8 or later BCL primitives`, and the tests assert the capability unconditionally because their own `#if` reflects the *test* project's TFM, not the library's.

Making those green needs a design decision — a runtime capability probe the tests can branch on, or narrowing which projects run in that stage — rather than more `#if` edits, and it deserves its own issue. I did not touch them, because the only way to turn them green today would be to weaken assertions.

## Related Issues

_No tracking issue; found by investigating nightly build 16786._

## Checklist

- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf) and read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have added tests that prove my fix is effective or that my feature works and increased code coverage.<br/>_Two new tests pin the format specifier and the all-or-nothing buffer contract; both fail on the previous code. The ECDSA fix is covered by the existing `CreateAndParseEcdsaCsrP256`, which could not pass in this configuration before._
- [x] I have added all necessary documentation.<br/>_Behaviour is documented in the code where the contract is asserted; no public API shape change._
- [x] I have verified that my changes do not introduce (new) build or analyzer warnings.<br/>_`Opc.Ua.Types` and `Opc.Ua.Security.Certificates` build across all six TFMs at 0 warnings / 0 errors._
- [x] I ran **all** tests locally using the **UA.slnx** solution against at least .net **framework** and .net **10**, and all passed.<br/>_`Opc.Ua.Types.Tests` and `Opc.Ua.Security.Certificates.Tests` green under **netstandard2.1** (the failing configuration), **net48** and **net10.0** — 8557/282, 8552/280, 8559/282 respectively._
- [ ] I fixed **all** failing and flaky tests in the CI pipelines and **all** CodeQL warnings.
- [ ] I have addressed **all** PR feedback received.
