### PR TITLE
Fix off-by-one ValueRank in the NodeState source generator

### DIFF
--- a/tests/Opc.Ua.SourceGeneration.Core.Tests/Schema/ModelDesignExtensionsTests.cs
+++ b/tests/Opc.Ua.SourceGeneration.Core.Tests/Schema/ModelDesignExtensionsTests.cs
@@ -3741,10 +3741,10 @@ namespace Opc.Ua.Schema.Model.Tests
 
         /// <summary>
         /// Tests GetValueRankString with OneOrMoreDimensions value rank and single dimension.
-        /// Expects the method to return the TwoDimensions constant string.
+        /// Expects the method to return the OneDimension constant string.
         /// </summary>
         [Test]
-        public void GetValueRankString_OneOrMoreDimensionsWithSingleDimension_ReturnsTwoDimensions()
+        public void GetValueRankString_OneOrMoreDimensionsWithSingleDimension_ReturnsOneDimension()
         {
             // Arrange
             const ValueRank valueRank = ValueRank.OneOrMoreDimensions;
@@ -3754,15 +3754,15 @@ namespace Opc.Ua.Schema.Model.Tests
             string result = valueRank.GetValueRankAsCode(arrayDimensions);
 
             // Assert
-            Assert.That(result, Is.EqualTo("global::Opc.Ua.ValueRanks.TwoDimensions"));
+            Assert.That(result, Is.EqualTo("global::Opc.Ua.ValueRanks.OneDimension"));
         }
 
         /// <summary>
         /// Tests GetValueRankString with OneOrMoreDimensions value rank and two dimensions.
-        /// Expects the method to return a formatted string with dimension count of 3.
+        /// Expects the method to return the TwoDimensions constant string.
         /// </summary>
         [Test]
-        public void GetValueRankString_OneOrMoreDimensionsWithTwoDimensions_ReturnsFormattedDimensionCount()
+        public void GetValueRankString_OneOrMoreDimensionsWithTwoDimensions_ReturnsTwoDimensions()
         {
             // Arrange
             const ValueRank valueRank = ValueRank.OneOrMoreDimensions;
@@ -3772,12 +3772,12 @@ namespace Opc.Ua.Schema.Model.Tests
             string result = valueRank.GetValueRankAsCode(arrayDimensions);
 
             // Assert
-            Assert.That(result, Is.EqualTo("3"));
+            Assert.That(result, Is.EqualTo("global::Opc.Ua.ValueRanks.TwoDimensions"));
         }
 
         /// <summary>
         /// Tests GetValueRankString with OneOrMoreDimensions value rank and three dimensions.
-        /// Expects the method to return a formatted string with dimension count of 4.
+        /// Expects the method to return a formatted string with dimension count of 3.
         /// </summary>
         [Test]
         public void GetValueRankString_OneOrMoreDimensionsWithThreeDimensions_ReturnsFormattedDimensionCount()
@@ -3790,12 +3790,12 @@ namespace Opc.Ua.Schema.Model.Tests
             string result = valueRank.GetValueRankAsCode(arrayDimensions);
 
             // Assert
-            Assert.That(result, Is.EqualTo("4"));
+            Assert.That(result, Is.EqualTo("3"));
         }
 
         /// <summary>
         /// Tests GetValueRankString with OneOrMoreDimensions value rank and multiple dimensions.
-        /// Expects the method to return a formatted string with dimension count of 6.
+        /// Expects the method to return a formatted string with dimension count of 5.
         /// </summary>
         [Test]
         public void GetValueRankString_OneOrMoreDimensionsWithMultipleDimensions_ReturnsFormattedDimensionCount()
@@ -3808,7 +3808,7 @@ namespace Opc.Ua.Schema.Model.Tests
             string result = valueRank.GetValueRankAsCode(arrayDimensions);
 
             // Assert
-            Assert.That(result, Is.EqualTo("6"));
+            Assert.That(result, Is.EqualTo("5"));
         }
 
         /// <summary>
@@ -3826,7 +3826,7 @@ namespace Opc.Ua.Schema.Model.Tests
             string result = valueRank.GetValueRankAsCode(arrayDimensions);
 
             // Assert
