### PR TITLE
fix: scope Cancel request matching to the current session (#4023)

### DIFF
--- a/Libraries/Opc.Ua.Server/Server/RequestManager.cs
+++ b/Libraries/Opc.Ua.Server/Server/RequestManager.cs
@@ -148,7 +148,7 @@ namespace Opc.Ua.Server
         /// <summary>
         /// Called when the client wishes to cancel one or more requests.
         /// </summary>
-        public void CancelRequests(uint requestHandle, out uint cancelCount)
+        public void CancelRequests(NodeId sessionId, uint requestHandle, out uint cancelCount)
         {
             var cancelledRequests = new List<uint>();
 
@@ -157,7 +157,8 @@ namespace Opc.Ua.Server
             {
                 foreach (OperationContext request in m_requests.Values)
                 {
-                    if (request.ClientHandle == requestHandle)
+                    if (request.SessionId == sessionId &&
+                        request.ClientHandle == requestHandle)
                     {
                         request.SetStatusCode(StatusCodes.BadRequestCancelledByRequest);
                         cancelledRequests.Add(request.RequestId);

--- a/Libraries/Opc.Ua.Server/Server/StandardServer.cs
+++ b/Libraries/Opc.Ua.Server/Server/StandardServer.cs
@@ -947,7 +947,10 @@ namespace Opc.Ua.Server
 
             try
             {
-                m_serverInternal.RequestManager.CancelRequests(requestHandle, out uint cancelCount);
+                m_serverInternal.RequestManager.CancelRequests(
+                    context.SessionId,
+                    requestHandle,
+                    out uint cancelCount);
 
                 return Task.FromResult(new CancelResponse
                 {

--- a/Tests/Opc.Ua.Server.Tests/RequestManagerTests.cs
+++ b/Tests/Opc.Ua.Server.Tests/RequestManagerTests.cs
@@ -26,12 +26,53 @@ namespace Opc.Ua.Server.Tests
 
             uint cancelCount = 0;
             Assert.DoesNotThrow(
-                () => requestManager.CancelRequests(requestHandle, out cancelCount));
+                () => requestManager.CancelRequests(context.SessionId, requestHandle, out cancelCount));
 
             Assert.That(cancelCount, Is.EqualTo(1));
             Assert.That(
                 context.OperationStatus.Code,
                 Is.EqualTo(StatusCodes.BadRequestCancelledByRequest));
+        }
+
+        [Test]
+        public void CancelRequestsDoesNotCancelMatchingHandleFromDifferentSession()
+        {
+            var serverMock = new Mock<IServerInternal>();
+            serverMock.Setup(s => s.Telemetry).Returns(NUnitTelemetryContext.Create());
+
+            using var requestManager = new RequestManager(serverMock.Object);
+
+            var cancellingSession = new Mock<ISession>();
+            cancellingSession.Setup(s => s.Id).Returns(new NodeId(1));
+
+            var otherSession = new Mock<ISession>();
+            otherSession.Setup(s => s.Id).Returns(new NodeId(2));
+
+            const uint requestHandle = 42;
+
+            var ownContext = new OperationContext(
+                new RequestHeader { RequestHandle = requestHandle },
+                null,
+                RequestType.Read,
+                cancellingSession.Object);
+            var otherContext = new OperationContext(
+                new RequestHeader { RequestHandle = requestHandle },
+                null,
+                RequestType.Read,
+                otherSession.Object);
+
+            requestManager.RequestReceived(ownContext);
+            requestManager.RequestReceived(otherContext);
+
+            requestManager.CancelRequests(cancellingSession.Object.Id, requestHandle, out uint cancelCount);
+
+            Assert.That(cancelCount, Is.EqualTo(1));
+            Assert.That(
+                ownContext.OperationStatus.Code,
+                Is.EqualTo(StatusCodes.BadRequestCancelledByRequest));
+            Assert.That(
+                otherContext.OperationStatus.Code,
+                Is.EqualTo(StatusCodes.Good));
         }
     }
 }


### PR DESCRIPTION
Backport of 70c74e7 from `master` to `master378`.

### Summary

Scopes `Cancel` request matching to the caller's session and adds a regression test verifying a request handle can no longer cancel work belonging to another session.

### Problem

Per OPC UA Part 4, `Cancel` applies to a request handle from the same session that issued the original request. Previously `StandardServer.CancelAsync` validated the caller's session but forwarded only the raw `requestHandle` to `RequestManager.CancelRequests`, which iterated the global outstanding-request table and canceled every request whose `ClientHandle` matched — regardless of owning session. Since request handles are only session-scoped and different sessions can reuse the same value, one session could cancel another session's in-flight request.

### Changes

- Pass the validated caller session id from `StandardServer.CancelAsync` into `RequestManager.CancelRequests`.
- Restrict `RequestManager.CancelRequests` to requests whose `SessionId` **and** `ClientHandle` both match.
- Update the existing request-manager test call and add `CancelRequestsDoesNotCancelMatchingHandleFromDifferentSession` regression test.

### Notes on the backport

The `master378` branch predates the `RequestLifetime` cancellation model and the `SessionPublishQueueTests` present on `master`, so those parts of the original commit do not apply. The core fix and the regression test were adapted to this branch's `SetStatusCode`/`OperationStatus` model. `Opc.Ua.Server.Tests` builds clean and both `RequestManagerTests` pass.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>