### PR TITLE
Harden server subscription deletion/transfer race

### DIFF
--- a/src/Opc.Ua.Server/Server/ServerInternalData.cs
+++ b/src/Opc.Ua.Server/Server/ServerInternalData.cs
@@ -851,7 +851,13 @@ namespace Opc.Ua.Server
             bool deleteSubscriptions,
             CancellationToken cancellationToken = default)
         {
-            MarkSessionClosing(sessionId);
+            // Only the first caller to mark the session closing performs the teardown. If the
+            // session is already closing another close is in progress, so return without racing it.
+            if (!MarkSessionClosing(sessionId))
+            {
+                return;
+            }
+
             try
             {
                 await NodeManager.SessionClosingAsync(context, sessionId, deleteSubscriptions, cancellationToken)
@@ -876,16 +882,21 @@ namespace Opc.Ua.Server
         /// on its way out.
         /// </summary>
         /// <param name="sessionId">The session being closed.</param>
-        private void MarkSessionClosing(NodeId sessionId)
+        /// <returns>
+        /// <c>true</c> when this call marked the session closing (or the session is unknown and the
+        /// teardown should still proceed); <c>false</c> when the session was already closing.
+        /// </returns>
+        private bool MarkSessionClosing(NodeId sessionId)
         {
             foreach (ISession session in SessionManager.GetSessions())
             {
                 if (session.Id == sessionId)
                 {
-                    (session as Session)?.MarkClosing();
-                    return;
+                    return (session as Session)?.MarkClosing() ?? true;
                 }
             }
+
+            return true;
         }
 
         /// <summary>

--- a/src/Opc.Ua.Server/Session/Session.cs
+++ b/src/Opc.Ua.Server/Session/Session.cs
@@ -479,9 +479,13 @@ namespace Opc.Ua.Server
         /// Session is on its way out, so nothing that would create new state for it is accepted
         /// again, even if the close itself fails.
         /// </summary>
-        internal void MarkClosing()
+        /// <returns>
+        /// <c>true</c> when this call transitioned the session into the closing state;
+        /// <c>false</c> when the session was already closing.
+        /// </returns>
+        internal bool MarkClosing()
         {
-            Volatile.Write(ref m_closing, 1);
+            return Interlocked.Exchange(ref m_closing, 1) == 0;
         }
 
         /// <summary>

--- a/src/Opc.Ua.Server/Subscription/ISubscription.cs
+++ b/src/Opc.Ua.Server/Subscription/ISubscription.cs
@@ -79,6 +79,12 @@ namespace Opc.Ua.Server
         bool IsDurable { get; }
 
         /// <summary>
+        /// True once the subscription has been deleted via <see cref="DeleteAsync"/>. Publicly
+        /// callable members throw Bad_SubscriptionIdInvalid once this is set.
+        /// </summary>
+        bool IsDeleted { get; }
+
+        /// <summary>
         /// Applies an update to the subscription diagnostics while holding the
         /// subscription's diagnostics lock.
         /// </summary>

--- a/src/Opc.Ua.Server/Subscription/Subscription.cs
+++ b/src/Opc.Ua.Server/Subscription/Subscription.cs
@@ -410,6 +410,13 @@ namespace Opc.Ua.Server
         public bool IsDurable { get; private set; }
 
         /// <summary>
+        /// True once the subscription has been deleted. Set when <see cref="DeleteAsync"/> is
+        /// called and never cleared: a deleted subscription is on its way out and must not serve
+        /// any further work.
+        /// </summary>
+        public bool IsDeleted => Volatile.Read(ref m_deleted) != 0;
+
+        /// <summary>
         /// Applies an update to the subscription diagnostics while holding the
         /// subscription's diagnostics lock.
         /// </summary>
@@ -629,6 +636,11 @@ namespace Opc.Ua.Server
         /// </summary>
         public async ValueTask DeleteAsync(OperationContext context, CancellationToken cancellationToken = default)
         {
+            // Mark the subscription deleted first so any concurrent service call that reaches a
+            // publicly callable method fails fast with Bad_SubscriptionIdInvalid instead of
+            // operating on a subscription that is being torn down.
+            Volatile.Write(ref m_deleted, 1);
+
             // delete the diagnostics.
             if (!m_diagnosticsId.IsNull)
             {
@@ -641,26 +653,49 @@ namespace Opc.Ua.Server
             {
                 TraceState(LogLevel.Information, TraceStateId.Deleted, "DELETED");
 
-                // the context may be null if the server is cleaning up expired subscriptions.
-                // in this case we create a context with a dummy request and use the current session.
-                if (context == null)
+                // detach the monitored items from the subscription.
+                List<IMonitoredItem> monitoredItems;
+                lock (m_lock)
                 {
-                    var requestHeader = new RequestHeader
-                    {
-                        ReturnDiagnostics = (int)DiagnosticsMasks.OperationSymbolicIdAndText
-                    };
-                    // Passed on to DeleteMonitoredItemsAsync below; it tracks no request, so there
-                    // is nothing to release when this scope ends.
-#pragma warning disable CA2000
-                    context = new OperationContext(requestHeader, null, RequestType.Unknown, RequestLifetime.None);
-#pragma warning restore CA2000
+                    monitoredItems = m_monitoredItems.Values.Select(node => node.Value).ToList();
+                    m_monitoredItems.Clear();
+                    m_itemsToTrigger.Clear();
+                    m_itemsToCheck.Clear();
+                    m_itemsToPublish.Clear();
                 }
 
-                await DeleteMonitoredItemsAsync(
-                    context,
-                    [.. m_monitoredItems.Keys],
-                    true,
-                    cancellationToken).ConfigureAwait(false);
+                if (monitoredItems.Count > 0)
+                {
+                    // the context may be null if the server is cleaning up expired subscriptions.
+                    // in this case we create a context with a dummy request and use the current session.
+                    if (context == null)
+                    {
+                        var requestHeader = new RequestHeader
+                        {
+                            ReturnDiagnostics = (int)DiagnosticsMasks.OperationSymbolicIdAndText
+                        };
+                        // The context tracks no request, so there is nothing to release when this scope ends.
+#pragma warning disable CA2000
+                        context = new OperationContext(requestHeader, null, RequestType.Unknown, RequestLifetime.None);
+#pragma warning restore CA2000
+                    }
+
+                    var errors = new List<ServiceResult>(monitoredItems.Count);
+                    for (int ii = 0; ii < monitoredItems.Count; ii++)
+                    {
+                        errors.Add(null!);
+                    }
+
+                    await m_server.NodeManager
+                        .DeleteMonitoredItemsAsync(context, Id, monitoredItems, errors, cancellationToken)
+                        .ConfigureAwait(false);
+
+                    // dispose the monitored items.
+                    foreach (IMonitoredItem monitoredItem in monitoredItems)
+                    {
+                        monitoredItem?.Dispose();
+                    }
+                }
             }
             catch (Exception e)
             {
@@ -836,6 +871,8 @@ namespace Opc.Ua.Server
             bool sendInitialValues,
             CancellationToken cancellationToken = default)
         {
+            ThrowIfDeleted();
+
             ISession destinationSession = context.Session;
             ISession? sourceSession;
             List<IMonitoredItem> monitoredItems;
@@ -1285,6 +1322,8 @@ namespace Opc.Ua.Server
         /// </summary>
         public void ResendData(OperationContext context)
         {
+            ThrowIfDeleted();
+
             // check session.
             VerifySession(context);
             lock (m_lock)
@@ -1390,6 +1429,8 @@ namespace Opc.Ua.Server
         /// </summary>
         public ServiceResult? Acknowledge(OperationContext context, uint sequenceNumber)
         {
+            ThrowIfDeleted();
+
             lock (m_lock)
             {
                 // check session.
@@ -1849,6 +1890,7 @@ namespace Opc.Ua.Server
             {
                 throw new ArgumentNullException(nameof(context));
             }
+            ThrowIfDeleted();
 
             lock (m_diagnosticsLock)
             {
@@ -1900,6 +1942,8 @@ namespace Opc.Ua.Server
             uint maxNotificationsPerPublish,
             byte priority)
         {
+            ThrowIfDeleted();
+
             lock (m_lock)
             {
                 // check session.
@@ -1950,6 +1994,8 @@ namespace Opc.Ua.Server
         /// </summary>
         public void SetPublishingMode(OperationContext context, bool publishingEnabled)
         {
+            ThrowIfDeleted();
+
             lock (m_lock)
             {
                 // check session.
@@ -2006,6 +2052,7 @@ namespace Opc.Ua.Server
             {
                 throw new ArgumentNullException(nameof(context));
             }
+            ThrowIfDeleted();
 
             // allocate results.
             bool diagnosticsExist = false;
@@ -2184,31 +2231,17 @@ namespace Opc.Ua.Server
         /// Adds monitored items to a subscription.
         /// </summary>
         /// <exception cref="ArgumentNullException"><paramref name="context"/> is <c>null</c>.</exception>
-        public ValueTask<CreateMonitoredItemsResponse> CreateMonitoredItemsAsync(
+        public async ValueTask<CreateMonitoredItemsResponse> CreateMonitoredItemsAsync(
             OperationContext context,
             TimestampsToReturn timestampsToReturn,
             ArrayOf<MonitoredItemCreateRequest> itemsToCreate,
             CancellationToken cancellationToken = default)
         {
-            return CreateMonitoredItemsCoreAsync(
-                context,
-                timestampsToReturn,
-                itemsToCreate,
-                cancellationToken);
-        }
-
-        private async ValueTask<CreateMonitoredItemsResponse>
-            CreateMonitoredItemsCoreAsync(
-                OperationContext context,
-                TimestampsToReturn timestampsToReturn,
-                ArrayOf<MonitoredItemCreateRequest> itemsToCreate,
-                CancellationToken cancellationToken)
-        {
             if (context == null)
             {
                 throw new ArgumentNullException(nameof(context));
             }
-            EnsureSessionNotClosing(context);
+            ThrowIfDeleted();
 
             int count = itemsToCreate.Count;
 
@@ -2410,31 +2443,17 @@ namespace Opc.Ua.Server
         /// Modifies monitored items in a subscription.
         /// </summary>
         /// <exception cref="ArgumentNullException"><paramref name="context"/> is <c>null</c>.</exception>
-        public ValueTask<ModifyMonitoredItemsResponse> ModifyMonitoredItemsAsync(
+        public async ValueTask<ModifyMonitoredItemsResponse> ModifyMonitoredItemsAsync(
             OperationContext context,
             TimestampsToReturn timestampsToReturn,
             ArrayOf<MonitoredItemModifyRequest> itemsToModify,
             CancellationToken cancellationToken = default)
         {
-            return ModifyMonitoredItemsCoreAsync(
-                context,
-                timestampsToReturn,
-                itemsToModify,
-                cancellationToken);
-        }
-
-        private async ValueTask<ModifyMonitoredItemsResponse>
-            ModifyMonitoredItemsCoreAsync(
-                OperationContext context,
-                TimestampsToReturn timestampsToReturn,
-                ArrayOf<MonitoredItemModifyRequest> itemsToModify,
-                CancellationToken cancellationToken)
-        {
             if (context == null)
             {
                 throw new ArgumentNullException(nameof(context));
             }
-            EnsureSessionNotClosing(context);
+            ThrowIfDeleted();
 
             int count = itemsToModify.Count;
 
@@ -2592,50 +2611,17 @@ namespace Opc.Ua.Server
         /// <summary>
         /// Deletes the monitored items in a subscription.
         /// </summary>
-        public ValueTask<DeleteMonitoredItemsResponse> DeleteMonitoredItemsAsync(
-            OperationContext context,
-            ArrayOf<uint> monitoredItemIds,
-            CancellationToken cancellationToken = default)
-        {
-            return DeleteMonitoredItemsAsync(
-                context,
-                monitoredItemIds,
-                false,
-                cancellationToken);
-        }
-
-        /// <summary>
-        /// Deletes the monitored items in a subscription.
-        /// </summary>
         /// <exception cref="ArgumentNullException"><paramref name="context"/> is <c>null</c>.</exception>
-        private ValueTask<DeleteMonitoredItemsResponse> DeleteMonitoredItemsAsync(
+        public async ValueTask<DeleteMonitoredItemsResponse> DeleteMonitoredItemsAsync(
             OperationContext context,
             ArrayOf<uint> monitoredItemIds,
-            bool doNotCheckSession,
             CancellationToken cancellationToken = default)
-        {
-            return DeleteMonitoredItemsCoreAsync(
-                context,
-                monitoredItemIds,
-                doNotCheckSession,
-                cancellationToken);
-        }
-
-        private async ValueTask<DeleteMonitoredItemsResponse>
-            DeleteMonitoredItemsCoreAsync(
-                OperationContext context,
-                ArrayOf<uint> monitoredItemIds,
-                bool doNotCheckSession,
-                CancellationToken cancellationToken)
         {
             if (context == null)
             {
                 throw new ArgumentNullException(nameof(context));
             }
-            if (!doNotCheckSession)
-            {
-                EnsureSessionNotClosing(context);
-            }
+            ThrowIfDeleted();
 
             int count = monitoredItemIds.Count;
 
@@ -2659,10 +2645,7 @@ namespace Opc.Ua.Server
             lock (m_lock)
             {
                 // check session.
-                if (!doNotCheckSession)
-                {
-                    VerifySession(context);
-                }
+                VerifySession(context);
 
                 // clear lifetime counter.
                 ResetLifetimeCount();
@@ -2799,32 +2782,17 @@ namespace Opc.Ua.Server
         /// Changes the monitoring mode for a set of items.
         /// </summary>
         /// <exception cref="ArgumentNullException"><paramref name="context"/> is <c>null</c>.</exception>
-        public ValueTask<(ArrayOf<StatusCode> results, ArrayOf<DiagnosticInfo> diagnosticInfos)> SetMonitoringModeAsync(
+        public async ValueTask<(ArrayOf<StatusCode> results, ArrayOf<DiagnosticInfo> diagnosticInfos)> SetMonitoringModeAsync(
             OperationContext context,
             MonitoringMode monitoringMode,
             ArrayOf<uint> monitoredItemIds,
             CancellationToken cancellationToken = default)
         {
-            return SetMonitoringModeCoreAsync(
-                context,
-                monitoringMode,
-                monitoredItemIds,
-                cancellationToken);
-        }
-
-        private async ValueTask<(
-            ArrayOf<StatusCode> results,
-            ArrayOf<DiagnosticInfo> diagnosticInfos)> SetMonitoringModeCoreAsync(
-                OperationContext context,
-                MonitoringMode monitoringMode,
-                ArrayOf<uint> monitoredItemIds,
-                CancellationToken cancellationToken)
-        {
             if (context == null)
             {
                 throw new ArgumentNullException(nameof(context));
             }
-            EnsureSessionNotClosing(context);
+            ThrowIfDeleted();
 
             int count = monitoredItemIds.Count;
 
@@ -2966,6 +2934,8 @@ namespace Opc.Ua.Server
         /// <exception cref="ServiceResultException"></exception>
         public void ValidateConditionRefresh(OperationContext context)
         {
+            ThrowIfDeleted();
+
             lock (m_lock)
             {
                 VerifySession(context);
@@ -3001,6 +2971,8 @@ namespace Opc.Ua.Server
         /// </summary>
         public async ValueTask ConditionRefreshAsync(CancellationToken cancellationToken = default)
         {
+            ThrowIfDeleted();
+
             var monitoredItems = new List<IEventMonitoredItem>();
 
             lock (m_lock)
@@ -3033,6 +3005,8 @@ namespace Opc.Ua.Server
         /// <exception cref="ServiceResultException"></exception>
         public async ValueTask ConditionRefresh2Async(uint monitoredItemId, CancellationToken cancellationToken = default)
         {
+            ThrowIfDeleted();
+
             var monitoredItems = new List<IEventMonitoredItem>();
 
             lock (m_lock)
@@ -3181,6 +3155,8 @@ namespace Opc.Ua.Server
         /// </summary>
         public ServiceResult SetSubscriptionDurable(uint maxLifetimeCount)
         {
+            ThrowIfDeleted();
+
             lock (m_lock)
             {
                 if (!m_supportsDurable)
@@ -3219,6 +3195,8 @@ namespace Opc.Ua.Server
         /// </summary>
         public void GetMonitoredItems(out ArrayOf<uint> serverHandles, out ArrayOf<uint> clientHandles)
         {
+            ThrowIfDeleted();
+
             lock (m_lock)
             {
                 uint[] serverHandleList = new uint[m_monitoredItems.Count];
@@ -3363,11 +3341,11 @@ namespace Opc.Ua.Server
             }
         }
 
-        private void EnsureSessionNotClosing(OperationContext context)
+        private void ThrowIfDeleted()
         {
-            if (context.Session is { IsClosing: true })
+            if (IsDeleted)
             {
-                throw new ServiceResultException(StatusCodes.BadSessionClosed);
+                throw new ServiceResultException(StatusCodes.BadSubscriptionIdInvalid);
             }
         }
 
@@ -3503,6 +3481,7 @@ namespace Opc.Ua.Server
         private bool m_refreshInProgress;
         private bool m_expired;
         private bool m_transferInProgress;
+        private int m_deleted;
         private readonly Dictionary<uint, List<ITriggeredMonitoredItem>> m_itemsToTrigger;
         private readonly bool m_supportsDurable;
         private readonly ILogger m_logger;

--- a/src/Opc.Ua.Server/Subscription/SubscriptionManager.cs
+++ b/src/Opc.Ua.Server/Subscription/SubscriptionManager.cs
@@ -583,6 +583,9 @@ namespace Opc.Ua.Server
                     // delete subscription.
                     await subscription.DeleteAsync(context, cancellationToken).ConfigureAwait(false);
 
+                    // release the subscription resources now that it has been deleted.
+                    subscription.Dispose();
+
                     // get the count for the diagnostics.
                     uint publishingIntervalCount = GetPublishingIntervalCount();
                     m_server.UpdateServerDiagnostics(diagnostics =>
@@ -768,6 +771,9 @@ namespace Opc.Ua.Server
 
                 // delete subscription.
                 await subscription.DeleteAsync(context, cancellationToken).ConfigureAwait(false);
+
+                // release the subscription resources now that it has been deleted.
+                subscription.Dispose();
 
                 // get the count for the diagnostics.
                 uint publishingIntervalCount = GetPublishingIntervalCount();

--- a/src/Opc.Ua.Server/Subscription/SubscriptionManager.cs
+++ b/src/Opc.Ua.Server/Subscription/SubscriptionManager.cs
@@ -580,11 +580,16 @@ namespace Opc.Ua.Server
                     // raise subscription event.
                     RaiseSubscriptionEvent(subscription, true);
 
-                    // delete subscription.
-                    await subscription.DeleteAsync(context, cancellationToken).ConfigureAwait(false);
-
-                    // release the subscription resources now that it has been deleted.
-                    subscription.Dispose();
+                    try
+                    {
+                        // delete subscription.
+                        await subscription.DeleteAsync(context, cancellationToken).ConfigureAwait(false);
+                    }
+                    finally
+                    {
+                        // release the subscription resources even if delete threw.
+                        subscription.Dispose();
+                    }
 
                     // get the count for the diagnostics.
                     uint publishingIntervalCount = GetPublishingIntervalCount();
@@ -769,11 +774,16 @@ namespace Opc.Ua.Server
                 // raise subscription event.
                 RaiseSubscriptionEvent(subscription, true);
 
-                // delete subscription.
-                await subscription.DeleteAsync(context, cancellationToken).ConfigureAwait(false);
-
-                // release the subscription resources now that it has been deleted.
-                subscription.Dispose();
+                try
+                {
+                    // delete subscription.
+                    await subscription.DeleteAsync(context, cancellationToken).ConfigureAwait(false);
+                }
+                finally
+                {
+                    // release the subscription resources even if delete threw.
+                    subscription.Dispose();
+                }
 
                 // get the count for the diagnostics.
                 uint publishingIntervalCount = GetPublishingIntervalCount();

--- a/tests/Opc.Ua.Server.Tests/SubscriptionLifecycleTests.cs
+++ b/tests/Opc.Ua.Server.Tests/SubscriptionLifecycleTests.cs
@@ -751,5 +751,89 @@ namespace Opc.Ua.Server.Tests
                 () => subscription.Republish(context: null, retransmitSequenceNumber: 1),
                 Throws.TypeOf<ArgumentNullException>());
         }
+
+        [Test]
+        public void IsDeletedIsFalseForNewSubscription()
+        {
+            using Subscription subscription = CreateSubscription();
+
+            Assert.That(subscription.IsDeleted, Is.False);
+        }
+
+        [Test]
+        public async System.Threading.Tasks.Task DeleteAsyncSetsIsDeleted()
+        {
+            using Subscription subscription = CreateSubscription();
+            OperationContext context = CreateOperationContext();
+
+            await subscription.DeleteAsync(context);
+
+            Assert.That(subscription.IsDeleted, Is.True);
+        }
+
+        [Test]
+        public async System.Threading.Tasks.Task GatedMethodsThrowBadSubscriptionIdInvalidAfterDelete()
+        {
+            using Subscription subscription = CreateSubscription();
+            OperationContext context = CreateOperationContext();
+
+            await subscription.DeleteAsync(context);
+
+            Assert.Multiple(() =>
+            {
+                AssertBadSubscriptionId(Assert.Throws<ServiceResultException>(
+                    () => subscription.Modify(context, 1000, 10, 5, 0, 0)));
+                AssertBadSubscriptionId(Assert.Throws<ServiceResultException>(
+                    () => subscription.SetPublishingMode(context, publishingEnabled: false)));
+                AssertBadSubscriptionId(Assert.Throws<ServiceResultException>(
+                    () => subscription.ResendData(context)));
+                AssertBadSubscriptionId(Assert.Throws<ServiceResultException>(
+                    () => subscription.Acknowledge(context, sequenceNumber: 1)));
+                AssertBadSubscriptionId(Assert.Throws<ServiceResultException>(
+                    () => subscription.Republish(context, retransmitSequenceNumber: 1)));
+                AssertBadSubscriptionId(Assert.Throws<ServiceResultException>(
+                    () => subscription.GetMonitoredItems(out _, out _)));
+                AssertBadSubscriptionId(Assert.Throws<ServiceResultException>(
+                    () => subscription.SetSubscriptionDurable(maxLifetimeCount: 100)));
+                AssertBadSubscriptionId(Assert.Throws<ServiceResultException>(
+                    () => subscription.ValidateConditionRefresh(context)));
+                AssertBadSubscriptionId(Assert.Throws<ServiceResultException>(
+                    () => subscription.SetTriggering(
+                        context, triggeringItemId: 1, linksToAdd: [], linksToRemove: [],
+                        out _, out _, out _, out _)));
+            });
+        }
+
+        [Test]
+        public async System.Threading.Tasks.Task GatedAsyncMethodsThrowBadSubscriptionIdInvalidAfterDelete()
+        {
+            using Subscription subscription = CreateSubscription();
+            OperationContext context = CreateOperationContext();
+
+            await subscription.DeleteAsync(context);
+
+            AssertBadSubscriptionId(Assert.ThrowsAsync<ServiceResultException>(
+                async () => await subscription.CreateMonitoredItemsAsync(
+                    context, TimestampsToReturn.Both, [])));
+            AssertBadSubscriptionId(Assert.ThrowsAsync<ServiceResultException>(
+                async () => await subscription.ModifyMonitoredItemsAsync(
+                    context, TimestampsToReturn.Both, [])));
+            AssertBadSubscriptionId(Assert.ThrowsAsync<ServiceResultException>(
+                async () => await subscription.DeleteMonitoredItemsAsync(context, [])));
+            AssertBadSubscriptionId(Assert.ThrowsAsync<ServiceResultException>(
+                async () => await subscription.SetMonitoringModeAsync(
+                    context, MonitoringMode.Reporting, [])));
+            AssertBadSubscriptionId(Assert.ThrowsAsync<ServiceResultException>(
+                async () => await subscription.ConditionRefreshAsync()));
+            AssertBadSubscriptionId(Assert.ThrowsAsync<ServiceResultException>(
+                async () => await subscription.TransferSessionAsync(
+                    context, sendInitialValues: false)));
+        }
+
+        private static void AssertBadSubscriptionId(ServiceResultException ex)
+        {
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex.Code, Is.EqualTo(StatusCodes.BadSubscriptionIdInvalid));
+        }
     }
 }

--- a/tests/Opc.Ua.Server.Tests/SubscriptionTests.cs
+++ b/tests/Opc.Ua.Server.Tests/SubscriptionTests.cs
@@ -143,7 +143,7 @@ namespace Opc.Ua.Server.Tests
 
         [Test]
         [Category("NodeManagerLifecycle")]
-        public void CreateMonitoredItemsRejectsClosingSession()
+        public void CreateMonitoredItemsDoesNotRejectClosingSession()
         {
             using ServerInternalData server = CreateServerInternalData();
             m_sessionMock.SetupGet(session => session.IsClosing).Returns(true);
@@ -162,19 +162,17 @@ namespace Opc.Ua.Server.Tests
                 m_sessionMock.Object,
                 DiagnosticsMasks.None);
 
-            ServiceResultException exception =
-                Assert.ThrowsAsync<ServiceResultException>(
-                    async () => await subscription
-                        .CreateMonitoredItemsAsync(
-                            context,
-                            TimestampsToReturn.Both,
-                            [],
-                            CancellationToken.None)
-                        .ConfigureAwait(false));
-
-            Assert.That(
-                exception.StatusCode,
-                Is.EqualTo(StatusCodes.BadSessionClosed));
+            // The subscription no longer gates monitored item operations on the
+            // owning session's closing state; ownership and deletion are the only
+            // guards. A closing session that still owns the subscription is allowed.
+            Assert.DoesNotThrowAsync(
+                async () => await subscription
+                    .CreateMonitoredItemsAsync(
+                        context,
+                        TimestampsToReturn.Both,
+                        [],
+                        CancellationToken.None)
+                    .ConfigureAwait(false));
         }
 
         private ServerInternalData CreateServerInternalData()


### PR DESCRIPTION
# Description

Deleting or transferring a server-side subscription concurrently with monitored-item operations was guarded by an ad-hoc, per-method `EnsureSessionNotClosing` check plus layers of `...Core` indirection. That made the actual lifecycle contract hard to reason about and left a window where a call could still race a delete. This tightens the model so a subscription has one explicit "deleted" gate and closing-session teardown is deterministic.

Key changes:

- **Collapse the indirection.** The subscription monitored-item overloads and `...Core` methods are folded back into the public interface methods (`CreateMonitoredItemsAsync`, `ModifyMonitoredItemsAsync`, `DeleteMonitoredItemsAsync`, `SetMonitoringModeAsync`). `EnsureSessionNotClosing` is removed; these operations now rely on session ownership via `VerifySession` plus the new deletion gate instead of an ad-hoc closing-session check.
- **Explicit deletion gate.** Added `ISubscription.IsDeleted`, set as the first step of `DeleteAsync`. Every publicly callable `Subscription` method throws `Bad_SubscriptionIdInvalid` once the subscription is deleted. `DeleteAsync` performs its own inline monitored-item teardown so it is not blocked by its own gate.
- **Deterministic disposal.** Subscriptions are disposed after `DeleteAsync` at both `SubscriptionManager` delete sites (`MonitoredItem.Dispose` is idempotent, so the redundant item teardown is safe).
- **Idempotent session close.** `ServerInternalData.CloseSessionAsync` now returns early when `MarkSessionClosing` reports the session was already closing; `Session.MarkClosing` returns whether it actually transitioned (via `Interlocked.Exchange`).

One behavior change worth a careful look: because the closing-session gate is gone, a closing session that still owns a subscription can complete monitored-item operations. The existing `CreateMonitoredItemsRejectsClosingSession` test was repurposed to `CreateMonitoredItemsDoesNotRejectClosingSession` to assert this new contract. `SubscriptionManager` still guards `CreateSubscription`, `Publish`, and `TransferSubscriptions` on `IsClosing` with `Bad_SessionClosed`.

## Related Issues

N/A

## Checklist

_Put an `x` in the boxes that apply. You can complete these step by step after opening the PR._

- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf) and read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added all necessary documentation.
- [x] I have verified that my changes do not introduce (new) build or analyzer warnings.
- [ ] I ran **all** tests locally using the **UA.slnx** solution against at least .net **framework** and .net **10**, and all passed. _(Validated the full `Opc.Ua.Server.Tests` project on net10.0 - 4095 passed, 5 skipped; net48 not yet run.)_
- [ ] I fixed **all** failing and flaky tests in the CI pipelines and **all** CodeQL warnings.
- [ ] I have addressed **all** PR feedback received.