### PR TITLE
Fix three flaky tests (Robotics, Client, Di)

### DIFF
--- a/tests/Opc.Ua.Client.Tests/ClientBuilder/ReverseConnectManagerLifecycleTests.cs
+++ b/tests/Opc.Ua.Client.Tests/ClientBuilder/ReverseConnectManagerLifecycleTests.cs
@@ -2688,8 +2688,8 @@ namespace Opc.Ua.Client.Tests.ClientBuilder
 
             await closeGateEntered.Task.ConfigureAwait(false);
             Assert.That(
-                callback.IsCompleted,
-                Is.True,
+                manager.ActiveConnectionCallbackCountForTest,
+                Is.Zero,
                 "the held callback must drain before the listener is torn down");
             Assert.That(
                 e.Accepted,

--- a/tests/Opc.Ua.Client.Tests/ClientBuilder/ReverseConnectManagerLifecycleTests.cs
+++ b/tests/Opc.Ua.Client.Tests/ClientBuilder/ReverseConnectManagerLifecycleTests.cs
@@ -2687,18 +2687,23 @@ namespace Opc.Ua.Client.Tests.ClientBuilder
             Task dispose = manager.DisposeAsync().AsTask();
 
             await closeGateEntered.Task.ConfigureAwait(false);
-            Assert.That(
-                manager.ActiveConnectionCallbackCountForTest,
-                Is.Zero,
-                "the held callback must drain before the listener is torn down");
-            Assert.That(
-                e.Accepted,
-                Is.False,
-                "the drained callback must leave the transport unaccepted");
-
-            releaseClose.TrySetResult(true);
-            await dispose.ConfigureAwait(false);
-            await callback.ConfigureAwait(false);
+            try
+            {
+                Assert.That(
+                    manager.ActiveConnectionCallbackCountForTest,
+                    Is.Zero,
+                    "the held callback must drain before the listener is torn down");
+                Assert.That(
+                    e.Accepted,
+                    Is.False,
+                    "the drained callback must leave the transport unaccepted");
+            }
+            finally
+            {
+                releaseClose.TrySetResult(true);
+                await dispose.ConfigureAwait(false);
+                await callback.ConfigureAwait(false);
+            }
 
             Assert.That(manager.CurrentStateForTest, Is.EqualTo("Disposed"));
             Assert.That(listener.IsOpen, Is.False);

--- a/tests/Opc.Ua.Di.Tests/PumpOpenUsdE2eTests.cs
+++ b/tests/Opc.Ua.Di.Tests/PumpOpenUsdE2eTests.cs
@@ -600,7 +600,19 @@ namespace Opc.Ua.Di.Tests
             var connector = new OpenUsdConnector(m_session!, sink);
 
             await connector.StartAsync(CancellationToken.None).ConfigureAwait(false);
-            await Task.Delay(4000, CancellationToken.None).ConfigureAwait(false);
+
+            // Poll for the expected sink writes instead of waiting a fixed delay:
+            // on a slow/loaded CI agent the first sampled values can take longer
+            // than a fixed sleep, so StopAsync would run before any value flowed.
+            DateTime deadline = DateTime.UtcNow.AddSeconds(30);
+            while (DateTime.UtcNow < deadline &&
+                !(sink.WasWritten("/Plant/Pumps/Pump_1/Impeller", "xformOp:rotateZ") &&
+                    sink.WasWritten("/Plant/Pumps/Pump_1/Body", "primvars:displayColor") &&
+                    sink.WasWritten("/Plant/Pumps/Pump_1/Discharge/Gauge/Needle", "xformOp:rotateZ")))
+            {
+                await Task.Delay(200, CancellationToken.None).ConfigureAwait(false);
+            }
+
             await connector.StopAsync().ConfigureAwait(false);
 
             Assert.Multiple(() =>

--- a/tests/Opc.Ua.Robotics.Tests/IntentControllerHostTests.cs
+++ b/tests/Opc.Ua.Robotics.Tests/IntentControllerHostTests.cs
@@ -522,6 +522,13 @@ namespace Opc.Ua.Robotics.Tests
             options.MaxQueueDepth = 1;
             using IntentControllerHost host = NewHost(options);
 
+            // Keep the first intent queued so the depth bound is exercised
+            // deterministically instead of racing the background dispatch pump,
+            // which can move "a" out of the queue into the executing slot (where
+            // it parks on the gate) before "b" is submitted. Pause only stops
+            // dispatch; admission still runs, so the bound is enforced reliably.
+            Assert.That(host.Pause(m_context, null), Is.True);
+
             host.SubmitIntent(m_context, null, Move("a", BufferModeEnum.Buffered));
             IntentAdmission overflow = host.SubmitIntent(
                 m_context, null, Move("b", BufferModeEnum.Buffered));
@@ -531,6 +538,8 @@ namespace Opc.Ua.Robotics.Tests
                 Assert.That(overflow.Accepted, Is.False);
                 Assert.That(overflow.Failure, Is.EqualTo(IntentFailureEnum.QueueFull));
             });
