### PR TITLE
Fix CI failures tracked by #4299

### DIFF
--- a/.azurepipelines/test.yml
+++ b/.azurepipelines/test.yml
@@ -224,6 +224,14 @@ jobs:
       # upload/download. It is only produced on an actual hang, so the cost is paid
       # rarely; the dump is published as a downloadable pipeline artifact below (it is
       # otherwise only reachable via the auth-gated test attachments API).
+      # --blame-crash/--blame-crash-dump-type mini: --blame-crash activates crash
+      # detection so a sequence file records which test was running when the host
+      # exited.  --blame-crash-dump-type mini additionally captures a minidump on
+      # crash - every thread's stack without serialising the managed heap (which
+      # would push it into multi-GB territory for a server-hosting test process).
+      # Only written on an actual crash; healthy runs pay no cost.  Both the
+      # sequence file and the dump land in $(Agent.TempDirectory) and are staged by
+      # the 'Stage diagnostic dumps' step below.
       # --logger trx + --results-directory: emit trx ourselves because we set
       # publishTestResults: false below to decouple "ran tests" from "published
       # results to AzDO" - the inline publish step inside DotNetCoreCLI@2 fails
@@ -231,7 +239,7 @@ jobs:
       # opcfoundation.visualstudio.com (observed on mac PR build 14614 log 737:
       # all 707 tests passed, then post-test publish errored with
       # "nodename nor servname provided, or not known" and failed the job).
-      arguments: '--no-restore ${{ variables.DotCliCommandline }} --configuration ${{ parameters.configuration }} ${{ variables.CoverageArgs }} ${{ variables.TestFilterArgs }} --blame-hang-timeout ${{ parameters.hangtimeout }} --blame-hang-dump-type mini --logger trx --results-directory $(Agent.TempDirectory)'
+      arguments: '--no-restore ${{ variables.DotCliCommandline }} --configuration ${{ parameters.configuration }} ${{ variables.CoverageArgs }} ${{ variables.TestFilterArgs }} --blame-hang-timeout ${{ parameters.hangtimeout }} --blame-hang-dump-type mini --blame-crash --blame-crash-dump-type mini --logger trx --results-directory $(Agent.TempDirectory)'
       publishTestResults: false
   - task: PublishTestResults@2
     displayName: 'Publish Test Results ${{ parameters.configuration }} (${{ parameters.framework }})'
@@ -369,6 +377,44 @@ jobs:
     condition: and(failed(), contains(variables['file'], 'Fuzz.Tests'), ne(variables['fuzzingartifacts.secureFilePath'], ''))
     inputs:
       PathtoPublish: '$(Agent.TempDirectory)/FuzzingArtifacts.zip'
+  - task: PowerShell@2
+    displayName: 'Stage macOS crash reports'
+    # Apple Crash Reporter writes .crash (legacy) and .ips (JSON, macOS 12+)
+    # diagnostic reports to ~/Library/Logs/DiagnosticReports/ when a process crashes.
+    # These are separate from the VSTest blame collector dumps and provide the native
+    # crash stack, OS thread state, and signal information needed to root-cause a
+    # testhost SIGABRT or SIGSEGV.  Only files whose base name contains 'testhost' or
+    # 'dotnet' (case-insensitive) are collected; this excludes unrelated host or
+    # application crash reports that accumulate on shared agents.  Qualifying reports
+    # created in the last two hours are copied into $(Agent.TempDirectory)/mac-diagnostics/
+    # so the 'Stage diagnostic dumps' CopyFiles step below picks them up automatically.
+    condition: and(succeededOrFailed(), eq(variables['Agent.OS'], 'Darwin'))
+    continueOnError: true
+    inputs:
+      targetType: inline
+      pwsh: true
+      script: |
+        $src = [System.IO.Path]::Combine($env:HOME, 'Library', 'Logs', 'DiagnosticReports')
+        $dst = '$(Agent.TempDirectory)/mac-diagnostics'
+        if (-not (Test-Path $src)) {
+            Write-Host "No DiagnosticReports directory found at '$src'; skipping."
+            exit 0
+        }
+        $cutoff = (Get-Date).AddHours(-2)
+        $files = @(Get-ChildItem -Path $src -File -ErrorAction SilentlyContinue |
+            Where-Object { ($_.Extension -ieq '.crash' -or $_.Extension -ieq '.ips') -and
+                           ($_.BaseName -ilike '*testhost*' -or $_.BaseName -ilike '*dotnet*') -and
+                           $_.LastWriteTime -ge $cutoff })
+        if ($files.Count -eq 0) {
+            Write-Host 'No recent macOS crash reports found.'
+            exit 0
+        }
+        $null = New-Item -ItemType Directory -Path $dst -Force
+        foreach ($f in $files) {
+            Copy-Item -Path $f.FullName -Destination $dst -Force
+            Write-Host "Staged: $($f.Name)"
+        }
+        Write-Host "Staged $($files.Count) macOS crash report(s) to '$dst'."
   # On job completion, collect any dumps written under the results directory
   # ($(Agent.TempDirectory)) and publish them as a downloadable pipeline
   # artifact.  Covers:
@@ -376,6 +422,7 @@ jobs:
   #   - --blame-crash-dump-type mini / full crash dumps (*.dmp)
   #   - Linux core dumps (core / core.*)
   #   - Any other dump variant a test collector might emit (*.mdmp, *.dump)
+  #   - macOS Apple Crash Reporter reports staged by the step above (*.crash, *.ips)
   # The blame collector otherwise only attaches the dump to the trx, which is
   # reachable solely through the auth-gated test attachments API; publishing
   # them as build artifacts makes teardown/shutdown hangs and testhost crashes
@@ -398,6 +445,8 @@ jobs:
         **/*.dmp
         **/*.mdmp
         **/*.dump
+        **/*.crash
+        **/*.ips
         **/core
         **/core.*
       TargetFolder: '$(Build.ArtifactStagingDirectory)/dumps'

--- a/.azurepipelines/test.yml
+++ b/.azurepipelines/test.yml
@@ -388,7 +388,7 @@ jobs:
     # application crash reports that accumulate on shared agents.  Qualifying reports
     # created in the last two hours are copied into $(Agent.TempDirectory)/mac-diagnostics/
     # so the 'Stage diagnostic dumps' CopyFiles step below picks them up automatically.
-    condition: and(succeededOrFailed(), eq(variables['Agent.OS'], 'Darwin'))
+    condition: and(failed(), eq(variables['Agent.OS'], 'Darwin'))
     continueOnError: true
     inputs:
       targetType: inline

