### PR TITLE
Remove re-entrancy from ChannelGate and delete its AsyncLocal

### DIFF
--- a/docs/MigrationGuide.md
+++ b/docs/MigrationGuide.md
@@ -158,8 +158,44 @@ A monitor cannot be held across an `await`, and the secure channel open
 path has to be able to await once a private key may be served over a
 network — see [Crypto provider](CryptoProvider.md). The channel now uses
 an internal gate that can be entered from a synchronous or an
-asynchronous path and that is re-entrant, which the code it replaces
-relies on.
+asynchronous path. Unlike a monitor the gate is **not re-entrant**: every
+channel path that used to take the lock while already holding it now
+calls a lock-free `Core` variant instead.
+
+That has one consequence for subclasses. The channel calls
+`HandleSocketError`, `NotifyMonitors` and `CompleteReverseHello` from
+paths that may already hold the gate, so an override of any of them must
+not call back into a channel method that takes it — `ForceChannelFault`
+and `SendResponse` in particular. Such an override would have silently
+nested before and will now block.
+
+For the same reason `SaveIntermediateChunk`, `GetSavedChunks` and
+`DoMessageLimitsExceeded` take an additional `gateHeld` argument. It says
+whether the calling frame already holds the gate, so that an override
+which tears the channel down can pick the locking or the lock-free path:
+
+```csharp
+// before
+protected override void DoMessageLimitsExceeded()
+{
+    base.DoMessageLimitsExceeded();
+    Shutdown(new ServiceResult(StatusCodes.BadResponseTooLarge));
+}
+
+// after
+protected override void DoMessageLimitsExceeded(bool gateHeld)
+{
+    base.DoMessageLimitsExceeded(gateHeld);
+
+    if (gateHeld)
+    {
+        ShutdownCore(new ServiceResult(StatusCodes.BadResponseTooLarge));
+        return;
+    }
+
+    Shutdown(new ServiceResult(StatusCodes.BadResponseTooLarge));
+}
+```
 
 There is no drop-in replacement to offer across an assembly boundary,
 because the gate has to be entered asynchronously on the open path and

--- a/docs/WhatsNewIn2.0.md
+++ b/docs/WhatsNewIn2.0.md
@@ -283,7 +283,9 @@ type test and uses where it can — user identity token signing and decryption,
 session activation, and the secure channel open and renew path. A software key
 implements neither, so those paths complete synchronously and nothing about
 their ordering changes. The secure channel no longer serialises its state on a
-monitor, and `UaSCBinaryChannel.DataLock` is `[Obsolete]`.
+monitor, and `UaSCBinaryChannel.DataLock` is `[Obsolete]`. The gate that replaced
+it is not re-entrant, so the channel calls a lock-free `Core` variant on every
+path that used to take the lock recursively.
 
 ## By layer
 

