### PR TITLE
Fix unordered server endpoint validation (#4029) [backport to master378]

### DIFF
--- a/Libraries/Opc.Ua.Client/Session/Session.cs
+++ b/Libraries/Opc.Ua.Client/Session/Session.cs
@@ -4000,43 +4000,13 @@ namespace Opc.Ua.Client
                         "Server did not return a number of ServerEndpoints that matches the one from GetEndpoints.");
                 }
 
-                for (int ii = 0; ii < expectedServerEndpoints.Count; ii++)
+                if (!HaveEquivalentServerEndpoints(
+                        expectedServerEndpoints,
+                        m_discoveryServerEndpoints))
                 {
-                    EndpointDescription serverEndpoint = expectedServerEndpoints[ii];
-                    EndpointDescription expectedServerEndpoint = m_discoveryServerEndpoints[ii];
-
-                    if (serverEndpoint.SecurityMode != expectedServerEndpoint.SecurityMode ||
-                        serverEndpoint.SecurityPolicyUri != expectedServerEndpoint
-                            .SecurityPolicyUri ||
-                        serverEndpoint.TransportProfileUri != expectedServerEndpoint
-                            .TransportProfileUri ||
-                        serverEndpoint.SecurityLevel != expectedServerEndpoint.SecurityLevel)
-                    {
-                        throw ServiceResultException.Create(
-                            StatusCodes.BadSecurityChecksFailed,
-                            "The list of ServerEndpoints returned at CreateSession does not match the list from GetEndpoints.");
-                    }
-
-                    if (serverEndpoint.UserIdentityTokens.Count != expectedServerEndpoint
-                        .UserIdentityTokens
-                        .Count)
-                    {
-                        throw ServiceResultException.Create(
-                            StatusCodes.BadSecurityChecksFailed,
-                            "The list of ServerEndpoints returned at CreateSession does not match the one from GetEndpoints.");
-                    }
-
-                    for (int jj = 0; jj < serverEndpoint.UserIdentityTokens.Count; jj++)
-                    {
-                        if (!serverEndpoint
-                                .UserIdentityTokens[jj]
-                                .IsEqual(expectedServerEndpoint.UserIdentityTokens[jj]))
-                        {
-                            throw ServiceResultException.Create(
-                                StatusCodes.BadSecurityChecksFailed,
-                                "The list of ServerEndpoints returned at CreateSession does not match the one from GetEndpoints.");
-                        }
-                    }
+                    throw ServiceResultException.Create(
+                        StatusCodes.BadSecurityChecksFailed,
+                        "The list of ServerEndpoints returned at CreateSession does not match the list from GetEndpoints.");
                 }
             }
 
@@ -4074,6 +4044,81 @@ namespace Opc.Ua.Client
                     StatusCodes.BadSecurityChecksFailed,
                     "Server did not return an EndpointDescription that matched the one used to create the secure channel.");
             }
+        }
+
+        private static bool HaveEquivalentServerEndpoints(
+            EndpointDescriptionCollection serverEndpoints,
+            EndpointDescriptionCollection discoveryEndpoints)
+        {
+            if (serverEndpoints.Count != discoveryEndpoints.Count)
+            {
+                return false;
+            }
+
+            var unmatchedDiscoveryEndpoints = new List<EndpointDescription>(discoveryEndpoints);
+
+            foreach (EndpointDescription serverEndpoint in serverEndpoints)
+            {
+                int matchIndex = unmatchedDiscoveryEndpoints.FindIndex(
+                    discoveryEndpoint => AreEquivalentServerEndpoints(
+                        serverEndpoint,
+                        discoveryEndpoint));
+
+                if (matchIndex < 0)
+                {
+                    return false;
+                }
+
+                unmatchedDiscoveryEndpoints.RemoveAt(matchIndex);
+            }
+
+            return unmatchedDiscoveryEndpoints.Count == 0;
+        }
+
+        private static bool AreEquivalentServerEndpoints(
+            EndpointDescription serverEndpoint,
+            EndpointDescription discoveryEndpoint)
+        {
+            return serverEndpoint.SecurityMode == discoveryEndpoint.SecurityMode &&
+                string.Equals(
+                    serverEndpoint.SecurityPolicyUri,
+                    discoveryEndpoint.SecurityPolicyUri,
+                    StringComparison.Ordinal) &&
+                string.Equals(
+                    serverEndpoint.TransportProfileUri,
+                    discoveryEndpoint.TransportProfileUri,
+                    StringComparison.Ordinal) &&
+                serverEndpoint.SecurityLevel == discoveryEndpoint.SecurityLevel &&
+                HaveEquivalentUserIdentityTokens(
+                    serverEndpoint.UserIdentityTokens,
+                    discoveryEndpoint.UserIdentityTokens);
+        }
+
+        private static bool HaveEquivalentUserIdentityTokens(
+            UserTokenPolicyCollection serverTokens,
+            UserTokenPolicyCollection discoveryTokens)
+        {
+            if (serverTokens.Count != discoveryTokens.Count)
+            {
+                return false;
+            }
+
+            var unmatchedDiscoveryTokens = new List<UserTokenPolicy>(discoveryTokens);
+
+            foreach (UserTokenPolicy serverToken in serverTokens)
+            {
+                int matchIndex = unmatchedDiscoveryTokens.FindIndex(
+                    discoveryToken => serverToken.IsEqual(discoveryToken));
+
+                if (matchIndex < 0)
+                {
+                    return false;
+                }
+
+                unmatchedDiscoveryTokens.RemoveAt(matchIndex);
+            }
+
+            return unmatchedDiscoveryTokens.Count == 0;
         }
 
         /// <summary>

