### PR TITLE
Add MultiState Discrete write validation

### DIFF
--- a/src/Opc.Ua.Core.Types/State/DiscreteItemState.cs
+++ b/src/Opc.Ua.Core.Types/State/DiscreteItemState.cs
@@ -1,0 +1,79 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+namespace Opc.Ua
+{
+    /// <summary>
+    /// Shared behavior for the concrete DiscreteItemType subtypes (Part 8 section
+    /// 5.3.3). The written value can arrive as any of the integer built-in types, so
+    /// the helper normalizes a scalar numeric variant to a 64-bit integer without
+    /// relying on the exact-type <see cref="Variant"/> accessors.
+    /// </summary>
+    public partial class DiscreteItemState
+    {
+        /// <summary>
+        /// Converts a scalar integer variant to a <see cref="long"/> regardless of its
+        /// concrete built-in type. Returns false for values that are not scalar
+        /// integers so the caller can defer to the base class.
+        /// </summary>
+        private protected static bool TryGetIntegerValue(in Variant value, out long number)
+        {
+            switch (value.TypeInfo.BuiltInType)
+            {
+                case BuiltInType.SByte:
+                    number = value.GetSByte();
+                    return true;
+                case BuiltInType.Byte:
+                    number = value.GetByte();
+                    return true;
+                case BuiltInType.Int16:
+                    number = value.GetInt16();
+                    return true;
+                case BuiltInType.UInt16:
+                    number = value.GetUInt16();
+                    return true;
+                case BuiltInType.Int32:
+                    number = value.GetInt32();
+                    return true;
+                case BuiltInType.UInt32:
+                    number = value.GetUInt32();
+                    return true;
+                case BuiltInType.Int64:
+                    number = value.GetInt64();
+                    return true;
+                case BuiltInType.UInt64:
+                    number = unchecked((long)value.GetUInt64());
+                    return true;
+                default:
+                    number = 0;
+                    return false;
+            }
+        }
+    }
+}

--- a/src/Opc.Ua.Core.Types/State/DiscreteItemState.cs
+++ b/src/Opc.Ua.Core.Types/State/DiscreteItemState.cs
@@ -27,6 +27,8 @@
  * http://opcfoundation.org/License/MIT/1.00/
  * ======================================================================*/
 