--- a/src/Opc.Ua.Core/Stack/Tcp/ChannelAsyncOperation.cs
+++ b/src/Opc.Ua.Core/Stack/Tcp/ChannelAsyncOperation.cs
@@ -433,14 +433,12 @@ namespace Opc.Ua.Bindings
             {
                 if (doNotBlock)
                 {
-                    // Queued without flowing the execution context, so the
-                    // callback does not inherit the logical context of whoever
-                    // completed the operation. That context may hold a channel's
-                    // gate, and an inherited entitlement to re-enter it would let
-                    // this callback run inside the guarded region alongside the
-                    // holder. UnsafeQueueUserWorkItem is used rather than
-                    // ExecutionContext.SuppressFlow because it cannot fail when
-                    // flow is already suppressed.
+                    // Queued rather than run inline because the completing frame
+                    // may hold a channel's gate, which is not re-entrant: a
+                    // callback that entered it from this stack would deadlock.
+                    // UnsafeQueueUserWorkItem also avoids capturing and
+                    // restoring the execution context, which this callback does
+                    // not need.
                     ThreadPool.UnsafeQueueUserWorkItem(
                         static state =>
                         {

--- a/src/Opc.Ua.Core/Stack/Tcp/ChannelGate.cs
+++ b/src/Opc.Ua.Core/Stack/Tcp/ChannelGate.cs
@@ -43,21 +43,23 @@ namespace Opc.Ua.Bindings
     /// <see langword="await"/>, and the secure channel open path has to await
     /// once a private key may be served over a network.
     /// <para>
-    /// It is <b>re-entrant</b>, because the code it replaces relies on that:
-    /// <c>HandleIncomingMessageAsync</c> holds the lock and calls
-    /// <c>ForceChannelFault</c>, which takes it again, and there are seven more
-    /// paths like it. A plain <see cref="SemaphoreSlim"/> would deadlock on each
-    /// of them. Re-entrancy is tracked per logical call context, which is what a
-    /// monitor does per thread and what an asynchronous continuation needs
-    /// instead.
+    /// It is <b>not re-entrant</b>. A monitor is, and the code this replaced
+    /// relied on that in about ten places, but re-entrancy cannot be tracked by
+    /// thread for a holder that awaits — the thread is returned to the pool at
+    /// every suspension point — so it had to be tracked per logical call context
+    /// with an <see cref="AsyncLocal{T}"/> instead. That was the source of most
+    /// of this type's defects: a logical context is inherited by work started
+    /// from it, so anything started while the gate was held inherited the right
+    /// to re-enter and ran <em>inside</em> the guarded region alongside whatever
+    /// started it. Each such path had to be found by review and opted out by
+    /// hand, with no compiler check.
     /// </para>
     /// <para>
-    /// One consequence has to be handled explicitly. A logical context is
-    /// inherited by work started from it, so a task started <em>while the gate is
-    /// held</em> would inherit the right to re-enter and could then run
-    /// concurrently with its parent inside the guarded region. Any such
-    /// fire-and-forget work must call <see cref="LeaveInheritedContext"/> first,
-    /// which drops the inherited entitlement for that branch only.
+    /// Every path that used to re-enter now calls a lock-free <c>Core</c> method
+    /// instead, so the ownership tracking is gone and with it that whole class of
+    /// defect. Entering twice from one flow now deadlocks, which is the ordinary
+    /// contract of a mutex and is diagnosable, rather than silently running two
+    /// flows inside a region that exists to keep them apart.
     /// </para>
     /// <para>
     /// It is deliberately <b>not</b> disposable. It replaces a monitor, which has
@@ -69,27 +71,14 @@ namespace Opc.Ua.Bindings
     /// it never is.
     /// </para>
     /// <para>
-    /// <b>What it costs.</b> Measured by <c>ChannelGateBenchmarks</c> against the
-    /// monitor it replaced: an uncontended acquisition is about 41 ns and 96 bytes
-    /// where the monitor was 13 ns and nothing, and a nested acquisition adds
-    /// about 5 ns and nothing. The per-message work the gate is taken around —
-    /// <c>SymmetricChannelCryptoBenchmarks.EncryptSignThenDecryptVerify</c> — is
-    /// about 10,500 ns, so the gate is under half a percent of it. The
+    /// <b>What it costs.</b> Measured by <c>ChannelGateBenchmarks</c>, an
+    /// uncontended acquisition costs what the underlying
+    /// <see cref="SemaphoreSlim"/> costs and allocates nothing, against about
+    /// 13 ns for the monitor it replaced. The per-message work it is taken
+    /// around — <c>SymmetricChannelCryptoBenchmarks.EncryptSignThenDecryptVerify</c>
+    /// — is about 10,500 ns, so the gate does not register against it. The
     /// asynchronous entry completes synchronously when uncontended, which a test
-    /// asserts, so it costs no suspension.
-    /// </para>
-    /// <para>
-    /// The 96 bytes are not a task: they are the execution context copy that
-    /// writing an <see cref="AsyncLocal{T}"/> makes, plus the holder. Returning
-    /// the acquisition through an <c>IValueTaskSource&lt;T&gt;</c>, or pooling
-    /// the <see cref="ValueTask{TResult}"/>, therefore cannot remove them — the
-    /// uncontended path already allocates no task at all. It would only affect
-    /// the contended path, where the cost is dominated by waiting, and it would
-    /// be unsafe here: a pooled token may be consumed exactly once, while
-    /// <see cref="Releaser"/> is a copyable struct. Recycling the holder is
-    /// unsafe for the same reason re-entrancy works at all — a forked context
-    /// keeps a reference to it, and would read a recycled one as its own
-    /// entitlement.
+    /// asserts, so it costs no suspension and no task.
     /// </para>
     /// </remarks>
     // CA1001: the semaphore is deliberately not disposed. This type replaces a
@@ -107,46 +96,15 @@ namespace Opc.Ua.Bindings
         /// </summary>
         /// <returns>A handle that leaves the gate when disposed.</returns>
         /// <remarks>
-        /// This is the direct replacement for the monitor the channel used to
-        /// take and behaves the same way, including when the caller already
-        /// holds the gate.
-        /// <para>
         /// <b>The handle this returns must not be held across an
-        /// <see langword="await"/>.</b> It records the acquiring thread so that an
-        /// inline completion callback can re-enter, and once the frame suspends
-        /// that thread returns to the pool: unrelated work scheduled onto it would
-        /// then be recognised as the holder. Use <see cref="EnterAsync"/> on any
-        /// path that awaits.
-        /// </para>
+        /// <see langword="await"/>.</b> Use <see cref="EnterAsync"/> on any path
+        /// that awaits, so the waiting thread is not occupied.
         /// </remarks>
         public Releaser Enter()
         {
-            Holder? holder = m_current.Value;
-
-            if (holder is { Depth: > 0 })
-            {
-                holder.Depth++;
-                return new Releaser(this, holder, owner: false);
-            }
-
-            // A monitor is re-entrant per thread, and the code this replaces
-            // relies on that in a way the logical context cannot express: a
-            // completion callback invoked inline runs on the thread that already
-            // holds the gate but under the context captured when the operation
-            // was started. Honouring thread identity as well keeps those paths
-            // working instead of deadlocking against themselves.
-            Holder? onThread = m_owner;
-
-            if (onThread is { Depth: > 0 } &&
-                m_owningThreadId == Environment.CurrentManagedThreadId)
-            {
-                onThread.Depth++;
-                return new Releaser(this, onThread, owner: false);
-            }
-
             m_semaphore.Wait();
 
-            return TakeOwnership();
+            return new Releaser(this);
         }
 
         /// <summary>
@@ -156,14 +114,6 @@ namespace Opc.Ua.Bindings
         /// <returns>A handle that leaves the gate when disposed.</returns>
         public ValueTask<Releaser> EnterAsync(CancellationToken ct = default)
         {
-            Holder? holder = m_current.Value;
-
-            if (holder is { Depth: > 0 })
-            {
-                holder.Depth++;
-                return new ValueTask<Releaser>(new Releaser(this, holder, owner: false));
-            }
-
             Task wait = m_semaphore.WaitAsync(ct);
 
             // Uncontended is the common case. Completing synchronously keeps the
@@ -172,51 +122,11 @@ namespace Opc.Ua.Bindings
             // targets, so the status is read directly.
             if (wait.Status == TaskStatus.RanToCompletion)
             {
-                return new ValueTask<Releaser>(TakeOwnership(recordThread: false));
+                return new ValueTask<Releaser>(new Releaser(this));
             }
 
-            // The holder must be published from the caller's frame. An
-            // AsyncLocal written inside an async method's continuation is
-            // discarded when that method completes, because the caller's
-            // execution context is restored over it — so a holder created in
-            // AwaitEntryAsync would never reach the caller, and the caller would
-            // hold the semaphore while believing it did not. Publishing the
-            // object here and raising its depth once the wait completes works
-            // because mutating a shared object is visible to every context that
-            // already references it.
-            var pending = new Holder { Depth = 0 };
-            m_current.Value = pending;
-
-            return AwaitEntryAsync(wait, pending);
+            return AwaitEntryAsync(wait);
         }
-
-        /// <summary>
-        /// Drops an entitlement to re-enter that was inherited from the context
-        /// this work was started in.
-        /// </summary>
-        /// <remarks>
-        /// Call this as the first statement of any work started with
-        /// fire-and-forget semantics from a path that may hold the gate. Without
-        /// it that work would believe it already holds the gate, and would run
-        /// inside the guarded region alongside whatever started it.
-        /// <para>
-        /// The write only affects the branch that makes it, so the caller keeps
-        /// the gate it actually holds.
-        /// </para>
-        /// </remarks>
-        public void LeaveInheritedContext()
-        {
-            m_current.Value = null;
-        }
-
-        /// <summary>
-        /// Whether the current context holds the gate.
-        /// </summary>
-        /// <remarks>
-        /// Intended for assertions and for code that must not assume it is
-        /// already inside the guarded region.
-        /// </remarks>
-        public bool IsHeldByCurrentContext => m_current.Value is { Depth: > 0 };
 
         /// <summary>
         /// Whether the gate is held by any context.
@@ -226,118 +136,46 @@ namespace Opc.Ua.Bindings
         /// </remarks>
         internal bool IsHeldBySomeContextForTest => m_semaphore.CurrentCount == 0;
 
-        private async ValueTask<Releaser> AwaitEntryAsync(Task wait, Holder holder)
+        private async ValueTask<Releaser> AwaitEntryAsync(Task wait)
         {
-            try
-            {
-                await wait.ConfigureAwait(false);
-            }
-            catch
-            {
-                // The wait was cancelled, so the published holder never took
-                // ownership. Leaving it at depth zero makes it inert.
-                holder.Depth = 0;
-                throw;
-            }
+            await wait.ConfigureAwait(false);
 
-            // Thread identity is deliberately not recorded here: see
-            // TakeOwnership for why an asynchronous holder must not claim one.
-            holder.Depth = 1;
-
-            return new Releaser(this, holder, owner: true);
+            return new Releaser(this);
         }
 
-        private Releaser TakeOwnership(bool recordThread = true)
+        private void Leave()
         {
-            var holder = new Holder { Depth = 1 };
-            m_current.Value = holder;
-
-            // Thread identity is only recorded for a synchronous entry. An
-            // asynchronous holder releases its thread at every await, and the
-            // thread pool is free to run something else on it — including a
-            // continuation of this very channel. Honouring thread identity for
-            // such a holder would let that unrelated work believe it already
-            // held the gate and run inside the guarded region.
-            if (recordThread)
-            {
-                m_owner = holder;
-                m_owningThreadId = Environment.CurrentManagedThreadId;
-            }
-
-            return new Releaser(this, holder, owner: true);
-        }
-
-        private void Leave(Holder holder, bool owner)
-        {
-            if (!owner)
-            {
-                // A nested entry never releases. Depth is clamped because a
-                // context that inherited this holder may leave after the owner
-                // already released it.
-                if (holder.Depth > 0)
-                {
-                    holder.Depth--;
-                }
-                return;
-            }
-
-            // The owner releases when it leaves, whatever the depth says.
-            // Liveness must not depend on that count: it lives in an AsyncLocal,
-            // so it is shared with every context forked from the owner's, and an
-            // increment from one of those would otherwise leave the owner's own
-            // exit believing the region is still occupied — stranding the
-            // permit and hanging every later entry on this channel.
-            holder.Depth = 0;
-            m_current.Value = null;
-            m_owner = null;
-            m_owningThreadId = 0;
             m_semaphore.Release();
         }
 
         private readonly SemaphoreSlim m_semaphore = new(1, 1);
-        private readonly AsyncLocal<Holder?> m_current = new();
-        private volatile Holder? m_owner;
-        private volatile int m_owningThreadId;
-
-        /// <summary>
-        /// Counts how deeply one logical context has entered the gate.
-        /// </summary>
-        /// <remarks>
-        /// A mutable instance rather than a counter held directly in the
-        /// <see cref="AsyncLocal{T}"/>: a nested frame has to be able to record
-        /// its exit where the frame that entered can see it, and a value written
-        /// to an <see cref="AsyncLocal{T}"/> by a callee is not visible to its
-        /// caller.
-        /// </remarks>
-        internal sealed class Holder
-        {
-            public int Depth;
-        }
 
         /// <summary>
         /// Leaves the gate when disposed.
         /// </summary>
+        /// <remarks>
+        /// A copyable struct, so disposing a copy releases as well. Every use in
+        /// the channel code is a <see langword="using"/> over the value returned
+        /// by <see cref="Enter"/> or <see cref="EnterAsync"/>, which is disposed
+        /// exactly once.
+        /// </remarks>
         internal readonly struct Releaser : IDisposable, IEquatable<Releaser>
         {
-            internal Releaser(ChannelGate gate, Holder holder, bool owner)
+            internal Releaser(ChannelGate gate)
             {
                 m_gate = gate;
-                m_holder = holder;
-                m_owner = owner;
             }
 
             /// <inheritdoc/>
             public void Dispose()
             {
-                m_gate?.Leave(m_holder, m_owner);
+                m_gate?.Leave();
             }
 
             /// <inheritdoc/>
             public bool Equals(Releaser other)
             {
-                return ReferenceEquals(m_gate, other.m_gate) &&
-                    ReferenceEquals(m_holder, other.m_holder) &&
-                    m_owner == other.m_owner;
+                return ReferenceEquals(m_gate, other.m_gate);
             }
 
             /// <inheritdoc/>
@@ -349,7 +187,7 @@ namespace Opc.Ua.Bindings
             /// <inheritdoc/>
             public override int GetHashCode()
             {
-                return HashCode.Combine(m_gate, m_holder, m_owner);
+                return m_gate?.GetHashCode() ?? 0;
             }
 
             public static bool operator ==(Releaser left, Releaser right)
@@ -363,8 +201,6 @@ namespace Opc.Ua.Bindings
             }
 
             private readonly ChannelGate m_gate;
-            private readonly Holder m_holder;
-            private readonly bool m_owner;
         }
     }
 }

--- a/src/Opc.Ua.Core/Stack/Tcp/TcpListenerChannel.cs
+++ b/src/Opc.Ua.Core/Stack/Tcp/TcpListenerChannel.cs
@@ -175,47 +175,44 @@ namespace Opc.Ua.Bindings
         /// <summary>
         /// Sets the callback used to receive notifications of new events.
         /// </summary>
+        /// <remarks>
+        /// Deliberately takes no lock. The listener calls this from the
+        /// reverse-hello completion callback, which the channel invokes inline
+        /// while it holds the gate, so taking the gate here would deadlock. A
+        /// single delegate field needs no more than a volatile write.
+        /// </remarks>
         public void SetRequestReceivedCallback(TcpChannelRequestEventHandler callback)
         {
-            using (Gate.Enter())
-            {
-                RequestReceived = callback;
-            }
+            RequestReceived = callback;
         }
 
         /// <summary>
         /// Sets the callback used to raise channel audit events.
         /// </summary>
+        /// <inheritdoc cref="SetRequestReceivedCallback" path="/remarks"/>
         public void SetReportOpenSecureChannelAuditCallback(
             ReportAuditOpenSecureChannelEventHandler callback)
         {
-            using (Gate.Enter())
-            {
-                ReportAuditOpenSecureChannelEvent = callback;
-            }
+            ReportAuditOpenSecureChannelEvent = callback;
         }
 
         /// <summary>
         /// Sets the callback used to raise channel audit events.
         /// </summary>
+        /// <inheritdoc cref="SetRequestReceivedCallback" path="/remarks"/>
         public void SetReportCloseSecureChannelAuditCallback(
             ReportAuditCloseSecureChannelEventHandler callback)
         {
-            using (Gate.Enter())
-            {
-                ReportAuditCloseSecureChannelEvent = callback;
-            }
+            ReportAuditCloseSecureChannelEvent = callback;
         }
 
         /// <summary>
         /// Sets the callback used to raise channel audit events.
         /// </summary>
+        /// <inheritdoc cref="SetRequestReceivedCallback" path="/remarks"/>
         public void SetReportCertificateAuditCallback(ReportAuditCertificateEventHandler callback)
         {
-            using (Gate.Enter())
-            {
-                ReportAuditCertificateEvent = callback;
-            }
+            ReportAuditCertificateEvent = callback;
         }
 
         /// <summary>
@@ -503,20 +500,21 @@ namespace Opc.Ua.Bindings
         /// <summary>
         /// Handles a socket error.
         /// </summary>
+        /// <remarks>
+        /// Called without the gate held, so it takes it through the locking
+        /// entry points.
+        /// </remarks>
         protected override void HandleSocketError(ServiceResult result)
         {
-            using (Gate.Enter())
+            // channel fault.
+            if (ServiceResult.IsBad(result))
             {
-                // channel fault.
-                if (ServiceResult.IsBad(result))
-                {
-                    ForceChannelFault(result);
-                    return;
-                }
-
-                // gracefully shutdown the channel.
-                ChannelClosed();
+                ForceChannelFault(result);
+                return;
             }
+
+            // gracefully shutdown the channel.
+            ChannelClosed();
         }
 
         /// <summary>
@@ -525,6 +523,27 @@ namespace Opc.Ua.Bindings
         protected void ForceChannelFault(StatusCode statusCode, string format, params object[] args)
         {
             ForceChannelFault(ServiceResult.Create(statusCode, format, args));
+
+            if (m_logger.IsEnabled(LogLevel.Error))
+            {
+                m_logger.TcpListenChannelLog2(ChannelId, Utils.Format(format, args));
+            }
+        }
+
+        /// <summary>
+        /// Forces the channel into a faulted state as a result of a fatal error,
+        /// without taking the gate.
+        /// </summary>
+        /// <remarks>
+        /// For callers that already hold it. See
+        /// <see cref="ForceChannelFaultCore(ServiceResult)"/>.
+        /// </remarks>
+        private protected void ForceChannelFaultCore(
+            StatusCode statusCode,
+            string format,
+            params object[] args)
+        {
+            ForceChannelFaultCore(ServiceResult.Create(statusCode, format, args));
 
             if (m_logger.IsEnabled(LogLevel.Error))
             {
@@ -550,72 +569,109 @@ namespace Opc.Ua.Bindings
         }
 
         /// <summary>
+        /// Forces the channel into a faulted state as a result of a fatal error,
+        /// without taking the gate.
+        /// </summary>
+        /// <remarks>
+        /// For callers that already hold it. See
+        /// <see cref="ForceChannelFaultCore(ServiceResult)"/>.
+        /// </remarks>
+        private protected void ForceChannelFaultCore(
+            Exception exception,
+            StatusCode defaultCode,
+            string format,
+            params object[] args)
+        {
+            ForceChannelFaultCore(ServiceResult.Create(exception, defaultCode, format, args));
+
+            if (m_logger.IsEnabled(LogLevel.Error))
+            {
+                m_logger.TcpListenChannelLog3(exception, ChannelId, Utils.Format(format, args));
+            }
+        }
+
+        /// <summary>
         /// Forces the channel into a faulted state as a result of a fatal error.
         /// </summary>
         protected void ForceChannelFault(ServiceResult reason)
         {
             using (Gate.Enter())
             {
-                CompleteReverseHello(new ServiceResultException(reason));
-
-                // nothing to do if channel already in a faulted state.
-                if (State == TcpChannelState.Faulted)
-                {
-                    return;
-                }
-
-                bool close = false;
-                if (State is not TcpChannelState.Connecting and not TcpChannelState.Opening)
-                {
-                    EndPoint? remoteEndpoint = Transport?.RemoteEndpoint;
-                    if (remoteEndpoint != null)
-                    {
-                        m_logger
-                            .TcpListenChannelLog4(
-                                ChannelName,
-                                remoteEndpoint,
-                                CurrentToken != null ? CurrentToken.ChannelId : 0,
-                                CurrentToken != null ? CurrentToken.TokenId : 0,
-                                reason);
-                    }
-                }
-                else
-                {
-                    // Close immediately if the client never got out of connecting or opening state
-                    close = true;
-                }
-
-                // send error and close response.
-                if (Transport != null && m_responseRequired)
-                {
-                    SendErrorMessage(reason);
-                }
-
-                State = TcpChannelState.Faulted;
-                m_responseRequired = false;
-
-                if (close)
-                {
-                    // mark the RemoteAddress as potential problematic if Basic128Rsa15
-                    if ((SecurityPolicyUri == SecurityPolicies.Basic128Rsa15) &&
-                        (
-                            reason.StatusCode == StatusCodes.BadSecurityChecksFailed ||
-                            reason.StatusCode == StatusCodes.BadTcpMessageTypeInvalid))
-                    {
-                        var tcpTransportListener = Listener as TcpTransportListener;
-                        if (Transport?.RemoteEndpoint is IPEndPoint ipEndpoint)
-                        {
-                            tcpTransportListener?.MarkAsPotentialProblematic(ipEndpoint.Address);
-                        }
-                    }
-
-                    // close channel immediately.
-                    ChannelFaulted();
-                }
-
-                // notify any monitors.
-                NotifyMonitors(reason, close);
+                ForceChannelFaultCore(reason);
             }
+        }
+
+        /// <summary>
+        /// Forces the channel into a faulted state as a result of a fatal error,
+        /// without taking the gate.
+        /// </summary>
+        /// <param name="reason">Why the channel faulted.</param>
+        /// <remarks>
+        /// The gate is not re-entrant, so a caller that already holds it — every
+        /// message dispatch path does — must call this rather than
+        /// <see cref="ForceChannelFault(ServiceResult)"/>.
+        /// </remarks>
+        private protected void ForceChannelFaultCore(ServiceResult reason)
+        {
+            CompleteReverseHello(new ServiceResultException(reason));
+
+            // nothing to do if channel already in a faulted state.
+            if (State == TcpChannelState.Faulted)
+            {
+                return;
+            }
+
+            bool close = false;
+            if (State is not TcpChannelState.Connecting and not TcpChannelState.Opening)
+            {
+                EndPoint? remoteEndpoint = Transport?.RemoteEndpoint;
+                if (remoteEndpoint != null)
+                {
+                    m_logger
+                        .TcpListenChannelLog4(
+                            ChannelName,
+                            remoteEndpoint,
+                            CurrentToken != null ? CurrentToken.ChannelId : 0,
+                            CurrentToken != null ? CurrentToken.TokenId : 0,
+                            reason);
+                }
+            }
+            else
+            {
+                // Close immediately if the client never got out of connecting or opening state
+                close = true;
+            }
+
+            // send error and close response.
+            if (Transport != null && m_responseRequired)
+            {
+                SendErrorMessage(reason);
+            }
+
+            State = TcpChannelState.Faulted;
+            m_responseRequired = false;
+
+            if (close)
+            {
+                // mark the RemoteAddress as potential problematic if Basic128Rsa15
+                if ((SecurityPolicyUri == SecurityPolicies.Basic128Rsa15) &&
+                    (
+                        reason.StatusCode == StatusCodes.BadSecurityChecksFailed ||
+                        reason.StatusCode == StatusCodes.BadTcpMessageTypeInvalid))
+                {
+                    var tcpTransportListener = Listener as TcpTransportListener;
+                    if (Transport?.RemoteEndpoint is IPEndPoint ipEndpoint)
+                    {
+                        tcpTransportListener?.MarkAsPotentialProblematic(ipEndpoint.Address);
+                    }
+                }
+
+                // close channel immediately.
+                ChannelFaulted();
+            }
+
+            // notify any monitors.
+            NotifyMonitors(reason, close);
         }
 
         /// <summary>
@@ -647,7 +703,9 @@ namespace Opc.Ua.Bindings
                         reason.ToString());
                 }
 
-                // close channel.
+                // close channel. Safe under the gate: the listener removes the
+                // channel from a lock-free map and disposes it, and disposal
+                // deliberately does not take the gate.
                 ChannelClosed();
             }
         }
@@ -776,7 +834,7 @@ namespace Opc.Ua.Bindings
 
                 m_logger.TcpListenChannelLog8(e, ChannelId, requestId, fault.StatusCode);
 