--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -159,7 +159,7 @@ jobs:
         }
         if ($includeMac -and $relevantChanges) {
             $testOs += 'macOS-latest'
-            $aotMatrix += @{ os = 'macos-13';     rid = 'osx-x64'  }
+            $aotMatrix += @{ os = 'macos-15-intel'; rid = 'osx-x64'  }
             $aotMatrix += @{ os = 'macos-latest'; rid = 'osx-arm64' }
         }
         Write-Host "Event=$($env:EVENT_NAME); include_macos=$includeMac"

--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -15,7 +15,7 @@ on:
   # Weekly nightly run mirroring azure-pipelines.yml — Sun 02:00 UTC.
   schedule:
     - cron: '0 2 * * 0'
-  # Manual dispatch with an opt-in for macOS runners.
+  # Manual dispatch can opt out of the macOS runners that are enabled by default.
   workflow_dispatch:
     inputs:
       include_macos:
@@ -101,11 +101,10 @@ jobs:
         Write-Host "Discovered $(@($projects).Count) project(s): $json"
         "csprojs=$json" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
 
-        # macOS is opt-in on pull_request events (default off) and included
-        # by default on push/schedule/workflow_dispatch.  When dispatched
+        # macOS is included by default on pull_request, push, and schedule events
+        # so platform-specific failures are caught before merge. When dispatched
         # manually the include_macos input can be flipped to false to skip.
         $includeMac = switch ($env:EVENT_NAME) {
-            'pull_request' { $false }
             'workflow_dispatch' { $env:INCLUDE_MACOS -eq 'true' }
             default { $true }
         }
@@ -188,9 +187,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # macOS is on by default for push/schedule/workflow_dispatch and
-        # off by default on pull_request; ubuntu drops out entirely when
-        # CI_BUILD_BACKEND hands the Linux matrix to Azure Pipelines.
+        # macOS is on by default for pull_request/push/schedule/workflow_dispatch;
+        # ubuntu drops out entirely when CI_BUILD_BACKEND hands the Linux matrix
+        # to Azure Pipelines.
         # Both are computed by discover.test_os.
         os: ${{ fromJSON(needs.discover.outputs.test_os) }}
         csproj: ${{ fromJSON(needs.discover.outputs.csprojs) }}
@@ -340,6 +339,15 @@ jobs:
           '10m',
           '--blame-hang-dump-type',
           'mini',
+          # --blame-crash enables crash detection so a sequence file records which
+          # test was running when the host exited.  --blame-crash-dump-type mini
+          # additionally captures a minidump on crash - every thread's stack without
+          # serialising the managed heap.  Only written on an actual crash so healthy
+          # runs pay no cost.  Both files land in TESTRESULTS and are uploaded by
+          # 'Upload test results' below.
+          '--blame-crash',
+          '--blame-crash-dump-type',
+          'mini',
           '--results-directory',
           '${{ env.TESTRESULTS }}')
 
@@ -350,6 +358,40 @@ jobs:
 
         dotnet test @testArgs
 
+    - name: Stage macOS crash reports
+      # Apple Crash Reporter writes .crash (legacy) and .ips (JSON, macOS 12+)
+      # diagnostic reports to ~/Library/Logs/DiagnosticReports/ when a process
+      # crashes.  These are separate from the VSTest blame collector dumps and
+      # contain the native crash stack and OS thread state needed to root-cause a
+      # testhost SIGABRT or SIGSEGV.  Only files whose base name contains
+      # 'testhost' or 'dotnet' (case-insensitive) are collected; this excludes
+      # unrelated host or application crash reports on shared runners.  Qualifying
+      # reports from the last two hours are copied into TESTRESULTS/mac-diagnostics/
+      # so the existing 'Upload test results' step picks them up automatically.
+      if: ${{ always() && runner.os == 'macOS' }}
+      shell: pwsh
+      run: |
+        $src = [System.IO.Path]::Combine($env:HOME, 'Library', 'Logs', 'DiagnosticReports')
+        $dst = "$env:TESTRESULTS/mac-diagnostics"
+        if (-not (Test-Path $src)) {
+            Write-Host "No DiagnosticReports directory found at '$src'; skipping."
+            exit 0
+        }
+        $cutoff = (Get-Date).AddHours(-2)
+        $files = @(Get-ChildItem -Path $src -File -ErrorAction SilentlyContinue |
+            Where-Object { ($_.Extension -ieq '.crash' -or $_.Extension -ieq '.ips') -and
+                           ($_.BaseName -ilike '*testhost*' -or $_.BaseName -ilike '*dotnet*') -and
+                           $_.LastWriteTime -ge $cutoff })
+        if ($files.Count -eq 0) {
+            Write-Host 'No recent macOS crash reports found.'
+            exit 0
+        }
+        $null = New-Item -ItemType Directory -Path $dst -Force
+        foreach ($f in $files) {
+            Copy-Item -Path $f.FullName -Destination $dst -Force
+            Write-Host "Staged: $($f.Name)"
+        }
+        Write-Host "Staged $($files.Count) macOS crash report(s) to '$dst'."
     - name: Upload test results
       uses: actions/upload-artifact@v7
       with:
@@ -548,10 +590,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # OS + RID pairs computed by `discover` so macOS entries drop out
-        # entirely on pull_request (default off) and the ubuntu entry drops
-        # out when CI_BUILD_BACKEND hands AoT to Azure Pipelines.  Windows AoT
-        # is covered by the AzDO testaot stage.
+        # OS + RID pairs computed by `discover`; the ubuntu entry drops out when
+        # CI_BUILD_BACKEND hands AoT to Azure Pipelines. Windows AoT is covered by
+        # the AzDO testaot stage.
         include: ${{ fromJSON(needs.discover.outputs.aot_matrix) }}
 
     env:

--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -368,7 +368,7 @@ jobs:
       # unrelated host or application crash reports on shared runners.  Qualifying
       # reports from the last two hours are copied into TESTRESULTS/mac-diagnostics/
       # so the existing 'Upload test results' step picks them up automatically.
-      if: ${{ always() && runner.os == 'macOS' }}
+      if: ${{ failure() && runner.os == 'macOS' }}
       shell: pwsh
       run: |
         $src = [System.IO.Path]::Combine($env:HOME, 'Library', 'Logs', 'DiagnosticReports')

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -94,10 +94,11 @@ pr:
 # Weekly full-scope run.  Fires every Sunday at 02:00 UTC (late Saturday
 # night in the Americas / early Sunday morning in EU).  `always: true`
 # forces the run even when there are no commits since the previous one so
-# the badge in README.md reflects a recent green build.  All stages that
-# are gated on `ScheduledBuild` (AOT, Debug, .NET 9/8/472/netstandard,
-# mac matrix) are automatically included because Build.Reason
-# is 'Schedule' for these runs.
+# the badge in README.md reflects a recent green build. All stages that
+# are gated on `ScheduledBuild` (AOT, Debug, .NET 9/8/472/netstandard)
+# are automatically included because Build.Reason is 'Schedule' for these runs.
+# macOS jobs are additionally controlled by MacOSJobsEnabled and are disabled
+# while GitHub Actions owns them.
 schedules:
 - cron: '0 2 * * 0'
   displayName: 'Weekly full-scope tests (Sat night UTC)'
