### PR TITLE
Set ContinuationPoint to null when browse is finished (port of #4057)

### DIFF
--- a/Libraries/Opc.Ua.Server/NodeManager/MasterNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/NodeManager/MasterNodeManager.cs
@@ -1292,7 +1292,11 @@ namespace Opc.Ua.Server
                 BrowseDescription nodeToBrowse = nodesToBrowse[ii];
 
                 // initialize result.
-                var result = new BrowseResult { StatusCode = StatusCodes.Good };
+                var result = new BrowseResult
+                {
+                    StatusCode = StatusCodes.Good,
+                    ContinuationPoint = default
+                };
                 results.Add(result);
 
                 ServiceResult error;
@@ -1452,7 +1456,11 @@ namespace Opc.Ua.Server
                         .ConfigureAwait(false);
                     if (ServiceResult.IsBad(validationResult))
                     {
-                        var badResult = new BrowseResult { StatusCode = validationResult.Code };
+                        var badResult = new BrowseResult
+                        {
+                            StatusCode = validationResult.Code,
+                            ContinuationPoint = default
+                        };
                         results.Add(badResult);
 
                         // put placeholder for diagnostics
@@ -1462,7 +1470,11 @@ namespace Opc.Ua.Server
                 }
 
                 // initialize result.
-                var result = new BrowseResult { StatusCode = StatusCodes.Good };
+                var result = new BrowseResult
+                {
+                    StatusCode = StatusCodes.Good,
+                    ContinuationPoint = default
+                };
                 results.Add(result);
 
                 // check if simply releasing the continuation point.

--- a/Tests/Opc.Ua.Server.Tests/MasterNodeManagerBrowseTests.cs
+++ b/Tests/Opc.Ua.Server.Tests/MasterNodeManagerBrowseTests.cs
@@ -1,0 +1,138 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using NUnit.Framework;
+using Opc.Ua.Tests;
+
+namespace Opc.Ua.Server.Tests
+{
+    /// <summary>
+    /// Tests that verify <see cref="MasterNodeManager"/> browse operations
+    /// return a null continuation point when the browse is finished,
+    /// aligning with the existing 1.5.xxx behavior.
+    /// </summary>
+    [TestFixture]
+    [Category("MasterNodeManager")]
+    [SetCulture("en-us")]
+    [SetUICulture("en-us")]
+    [NonParallelizable]
+    public class MasterNodeManagerBrowseTests
+    {
+        private ServerFixture<StandardServer> m_fixture;
+        private StandardServer m_server;
+
+        [OneTimeSetUp]
+        public async Task OneTimeSetUpAsync()
+        {
+            m_fixture = new ServerFixture<StandardServer>();
+            m_server = await m_fixture.StartAsync().ConfigureAwait(false);
+        }
+
+        [OneTimeTearDown]
+        public async Task OneTimeTearDownAsync()
+        {
+            await m_fixture.StopAsync().ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// A completed browse (all references returned, no continuation point
+        /// required) must leave the continuation point null rather than an
+        /// empty array.
+        /// </summary>
+        [Test]
+        public async Task BrowseAsyncCompletedBrowseReturnsNullContinuationPointAsync()
+        {
+            MasterNodeManager sut = m_server.CurrentInstance.NodeManager;
+            OperationContext ctx = CreateContext();
+
+            var nodeToBrowse = new BrowseDescription
+            {
+                NodeId = ObjectIds.ViewsFolder,
+                BrowseDirection = BrowseDirection.Forward,
+                ReferenceTypeId = ReferenceTypeIds.HierarchicalReferences,
+                IncludeSubtypes = true,
+                ResultMask = (uint)BrowseResultMask.All
+            };
+
+            (BrowseResultCollection results, _) = await sut.BrowseAsync(
+                ctx,
+                new ViewDescription(),
+                0u,
+                new BrowseDescriptionCollection { nodeToBrowse },
+                CancellationToken.None).ConfigureAwait(false);
+
+            Assert.That(results.Count, Is.EqualTo(1));
+            Assert.That(results[0].StatusCode, Is.EqualTo((StatusCode)StatusCodes.Good));
+            Assert.That(results[0].ContinuationPoint, Is.Null);
+        }
+
+        /// <summary>
+        /// A browse of an unknown node returns a bad status code and a null
+        /// continuation point.
+        /// </summary>
+        [Test]
+        public async Task BrowseAsyncUnknownNodeReturnsNullContinuationPointAsync()
+        {
+            MasterNodeManager sut = m_server.CurrentInstance.NodeManager;
+            OperationContext ctx = CreateContext();
+
+            var nodeToBrowse = new BrowseDescription
+            {
+                NodeId = new NodeId(99999u),
+                BrowseDirection = BrowseDirection.Forward
+            };
+
+            (BrowseResultCollection results, _) = await sut.BrowseAsync(
+                ctx,
+                new ViewDescription(),
+                0u,
+                new BrowseDescriptionCollection { nodeToBrowse },
+                CancellationToken.None).ConfigureAwait(false);
+
+            Assert.That(results.Count, Is.EqualTo(1));
+            Assert.That(results[0].StatusCode, Is.EqualTo((StatusCode)StatusCodes.BadNodeIdUnknown));
+            Assert.That(results[0].ContinuationPoint, Is.Null);
+        }
+
+        private static OperationContext CreateContext()
+        {
+            var session = new Mock<ISession>();
+            session.Setup(s => s.EffectiveIdentity).Returns(new Mock<IUserIdentity>().Object);
+            session.Setup(s => s.PreferredLocales).Returns([]);
+            return new OperationContext(
+                new RequestHeader(),
+                null,
+                RequestType.Read,
+                session.Object);
+        }
+    }
+}


### PR DESCRIPTION
Ports the ContinuationPoint fix from master commit a568a7e (PR #4057) back to master378.

## What changed
`MasterNodeManager.Browse`/`BrowseNext` now explicitly set `BrowseResult.ContinuationPoint = default` (i.e. null) when no continuation point is present, instead of leaving it as an empty array. This aligns server behavior with the existing 1.5.xxx contract.

Three call sites in `Libraries/Opc.Ua.Server/NodeManager/MasterNodeManager.cs` were updated:
- initial browse result
- bad validation result in BrowseNext
- good result in BrowseNext

## Tests
Added `Tests/Opc.Ua.Server.Tests/MasterNodeManagerBrowseTests.cs`, porting the relevant test coverage from #4057 and adapting it to the master378 server test API (`BrowseResultCollection`, `byte[]` continuation point, `OperationContext` ctor):
- `BrowseAsyncCompletedBrowseReturnsNullContinuationPointAsync` — a completed browse returns Good and a null continuation point.
- `BrowseAsyncUnknownNodeReturnsNullContinuationPointAsync` — an unknown node returns `BadNodeIdUnknown` and a null continuation point.

## Not ported
The original commit also touched files that do not exist on master378:
- `samples/PumpDeviceIntegrationServer/Dockerfile` (unrelated diagnostics-socket change; sample not present)
- The v2.0-era test files (`BrowseContinuationPointTests.cs`, `BrowseTests.cs`, `MasterNodeManagerDeterministicTests.cs`) that were added in the v2.0 refactor and don't exist on master378.

## Validation
- `dotnet build Libraries/Opc.Ua.Server` (net8.0, Release): succeeded, 0 warnings.
- `dotnet test Tests/Opc.Ua.Server.Tests --filter MasterNodeManagerBrowseTests` (net8.0): 2 passed.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>