### PR TITLE
Emit WriteMask from the model in the source generator

### DIFF
--- a/tests/Opc.Ua.SourceGeneration.Core.Tests/Schema/ModelDesignExtensionsTests.cs
+++ b/tests/Opc.Ua.SourceGeneration.Core.Tests/Schema/ModelDesignExtensionsTests.cs
@@ -11225,6 +11225,37 @@ namespace Opc.Ua.Schema.Model.Tests
         }
 
         /// <summary>
+        /// Tests that GetWriteMaskAsCode maps a node's WriteAccess (WriteMask)
+        /// bitmask onto code: zero yields None, and any non-zero value is
+        /// emitted as an AttributeWriteMask cast so NodeSet-declared writable
+        /// attributes (for example DisplayName and Description) stay writable.
+        /// </summary>
+        /// <param name="writeAccess">The WriteAccess bitmask to test.</param>
+        /// <param name="expectedResult">The expected code string.</param>
+        [TestCase(0u, "global::Opc.Ua.AttributeWriteMask.None")]
+        [TestCase(96u, "(global::Opc.Ua.AttributeWriteMask)96")]
+        [TestCase(32u, "(global::Opc.Ua.AttributeWriteMask)32")]
+        public void GetWriteMaskAsCodeMapsWriteAccessOntoCode(uint writeAccess, string expectedResult)
+        {
+            var node = new VariableDesign { WriteAccess = writeAccess };
+
+            string result = node.GetWriteMaskAsCode();
+
+            Assert.That(result, Is.EqualTo(expectedResult));
+        }
+
+        /// <summary>
+        /// Tests that GetWriteMaskAsCode tolerates a null node and returns None.
+        /// </summary>
+        [Test]
+        public void GetWriteMaskAsCodeWithNullNodeReturnsNone()
+        {
+            string result = ((NodeDesign)null).GetWriteMaskAsCode();
+
+            Assert.That(result, Is.EqualTo("global::Opc.Ua.AttributeWriteMask.None"));
+        }
+
+        /// <summary>
         /// Tests that GetMethodArgumentDotNetType converts object to Variant array with array value rank.
         /// Input: Array value rank, type name "object" or "object?".
         /// Expected: Returns "global::Opc.Ua.Variant[]".

--- a/tools/Opc.Ua.SourceGeneration.Core/Generators/NodeStateGenerator.cs
+++ b/tools/Opc.Ua.SourceGeneration.Core/Generators/NodeStateGenerator.cs
@@ -1402,10 +1402,10 @@ namespace Opc.Ua.SourceGeneration
                 GetDescriptionValue(root));
             context.Template.AddReplacement(
                 Tokens.WriteMaskValue,
-                "global::Opc.Ua.AttributeWriteMask.None");
+                root.GetWriteMaskAsCode());
             context.Template.AddReplacement(
                 Tokens.UserWriteMaskValue,
-                "global::Opc.Ua.AttributeWriteMask.None");
+                root.GetWriteMaskAsCode());
 
             // Add Children
             context.Template.AddReplacement(

--- a/tools/Opc.Ua.SourceGeneration.Core/Schema/ModelDesignExtensions.cs
+++ b/tools/Opc.Ua.SourceGeneration.Core/Schema/ModelDesignExtensions.cs
@@ -2442,6 +2442,24 @@ namespace Opc.Ua.Schema.Model
             }
         }
 
+        /// <summary>
+        /// Maps the WriteAccess (WriteMask) of a node onto code. The verbatim
+        /// OPC UA WriteMask bitmask is emitted so that attributes advertised as
+        /// writable in the NodeSet (for example DisplayName and Description)
+        /// stay writable at runtime instead of defaulting to None.
+        /// </summary>
+        public static string GetWriteMaskAsCode(this NodeDesign node)
+        {
+            uint writeMask = node?.WriteAccess ?? 0;
+            if (writeMask == 0)
+            {
+                return "global::Opc.Ua.AttributeWriteMask.None";
+            }
+            return CoreUtils.Format(
+                "(global::Opc.Ua.AttributeWriteMask){0}",
+                writeMask);
+        }
+
         public static string GetLocalizedTextAsCode(this string localizedText)
         {
             return GetLocalizedTextAsCode(new LocalizedText


### PR DESCRIPTION
## Summary

Isolates a self-contained OPC UA source-generator bug fix, extracted from PR #4220 (which targets a different base branch) so it can merge independently against `master`.

## Fix: Emit node WriteMask from the model

**Bug:** The `NodeState` source generator hardcoded `global::Opc.Ua.AttributeWriteMask.None` for both the `WriteMask` and `UserWriteMask` attribute replacements. As a result, attributes declared writable in a NodeSet2 model (for example `WriteMask=96`) were emitted as `None`, so writes to those attributes failed with `BadNotWritable`.

**Change:**
- `tools/Opc.Ua.SourceGeneration.Core/Generators/NodeStateGenerator.cs` - the common node replacements now emit `root.GetWriteMaskAsCode()` for the `WriteMask` and `UserWriteMask` tokens instead of the hardcoded `AttributeWriteMask.None`.
- `tools/Opc.Ua.SourceGeneration.Core/Schema/ModelDesignExtensions.cs` - adds a `GetWriteMaskAsCode(this NodeDesign node)` helper that returns `global::Opc.Ua.AttributeWriteMask.None` when `WriteAccess == 0`, otherwise `(global::Opc.Ua.AttributeWriteMask){writeMask}`.

## Tests

- `tests/Opc.Ua.SourceGeneration.Core.Tests/Schema/ModelDesignExtensionsTests.cs` - adds `[TestCase]`-driven coverage for `GetWriteMaskAsCode` across representative write-mask values plus a null-node test.

## Validation

- `dotnet build tools\Opc.Ua.SourceGeneration.Core\Opc.Ua.SourceGeneration.Core.csproj -c Release` - 0 warnings, 0 errors.
- `dotnet test tests\Opc.Ua.SourceGeneration.Core.Tests\Opc.Ua.SourceGeneration.Core.Tests.csproj -f net8.0 -c Release` - 3775 passed, 0 failed, 8 skipped.

## Note on the Views fix (excluded)

A second generator fix (preserve forward same-namespace `Organizes` references to `ViewDesign` targets in `NodeSetToModelDesign`) was intended to ship here as well, but it was excluded. That fix compensates for behavior introduced by #4220 where imported Views are promoted to top-level `ViewDesign` nodes and their `ParentNodeId` is cleared. On `master` that promotion does not happen (Views remain children of their folder), so the fix and its test do not apply and cannot be cleanly isolated. It will land with #4220.