### PR TITLE
Fix SourceGeneration tests to probe actual Opc.Ua.Server TFM output folder

### DIFF
--- a/tests/Opc.Ua.SourceGeneration.Tests/ModelDependencyScannerTests.cs
+++ b/tests/Opc.Ua.SourceGeneration.Tests/ModelDependencyScannerTests.cs
@@ -1097,8 +1097,10 @@ namespace Opc.Ua.SourceGeneration
                 ?? candidates.Find(d => string.Equals(
                     d.Name, "netstandard2.0", StringComparison.OrdinalIgnoreCase))
                 ?? candidates
-                    .Where(d => Directory.EnumerateFiles(d.FullName, "Opc.Ua.Server.dll").Any())
-                    .OrderByDescending(d => d.Name, StringComparer.OrdinalIgnoreCase)
+                    .Select(d => new FileInfo(Path.Combine(d.FullName, "Opc.Ua.Server.dll")))
+                    .Where(f => f.Exists)
+                    .OrderByDescending(f => f.LastWriteTimeUtc)
+                    .Select(f => f.Directory)
                     .FirstOrDefault();
 
             if (match == null)

--- a/tests/Opc.Ua.SourceGeneration.Tests/ModelDependencyScannerTests.cs
+++ b/tests/Opc.Ua.SourceGeneration.Tests/ModelDependencyScannerTests.cs
@@ -1056,19 +1056,58 @@ namespace Opc.Ua.SourceGeneration
                 directory = directory.Parent
                     ?? throw new InvalidOperationException("Repository root was not found.");
             }
-            string serverOutput = Path.Combine(
+            string serverBin = Path.Combine(
                 directory.FullName,
                 "src",
                 "Opc.Ua.Server",
                 "bin",
-                configuration,
-                targetFramework);
+                configuration);
+            string serverOutput = ResolveServerOutputFolder(serverBin, targetFramework);
             return Directory.EnumerateFiles(serverOutput, "Opc.Ua*.dll")
                 .Where(path => !string.Equals(
                     Path.GetFileName(path),
                     "Opc.Ua.Types.dll",
                     StringComparison.OrdinalIgnoreCase))
                 .Select(path => MetadataReference.CreateFromFile(path));
+        }
+
+        private static string ResolveServerOutputFolder(string serverBin, string testTargetFramework)
+        {
+            if (!Directory.Exists(serverBin))
+            {
+                throw new InvalidOperationException(
+                    $"Opc.Ua.Server output folder was not found at '{serverBin}'. "
+                    + "Build Opc.Ua.Server before running these tests.");
+            }
+
+            // The Opc.Ua.Server project may be built for a different target framework
+            // than the test assembly (e.g. netstandard2.1 while the tests run as net8.0).
+            // Probe the actual bin folder for whichever TFM subfolder exists instead of
+            // assuming the test's TFM. Prefer an exact match, then well-known fallbacks.
+            var candidates = Directory
+                .EnumerateDirectories(serverBin)
+                .Select(path => new DirectoryInfo(path))
+                .ToList();
+
+            DirectoryInfo match =
+                candidates.Find(d => string.Equals(
+                    d.Name, testTargetFramework, StringComparison.OrdinalIgnoreCase))
+                ?? candidates.Find(d => string.Equals(
+                    d.Name, "netstandard2.1", StringComparison.OrdinalIgnoreCase))
+                ?? candidates.Find(d => string.Equals(
+                    d.Name, "netstandard2.0", StringComparison.OrdinalIgnoreCase))
+                ?? candidates
+                    .Where(d => Directory.EnumerateFiles(d.FullName, "Opc.Ua.Server.dll").Any())
+                    .OrderByDescending(d => d.Name, StringComparer.OrdinalIgnoreCase)
+                    .FirstOrDefault();
+
+            if (match == null)
+            {
+                throw new InvalidOperationException(
+                    $"No Opc.Ua.Server build output was found under '{serverBin}'.");
+            }
+
+            return match.FullName;
         }
 
         private const string DemoModelUri = "urn:opcfoundation.org:2024-01:DemoModel";


### PR DESCRIPTION
# Description

`ModelDependencyScannerTests.GetStackReferences()` reconstructed the `Opc.Ua.Server` output path from the **test assembly's own TFM** (`bin/Release/net8.0`). On the netstandard2.1 nightly leg the tests run as `net8.0` while `Opc.Ua.Server` is built as `netstandard2.1`, so the hardcoded `net8.0` folder does not exist and every stack-compilation test threw `System.IO.DirectoryNotFoundException`. Because this only happens on a nightly-only leg, it was not caught by per-commit CI and remained on `master`.

The fix stops assuming the test's TFM. A new `ResolveServerOutputFolder()` helper probes `src/Opc.Ua.Server/bin/<config>` for whichever TFM subfolder actually exists, preferring an exact match to the test TFM, then falling back to `netstandard2.1`, `netstandard2.0`, or any subfolder containing `Opc.Ua.Server.dll`. It also throws a clear, actionable message when the server has not been built yet.

This is test-only; no product code changes. Build passes with 0 warnings and the previously failing tests pass locally.

## Related Issues

- Fixes #4283

## Checklist

_Put an `x` in the boxes that apply. You can complete these step by step after opening the PR._

- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf) and read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [x] I have added all necessary documentation.
- [x] I have verified that my changes do not introduce (new) build or analyzer warnings.
- [ ] I ran **all** tests locally using the **UA.slnx** solution against at least .net **framework** and .net **10**, and all passed.
- [ ] I fixed **all** failing and flaky tests in the CI pipelines and **all** CodeQL warnings.
- [ ] I have addressed **all** PR feedback received.