@@ -114,8 +115,9 @@ variables:
   # Schedule/Manual-only here, additionally runs on pull requests while this is
   # True, because it is then the only place that work happens.
   AdoOwnsMatrix: ${{ eq(parameters.ciBuildBackend, 'ado') }}
-  # macOS jobs always run on Microsoft-hosted agents because Managed DevOps Pools
-  # does not provide macOS images.
+  # GitHub Actions owns macOS validation. Keep the Azure definitions available
+  # for emergency/manual use, but do not schedule them unless explicitly enabled.
+  MacOSJobsEnabled: false
   macImage: 'macOS-15'
   # Two pool profiles are defined so stages can be routed independently and the
   # netstandard Managed DevOps Pool and the Microsoft-hosted agents share the
@@ -228,12 +230,7 @@ stages:
       hosted: true
       poolName: ${{ variables.mgdPoolName }}
       windowsImage: ${{ variables.mgdWindowsImage }}
-      # macOS runs only on Schedule/Manual (nightly + on-demand), not on
-      # PR or master push, to keep the PR gate fast and Windows-focused.
-      # Passed bare: test.yml wraps it in succeeded() for the test jobs and in
-      # not(canceled()) for the coverage gate, which has to report a failure
-      # rather than skip when a test job failed.
-      condition: ne(variables.ScheduledBuild, 'False')
+      condition: and(eq(variables.MacOSJobsEnabled, 'True'), ne(variables.ScheduledBuild, 'False'))
 - stage: testaot
   dependsOn: []
   displayName: 'Test Native AoT'
@@ -271,6 +268,7 @@ stages:
       hosted: true
       poolName: ${{ variables.hostPoolName }}
       windowsImage: ${{ variables.hostWindowsImage }}
+      condition: eq(variables.MacOSJobsEnabled, 'True')
 - stage: testnet90
   dependsOn: [build]
   displayName: 'Test .NET 9.0'
@@ -293,6 +291,7 @@ stages:
       hosted: true
       poolName: ${{ variables.mgdPoolName }}
       windowsImage: ${{ variables.mgdWindowsImage }}
+      condition: eq(variables.MacOSJobsEnabled, 'True')
 - stage: testnet80
   dependsOn: [build]
   displayName: 'Test .NET 8.0'
@@ -315,6 +314,7 @@ stages:
       hosted: true
       poolName: ${{ variables.hostPoolName }}
       windowsImage: ${{ variables.hostWindowsImage }}
+      condition: eq(variables.MacOSJobsEnabled, 'True')
 - stage: testnet472
   dependsOn: [build]
   displayName: 'Test .NET 4.7.2'
@@ -367,6 +367,7 @@ stages:
       hosted: true
       poolName: ${{ variables.mgdPoolName }}
       windowsImage: ${{ variables.mgdWindowsImage }}
+      condition: eq(variables.MacOSJobsEnabled, 'True')
 - stage: testnightly
   dependsOn: [build]
   displayName: 'Test long-running tiers'

--- a/samples/OpenUsd/GeneratorServer/GeneratorServer.csproj
+++ b/samples/OpenUsd/GeneratorServer/GeneratorServer.csproj
@@ -29,6 +29,11 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" />
   </ItemGroup>
+  <!-- The conformance tests read the simulation constants to verify that they
+       agree with the published datasheet instead of duplicating those values. -->
+  <ItemGroup>
+    <InternalsVisibleTo Include="Opc.Ua.OpenUsd.Tests" />
+  </ItemGroup>
   <!-- Authored USD layers embedded so the server ships (and serves) its own twin
        geometry: Powerhouse.usda (RootLayer) + generator.usda (Reference). -->
   <ItemGroup>

--- a/samples/OpenUsd/GeneratorServer/Properties/AssemblyInfo.cs
+++ b/samples/OpenUsd/GeneratorServer/Properties/AssemblyInfo.cs
@@ -28,12 +28,5 @@
  * ======================================================================*/
 
 using System;
-using System.Runtime.CompilerServices;
 
 [assembly: CLSCompliant(false)]
-
-// The conformance tests assert that the simulation constants and the published
-// datasheet agree, which means reading the constants rather than re-declaring
-// them - a test that carried its own copy of the numbers would pass while the
-// server served something else entirely.
-[assembly: InternalsVisibleTo("Opc.Ua.OpenUsd.Tests")]

--- a/src/Opc.Ua.Core/Stack/Tcp/UaSCBinaryChannel.cs
+++ b/src/Opc.Ua.Core/Stack/Tcp/UaSCBinaryChannel.cs
@@ -900,12 +900,14 @@ namespace Opc.Ua.Bindings
         /// </summary>
         protected void BeginWriteMessage(BufferCollection buffers, object? state)
         {
+            Interlocked.Increment(ref m_activeWriteRequests);
+
             IUaSCByteTransport? transport = m_transport;
             if (transport == null)
             {
-                // Mirror the legacy contract: report failure via HandleWriteComplete
-                // rather than throwing synchronously so callers' state is released.
-                HandleWriteComplete(
+                // The caller can hold the channel gate. Report asynchronously
+                // because client write completion enters the same non-reentrant gate.
+                ReportWriteComplete(
                     buffers,
                     state,
                     0,
@@ -914,8 +916,6 @@ namespace Opc.Ua.Bindings
                         "The transport was closed by the remote application."));
                 return;
             }
-
-            Interlocked.Increment(ref m_activeWriteRequests);
 
             // Queued rather than started inline, for the reason given in
             // BeginWriteMessage(ArraySegment{byte}, object).

--- a/tests/Opc.Ua.Client.TestFramework/ClientTestFramework.cs
+++ b/tests/Opc.Ua.Client.TestFramework/ClientTestFramework.cs
@@ -160,6 +160,7 @@ namespace Opc.Ua.Client.TestFramework
             Telemetry = telemetry ?? NUnitTelemetryContext.Create();
             m_logger = Telemetry.CreateLogger<ClientTestFramework>();
             UriScheme = uriScheme;
+            MaxFailedAuthenticationAttempts = 0;
             TestSetStatic = CommonTestWorkers.NodeIdTestSetStatic;
             TestSetStaticMassNumeric = CommonTestWorkers.NodeIdTestSetStaticMassNumeric;
             TestSetSimulation = CommonTestWorkers.NodeIdTestSetSimulation;

--- a/tests/Opc.Ua.Client.TestFramework/ClientTestFramework.cs
+++ b/tests/Opc.Ua.Client.TestFramework/ClientTestFramework.cs
@@ -66,12 +66,13 @@ namespace Opc.Ua.Client.TestFramework
 
         /// <summary>
         /// The server's maximum failed-authentication attempts before a client is
-        /// locked out. Defaults to the production default (5). A value of zero or
-        /// less disables the brute-force lockout, which load/scale fixtures that
-        /// open many sessions from a single client certificate need so transient
-        /// connect failures cannot lock the shared certificate out.
+        /// locked out. Defaults to 0 (disabled) so that transient connection
+        /// failures in load and scale fixtures never lock out the shared client
+        /// certificate. Tests that explicitly validate lockout behaviour must set
+        /// this to a positive value (e.g. 5) before calling
+        /// <see cref="CreateReferenceServerFixtureAsync"/>.
         /// </summary>
-        public int MaxFailedAuthenticationAttempts { get; set; } = 5;
+        public int MaxFailedAuthenticationAttempts { get; set; }
 
         /// <summary>
         /// The server's maximum number of concurrent request-processing worker

--- a/tests/Opc.Ua.Core.Tests/Stack/Transport/UaSCBinaryClientChannelDeterministicTests.cs
+++ b/tests/Opc.Ua.Core.Tests/Stack/Transport/UaSCBinaryClientChannelDeterministicTests.cs
@@ -407,6 +407,35 @@ namespace Opc.Ua.Core.Tests.Stack.Transport
             Assert.That(channel.CurrentState, Is.EqualTo(TcpChannelState.Closed));
         }
 