--- a/Tests/Opc.Ua.Client.Tests/SessionMock.cs
+++ b/Tests/Opc.Ua.Client.Tests/SessionMock.cs
@@ -66,10 +66,34 @@ namespace Opc.Ua.Client.Tests
         }
 
         /// <summary>
+        /// Create the mock with explicit discovery endpoints
+        /// </summary>
+        internal SessionMock(
+            Mock<ITransportChannel> channel,
+            ApplicationConfiguration configuration,
+            ConfiguredEndpoint endpoint,
+            EndpointDescriptionCollection availableEndpoints,
+            StringCollection discoveryProfileUris = null)
+            : base(
+                  channel.Object,
+                  configuration,
+                  endpoint,
+                  clientCertificate: null,
+                  clientCertificateChain: null,
+                  availableEndpoints: availableEndpoints,
+                  discoveryProfileUris: discoveryProfileUris)
+        {
+            Channel = channel;
+        }
+
+        /// <summary>
         /// Create default mock
         /// </summary>
         /// <returns></returns>
-        public static SessionMock Create(EndpointDescription endpoint = null)
+        public static SessionMock Create(
+            EndpointDescription endpoint = null,
+            EndpointDescriptionCollection availableEndpoints = null,
+            StringCollection discoveryProfileUris = null)
         {
             ITelemetryContext telemetry = NUnitTelemetryContext.Create();
             var channel = new Mock<ITransportChannel>();
@@ -102,18 +126,31 @@ namespace Opc.Ua.Client.Tests
                 application.CheckApplicationInstanceCertificatesAsync(true).AsTask().GetAwaiter().GetResult();
             }
 
-            return new SessionMock(channel, configuration,
-                new ConfiguredEndpoint(null, endpoint ??
-                    new EndpointDescription
-                    {
-                        SecurityMode = MessageSecurityMode.None,
-                        SecurityPolicyUri = SecurityPolicies.None,
-                        EndpointUrl = "opc.tcp://localhost:4840",
-                        UserIdentityTokens =
-                        [
-                            new UserTokenPolicy()
-                        ]
-                    }));
+            var configuredEndpoint = new ConfiguredEndpoint(
+                null,
+                endpoint ?? new EndpointDescription
+                {
+                    SecurityMode = MessageSecurityMode.None,
+                    SecurityPolicyUri = SecurityPolicies.None,
+                    EndpointUrl = "opc.tcp://localhost:4840",
+                    UserIdentityTokens =
+                    [
+                        new UserTokenPolicy()
+                    ]
+                });
+
+            if ((availableEndpoints == null || availableEndpoints.Count == 0) &&
+                (discoveryProfileUris == null || discoveryProfileUris.Count == 0))
+            {
+                return new SessionMock(channel, configuration, configuredEndpoint);
+            }
+
+            return new SessionMock(
+                channel,
+                configuration,
+                configuredEndpoint,
+                availableEndpoints,
+                discoveryProfileUris);
         }
 
         internal void SetConnected()