-                ForceChannelFault(
+                ForceChannelFaultCore(
                     ServiceResult.Create(
                         e,
                         StatusCodes.BadTcpInternalError,
@@ -840,24 +898,44 @@ namespace Opc.Ua.Bindings
         /// <summary>
         /// The channel request event handler.
         /// </summary>
-        protected TcpChannelRequestEventHandler? RequestReceived { get; private set; }
+        protected TcpChannelRequestEventHandler? RequestReceived
+        {
+            get => m_requestReceived;
+            private set => m_requestReceived = value;
+        }
 
         /// <summary>
         /// The report open secure channel audit event handler.
         /// </summary>
-        protected ReportAuditOpenSecureChannelEventHandler? ReportAuditOpenSecureChannelEvent { get; private set; }
+        protected ReportAuditOpenSecureChannelEventHandler? ReportAuditOpenSecureChannelEvent
+        {
+            get => m_reportAuditOpenSecureChannelEvent;
+            private set => m_reportAuditOpenSecureChannelEvent = value;
+        }
 
         /// <summary>
         /// The report close secure channel audit event handler.
         /// </summary>
-        protected ReportAuditCloseSecureChannelEventHandler? ReportAuditCloseSecureChannelEvent { get; private set; }
+        protected ReportAuditCloseSecureChannelEventHandler? ReportAuditCloseSecureChannelEvent
+        {
+            get => m_reportAuditCloseSecureChannelEvent;
+            private set => m_reportAuditCloseSecureChannelEvent = value;
+        }
 
         /// <summary>
         /// The report certificate audit event handler.
         /// </summary>
-        protected ReportAuditCertificateEventHandler? ReportAuditCertificateEvent { get; private set; }
+        protected ReportAuditCertificateEventHandler? ReportAuditCertificateEvent
+        {
+            get => m_reportAuditCertificateEvent;
+            private set => m_reportAuditCertificateEvent = value;
+        }
 
         private readonly ILogger m_logger;
+        private volatile TcpChannelRequestEventHandler? m_requestReceived;
+        private volatile ReportAuditOpenSecureChannelEventHandler? m_reportAuditOpenSecureChannelEvent;
+        private volatile ReportAuditCloseSecureChannelEventHandler? m_reportAuditCloseSecureChannelEvent;
+        private volatile ReportAuditCertificateEventHandler? m_reportAuditCertificateEvent;
         private bool m_responseRequired;
         private uint m_lastTokenId;
         private int m_sessionCount;

--- a/src/Opc.Ua.Core/Stack/Tcp/TcpListenerChannel.cs
+++ b/src/Opc.Ua.Core/Stack/Tcp/TcpListenerChannel.cs
@@ -627,13 +627,12 @@ namespace Opc.Ua.Bindings
                 EndPoint? remoteEndpoint = Transport?.RemoteEndpoint;
                 if (remoteEndpoint != null)
                 {
-                    m_logger
-                        .TcpListenChannelLog4(
-                            ChannelName,
-                            remoteEndpoint,
-                            CurrentToken != null ? CurrentToken.ChannelId : 0,
-                            CurrentToken != null ? CurrentToken.TokenId : 0,
-                            reason);
+                    m_logger.TcpListenChannelLog4(
+                        ChannelName,
+                        remoteEndpoint,
+                        CurrentToken != null ? CurrentToken.ChannelId : 0,
+                        CurrentToken != null ? CurrentToken.TokenId : 0,
+                        reason);
                 }
             }
             else
@@ -654,9 +653,8 @@ namespace Opc.Ua.Bindings
             if (close)
             {
                 // mark the RemoteAddress as potential problematic if Basic128Rsa15
-                if ((SecurityPolicyUri == SecurityPolicies.Basic128Rsa15) &&
-                    (
-                        reason.StatusCode == StatusCodes.BadSecurityChecksFailed ||
+                if (SecurityPolicyUri == SecurityPolicies.Basic128Rsa15 &&
+                    (reason.StatusCode == StatusCodes.BadSecurityChecksFailed ||
                         reason.StatusCode == StatusCodes.BadTcpMessageTypeInvalid))
                 {
                     var tcpTransportListener = Listener as TcpTransportListener;

--- a/src/Opc.Ua.Core/Stack/Tcp/TcpReverseConnectChannel.cs
+++ b/src/Opc.Ua.Core/Stack/Tcp/TcpReverseConnectChannel.cs
@@ -147,7 +147,7 @@ namespace Opc.Ua.Bindings
                     }
 
                     // invalid message type - must close socket and reconnect.
-                    ForceChannelFault(
+                    ForceChannelFaultCore(
                         StatusCodes.BadTcpMessageTypeInvalid,
                         "The reverse connect handler does not recognize the message type: {0:X8}.",
                         messageType);
@@ -169,7 +169,7 @@ namespace Opc.Ua.Bindings
             // validate the channel state.
             if (State != TcpChannelState.Connecting)
             {
-                ForceChannelFault(
+                ForceChannelFaultCore(
                     StatusCodes.BadTcpMessageTypeInvalid,
                     "Client sent an unexpected ReverseHello message.");
                 return false;
@@ -192,10 +192,6 @@ namespace Opc.Ua.Bindings
 
                 var t = Task.Run(async () =>
                 {
-                    // Started while the gate is held, and ForceChannelFault takes
-                    // it, so the inherited entitlement has to be dropped first.
-                    Gate.LeaveInheritedContext();
-
                     try
                     {
                         if (!await Listener
@@ -219,7 +215,7 @@ namespace Opc.Ua.Bindings
             }
             catch (Exception e)
             {
-                ForceChannelFault(
+                ForceChannelFaultCore(
                     e,
                     StatusCodes.BadTcpInternalError,
                     "Unexpected error while processing a ReverseHello message.");

--- a/src/Opc.Ua.Core/Stack/Tcp/TcpServerChannel.cs
+++ b/src/Opc.Ua.Core/Stack/Tcp/TcpServerChannel.cs
@@ -98,16 +98,19 @@ namespace Opc.Ua.Bindings
         /// <summary>
         /// An overrideable version of the Dispose.
         /// </summary>
+        /// <remarks>
+        /// Deliberately does not take the gate. Disposal is terminal and is not
+        /// thread-safe by contract, and the listener disposes the channel from
+        /// inside <c>ChannelClosed</c>, which is itself reached with the gate
+        /// held — taking it here would deadlock.
+        /// </remarks>
         protected override void Dispose(bool disposing)
         {
             if (disposing)
             {
-                using (Gate.Enter())
-                {
-                    ClientCertificate?.Dispose();
-                    ClientCertificate = null;
-                    base.Dispose(disposing);
-                }
+                ClientCertificate?.Dispose();
+                ClientCertificate = null;
+                base.Dispose(disposing);
             }
         }
 
@@ -200,9 +203,6 @@ namespace Opc.Ua.Bindings
             Uri endpointUrl,
             ReverseConnectAsyncResult ar)
         {
-            // Detached from the caller, which may hold the gate.
-            Gate.LeaveInheritedContext();
-
             try
             {
                 await transport.ConnectAsync(endpointUrl, CancellationToken.None).ConfigureAwait(false);
@@ -370,6 +370,9 @@ namespace Opc.Ua.Bindings
             ArraySegment<byte> messageChunk,
             CancellationToken ct)
         {
+            PendingRequestDispatch? pending = null;
+            bool ownsBuffer;
+
             using (await Gate.EnterAsync(ct).ConfigureAwait(false))
             {
                 SetResponseRequired(true);
@@ -383,44 +386,64 @@ namespace Opc.Ua.Bindings
                         //     Utils.TraceMasks.ServiceDetail,
                         //     "ChannelId {Id}: ProcessRequestMessage",
                         //     ChannelId);
-                        return ProcessRequestMessage(messageType, messageChunk);
+                        ownsBuffer = ProcessRequestMessage(messageType, messageChunk, out pending);
                     }
-
                     // check for hello.
-                    if (messageType == TcpMessageType.Hello)
+                    else if (messageType == TcpMessageType.Hello)
                     {
                         m_logger.TcpServerLog1(ChannelId);
-                        return ProcessHelloMessage(messageChunk);
+                        ownsBuffer = ProcessHelloMessage(messageChunk);
                     }
-
                     // process open secure channel repsonse.
-                    if (TcpMessageType.IsType(messageType, TcpMessageType.Open))
+                    else if (TcpMessageType.IsType(messageType, TcpMessageType.Open))
                     {
                         m_logger.TcpServerLog2(ChannelId);
-                        return await ProcessOpenSecureChannelRequestAsync(
+                        ownsBuffer = await ProcessOpenSecureChannelRequestAsync(
                             messageType, messageChunk, ct).ConfigureAwait(false);
                     }
-
                     // process close secure channel response.
-                    if (TcpMessageType.IsType(messageType, TcpMessageType.Close))
+                    else if (TcpMessageType.IsType(messageType, TcpMessageType.Close))
                     {
                         m_logger.TcpServerLog3(ChannelId);
-                        return ProcessCloseSecureChannelRequest(messageType, messageChunk);
+                        ownsBuffer = ProcessCloseSecureChannelRequest(messageType, messageChunk);
                     }
+                    else
+                    {
+                        // invalid message type - must close socket and reconnect.
+                        ForceChannelFaultCore(
+                            StatusCodes.BadTcpMessageTypeInvalid,
+                            "The server does not recognize the message type: {0:X8}.",
+                            messageType);
 
-                    // invalid message type - must close socket and reconnect.
-                    ForceChannelFault(
-                        StatusCodes.BadTcpMessageTypeInvalid,
-                        "The server does not recognize the message type: {0:X8}.",
-                        messageType);
-
-                    return false;
+                        ownsBuffer = false;
+                    }
                 }
                 finally
                 {
                     SetResponseRequired(false);
                 }
             }
+
+            // Outside the gate on purpose: the handler is application code, and
+            // its continuation may call SendResponse straight back on this
+            // stack. See ProcessRequestMessage.
+            if (pending != null)
+            {
+                try
+                {
+                    RequestReceived?.Invoke(this, pending.RequestId, pending.Request);
+                }
+                catch (Exception e)
+                {
+                    // The handler is application code and may throw. Letting it
+                    // escape would unwind into the receive loop, which returns
+                    // the chunk buffer that this call already reported taking
+                    // ownership of — a double release.
+                    m_logger.TcpServerLog16(e);
+                }
+            }
+
+            return ownsBuffer;
         }
 
         /// <summary>
@@ -463,7 +486,7 @@ namespace Opc.Ua.Bindings
             // validate the channel state.
             if (State != TcpChannelState.Connecting)
             {
-                ForceChannelFault(
+                ForceChannelFaultCore(
                     StatusCodes.BadTcpMessageTypeInvalid,
                     "Client sent an unexpected Hello message.");
                 return false;
@@ -500,7 +523,7 @@ namespace Opc.Ua.Bindings
                     {
                         if (length > TcpMessageLimits.MaxEndpointUrlLength)
                         {
-                            ForceChannelFault(StatusCodes.BadTcpEndpointUrlInvalid);
+                            ForceChannelFaultCore(StatusCodes.BadTcpEndpointUrlInvalid);
                             return false;
                         }
 
@@ -514,7 +537,7 @@ namespace Opc.Ua.Bindings
                         if (!SetEndpointUrl(
                             Encoding.UTF8.GetString(endpointUrl, 0, endpointUrl.Length)))
                         {
-                            ForceChannelFault(StatusCodes.BadTcpEndpointUrlInvalid);
+                            ForceChannelFaultCore(StatusCodes.BadTcpEndpointUrlInvalid);
                             return false;
                         }
                     }
@@ -599,7 +622,7 @@ namespace Opc.Ua.Bindings
             }
             catch (Exception e)
             {
-                ForceChannelFault(
+                ForceChannelFaultCore(
                     e,
                     StatusCodes.BadTcpInternalError,
                     "Unexpected error while processing a Hello message.");
@@ -623,7 +646,7 @@ namespace Opc.Ua.Bindings
             // validate the channel state.
             if (State is not TcpChannelState.Opening and not TcpChannelState.Open)
             {
-                ForceChannelFault(
+                ForceChannelFaultCore(
                     StatusCodes.BadTcpMessageTypeInvalid,
                     "Client sent an unexpected OpenSecureChannel message.");
                 return false;
@@ -705,7 +728,7 @@ namespace Opc.Ua.Bindings
                             innerException.InnerResult.StatusCode == StatusCodes
                                 .BadCertificateUntrusted))
                     {
-                        ForceChannelFault(
+                        ForceChannelFaultCore(
                             StatusCodes.BadSecurityChecksFailed,
                             errorSecurityChecksFailed);
                         return false;
@@ -720,12 +743,12 @@ namespace Opc.Ua.Bindings
                         innerException.StatusCode == StatusCodes.BadCertificateIssuerRevocationUnknown ||
                         innerException.StatusCode == StatusCodes.BadCertificateIssuerRevoked)
                     {
-                        ForceChannelFault(innerException, innerException.StatusCode, e.Message);
+                        ForceChannelFaultCore(innerException, innerException.StatusCode, e.Message);
                         return false;
                     }
                 }
 
-                ForceChannelFault(StatusCodes.BadSecurityChecksFailed, errorSecurityChecksFailed);
+                ForceChannelFaultCore(StatusCodes.BadSecurityChecksFailed, errorSecurityChecksFailed);
                 return false;
             }
 
@@ -750,11 +773,11 @@ namespace Opc.Ua.Bindings
                 // check if it is necessary to wait for more chunks.
                 if (!TcpMessageType.IsFinal(messageType))
                 {
-                    SaveIntermediateChunk(requestId, messageBody, true);
+                    SaveIntermediateChunk(requestId, messageBody, true, gateHeld: true);
                     return false;
                 }
                 // get the chunks to process.
-                chunksToProcess = GetSavedChunks(requestId, messageBody, true);
+                chunksToProcess = GetSavedChunks(requestId, messageBody, true, gateHeld: true);
 
                 using var openRequestStream = new ArraySegmentStream(chunksToProcess);
                 request =
@@ -1019,7 +1042,7 @@ namespace Opc.Ua.Bindings
 
                 m_logger.TcpServerLog8(e, ChannelId, requestId, fault.StatusCode);
 
-                ForceChannelFault(
+                ForceChannelFaultCore(
                     ServiceResult.Create(
                         e,
                         StatusCodes.BadTcpInternalError,
@@ -1203,12 +1226,12 @@ namespace Opc.Ua.Bindings
                 // check if it is necessary to wait for more chunks.
                 if (!TcpMessageType.IsFinal(messageType))
                 {
-                    SaveIntermediateChunk(requestId, messageBody, true);
+                    SaveIntermediateChunk(requestId, messageBody, true, gateHeld: true);
                     return false;
                 }
 
                 // get the chunks to process.
-                chunksToProcess = GetSavedChunks(requestId, messageBody, true);
+                chunksToProcess = GetSavedChunks(requestId, messageBody, true, gateHeld: true);
 
                 using var closeRequestStream = new ArraySegmentStream(chunksToProcess);
                 CloseSecureChannelRequest request =
@@ -1251,18 +1274,38 @@ namespace Opc.Ua.Bindings
         }
 
         /// <summary>
+        /// A decoded request waiting to be handed to the server once the channel
+        /// gate has been released.
+        /// </summary>
+        /// <param name="RequestId">The request identifier.</param>
+        /// <param name="Request">The decoded request.</param>
+        private sealed record PendingRequestDispatch(uint RequestId, IServiceRequest Request);
+
+        /// <summary>
         /// Processes a request message.
         /// </summary>
+        /// <param name="messageType">The UA TCP message type.</param>
+        /// <param name="messageChunk">The chunk to process.</param>
+        /// <param name="pending">
+        /// Set to the request to hand to the server once the caller has left the
+        /// gate, or <see langword="null"/> when there is nothing to dispatch.
+        /// </param>
+        /// <returns>True if the implementor takes ownership of the buffer.</returns>
         /// <exception cref="ServiceResultException"></exception>
-        private bool ProcessRequestMessage(uint messageType, ArraySegment<byte> messageChunk)
+        private bool ProcessRequestMessage(
+            uint messageType,
+            ArraySegment<byte> messageChunk,
+            out PendingRequestDispatch? pending)
         {
+            pending = null;
+
             // Communication is active on the channel
             UpdateLastActiveTime();
 
             // validate the channel state.
             if (State != TcpChannelState.Open)
             {
-                ForceChannelFault(
+                ForceChannelFaultCore(
                     StatusCodes.BadTcpMessageTypeInvalid,
                     "Client sent an unexpected request message.");
                 return false;
@@ -1300,7 +1343,7 @@ namespace Opc.Ua.Bindings
             }
             catch (Exception e)
             {
-                ForceChannelFault(
+                ForceChannelFaultCore(
                     e,
                     StatusCodes.BadSecurityChecksFailed,
                     "Could not verify security on incoming request.");
@@ -1331,14 +1374,14 @@ namespace Opc.Ua.Bindings
                 if (TcpMessageType.IsAbort(messageType))
                 {
                     m_logger.TcpServerLog15(ChannelId, requestId);
-                    chunksToProcess = GetSavedChunks(requestId, messageBody, true);
+                    chunksToProcess = GetSavedChunks(requestId, messageBody, true, gateHeld: true);
                     return true;
                 }
 
                 // check if it is necessary to wait for more chunks.
                 if (!TcpMessageType.IsFinal(messageType))
                 {
-                    bool firstChunk = SaveIntermediateChunk(requestId, messageBody, true);
+                    bool firstChunk = SaveIntermediateChunk(requestId, messageBody, true, gateHeld: true);
 
                     // validate the type is allowed with a discovery channel
                     if (DiscoveryOnly)
@@ -1357,7 +1400,7 @@ namespace Opc.Ua.Bindings
                         else if (GetSavedChunksTotalSize() > TcpMessageLimits
                             .DefaultDiscoveryMaxMessageSize)
                         {
-                            chunksToProcess = GetSavedChunks(0, messageBody, true);
+                            chunksToProcess = GetSavedChunks(0, messageBody, true, gateHeld: true);
                             SendServiceFault(
                                 token,
                                 requestId,
@@ -1388,7 +1431,7 @@ namespace Opc.Ua.Bindings
                 }
 
                 // get the chunks to process.
-                chunksToProcess = GetSavedChunks(requestId, messageBody, true);
+                chunksToProcess = GetSavedChunks(requestId, messageBody, true, gateHeld: true);
 
                 // decode the request.
                 using var serviceRequestStream = new ArraySegmentStream(chunksToProcess);
@@ -1419,8 +1462,13 @@ namespace Opc.Ua.Bindings
                     return true;
                 }
 
-                // hand the request to the server.
-                RequestReceived?.Invoke(this, requestId, request);
+                // Hand the request to the server, but not while the gate is
+                // held. The handler is application code and its continuation may
+                // call SendResponse straight back on this stack, which takes the
+                // gate; more importantly, holding the channel's lock across
+                // arbitrary request processing serialises the whole channel on
+                // it. The caller dispatches this once it has left the gate.
+                pending = new PendingRequestDispatch(requestId, request);
 
                 return true;
             }
@@ -1544,9 +1592,13 @@ namespace Opc.Ua.Bindings
         /// <summary>
         /// Closes the channel in case the message limits have been exceeded
         /// </summary>
-        protected override void DoMessageLimitsExceeded()
+        /// <remarks>
+        /// <c>ChannelClosed</c> takes no lock, so it is correct from either
+        /// context.
+        /// </remarks>
+        protected override void DoMessageLimitsExceeded(bool gateHeld)
         {
-            base.DoMessageLimitsExceeded();
+            base.DoMessageLimitsExceeded(gateHeld);
             ChannelClosed();
         }
 
@@ -1568,7 +1620,7 @@ namespace Opc.Ua.Bindings
                 typeId != ObjectIds.FindServersRequest_Encoding_DefaultBinary &&
                 typeId != ObjectIds.FindServersOnNetworkRequest_Encoding_DefaultBinary)
             {
-                chunksToProcess = GetSavedChunks(0, messageBody, true);
+                chunksToProcess = GetSavedChunks(0, messageBody, true, gateHeld: true);
                 SendServiceFault(
                     token,
                     requestId,

--- a/src/Opc.Ua.Core/Stack/Tcp/UaSCBinaryChannel.Asymmetric.cs
+++ b/src/Opc.Ua.Core/Stack/Tcp/UaSCBinaryChannel.Asymmetric.cs
@@ -47,22 +47,17 @@ namespace Opc.Ua.Bindings
         /// <summary>
         /// Returns the endpoint description selected by the client.
         /// </summary>
+        /// <remarks>
+        /// Deliberately lock-free. This publishes a single reference, so a
+        /// volatile read and write give the same visibility the gate did, and
+        /// taking the gate here made every gate-holding caller that reads the
+        /// property a re-entrant one — <c>ConnectAsync</c> reads it four times
+        /// while holding it.
+        /// </remarks>
         public EndpointDescription? EndpointDescription
         {
-            get
-            {
-                using (Gate.Enter())
-                {
-                    return m_selectedEndpoint;
-                }
-            }
-            protected set
-            {
-                using (Gate.Enter())
-                {
-                    m_selectedEndpoint = value;
-                }
-            }
+            get => Volatile.Read(ref m_selectedEndpoint);
+            protected set => Volatile.Write(ref m_selectedEndpoint, value);
         }
 
         /// <summary>
@@ -1249,7 +1244,7 @@ namespace Opc.Ua.Bindings
                             endpoint.SecurityPolicyUri == SecurityPolicyUri)
                         {
                             SecurityMode = endpoint.SecurityMode;
-                            m_selectedEndpoint = endpoint;
+                            Volatile.Write(ref m_selectedEndpoint, endpoint);
                             using (CertificateEntry? instanceEntry =
                                 m_serverCertificates!
                                     .AcquireApplicationCertificateBySecurityPolicy(SecurityPolicyUri))
@@ -1315,7 +1310,7 @@ namespace Opc.Ua.Bindings
                         ? null
                         : BuildServerCertificateChain(instanceEntry);
                 }
-                m_selectedEndpoint = endpoint;
+                Volatile.Write(ref m_selectedEndpoint, endpoint);
                 return true;
             }
 
@@ -1560,7 +1555,7 @@ namespace Opc.Ua.Bindings
                         SecurityPolicyUri = securityPolicyUri;
                         DiscoveryOnly = false;
                         m_uninitialized = false;
-                        m_selectedEndpoint = endpoint;
+                        Volatile.Write(ref m_selectedEndpoint, endpoint);
 
                         // recalculate the key sizes.
                         CalculateSymmetricKeySizes();
@@ -1583,7 +1578,7 @@ namespace Opc.Ua.Bindings
                 SecurityPolicyUri = SecurityPolicies.None;
                 DiscoveryOnly = true;
                 m_uninitialized = false;
-                m_selectedEndpoint = null;
+                Volatile.Write(ref m_selectedEndpoint, null);
             }
         }
 

--- a/src/Opc.Ua.Core/Stack/Tcp/UaSCBinaryChannel.cs
+++ b/src/Opc.Ua.Core/Stack/Tcp/UaSCBinaryChannel.cs
@@ -374,12 +374,15 @@ namespace Opc.Ua.Bindings
         /// <summary>
         /// Raised when the state of the channel changes.
         /// </summary>
+        /// <remarks>
+        /// Deliberately takes no lock, for the same reason as
+        /// <c>TcpListenerChannel.SetRequestReceivedCallback</c>: a single
+        /// delegate field needs no more than a volatile write, and the gate is
+        /// not re-entrant.
+        /// </remarks>
         public void SetStateChangedCallback(TcpChannelStateEventHandler callback)
         {
-            using (Gate.Enter())
-            {
-                m_stateChanged = callback;
-            }
+            m_stateChanged = callback;
         }
 
         /// <summary>
@@ -513,10 +516,19 @@ namespace Opc.Ua.Bindings
         /// <summary>
         /// Saves an intermediate chunk for an incoming message.
         /// </summary>
+        /// <param name="requestId">The request the chunk belongs to.</param>
+        /// <param name="chunk">The chunk to save.</param>
+        /// <param name="isServerContext">Whether this is a server channel.</param>
+        /// <param name="gateHeld">
+        /// Whether the caller already holds the channel gate. Passed on to
+        /// <see cref="DoMessageLimitsExceeded(bool)"/>, which tears the channel
+        /// down and must know whether it may take the gate.
+        /// </param>
         protected bool SaveIntermediateChunk(
             uint requestId,
             ArraySegment<byte> chunk,
-            bool isServerContext)
+            bool isServerContext,
+            bool gateHeld)
         {
             bool firstChunk = false;
             if (m_partialMessageChunks == null)
@@ -542,7 +554,7 @@ namespace Opc.Ua.Bindings
 
             if (chunkOrSizeLimitsExceeded)
             {
-                DoMessageLimitsExceeded();
+                DoMessageLimitsExceeded(gateHeld);
                 return firstChunk;
             }
 
@@ -558,12 +570,14 @@ namespace Opc.Ua.Bindings
         /// <summary>
         /// Returns the chunks saved for message.
         /// </summary>
+        /// <inheritdoc cref="SaveIntermediateChunk" path="/param"/>
         protected BufferCollection GetSavedChunks(
             uint requestId,
             ArraySegment<byte> chunk,
-            bool isServerContext)
+            bool isServerContext,
+            bool gateHeld)
         {
-            SaveIntermediateChunk(requestId, chunk, isServerContext);
+            SaveIntermediateChunk(requestId, chunk, isServerContext, gateHeld);
             BufferCollection savedChunks = m_partialMessageChunks!;
             m_partialMessageChunks = null;
             return savedChunks;
@@ -580,7 +594,12 @@ namespace Opc.Ua.Bindings
         /// <summary>
         /// Code executed when the message limits are exceeded.
         /// </summary>
-        protected virtual void DoMessageLimitsExceeded()
+        /// <param name="gateHeld">
+        /// Whether the caller already holds the channel gate. The gate is not
+        /// re-entrant, so an override that tears the channel down must call the
+        /// lock-free core of that teardown when this is <c>true</c>.
+        /// </param>
+        protected virtual void DoMessageLimitsExceeded(bool gateHeld)
         {
             m_logger.UaSCChannelLog5(ChannelId);
         }
@@ -685,12 +704,15 @@ namespace Opc.Ua.Bindings
         /// Reports a fatal transport-level error (connection closed, framing
         /// error, etc.) from the receive loop into the channel pipeline.
         /// </summary>
+        /// <remarks>
+        /// Deliberately does not hold the gate. <see cref="HandleSocketError"/>
+        /// tears the channel down, which notifies the listener, which disposes
+        /// the channel — and disposal takes the gate. Each override takes the
+        /// gate for the state it actually mutates instead.
+        /// </remarks>
         protected virtual void OnTransportError(ServiceResult result)
         {
-            using (Gate.Enter())
-            {
-                HandleSocketError(result);
-            }
+            HandleSocketError(result);
         }
 
         /// <summary>
@@ -742,11 +764,6 @@ namespace Opc.Ua.Bindings
             m_receiveLoopTask = Task.Run(
                 async () =>
                 {
-                    // Started from Attach, which holds the gate. Without this the
-                    // loop would inherit the right to re-enter and would run
-                    // inside the guarded region alongside whatever started it.
-                    Gate.LeaveInheritedContext();
-
                     try
                     {
                         await loopBody(transport, ct).ConfigureAwait(false);
@@ -986,10 +1003,6 @@ namespace Opc.Ua.Bindings
             ReadOnlyMemory<byte> chunk,
             byte[] backingBuffer)
         {
-            // The continuation may resume on another thread while the caller
-            // still holds the gate, so it must not carry the caller's holder.
-            Gate.LeaveInheritedContext();
-
             try
             {
                 await transport.SendChunkAsync(chunk, CancellationToken.None).ConfigureAwait(false);
@@ -1023,10 +1036,6 @@ namespace Opc.Ua.Bindings
             byte[] backingBuffer,
             object? state)
         {
-            // Started while the gate may be held, and completes by calling
-            // HandleWriteComplete, which takes it.
-            Gate.LeaveInheritedContext();
-
             ServiceResult result = ServiceResult.Good;
             int sent = chunk.Length;
             try
@@ -1068,10 +1077,6 @@ namespace Opc.Ua.Bindings
             BufferCollection buffers,
             object? state)
         {
-            // Started while the gate may be held, and completes by calling
-            // HandleWriteComplete, which takes it.
-            Gate.LeaveInheritedContext();
-
             ServiceResult result = ServiceResult.Good;
             int sent = buffers.TotalSize;
             try
@@ -1117,9 +1122,6 @@ namespace Opc.Ua.Bindings
         {
             _ = Task.Run(() =>
             {
-                // Detached, and the gate may be held by whoever queued the write.
-                Gate.LeaveInheritedContext();
-
                 try
                 {
                     HandleWriteComplete(buffers, state, sent, result);
@@ -1272,10 +1274,9 @@ namespace Opc.Ua.Bindings
         /// secure channel open path has to await once a private key may be served
         /// over a network.
         /// <para>
-        /// It is re-entrant, so the paths that take it while already holding it
-        /// behave as they did. Work started with fire-and-forget semantics from a
-        /// path that may hold it must call
-        /// <see cref="ChannelGate.LeaveInheritedContext"/> first.
+        /// Unlike a monitor it is <b>not re-entrant</b>. A method that runs with
+        /// the gate held must call the lock-free <c>Core</c> variant of anything
+        /// that would otherwise take it again.
         /// </para>
         /// </remarks>
         internal ChannelGate Gate { get; } = new();
@@ -1487,7 +1488,7 @@ namespace Opc.Ua.Bindings
         private Task? m_receiveLoopTask;
         private int m_receiveLoopRunning;
 
-        private TcpChannelStateEventHandler? m_stateChanged;
+        private volatile TcpChannelStateEventHandler? m_stateChanged;
         private const uint kMaxValueLegacyTrue = TcpMessageLimits.MinSequenceNumber;
         private const uint kMaxValueLegacyFalse = uint.MaxValue;
     }

--- a/src/Opc.Ua.Core/Stack/Tcp/UaSCBinaryClientChannel.cs
+++ b/src/Opc.Ua.Core/Stack/Tcp/UaSCBinaryClientChannel.cs
@@ -460,7 +460,7 @@ namespace Opc.Ua.Bindings
             // check state.
             if (State != TcpChannelState.Connecting)
             {
-                ForceReconnect(
+                ForceReconnectCore(
                     ServiceResult.Create(
                         StatusCodes.BadTcpMessageTypeInvalid,
                         "Server sent an unexpected acknowledge message."));
@@ -674,7 +674,7 @@ namespace Opc.Ua.Bindings
             // validate the channel state.
             if (State is not TcpChannelState.Opening and not TcpChannelState.Open)
             {
-                ForceReconnect(
+                ForceReconnectCore(
                     ServiceResult.Create(
                         StatusCodes.BadTcpMessageTypeInvalid,
                         "Server sent an unexpected OpenSecureChannel response."));
@@ -728,7 +728,7 @@ namespace Opc.Ua.Bindings
 
                 m_logger.UaSCClientLog9(e, ChannelId);
 
-                ForceReconnect(
+                ForceReconnectCore(
                     ServiceResult.Create(
                         e,
                         StatusCodes.BadSecurityChecksFailed,
@@ -749,12 +749,12 @@ namespace Opc.Ua.Bindings
                 // check if it is necessary to wait for more chunks.
                 if (!TcpMessageType.IsFinal(messageType))
                 {
-                    SaveIntermediateChunk(requestId, messageBody, false);
+                    SaveIntermediateChunk(requestId, messageBody, false, gateHeld: true);
                     return false;
                 }
 
                 // get the chunks to process.
-                chunksToProcess = GetSavedChunks(requestId, messageBody, false);
+                chunksToProcess = GetSavedChunks(requestId, messageBody, false, gateHeld: true);
 
                 // read message body.
 
@@ -850,15 +850,26 @@ namespace Opc.Ua.Bindings
         /// <summary>
         /// Closes the channel in case the message limits have been exceeded
         /// </summary>
-        protected override void DoMessageLimitsExceeded()
+        protected override void DoMessageLimitsExceeded(bool gateHeld)
         {
-            base.DoMessageLimitsExceeded();
+            base.DoMessageLimitsExceeded(gateHeld);
+
+            if (gateHeld)
+            {
+                ShutdownCore(new ServiceResult(StatusCodes.BadResponseTooLarge));
+                return;
+            }
+
             Shutdown(new ServiceResult(StatusCodes.BadResponseTooLarge));
         }
 
         /// <summary>
         /// Handles a socket error.
         /// </summary>
+        /// <remarks>
+        /// Called without the gate held, so it takes it through the locking
+        /// entry point.
+        /// </remarks>
         protected override void HandleSocketError(ServiceResult result)
         {
             ForceReconnect(result);
@@ -893,8 +904,12 @@ namespace Opc.Ua.Bindings
             ArraySegment<byte> messageChunk,
             CancellationToken ct)
         {
-            // process a response.
-            if (TcpMessageType.IsType(messageType, TcpMessageType.Message))
+            // Processed outside the gate. ProcessResponseMessage takes the gate
+            // itself where it needs it, and handling both response paths the
+            // same way keeps it from being a caller that sometimes holds the
+            // gate and sometimes does not.
+            if (TcpMessageType.IsType(messageType, TcpMessageType.Message) ||
+                TcpMessageType.IsType(messageType, TcpMessageType.Close))
             {
                 m_logger.UaSCClientLog11(ChannelId);
                 return ProcessResponseMessage(messageType, messageChunk);
@@ -922,15 +937,9 @@ namespace Opc.Ua.Bindings
                     return await ProcessOpenSecureChannelResponseAsync(
                         messageType, messageChunk, ct).ConfigureAwait(false);
                 }
-                // process a response to a close request.
-                else if (TcpMessageType.IsType(messageType, TcpMessageType.Close))
-                {
-                    m_logger.UaSCClientLog15(ChannelId);
-                    return ProcessResponseMessage(messageType, messageChunk);
-                }
 
                 // invalid message type - must close socket and reconnect.
-                ForceReconnect(
+                ForceReconnectCore(
                     ServiceResult.Create(
                         StatusCodes.BadTcpMessageTypeInvalid,
                         "The client does not recognize the message type: {0:X8}.",
@@ -998,6 +1007,21 @@ namespace Opc.Ua.Bindings
         {
             using (Gate.Enter())
             {
+                CompleteConnectCore(operation);
+            }
+        }
+
+        /// <summary>
+        /// Completes the connect handshake without taking the gate.
+        /// </summary>
+        /// <param name="operation">The pending handshake operation.</param>
+        /// <remarks>
+        /// The gate is not re-entrant, so a caller that already holds it must
+        /// call this rather than <see cref="CompleteConnect"/>.
+        /// </remarks>
+        private void CompleteConnectCore(WriteOperation operation)
+        {
+            {
                 try
                 {
                     // check for closed transport.
@@ -1031,10 +1055,6 @@ namespace Opc.Ua.Bindings
         /// <exception cref="ServiceResultException"></exception>
         private async void OnScheduledHandshakeAsync(object? state)
         {
-            // A timer callback, which runs on the context the timer was created
-            // in. That may have been holding the gate.
-            Gate.LeaveInheritedContext();
-
             if (m_via == null)
             {
                 throw ServiceResultException.Unexpected("Endpoint not defined.");
@@ -1045,7 +1065,7 @@ namespace Opc.Ua.Bindings
 
                 IUaSCByteTransport? transport = null;
                 WriteOperation? operation = null;
-                    using (await Gate.EnterAsync(CancellationToken.None).ConfigureAwait(false))
+                using (await Gate.EnterAsync(CancellationToken.None).ConfigureAwait(false))
                 {
                     // check if renewing a token.
                     var token = state as ChannelToken;
@@ -1172,8 +1192,7 @@ namespace Opc.Ua.Bindings
                         OperationCompleted(operation);
 
                         m_reconnecting = false;
-                    }
-                }
+                    }                }
             }
             catch (Exception e)
             {
@@ -1191,11 +1210,6 @@ namespace Opc.Ua.Bindings
         /// </summary>
         private void OnHandshakeComplete(IAsyncResult? result)
         {
-            // No disclaimer here: this callback is invoked inline as well as from
-            // a detached task, and disclaiming on the inline path would make the
-            // gate below deadlock against the frame that already holds it. The
-            // detached path drops the inherited context where it detaches, in
-            // ChannelAsyncOperation.
             using (Gate.Enter())
             {
                 ServiceResult? error = null;
@@ -1226,7 +1240,7 @@ namespace Opc.Ua.Bindings
                         error.StatusCode == StatusCodes.BadSecurityChecksFailed)
                     {
                         m_logger.UaSCClientLog26(ChannelId);
-                        Shutdown(error);
+                        ShutdownCore(error);
                         return;
                     }
                 }
@@ -1236,7 +1250,7 @@ namespace Opc.Ua.Bindings
                     m_reconnecting = false;
                 }
 
-                ForceReconnect(error);
+                ForceReconnectCore(error);
             }
         }
 
@@ -1322,6 +1336,22 @@ namespace Opc.Ua.Bindings
 
             using (Gate.Enter())
             {
+                ShutdownCore(reason);
+            }
+        }
+
+        /// <summary>
+        /// Cancels all pending requests and closes the channel, without taking
+        /// the gate.
+        /// </summary>
+        /// <param name="reason">Why the channel is shutting down.</param>
+        /// <remarks>
+        /// The gate is not re-entrant, so a caller that already holds it must
+        /// call this rather than <see cref="Shutdown"/>.
+        /// </remarks>
+        private void ShutdownCore(ServiceResult reason)
+        {
+            {
                 // channel may already be closed
                 if (State == TcpChannelState.Closed)
                 {
@@ -1329,7 +1359,7 @@ namespace Opc.Ua.Bindings
                 }
 
                 // clear an unprocessed chunks.
-                SaveIntermediateChunk(0, new ArraySegment<byte>(), false);
+                SaveIntermediateChunk(0, new ArraySegment<byte>(), false, gateHeld: true);
 
                 // halt any scheduled tasks.
                 m_handshakeTimer?.Dispose();
@@ -1387,6 +1417,23 @@ namespace Opc.Ua.Bindings
         {
             using (Gate.Enter())
             {
+                ForceReconnectCore(reason);
+            }
+        }
+
+        /// <summary>
+        /// Closes the channel and attempts to reconnect, without taking the
+        /// gate.
+        /// </summary>
+        /// <param name="reason">Why the channel is reconnecting.</param>
+        /// <remarks>
+        /// The gate is not re-entrant, so a caller that already holds it — every
+        /// message dispatch path does — must call this rather than
+        /// <see cref="ForceReconnect"/>.
+        /// </remarks>
+        private void ForceReconnectCore(ServiceResult reason)
+        {
+            {
                 // check if reconnect already started.
                 if (m_reconnecting)
                 {
@@ -1396,7 +1443,7 @@ namespace Opc.Ua.Bindings
                 // check if reconnects are disabled.
                 if (State == TcpChannelState.Closing || m_waitBetweenReconnects == Timeout.Infinite)
                 {
-                    Shutdown(reason);
+                    ShutdownCore(reason);
                     return;
                 }
 
@@ -1418,7 +1465,7 @@ namespace Opc.Ua.Bindings
                 }
 
                 // clear an unprocessed chunks.
-                SaveIntermediateChunk(0, new ArraySegment<byte>(), false);
+                SaveIntermediateChunk(0, new ArraySegment<byte>(), false, gateHeld: true);
 
                 // halt any scheduled tasks.
                 m_handshakeTimer?.Dispose();
@@ -1674,7 +1721,7 @@ namespace Opc.Ua.Bindings
             }
 
             // handle the fatal error.
-            ForceReconnect(error);
+            ForceReconnectCore(error);
             return false;
         }
 
@@ -1775,7 +1822,7 @@ namespace Opc.Ua.Bindings
                 if (TcpMessageType.IsAbort(messageType))
                 {
                     // get the chunks to process.
-                    chunksToProcess = GetSavedChunks(requestId, messageBody, false);
+                    chunksToProcess = GetSavedChunks(requestId, messageBody, false, gateHeld: false);
 
                     ServiceResult error;
 
@@ -1793,12 +1840,12 @@ namespace Opc.Ua.Bindings
                 // check if it is necessary to wait for more chunks.
                 if (!TcpMessageType.IsFinal(messageType))
                 {
-                    SaveIntermediateChunk(requestId, messageBody, false);
+                    SaveIntermediateChunk(requestId, messageBody, false, gateHeld: false);
                     return true;
                 }
 
                 // get the chunks to process.
-                chunksToProcess = GetSavedChunks(requestId, messageBody, false);
+                chunksToProcess = GetSavedChunks(requestId, messageBody, false, gateHeld: false);
 
                 // get response.
                 operation.MessageBody = ParseResponse(chunksToProcess);

--- a/src/Opc.Ua.Core/Stack/Tcp/UaSCBinaryClientChannel.cs
+++ b/src/Opc.Ua.Core/Stack/Tcp/UaSCBinaryClientChannel.cs
@@ -1021,31 +1021,29 @@ namespace Opc.Ua.Bindings
         /// </remarks>
         private void CompleteConnectCore(WriteOperation operation)
         {
+            try
             {
-                try
+                // check for closed transport.
+                if (Transport == null)
                 {
-                    // check for closed transport.
-                    if (Transport == null)
-                    {
-                        operation.Fault(StatusCodes.BadSecureChannelClosed);
-                        return;
-                    }
-
-                    // start reading messages.
-                    StartReceiveLoop();
-
-                    // send the hello message.
-                    SendHelloMessage(operation);
+                    operation.Fault(StatusCodes.BadSecureChannelClosed);
+                    return;
                 }
-                catch (Exception ex)
-                {
-                    var fault = ServiceResult.Create(
-                        ex,
-                        StatusCodes.BadTcpInternalError,
-                        "An unexpected error occurred while connecting to the server.");
 
-                    operation.Fault(fault);
-                }
+                // start reading messages.
+                StartReceiveLoop();
+
+                // send the hello message.
+                SendHelloMessage(operation);
+            }
+            catch (Exception ex)
+            {
+                var fault = ServiceResult.Create(
+                    ex,
+                    StatusCodes.BadTcpInternalError,
+                    "An unexpected error occurred while connecting to the server.");
+
+                operation.Fault(fault);
             }
         }
 
@@ -1351,63 +1349,61 @@ namespace Opc.Ua.Bindings
         /// </remarks>
         private void ShutdownCore(ServiceResult reason)
         {
+            // channel may already be closed
+            if (State == TcpChannelState.Closed)
             {
-                // channel may already be closed
-                if (State == TcpChannelState.Closed)
-                {
-                    return;
-                }
-
-                // clear an unprocessed chunks.
-                SaveIntermediateChunk(0, new ArraySegment<byte>(), false, gateHeld: true);
-
-                // halt any scheduled tasks.
-                m_handshakeTimer?.Dispose();
-                m_handshakeTimer = null;
-
-                // halt any existing handshake.
-                if (m_handshakeOperation?.IsCompleted == false)
-                {
-                    m_handshakeOperation.Fault(reason);
-                }
-
-                // cancel all requests.
-                foreach (KeyValuePair<uint, WriteOperation> operation in m_requests.ToArray())
-                {
-                    operation.Value
-                        .Fault(new ServiceResult(StatusCodes.BadSecureChannelClosed, reason));
-                }
-                m_requests.Clear();
-
-                uint channelId = ChannelId;
-
-                // close the socket.
-                State = TcpChannelState.Closed;
-
-                // dispose of the tokens.
-                ChannelId = 0;
-                DiscardTokens();
-
-                // clear the handshake state.
-                m_handshakeOperation = null;
-                m_requestedToken?.Dispose();
-                m_requestedToken = null;
-                m_reconnecting = false;
-
-                IUaSCByteTransport? transport = Transport;
-                if (transport != null)
-                {
-                    Transport = null;
-                    m_logger
-                        .UaSCClientLog27(
-                            channelId,
-                            transport.RemoteEndpoint);
-                    transport.Close();
-                }
-
-                // set the state.
-                ChannelStateChanged(TcpChannelState.Closed, reason);
+                return;
             }
+
+            // clear an unprocessed chunks.
+            SaveIntermediateChunk(0, new ArraySegment<byte>(), false, gateHeld: true);
+
+            // halt any scheduled tasks.
+            m_handshakeTimer?.Dispose();
+            m_handshakeTimer = null;
+
+            // halt any existing handshake.
+            if (m_handshakeOperation?.IsCompleted == false)
+            {
+                m_handshakeOperation.Fault(reason);
+            }
+
+            // cancel all requests.
+            foreach (KeyValuePair<uint, WriteOperation> operation in m_requests.ToArray())
+            {
+                operation.Value
+                    .Fault(new ServiceResult(StatusCodes.BadSecureChannelClosed, reason));
+            }
+            m_requests.Clear();
+
+            uint channelId = ChannelId;
+
+            // close the socket.
+            State = TcpChannelState.Closed;
+
+            // dispose of the tokens.
+            ChannelId = 0;
+            DiscardTokens();
+
+            // clear the handshake state.
+            m_handshakeOperation = null;
+            m_requestedToken?.Dispose();
+            m_requestedToken = null;
+            m_reconnecting = false;
+
+            IUaSCByteTransport? transport = Transport;
+            if (transport != null)
+            {
+                Transport = null;
+                m_logger
+                    .UaSCClientLog27(
+                        channelId,
+                        transport.RemoteEndpoint);
+                transport.Close();
+            }
+
+            // set the state.
+            ChannelStateChanged(TcpChannelState.Closed, reason);
         }
 
         /// <summary>
@@ -1433,82 +1429,80 @@ namespace Opc.Ua.Bindings
         /// </remarks>
         private void ForceReconnectCore(ServiceResult reason)
         {
+            // check if reconnect already started.
+            if (m_reconnecting)
             {
-                // check if reconnect already started.
-                if (m_reconnecting)
-                {
-                    return;
-                }
-
-                // check if reconnects are disabled.
-                if (State == TcpChannelState.Closing || m_waitBetweenReconnects == Timeout.Infinite)
-                {
-                    ShutdownCore(reason);
-                    return;
-                }
-
-                m_logger.UaSCClientLog28(Id, reason);
-
-                // cancel all requests.
-                foreach (KeyValuePair<uint, WriteOperation> operation in m_requests.ToArray())
-                {
-                    operation.Value
-                        .Fault(new ServiceResult(StatusCodes.BadSecureChannelClosed, reason));
-                }
-                m_requests.Clear();
-
-                // halt any existing handshake.
-                if (m_handshakeOperation?.IsCompleted == false)
-                {
-                    m_handshakeOperation.Fault(reason);
-                    return;
-                }
-
-                // clear an unprocessed chunks.
-                SaveIntermediateChunk(0, new ArraySegment<byte>(), false, gateHeld: true);
-
-                // halt any scheduled tasks.
-                m_handshakeTimer?.Dispose();
-                m_handshakeTimer = null;
-
-                // clear the handshake state.
-                m_handshakeOperation = null;
-                m_requestedToken?.Dispose();
-                m_requestedToken = null;
-                m_reconnecting = true;
-
-                // close the socket.
-                State = TcpChannelState.Faulted;
-
-                // schedule a reconnect.
-                if (m_logger.IsEnabled(LogLevel.Information))
-                {
-                    m_logger.UaSCClientLog29(
-                        ChannelId,
-                        m_waitBetweenReconnects,
-                        reason.ToLongString());
-                }
-                m_handshakeTimer = TimeProvider.CreateTimer(
-                    m_startHandshake,
-                    null,
-                    TimeSpan.FromMilliseconds(m_waitBetweenReconnects),
-                    Timeout.InfiniteTimeSpan);
-
-                // set next reconnect period.
-                m_waitBetweenReconnects *= 2;
-
-                if (m_waitBetweenReconnects <= TcpMessageLimits.MinTimeBetweenReconnects)
-                {
-                    m_waitBetweenReconnects = TcpMessageLimits.MinTimeBetweenReconnects + 1000;
-                }
-
-                if (m_waitBetweenReconnects > TcpMessageLimits.MaxTimeBetweenReconnects)
-                {
-                    m_waitBetweenReconnects = TcpMessageLimits.MaxTimeBetweenReconnects;
-                }
-
-                ChannelStateChanged(TcpChannelState.Faulted, reason);
+                return;
             }
+
+            // check if reconnects are disabled.
+            if (State == TcpChannelState.Closing || m_waitBetweenReconnects == Timeout.Infinite)
+            {
+                ShutdownCore(reason);
+                return;
+            }
+
+            m_logger.UaSCClientLog28(Id, reason);
+
+            // cancel all requests.
+            foreach (KeyValuePair<uint, WriteOperation> operation in m_requests.ToArray())
+            {
+                operation.Value
+                    .Fault(new ServiceResult(StatusCodes.BadSecureChannelClosed, reason));
+            }
+            m_requests.Clear();
+
+            // halt any existing handshake.
+            if (m_handshakeOperation?.IsCompleted == false)
+            {
+                m_handshakeOperation.Fault(reason);
+                return;
+            }
+
+            // clear an unprocessed chunks.
+            SaveIntermediateChunk(0, new ArraySegment<byte>(), false, gateHeld: true);
+
+            // halt any scheduled tasks.
+            m_handshakeTimer?.Dispose();
+            m_handshakeTimer = null;
+
+            // clear the handshake state.
+            m_handshakeOperation = null;
+            m_requestedToken?.Dispose();
+            m_requestedToken = null;
+            m_reconnecting = true;
+
+            // close the socket.
+            State = TcpChannelState.Faulted;
+
+            // schedule a reconnect.
+            if (m_logger.IsEnabled(LogLevel.Information))
+            {
+                m_logger.UaSCClientLog29(
+                    ChannelId,
+                    m_waitBetweenReconnects,
+                    reason.ToLongString());
+            }
+            m_handshakeTimer = TimeProvider.CreateTimer(
+                m_startHandshake,
+                null,
+                TimeSpan.FromMilliseconds(m_waitBetweenReconnects),
+                Timeout.InfiniteTimeSpan);
+
+            // set next reconnect period.
+            m_waitBetweenReconnects *= 2;
+
+            if (m_waitBetweenReconnects <= TcpMessageLimits.MinTimeBetweenReconnects)
+            {
+                m_waitBetweenReconnects = TcpMessageLimits.MinTimeBetweenReconnects + 1000;
+            }
+
+            if (m_waitBetweenReconnects > TcpMessageLimits.MaxTimeBetweenReconnects)
+            {
+                m_waitBetweenReconnects = TcpMessageLimits.MaxTimeBetweenReconnects;
+            }
+
+            ChannelStateChanged(TcpChannelState.Faulted, reason);
         }
 
         /// <summary>

--- a/tests/Opc.Ua.Core.Tests/Stack/Tcp/ChannelGateBenchmarks.cs
+++ b/tests/Opc.Ua.Core.Tests/Stack/Tcp/ChannelGateBenchmarks.cs
@@ -103,9 +103,9 @@ namespace Opc.Ua.Core.Tests.Stack.Tcp
         }
 
         /// <summary>
-        /// A bare semaphore, which is what the gate would be without
-        /// re-entrancy. The difference between this and
-        /// <see cref="GateEnterLeave"/> is what re-entrancy costs.
+        /// A bare semaphore, which is what the gate now is. The difference
+        /// between this and <see cref="GateEnterLeave"/> is what the wrapper
+        /// costs.
         /// </summary>
         /// <returns>A value, so the body cannot be optimised away.</returns>
         [Benchmark]
@@ -137,28 +137,6 @@ namespace Opc.Ua.Core.Tests.Stack.Tcp
         }
 
         /// <summary>
-        /// A nested acquisition, which the channel performs whenever a path that
-        /// holds the gate faults: it is the case a bare semaphore cannot serve.
-        /// </summary>
-        /// <returns>A value, so the body cannot be optimised away.</returns>
-        [Benchmark]
-        public int GateEnterReentrant()
-        {
-            using (ChannelGate.Releaser outer = m_gate.Enter())
-            {
-                // Deliberately nested rather than combined: the inner
-                // acquisition is the measurement, and combining the two would
-                // measure a single one.
-#pragma warning disable RCS1005
-                using (ChannelGate.Releaser nested = m_gate.Enter())
-#pragma warning restore RCS1005
-                {
-                    return ++m_sink;
-                }
-            }
-        }
-
-        /// <summary>
         /// The uncontended asynchronous acquisition, which is what the receive
         /// loop pays per chunk.
         /// </summary>
@@ -186,8 +164,7 @@ namespace Opc.Ua.Core.Tests.Stack.Tcp
                 Assert.That(MonitorEnterExit(), Is.GreaterThan(0));
                 Assert.That(SemaphoreWaitRelease(), Is.GreaterThan(0));
                 Assert.That(GateEnterLeave(), Is.GreaterThan(0));
-                Assert.That(GateEnterReentrant(), Is.GreaterThan(0));
-                Assert.That(m_gate.IsHeldByCurrentContext, Is.False);
+                Assert.That(m_gate.IsHeldBySomeContextForTest, Is.False);
             });
         }
 
@@ -211,7 +188,7 @@ namespace Opc.Ua.Core.Tests.Stack.Tcp
             Assert.That(
                 await GateEnterAsyncUncontendedAsync().ConfigureAwait(false),
                 Is.GreaterThan(0));
-            Assert.That(m_gate.IsHeldByCurrentContext, Is.False);
+            Assert.That(m_gate.IsHeldBySomeContextForTest, Is.False);
         }
 
         private ChannelGate m_gate = new();

--- a/tests/Opc.Ua.Core.Tests/Stack/Tcp/ChannelGateTests.cs
+++ b/tests/Opc.Ua.Core.Tests/Stack/Tcp/ChannelGateTests.cs
@@ -39,11 +39,13 @@ namespace Opc.Ua.Core.Tests.Stack.Tcp
     /// Covers the gate that replaces the channel's monitor.
     /// </summary>
     /// <remarks>
-    /// The three properties that matter are proved here rather than argued:
-    /// it excludes, it tolerates the re-entrancy the channel code relies on, and
-    /// work started while it is held does not inherit the right to re-enter.
-    /// The last one is the failure a naive implementation would ship with, and it
-    /// would be silent.
+    /// Two properties matter and are proved here rather than argued: it excludes
+    /// across both entry modes, and work started while it is held is excluded
+    /// too. The second used to be the hazard — the gate tracked ownership in an
+    /// <c>AsyncLocal</c>, which is inherited, so anything started from inside the
+    /// guarded region believed it was already the holder unless it opted out by
+    /// hand. That opt-out is gone along with the re-entrancy, and these tests pin
+    /// the behaviour that replaced it.
     /// </remarks>
     [TestFixture]
     [Category("ChannelGate")]
@@ -80,169 +82,56 @@ namespace Opc.Ua.Core.Tests.Stack.Tcp
                 async () => await pending.ConfigureAwait(false),
                 Throws.InstanceOf<OperationCanceledException>());
 
-            // A cancelled wait must not have taken the gate, and must not leave
-            // the cancelled context believing it holds it.
-            Assert.That(gate.IsHeldByCurrentContext, Is.False);
-
             blocking.TrySetResult(true);
             await holder.ConfigureAwait(false);
 
+            // A cancelled wait must not have consumed the permit.
             using (gate.Enter())
             {
-                Assert.That(gate.IsHeldByCurrentContext, Is.True);
+                Assert.That(gate.IsHeldBySomeContextForTest, Is.True);
             }
-        }
 
-        [Test]
-        public void ReleasersCompareByGateAndHolder()
-        {
-            var gate = new ChannelGate();
-
-            using ChannelGate.Releaser outer = gate.Enter();
-            using ChannelGate.Releaser nested = gate.Enter();
-
-            ChannelGate.Releaser copy = outer;
-
-            Assert.Multiple(() =>
-            {
-                Assert.That(copy, Is.EqualTo(outer));
-                Assert.That(nested, Is.Not.EqualTo(outer));
-                Assert.That(copy.GetHashCode(), Is.EqualTo(outer.GetHashCode()));
-            });
+            Assert.That(gate.IsHeldBySomeContextForTest, Is.False);
         }
 
         [Test]
         [CancelAfter(30000)]
-        public async Task InheritedReentryDoesNotStrandTheGateAsync()
-        {
-            var gate = new ChannelGate();
-            var forkEntered = new TaskCompletionSource<bool>(
-                TaskCreationOptions.RunContinuationsAsynchronously);
-            var ownerLeaving = new TaskCompletionSource<bool>(
-                TaskCreationOptions.RunContinuationsAsynchronously);
-
-            Task fork;
-
-            using (gate.Enter())
-            {
-                // Work started from inside the guarded region without disclaiming
-                // inherits the holder. A timer callback whose timer was created
-                // here behaves exactly like this.
-                fork = Task.Run(async () =>
-                {
-                    using (gate.Enter())
-                    {
-                        forkEntered.TrySetResult(true);
-                        await ownerLeaving.Task.ConfigureAwait(false);
-                    }
-                });
-
-                await forkEntered.Task.ConfigureAwait(false);
-            }
-
-            // The owner has left, so the gate must be free even though the forked
-            // context is still inside its own nested entry.
-            ownerLeaving.TrySetResult(true);
-
-            using (ChannelGate.Releaser entered = await gate
-                .EnterAsync(new CancellationTokenSource(TimeSpan.FromSeconds(10)).Token)
-                .ConfigureAwait(false))
-            {
-                Assert.That(gate.IsHeldByCurrentContext, Is.True);
-            }
-
-            await fork.ConfigureAwait(false);
-        }
-
-        [Test]
-        public void EnterIsReentrantOnTheSameContext()
-        {            var gate = new ChannelGate();
-
-            using (gate.Enter())
-            {
-                Assert.That(gate.IsHeldByCurrentContext, Is.True);
-
-                // The channel does exactly this: HandleIncomingMessage holds the
-                // gate and calls ForceChannelFault, which takes it again.
-                using (gate.Enter())
-                {
-                    Assert.That(gate.IsHeldByCurrentContext, Is.True);
-                }
-
-                Assert.That(
-                    gate.IsHeldByCurrentContext,
-                    Is.True,
-                    "leaving a nested entry must not release the gate");
-            }
-
-            Assert.That(gate.IsHeldByCurrentContext, Is.False);
-        }
-
-        [Test]
-        public async Task EnterAsyncIsReentrantOnTheSameContextAsync()
+        public async Task AnUncontendedAsynchronousEntryCompletesSynchronouslyAsync()
         {
             var gate = new ChannelGate();
 
-            using (await gate.EnterAsync())
+            ValueTask<ChannelGate.Releaser> entry = gate.EnterAsync();
+
+            Assert.That(
+                entry.IsCompleted,
+                Is.True,
+                "an uncontended entry must not suspend or allocate a task");
+
+            using (await entry.ConfigureAwait(false))
             {
-                using (await gate.EnterAsync())
-                {
-                    Assert.That(gate.IsHeldByCurrentContext, Is.True);
-                }
-
-                Assert.That(gate.IsHeldByCurrentContext, Is.True);
+                Assert.That(gate.IsHeldBySomeContextForTest, Is.True);
             }
-
-            Assert.That(gate.IsHeldByCurrentContext, Is.False);
-        }
-
-        /// <summary>
-        /// Re-entrancy must survive a suspension point, or the open path could
-        /// not await at all.
-        /// </summary>
-        [Test]
-        public async Task ReentrancySurvivesAnAwaitAsync()
-        {
-            var gate = new ChannelGate();
-
-            using (await gate.EnterAsync())
-            {
-                await Task.Yield();
-
-                Assert.That(gate.IsHeldByCurrentContext, Is.True);
-
-                using (gate.Enter())
-                {
-                    Assert.That(gate.IsHeldByCurrentContext, Is.True);
-                }
-            }
-
-            Assert.That(gate.IsHeldByCurrentContext, Is.False);
         }
 
         [Test]
+        [CancelAfter(30000)]
         public async Task TheGateExcludesADifferentContextAsync()
         {
             var gate = new ChannelGate();
             var entered = new TaskCompletionSource<bool>(
                 TaskCreationOptions.RunContinuationsAsynchronously);
 
-            ChannelGate.Releaser held = await gate.EnterAsync();
+            ChannelGate.Releaser held = await gate.EnterAsync().ConfigureAwait(false);
 
             Task contender = Task.Run(async () =>
             {
-                // A genuinely different context. Started from the holder here only
-                // because a test has to, so it disclaims the inheritance the way
-                // every detached path in the channel does.
-                gate.LeaveInheritedContext();
-
-                using (await gate.EnterAsync())
+                using (await gate.EnterAsync().ConfigureAwait(false))
                 {
                     entered.TrySetResult(true);
                 }
             });
 
-            Task first = await Task.WhenAny(contender, Task.Delay(250));
+            Task first = await Task.WhenAny(contender, Task.Delay(250)).ConfigureAwait(false);
 
             Assert.That(
                 first,
@@ -256,82 +145,51 @@ namespace Opc.Ua.Core.Tests.Stack.Tcp
         }
 
         /// <summary>
-        /// This is the hazard the design has to answer. Work started while the
-        /// gate is held inherits the logical context, so without an explicit
-        /// disclaimer it would believe it already holds the gate and would run
-        /// inside the guarded region alongside its parent.
+        /// The defect this design removed. Work started while the gate is held
+        /// inherits the logical execution context, and the gate used to record
+        /// ownership there — so such work believed it was already the holder and
+        /// ran inside the guarded region alongside its parent unless it opted out
+        /// by hand. Ownership is no longer contextual, so it is simply excluded.
         /// </summary>
         [Test]
-        public async Task WorkStartedWhileHeldMustDisclaimTheInheritedContextAsync()
+        [CancelAfter(30000)]
+        public async Task WorkStartedWhileHeldIsExcludedWithoutOptingOutAsync()
         {
             var gate = new ChannelGate();
-            bool inheritedWithoutDisclaimer;
-            bool inheritedAfterDisclaimer;
-
-            using (await gate.EnterAsync())
-            {
-                inheritedWithoutDisclaimer = await Task.Run(() => gate.IsHeldByCurrentContext)
-                    .ConfigureAwait(false);
-
-                inheritedAfterDisclaimer = await Task.Run(() =>
-                {
-                    gate.LeaveInheritedContext();
-                    return gate.IsHeldByCurrentContext;
-                }).ConfigureAwait(false);
-
-                Assert.That(
-                    gate.IsHeldByCurrentContext,
-                    Is.True,
-                    "a branch disclaiming its inheritance must not release the holder's gate");
-            }
-
-            Assert.Multiple(() =>
-            {
-                Assert.That(
-                    inheritedWithoutDisclaimer,
-                    Is.True,
-                    "the inheritance is real, which is why every detached path must disclaim it");
-                Assert.That(
-                    inheritedAfterDisclaimer,
-                    Is.False,
-                    "disclaiming must drop the inherited entitlement");
-            });
-        }
-
-        /// <summary>
-        /// After disclaiming, detached work must actually be excluded, not merely
-        /// report that it does not hold the gate.
-        /// </summary>
-        [Test]
-        public async Task DisclaimedWorkIsExcludedUntilTheHolderLeavesAsync()
-        {
-            var gate = new ChannelGate();
-            var reachedGuardedRegion = new TaskCompletionSource<bool>(
+            var started = new TaskCompletionSource<bool>(
                 TaskCreationOptions.RunContinuationsAsynchronously);
-            Task detached;
+            bool ranInsideTheRegion = false;
 
-            using (await gate.EnterAsync())
+            ChannelGate.Releaser held = gate.Enter();
+
+            // Started from inside the guarded region and deliberately not
+            // disclaiming anything, which is what every fire-and-forget path
+            // in the channel used to have to do.
+            Task detached = Task.Run(async () =>
             {
-                detached = Task.Run(async () =>
+                started.TrySetResult(true);
+
+                using (await gate.EnterAsync().ConfigureAwait(false))
                 {
-                    gate.LeaveInheritedContext();
+                    ranInsideTheRegion = true;
+                }
+            });
 
-                    using (await gate.EnterAsync())
-                    {
-                        reachedGuardedRegion.TrySetResult(true);
-                    }
-                });
+            Assert.That(await started.Task.ConfigureAwait(false), Is.True);
 
-                Task first = await Task.WhenAny(detached, Task.Delay(250));
+            Task first = await Task.WhenAny(detached, Task.Delay(250)).ConfigureAwait(false);
 
-                Assert.That(
-                    first,
-                    Is.Not.SameAs(detached),
-                    "detached work must wait for the holder");
-            }
+            Assert.That(
+                first,
+                Is.Not.SameAs(detached),
+                "work started while the gate was held entered the guarded region");
+            Assert.That(ranInsideTheRegion, Is.False);
+
+            held.Dispose();
 
             await detached.ConfigureAwait(false);
-            Assert.That(await reachedGuardedRegion.Task.ConfigureAwait(false), Is.True);
+
+            Assert.That(ranInsideTheRegion, Is.True);
         }
 
         /// <summary>
@@ -339,6 +197,7 @@ namespace Opc.Ua.Core.Tests.Stack.Tcp
         /// point of replacing the monitor rather than removing it.
         /// </summary>
         [Test]
+        [CancelAfter(60000)]
         public async Task ConcurrentContextsNeverOverlapAsync()
         {
             var gate = new ChannelGate();
@@ -347,11 +206,9 @@ namespace Opc.Ua.Core.Tests.Stack.Tcp
 
             async Task WorkerAsync()
             {
-                gate.LeaveInheritedContext();
-
                 for (int ii = 0; ii < 50; ii++)
                 {
-                    using (await gate.EnterAsync())
+                    using (await gate.EnterAsync().ConfigureAwait(false))
                     {
                         int now = Interlocked.Increment(ref inside);
                         InterlockedMax(ref maximumObserved, now);
@@ -399,9 +256,7 @@ namespace Opc.Ua.Core.Tests.Stack.Tcp
 
             Task contender = Task.Run(async () =>
             {
-                gate.LeaveInheritedContext();
-
-                using (await gate.EnterAsync())
+                using (await gate.EnterAsync().ConfigureAwait(false))
                 {
                     contenderEntered = true;
                 }
@@ -419,273 +274,82 @@ namespace Opc.Ua.Core.Tests.Stack.Tcp
             Assert.That(contenderEntered, Is.True);
         }
 
+        /// <summary>
+        /// A thread that already holds the gate is not recognised, so re-entering
+        /// blocks. The channel code therefore calls a lock-free core method on
+        /// every path that used to re-enter.
+        /// </summary>
         [Test]
-        public void ReleaserEqualityDistinguishesInstances()
+        public void ReenteringFromTheHoldingThreadBlocks()
         {
             var gate = new ChannelGate();
 
-            ChannelGate.Releaser outer = gate.Enter();
-            ChannelGate.Releaser nested = gate.Enter();
-            ChannelGate.Releaser sameAsOuter = outer;
+            using (gate.Enter())
+            {
+                using var reentry = new CancellationTokenSource();
+                ValueTask<ChannelGate.Releaser> nested = gate.EnterAsync(reentry.Token);
+
+                Assert.That(
+                    nested.IsCompleted,
+                    Is.False,
+                    "the gate must not be re-entrant");
+
+                reentry.Cancel();
+
+                Assert.That(
+                    async () => await nested.ConfigureAwait(false),
+                    Throws.InstanceOf<OperationCanceledException>());
+            }
+        }
+
+        [Test]
+        public void ReleaserEqualityComparesTheGate()
+        {
+            var gate = new ChannelGate();
+            var other = new ChannelGate();
+
+            ChannelGate.Releaser held = gate.Enter();
+            ChannelGate.Releaser copy = held;
+            ChannelGate.Releaser onOther = other.Enter();
 
             try
             {
+                bool copyEqualsHeld = copy == held;
+                bool otherDiffersFromHeld = onOther != held;
+
                 Assert.Multiple(() =>
                 {
-                    Assert.That(outer, Is.Not.EqualTo(nested));
-                    Assert.That(sameAsOuter, Is.EqualTo(outer));
-                    Assert.That(nested, Is.Not.EqualTo((object)outer));
-                    Assert.That(outer.GetHashCode(), Is.Not.EqualTo(nested.GetHashCode()));
+                    Assert.That(copy, Is.EqualTo(held));
+                    Assert.That(copyEqualsHeld, Is.True);
+                    Assert.That(onOther, Is.Not.EqualTo(held));
+                    Assert.That(otherDiffersFromHeld, Is.True);
+                    Assert.That(onOther, Is.Not.EqualTo((object)held));
+                    Assert.That(copy.GetHashCode(), Is.EqualTo(held.GetHashCode()));
+                    Assert.That(default(ChannelGate.Releaser), Is.Not.EqualTo(held));
+                    Assert.That(default(ChannelGate.Releaser).GetHashCode(), Is.Zero);
                 });
             }
             finally
             {
-                nested.Dispose();
-                outer.Dispose();
+                onOther.Dispose();
+                held.Dispose();
             }
-        }
-
-        /// <summary>
-        /// A monitor is re-entrant per thread. A completion callback invoked
-        /// inline runs on the thread that already holds the gate but under the
-        /// context captured when the operation was started, so context alone
-        /// would not recognise it and the thread would deadlock against itself.
-        /// </summary>
-        /// <remarks>
-        /// This is not hypothetical: <c>ChannelAsyncOperation</c> invokes its
-        /// callback inline, and the whole channel test suite crashes without it.
-        /// </remarks>
-        [Test]
-        public void EnterIsReentrantOnTheSameThreadUnderADifferentContext()
-        {
-            var gate = new ChannelGate();
-            bool reentered = false;
-
-            using (gate.Enter())
-            {
-                // Runs on this thread but under the captured context, which is the
-                // one that existed before the gate was entered. This is what an
-                // inline completion callback does.
-                ExecutionContext captured = CaptureContextWithoutTheGate(gate);
-
-                ExecutionContext.Run(
-                    captured,
-                    _ =>
-                    {
-                        Assert.That(
-                            gate.IsHeldByCurrentContext,
-                            Is.False,
-                            "the captured context predates the entry");
-
-                        using (gate.Enter())
-                        {
-                            reentered = true;
-                        }
-                    },
-                    null);
-            }
-
-            Assert.That(reentered, Is.True, "the same thread must be able to re-enter");
-        }
-
-        private static ExecutionContext CaptureContextWithoutTheGate(ChannelGate gate)
-        {
-            ExecutionContext captured = null!;
-
-            var thread = new Thread(() =>
-            {
-                gate.LeaveInheritedContext();
-                captured = ExecutionContext.Capture();
-            });
-
-            thread.Start();
-            thread.Join(TimeSpan.FromSeconds(5));
-
-            return captured!;
-        }
-
-        /// <summary>
-        /// A synchronous holder that suspends releases its thread, and the pool is
-        /// free to run something else on it. That work must not be mistaken for
-        /// the holder.
-        /// </summary>
-        /// <remarks>
-        /// This is the defect that hung the Server integration suite: a
-        /// <see cref="ChannelGate.Enter"/> handle was held across an
-        /// <see langword="await"/> in the token renewal path, so an unrelated
-        /// continuation reusing the thread re-entered the guarded region and
-        /// decremented the holder's depth, releasing the gate while the holder was
-        /// still inside.
-        /// </remarks>
-        [Test]
-        public async Task WorkReusingASuspendedHoldersThreadDoesNotInheritTheGateAsync()
-        {
-            var gate = new ChannelGate();
-            int managedThreadId = Environment.CurrentManagedThreadId;
-
-            using (await gate.EnterAsync().ConfigureAwait(false))
-            {
-                // Simulates a pool thread being reused while the holder is
-                // suspended: same thread identity, unrelated logical context.
-                bool observed = await Task.Factory.StartNew(
-                    () =>
-                    {
-                        gate.LeaveInheritedContext();
-                        return gate.IsHeldByCurrentContext;
-                    },
-                    CancellationToken.None,
-                    TaskCreationOptions.None,
-                    TaskScheduler.Default).ConfigureAwait(false);
-
-                Assert.That(
-                    observed,
-                    Is.False,
-                    "an asynchronous holder must not grant entry by thread identity");
-            }
-
-            Assert.Multiple(() =>
-            {
-                Assert.That(gate.IsHeldByCurrentContext, Is.False);
-                Assert.That(managedThreadId, Is.GreaterThan(0));
-            });
-        }
-
-        /// <summary>
-        /// Work started while the gate is held must not run its prologue on the
-        /// holder's stack, disclaim the holder's entitlement, and then block on the
-        /// gate the holder still owns.
-        /// </summary>
-        /// <remarks>
-        /// This is the deadlock that stopped the secure channel handshake: the
-        /// channel started its write inline, so <see cref="ChannelGate.LeaveInheritedContext"/>
-        /// ran on the caller's stack and stripped the caller's own right to
-        /// re-enter; when the send completed synchronously the completion then
-        /// blocked on a gate that very thread was holding. The channel now queues
-        /// the write, and this test states the rule the fix relies on.
-        /// </remarks>
-        [Test]
-        public async Task DisclaimingOnTheHoldersOwnStackWouldSelfDeadlockAsync()
-        {
-            var gate = new ChannelGate();
-
-            using (await gate.EnterAsync().ConfigureAwait(false))
-            {
-                // Running the disclaimer inline is what the channel used to do.
-                gate.LeaveInheritedContext();
-
-                Assert.That(
-                    gate.IsHeldByCurrentContext,
-                    Is.False,
-                    "disclaiming inline strips the holder's own entitlement, which is " +
-                    "why detached work must be queued rather than started inline");
-            }
-
-            // Once the holder has left, the gate is free again, which shows the
-            // depth accounting was not corrupted by the disclaimer.
-            using (await gate.EnterAsync().ConfigureAwait(false))
-            {
-                Assert.That(gate.IsHeldByCurrentContext, Is.True);
-            }
-        }
-
-        /// <summary>
-        /// A contended acquisition must leave the caller holding the gate, not
-        /// merely owning the semaphore.
-        /// </summary>
-        /// <remarks>
-        /// The holder is published by writing an <see cref="AsyncLocal{T}"/>. On
-        /// the contended path that write happens inside the awaiting state
-        /// machine, and an async method's context is not restored into its
-        /// caller — so the caller would come back holding the semaphore but with
-        /// no record of it, and the next re-entrant acquisition would block on a
-        /// gate its own context already owns.
-        /// <para>
-        /// Every re-entrant path in the channel reaches this:
-        /// <c>HandleIncomingMessageAsync</c> enters with <c>EnterAsync</c> and
-        /// calls <c>ForceChannelFault</c>, which enters with <c>Enter</c>.
-        /// </para>
-        /// </remarks>
-        [Test]
-        public async Task ContendedEntryStillRecordsTheHolderAsync()
-        {
-            var gate = new ChannelGate();
-            var blocking = new TaskCompletionSource<bool>(
-                TaskCreationOptions.RunContinuationsAsynchronously);
-            var aboutToEnter = new TaskCompletionSource<bool>(
-                TaskCreationOptions.RunContinuationsAsynchronously);
-
-            // Hold the gate from an unrelated context so the entry below must wait.
-            Task holder = Task.Run(async () =>
-            {
-                gate.LeaveInheritedContext();
-
-                using (await gate.EnterAsync().ConfigureAwait(false))
-                {
-                    await blocking.Task.ConfigureAwait(false);
-                }
-            });
-
-            while (!gate.IsHeldBySomeContextForTest)
-            {
-                await Task.Delay(5).ConfigureAwait(false);
-            }
-
-            Task<bool> contended = Task.Run(async () =>
-            {
-                gate.LeaveInheritedContext();
-
-                aboutToEnter.TrySetResult(true);
-
-                using (await gate.EnterAsync().ConfigureAwait(false))
-                {
-                    if (!gate.IsHeldByCurrentContext)
-                    {
-                        return false;
-                    }
-
-                    // Re-entering must not block. This is what ForceChannelFault
-                    // does from inside HandleIncomingMessageAsync.
-                    using (gate.Enter())
-                    {
-                        return true;
-                    }
-                }
-            });
-
-            // Let the contender actually block on the semaphore before the holder
-            // lets go, so the contended path is the one under test.
-            await aboutToEnter.Task.ConfigureAwait(false);
-            await Task.Delay(250).ConfigureAwait(false);
-
-            blocking.TrySetResult(true);
-            await holder.ConfigureAwait(false);
-
-            Task first = await Task.WhenAny(contended, Task.Delay(5000)).ConfigureAwait(false);
-
-            Assert.That(
-                first,
-                Is.SameAs(contended),
-                "a contended acquisition left the caller unable to re-enter");
-            Assert.That(
-                await contended.ConfigureAwait(false),
-                Is.True,
-                "a contended acquisition did not record the holder");
         }
 
         private static void InterlockedMax(ref int target, int value)
         {
-            int current = Volatile.Read(ref target);
+            int seen = Volatile.Read(ref target);
 
-            while (value > current)
+            while (value > seen)
             {
-                int previous = Interlocked.CompareExchange(ref target, value, current);
+                int previous = Interlocked.CompareExchange(ref target, value, seen);
 
-                if (previous == current)
+                if (previous == seen)
                 {
                     return;
                 }
 
-                current = previous;
+                seen = previous;
             }
         }
     }

--- a/tests/Opc.Ua.Core.Tests/Stack/Tcp/ChannelGateTests.cs
+++ b/tests/Opc.Ua.Core.Tests/Stack/Tcp/ChannelGateTests.cs
@@ -131,14 +131,22 @@ namespace Opc.Ua.Core.Tests.Stack.Tcp
                 }
             });
 
-            Task first = await Task.WhenAny(contender, Task.Delay(250)).ConfigureAwait(false);
+            // Released in a finally so that a failing assertion reports the
+            // failure rather than stranding the gate and hanging the contender
+            // until the timeout.
+            try
+            {
+                Task first = await Task.WhenAny(contender, Task.Delay(250)).ConfigureAwait(false);
 
-            Assert.That(
-                first,
-                Is.Not.SameAs(contender),
-                "another context must not enter while the gate is held");
-
-            held.Dispose();
+                Assert.That(
+                    first,
+                    Is.Not.SameAs(contender),
+                    "another context must not enter while the gate is held");
+            }
+            finally
+            {
+                held.Dispose();
+            }
 
             await contender.ConfigureAwait(false);
             Assert.That(await entered.Task.ConfigureAwait(false), Is.True);
@@ -175,17 +183,27 @@ namespace Opc.Ua.Core.Tests.Stack.Tcp
                 }
             });
 
-            Assert.That(await started.Task.ConfigureAwait(false), Is.True);
+            // The gate is released in a finally rather than by a using, because
+            // it has to be released before the assertions below are awaited to
+            // completion but exactly once. A failing assertion would otherwise
+            // strand it and leave the detached task blocked until the timeout,
+            // reporting a hang instead of the failure.
+            try
+            {
+                Assert.That(await started.Task.ConfigureAwait(false), Is.True);
 
-            Task first = await Task.WhenAny(detached, Task.Delay(250)).ConfigureAwait(false);
+                Task first = await Task.WhenAny(detached, Task.Delay(250)).ConfigureAwait(false);
 
-            Assert.That(
-                first,
-                Is.Not.SameAs(detached),
-                "work started while the gate was held entered the guarded region");
-            Assert.That(ranInsideTheRegion, Is.False);
-
-            held.Dispose();
+                Assert.That(
+                    first,
+                    Is.Not.SameAs(detached),
+                    "work started while the gate was held entered the guarded region");
+                Assert.That(ranInsideTheRegion, Is.False);
+            }
+            finally
+            {
+                held.Dispose();
+            }
 
             await detached.ConfigureAwait(false);
 

--- a/tests/Opc.Ua.Core.Tests/Stack/Transport/TcpServerChannelDeterministicTests.cs
+++ b/tests/Opc.Ua.Core.Tests/Stack/Transport/TcpServerChannelDeterministicTests.cs
@@ -459,9 +459,9 @@ namespace Opc.Ua.Core.Tests.Stack.Transport
                 return HandleIncomingMessageAsync(messageType, chunk, CancellationToken.None);
             }
 
-            public void ForceMessageLimitsExceeded()
+            public void ForceMessageLimitsExceeded(bool gateHeld = false)
             {
-                DoMessageLimitsExceeded();
+                DoMessageLimitsExceeded(gateHeld);
             }
 
             public void CallSendServiceFault(uint requestId, bool renew, ServiceResult fault)

--- a/tests/Opc.Ua.Core.Tests/Stack/Transport/UaSCBinaryClientChannelDeterministicTests.cs
+++ b/tests/Opc.Ua.Core.Tests/Stack/Transport/UaSCBinaryClientChannelDeterministicTests.cs
@@ -381,6 +381,32 @@ namespace Opc.Ua.Core.Tests.Stack.Transport
             Assert.That(channel.CurrentState, Is.EqualTo(TcpChannelState.Closed));
         }
 
+        /// <summary>
+        /// The gate is not re-entrant, so the open-response path — which reaches
+        /// this with the gate held — must tear the channel down without taking
+        /// it again. Before this was propagated, an oversized OpenSecureChannel
+        /// response deadlocked the receive loop against itself.
+        /// </summary>
+        [Test]
+        [CancelAfter(15000)]
+        public void DoMessageLimitsExceededWithTheGateHeldDoesNotDeadlock()
+        {
+            var timeProvider = new FakeTimeProvider();
+            using var channel = new TestClientChannel(
+                m_buffers,
+                new RecordingByteTransportFactory(),
+                m_quotas,
+                null,
+                BuildEndpoint(MessageSecurityMode.None, SecurityPolicies.None),
+                m_telemetry,
+                timeProvider);
+            channel.CurrentState = TcpChannelState.Opening;
+
+            channel.ForceMessageLimitsExceededUnderGate();
+
+            Assert.That(channel.CurrentState, Is.EqualTo(TcpChannelState.Closed));
+        }
+
         private async Task<ServiceResultException> RunHandshakeToFaultAsync(
             Func<TestClientChannel, ValueTask<bool>> feed)
         {
@@ -595,9 +621,17 @@ namespace Opc.Ua.Core.Tests.Stack.Transport
                 return ProcessErrorMessage(chunk);
             }
 
-            public void ForceMessageLimitsExceeded()
+            public void ForceMessageLimitsExceeded(bool gateHeld = false)
             {
-                DoMessageLimitsExceeded();
+                DoMessageLimitsExceeded(gateHeld);
+            }
+
+            public void ForceMessageLimitsExceededUnderGate()
+            {
+                using (Gate.Enter())
+                {
+                    DoMessageLimitsExceeded(gateHeld: true);
+                }
             }
 
             public static ServiceResult CallReadErrorMessageBody(BinaryDecoder decoder)


### PR DESCRIPTION
# Description

Stacked on #4232 — please review and merge that first. This PR targets its branch, so the diff here is only the three commits on top.

`ChannelGate` replaced the monitor the UA-TCP secure channel used to serialise its state on, because a monitor cannot be held across an `await` and the open path has to await once a private key may be served over a network. It was made **re-entrant**, because the code it replaced relied on that in about ten places.

Re-entrancy is what forced the design that has caused the trouble. A holder that awaits releases its thread, so ownership cannot be tracked by thread identity; it had to be tracked per logical call context in an `AsyncLocal<Holder?>`. And a logical context is **inherited by work started from it** — so anything started while the gate was held inherited the right to re-enter and ran *inside* the guarded region alongside whatever started it. The only defence was a manual `LeaveInheritedContext()` as the first statement of every fire-and-forget path, at eight sites, enforced by review alone with no compiler check.

That mechanism was responsible for 5 of the 11 concurrency defects fixed in #4232, including two CI hangs.

This PR removes the *requirement* rather than the mechanism, and the `AsyncLocal` then deletes itself.

## What changed

**1. Every path that re-entered now calls a lock-free `Core` method.** The standard locking-wrapper + private-core split:

| Locking entry point | Lock-free core |
| --- | --- |
| `ForceChannelFault` (3 overloads) | `ForceChannelFaultCore` |
| `Shutdown` | `ShutdownCore` |
| `ForceReconnect` | `ForceReconnectCore` |
| `CompleteConnect` | `CompleteConnectCore` |

**2. Three regions stopped running foreign code under the lock.**

- The `RequestReceived` dispatch is deferred until the gate is released. The handler is application code whose continuation calls `SendResponse` back on the same stack — and holding the channel's lock across arbitrary request processing serialised the whole channel on it. This was the dominant re-entrancy chain. A throwing handler is now caught so it cannot unwind into the receive loop and return the chunk buffer twice.
- `OnTransportError` no longer wraps the `HandleSocketError` virtual. That virtual tears the channel down, which notifies the listener, which disposes the channel — and disposal takes the gate.
- The callback setters (`SetRequestReceivedCallback`, the three audit setters, `SetStateChangedCallback`) and `EndpointDescription` no longer lock. Each publishes a single reference, for which a volatile write is sufficient. This is load-bearing: `AsyncResultBase.OperationCompleted` invokes the reverse-hello callback **inline** while the gate is held, reaching `TcpTransportListener.OnReverseHelloComplete` → `SetRequestReceivedCallback`.

**3. `ChannelGate` becomes a `SemaphoreSlim(1,1)` behind a `Releaser`.** Gone: `AsyncLocal<Holder?>`, `Holder`, `m_owner`/`m_owningThreadId`, `LeaveInheritedContext`, `IsHeldByCurrentContext`, `TakeOwnership`, depth counting, and all eight disclaimer calls. The call shape at all 32 sites is unchanged.

**4. `SaveIntermediateChunk`, `GetSavedChunks` and `DoMessageLimitsExceeded` carry a `gateHeld` argument.** The client reaches them from the open path (gate held) *and* the response path (not held) and must pick the matching teardown. Without this an oversized `OpenSecureChannel` response deadlocked the receive loop against itself.

## How the remaining paths were found

Reading the code is what missed these paths originally, so it was not used to find them. A temporary strict mode made every re-entrant acquisition throw with the acquiring stack, turning silent deadlocks into an enumerable worklist; the suite was run under it until clean, and it was deleted with the re-entrancy it was measuring.

It found two sites static reading had missed: the `EndpointDescription` **property getter** taking the gate (property accessors that lock are silent re-entrancy generators), and the `RequestReceived` dispatch to application code happening **inside** the guarded region — 780 hits.

## Behaviour and cost

Entering twice from one flow now blocks. That is the ordinary contract of a mutex and is diagnosable, rather than silently running two flows inside a region whose purpose is to keep them apart.

An uncontended acquisition now costs what the semaphore costs and allocates nothing, against ~41 ns and 96 bytes before — those 96 bytes were the execution context copy that writing an `AsyncLocal` makes. This was never the motivation: the guarded per-message crypto is ~10,500 ns, so the gate did not register against it either way. The defect history was the motivation.

## Breaking changes for channel subclasses

Documented in `docs/MigrationGuide.md`:

- `HandleSocketError`, `NotifyMonitors` and `CompleteReverseHello` are called from paths that may hold the gate, so an override must not call back into a channel method that takes it (`ForceChannelFault`, `SendResponse`). Such an override nested silently before and will now block.
- `SaveIntermediateChunk`, `GetSavedChunks` and `DoMessageLimitsExceeded` gained the `gateHeld` parameter, with a before/after example in the guide.

## Known residuals

Two deliberate limits, called out for reviewer attention:

1. **`Dispose` no longer takes the gate**, so listener shutdown can race an in-flight operation. This is not avoidable without restructuring every `ChannelClosed`/`ChannelFaulted` caller: `ForceChannelFaultCore` runs with the gate held and reaches `Dispose` via the listener. Under the old re-entrant gate that acquisition was a recursive no-op, so it excluded nothing on that path anyway, and `Dispose` is not thread-safe by contract.
2. **The deferred request dispatch builds `SecureChannelContext` just after gate release** rather than under it. The window is a few field reads on the same stack before the handler's first `await`, the same exposure already exists for everything after that `await`, and the failure mode is now caught and logged. Closing it means changing a public delegate used by three listeners.

## Related Issues

Follow-up to #4232, which introduced `ChannelGate`. No separate tracking issue — this removes a mechanism added in that PR rather than changing externally visible behaviour.

- Follows up #4232

## Checklist

- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf) and read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [x] I have added all necessary documentation.
- [x] I have verified that my changes do not introduce (new) build or analyzer warnings.
- [x] I ran **all** tests locally using the **UA.slnx** solution against at least .net **framework** and .net **10**, and all passed.
- [ ] I fixed **all** failing and flaky tests in the CI pipelines and **all** CodeQL warnings.
- [ ] I have addressed **all** PR feedback received.

### Test results

`dotnet build UA.slnx -c Release` — **0 warnings, 0 errors** across all six TFMs.

| Suite | Result |
| --- | --- |
| `Opc.Ua.Core.Tests` (net10.0) | 4381 total, 0 failed |
| `Opc.Ua.Core.Tests` (net48) | 4311 total, 0 failed |
| `Opc.Ua.Core.Security.Tests` | 617 total, 0 failed |
| `Opc.Ua.Server.Tests` | 4053 total, 0 failed |
| `Opc.Ua.Client.Tests` | 2123 total, 0 failed |
| `Opc.Ua.PubSub.Tests` | 1350 total, 0 failed |
| `Opc.Ua.Features.Tests` | 156 total, 0 failed |
| `Opc.Ua.Subscriptions.Classic.Tests` | 32 total, 0 failed |

All match the pre-change baselines. Core moves from 4388 to 4381: eight re-entrancy tests removed with the behaviour they covered, one deadlock regression test added.

`ChannelGateTests` was rewritten around the new contract — exclusion across both entry modes, an uncontended asynchronous entry not suspending, re-entry blocking by contract, and the property that used to be the hazard: **work started while the gate is held is excluded without having to opt out**. `GateEnterReentrant` was dropped from the benchmarks.