+        [Test]
+        public async Task ClosedTransportWriteCompletesWithoutGateReentryAsync()
+        {
+            using var channel = new TestClientChannel(
+                m_buffers,
+                new RecordingByteTransportFactory(),
+                m_quotas,
+                null,
+                BuildEndpoint(MessageSecurityMode.None, SecurityPolicies.None),
+                m_telemetry,
+                new FakeTimeProvider());
+            byte[] buffer = m_buffers.TakeBuffer(
+                16,
+                nameof(ClosedTransportWriteCompletesWithoutGateReentryAsync));
+            var buffers = new BufferCollection { new ArraySegment<byte>(buffer, 0, 16) };
+
+            Task beginWrite = Task.Run(() => channel.BeginClosedTransportWriteUnderGate(buffers));
+
+            Assert.That(
+                await CompletesWithinAsync(beginWrite, 30).ConfigureAwait(false),
+                Is.True,
+                "begin write re-entered its own channel gate");
+            await beginWrite.ConfigureAwait(false);
+            Assert.That(
+                await CompletesWithinAsync(channel.WriteCompletion, 30).ConfigureAwait(false),
+                Is.True,
+                "closed transport write completion was not reported");
+        }
+
         private async Task<ServiceResultException> RunHandshakeToFaultAsync(
             Func<TestClientChannel, ValueTask<bool>> feed)
         {
@@ -603,6 +632,16 @@ namespace Opc.Ua.Core.Tests.Stack.Transport
 
             public int TestTransportReceiveBufferSize => TransportReceiveBufferSize;
 
+            public Task WriteCompletion => m_writeCompletion.Task;
+
+            public void BeginClosedTransportWriteUnderGate(BufferCollection buffers)
+            {
+                using (Gate.Enter())
+                {
+                    BeginWriteMessage(buffers, null);
+                }
+            }
+
             public void SetupReverseTransport(IUaSCByteTransport transport)
             {
                 ReverseSocket = true;
@@ -649,6 +688,19 @@ namespace Opc.Ua.Core.Tests.Stack.Transport
             {
                 ReadAndVerifyMessageTypeAndSize(decoder, expectedMessageType, count);
             }
+
+            protected override void HandleWriteComplete(
+                BufferCollection? buffers,
+                object? state,
+                int bytesWritten,
+                ServiceResult result)
+            {
+                base.HandleWriteComplete(buffers, state, bytesWritten, result);
+                m_writeCompletion.TrySetResult(true);
+            }
+
+            private readonly TaskCompletionSource<bool> m_writeCompletion =
+                new(TaskCreationOptions.RunContinuationsAsynchronously);
         }
 
         private sealed class RecordingByteTransportFactory : IUaSCByteTransportFactory

--- a/tests/Opc.Ua.Di.Tests/PumpAddressSpaceComplianceTests.cs
+++ b/tests/Opc.Ua.Di.Tests/PumpAddressSpaceComplianceTests.cs
@@ -39,6 +39,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using NUnit.Framework;
 using Opc.Ua.Client.TestFramework;
+using Opc.Ua.Client.Alarms;
 using Opc.Ua.Di.Server.Builders;
 using Opc.Ua.Pumps;
 using Opc.Ua.Server;
@@ -834,12 +835,17 @@ namespace Opc.Ua.Di.Tests
                         Is.True,
                         "Event monitored item creation failed: " + monitoredItems.Results[0].StatusCode);
 
+                    AlarmClient alarmClient = session.GetAlarmClient(server.Telemetry);
+                    await alarmClient.ConditionRefreshAsync(
+                        subscription.SubscriptionId,
+                        CancellationToken.None).ConfigureAwait(false);
+
                     Assert.That(
                         await WaitForAlarmEventAsync(
                             session,
                             subscription.SubscriptionId,
                             alarmNodeId,
-                            TimeSpan.FromSeconds(5)).ConfigureAwait(false),
+                            TimeSpan.FromSeconds(30)).ConfigureAwait(false),
                         Is.True,
                         "No OverTempAlarm event was received through a client event subscription.");
                 }

--- a/tests/Opc.Ua.History.Tests/AlarmEventCollector.cs
+++ b/tests/Opc.Ua.History.Tests/AlarmEventCollector.cs
@@ -242,10 +242,15 @@ namespace Opc.Ua.History.Tests
             {
                 try
                 {
+                    using var deleteCts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
                     await m_session.DeleteSubscriptionsAsync(
                         null,
                         new uint[] { m_subscriptionId }.ToArrayOf(),
-                        CancellationToken.None).ConfigureAwait(false);
+                        deleteCts.Token).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    // Deletion timed out; best-effort cleanup.
                 }
                 catch (ServiceResultException)
                 {
@@ -383,9 +388,20 @@ namespace Opc.Ua.History.Tests
                         : await m_session.PublishWithTimeoutAsync(acknowledgements, 1000).ConfigureAwait(false);
                     acknowledgements = Array.Empty<SubscriptionAcknowledgement>().ToArrayOf();
                 }
+                catch (OperationCanceledException) when (m_shutdown.IsCancellationRequested)
+                {
+                    // Cancelled by expected shutdown; exit the loop cleanly.
+                    break;
+                }
                 catch (ServiceResultException ex) when (ex.StatusCode == StatusCodes.BadRequestTimeout)
                 {
+                    // Normal publish poll timeout; try again.
                     continue;
+                }
+                catch (ServiceResultException ex) when (IsShutdownStatus(ex.StatusCode) && m_shutdown.IsCancellationRequested)
+                {
+                    // Session or subscription is gone during expected shutdown; exit the loop cleanly.
+                    break;
                 }
 
                 ProcessNotificationMessage(publishResponse.NotificationMessage);