+using System;
+
 namespace Opc.Ua
 {
     /// <summary>
@@ -40,36 +42,31 @@ namespace Opc.Ua
         /// <summary>
         /// Converts a scalar integer variant to a <see cref="long"/> regardless of its
         /// concrete built-in type. Returns false for values that are not scalar
-        /// integers so the caller can defer to the base class.
+        /// integers that fit in <see cref="long"/> so the caller can defer to the
+        /// base class for non-integer or overflowing unsigned values.
         /// </summary>
         private protected static bool TryGetIntegerValue(in Variant value, out long number)
         {
             switch (value.TypeInfo.BuiltInType)
             {
                 case BuiltInType.SByte:
-                    number = value.GetSByte();
-                    return true;
                 case BuiltInType.Byte:
-                    number = value.GetByte();
-                    return true;
                 case BuiltInType.Int16:
-                    number = value.GetInt16();
-                    return true;
                 case BuiltInType.UInt16:
-                    number = value.GetUInt16();
-                    return true;
                 case BuiltInType.Int32:
-                    number = value.GetInt32();
-                    return true;
                 case BuiltInType.UInt32:
-                    number = value.GetUInt32();
-                    return true;
                 case BuiltInType.Int64:
-                    number = value.GetInt64();
-                    return true;
                 case BuiltInType.UInt64:
-                    number = unchecked((long)value.GetUInt64());
-                    return true;
+                    try
+                    {
+                        number = value.ConvertToInt64().GetInt64();
+                        return true;
+                    }
+                    catch (OverflowException)
+                    {
+                        number = 0;
+                        return false;
+                    }
                 default:
                     number = 0;
                     return false;

--- a/src/Opc.Ua.Core.Types/State/MultiStateDiscreteState.cs
+++ b/src/Opc.Ua.Core.Types/State/MultiStateDiscreteState.cs
@@ -1,0 +1,83 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+namespace Opc.Ua
+{
+    /// <summary>
+    /// Enforces the MultiStateDiscreteType write contract from OPC UA Part 8 section
+    /// 5.3.3.3: the numeric value written to a MultiStateDiscrete variable is an index
+    /// into the mandatory EnumStrings lookup table, so writes outside the range
+    /// [0, EnumStrings.Length) are rejected with BadOutOfRange. Access level, data type
+    /// and index range validation continue to be handled by the base class.
+    /// </summary>
+    public partial class MultiStateDiscreteState
+    {
+        /// <inheritdoc/>
+        protected override ServiceResult WriteValueAttribute(
+            ISystemContext context,
+            NumericRange indexRange,
+            Variant value,
+            StatusCode statusCode,
+            DateTimeUtc sourceTimestamp)
+        {
+            // Only scalar numeric writes are validated here. Everything else (type
+            // mismatches, array writes, index ranges) is left to the base class.
+            if (indexRange.IsNull &&
+                value.TypeInfo.IsScalar &&
+                TryGetIntegerValue(value, out long number) &&
+                TryGetEnumStringsCount(out int count) &&
+                (number < 0 || number >= count))
+            {
+                return StatusCodes.BadOutOfRange;
+            }
+
+            return base.WriteValueAttribute(context, indexRange, value, statusCode, sourceTimestamp);
+        }
+
+        /// <summary>
+        /// Gets the number of entries in the mandatory EnumStrings lookup table.
+        /// Returns false when the property is absent so the caller can defer to the
+        /// base class; a present but empty array yields a count of zero so that every
+        /// index is rejected.
+        /// </summary>
+        private bool TryGetEnumStringsCount(out int count)
+        {
+            if (EnumStrings is { } enumStrings &&
+                enumStrings.WrappedValue.TryGetValue(out ArrayOf<LocalizedText> entries) &&
+                !entries.IsNull)
+            {
+                count = entries.Count;
+                return true;
+            }
+
+            count = 0;
+            return false;
+        }
+    }
+}

--- a/src/Opc.Ua.Core.Types/State/MultiStateValueDiscreteState.cs
+++ b/src/Opc.Ua.Core.Types/State/MultiStateValueDiscreteState.cs
@@ -1,0 +1,118 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+namespace Opc.Ua
+{
+    /// <summary>
+    /// Enforces the MultiStateValueDiscreteType write contract from OPC UA Part 8
+    /// section 5.3.3.4: the numeric value written must match one of the entries in the
+    /// mandatory EnumValues array (which, unlike EnumStrings, may be sparse or not
+    /// zero-based). Writes that do not match an entry are rejected with BadOutOfRange,
+    /// and on a successful scalar write the ValueAsText property is updated with the
+    /// matching entry's display name. Access level, data type and index range
+    /// validation continue to be handled by the base class.
+    /// </summary>
+    public partial class MultiStateValueDiscreteState
+    {
+        /// <inheritdoc/>
+        protected override ServiceResult WriteValueAttribute(
+            ISystemContext context,
+            NumericRange indexRange,
+            Variant value,
+            StatusCode statusCode,
+            DateTimeUtc sourceTimestamp)
+        {
+            LocalizedText matchedText = LocalizedText.Null;
+            bool matched = false;
+
+            // Only scalar numeric writes are validated here. Everything else (type
+            // mismatches, array writes, index ranges) is left to the base class.
+            if (indexRange.IsNull &&
+                value.TypeInfo.IsScalar &&
+                TryGetIntegerValue(value, out long number) &&
+                TryGetEnumValues(out ArrayOf<EnumValueType> enumValues))
+            {
+                foreach (EnumValueType entry in enumValues)
+                {
+                    if (entry.Value == number)
+                    {
+                        matchedText = entry.DisplayName;
+                        matched = true;
+                        break;
+                    }
+                }
+
+                if (!matched)
+                {
+                    return StatusCodes.BadOutOfRange;
+                }
+            }
+
+            ServiceResult result = base.WriteValueAttribute(
+                context, indexRange, value, statusCode, sourceTimestamp);
+
+            if (matched && ServiceResult.IsGood(result))
+            {
+                UpdateValueAsText(matchedText);
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Gets the mandatory EnumValues array. Returns false when the property is
+        /// absent so the caller can defer to the base class; a present but empty array
+        /// yields true so that no value matches and every write is rejected.
+        /// </summary>
+        private bool TryGetEnumValues(out ArrayOf<EnumValueType> enumValues)
+        {
+            if (EnumValues is { } property &&
+                property.WrappedValue.TryGetValue(out enumValues, null) &&
+                !enumValues.IsNull)
+            {
+                return true;
+            }
+
+            enumValues = default;
+            return false;
+        }
+
+        /// <summary>
+        /// Writes the localized display name of the current enumeration value to the
+        /// ValueAsText property when it is present.
+        /// </summary>
+        private void UpdateValueAsText(LocalizedText text)
+        {
+            if (ValueAsText is { } property)
+            {
+                property.WrappedValue = Variant.From(text);
+            }
+        }
+    }
+}

--- a/src/Opc.Ua.Core.Types/State/MultiStateValueDiscreteState.cs
+++ b/src/Opc.Ua.Core.Types/State/MultiStateValueDiscreteState.cs
@@ -56,7 +56,7 @@ namespace Opc.Ua
             if (indexRange.IsNull &&
                 value.TypeInfo.IsScalar &&
                 TryGetIntegerValue(value, out long number) &&
-                TryGetEnumValues(out ArrayOf<EnumValueType> enumValues))
+                TryGetEnumValues(context, out ArrayOf<EnumValueType> enumValues))
             {
                 foreach (EnumValueType entry in enumValues)
                 {
@@ -90,10 +90,10 @@ namespace Opc.Ua
         /// absent so the caller can defer to the base class; a present but empty array
         /// yields true so that no value matches and every write is rejected.
         /// </summary>
-        private bool TryGetEnumValues(out ArrayOf<EnumValueType> enumValues)
+        private bool TryGetEnumValues(ISystemContext context, out ArrayOf<EnumValueType> enumValues)
         {
             if (EnumValues is { } property &&
-                property.WrappedValue.TryGetValue(out enumValues, null) &&
+                property.WrappedValue.TryGetValue(out enumValues, context.AsMessageContext()) &&
                 !enumValues.IsNull)
             {
                 return true;

--- a/tests/Opc.Ua.Core.Tests/Stack/State/MultiStateDiscreteStateTests.cs
+++ b/tests/Opc.Ua.Core.Tests/Stack/State/MultiStateDiscreteStateTests.cs
@@ -1,0 +1,171 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using NUnit.Framework;
+using Opc.Ua.Tests;
+
+namespace Opc.Ua.Core.Tests.Stack.State
+{
+    /// <summary>
+    /// Tests for the handwritten MultiStateDiscreteState write validation which rejects
+    /// numeric writes that fall outside the range of the EnumStrings lookup table.
+    /// </summary>
+    [TestFixture]
+    [Category("NodeState")]
+    [SetCulture("en-us")]
+    [SetUICulture("en-us")]
+    [Parallelizable]
+    public class MultiStateDiscreteStateTests
+    {
+        private static readonly string[] s_states = ["open", "closed", "jammed"];
+
+        private SystemContext m_context;
+
+        [OneTimeSetUp]
+        public void OneTimeSetUp()
+        {
+            ITelemetryContext telemetry = NUnitTelemetryContext.Create();
+            var messageContext = ServiceMessageContext.CreateEmpty(telemetry);
+            m_context = new SystemContext(telemetry)
+            {
+                NamespaceUris = messageContext.NamespaceUris,
+                ServerUris = messageContext.ServerUris,
+                EncodeableFactory = messageContext.Factory,
+                TypeTable = new TypeTable(messageContext.NamespaceUris)
+            };
+        }
+
+        [Test]
+        public void WriteInRangeValueSucceeds()
+        {
+            MultiStateDiscreteState node = CreateNode(s_states);
+
+            ServiceResult result = WriteValue(node, Variant.From((uint)2));
+
+            Assert.That(ServiceResult.IsGood(result), Is.True);
+            Assert.That(node.WrappedValue.TryGetValue(out uint written), Is.True);
+            Assert.That(written, Is.EqualTo(2u));
+        }
+
+        [Test]
+        public void WriteValueEqualToLengthReturnsBadOutOfRange()
+        {
+            MultiStateDiscreteState node = CreateNode(s_states);
+
+            ServiceResult result = WriteValue(node, Variant.From((uint)3));
+
+            Assert.That(result.StatusCode.Code, Is.EqualTo(StatusCodes.BadOutOfRange));
+        }
+
+        [Test]
+        public void WriteValueAboveRangeReturnsBadOutOfRange()
+        {
+            MultiStateDiscreteState node = CreateNode(s_states);
+
+            ServiceResult result = WriteValue(node, Variant.From((uint)99));
+
+            Assert.That(result.StatusCode.Code, Is.EqualTo(StatusCodes.BadOutOfRange));
+        }
+
+        [Test]
+        public void WriteWithEmptyEnumStringsRejectsEveryValue()
+        {
+            MultiStateDiscreteState node = CreateNode([]);
+
+            ServiceResult result = WriteValue(node, Variant.From((uint)0));
+
+            Assert.That(result.StatusCode.Code, Is.EqualTo(StatusCodes.BadOutOfRange));
+        }
+
+        [Test]
+        public void WriteWithoutEnumStringsChildFallsThroughToBase()
+        {
+            MultiStateDiscreteState node = CreateNode(null);
+
+            ServiceResult result = WriteValue(node, Variant.From((uint)42));
+
+            Assert.That(ServiceResult.IsGood(result), Is.True);
+            Assert.That(node.WrappedValue.TryGetValue(out uint written), Is.True);
+            Assert.That(written, Is.EqualTo(42u));
+        }
+
+        [Test]
+        public void WriteMemberButNotWritableReturnsBadNotWritable()
+        {
+            MultiStateDiscreteState node = CreateNode(s_states);
+            node.AccessLevel = AccessLevels.CurrentRead;
+            node.UserAccessLevel = AccessLevels.CurrentRead;
+
+            ServiceResult result = WriteValue(node, Variant.From((uint)1));
+
+            Assert.That(result.StatusCode.Code, Is.EqualTo(StatusCodes.BadNotWritable));
+        }
+
+        private MultiStateDiscreteState CreateNode(string[] enumStrings)
+        {
+            var node = new MultiStateDiscreteState(null)
+            {
+                NodeId = new NodeId(1000),
+                BrowseName = new QualifiedName("States"),
+                DataType = DataTypeIds.UInt32,
+                ValueRank = ValueRanks.Scalar,
+                AccessLevel = AccessLevels.CurrentReadOrWrite,
+                UserAccessLevel = AccessLevels.CurrentReadOrWrite,
+                Value = Variant.From((uint)0)
+            };
+
+            if (enumStrings != null)
+            {
+                var entries = new LocalizedText[enumStrings.Length];
+                for (int ii = 0; ii < enumStrings.Length; ii++)
+                {
+                    entries[ii] = LocalizedText.From(enumStrings[ii]);
+                }
+
+                node.EnumStrings = PropertyState<ArrayOf<LocalizedText>>.With<VariantBuilder>(
+                    node, entries.ToArrayOf());
+                node.EnumStrings.NodeId = new NodeId(1001);
+                node.EnumStrings.BrowseName = new QualifiedName(BrowseNames.EnumStrings);
+                node.EnumStrings.DataType = DataTypeIds.LocalizedText;
+                node.EnumStrings.ValueRank = ValueRanks.OneDimension;
+            }
+
+            return node;
+        }
+
+        private ServiceResult WriteValue(MultiStateDiscreteState node, Variant value)
+        {
+            return node.WriteAttribute(
+                m_context,
+                Attributes.Value,
+                NumericRange.Null,
+                new DataValue(value));
+        }
+    }
+}

--- a/tests/Opc.Ua.Core.Tests/Stack/State/MultiStateValueDiscreteStateTests.cs
+++ b/tests/Opc.Ua.Core.Tests/Stack/State/MultiStateValueDiscreteStateTests.cs
@@ -1,0 +1,202 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using NUnit.Framework;
+using Opc.Ua.Tests;
+
+namespace Opc.Ua.Core.Tests.Stack.State
+{
+    /// <summary>
+    /// Tests for the handwritten MultiStateValueDiscreteState write validation which
+    /// rejects numeric writes that do not match an EnumValues entry and refreshes the
+    /// ValueAsText property on a successful scalar write.
+    /// </summary>
+    [TestFixture]
+    [Category("NodeState")]
+    [SetCulture("en-us")]
+    [SetUICulture("en-us")]
+    [Parallelizable]
+    public class MultiStateValueDiscreteStateTests
+    {
+        // Deliberately sparse / non-zero-based to exercise the EnumValues lookup.
+        private static readonly (long Value, string Name)[] s_states =
+            [(1, "one"), (2, "two"), (4, "four"), (8, "eight")];
+
+        private SystemContext m_context;
+
+        [OneTimeSetUp]
+        public void OneTimeSetUp()
+        {
+            ITelemetryContext telemetry = NUnitTelemetryContext.Create();
+            var messageContext = ServiceMessageContext.CreateEmpty(telemetry);
+            m_context = new SystemContext(telemetry)
+            {
+                NamespaceUris = messageContext.NamespaceUris,
+                ServerUris = messageContext.ServerUris,
+                EncodeableFactory = messageContext.Factory,
+                TypeTable = new TypeTable(messageContext.NamespaceUris)
+            };
+        }
+
+        [Test]
+        public void WriteMatchingSparseValueSucceeds()
+        {
+            MultiStateValueDiscreteState node = CreateNode(s_states);
+
+            ServiceResult result = WriteValue(node, Variant.From((uint)4));
+
+            Assert.That(ServiceResult.IsGood(result), Is.True);
+            Assert.That(node.WrappedValue.TryGetValue(out uint written), Is.True);
+            Assert.That(written, Is.EqualTo(4u));
+        }
+
+        [Test]
+        public void WriteMatchingValueUpdatesValueAsText()
+        {
+            MultiStateValueDiscreteState node = CreateNode(s_states);
+
+            ServiceResult result = WriteValue(node, Variant.From((uint)8));
+
+            Assert.That(ServiceResult.IsGood(result), Is.True);
+            Assert.That(node.ValueAsText, Is.Not.Null);
+            Assert.That(node.ValueAsText.WrappedValue.TryGetValue(out LocalizedText text), Is.True);
+            Assert.That(text.Text, Is.EqualTo("eight"));
+        }
+
+        [Test]
+        public void WriteValueBetweenGapsReturnsBadOutOfRange()
+        {
+            MultiStateValueDiscreteState node = CreateNode(s_states);
+
+            ServiceResult result = WriteValue(node, Variant.From((uint)3));
+
+            Assert.That(result.StatusCode.Code, Is.EqualTo(StatusCodes.BadOutOfRange));
+        }
+
+        [Test]
+        public void WriteValueBetweenGapsLeavesValueAsTextUnchanged()
+        {
+            MultiStateValueDiscreteState node = CreateNode(s_states);
+
+            _ = WriteValue(node, Variant.From((uint)3));
+
+            Assert.That(node.ValueAsText, Is.Not.Null);
+            Assert.That(node.ValueAsText.WrappedValue.TryGetValue(out LocalizedText text), Is.True);
+            Assert.That(text.Text, Is.EqualTo("initial"));
+        }
+
+        [Test]
+        public void WriteWithEmptyEnumValuesRejectsEveryValue()
+        {
+            MultiStateValueDiscreteState node = CreateNode([]);
+
+            ServiceResult result = WriteValue(node, Variant.From((uint)1));
+
+            Assert.That(result.StatusCode.Code, Is.EqualTo(StatusCodes.BadOutOfRange));
+        }
+
+        [Test]
+        public void WriteWithoutEnumValuesChildFallsThroughToBase()
+        {
+            MultiStateValueDiscreteState node = CreateNode(null);
+
+            ServiceResult result = WriteValue(node, Variant.From((uint)99));
+
+            Assert.That(ServiceResult.IsGood(result), Is.True);
+            Assert.That(node.WrappedValue.TryGetValue(out uint written), Is.True);
+            Assert.That(written, Is.EqualTo(99u));
+        }
+
+        [Test]
+        public void WriteMatchingButNotWritableReturnsBadNotWritable()
+        {
+            MultiStateValueDiscreteState node = CreateNode(s_states);
+            node.AccessLevel = AccessLevels.CurrentRead;
+            node.UserAccessLevel = AccessLevels.CurrentRead;
+
+            ServiceResult result = WriteValue(node, Variant.From((uint)4));
+
+            Assert.That(result.StatusCode.Code, Is.EqualTo(StatusCodes.BadNotWritable));
+        }
+
+        private MultiStateValueDiscreteState CreateNode((long Value, string Name)[] states)
+        {
+            var node = new MultiStateValueDiscreteState(null)
+            {
+                NodeId = new NodeId(1000),
+                BrowseName = new QualifiedName("States"),
+                DataType = DataTypeIds.UInt32,
+                ValueRank = ValueRanks.Scalar,
+                AccessLevel = AccessLevels.CurrentReadOrWrite,
+                UserAccessLevel = AccessLevels.CurrentReadOrWrite,
+                Value = Variant.From((uint)0)
+            };
+
+            if (states != null)
+            {
+                var values = new EnumValueType[states.Length];
+                for (int ii = 0; ii < states.Length; ii++)
+                {
+                    LocalizedText text = LocalizedText.From(states[ii].Name);
+                    values[ii] = new EnumValueType
+                    {
+                        Value = states[ii].Value,
+                        DisplayName = text,
+                        Description = text
+                    };
+                }
+
+                node.EnumValues = PropertyState<ArrayOf<EnumValueType>>
+                    .With<StructureBuilder<EnumValueType>>(node, values.ToArrayOf());
+                node.EnumValues.NodeId = new NodeId(1001);
+                node.EnumValues.BrowseName = new QualifiedName(BrowseNames.EnumValues);
+                node.EnumValues.DataType = DataTypeIds.EnumValueType;
+                node.EnumValues.ValueRank = ValueRanks.OneDimension;
+            }
+
+            node.ValueAsText = PropertyState<LocalizedText>.With<VariantBuilder>(
+                node, LocalizedText.From("initial"));
+            node.ValueAsText.NodeId = new NodeId(1002);
+            node.ValueAsText.BrowseName = new QualifiedName(BrowseNames.ValueAsText);
+            node.ValueAsText.DataType = DataTypeIds.LocalizedText;
+            node.ValueAsText.ValueRank = ValueRanks.Scalar;
+
+            return node;
+        }
+
+        private ServiceResult WriteValue(MultiStateValueDiscreteState node, Variant value)
+        {
+            return node.WriteAttribute(
+                m_context,
+                Attributes.Value,
+                NumericRange.Null,
+                new DataValue(value));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds hand-written partial state classes that enforce OPC UA Part 8 §5.3.3 write validation for the `DiscreteItemType` subtypes, plus tests.

## Details

- **`MultiStateDiscreteState`** — a written value is treated as an index into `EnumStrings`. Returns `BadOutOfRange` when the index is outside `[0, len)`.
- **`MultiStateValueDiscreteState`** — a written value is matched against the sparse `EnumValues` set. Returns `BadOutOfRange` when no entry matches. On a good write, `ValueAsText` is refreshed from the matching entry's display name.
- **`DiscreteItemState`** — provides the shared `TryGetIntegerValue` helper that normalizes any scalar integer built-in type to `long` (the exact-type `Variant` accessors return `default` on a built-in-type mismatch, so a `BuiltInType` switch is required).
- **`TwoStateDiscreteType`** intentionally has no hand-written class.

These 3 classes are `public partial class` extending the source-generated DataAccess partials already present on `master`. They read via the typed properties (`EnumStrings`, `EnumValues`, `ValueAsText`) rather than `FindChild`, because `BaseDataVariableState.FindChild` special-cases the `EnumStrings` BrowseName and never falls through to the `AddChild`'d children.

## Testing

- `dotnet build src\Opc.Ua.Core.Types\Opc.Ua.Core.Types.csproj -c Release -f net10.0` → 0 warnings, 0 errors.
- 13 tests across `MultiStateDiscreteStateTests` and `MultiStateValueDiscreteStateTests` pass (13 passed, 0 failed).