### PR TITLE
Fix MissingMethodException on Crdt init setters for netstandard2.1 build

### DIFF
--- a/src/Opc.Ua.Redundancy.Server/ReplicatedGossipOptions.cs
+++ b/src/Opc.Ua.Redundancy.Server/ReplicatedGossipOptions.cs
@@ -188,12 +188,35 @@ namespace Opc.Ua.Redundancy.Server
         /// </summary>
         internal CrdtReaderOptions CreateReaderOptions()
         {
+#if NETSTANDARD
+            // Crdt's netstandard build declares MaxCollectionCount/MaxStringBytes/MaxDepth as init-only
+            // setters whose modreq references an IsExternalInit type defined *inside* the netstandard Crdt
+            // assembly (netstandard has no BCL IsExternalInit). When this netstandard-compiled assembly is
+            // loaded on a .NET runtime - as the nightly "NETStandard 2.1" test leg does on net8.0 - the
+            // matching net8.0 Crdt assembly is loaded instead, whose setters carry a modreq to the BCL
+            // IsExternalInit. That modreq mismatch makes the C#-emitted init call unresolvable at runtime
+            // (MissingMethodException on set_MaxCollectionCount). Reflection binds by name and ignores the
+            // modreq, so it resolves against whichever Crdt build is actually loaded.
+            var options = new CrdtReaderOptions();
+            SetLimit(nameof(CrdtReaderOptions.MaxCollectionCount), MaxEntryCount);
+            SetLimit(nameof(CrdtReaderOptions.MaxStringBytes), MaxPayloadBytes);
+            SetLimit(nameof(CrdtReaderOptions.MaxDepth), CrdtReaderOptions.Default.MaxDepth);
+            return options;
+
+            void SetLimit(string name, int value)
+            {
+                System.Reflection.PropertyInfo property = typeof(CrdtReaderOptions).GetProperty(name)
+                    ?? throw new MissingMemberException(nameof(CrdtReaderOptions), name);
+                property.SetValue(options, value);
+            }
+#else
             return new CrdtReaderOptions
             {
                 MaxCollectionCount = MaxEntryCount,
                 MaxStringBytes = MaxPayloadBytes,
                 MaxDepth = CrdtReaderOptions.Default.MaxDepth
             };
+#endif
         }
 
         /// <summary>


### PR DESCRIPTION
# Description

The nightly `Test .NETStandard 2.1 Tests (net8.0)` leg builds `Opc.Ua.Redundancy.Server` as `netstandard2.1` but runs it on the net8.0 runtime, where `Opc.Ua.Redundancy.Server.Tests` failed with `MissingMethodException: Void Crdt.CrdtReaderOptions.set_MaxCollectionCount(Int32)`. Because this only runs nightly, per-commit CI never caught it and it is still present on `master`.

**Root cause.** `ReplicatedGossipOptions.CreateReaderOptions()` uses an object initializer on `Crdt.CrdtReaderOptions`, whose `MaxCollectionCount` / `MaxStringBytes` / `MaxDepth` are `init`-only setters. Confirmed by reflecting on Crdt 1.1.2:

- The **netstandard2.1** Crdt assembly defines its own internal `System.Runtime.CompilerServices.IsExternalInit` (netstandard has no BCL one), and its `init` setters carry a `modreq` to that in-assembly type.
- The **net8.0** Crdt assembly's setters carry a `modreq` to the BCL `System.Runtime` `IsExternalInit`.

When the netstandard2.1-compiled `Opc.Ua.Redundancy.Server` is loaded on net8.0, the net8.0 Crdt is loaded at runtime, so the `modreq` the compiler baked into our `init` call (pointing at Crdt's in-assembly `IsExternalInit`) no longer resolves, producing the `MissingMethodException`. This is not version drift (Crdt is pinned to 1.1.2); it is a cross-TFM `init`/modreq identity mismatch.

**Fix.** TFM-guard the setter assignment in `ReplicatedGossipOptions.CreateReaderOptions()`:

- On `netstandard`, set the three limits via reflection (`PropertyInfo.SetValue` binds by name and ignores the modreq, so it resolves against whichever Crdt build is actually loaded).
- On net TFMs (net8/9/10, including the AOT-compiled build), keep the plain object initializer so the build stays reflection-free.

No production behavior changes on the net runtimes; only the netstandard build path is affected.

## Related Issues

- Fixes #4284

## Verification

- netstandard2.1 leg (`CustomTestTarget=netstandard2.1`, runs on net8.0): 12/12 `ReplicatedOptionsTests` pass (previously failing).
- Default net10.0 path: 12/12 pass.

## Checklist

- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf) and read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [x] I have added all necessary documentation.
- [x] I have verified that my changes do not introduce (new) build or analyzer warnings.
- [ ] I ran **all** tests locally using the **UA.slnx** solution against at least .net **framework** and .net **10**, and all passed.
- [ ] I fixed **all** failing and flaky tests in the CI pipelines and **all** CodeQL warnings.
- [ ] I have addressed **all** PR feedback received.