--- a/tests/Opc.Ua.History.Tests/AlarmEventCollector.cs
+++ b/tests/Opc.Ua.History.Tests/AlarmEventCollector.cs
@@ -398,9 +398,14 @@ namespace Opc.Ua.History.Tests
                     // Normal publish poll timeout; try again.
                     continue;
                 }
-                catch (ServiceResultException ex) when (IsShutdownStatus(ex.StatusCode) && m_shutdown.IsCancellationRequested)
+                catch (ServiceResultException) when (m_shutdown.IsCancellationRequested)
                 {
-                    // Session or subscription is gone during expected shutdown; exit the loop cleanly.
+                    // The session may report any service failure while expected shutdown tears it down.
+                    break;
+                }
+
+                if (m_shutdown.IsCancellationRequested)
+                {
                     break;
                 }
 

--- a/tests/Opc.Ua.History.Tests/AlarmsAndConditionsAlarmTests.cs
+++ b/tests/Opc.Ua.History.Tests/AlarmsAndConditionsAlarmTests.cs
@@ -102,6 +102,7 @@ namespace Opc.Ua.History.Tests
             collector.Reset();
 
             await WriteAlarmSourceValueAsync(alarmId, new Variant(90)).ConfigureAwait(false);
+            await collector.ConditionRefreshAsync().ConfigureAwait(false);
             EventFieldList activeEvent = await collector.WaitForEventAsync(
                 alarmId,
                 e => AlarmEventCollector.TryGetBoolean(
@@ -121,6 +122,7 @@ namespace Opc.Ua.History.Tests
                 "Active transition should require acknowledgement.");
 
             await WriteAlarmSourceValueAsync(alarmId, new Variant(50)).ConfigureAwait(false);
+            await collector.ConditionRefreshAsync().ConfigureAwait(false);
             EventFieldList normalEvent = await collector.WaitForEventAsync(
                 alarmId,
                 e => AlarmEventCollector.TryGetBoolean(

--- a/tests/Opc.Ua.History.Tests/AlarmsAndConditionsNonExclusiveLimitTests.cs
+++ b/tests/Opc.Ua.History.Tests/AlarmsAndConditionsNonExclusiveLimitTests.cs
@@ -53,6 +53,7 @@ namespace Opc.Ua.History.Tests
             collector.Reset();
 
             await WriteAlarmSourceValueAsync(alarmId, new Variant(90)).ConfigureAwait(false);
+            await collector.ConditionRefreshAsync().ConfigureAwait(false);
             EventFieldList activeEvent = await collector.WaitForEventAsync(
                 alarmId,
                 e => AlarmEventCollector.TryGetBoolean(
@@ -72,6 +73,7 @@ namespace Opc.Ua.History.Tests
                 "Active transition should require acknowledgement.");
 
             await WriteAlarmSourceValueAsync(alarmId, new Variant(50)).ConfigureAwait(false);
+            await collector.ConditionRefreshAsync().ConfigureAwait(false);
             EventFieldList normalEvent = await collector.WaitForEventAsync(
                 alarmId,
                 e => AlarmEventCollector.TryGetBoolean(

--- a/tests/Opc.Ua.Redundancy.Samples.Tests/SampleHaLongHaulTests.cs
+++ b/tests/Opc.Ua.Redundancy.Samples.Tests/SampleHaLongHaulTests.cs
@@ -160,7 +160,7 @@ namespace Opc.Ua.Redundancy.Samples.Tests
                 "Redundancy/RedundantPubSub",
                 "RedundantPubSub",
                 ["--role", "demo", "--ha-mode", mode],
-                SampleTestEnvironment.FastDemo);
+                SampleTestEnvironment.BuildFastDemo());
 
             await demo.WaitForLineAsync(
                 "FAILOVER: stopping publisher-a; publisher-b is promoted.",

--- a/tests/Opc.Ua.Redundancy.Samples.Tests/SampleHaShortHaulTests.cs
+++ b/tests/Opc.Ua.Redundancy.Samples.Tests/SampleHaShortHaulTests.cs
@@ -59,7 +59,7 @@ namespace Opc.Ua.Redundancy.Samples.Tests
                 "Redundancy/RedundantPubSub",
                 "RedundantPubSub",
                 ["--role", "demo", "--ha-mode", "hot"],
-                SampleTestEnvironment.FastDemo);
+                SampleTestEnvironment.BuildFastDemo());
 
             await demo.WaitForLineAsync(
                 "FAILOVER: stopping publisher-a; publisher-b is promoted.",
@@ -93,7 +93,7 @@ namespace Opc.Ua.Redundancy.Samples.Tests
                 "Redundancy/RedundantPubSub",
                 "RedundantPubSub",
                 ["--role", "demo", "--ha-mode", "cold"],
-                SampleTestEnvironment.FastDemo);
+                SampleTestEnvironment.BuildFastDemo());
 
             await demo.WaitForLineAsync(
                 "FAILOVER: stopping publisher-a; publisher-b is promoted.",

--- a/tests/Opc.Ua.Redundancy.Samples.Tests/SampleTestEnvironment.cs
+++ b/tests/Opc.Ua.Redundancy.Samples.Tests/SampleTestEnvironment.cs
@@ -34,23 +34,35 @@ using System.Globalization;
 namespace Opc.Ua.Redundancy.Samples.Tests
 {
     /// <summary>
-    /// Shared environment-variable presets used to launch the redundant sample
-    /// applications from the integration tests.
+    /// Shared environment-variable helpers used to launch the redundant sample
+    /// applications from the integration tests. Factory methods rather than
+    /// static properties are used where the environment depends on a freshly
+    /// allocated port so that parallel test children do not share the same
+    /// network resource.
     /// </summary>
     internal static class SampleTestEnvironment
     {
         /// <summary>
-        /// Environment for the single-process PubSub demo that shortens the two demo
-        /// phases so the failover narrative completes quickly during tests.
+        /// Builds an environment for the single-process PubSub demo that shortens
+        /// the two demo phases so the failover narrative completes quickly during
+        /// tests. Each call allocates a fresh loopback UDP port so that parallel
+        /// test processes do not contend on the same endpoint.
         /// </summary>
-        public static IReadOnlyDictionary<string, string?> FastDemo { get; } =
-            new Dictionary<string, string?>(StringComparer.Ordinal)
+        /// <returns>
+        /// A new environment dictionary with a unique <c>PUBSUB_ENDPOINT</c> for
+        /// this child process.
+        /// </returns>
+        public static IReadOnlyDictionary<string, string?> BuildFastDemo()
+        {
+            int port = TestPorts.GetFreeUdpPort();
+            return new Dictionary<string, string?>(StringComparer.Ordinal)
             {
                 ["DEMO_FIRST_SECONDS"] = "1",
                 ["DEMO_SECOND_SECONDS"] = "1",
-                ["PUBSUB_ENDPOINT"] = "opc.udp://127.0.0.1:4841",
+                ["PUBSUB_ENDPOINT"] = "opc.udp://127.0.0.1:" + port.ToString(CultureInfo.InvariantCulture),
                 ["HA_INSECURE"] = "true"
             };
+        }
 
         /// <summary>
         /// Environment for a plain, independent managed RedundantClient (one that fails

--- a/tests/Opc.Ua.Redundancy.Samples.Tests/SampleTestEnvironmentTests.cs
+++ b/tests/Opc.Ua.Redundancy.Samples.Tests/SampleTestEnvironmentTests.cs
@@ -27,6 +27,7 @@
  * http://opcfoundation.org/License/MIT/1.00/
  * ======================================================================*/
 
+using System.Collections.Generic;
 using NUnit.Framework;
 
 namespace Opc.Ua.Redundancy.Samples.Tests
@@ -36,19 +37,33 @@ namespace Opc.Ua.Redundancy.Samples.Tests
     internal sealed class SampleTestEnvironmentTests
     {
         [Test]
-        public void FastDemoUsesLoopbackEndpointAndInsecureDemoKey()
+        public void BuildFastDemoUsesLoopbackEndpointAndInsecureDemoKey()
         {
+            IReadOnlyDictionary<string, string?> env = SampleTestEnvironment.BuildFastDemo();
             Assert.Multiple(() =>
             {
                 Assert.That(
-                    SampleTestEnvironment.FastDemo.TryGetValue("PUBSUB_ENDPOINT", out string? endpoint),
+                    env.TryGetValue("PUBSUB_ENDPOINT", out string? endpoint),
                     Is.True);
-                Assert.That(endpoint, Is.EqualTo("opc.udp://127.0.0.1:4841"));
+                Assert.That(endpoint, Is.Not.Null.And.StartsWith("opc.udp://127.0.0.1:"),
+                    "PUBSUB_ENDPOINT must use the loopback address with a dynamically allocated port.");
                 Assert.That(
-                    SampleTestEnvironment.FastDemo.TryGetValue("HA_INSECURE", out string? insecure),
+                    env.TryGetValue("HA_INSECURE", out string? insecure),
                     Is.True);
                 Assert.That(insecure, Is.EqualTo("true"));
             });
+        }
+
+        [Test]
+        public void BuildFastDemoAllocatesDistinctUdpPortsPerCall()
+        {
+            IReadOnlyDictionary<string, string?> envA = SampleTestEnvironment.BuildFastDemo();
+            IReadOnlyDictionary<string, string?> envB = SampleTestEnvironment.BuildFastDemo();
+
+            Assert.That(envA.TryGetValue("PUBSUB_ENDPOINT", out string? endpointA), Is.True);
+            Assert.That(envB.TryGetValue("PUBSUB_ENDPOINT", out string? endpointB), Is.True);
+            Assert.That(endpointA, Is.Not.EqualTo(endpointB),
+                "Each BuildFastDemo call must produce a unique endpoint so parallel children do not share a port.");
         }
     }
 }

--- a/tests/Opc.Ua.Redundancy.Samples.Tests/TestPorts.cs
+++ b/tests/Opc.Ua.Redundancy.Samples.Tests/TestPorts.cs
@@ -43,10 +43,11 @@ namespace Opc.Ua.Redundancy.Samples.Tests
     internal static class TestPorts
     {
         /// <summary>
-        /// Reserves and returns a currently-free loopback UDP port that has not
+        /// Finds and returns a currently-free loopback UDP port that has not
         /// been previously returned by this method in the current process. The
         /// allocation is tracked process-wide so that sequential OS port-0
         /// requests, which may return the same number, never produce a duplicate.
+        /// The port is released before this method returns.
         /// </summary>
         /// <returns>A free UDP port number.</returns>
         public static int GetFreeUdpPort()
@@ -63,7 +64,7 @@ namespace Opc.Ua.Redundancy.Samples.Tests
         }
 
         /// <summary>
-        /// Reserves and returns a currently-free loopback TCP port.
+        /// Finds and returns a currently-free loopback TCP port.
         /// </summary>
         /// <returns>A free TCP port number.</returns>
         public static int GetFreePort()
@@ -81,7 +82,7 @@ namespace Opc.Ua.Redundancy.Samples.Tests
         }
 
         /// <summary>
-        /// Reserves and returns the requested number of distinct free loopback TCP ports.
+        /// Finds and returns the requested number of distinct free loopback TCP ports.
         /// </summary>
         /// <param name="count">The number of ports to allocate.</param>
         /// <returns>The allocated distinct ports.</returns>

--- a/tests/Opc.Ua.Redundancy.Samples.Tests/TestPorts.cs
+++ b/tests/Opc.Ua.Redundancy.Samples.Tests/TestPorts.cs
@@ -27,6 +27,7 @@
  * http://opcfoundation.org/License/MIT/1.00/
  * ======================================================================*/
 
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Net;
 using System.Net.Sockets;
@@ -34,12 +35,33 @@ using System.Net.Sockets;
 namespace Opc.Ua.Redundancy.Samples.Tests
 {
     /// <summary>
-    /// Allocates free loopback TCP ports for the sample processes. Using OS-assigned
-    /// ephemeral ports avoids collisions with other processes and with host-reserved or
-    /// excluded port ranges (for example the Hyper-V / WSL exclusions on Windows).
+    /// Allocates free loopback TCP and UDP ports for the sample processes. Using
+    /// OS-assigned ephemeral ports avoids collisions with other processes and with
+    /// host-reserved or excluded port ranges (for example the Hyper-V / WSL
+    /// exclusions on Windows).
     /// </summary>
     internal static class TestPorts
     {
+        /// <summary>
+        /// Reserves and returns a currently-free loopback UDP port that has not
+        /// been previously returned by this method in the current process. The
+        /// allocation is tracked process-wide so that sequential OS port-0
+        /// requests, which may return the same number, never produce a duplicate.
+        /// </summary>
+        /// <returns>A free UDP port number.</returns>
+        public static int GetFreeUdpPort()
+        {
+            while (true)
+            {
+                using var udpClient = new UdpClient(new IPEndPoint(IPAddress.Loopback, 0));
+                int port = ((IPEndPoint)udpClient.Client.LocalEndPoint!).Port;
+                if (s_allocatedUdpPorts.TryAdd(port, 0))
+                {
+                    return port;
+                }
+            }
+        }
+
         /// <summary>
         /// Reserves and returns a currently-free loopback TCP port.
         /// </summary>
@@ -75,5 +97,7 @@ namespace Opc.Ua.Redundancy.Samples.Tests
             ports.CopyTo(result);
             return result;
         }
+
+        private static readonly ConcurrentDictionary<int, byte> s_allocatedUdpPorts = new();
     }
 }

--- a/tests/Opc.Ua.Robotics.Tests/IntentClientRuntimeTests.cs
+++ b/tests/Opc.Ua.Robotics.Tests/IntentClientRuntimeTests.cs
@@ -68,7 +68,7 @@ namespace Opc.Ua.Robotics.Client.Tests
                 "i1",
                 new NodeId(10));
 
-            IntentResultDataType result = await AwaitWithTimeoutAsync(handle.Completion, TimeSpan.FromSeconds(1));
+            IntentResultDataType result = await AwaitWithTimeoutAsync(handle.Completion, s_handshakeTimeout);
 
             Assert.That(result.State, Is.EqualTo(state));
         }