--- a/Tests/Opc.Ua.Client.Tests/SessionTests.cs
+++ b/Tests/Opc.Ua.Client.Tests/SessionTests.cs
@@ -1570,5 +1570,180 @@ namespace Opc.Ua.Client.Tests
             Assert.That(loadedSubscriptions.Count, Is.EqualTo(2), "Only the specified subscriptions should be saved");
             Assert.That(loadedSubscriptions.Select(s => s.DisplayName), Is.EquivalentTo(["Subscription1", "Subscription3"]));
         }
+
+        [Test]
+        public async Task OpenAsyncAcceptsServerEndpointsWithDifferentOrderingAsync()
+        {
+            EndpointDescription primaryEndpoint = CreateSessionEndpointDescription(
+                "opc.tcp://localhost:4840");
+            primaryEndpoint.SecurityLevel = 1;
+            primaryEndpoint.TransportProfileUri = Profiles.UaTcpTransport;
+
+            EndpointDescription secondaryEndpoint = CreateSessionEndpointDescription(
+                "opc.tcp://localhost:4841");
+            secondaryEndpoint.SecurityMode = MessageSecurityMode.Sign;
+            secondaryEndpoint.SecurityPolicyUri = SecurityPolicies.Basic256Sha256;
+            secondaryEndpoint.SecurityLevel = 2;
+            secondaryEndpoint.TransportProfileUri = Profiles.UaTcpTransport;
+
+            using var sut = SessionMock.Create(
+                primaryEndpoint,
+                [primaryEndpoint, secondaryEndpoint],
+                [Profiles.UaTcpTransport]);
+
+            ConfigureSuccessfulOpenResponses(
+                sut.Channel,
+                [secondaryEndpoint, primaryEndpoint],
+                [1, 2, 3, 4],
+                NodeId.Parse("s=cookie"));
+
+            await sut.OpenAsync("test", new UserIdentity(), CancellationToken.None)
+                .ConfigureAwait(false);
+
+            Assert.That(sut.ServerNonce, Is.EquivalentTo(new byte[] { 1, 2, 3, 4 }));
+            sut.Channel.Verify();
+        }
+
+        [Test]
+        public async Task OpenAsyncAcceptsUserTokenPoliciesWithDifferentOrderingAsync()
+        {
+            EndpointDescription discoveryEndpoint = CreateSessionEndpointDescription(
+                "opc.tcp://localhost:4840");
+            discoveryEndpoint.TransportProfileUri = Profiles.UaTcpTransport;
+            discoveryEndpoint.UserIdentityTokens =
+            [
+                CreateUserTokenPolicy("anonymous", UserTokenType.Anonymous),
+                CreateUserTokenPolicy("username", UserTokenType.UserName)
+            ];
+
+            EndpointDescription responseEndpoint = CreateSessionEndpointDescription(
+                "opc.tcp://localhost:4840");
+            responseEndpoint.TransportProfileUri = Profiles.UaTcpTransport;
+            responseEndpoint.UserIdentityTokens =
+            [
+                CreateUserTokenPolicy("username", UserTokenType.UserName),
+                CreateUserTokenPolicy("anonymous", UserTokenType.Anonymous)
+            ];
+
+            using var sut = SessionMock.Create(
+                discoveryEndpoint,
+                [discoveryEndpoint],
+                [Profiles.UaTcpTransport]);
+
+            ConfigureSuccessfulOpenResponses(
+                sut.Channel,
+                [responseEndpoint],
+                [1, 2, 3, 4],
+                NodeId.Parse("s=cookie"));
+
+            await sut.OpenAsync("test", new UserIdentity(), CancellationToken.None)
+                .ConfigureAwait(false);
+
+            Assert.That(sut.ServerNonce, Is.EquivalentTo(new byte[] { 1, 2, 3, 4 }));
+            sut.Channel.Verify();
+        }
+
+        private static EndpointDescription CreateSessionEndpointDescription(string endpointUrl)
+        {
+            return new EndpointDescription
+            {
+                SecurityMode = MessageSecurityMode.None,
+                SecurityPolicyUri = SecurityPolicies.None,
+                EndpointUrl = endpointUrl,
+                UserIdentityTokens =
+                [
+                    new UserTokenPolicy()
+                ]
+            };
+        }
+
+        private static UserTokenPolicy CreateUserTokenPolicy(
+            string policyId,
+            UserTokenType tokenType)
+        {
+            return new UserTokenPolicy
+            {
+                PolicyId = policyId,
+                TokenType = tokenType,
+                SecurityPolicyUri = SecurityPolicies.None
+            };
+        }
+
+        private static void ConfigureSuccessfulOpenResponses(
+            Mock<ITransportChannel> channel,
+            EndpointDescriptionCollection serverEndpoints,
+            byte[] serverNonce,
+            NodeId authToken)
+        {
+            channel
+                .Setup(c => c.SendRequestAsync(
+                    It.IsAny<CreateSessionRequest>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns(new ValueTask<IServiceResponse>(new CreateSessionResponse
+                {
+                    ServerNonce = serverNonce,
+                    SessionId = NodeId.Parse("s=connected"),
+                    AuthenticationToken = authToken,
+                    ServerEndpoints = serverEndpoints
+                }));
+
+            channel
+                .Setup(c => c.SendRequestAsync(
+                    It.Is<ActivateSessionRequest>(r => r.RequestHeader.AuthenticationToken == authToken),
+                    It.IsAny<CancellationToken>()))
+                .Returns(new ValueTask<IServiceResponse>(new ActivateSessionResponse
+                {
+                    ServerNonce = serverNonce,
+                    Results = [],
+                    DiagnosticInfos = []
+                }));
+
+            ConfigureOpenAsyncReadResponses(channel);
+        }
+
+        private static void ConfigureOpenAsyncReadResponses(Mock<ITransportChannel> channel)
+        {
+            // Read limit and also first keep alive timers
+            channel
+                .Setup(c => c.SendRequestAsync(
+                    It.Is<ReadRequest>(r => r.NodesToRead.Count == 1),
+                    It.IsAny<CancellationToken>()))
+                .Returns(new ValueTask<IServiceResponse>(new ReadResponse
+                {
+                    Results =
+                    [
+                        new (new Variant(0))
+                    ],
+                    DiagnosticInfos = []
+                }));
+
+            // Operation limits
+            channel
+                .Setup(c => c.SendRequestAsync(
+                    It.Is<ReadRequest>(r => r.NodesToRead.Count == 27),
+                    It.IsAny<CancellationToken>()))
+                .Returns(new ValueTask<IServiceResponse>(new ReadResponse
+                {
+                    Results = [.. Enumerable
+                        .Range(0, 27)
+                        .Select(_ => new DataValue(Variant.Null))],
+                    DiagnosticInfos = []
+                }));
+
+            // Namespaces
+            channel
+                .Setup(c => c.SendRequestAsync(
+                    It.Is<ReadRequest>(r => r.NodesToRead.Count == 2),
+                    It.IsAny<CancellationToken>()))
+                .Returns(new ValueTask<IServiceResponse>(new ReadResponse
+                {
+                    Results =
+                    [
+                        new (new[] { Ua.Namespaces.OpcUa }),
+                        new(Array.Empty<string>())
+                    ],
+                    DiagnosticInfos = []
+                }));
+        }
     }
 }