+
+            host.Resume(m_context, null);
             m_executor.Gate!.Release(4);
         }
 

--- a/tests/Opc.Ua.Robotics.Tests/IntentControllerHostTests.cs
+++ b/tests/Opc.Ua.Robotics.Tests/IntentControllerHostTests.cs
@@ -529,18 +529,23 @@ namespace Opc.Ua.Robotics.Tests
             // dispatch; admission still runs, so the bound is enforced reliably.
             Assert.That(host.Pause(m_context, null), Is.True);
 
-            host.SubmitIntent(m_context, null, Move("a", BufferModeEnum.Buffered));
-            IntentAdmission overflow = host.SubmitIntent(
-                m_context, null, Move("b", BufferModeEnum.Buffered));
-
-            Assert.Multiple(() =>
+            try
             {
-                Assert.That(overflow.Accepted, Is.False);
-                Assert.That(overflow.Failure, Is.EqualTo(IntentFailureEnum.QueueFull));
-            });
+                host.SubmitIntent(m_context, null, Move("a", BufferModeEnum.Buffered));
+                IntentAdmission overflow = host.SubmitIntent(
+                    m_context, null, Move("b", BufferModeEnum.Buffered));
 
-            host.Resume(m_context, null);
-            m_executor.Gate!.Release(4);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(overflow.Accepted, Is.False);
+                    Assert.That(overflow.Failure, Is.EqualTo(IntentFailureEnum.QueueFull));
+                });
+            }
+            finally
+            {
+                host.Resume(m_context, null);
+                m_executor.Gate!.Release(4);
+            }
         }
 
         [Test]


### PR DESCRIPTION
## Summary
Fixes the three flaky tests surfaced in the last full nightly (ADO build 17152, commit `aad8350`, run [95295970000](https://github.com/OPCFoundation/UA-.NETStandard/runs/95295970000)). Each failure has a cross‑platform/cross‑TFM signature (fails on multiple legs), confirming a race/timing issue rather than a platform bug. All changes are **test-only** — no production behavior changes.

## Fixes

### Robotics `TheQueueIsBoundedByMaxQueueDepth` (#4286)
The executor gate blocks execution *after* an item is dequeued, and `MaxQueueDepth` counts only queued items. The background dispatch pump could move `"a"` out of the queue into the executing slot before `"b"` was submitted, so the queue wasn't full and `"b"` was admitted. Fix: `Pause` queue dispatch before submitting (admission still runs) so `"a"` stays queued and the bound is enforced deterministically.

### Client `DisposeDrainsHeldConnectionCallbackBeforeListenerDisposal` (#4287)
The drain ordering in production is correct, but the test asserted `callback.IsCompleted`, which flips one async continuation *after* the drain signal fires — so the close gate can be entered before the returned Task transitions to completed. Fix: assert on `ActiveConnectionCallbackCountForTest == 0` (`Is.Zero`), the deterministic invariant the drain actually waits on.

### Di `LiveValuesFlowThroughConnectorToUsdSinkAsync` (#4288)
Used a fixed `Task.Delay(4000)` before asserting sink writes; slow mac agents didn't deliver in time. Fix: poll `WasWritten(...)` up to 30s (fast on healthy runs, robust on slow agents), then stop.

## Validation
Built and ran each affected test on `net10.0` — all pass:
- `Opc.Ua.Robotics.Tests` — 1/1 passed
- `Opc.Ua.Client.Tests` — 1/1 passed
- `Opc.Ua.Di.Tests` — 1/1 passed

Closes #4286
Closes #4287
Closes #4288