-            Assert.That(result, Is.EqualTo("4"));
+            Assert.That(result, Is.EqualTo("3"));
         }
 
         /// <summary>
@@ -3844,7 +3844,7 @@ namespace Opc.Ua.Schema.Model.Tests
             string result = valueRank.GetValueRankAsCode(arrayDimensions);
 
             // Assert
-            Assert.That(result, Is.EqualTo("3"));
+            Assert.That(result, Is.EqualTo("global::Opc.Ua.ValueRanks.TwoDimensions"));
         }
 
         /// <summary>
@@ -3852,7 +3852,7 @@ namespace Opc.Ua.Schema.Model.Tests
         /// Expects the method to treat it as empty and return OneOrMoreDimensions.
         /// </summary>
         [Test]
-        public void GetValueRankString_OneOrMoreDimensionsWithOnlyCommas_ReturnsOneDimension()
+        public void GetValueRankString_OneOrMoreDimensionsWithOnlyCommas_ReturnsOneOrMoreDimensions()
         {
             // Arrange
             const ValueRank valueRank = ValueRank.OneOrMoreDimensions;
@@ -3862,7 +3862,7 @@ namespace Opc.Ua.Schema.Model.Tests
             string result = valueRank.GetValueRankAsCode(arrayDimensions);
 
             // Assert
-            Assert.That(result, Is.EqualTo("global::Opc.Ua.ValueRanks.OneDimension"));
+            Assert.That(result, Is.EqualTo("global::Opc.Ua.ValueRanks.OneOrMoreDimensions"));
         }
 
         /// <summary>

--- a/tools/Opc.Ua.SourceGeneration.Core/Schema/ModelDesignExtensions.cs
+++ b/tools/Opc.Ua.SourceGeneration.Core/Schema/ModelDesignExtensions.cs
@@ -928,10 +928,16 @@ namespace Opc.Ua.Schema.Model
                         return "global::Opc.Ua.ValueRanks.OneOrMoreDimensions";
                     }
 
-                    // TODO: "is ,,, not considered 3 dim?
-
+                    // The number of entries in ArrayDimensions is the number of
+                    // dimensions, which equals the ValueRank for a fixed-size
+                    // multi-dimensional array (e.g. "3,3" is a two-dimensional
+                    // array with ValueRank 2).
                     string[] dimensions = arrayDimensions.Split([','], StringSplitOptions.RemoveEmptyEntries);
-                    int dims = dimensions.Length + 1;
+                    int dims = dimensions.Length;
+                    if (dims == 0)
+                    {
+                        return "global::Opc.Ua.ValueRanks.OneOrMoreDimensions";
+                    }
                     if (dims == 1)
                     {
                         return "global::Opc.Ua.ValueRanks.OneDimension";


### PR DESCRIPTION
## Summary

`ModelDesignExtensions.GetValueRankAsCode` in the NodeState source generator computed the ValueRank for a fixed-size multi-dimensional `ArrayDimensions` string (e.g. `"3,3"`) as `dimensions.Length + 1`, which over-counted the rank by one. The number of comma-separated entries in `ArrayDimensions` already **is** the ValueRank — `"3,3"` is a two-dimensional array with ValueRank `2`, not `3`.

## Changes

- `dims = dimensions.Length + 1` → `dims = dimensions.Length` (entry count already equals the ValueRank).
- Added a guard: when there are zero entries (empty or all-commas `ArrayDimensions`, which `Split(..., RemoveEmptyEntries)` reduces to length 0), the method now returns `OneOrMoreDimensions`.
- Refreshed the stale explanatory comment / removed the obsolete `TODO`.
- Updated the `GetValueRankString_*` unit tests in `ModelDesignExtensionsTests.cs` to the corrected expected ranks.

## Validation

- `dotnet build` of `Opc.Ua.SourceGeneration.Core` (Release): 0 warnings / 0 errors.
- Filtered `GetValueRankString` tests on net8.0: 18/18 passed.

Extracted from the larger PR #4220 work; this PR contains **only** the ValueRank fix (two files).