### PR DESCRIPTION
Backport of OPCFoundation/UA-.NETStandard@8f4087605afa29e2fe37e42f154d562d56f92744 from `master` to `master378`.

### Summary
Makes `Session.ValidateServerEndpoints()` compare `ServerEndpoints` and `UserIdentityTokens` as unordered sets and adds regression tests verifying `OpenAsync()` no longer rejects legal servers that return the same endpoint data in a different order.

### Problem
Per OPC UA Part 4, the client validates the endpoint set returned by `CreateSessionResponse.ServerEndpoints` against the set observed during discovery. The spec describes these as a *set* of endpoint descriptions filtered by transport profile, not an ordered array. Previously the validation compared `m_discoveryServerEndpoints[ii]` against `serverEndpoints[ii]` by index, and `UserIdentityTokens[jj]` by index. A server returning the same legal endpoints/token policies in a different order could be wrongly rejected with `BadSecurityChecksFailed`.

### Changes
- Replace index-based `ServerEndpoints` validation with unordered matching on the same endpoint fields already validated by the client.
- Compare `UserIdentityTokens` as an unordered multiset.
- Extend the client session test scaffolding so discovery endpoints can be supplied explicitly.
- Add regression tests for reordered `ServerEndpoints` and reordered `UserIdentityTokens`.

### Notes
Adapted to the `master378` API surface (`EndpointDescriptionCollection` / `UserTokenPolicyCollection` / `StringCollection` / `byte[]` server nonce) and the `Libraries/`/`Tests/` layout. Client tests build and the new tests pass.