@@ -86,7 +86,7 @@ namespace Opc.Ua.Robotics.Client.Tests
                 "i1",
                 new NodeId(10));
 
-            Assert.That(await AwaitWithTimeoutAsync(handle.Completion, TimeSpan.FromSeconds(1)), Is.Not.Null);
+            Assert.That(await AwaitWithTimeoutAsync(handle.Completion, s_handshakeTimeout), Is.Not.Null);
             Assert.That(transport.SubscribeCount, Is.EqualTo(1));
             Assert.That(transport.ReadSnapshotCount, Is.EqualTo(1));
         }
@@ -116,7 +116,7 @@ namespace Opc.Ua.Robotics.Client.Tests
                 State = ExecutionStateEnum.Succeeded
             };
             transport.PublishChange("Result", Variant.FromStructure(expected));
-            IntentResultDataType result = await AwaitWithTimeoutAsync(handle.Completion, TimeSpan.FromSeconds(1));
+            IntentResultDataType result = await AwaitWithTimeoutAsync(handle.Completion, s_handshakeTimeout);
 
             Assert.Multiple(() =>
             {
@@ -140,7 +140,7 @@ namespace Opc.Ua.Robotics.Client.Tests
                 new NodeId(10));
             transport.Snapshot = Snapshot(ExecutionStateEnum.Succeeded);
             transport.PublishReconnect();
-            IntentResultDataType result = await AwaitWithTimeoutAsync(handle.Completion, TimeSpan.FromSeconds(1));
+            IntentResultDataType result = await AwaitWithTimeoutAsync(handle.Completion, s_handshakeTimeout);
 
             Assert.That(result.State, Is.EqualTo(ExecutionStateEnum.Succeeded));
             Assert.That(transport.ReadSnapshotCount, Is.GreaterThanOrEqualTo(2));
@@ -240,7 +240,7 @@ namespace Opc.Ua.Robotics.Client.Tests
             {
                 transport.ControlOwner = new NodeId(2);
                 transport.PublishOwner(new NodeId(2));
-                await WaitUntilAsync(() => Equals(lease.CurrentOwner, new NodeId(2)), TimeSpan.FromSeconds(1))
+                await WaitUntilAsync(() => Equals(lease.CurrentOwner, new NodeId(2)), s_handshakeTimeout)
                     .ConfigureAwait(false);
 
                 Assert.That(lease.CurrentOwner, Is.EqualTo(new NodeId(2)));
@@ -263,7 +263,7 @@ namespace Opc.Ua.Robotics.Client.Tests
             int notifications = 0;
             lease.OwnerChanged += _ => Interlocked.Increment(ref notifications);
             transport.PublishOwner(owner);
-            await WaitUntilAsync(() => Volatile.Read(ref notifications) > 0, TimeSpan.FromSeconds(1))
+            await WaitUntilAsync(() => Volatile.Read(ref notifications) > 0, s_handshakeTimeout)
                 .ConfigureAwait(false);
 
             Assert.Multiple(() =>
@@ -339,11 +339,11 @@ namespace Opc.Ua.Robotics.Client.Tests
             handle.Changed += _ =>
             {
                 callbackEntered.TrySetResult(true);
-                Assert.That(allowCallbackToExit.Wait(TimeSpan.FromSeconds(1)), Is.True);
+                Assert.That(allowCallbackToExit.Wait(s_handshakeTimeout), Is.True);
             };
 
             transport.PublishChange(Variant.From((int)ExecutionStateEnum.Succeeded));
-            await AwaitWithTimeoutAsync(callbackEntered.Task, TimeSpan.FromSeconds(1));
+            await AwaitWithTimeoutAsync(callbackEntered.Task, s_handshakeTimeout);
             Task dispose = handle.DisposeAsync().AsTask();
             allowCallbackToExit.Set();
 
@@ -441,7 +441,7 @@ namespace Opc.Ua.Robotics.Client.Tests
 
             await using RealTimeChannelLease lease = new(transport, "rt1", TimeSpan.FromMilliseconds(30));
             await lease.OpenAsync();
-            await AwaitWithTimeoutAsync(transport.WaitForOpenChannelCountAsync(2), TimeSpan.FromSeconds(1));
+            await AwaitWithTimeoutAsync(transport.WaitForOpenChannelCountAsync(2), s_handshakeTimeout);
 
             Assert.That(transport.OpenChannelCount, Is.GreaterThan(1));
             Assert.That(lease.EndpointUrl, Is.EqualTo("opc.tcp://rt"));
@@ -480,7 +480,7 @@ namespace Opc.Ua.Robotics.Client.Tests
 
             await using RealTimeChannelLease lease = new(transport, "rt1", TimeSpan.FromMilliseconds(30));
             await lease.OpenAsync();
-            await WaitUntilAsync(() => transport.OpenChannelCount >= 3, TimeSpan.FromSeconds(2));
+            await WaitUntilAsync(() => transport.OpenChannelCount >= 3, s_handshakeTimeout);
 
             Assert.That(transport.OpenChannelCount, Is.GreaterThanOrEqualTo(3));
             Assert.That(lease.Granted, Is.True);
@@ -504,7 +504,7 @@ namespace Opc.Ua.Robotics.Client.Tests
 
             var lease = new RealTimeChannelLease(transport, "rt1", TimeSpan.FromMilliseconds(30));
             await lease.OpenAsync();
-            await AwaitWithTimeoutAsync(transport.WaitForOpenChannelCountAsync(2), TimeSpan.FromSeconds(1));
+            await AwaitWithTimeoutAsync(transport.WaitForOpenChannelCountAsync(2), s_handshakeTimeout);
 
             Assert.DoesNotThrowAsync(async () => await lease.DisposeAsync());
             Assert.That(transport.CloseChannelCount, Is.EqualTo(1));
@@ -795,6 +795,10 @@ namespace Opc.Ua.Robotics.Client.Tests
             Assert.That(method, Is.Not.Null);
             return (TimeSpan)method!.Invoke(lease, [])!;
         }
+
+        // Generous scheduling/handshake timeout used for AwaitWithTimeoutAsync and WaitUntilAsync
+        // calls only. Does not affect behavioral lease durations or expiry times.
+        private static readonly TimeSpan s_handshakeTimeout = TimeSpan.FromSeconds(30);
 
         private static async Task AwaitWithTimeoutAsync(Task task, TimeSpan timeout)
         {

--- a/tests/Opc.Ua.Sessions.Tests/ClientLockoutIntegrationTests.cs
+++ b/tests/Opc.Ua.Sessions.Tests/ClientLockoutIntegrationTests.cs
@@ -58,6 +58,11 @@ namespace Opc.Ua.Sessions.Tests
         private ArrayOf<EndpointDescription> m_endpoints;
         private ITelemetryContext m_telemetry;
 
+        // Leave margin for internal ActivateSession retries in reset-counter tests.
+        private const int LockoutThreshold = 10;
+        private const int PreResetFailedAttempts = 3;
+        private const int PostResetFailedAttempts = 4;
+
         [SetUp]
         public async Task SetUpAsync()
         {
@@ -79,6 +84,7 @@ namespace Opc.Ua.Sessions.Tests
 
             m_serverFixture.Config.ServerConfiguration.UserTokenPolicies +=
                 new UserTokenPolicy(UserTokenType.UserName);
+            m_serverFixture.Config.ServerConfiguration.MaxFailedAuthenticationAttempts = LockoutThreshold;
 
             m_server = await m_serverFixture.StartAsync().ConfigureAwait(false);
             m_server.TokenValidator = new TokenValidatorMock();
@@ -130,7 +136,7 @@ namespace Opc.Ua.Sessions.Tests
             var endpointConfiguration = EndpointConfiguration.Create(m_clientFixture.Config);
             var configuredEndpoint = new ConfiguredEndpoint(null, endpoint, endpointConfiguration);
 
-            for (int attempt = 0; attempt < 5; attempt++)
+            for (int attempt = 0; attempt < LockoutThreshold; attempt++)
             {
                 try
                 {
@@ -184,7 +190,7 @@ namespace Opc.Ua.Sessions.Tests
             var endpointConfiguration = EndpointConfiguration.Create(m_clientFixture.Config);
             var configuredEndpoint = new ConfiguredEndpoint(null, endpoint, endpointConfiguration);
 
-            for (int attempt = 0; attempt < 3; attempt++)
+            for (int attempt = 0; attempt < PreResetFailedAttempts; attempt++)
             {
                 try
                 {
@@ -221,7 +227,7 @@ namespace Opc.Ua.Sessions.Tests
                 Assert.That(successSession.Connected, Is.True);
             }
 
-            for (int attempt = 0; attempt < 4; attempt++)
+            for (int attempt = 0; attempt < PostResetFailedAttempts; attempt++)
             {
                 try
                 {
@@ -267,7 +273,7 @@ namespace Opc.Ua.Sessions.Tests
             var endpointConfiguration = EndpointConfiguration.Create(m_clientFixture.Config);
             var configuredEndpoint = new ConfiguredEndpoint(null, endpoint, endpointConfiguration);
 
-            for (int attempt = 0; attempt < 5; attempt++)
+            for (int attempt = 0; attempt < LockoutThreshold; attempt++)
             {
                 try
                 {

--- a/tools/Opc.Ua.OpenUsd.Connector.Viewer/Opc.Ua.OpenUsd.Connector.Viewer.csproj
+++ b/tools/Opc.Ua.OpenUsd.Connector.Viewer/Opc.Ua.OpenUsd.Connector.Viewer.csproj
@@ -36,5 +36,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="NugetREADME.md" Pack="true" PackagePath="\" />
+    <InternalsVisibleTo Include="Opc.Ua.OpenUsd.Tests" />
   </ItemGroup>
 </Project>

--- a/tools/Opc.Ua.OpenUsd.Connector.Viewer/Properties/AssemblyInfo.cs
+++ b/tools/Opc.Ua.OpenUsd.Connector.Viewer/Properties/AssemblyInfo.cs
@@ -28,7 +28,5 @@
  * ======================================================================*/
 
 using System;
-using System.Runtime.CompilerServices;
 
 [assembly: CLSCompliant(false)]
-[assembly: InternalsVisibleTo("Opc.Ua.OpenUsd.Tests")]

--- a/tools/Opc.Ua.OpenUsd.Connector/Opc.Ua.OpenUsd.Connector.csproj
+++ b/tools/Opc.Ua.OpenUsd.Connector/Opc.Ua.OpenUsd.Connector.csproj
@@ -15,6 +15,7 @@
   </PropertyGroup>
   <ItemGroup>
     <None Include="NugetREADME.md" Pack="true" PackagePath="\" />
+    <InternalsVisibleTo Include="Opc.Ua.OpenUsd.Tests" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Opc.Ua.Configuration\Opc.Ua.Configuration.csproj" />

--- a/tools/Opc.Ua.OpenUsd.Connector/Properties/AssemblyInfo.cs
+++ b/tools/Opc.Ua.OpenUsd.Connector/Properties/AssemblyInfo.cs
@@ -28,7 +28,5 @@
  * ======================================================================*/
 
 using System;
-using System.Runtime.CompilerServices;
 
 [assembly: CLSCompliant(false)]
-[assembly: InternalsVisibleTo("Opc.Ua.OpenUsd.Tests")]


### PR DESCRIPTION
## Summary
- stabilize the History, authentication lockout, Robotics, redundancy, and DI tests reported in #4301-#4305
- fix the closed-transport buffered-write completion deadlock that hung `ConnectMultipleSessionsAsync`
- add macOS crash diagnostics for #4306 and retain evidence for root-cause analysis
- run macOS tests and NativeAOT in GitHub Actions pull requests, using supported Intel and ARM64 runners, while keeping every Azure macOS definition disabled by default
- move all remaining source-level `InternalsVisibleTo` declarations into project files so signed OpenUSD builds receive the repository public key

## Local validation
- MCP PubSub: 29 passed
- History focused tests: 3 passed
- Sessions lockout: 3 passed
- Sessions multiple-session regression: 3 passed
- deterministic binary client channel tests: 22 passed
- Robotics runtime: 34 passed
- Redundancy focused tests: 4 passed
- OpenUSD net10.0: 914 passed
- affected OpenUSD projects build on net10.0 and net48

Refs #4299, #4300, #4306

Fixes #4301
Fixes #4302
Fixes #4303
Fixes #4304
Fixes #4305
