### PR TITLE
fix: don't return continuation points on BadNoContinuationPoints (#4022) [backport to master378]

### DIFF
--- a/Libraries/Opc.Ua.Server/NodeManager/MasterNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/NodeManager/MasterNodeManager.cs
@@ -1534,7 +1534,7 @@ namespace Opc.Ua.Server
                 }
 
                 // check for continuation point.
-                if (cp != null)
+                if (cp != null && ServiceResult.IsGood(error))
                 {
                     result.StatusCode = StatusCodes.Good;
                     result.ContinuationPoint = cp.Id.ToByteArray();
@@ -1637,7 +1637,7 @@ namespace Opc.Ua.Server
             result.References = references;
 
             // save continuation point.
-            if (cp != null)
+            if (cp != null && ServiceResult.IsGood(error))
             {
                 result.StatusCode = StatusCodes.Good;
                 result.ContinuationPoint = cp.Id.ToByteArray();
@@ -1719,7 +1719,8 @@ namespace Opc.Ua.Server
                 {
                     if (!assignContinuationPoint)
                     {
-                        return (StatusCodes.BadNoContinuationPoints, cp, references);
+                        cp.Dispose();
+                        return (StatusCodes.BadNoContinuationPoints, null, references);
                     }
 
                     cp.Id = Guid.NewGuid();

--- a/Tests/Opc.Ua.Server.Tests/MasterNodeManagerTests.cs
+++ b/Tests/Opc.Ua.Server.Tests/MasterNodeManagerTests.cs
@@ -27,8 +27,11 @@
  * http://opcfoundation.org/License/MIT/1.00/
  * ======================================================================*/
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
 using Moq;
 using NUnit.Framework;
@@ -295,6 +298,185 @@ namespace Opc.Ua.Server.Tests
             {
                 await fixture.StopAsync().ConfigureAwait(false);
             }
+        }
+
+        /// <summary>
+        /// Verifies that Browse returns Bad_NoContinuationPoints without a
+        /// continuation point when the continuation-point quota is exhausted.
+        /// </summary>
+        [Test]
+        public async Task BrowseWhenNoContinuationPointCanBeAssignedReturnsBadNoContinuationPointsWithoutContinuationPointAsync()
+        {
+            var fixture = new ServerFixture<StandardServer>();
+
+            try
+            {
+                StandardServer server = await fixture.StartAsync().ConfigureAwait(false);
+                MasterNodeManager sut = server.CurrentInstance.NodeManager;
+                OperationContext ctx = CreateContextWithContinuationStore();
+                uint originalLimit = GetMaxBrowseContinuationPointsPerBrowse(sut);
+
+                try
+                {
+                    SetMaxBrowseContinuationPointsPerBrowse(sut, 0u);
+
+                    var nodeToBrowse = new BrowseDescription
+                    {
+                        NodeId = ObjectIds.RootFolder,
+                        BrowseDirection = BrowseDirection.Forward
+                    };
+
+                    (BrowseResultCollection results, _) = await sut.BrowseAsync(
+                        ctx,
+                        new ViewDescription(),
+                        1u,
+                        new BrowseDescriptionCollection { nodeToBrowse },
+                        CancellationToken.None).ConfigureAwait(false);
+
+                    Assert.AreEqual(1, results.Count);
+                    Assert.AreEqual(StatusCodes.BadNoContinuationPoints, (uint)results[0].StatusCode);
+                    NUnit.Framework.Assert.That(
+                        results[0].ContinuationPoint == null || results[0].ContinuationPoint.Length == 0,
+                        Is.True);
+                }
+                finally
+                {
+                    SetMaxBrowseContinuationPointsPerBrowse(sut, originalLimit);
+                }
+            }
+            finally
+            {
+                await fixture.StopAsync().ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that BrowseNext returns Bad_NoContinuationPoints without a
+        /// continuation point when the continuation-point quota is exhausted.
+        /// </summary>
+        [Test]
+        public async Task BrowseNextWhenNoContinuationPointCanBeAssignedReturnsBadNoContinuationPointsWithoutContinuationPointAsync()
+        {
+            var fixture = new ServerFixture<StandardServer>();
+
+            try
+            {
+                StandardServer server = await fixture.StartAsync().ConfigureAwait(false);
+                MasterNodeManager sut = server.CurrentInstance.NodeManager;
+                OperationContext ctx = CreateContextWithContinuationStore();
+                uint originalLimit = GetMaxBrowseContinuationPointsPerBrowse(sut);
+
+                try
+                {
+                    var nodeToBrowse = new BrowseDescription
+                    {
+                        NodeId = ObjectIds.RootFolder,
+                        BrowseDirection = BrowseDirection.Forward
+                    };
+
+                    (BrowseResultCollection firstResults, _) = await sut.BrowseAsync(
+                        ctx,
+                        new ViewDescription(),
+                        1u,
+                        new BrowseDescriptionCollection { nodeToBrowse },
+                        CancellationToken.None).ConfigureAwait(false);
+
+                    Assert.AreEqual(1, firstResults.Count);
+                    Assert.AreEqual(StatusCodes.Good, (uint)firstResults[0].StatusCode);
+                    NUnit.Framework.Assert.That(
+                        firstResults[0].ContinuationPoint != null && firstResults[0].ContinuationPoint.Length > 0,
+                        Is.True);
+
+                    (BrowseResultCollection nextResults, _) = await sut.BrowseNextAsync(
+                        ctx,
+                        false,
+                        new ByteStringCollection { firstResults[0].ContinuationPoint },
+                        CancellationToken.None).ConfigureAwait(false);
+
+                    Assert.AreEqual(1, nextResults.Count);
+                    Assert.AreEqual(StatusCodes.Good, (uint)nextResults[0].StatusCode);
+                    NUnit.Framework.Assert.That(
+                        nextResults[0].ContinuationPoint != null && nextResults[0].ContinuationPoint.Length > 0,
+                        Is.True);
+
+                    SetMaxBrowseContinuationPointsPerBrowse(sut, 0u);
+
+                    (BrowseResultCollection finalResults, _) = await sut.BrowseNextAsync(
+                        ctx,
+                        false,
+                        new ByteStringCollection { nextResults[0].ContinuationPoint },
+                        CancellationToken.None).ConfigureAwait(false);
+
+                    Assert.AreEqual(1, finalResults.Count);
+                    Assert.AreEqual(StatusCodes.BadNoContinuationPoints, (uint)finalResults[0].StatusCode);
+                    NUnit.Framework.Assert.That(
+                        finalResults[0].ContinuationPoint == null || finalResults[0].ContinuationPoint.Length == 0,
+                        Is.True);
+                }
+                finally
+                {
+                    SetMaxBrowseContinuationPointsPerBrowse(sut, originalLimit);
+                }
+            }
+            finally
+            {
+                await fixture.StopAsync().ConfigureAwait(false);
+            }
+        }
+
+        private static OperationContext CreateContextWithContinuationStore()
+        {
+            var continuationPoints = new Dictionary<string, ContinuationPoint>();
+            var session = new Mock<ISession>();
+            session.Setup(s => s.EffectiveIdentity).Returns(new Mock<IUserIdentity>().Object);
+            session.Setup(s => s.PreferredLocales).Returns([]);
+            session
+                .Setup(s => s.SaveContinuationPoint(It.IsAny<ContinuationPoint>()))
+                .Callback<ContinuationPoint>(cp =>
+                {
+                    continuationPoints[ToContinuationPointKey(cp.Id.ToByteArray())] = cp;
+                });
+            session
+                .Setup(s => s.RestoreContinuationPoint(It.IsAny<byte[]>()))
+                .Returns<byte[]>(cpBytes =>
+                {
+                    string key = ToContinuationPointKey(cpBytes);
+                    if (continuationPoints.TryGetValue(key, out ContinuationPoint cp))
+                    {
+                        continuationPoints.Remove(key);
+                        return cp;
+                    }
+
+                    return null;
+                });
+
+            return new OperationContext(
+                new RequestHeader(), null, RequestType.Read, session.Object);
+        }
+
+        private static void SetMaxBrowseContinuationPointsPerBrowse(MasterNodeManager sut, uint value)
+        {
+            FieldInfo field = typeof(MasterNodeManager).GetField(
+                "m_maxContinuationPointsPerBrowse",
+                BindingFlags.Instance | BindingFlags.NonPublic);
+
+            Assert.IsNotNull(field);
+            field.SetValue(sut, value);
+        }
+
+        private static uint GetMaxBrowseContinuationPointsPerBrowse(MasterNodeManager sut)
+        {
+            FieldInfo field = typeof(MasterNodeManager).GetField(
+                "m_maxContinuationPointsPerBrowse",
+                BindingFlags.Instance | BindingFlags.NonPublic);
+
+            Assert.IsNotNull(field);
+            return (uint)field.GetValue(sut);
+        }
+
+        private static string ToContinuationPointKey(byte[] continuationPoint)
+        {
+            return Convert.ToBase64String(continuationPoint);
         }
     }
 }


### PR DESCRIPTION
### Summary

Backport of commit 399747f (#4022) from `master` to `master378`.

Fixes `Browse` and `BrowseNext` so they do not return a usable continuation point when the server reports `BadNoContinuationPoints`, and adds regression tests covering both code paths.

### Problem

Per OPC UA Part 4, if the server cannot allocate another continuation point for a `Browse`/`BrowseNext` operation, the result should be `Bad_NoContinuationPoints` and the server must not also return a usable continuation point. Previously `FetchReferences` could return `BadNoContinuationPoints` while still passing a live continuation point back to its callers, producing a contradictory response (`BadNoContinuationPoints` with a non-empty `ContinuationPoint`), and `BrowseNext` could overwrite the error with `Good`.

### Changes

- Dispose and clear the continuation point when `FetchReferences` hits the no-continuation-points path.
- Only copy a continuation point into `Browse` and `BrowseNext` results when the operation completed successfully (`ServiceResult.IsGood(error)`).
- Add deterministic regression tests for both `Browse` and `BrowseNext`, adapted to the `master378` server API.

### Notes

The upstream commit targets the v2.0 APIs (`ArrayOf`/`ByteString`); the source fix and tests here were adapted to the `master378` API (`byte[]` continuation points, `BrowseResultCollection`/`ByteStringCollection`, 4-arg `OperationContext` constructor). Both new tests pass.