### PR TITLE
Fully support AliasNames in ConsoleReferenceServer (#4012)

### DIFF
--- a/docs/AliasNames.md
+++ b/docs/AliasNames.md
@@ -13,8 +13,8 @@ side) and **`Opc.Ua.Client`** (client side). The implementation covers:
 
 | Spec section | Type / Method                            | Status |
 | ------------ | ---------------------------------------- | ------ |
-| §6.2         | `AliasNameType`                          | ✔      |
-| §6.3.1       | `AliasNameCategoryType`                  | ✔      |
+| §6.2         | `AliasNameType` (browsable instance nodes) | ✔ opt-in — see below |
+| §6.3.1       | `AliasNameCategoryType` (incl. nesting)  | ✔ (nested instances opt-in — see below) |
 | §6.3.1       | `LastChange` (`VersionTime`)             | ✔      |
 | §6.3.2       | `FindAlias`                              | ✔      |
 | §6.3.3       | `FindAliasVerbose`                       | ✔      |
@@ -23,12 +23,9 @@ side) and **`Opc.Ua.Client`** (client side). The implementation covers:
 | §7.2         | `AliasNameDataType`                      | ✔      |
 | §7.3         | `AliasNameVerboseDataType`               | ✔      |
 | §8.2         | `AliasFor` reference type                | ✔      |
-| §9.2         | Well-known `Aliases (i=23470)`           | ✔ wired |
-| §9.3         | Well-known `TagVariables (i=23479)`      | ✔ wired |
-| §9.4         | Well-known `Topics (i=23488)`            | ✔ wired |
-| §6.2         | Browsable `AliasNameType` instance nodes | ✔ opt-in — see below |
-| §6.3.1       | Nested `AliasNameCategoryType` instances | ✔ opt-in — see below |
-| §6.3.3–6.3.5 | Optional methods on the well-known nodes | ✔ opt-in — see below |
+| §9.2         | Well-known `Aliases (i=23470)`           | ✔ wired; optional methods opt-in — see below |
+| §9.3         | Well-known `TagVariables (i=23479)`      | ✔ wired; optional methods opt-in — see below |
+| §9.4         | Well-known `Topics (i=23488)`            | ✔ wired; optional methods opt-in — see below |
 | Annex D      | PubSub replication (LastChange notifications) | ✔ transport-agnostic — see below |
 
 ## Server side — `Opc.Ua.Server.AliasNames`
@@ -122,8 +119,19 @@ that for every registered store: one `AliasNameType` instance per alias
 targets, and the inverse `HasAlias` reference added on each local
 target — plus an `AliasNameCategoryType` instance for every store
 category the standard NodeSet does not already ship (nested categories
-included). Call it from an overridden `CreateAddressSpaceAsync`, after
-`base` has loaded the standard categories:
+included; a root category from the store is organized under the
+standard `Aliases` object so it stays browse-discoverable). Remote
+targets get their server URI registered in the server's `ServerUris`
+table and referenced with the matching `ServerIndex`. Server-defined
+BrowseNames that a descriptor left in namespace 0 — reserved for
+OPC-Foundation-defined names — are re-homed into the diagnostics
+namespace; Part 17 clients compare alias names ignoring the namespace,
+so this is transparent to them. The pass is idempotent, and only
+creates category nodes whose NodeId lies in the diagnostics namespace —
+a descriptor pointing anywhere else is skipped with a warning rather
+than claiming another manager's (or the standard NodeSet's) ids. Call
+it from an overridden `CreateAddressSpaceAsync`, after `base` has
+loaded the standard categories:
 
 ```csharp
 public override async ValueTask CreateAddressSpaceAsync(
@@ -161,10 +169,35 @@ address-space creation — aliases added or removed later through
 `FindAlias` returns and advance `LastChange`, but do not add or remove
 `AliasNameType` nodes.
 
+The browse view carries `AliasFor` associations only: an entry a store
+holds under an unrelated reference type is not a Part 17 §6.2 alias
+association, so it is served by `FindAlias` (with a matching filter)
+but not materialized. Entries stored under an `AliasFor` *subtype* are
+materialized, but always as the base `AliasFor` reference — the
+verbose record does not carry the concrete reference type.
+
+Two things the caller controls:
+
+* Give category descriptors a BrowseName in a namespace the server
+  owns. The store stamps that namespace onto every alias
+  `QualifiedName` it reports, and the materializer re-homes ns=0
+  BrowseNames out of the reserved OPC Foundation namespace — with a
+  server-owned descriptor namespace the query results and the
+  browsable nodes agree, so a returned alias name resolves via
+  `TranslateBrowsePathsToNodeIds`. The reference server uses the
+  diagnostics namespace for all its descriptors.
+* Part 17 §9 constrains `Topics` aliases to `PublishedDataSetType`
+  targets. Neither the store nor `AddAliasesToCategory` enforces
+  this — a server that exposes the mutation methods on `Topics` should
+  only grant them to operators who preserve the constraint.
+
 `Quickstarts.ReferenceServer` uses this in
-`ReferenceServerConfigurationNodeManager`, which is also where its
-`Devices` sub-category under `TagVariables` and the `PublishedDataSet`
-instances the `Topics` aliases point at come from.
+`ReferenceServerConfigurationNodeManager`, which also creates the
+`PublishedDataSet` instances and seeds the `Topics` aliases that point
+at them — in the same place, so an alias can never target a dataset
+that was not created. The nested `Devices` sub-category under
+`TagVariables` is declared with the store seeding in
+`ReferenceServer.ConfigureAliasNameStore`.
 
 ### Custom backend
 

--- a/docs/AliasNames.md
+++ b/docs/AliasNames.md
@@ -26,8 +26,10 @@ side) and **`Opc.Ua.Client`** (client side). The implementation covers:
 | §9.2         | Well-known `Aliases (i=23470)`           | ✔ wired |
 | §9.3         | Well-known `TagVariables (i=23479)`      | ✔ wired |
 | §9.4         | Well-known `Topics (i=23488)`            | ✔ wired |
+| §6.2         | Browsable `AliasNameType` instance nodes | ✔ opt-in — see below |
+| §6.3.1       | Nested `AliasNameCategoryType` instances | ✔ opt-in — see below |
+| §6.3.3–6.3.5 | Optional methods on the well-known nodes | ✔ opt-in — see below |
 | Annex D      | PubSub replication (LastChange notifications) | ✔ transport-agnostic — see below |
-| Annex D      | PubSub replication                       | not implemented |
 
 ## Server side — `Opc.Ua.Server.AliasNames`
 
@@ -105,6 +107,64 @@ Options:
 * `RegisterWithServerRegistry` (default `true`) — also registers the
   store with `IAliasNameStoreRegistry` so the well-known standard nodes
   see it.
+
+### Browsable alias nodes
+
+Registering a store makes `FindAlias` answer from it, but the aliases
+themselves stay inside the store — nothing in the address space shows
+them. Part 17 §6.2 clients (the OPC Foundation CTT among them) also
+*browse* for aliases, so a server under conformance test needs the
+alias hierarchy materialized as real nodes.
+
+`DiagnosticsNodeManager.MaterializeRegisteredAliasNameNodesAsync` does
+that for every registered store: one `AliasNameType` instance per alias
+— BrowseName carrying the alias name, `AliasFor` references to its
+targets, and the inverse `HasAlias` reference added on each local
+target — plus an `AliasNameCategoryType` instance for every store
+category the standard NodeSet does not already ship (nested categories
+included). Call it from an overridden `CreateAddressSpaceAsync`, after
+`base` has loaded the standard categories:
+
+```csharp
+public override async ValueTask CreateAddressSpaceAsync(
+    IDictionary<NodeId, IList<IReference>> externalReferences,
+    CancellationToken cancellationToken = default)
+{
+    await base.CreateAddressSpaceAsync(externalReferences, cancellationToken)
+        .ConfigureAwait(false);
+
+    await MaterializeRegisteredAliasNameNodesAsync(
+        externalReferences, cancellationToken).ConfigureAwait(false);
+}
+```
+
+The same pass also instantiates the **optional Part 17 methods** —
+`FindAliasVerbose`, `AddAliasesToCategory`, `DeleteAliasesFromCategory`
+and `LastChange` — on every category whose descriptor declares them
+through `AliasNameCapabilities`, including the well-known ones the
+standard NodeSet ships without them:
+
+```csharp
+var tagVariables = new AliasNameCategoryDescriptor(
+    ObjectIds.TagVariables,
+    QualifiedName.From(BrowseNames.TagVariables),
+    AliasNameCapabilities.All);       // verbose + add + delete + LastChange
+```
+
+Mutation calls are gated on a `SecurityAdmin` caller over a
+`SignAndEncrypt` channel and return `BadUserAccessDenied` otherwise.
+
+It is opt-in: servers that only need `FindAlias` to answer from their
+store pay nothing. The created nodes are a snapshot taken at
+address-space creation — aliases added or removed later through
+`AddAliasesToCategory` / `DeleteAliasesFromCategory` change what
+`FindAlias` returns and advance `LastChange`, but do not add or remove
+`AliasNameType` nodes.
+
+`Quickstarts.ReferenceServer` uses this in
+`ReferenceServerConfigurationNodeManager`, which is also where its
+`Devices` sub-category under `TagVariables` and the `PublishedDataSet`
+instances the `Topics` aliases point at come from.
 
 ### Custom backend
 
@@ -227,15 +287,39 @@ monitored-item variant. Disposal is idempotent and never throws.
   Quickstart sample used `NodeId[]` and has been removed.
 * **Standard well-known nodes** — the OPC UA NodeSet instantiates only
   `FindAlias` on `Aliases`/`TagVariables`/`Topics` (plus `LastChange` on
-  `Aliases`). Optional methods (`FindAliasVerbose`/`Add`/`Delete`) on
-  the standard nodes would require NodeSet extension and are not wired
-  by the binder. To expose those, use a standalone
-  `AliasNameNodeManager` with your own category nodes.
+  `Aliases`), so the always-on binder wires just those. The optional
+  methods are added by `MaterializeRegisteredAliasNameNodesAsync`
+  through the generated `AddFindAliasVerbose` /
+  `AddAddAliasesToCategory` / `AddDeleteAliasesFromCategory` optional-
+  child helpers, for each category whose descriptor declares the
+  matching `AliasNameCapabilities`. Each child is created at the NodeId
+  the OPC Foundation reserves for it (`Aliases.FindAliasVerbose` =
+  `i=24054`, `TagVariables.LastChange` = `i=32854`, and so on).
+
+  Those identifiers are allocated in the standard identifier registry
+  (`StandardTypes.csv`) but are deliberately **not** declared in the
+  ModelDesign and **not** present in the published NodeSet — the
+  standard address space does not instantiate optional children. A
+  reserved id is a number set aside for the node *if* a server chooses
+  to expose it, not a node the server must have. Consequently the source
+  generator emits no parent-to-instance mapping and no `MethodIds`
+  constant for them, and `DiagnosticsNodeManager.ReservedChildIds`
+  supplies the nine method ids and the two missing `LastChange` ids
+  explicitly, each traceable to its registry row. The argument
+  properties do have generated `VariableIds` constants and are
+  referenced through those.
+
+  Do not "fix" this by declaring the children in `StandardTypes.xml`:
+  that file is a verbatim copy of the OPC Foundation's ModelDesign and
+  is re-synced from upstream, so a local edit is lost on the next sync
+  and the NodeIds silently revert to factory-minted ones.
 * **`AliasNameCapabilities.AddAliasesToCategory` /
-  `DeleteAliasesFromCategory`** — defaults to `SecurityAdmin`-only
-  via `AliasNameNodeManagerOptions.RequireSecurityAdminForMutations`.
-  The check requires both the role grant AND a `SignAndEncrypt`
-  channel; opt out via the option for development scenarios only.
+  `DeleteAliasesFromCategory`** — on an `AliasNameNodeManager` this
+  defaults to `SecurityAdmin`-only via
+  `AliasNameNodeManagerOptions.RequireSecurityAdminForMutations`; on the
+  standard well-known nodes the same check is always applied and cannot
+  be opted out of. It requires both the role grant AND a
+  `SignAndEncrypt` channel.
 * **`ReferenceTypeFilter` semantics** — null/empty and
   `ReferenceTypeIds.References` match every alias regardless of
   reference type. Otherwise matches are limited to aliases whose

--- a/docs/AliasNames.md
+++ b/docs/AliasNames.md
@@ -236,7 +236,11 @@ public interface IAliasNameStore
 
 The reference `InMemoryAliasNameStore` is thread-safe (SemaphoreSlim),
 supports nested categories and emits `Changed` events that bubble up to
-the address-space `LastChange` property.
+the address-space `LastChange` property. A mutation on a nested
+category bumps — and notifies for — every ancestor category as well,
+per Part 17 §6.3.1/§9.2: a category's `LastChange` reflects the most
+recent change anywhere in its subtree, and the root `Aliases` value
+reflects any change at all.
 
 ## Client side — `Opc.Ua.Client.AliasNames`
 

--- a/docs/AliasNames.md
+++ b/docs/AliasNames.md
@@ -92,7 +92,14 @@ Options:
 
 * `NamespaceUri` — controls the namespace under which the manager
   registers its category instances. Defaults to
-  `http://opcfoundation.org/UA/AliasName/`.
+  `http://opcfoundation.org/UA/AliasName/`. Every category descriptor's
+  NodeId must lie in this namespace; descriptors pointing anywhere else
+  are skipped with a warning rather than claiming another manager's
+  ids.
+* `MaterializeAliasNodes` (default `true`) — creates one browsable
+  `AliasNameType` node per alias, with `AliasFor` references to its
+  targets, exactly as the standard-node materialization below does.
+  Disable to expose only the category tree.
 * `LinkToStandardAliasesObject` (default `true`) — adds `Organizes`
   external references from the well-known `Aliases (i=23470)` object to
   the manager's root categories so they show up in the standard browse
@@ -112,6 +119,13 @@ themselves stay inside the store — nothing in the address space shows
 them. Part 17 §6.2 clients (the OPC Foundation CTT among them) also
 *browse* for aliases, so a server under conformance test needs the
 alias hierarchy materialized as real nodes.
+
+Both materialization paths — `AliasNameNodeManager` for
+application-defined namespaces and
+`DiagnosticsNodeManager.MaterializeRegisteredAliasNameNodesAsync` for
+the standard well-known nodes — run the same shared walker
+(`AliasNameNodeMaterializer`), so they produce structurally identical
+Part 17 trees and every fix lands in both at once.
 
 `DiagnosticsNodeManager.MaterializeRegisteredAliasNameNodesAsync` does
 that for every registered store: one `AliasNameType` instance per alias

--- a/samples/Quickstarts.Servers/ReferenceServer/ReferenceServer.cs
+++ b/samples/Quickstarts.Servers/ReferenceServer/ReferenceServer.cs
@@ -234,33 +234,46 @@ namespace Quickstarts.ReferenceServer
                 return;
             }
 
+            // A nested category under TagVariables: Part 17 §6.3.1 allows
+            // AliasNameCategoryType instances to be organized under one
+            // another, and FindAlias on the parent searches the whole
+            // sub-tree while FindAlias on the child is restricted to it.
+            // Its NodeId lives in the diagnostics namespace because that is
+            // where DiagnosticsNodeManager materializes the node — which
+            // means the namespace is registered here, ahead of the node
+            // manager that would otherwise be the first to add it.
+            var devices = new Opc.Ua.Server.AliasNames.AliasNameCategoryDescriptor(
+                new NodeId(
+                    DevicesCategoryName,
+                    server.NamespaceUris.GetIndexOrAppend(DiagnosticsNamespaceUri)),
+                new QualifiedName(DevicesCategoryName, 0),
+                Opc.Ua.Server.AliasNames.AliasNameCapabilities.All);
+
             var tagVariables = new Opc.Ua.Server.AliasNames.AliasNameCategoryDescriptor(
                 Opc.Ua.ObjectIds.TagVariables,
                 QualifiedName.From(Opc.Ua.BrowseNames.TagVariables),
-                Opc.Ua.Server.AliasNames.AliasNameCapabilities.FindAliasVerbose);
+                Opc.Ua.Server.AliasNames.AliasNameCapabilities.All,
+                subCategories: [devices]);
             var topics = new Opc.Ua.Server.AliasNames.AliasNameCategoryDescriptor(
                 Opc.Ua.ObjectIds.Topics,
                 QualifiedName.From(Opc.Ua.BrowseNames.Topics),
-                Opc.Ua.Server.AliasNames.AliasNameCapabilities.FindAliasVerbose);
+                Opc.Ua.Server.AliasNames.AliasNameCapabilities.All);
 
             // Root the Aliases (i=23470) object too so FindAlias /
             // FindAliasVerbose / LastChange dispatched against it
             // aggregate the TagVariables / Topics sub-categories
             // (per Part 17 §6.3.2 recursive matching semantics).
-            // AddAliasesToCategory / DeleteAliasesFromCategory are enabled
-            // on the in-memory store so server-side test/admin code can
-            // bump LastChange via store.AddAliasesAsync / DeleteAliasesAsync.
-            // The standard well-known Aliases (i=23470) node does not
-            // instantiate Add/Delete method nodes (per the OPC UA NodeSet),
-            // so this is a server-side capability only and does not
-            // expose mutation methods over the wire on the standard node.
+            //
+            // Every category declares the full capability set: the standard
+            // NodeSet instantiates none of the optional Part 17 children on
+            // the well-known objects, so DiagnosticsNodeManager adds them
+            // during materialization.
+            // AddAliasesToCategory / DeleteAliasesFromCategory require a
+            // SecurityAdmin caller on a SignAndEncrypt channel.
             var aliases = new Opc.Ua.Server.AliasNames.AliasNameCategoryDescriptor(
                 Opc.Ua.ObjectIds.Aliases,
                 QualifiedName.From(Opc.Ua.BrowseNames.Aliases),
-                Opc.Ua.Server.AliasNames.AliasNameCapabilities.FindAliasVerbose |
-                Opc.Ua.Server.AliasNames.AliasNameCapabilities.LastChange |
-                Opc.Ua.Server.AliasNames.AliasNameCapabilities.AddAliasesToCategory |
-                Opc.Ua.Server.AliasNames.AliasNameCapabilities.DeleteAliasesFromCategory,
+                Opc.Ua.Server.AliasNames.AliasNameCapabilities.All,
                 subCategories: [tagVariables, topics]);
 
             // CA2000: ownership transferred to the registry which disposes
@@ -280,40 +293,72 @@ namespace Quickstarts.ReferenceServer
 
             if (refServerNs != ushort.MaxValue)
             {
-                SeedTag(store, "TIC101_Setpoint",
+                SeedTag(store, Opc.Ua.ObjectIds.TagVariables, "TIC101_Setpoint",
                     new ExpandedNodeId("Scalar_Static_Double", refServerNs));
-                SeedTag(store, "TIC101_PV",
+                SeedTag(store, Opc.Ua.ObjectIds.TagVariables, "TIC101_PV",
                     new ExpandedNodeId("Scalar_Static_Float", refServerNs));
-                SeedTag(store, "FIC202_Flow",
+                SeedTag(store, Opc.Ua.ObjectIds.TagVariables, "FIC202_Flow",
                     new ExpandedNodeId("Scalar_Simulation_Double", refServerNs));
-                SeedTag(store, "Pump1_Status",
-                    new ExpandedNodeId("Scalar_Static_Boolean", refServerNs));
-                SeedTag(store, "Heater_Power",
-                    new ExpandedNodeId("Scalar_Static_Int32", refServerNs));
-                SeedTag(store, "MultiRefAlias",
+                SeedTag(store, Opc.Ua.ObjectIds.TagVariables, "MultiRefAlias",
                     new ExpandedNodeId("Scalar_Static_Double", refServerNs));
-                SeedTag(store, "MultiRefAlias",
+                SeedTag(store, Opc.Ua.ObjectIds.TagVariables, "MultiRefAlias",
+                    new ExpandedNodeId("Scalar_Static_Int32", refServerNs));
+
+                // The device tags live in the nested category, so FindAlias
+                // on Devices returns exactly these two while FindAlias on
+                // TagVariables still returns all six.
+                SeedTag(store, devices.NodeId, "Pump1_Status",
+                    new ExpandedNodeId("Scalar_Static_Boolean", refServerNs));
+                SeedTag(store, devices.NodeId, "Heater_Power",
                     new ExpandedNodeId("Scalar_Static_Int32", refServerNs));
             }
 
-            store.Seed(Opc.Ua.ObjectIds.Topics, "ServerEvents",
-                Opc.Ua.ObjectIds.Server, serverUri: null, referenceTypeId: aliasFor);
-            store.Seed(Opc.Ua.ObjectIds.Topics, "AuditEvents",
-                new ExpandedNodeId(ObjectTypes.AuditEventType),
+            // Part 17 §9 constrains the Topics hierarchy to aliases for
+            // PublishedDataSetType instances, so these target the datasets
+            // ReferenceServerConfigurationNodeManager creates under
+            // PublishedDataSets (i=17371). They are addressed by namespace
+            // URI rather than by index so the seeds stay valid however the
+            // namespace table is ordered; the materializer resolves them
+            // against the live table.
+            store.Seed(Opc.Ua.ObjectIds.Topics,
+                ReferenceServerConfigurationNodeManager.ReferenceDataSetName,
+                new ExpandedNodeId(
+                    ReferenceServerConfigurationNodeManager.ReferenceDataSetName,
+                    DiagnosticsNamespaceUri),
                 serverUri: null, referenceTypeId: aliasFor);
+
+            foreach (string dataSetName in
+                ReferenceServerConfigurationNodeManager.EventDataSetNames)
+            {
+                store.Seed(Opc.Ua.ObjectIds.Topics, dataSetName,
+                    new ExpandedNodeId(dataSetName, DiagnosticsNamespaceUri),
+                    serverUri: null, referenceTypeId: aliasFor);
+            }
 
             provider.AliasNameStoreRegistry.Register(store);
 
             static void SeedTag(
                 Opc.Ua.Server.AliasNames.InMemoryAliasNameStore store,
+                NodeId categoryId,
                 string name,
                 ExpandedNodeId target)
             {
-                store.Seed(Opc.Ua.ObjectIds.TagVariables, name, target,
+                store.Seed(categoryId, name, target,
                     serverUri: null,
                     referenceTypeId: ReferenceTypeIds.AliasFor);
             }
         }
+
+        /// <summary>
+        /// BrowseName of the AliasNameCategory nested under TagVariables.
+        /// </summary>
+        private const string DevicesCategoryName = "Devices";
+
+        /// <summary>
+        /// Namespace that <c>DiagnosticsNodeManager</c> owns and in which
+        /// the materialized alias nodes and the conformance datasets live.
+        /// </summary>
+        private const string DiagnosticsNamespaceUri = Opc.Ua.Namespaces.OpcUa + "Diagnostics";
 
         /// <summary>
         /// Overrides the SDK default factory to plug in a

--- a/samples/Quickstarts.Servers/ReferenceServer/ReferenceServer.cs
+++ b/samples/Quickstarts.Servers/ReferenceServer/ReferenceServer.cs
@@ -242,21 +242,33 @@ namespace Quickstarts.ReferenceServer
             // where DiagnosticsNodeManager materializes the node — which
             // means the namespace is registered here, ahead of the node
             // manager that would otherwise be the first to add it.
+            // BrowseName and NodeId share the diagnostics namespace:
+            // namespace 0 is reserved for OPC-Foundation-defined names, so
+            // a server-defined category (and the aliases that inherit its
+            // BrowseName namespace via the store) must not publish there.
+            ushort diagnosticsNamespaceIndex =
+                server.NamespaceUris.GetIndexOrAppend(DiagnosticsNamespaceUri);
             var devices = new Opc.Ua.Server.AliasNames.AliasNameCategoryDescriptor(
-                new NodeId(
-                    DevicesCategoryName,
-                    server.NamespaceUris.GetIndexOrAppend(DiagnosticsNamespaceUri)),
-                new QualifiedName(DevicesCategoryName, 0),
+                new NodeId(DevicesCategoryName, diagnosticsNamespaceIndex),
+                new QualifiedName(DevicesCategoryName, diagnosticsNamespaceIndex),
                 Opc.Ua.Server.AliasNames.AliasNameCapabilities.All);
 
+            // The descriptor BrowseName's namespace is what the store
+            // stamps onto every alias QualifiedName it reports, and the
+            // materializer re-homes ns=0 alias BrowseNames into the
+            // diagnostics namespace — declaring the diagnostics namespace
+            // here keeps FindAlias results and the browsable nodes'
+            // BrowseNames identical, so TranslateBrowsePaths with a
+            // returned alias name resolves. (The predefined TagVariables/
+            // Topics nodes keep their own NodeSet BrowseNames regardless.)
             var tagVariables = new Opc.Ua.Server.AliasNames.AliasNameCategoryDescriptor(
                 Opc.Ua.ObjectIds.TagVariables,
-                QualifiedName.From(Opc.Ua.BrowseNames.TagVariables),
+                new QualifiedName(Opc.Ua.BrowseNames.TagVariables, diagnosticsNamespaceIndex),
                 Opc.Ua.Server.AliasNames.AliasNameCapabilities.All,
                 subCategories: [devices]);
             var topics = new Opc.Ua.Server.AliasNames.AliasNameCategoryDescriptor(
                 Opc.Ua.ObjectIds.Topics,
-                QualifiedName.From(Opc.Ua.BrowseNames.Topics),
+                new QualifiedName(Opc.Ua.BrowseNames.Topics, diagnosticsNamespaceIndex),
                 Opc.Ua.Server.AliasNames.AliasNameCapabilities.All);
 
             // Root the Aliases (i=23470) object too so FindAlias /
@@ -272,7 +284,7 @@ namespace Quickstarts.ReferenceServer
             // SecurityAdmin caller on a SignAndEncrypt channel.
             var aliases = new Opc.Ua.Server.AliasNames.AliasNameCategoryDescriptor(
                 Opc.Ua.ObjectIds.Aliases,
-                QualifiedName.From(Opc.Ua.BrowseNames.Aliases),
+                new QualifiedName(Opc.Ua.BrowseNames.Aliases, diagnosticsNamespaceIndex),
                 Opc.Ua.Server.AliasNames.AliasNameCapabilities.All,
                 subCategories: [tagVariables, topics]);
 
@@ -288,8 +300,6 @@ namespace Quickstarts.ReferenceServer
             ushort refServerNs = refServerNsIndex >= 0
                 ? (ushort)refServerNsIndex
                 : ushort.MaxValue;
-
-            NodeId aliasFor = ReferenceTypeIds.AliasFor;
 
             if (refServerNs != ushort.MaxValue)
             {
@@ -313,27 +323,12 @@ namespace Quickstarts.ReferenceServer
                     new ExpandedNodeId("Scalar_Static_Int32", refServerNs));
             }
 
-            // Part 17 §9 constrains the Topics hierarchy to aliases for
-            // PublishedDataSetType instances, so these target the datasets
-            // ReferenceServerConfigurationNodeManager creates under
-            // PublishedDataSets (i=17371). They are addressed by namespace
-            // URI rather than by index so the seeds stay valid however the
-            // namespace table is ordered; the materializer resolves them
-            // against the live table.
-            store.Seed(Opc.Ua.ObjectIds.Topics,
-                ReferenceServerConfigurationNodeManager.ReferenceDataSetName,
-                new ExpandedNodeId(
-                    ReferenceServerConfigurationNodeManager.ReferenceDataSetName,
-                    DiagnosticsNamespaceUri),
-                serverUri: null, referenceTypeId: aliasFor);
-
-            foreach (string dataSetName in
-                ReferenceServerConfigurationNodeManager.EventDataSetNames)
-            {
-                store.Seed(Opc.Ua.ObjectIds.Topics, dataSetName,
-                    new ExpandedNodeId(dataSetName, DiagnosticsNamespaceUri),
-                    serverUri: null, referenceTypeId: aliasFor);
-            }
+            // The Topics aliases are NOT seeded here: Part 17 §9 constrains
+            // that hierarchy to aliases for PublishedDataSetType instances,
+            // and those dataset nodes are created later by
+            // ReferenceServerConfigurationNodeManager.AddConformanceDataSetsAsync
+            // — which seeds the aliases in the same place, so an alias can
+            // never point at a dataset that was not created.
 
             provider.AliasNameStoreRegistry.Register(store);
 
@@ -357,8 +352,11 @@ namespace Quickstarts.ReferenceServer
         /// <summary>
         /// Namespace that <c>DiagnosticsNodeManager</c> owns and in which
         /// the materialized alias nodes and the conformance datasets live.
+        /// Shared with <see cref="ReferenceServerConfigurationNodeManager"/>
+        /// so the dataset NodeIds and the alias seeds that target them can
+        /// never drift apart.
         /// </summary>
-        private const string DiagnosticsNamespaceUri = Opc.Ua.Namespaces.OpcUa + "Diagnostics";
+        internal const string DiagnosticsNamespaceUri = Opc.Ua.Namespaces.OpcUa + "Diagnostics";
 
         /// <summary>
         /// Overrides the SDK default factory to plug in a

--- a/samples/Quickstarts.Servers/ReferenceServer/ReferenceServerConfigurationNodeManager.cs
+++ b/samples/Quickstarts.Servers/ReferenceServer/ReferenceServerConfigurationNodeManager.cs
@@ -72,7 +72,7 @@ namespace Quickstarts.ReferenceServer
                 .ConfigureAwait(false);
 
             ushort diagnosticsNamespaceIndex = Server.NamespaceUris
-                .GetIndexOrAppend(Opc.Ua.Namespaces.OpcUa + "Diagnostics");
+                .GetIndexOrAppend(ReferenceServer.DiagnosticsNamespaceUri);
 
             var addedNodes = new List<NodeState>();
 
@@ -211,10 +211,14 @@ namespace Quickstarts.ReferenceServer
                 .ConfigureAwait(false));
 
             // CTT: Part 17 clients discover aliases by browsing, so turn the
-            // aliases seeded into the server's alias store (see
-            // ReferenceServer.ConfigureAliasNameStore) into AliasNameType
-            // instances and nested AliasNameCategoryType objects. This
-            // imports the created nodes into the CoreNodeManager itself.
+            // aliases seeded into the server's alias store (tag aliases in
+            // ReferenceServer.ConfigureAliasNameStore, Topics aliases in
+            // AddConformanceDataSetsAsync above) into AliasNameType
+            // instances and nested AliasNameCategoryType objects. The
+            // created nodes are registered as predefined nodes of this
+            // manager, which serves Browse and Call for them — they are
+            // deliberately NOT imported into the CoreNodeManager, which
+            // would register the same NodeIds twice.
             await MaterializeRegisteredAliasNameNodesAsync(
                 externalReferences, cancellationToken).ConfigureAwait(false);
 
@@ -233,12 +237,13 @@ namespace Quickstarts.ReferenceServer
         }
 
         /// <summary>
-        /// Creates the three PublishedDataSet instances that the Topics
-        /// aliases seeded in <c>ReferenceServer.ConfigureAliasNameStore</c>
-        /// point at. Part 17 §9 requires every alias in the Topics
-        /// hierarchy to reference an instance of <c>PublishedDataSetType</c>,
-        /// and the standard NodeSet ships the <c>PublishedDataSets</c>
-        /// folder (<c>i=17371</c>) empty.
+        /// Creates the three PublishedDataSet instances under the standard
+        /// <c>PublishedDataSets</c> folder (<c>i=17371</c>, shipped empty)
+        /// and seeds the matching Topics aliases into the server's alias
+        /// store. Part 17 §9 requires every alias in the Topics hierarchy
+        /// to reference an instance of <c>PublishedDataSetType</c> —
+        /// creating the dataset and seeding its alias in one place makes a
+        /// dangling alias impossible: no folder, no datasets, no aliases.
         /// </summary>
         /// <remarks>
         /// These are address-space instances only — the reference server
@@ -261,7 +266,7 @@ namespace Quickstarts.ReferenceServer
             }
 
             ushort diagnosticsNamespaceIndex = Server.NamespaceUris
-                .GetIndexOrAppend(Opc.Ua.Namespaces.OpcUa + "Diagnostics");
+                .GetIndexOrAppend(ReferenceServer.DiagnosticsNamespaceUri);
 
             PublishedDataItemsState dataItems = SystemContext
                 .CreateInstanceOfPublishedDataItemsType();
@@ -308,6 +313,26 @@ namespace Quickstarts.ReferenceServer
                     ReferenceTypeIds.HasComponent, true, publishedDataSets.NodeId);
                 await AddPredefinedNodeAsync(SystemContext, dataSet, cancellationToken)
                     .ConfigureAwait(false);
+            }
+
+            // Seed the Topics aliases only now that their targets exist.
+            // Index-form ExpandedNodeIds keep FindAlias results directly
+            // comparable with the NodeIds a client obtains by browsing
+            // PublishedDataSets (the tag aliases are seeded the same way).
+            if ((Server as Opc.Ua.Server.AliasNames.IAliasNameStoreRegistryProvider)?
+                    .AliasNameStoreRegistry
+                    .GetStoreForCategory(Opc.Ua.ObjectIds.Topics)
+                is Opc.Ua.Server.AliasNames.InMemoryAliasNameStore aliasStore)
+            {
+                foreach (NodeState dataSet in created)
+                {
+                    aliasStore.Seed(
+                        Opc.Ua.ObjectIds.Topics,
+                        dataSet.BrowseName.Name ?? dataSet.SymbolicName,
+                        new ExpandedNodeId(dataSet.NodeId),
+                        serverUri: null,
+                        referenceTypeId: ReferenceTypeIds.AliasFor);
+                }
             }
 
             return created;
@@ -386,8 +411,10 @@ namespace Quickstarts.ReferenceServer
 
         /// <summary>
         /// BrowseNames / string identifiers of the event datasets created
-        /// under <c>PublishedDataSets</c>. These match the Topics alias
-        /// names seeded by <c>ReferenceServer.ConfigureAliasNameStore</c>.
+        /// under <c>PublishedDataSets</c>. The matching Topics aliases are
+        /// seeded in <c>AddConformanceDataSetsAsync</c>, right after each
+        /// dataset node is created — never anywhere else, so an alias
+        /// cannot exist without its dataset.
         /// </summary>
         internal static readonly string[] EventDataSetNames =
         [

--- a/samples/Quickstarts.Servers/ReferenceServer/ReferenceServerConfigurationNodeManager.cs
+++ b/samples/Quickstarts.Servers/ReferenceServer/ReferenceServerConfigurationNodeManager.cs
@@ -203,6 +203,21 @@ namespace Quickstarts.ReferenceServer
 
             await RemovePubSubKeyServiceFoldersAsync(cancellationToken).ConfigureAwait(false);
 
+            // CTT: the AliasName Category Topics conformance unit requires
+            // every alias under Topics (i=23488) to reference a
+            // PublishedDataSetType instance. Create the datasets first, then
+            // materialize the alias nodes that point at them.
+            addedNodes.AddRange(await AddConformanceDataSetsAsync(cancellationToken)
+                .ConfigureAwait(false));
+
+            // CTT: Part 17 clients discover aliases by browsing, so turn the
+            // aliases seeded into the server's alias store (see
+            // ReferenceServer.ConfigureAliasNameStore) into AliasNameType
+            // instances and nested AliasNameCategoryType objects. This
+            // imports the created nodes into the CoreNodeManager itself.
+            await MaterializeRegisteredAliasNameNodesAsync(
+                externalReferences, cancellationToken).ConfigureAwait(false);
+
             // Push any newly added namespace-0 nodes into the CoreNodeManager
             // so they are reachable via Browse from the standard address
             // space (base.CreateAddressSpaceAsync already performed the bulk
@@ -214,6 +229,128 @@ namespace Quickstarts.ReferenceServer
                     addedNodes,
                     true,
                     cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
+        /// Creates the three PublishedDataSet instances that the Topics
+        /// aliases seeded in <c>ReferenceServer.ConfigureAliasNameStore</c>
+        /// point at. Part 17 §9 requires every alias in the Topics
+        /// hierarchy to reference an instance of <c>PublishedDataSetType</c>,
+        /// and the standard NodeSet ships the <c>PublishedDataSets</c>
+        /// folder (<c>i=17371</c>) empty.
+        /// </summary>
+        /// <remarks>
+        /// These are address-space instances only — the reference server
+        /// implements no PubSub runtime, so the datasets publish nothing.
+        /// They exist so the alias targets have the type the Topics
+        /// conformance unit checks for. NodeIds are deterministic string
+        /// ids in the diagnostics namespace, matching the identifiers the
+        /// alias seeds resolve against.
+        /// </remarks>
+        private async ValueTask<IReadOnlyList<NodeState>> AddConformanceDataSetsAsync(
+            CancellationToken cancellationToken)
+        {
+            var created = new List<NodeState>();
+
+            FolderState publishedDataSets = FindPredefinedNode<FolderState>(
+                Opc.Ua.ObjectIds.PublishSubscribe_PublishedDataSets);
+            if (publishedDataSets == null)
+            {
+                return created;
+            }
+
+            ushort diagnosticsNamespaceIndex = Server.NamespaceUris
+                .GetIndexOrAppend(Opc.Ua.Namespaces.OpcUa + "Diagnostics");
+
+            PublishedDataItemsState dataItems = SystemContext
+                .CreateInstanceOfPublishedDataItemsType();
+            InitializeDataSet(dataItems, ReferenceDataSetName, diagnosticsNamespaceIndex);
+
+            // Only name a published variable when the reference node manager
+            // actually contributed its namespace — in provisioning mode it
+            // does not, and appending the namespace just to build a NodeId
+            // would advertise a namespace with no nodes behind it.
+            int referenceServerNamespaceIndex = Server.NamespaceUris
+                .GetIndex(Namespaces.ReferenceServer);
+            if (dataItems.PublishedData != null && referenceServerNamespaceIndex >= 0)
+            {
+                dataItems.PublishedData.Value = new PublishedVariableDataType[]
+                {
+                    new()
+                    {
+                        PublishedVariable = new NodeId(
+                            "Scalar_Simulation_Double",
+                            (ushort)referenceServerNamespaceIndex),
+                        AttributeId = Attributes.Value
+                    }
+                }.ToArrayOf();
+            }
+            created.Add(dataItems);
+
+            foreach (string name in EventDataSetNames)
+            {
+                PublishedEventsState events = SystemContext
+                    .CreateInstanceOfPublishedEventsType();
+                InitializeDataSet(events, name, diagnosticsNamespaceIndex);
+                if (events.PubSubEventNotifier != null)
+                {
+                    events.PubSubEventNotifier.Value = Opc.Ua.ObjectIds.Server;
+                }
+                created.Add(events);
+            }
+
+            foreach (NodeState dataSet in created)
+            {
+                publishedDataSets.AddReference(
+                    ReferenceTypeIds.HasComponent, false, dataSet.NodeId);
+                dataSet.AddReference(
+                    ReferenceTypeIds.HasComponent, true, publishedDataSets.NodeId);
+                await AddPredefinedNodeAsync(SystemContext, dataSet, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+
+            return created;
+        }
+
+        /// <summary>
+        /// Applies the identity attributes and the mandatory
+        /// <c>PublishedDataSetType</c> properties to a freshly created
+        /// dataset instance.
+        /// </summary>
+        private void InitializeDataSet(
+            PublishedDataSetState dataSet,
+            string name,
+            ushort namespaceIndex)
+        {
+            // Mint ids for the mandatory children first: AssignNodeIds also
+            // replaces the node's own id, so it has to run before the
+            // deterministic id the alias seeds resolve against is applied.
+            dataSet.AssignNodeIds(SystemContext, []);
+
+            dataSet.SymbolicName = name;
+            dataSet.NodeId = new NodeId(name, namespaceIndex);
+            dataSet.BrowseName = new QualifiedName(name, namespaceIndex);
+            dataSet.DisplayName = LocalizedText.From(name);
+            dataSet.ReferenceTypeId = ReferenceTypeIds.HasComponent;
+
+            if (dataSet.ConfigurationVersion != null)
+            {
+                dataSet.ConfigurationVersion.Value = new ConfigurationVersionDataType
+                {
+                    MajorVersion = 1,
+                    MinorVersion = 0
+                };
+            }
+            if (dataSet.DataSetMetaData != null)
+            {
+                dataSet.DataSetMetaData.Value = new DataSetMetaDataType
+                {
+                    Name = name,
+                    Description = LocalizedText.From(name),
+                    ConfigurationVersion = dataSet.ConfigurationVersion?.Value ??
+                        new ConfigurationVersionDataType()
+                };
             }
         }
 
@@ -240,6 +377,23 @@ namespace Quickstarts.ReferenceServer
                 }
             }
         }
+
+        /// <summary>
+        /// BrowseName / string identifier of the data-items dataset created
+        /// under <c>PublishedDataSets</c>.
+        /// </summary>
+        internal const string ReferenceDataSetName = "ReferenceDataSet";
+
+        /// <summary>
+        /// BrowseNames / string identifiers of the event datasets created
+        /// under <c>PublishedDataSets</c>. These match the Topics alias
+        /// names seeded by <c>ReferenceServer.ConfigureAliasNameStore</c>.
+        /// </summary>
+        internal static readonly string[] EventDataSetNames =
+        [
+            "ServerEvents",
+            "AuditEvents"
+        ];
 
         private static readonly NodeId[] s_optionalPubSubFolders =
         [

--- a/src/Opc.Ua.Server/AliasNames/AliasNameMethodDispatcher.cs
+++ b/src/Opc.Ua.Server/AliasNames/AliasNameMethodDispatcher.cs
@@ -125,14 +125,19 @@ namespace Opc.Ua.Server.AliasNames
             NodeId targetReferenceType,
             CancellationToken ct)
         {
-            if (aliasNames.Count != targetNodes.Count ||
-                aliasNames.Count != targetServers.Count)
+            // Part 17 §6.3.4: Bad_InvalidArgument when the array sizes of
+            // all arguments EXCEPT TargetServers differ, or all arrays are
+            // empty. TargetServers is exempt — a caller with only local
+            // targets may pass an empty (or shorter) array, and a missing
+            // entry means the target is on the local server.
+            if (aliasNames.Count == 0 ||
+                aliasNames.Count != targetNodes.Count)
             {
                 return new AddAliasesToCategoryMethodStateResult
                 {
                     ServiceResult = ServiceResult.Create(
                         StatusCodes.BadInvalidArgument,
-                        "AliasNames, TargetNodes and TargetServers must have equal length."),
+                        "AliasNames and TargetNodes must be non-empty and of equal length."),
                     ErrorCodes = default
                 };
             }
@@ -143,7 +148,7 @@ namespace Opc.Ua.Server.AliasNames
                 requests.Add(new AliasAddRequest(
                     aliasNames[i] ?? string.Empty,
                     targetNodes[i],
-                    targetServers[i],
+                    i < targetServers.Count ? targetServers[i] : null,
                     targetReferenceType));
             }
 
@@ -170,13 +175,16 @@ namespace Opc.Ua.Server.AliasNames
             ArrayOf<ExpandedNodeId> targetNodes,
             CancellationToken ct)
         {
-            if (aliasNames.Count != targetNodes.Count)
+            // Part 17 §6.3.5: Bad_InvalidArgument when the array sizes
+            // differ or the arrays are empty.
+            if (aliasNames.Count == 0 ||
+                aliasNames.Count != targetNodes.Count)
             {
                 return new DeleteAliasesFromCategoryMethodStateResult
                 {
                     ServiceResult = ServiceResult.Create(
                         StatusCodes.BadInvalidArgument,
-                        "AliasNames and TargetNodes must have equal length."),
+                        "AliasNames and TargetNodes must be non-empty and of equal length."),
                     ErrorCodes = default
                 };
             }

--- a/src/Opc.Ua.Server/AliasNames/AliasNameMethodDispatcher.cs
+++ b/src/Opc.Ua.Server/AliasNames/AliasNameMethodDispatcher.cs
@@ -200,6 +200,27 @@ namespace Opc.Ua.Server.AliasNames
             };
         }
 
+        /// <summary>
+        /// The default authorization gate for the Part 17 mutation methods
+        /// (<c>AddAliasesToCategory</c>/<c>DeleteAliasesFromCategory</c>):
+        /// the caller must hold the <c>SecurityAdmin</c> role AND be on a
+        /// <c>SignAndEncrypt</c> channel.
+        /// </summary>
+        public static bool HasSecureAdminAccess(ISystemContext context)
+        {
+            if (context is SessionSystemContext { OperationContext: OperationContext op } session)
+            {
+                if (op.ChannelContext?.EndpointDescription?.SecurityMode !=
+                    MessageSecurityMode.SignAndEncrypt)
+                {
+                    return false;
+                }
+                return session.UserIdentity?.GrantedRoleIds
+                    .Contains(ObjectIds.WellKnownRole_SecurityAdmin) == true;
+            }
+            return false;
+        }
+
         private static ArrayOf<T> ToArrayOf<T>(IReadOnlyList<T> items)
         {
             if (items == null || items.Count == 0)

--- a/src/Opc.Ua.Server/AliasNames/AliasNameMethodDispatcher.cs
+++ b/src/Opc.Ua.Server/AliasNames/AliasNameMethodDispatcher.cs
@@ -206,7 +206,7 @@ namespace Opc.Ua.Server.AliasNames
         /// the caller must hold the <c>SecurityAdmin</c> role AND be on a
         /// <c>SignAndEncrypt</c> channel.
         /// </summary>
-        public static bool HasSecureAdminAccess(ISystemContext context)
+        internal static bool HasSecureAdminAccess(ISystemContext context)
         {
             if (context is SessionSystemContext { OperationContext: OperationContext op } session)
             {

--- a/src/Opc.Ua.Server/AliasNames/AliasNameNodeManager.cs
+++ b/src/Opc.Ua.Server/AliasNames/AliasNameNodeManager.cs
@@ -398,17 +398,7 @@ namespace Opc.Ua.Server.AliasNames
 
         private static bool HasSecureAdminAccess(ISystemContext context)
         {
-            if (context is SessionSystemContext { OperationContext: OperationContext op } session)
-            {
-                if (op.ChannelContext?.EndpointDescription?.SecurityMode !=
-                    MessageSecurityMode.SignAndEncrypt)
-                {
-                    return false;
-                }
-                return session.UserIdentity?.GrantedRoleIds
-                    .Contains(ObjectIds.WellKnownRole_SecurityAdmin) == true;
-            }
-            return false;
+            return AliasNameMethodDispatcher.HasSecureAdminAccess(context);
         }
 
         private static string ResolveNamespaceUri(AliasNameNodeManagerOptions? options)

--- a/src/Opc.Ua.Server/AliasNames/AliasNameNodeManager.cs
+++ b/src/Opc.Ua.Server/AliasNames/AliasNameNodeManager.cs
@@ -37,8 +37,10 @@ namespace Opc.Ua.Server.AliasNames
 {
     /// <summary>
     /// Standalone OPC UA Part 17 (Alias Names) node manager. Builds an
-    /// address-space tree of <c>AliasNameCategoryType</c> instances from
-    /// an <see cref="IAliasNameStore"/>'s
+    /// address-space tree of <c>AliasNameCategoryType</c> instances — and,
+    /// by default, one browsable <c>AliasNameType</c> instance per alias
+    /// with its <c>AliasFor</c> references (Part 17 §6.2) — from an
+    /// <see cref="IAliasNameStore"/>'s
     /// <see cref="IAliasNameStore.RootCategories"/>, wires the typed
     /// <c>OnCallAsync</c> handlers of the generated
     /// <c>FindAliasMethodState</c>/<c>FindAliasVerboseMethodState</c>/<c>AddAliasesToCategoryMethodState</c>/<c>DeleteAliasesFromCategoryMethodState</c>
@@ -53,10 +55,20 @@ namespace Opc.Ua.Server.AliasNames
     /// Apps opt in by adding this manager to their server's node-manager
     /// list. The manager owns a single namespace
     /// (<see cref="AliasNameNodeManagerOptions.NamespaceUri"/>) under
-    /// which it creates its category and alias instances; standard
+    /// which it creates its category and alias instances; every
+    /// <see cref="AliasNameCategoryDescriptor.NodeId"/> must lie in that
+    /// namespace — a descriptor pointing anywhere else is skipped with a
+    /// warning rather than claiming another manager's ids. Standard
     /// well-known categories owned by <c>DiagnosticsNodeManager</c> are
     /// not duplicated — only their methods are wired through the
     /// registry.
+    /// </para>
+    /// <para>
+    /// The address space is built by the same shared
+    /// <see cref="AliasNameNodeMaterializer"/> that
+    /// <c>DiagnosticsNodeManager.MaterializeRegisteredAliasNameNodesAsync</c>
+    /// uses for the standard well-known nodes, so both paths produce
+    /// structurally identical Part 17 trees.
     /// </para>
     /// <para>
     /// All four Part 17 methods are exposed only when the corresponding
@@ -69,7 +81,7 @@ namespace Opc.Ua.Server.AliasNames
     /// to opt out.
     /// </para>
     /// </remarks>
-    public class AliasNameNodeManager : AsyncCustomNodeManager
+    public class AliasNameNodeManager : AsyncCustomNodeManager, IAliasNameMaterializerHost
     {
         /// <summary>
         /// Initializes a new instance.
@@ -95,6 +107,11 @@ namespace Opc.Ua.Server.AliasNames
             m_registry = ResolveServerRegistry(server);
             m_localCategoryDispatcher = new AliasNameStoreRegistry();
             m_localCategoryDispatcher.Register(Store);
+            m_materializer = new AliasNameNodeMaterializer(
+                this,
+                m_localCategoryDispatcher,
+                AuthorizeMutation,
+                m_aliasLogger);
         }
 
         /// <summary>
@@ -129,29 +146,18 @@ namespace Opc.Ua.Server.AliasNames
             await base.CreateAddressSpaceAsync(externalReferences, cancellationToken)
                 .ConfigureAwait(false);
 
-            foreach (AliasNameCategoryDescriptor root in Store.RootCategories)
-            {
-                AliasNameCategoryState rootState = BuildCategoryTree(root);
-                m_rootCategoryStates[root.NodeId] = rootState;
+            var created = new List<NodeState>();
+            var visited = new HashSet<NodeId>();
 
-                if (Options.LinkToStandardAliasesObject)
-                {
-                    AddExternalReference(
-                        ObjectIds.Aliases,
-                        ReferenceTypeIds.Organizes,
-                        isInverse: false,
-                        rootState.NodeId,
-                        externalReferences);
-                    rootState.AddReference(
-                        ReferenceTypeIds.Organizes,
-                        isInverse: true,
-                        ObjectIds.Aliases);
-                }
+            await m_materializer.MaterializeStoreAsync(
+                Store,
+                externalReferences,
+                created,
+                visited,
+                Options.MaterializeAliasNodes,
+                cancellationToken).ConfigureAwait(false);
 
-                await AddPredefinedNodeAsync(
-                    SystemContext, rootState, cancellationToken)
-                    .ConfigureAwait(false);
-            }
+            m_aliasLogger.MaterializedAliasNameNodes(created.Count);
 
             if (Options.RegisterWithServerRegistry && m_registry != null)
             {
@@ -185,220 +191,105 @@ namespace Opc.Ua.Server.AliasNames
             base.Dispose(disposing);
         }
 
-        /// <summary>
-        /// Recursively builds an <see cref="AliasNameCategoryState"/>
-        /// instance for the supplied descriptor — including any optional
-        /// children declared by its capabilities and any nested
-        /// sub-categories — and wires every method's typed
-        /// <c>OnCallAsync</c> handler to the dispatcher.
-        /// </summary>
-        protected virtual AliasNameCategoryState BuildCategoryTree(
-            AliasNameCategoryDescriptor descriptor)
-        {
-            // CreateInstanceOf... returns a typed instance with the
-            // mandatory FindAlias child already created. We then override
-            // the identity attributes and add the optional Part 17
-            // children we have been asked to expose.
-            AliasNameCategoryState category =
-                SystemContext.CreateInstanceOfAliasNameCategoryType();
-            category.NodeId = descriptor.NodeId;
-            category.BrowseName = descriptor.BrowseName;
-            category.DisplayName = new LocalizedText(descriptor.BrowseName.Name);
-            category.SymbolicName = descriptor.BrowseName.Name!;
-            category.TypeDefinitionId = ObjectTypeIds.AliasNameCategoryType;
-            category.ReferenceTypeId = ReferenceTypeIds.Organizes;
-
-            AliasNameCapabilities cap = descriptor.Capabilities;
-            if ((cap & AliasNameCapabilities.FindAliasVerbose) != 0)
-            {
-                category.AddFindAliasVerbose(SystemContext);
-            }
-            if ((cap & AliasNameCapabilities.LastChange) != 0)
-            {
-                category.AddLastChange(SystemContext);
-            }
-            if ((cap & AliasNameCapabilities.AddAliasesToCategory) != 0)
-            {
-                category.AddAddAliasesToCategory(SystemContext);
-            }
-            if ((cap & AliasNameCapabilities.DeleteAliasesFromCategory) != 0)
-            {
-                category.AddDeleteAliasesFromCategory(SystemContext);
-            }
-
-            foreach (AliasNameCategoryDescriptor child in descriptor.SubCategories)
-            {
-                AliasNameCategoryState childState = BuildCategoryTree(child);
-                childState.ReferenceTypeId = ReferenceTypeIds.Organizes;
-                category.AddChild(childState);
-            }
-
-            // Auto-assign NodeIds to every child not pre-pinned in our
-            // namespace.
-            category.AssignNodeIds(SystemContext, []);
-
-            // Wire method handlers (after node ids are stable).
-            WireCategoryHandlers(descriptor.NodeId, category);
-
-            // Seed LastChange.
-            category.LastChange?.Value
-                    = Store.GetLastChange(descriptor.NodeId) ?? 0u;
-
-            return category;
-        }
-
-        private void WireCategoryHandlers(NodeId categoryId, AliasNameCategoryState category)
-        {
-            category.FindAlias?.OnCallAsync = (ctx, method, objId, pattern, refType, ct) =>
-                    AliasNameMethodDispatcher.FindAliasAsync(
-                        m_localCategoryDispatcher,
-                        Server.TypeTree,
-                        objId.IsNull ? categoryId : objId,
-                        pattern,
-                        refType,
-                        ct);
-            category.FindAliasVerbose?.OnCallAsync = (ctx, method, objId, pattern, refType, ct) =>
-                    AliasNameMethodDispatcher.FindAliasVerboseAsync(
-                        m_localCategoryDispatcher,
-                        Server.TypeTree,
-                        objId.IsNull ? categoryId : objId,
-                        pattern,
-                        refType,
-                        ct);
-            category.AddAliasesToCategory?.OnCallAsync =
-                    (ctx, method, objId, names, targets, servers, refType, ct) =>
-                        DispatchAddAsync(ctx, categoryId, objId, names, targets, servers, refType, ct);
-            category.DeleteAliasesFromCategory?.OnCallAsync =
-                    (ctx, method, objId, names, targets, ct) =>
-                        DispatchDeleteAsync(ctx, categoryId, objId, names, targets, ct);
-
-            // Recurse into sub-category children (already wired through
-            // BuildCategoryTree, but their state objects sit on this
-            // node's children list — wire those too).
-            var children = new List<BaseInstanceState>();
-            category.GetChildren(SystemContext, children);
-            foreach (BaseInstanceState child in children)
-            {
-                if (child is AliasNameCategoryState childCategory &&
-                    !ReferenceEquals(childCategory, category))
-                {
-                    WireCategoryHandlers(childCategory.NodeId, childCategory);
-                }
-            }
-        }
-
-        private ValueTask<AddAliasesToCategoryMethodStateResult> DispatchAddAsync(
-            ISystemContext context,
-            NodeId fallbackCategoryId,
-            NodeId objectId,
-            ArrayOf<string> aliasNames,
-            ArrayOf<ExpandedNodeId> targetNodes,
-            ArrayOf<string> targetServers,
-            NodeId targetReferenceType,
-            CancellationToken ct)
-        {
-            if (Options.RequireSecurityAdminForMutations &&
-                !HasSecureAdminAccess(context))
-            {
-                return new ValueTask<AddAliasesToCategoryMethodStateResult>(
-                    new AddAliasesToCategoryMethodStateResult
-                    {
-                        ServiceResult = new ServiceResult(StatusCodes.BadUserAccessDenied),
-                        ErrorCodes = default
-                    });
-            }
-            return AliasNameMethodDispatcher.AddAliasesAsync(
-                m_localCategoryDispatcher,
-                objectId.IsNull ? fallbackCategoryId : objectId,
-                aliasNames,
-                targetNodes,
-                targetServers,
-                targetReferenceType,
-                ct);
-        }
-
-        private ValueTask<DeleteAliasesFromCategoryMethodStateResult> DispatchDeleteAsync(
-            ISystemContext context,
-            NodeId fallbackCategoryId,
-            NodeId objectId,
-            ArrayOf<string> aliasNames,
-            ArrayOf<ExpandedNodeId> targetNodes,
-            CancellationToken ct)
-        {
-            if (Options.RequireSecurityAdminForMutations &&
-                !HasSecureAdminAccess(context))
-            {
-                return new ValueTask<DeleteAliasesFromCategoryMethodStateResult>(
-                    new DeleteAliasesFromCategoryMethodStateResult
-                    {
-                        ServiceResult = new ServiceResult(StatusCodes.BadUserAccessDenied),
-                        ErrorCodes = default
-                    });
-            }
-            return AliasNameMethodDispatcher.DeleteAliasesAsync(
-                m_localCategoryDispatcher,
-                objectId.IsNull ? fallbackCategoryId : objectId,
-                aliasNames,
-                targetNodes,
-                ct);
-        }
-
         private void OnStoreChanged(object? sender, AliasStoreChangedEventArgs e)
         {
             lock (m_lock)
             {
-                if (!m_rootCategoryStates.TryGetValue(e.CategoryId, out AliasNameCategoryState? root))
+                // Every category the materializer touched is a registered
+                // predefined node, so the direct lookup replaces the tree
+                // walk older versions needed.
+                AliasNameCategoryState? category =
+                    FindPredefinedNode<AliasNameCategoryState>(e.CategoryId);
+                if (category?.LastChange != null)
                 {
-                    root = FindCategoryNode(e.CategoryId);
-                }
-                if (root?.LastChange != null)
-                {
-                    root.LastChange.Value = e.LastChange;
-                    root.LastChange.ClearChangeMasks(SystemContext, false);
+                    category.LastChange.Value = e.LastChange;
+                    category.LastChange.ClearChangeMasks(SystemContext, false);
                 }
             }
         }
 
-        private AliasNameCategoryState? FindCategoryNode(NodeId categoryId)
+        private bool AuthorizeMutation(ISystemContext context)
         {
-            foreach (AliasNameCategoryState root in m_rootCategoryStates.Values)
-            {
-                AliasNameCategoryState? found = FindRecursive(root, categoryId);
-                if (found != null)
-                {
-                    return found;
-                }
-            }
-            return null;
+            return !Options.RequireSecurityAdminForMutations ||
+                AliasNameMethodDispatcher.HasSecureAdminAccess(context);
         }
 
-        private AliasNameCategoryState? FindRecursive(
-            AliasNameCategoryState node,
-            NodeId target)
+        ISystemContext IAliasNameMaterializerHost.SystemContext => SystemContext;
+
+        ITypeTable IAliasNameMaterializerHost.TypeTree => Server.TypeTree;
+
+        NamespaceTable IAliasNameMaterializerHost.NamespaceUris => Server.NamespaceUris;
+
+        StringTable IAliasNameMaterializerHost.ServerUris => Server.ServerUris;
+
+        ushort IAliasNameMaterializerHost.MaterializationNamespaceIndex => NamespaceIndex;
+
+        AliasNameCategoryState? IAliasNameMaterializerHost.FindCategoryNode(NodeId nodeId)
         {
-            if (node.NodeId == target)
-            {
-                return node;
-            }
-            var children = new List<BaseInstanceState>();
-            node.GetChildren(SystemContext, children);
-            foreach (BaseInstanceState child in children)
-            {
-                if (child is AliasNameCategoryState sub)
-                {
-                    AliasNameCategoryState? hit = FindRecursive(sub, target);
-                    if (hit != null)
-                    {
-                        return hit;
-                    }
-                }
-            }
-            return null;
+            return FindPredefinedNode<AliasNameCategoryState>(nodeId);
         }
 
-        private static bool HasSecureAdminAccess(ISystemContext context)
+        bool IAliasNameMaterializerHost.TryGetNode(NodeId nodeId, out NodeState? node)
         {
-            return AliasNameMethodDispatcher.HasSecureAdminAccess(context);
+            return PredefinedNodes.TryGetValue(nodeId, out node);
+        }
+
+        ValueTask IAliasNameMaterializerHost.RegisterNodeAsync(
+            NodeState node, CancellationToken cancellationToken)
+        {
+            return AddPredefinedNodeAsync(SystemContext, node, cancellationToken);
+        }
+
+        NodeId IAliasNameMaterializerHost.MintNodeId(NodeState node)
+        {
+            return New(SystemContext, node);
+        }
+
+        void IAliasNameMaterializerHost.LinkRootCategory(
+            AliasNameCategoryState root,
+            IDictionary<NodeId, IList<IReference>> externalReferences)
+        {
+            if (!Options.LinkToStandardAliasesObject)
+            {
+                return;
+            }
+
+            // The standard Aliases (i=23470) object lives in another node
+            // manager, so the forward half of the Organizes pair travels
+            // through the external-references dictionary.
+            AddExternalReference(
+                ObjectIds.Aliases,
+                ReferenceTypeIds.Organizes,
+                isInverse: false,
+                root.NodeId,
+                externalReferences);
+            if (!root.ReferenceExists(ReferenceTypeIds.Organizes, true, ObjectIds.Aliases))
+            {
+                root.AddReference(
+                    ReferenceTypeIds.Organizes,
+                    isInverse: true,
+                    ObjectIds.Aliases);
+            }
+        }
+
+        void IAliasNameMaterializerHost.AddInverseAliasReference(
+            NodeId targetId,
+            NodeId aliasNodeId,
+            IDictionary<NodeId, IList<IReference>> externalReferences)
+        {
+            AddExternalReference(
+                targetId,
+                ReferenceTypeIds.AliasFor,
+                true,
+                aliasNodeId,
+                externalReferences);
+        }
+
+        void IAliasNameMaterializerHost.OnLastChangeBound(
+            NodeId categoryId, PropertyState<uint> lastChange)
+        {
+            // Nothing to record: OnStoreChanged resolves the category by
+            // NodeId at event time.
         }
 
         private static string ResolveNamespaceUri(AliasNameNodeManagerOptions? options)
@@ -414,6 +305,7 @@ namespace Opc.Ua.Server.AliasNames
 
         private readonly ILogger m_aliasLogger;
         private readonly IAliasNameStoreRegistry? m_registry;
+        private readonly AliasNameNodeMaterializer m_materializer;
 
         /// <summary>
         /// Always-available dispatcher that wraps just this manager's
@@ -421,7 +313,6 @@ namespace Opc.Ua.Server.AliasNames
         /// server does not implement IAliasNameStoreRegistryProvider.
         /// </summary>
         private readonly AliasNameStoreRegistry m_localCategoryDispatcher;
-        private readonly Dictionary<NodeId, AliasNameCategoryState> m_rootCategoryStates = [];
         private bool m_registeredWithServer;
         private uint m_nextNodeId;
         private readonly Lock m_lock = new();
@@ -437,5 +328,4 @@ namespace Opc.Ua.Server.AliasNames
                 "well-known Aliases methods will not dispatch through it.")]
         public static partial void AliasNameStoreCouldNotBeRegisteredWithThe(this ILogger logger, Exception ex);
     }
-
 }

--- a/src/Opc.Ua.Server/AliasNames/AliasNameNodeManagerOptions.cs
+++ b/src/Opc.Ua.Server/AliasNames/AliasNameNodeManagerOptions.cs
@@ -64,6 +64,19 @@ namespace Opc.Ua.Server.AliasNames
         public bool RequireSecurityAdminForMutations { get; set; } = true;
 
         /// <summary>
+        /// When <c>true</c> (default), the manager creates one browsable
+        /// <c>AliasNameType</c> instance per alias — BrowseName carrying
+        /// the alias name, <c>AliasFor</c> references to its targets and
+        /// the inverse <c>HasAlias</c> reference on local targets — as
+        /// Part 17 §6.2 clients (the CTT among them) discover aliases by
+        /// browsing. Disable to expose only the category tree and serve
+        /// aliases through <c>FindAlias</c>/<c>FindAliasVerbose</c>.
+        /// The nodes are a snapshot taken at address-space creation;
+        /// later store mutations change query results but not the nodes.
+        /// </summary>
+        public bool MaterializeAliasNodes { get; set; } = true;
+
+        /// <summary>
         /// When <c>true</c> (default), the manager registers its
         /// <see cref="IAliasNameStore"/> with the server-wide
         /// <see cref="IAliasNameStoreRegistry"/> resolved through

--- a/src/Opc.Ua.Server/AliasNames/AliasNameNodeMaterializer.cs
+++ b/src/Opc.Ua.Server/AliasNames/AliasNameNodeMaterializer.cs
@@ -1,0 +1,1002 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace Opc.Ua.Server.AliasNames
+{
+    /// <summary>
+    /// The node-manager capabilities the
+    /// <see cref="AliasNameNodeMaterializer"/> needs from its host. Both
+    /// <c>DiagnosticsNodeManager</c> (which owns the standard well-known
+    /// Part 17 nodes) and <see cref="AliasNameNodeManager"/> (which owns an
+    /// application namespace) implement this over their
+    /// <c>AsyncCustomNodeManager</c> surface, so the descriptor walk,
+    /// capability handling and alias materialization exist exactly once.
+    /// </summary>
+    internal interface IAliasNameMaterializerHost
+    {
+        /// <summary>
+        /// The host manager's system context.
+        /// </summary>
+        ISystemContext SystemContext { get; }
+
+        /// <summary>
+        /// The server type tree used for reference-type filter matching.
+        /// </summary>
+        ITypeTable TypeTree { get; }
+
+        /// <summary>
+        /// The server namespace table, for resolving namespace-URI-form
+        /// <see cref="ExpandedNodeId"/> targets.
+        /// </summary>
+        NamespaceTable NamespaceUris { get; }
+
+        /// <summary>
+        /// The server table of server URIs; remote alias targets register
+        /// their URI here and reference it via <c>ServerIndex</c>.
+        /// </summary>
+        StringTable ServerUris { get; }
+
+        /// <summary>
+        /// The single namespace the materializer may mint NodeIds and
+        /// BrowseNames into. Descriptors whose category NodeId lies in any
+        /// other namespace resolve to predefined nodes or are skipped.
+        /// </summary>
+        ushort MaterializationNamespaceIndex { get; }
+
+        /// <summary>
+        /// Resolves an already-registered category node, or null.
+        /// </summary>
+        AliasNameCategoryState? FindCategoryNode(NodeId nodeId);
+
+        /// <summary>
+        /// Looks up any registered node at the given id — used to detect
+        /// occupants that are not alias nodes before minting.
+        /// </summary>
+        bool TryGetNode(NodeId nodeId, out NodeState? node);
+
+        /// <summary>
+        /// Registers a node (and its children) with the host manager so it
+        /// serves Browse and Call for it.
+        /// </summary>
+        ValueTask RegisterNodeAsync(NodeState node, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Mints a fresh NodeId for a node whose deterministic id
+        /// collided.
+        /// </summary>
+        NodeId MintNodeId(NodeState node);
+
+        /// <summary>
+        /// Links a root category (one with no parent in the descriptor
+        /// tree) into the browse hierarchy — typically under the standard
+        /// <c>Aliases (i=23470)</c> object, directly when the host owns
+        /// that node and via <paramref name="externalReferences"/>
+        /// otherwise. Hosts may make this a no-op (an opt-out option, or a
+        /// root that is itself the standard Aliases node).
+        /// </summary>
+        void LinkRootCategory(
+            AliasNameCategoryState root,
+            IDictionary<NodeId, IList<IReference>> externalReferences);
+
+        /// <summary>
+        /// Queues the inverse <c>HasAlias</c> (<c>AliasFor</c> inverse)
+        /// reference on a local target node, which usually lives in
+        /// another node manager and therefore travels through
+        /// <paramref name="externalReferences"/>.
+        /// </summary>
+        void AddInverseAliasReference(
+            NodeId targetId,
+            NodeId aliasNodeId,
+            IDictionary<NodeId, IList<IReference>> externalReferences);
+
+        /// <summary>
+        /// Notifies the host that a category's <c>LastChange</c> property
+        /// was created or seeded, so the host can keep it current from its
+        /// store/registry Changed events.
+        /// </summary>
+        void OnLastChangeBound(NodeId categoryId, PropertyState<uint> lastChange);
+    }
+
+    /// <summary>
+    /// Shared OPC UA Part 17 address-space builder: walks an
+    /// <see cref="IAliasNameStore"/>'s descriptor tree and materializes it
+    /// as browsable nodes — an <c>AliasNameCategoryType</c> instance per
+    /// category the host does not already ship (with the optional
+    /// <c>FindAliasVerbose</c>/<c>AddAliasesToCategory</c>/<c>DeleteAliasesFromCategory</c>/<c>LastChange</c>
+    /// children its <see cref="AliasNameCapabilities"/> declare, wired to
+    /// an <see cref="IAliasNameStoreRegistry"/>) and, when enabled, one
+    /// <c>AliasNameType</c> instance per alias carrying the
+    /// <c>AliasFor</c> references to its targets.
+    /// </summary>
+    /// <remarks>
+    /// The walk is idempotent and DAG-safe: a category reached twice (a
+    /// shared sub-category descriptor, or a repeat call after another
+    /// store registered) only gains any missing parent linkage, and alias
+    /// nodes registered by an earlier pass are reused. Server-defined
+    /// BrowseNames a descriptor left in namespace 0 — reserved by Part 3
+    /// for OPC-Foundation-defined names — are re-homed into the host's
+    /// materialization namespace; Part 17 §6.2 clients compare alias names
+    /// ignoring the namespace, so this is transparent to them.
+    /// </remarks>
+    internal sealed class AliasNameNodeMaterializer
+    {
+        /// <summary>
+        /// The Part 4 §7.40 Like-pattern that matches every alias name.
+        /// </summary>
+        private const string AllAliasesPattern = "%";
+
+        private readonly IAliasNameMaterializerHost m_host;
+        private readonly IAliasNameStoreRegistry m_dispatchRegistry;
+        private readonly Func<ISystemContext, bool> m_authorizeMutations;
+        private readonly ILogger m_logger;
+
+        /// <summary>
+        /// Initializes the materializer for one host manager.
+        /// </summary>
+        /// <param name="host">The owning node manager's capabilities.</param>
+        /// <param name="dispatchRegistry">The registry every created
+        /// method handler dispatches through — the server-wide registry
+        /// for the standard nodes, or a local single-store registry for a
+        /// standalone manager.</param>
+        /// <param name="authorizeMutations">Authorization gate consulted
+        /// by <c>AddAliasesToCategory</c>/<c>DeleteAliasesFromCategory</c>
+        /// handlers; a denied call returns <c>BadUserAccessDenied</c>.</param>
+        /// <param name="logger">Log sink for skip/collision warnings.</param>
+        public AliasNameNodeMaterializer(
+            IAliasNameMaterializerHost host,
+            IAliasNameStoreRegistry dispatchRegistry,
+            Func<ISystemContext, bool> authorizeMutations,
+            ILogger logger)
+        {
+            m_host = host ?? throw new ArgumentNullException(nameof(host));
+            m_dispatchRegistry = dispatchRegistry ??
+                throw new ArgumentNullException(nameof(dispatchRegistry));
+            m_authorizeMutations = authorizeMutations ??
+                throw new ArgumentNullException(nameof(authorizeMutations));
+            m_logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        /// <summary>
+        /// Materializes one store's root categories, their capability
+        /// children and — when <paramref name="materializeAliasNodes"/> is
+        /// set — their alias instance nodes.
+        /// </summary>
+        /// <param name="store">The store whose descriptor tree is walked;
+        /// aliases are read through one recursive
+        /// <c>FindAliasVerbose</c> query per root.</param>
+        /// <param name="externalReferences">The dictionary supplied to
+        /// <c>CreateAddressSpaceAsync</c>, used for references into other
+        /// node managers.</param>
+        /// <param name="created">Receives every node this call created.</param>
+        /// <param name="visited">Category ids already handled — pass one
+        /// set across stores (and across repeat calls within one pass) so
+        /// shared categories materialize once.</param>
+        /// <param name="materializeAliasNodes">When set, one
+        /// <c>AliasNameType</c> node is created per alias (Part 17 §6.2
+        /// browse discovery); otherwise only the category tree is built.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        public async ValueTask MaterializeStoreAsync(
+            IAliasNameStore store,
+            IDictionary<NodeId, IList<IReference>> externalReferences,
+            List<NodeState> created,
+            HashSet<NodeId> visited,
+            bool materializeAliasNodes,
+            CancellationToken cancellationToken)
+        {
+            foreach (AliasNameCategoryDescriptor root in store.RootCategories)
+            {
+                // One recursive query per root — every alias in the
+                // subtree comes back tagged with its home category, so
+                // per-category re-queries (each of which would scan the
+                // whole subtree again) are unnecessary. The query is
+                // restricted to AliasFor and its subtypes because that is
+                // the reference the materialized nodes carry; entries a
+                // store holds under unrelated reference types are not
+                // Part 17 §6.2 alias associations and are served by
+                // FindAlias only.
+                Dictionary<NodeId, List<AliasNameVerboseDataType>>? aliasesByCategory = null;
+                if (materializeAliasNodes)
+                {
+                    IReadOnlyList<AliasNameVerboseDataType> aliases = await store
+                        .FindAliasVerboseAsync(
+                            root.NodeId,
+                            AllAliasesPattern,
+                            ReferenceTypeIds.AliasFor,
+                            m_host.TypeTree,
+                            cancellationToken).ConfigureAwait(false);
+
+                    aliasesByCategory = [];
+                    foreach (AliasNameVerboseDataType alias in aliases)
+                    {
+                        if (!aliasesByCategory.TryGetValue(
+                                alias.AliasNameCategoryId,
+                                out List<AliasNameVerboseDataType>? bucket))
+                        {
+                            bucket = [];
+                            aliasesByCategory[alias.AliasNameCategoryId] = bucket;
+                        }
+                        bucket.Add(alias);
+                    }
+                }
+
+                await MaterializeCategoryAsync(
+                    root,
+                    parent: null,
+                    aliasesByCategory,
+                    visited,
+                    externalReferences,
+                    created,
+                    cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
+        /// Materializes one category — reusing the host's predefined node
+        /// when one exists — then its aliases and sub-categories.
+        /// </summary>
+        private async ValueTask MaterializeCategoryAsync(
+            AliasNameCategoryDescriptor descriptor,
+            AliasNameCategoryState? parent,
+            IReadOnlyDictionary<NodeId, List<AliasNameVerboseDataType>>? aliasesByCategory,
+            HashSet<NodeId> visited,
+            IDictionary<NodeId, IList<IReference>> externalReferences,
+            List<NodeState> created,
+            CancellationToken cancellationToken)
+        {
+            AliasNameCategoryState? category = m_host.FindCategoryNode(descriptor.NodeId);
+
+            if (!visited.Add(descriptor.NodeId))
+            {
+                // Reached a second time — a descriptor shared by two
+                // parents, or a repeat materialization call. The node and
+                // its aliases already exist; only this parent's linkage
+                // can be missing.
+                if (category != null && parent != null)
+                {
+                    LinkOrganizes(parent, category);
+                }
+                return;
+            }
+
+            bool isNewCategory = category == null;
+
+            if (category == null)
+            {
+                bool creatable;
+                if (descriptor.NodeId.NamespaceIndex != m_host.MaterializationNamespaceIndex)
+                {
+                    // Only nodes in the host's own namespace may be minted
+                    // here. Anything else is either a namespace owned by
+                    // another node manager or a mis-seeded well-known id —
+                    // e.g. a ns=0 descriptor pointing at a node that is
+                    // not an alias category, which creating would silently
+                    // replace.
+                    m_logger.SkippedAliasCategoryOutsideNamespace(descriptor.NodeId);
+                    creatable = false;
+                }
+                else if (m_host.TryGetNode(descriptor.NodeId, out NodeState? occupant))
+                {
+                    // The id exists but is not an AliasNameCategoryState —
+                    // creating the category would replace the occupant.
+                    m_logger.SkippedAliasCategoryOccupiedNodeId(
+                        descriptor.NodeId, occupant?.GetType().Name ?? "unknown");
+                    creatable = false;
+                }
+                else
+                {
+                    creatable = true;
+                }
+
+                if (!creatable)
+                {
+                    // The category itself cannot be materialized, but its
+                    // sub-tree may still hold categories the host owns —
+                    // do not swallow them. With no parent node to hang
+                    // off, they link into the hierarchy via the host's
+                    // root linkage.
+                    foreach (AliasNameCategoryDescriptor child in descriptor.SubCategories)
+                    {
+                        await MaterializeCategoryAsync(
+                            child,
+                            parent: null,
+                            aliasesByCategory,
+                            visited,
+                            externalReferences,
+                            created,
+                            cancellationToken).ConfigureAwait(false);
+                    }
+                    return;
+                }
+
+                category = m_host.SystemContext.CreateInstanceOfAliasNameCategoryType();
+                category.BrowseName = RehomeServerDefinedName(descriptor.BrowseName);
+                category.DisplayName = new LocalizedText(descriptor.BrowseName.Name);
+                category.SymbolicName = descriptor.BrowseName.Name!;
+                category.TypeDefinitionId = ObjectTypeIds.AliasNameCategoryType;
+                category.ReferenceTypeId = ReferenceTypeIds.Organizes;
+
+                // Mint ids for the mandatory children first — the host's
+                // id factory does not preserve a caller-assigned id — then
+                // pin the category to the descriptor's NodeId, which is
+                // the key the store and the registry dispatch on.
+                category.AssignNodeIds(m_host.SystemContext, []);
+                category.NodeId = descriptor.NodeId;
+            }
+
+            // The mandatory FindAlias is wired for every materialized
+            // category — including one that pre-existed as a predefined
+            // node (from a companion NodeSet) without a handler; without
+            // this a client would see the optional methods succeed while
+            // the mandatory one returns BadNotImplemented.
+            WireFindAlias(category, descriptor.NodeId, m_dispatchRegistry, m_host.TypeTree);
+
+            // Add and wire the optional Part 17 children the store's
+            // descriptor declares. For a category created above this only
+            // grows the subtree before it is registered; for a
+            // pre-existing category the new children are registered
+            // individually.
+            await ApplyCategoryCapabilitiesAsync(
+                descriptor,
+                category,
+                registerNewChildren: !isNewCategory,
+                created,
+                cancellationToken).ConfigureAwait(false);
+
+            if (isNewCategory)
+            {
+                // A root category from the store has no parent in the
+                // descriptor tree — the host links it into the browse
+                // hierarchy (typically under the standard Aliases
+                // (i=23470) object). Without an incoming hierarchical
+                // reference the node would exist but be reachable only by
+                // NodeId, defeating the Part 17 §6.2 browse-discovery
+                // purpose of materialization.
+                if (parent != null)
+                {
+                    LinkOrganizes(parent, category);
+                }
+                else
+                {
+                    m_host.LinkRootCategory(category, externalReferences);
+                }
+
+                await m_host.RegisterNodeAsync(category, cancellationToken)
+                    .ConfigureAwait(false);
+                created.Add(category);
+            }
+            else if (parent != null)
+            {
+                LinkOrganizes(parent, category);
+            }
+
+            if (aliasesByCategory != null)
+            {
+                await MaterializeAliasesAsync(
+                    descriptor,
+                    category,
+                    aliasesByCategory.TryGetValue(
+                        descriptor.NodeId, out List<AliasNameVerboseDataType>? bucket)
+                        ? bucket
+                        : null,
+                    externalReferences,
+                    created,
+                    cancellationToken).ConfigureAwait(false);
+            }
+
+            foreach (AliasNameCategoryDescriptor child in descriptor.SubCategories)
+            {
+                await MaterializeCategoryAsync(
+                    child,
+                    category,
+                    aliasesByCategory,
+                    visited,
+                    externalReferences,
+                    created,
+                    cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
+        /// Instantiates and wires the optional Part 17 children a category
+        /// declares through <see cref="AliasNameCategoryDescriptor.Capabilities"/>:
+        /// <c>FindAliasVerbose</c> (§6.3.3), <c>AddAliasesToCategory</c>
+        /// (§6.3.4), <c>DeleteAliasesFromCategory</c> (§6.3.5) and
+        /// <c>LastChange</c> (§6.3.1). Each child is created AND wired only
+        /// under its capability flag: a child that already exists on the
+        /// node (a companion NodeSet may ship one) but that the descriptor
+        /// did not declare stays unwired — otherwise a category declared
+        /// read-only would silently accept mutations. Children on the
+        /// well-known standard categories are created at the NodeIds
+        /// Part 17 §9 reserves for them
+        /// (<see cref="AliasNameReservedChildIds"/>).
+        /// </summary>
+        private async ValueTask ApplyCategoryCapabilitiesAsync(
+            AliasNameCategoryDescriptor descriptor,
+            AliasNameCategoryState category,
+            bool registerNewChildren,
+            List<NodeState> created,
+            CancellationToken cancellationToken)
+        {
+            ISystemContext context = m_host.SystemContext;
+            AliasNameCapabilities capabilities = descriptor.Capabilities;
+            AliasNameReservedChildIds reserved =
+                AliasNameReservedChildIds.For(descriptor.NodeId);
+            NodeId categoryId = descriptor.NodeId;
+            IAliasNameStoreRegistry registry = m_dispatchRegistry;
+            ITypeTable typeTree = m_host.TypeTree;
+            Func<ISystemContext, bool> authorize = m_authorizeMutations;
+            var addedChildren = new List<NodeState>();
+
+            if ((capabilities & AliasNameCapabilities.FindAliasVerbose) != 0)
+            {
+                if (category.FindAliasVerbose == null)
+                {
+                    category.AddFindAliasVerbose(context, reserved.FindAliasVerbose.Method);
+                    ApplyReservedArgumentIds(
+                        category.FindAliasVerbose, reserved.FindAliasVerbose);
+                    addedChildren.Add(category.FindAliasVerbose!);
+                }
+
+                category.FindAliasVerbose!.OnCallAsync =
+                    (ctx, method, objId, pattern, refType, ct) =>
+                        AliasNameMethodDispatcher.FindAliasVerboseAsync(
+                            registry,
+                            typeTree,
+                            objId.IsNull ? categoryId : objId,
+                            pattern,
+                            refType,
+                            ct);
+            }
+
+            if ((capabilities & AliasNameCapabilities.AddAliasesToCategory) != 0)
+            {
+                if (category.AddAliasesToCategory == null)
+                {
+                    category.AddAddAliasesToCategory(
+                        context, reserved.AddAliasesToCategory.Method);
+                    ApplyReservedArgumentIds(
+                        category.AddAliasesToCategory, reserved.AddAliasesToCategory);
+                    addedChildren.Add(category.AddAliasesToCategory!);
+                }
+
+                category.AddAliasesToCategory!.OnCallAsync =
+                    (ctx, method, objId, names, targets, servers, refType, ct) =>
+                        !authorize(ctx)
+                            ? new ValueTask<AddAliasesToCategoryMethodStateResult>(
+                                new AddAliasesToCategoryMethodStateResult
+                                {
+                                    ServiceResult = new ServiceResult(StatusCodes.BadUserAccessDenied),
+                                    ErrorCodes = default
+                                })
+                            : AliasNameMethodDispatcher.AddAliasesAsync(
+                                registry,
+                                objId.IsNull ? categoryId : objId,
+                                names,
+                                targets,
+                                servers,
+                                refType,
+                                ct);
+            }
+
+            if ((capabilities & AliasNameCapabilities.DeleteAliasesFromCategory) != 0)
+            {
+                if (category.DeleteAliasesFromCategory == null)
+                {
+                    category.AddDeleteAliasesFromCategory(
+                        context, reserved.DeleteAliasesFromCategory.Method);
+                    ApplyReservedArgumentIds(
+                        category.DeleteAliasesFromCategory, reserved.DeleteAliasesFromCategory);
+                    addedChildren.Add(category.DeleteAliasesFromCategory!);
+                }
+
+                category.DeleteAliasesFromCategory!.OnCallAsync =
+                    (ctx, method, objId, names, targets, ct) =>
+                        !authorize(ctx)
+                            ? new ValueTask<DeleteAliasesFromCategoryMethodStateResult>(
+                                new DeleteAliasesFromCategoryMethodStateResult
+                                {
+                                    ServiceResult = new ServiceResult(StatusCodes.BadUserAccessDenied),
+                                    ErrorCodes = default
+                                })
+                            : AliasNameMethodDispatcher.DeleteAliasesAsync(
+                                registry,
+                                objId.IsNull ? categoryId : objId,
+                                names,
+                                targets,
+                                ct);
+            }
+
+            if ((capabilities & AliasNameCapabilities.LastChange) != 0)
+            {
+                if (category.LastChange == null)
+                {
+                    category.AddLastChange(context, reserved.LastChange);
+                    addedChildren.Add(category.LastChange!);
+                }
+
+                SeedLastChange(
+                    category, categoryId, registry, context, m_host.OnLastChangeBound);
+            }
+
+            // Every added child is reported to the caller; only children
+            // of an already-registered category also need individual
+            // registration — a category not yet registered covers its
+            // whole subtree when it is.
+            created.AddRange(addedChildren);
+            if (registerNewChildren)
+            {
+                foreach (NodeState child in addedChildren)
+                {
+                    await m_host.RegisterNodeAsync(child, cancellationToken)
+                        .ConfigureAwait(false);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Points a category's mandatory <c>FindAlias</c> method at the
+        /// supplied registry. Shared by the standard well-known categories
+        /// (wired at startup by <c>DiagnosticsNodeManager</c>) and by the
+        /// categories materialized from a store's descriptor tree.
+        /// </summary>
+        internal static void WireFindAlias(
+            AliasNameCategoryState category,
+            NodeId categoryId,
+            IAliasNameStoreRegistry registry,
+            ITypeTable typeTree)
+        {
+            category.FindAlias?.OnCallAsync = (ctx, method, objId, pattern, refType, ct) =>
+                    AliasNameMethodDispatcher.FindAliasAsync(
+                        registry,
+                        typeTree,
+                        objId.IsNull ? categoryId : objId,
+                        pattern,
+                        refType,
+                        ct);
+        }
+
+        /// <summary>
+        /// Seeds a category's <c>LastChange</c> property from the store
+        /// that owns it and hands the node to
+        /// <paramref name="onBound"/> so the caller can keep it current.
+        /// No-op for a category without the property. The registry's
+        /// ownership map is authoritative — asking every store in turn
+        /// would seed from whichever store happens to answer first for a
+        /// category it does not own.
+        /// </summary>
+        internal static void SeedLastChange(
+            AliasNameCategoryState category,
+            NodeId categoryId,
+            IAliasNameStoreRegistry registry,
+            ISystemContext context,
+            Action<NodeId, PropertyState<uint>>? onBound)
+        {
+            if (category.LastChange == null)
+            {
+                return;
+            }
+
+            uint? seed = registry.GetStoreForCategory(categoryId)?.GetLastChange(categoryId);
+            if (seed.HasValue)
+            {
+                category.LastChange.Value = seed.Value;
+                category.LastChange.ClearChangeMasks(context, false);
+            }
+
+            onBound?.Invoke(categoryId, category.LastChange);
+        }
+
+        /// <summary>
+        /// Adds the forward and inverse <c>Organizes</c> pair between two
+        /// category nodes, tolerating either half already being present —
+        /// <c>NodeState.AddReference</c> throws on duplicates.
+        /// </summary>
+        internal static void LinkOrganizes(
+            AliasNameCategoryState parent,
+            AliasNameCategoryState child)
+        {
+            if (!parent.ReferenceExists(ReferenceTypeIds.Organizes, false, child.NodeId))
+            {
+                parent.AddReference(ReferenceTypeIds.Organizes, false, child.NodeId);
+            }
+            if (!child.ReferenceExists(ReferenceTypeIds.Organizes, true, parent.NodeId))
+            {
+                child.AddReference(ReferenceTypeIds.Organizes, true, parent.NodeId);
+            }
+        }
+
+        /// <summary>
+        /// Pins a method's argument properties to their reserved NodeIds.
+        /// The generated <c>Add…</c> helper rebases the arguments through
+        /// the node-id factory when it is handed an explicit method NodeId,
+        /// so they have to be re-pinned afterwards. A no-op when the
+        /// category has no reserved allocation.
+        /// </summary>
+        private static void ApplyReservedArgumentIds(
+            MethodState? method,
+            AliasNameReservedMethodIds reserved)
+        {
+            if (method == null || reserved.Method.IsNull)
+            {
+                return;
+            }
+            if (method.InputArguments != null)
+            {
+                method.InputArguments.NodeId = reserved.InputArguments;
+            }
+            if (method.OutputArguments != null)
+            {
+                method.OutputArguments.NodeId = reserved.OutputArguments;
+            }
+        }
+
+        /// <summary>
+        /// Creates one <c>AliasNameType</c> instance per alias whose home
+        /// category is <paramref name="descriptor"/> — the bucket handed in
+        /// holds exactly those. Aliases contributed by sub-categories are
+        /// materialized under their own category.
+        /// </summary>
+        private async ValueTask MaterializeAliasesAsync(
+            AliasNameCategoryDescriptor descriptor,
+            AliasNameCategoryState category,
+            List<AliasNameVerboseDataType>? aliases,
+            IDictionary<NodeId, IList<IReference>> externalReferences,
+            List<NodeState> created,
+            CancellationToken cancellationToken)
+        {
+            if (aliases == null || aliases.Count == 0)
+            {
+                return;
+            }
+
+            // One node per alias name; the store reports a separate record
+            // per reference type, and a name may carry several targets.
+            // Duplicate targets — including the same node seeded once in
+            // namespace-URI form and once in index form — are absorbed by
+            // the ReferenceExists guards in AddAliasForReference.
+            var byName = new Dictionary<string, AliasNameState>();
+
+            foreach (AliasNameVerboseDataType alias in aliases)
+            {
+                if (string.IsNullOrEmpty(alias.AliasName.Name))
+                {
+                    continue;
+                }
+
+                string name = alias.AliasName.Name!;
+                if (!byName.TryGetValue(name, out AliasNameState? aliasNode))
+                {
+                    aliasNode = await GetOrCreateAliasNodeAsync(
+                        descriptor, category, alias.AliasName, name, created,
+                        cancellationToken).ConfigureAwait(false);
+                    byName[name] = aliasNode;
+                }
+
+                for (int ii = 0; ii < alias.ReferencedNodes.Count; ii++)
+                {
+                    AddAliasForReference(
+                        aliasNode,
+                        alias.ReferencedNodes[ii],
+                        ii < alias.ServerUris.Count ? alias.ServerUris[ii] : null,
+                        externalReferences);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Resolves or builds the <c>AliasNameType</c> instance for one
+        /// alias. Per Part 17 §6.2 the BrowseName carries the alias name
+        /// and the DisplayName repeats it with an empty locale.
+        /// </summary>
+        /// <remarks>
+        /// The deterministic string id minted from category id + alias name
+        /// is ambiguous — <c>"…s=A"</c> with alias <c>"B.C"</c> and
+        /// <c>"…s=A.B"</c> with alias <c>"C"</c> concatenate identically —
+        /// and a repeat materialization revisits ids it minted before. A
+        /// node already registered under the minted id is therefore reused
+        /// when it is the same alias, and a different occupant makes this
+        /// alias fall back to a factory-minted id instead of silently
+        /// replacing the occupant.
+        /// </remarks>
+        private async ValueTask<AliasNameState> GetOrCreateAliasNodeAsync(
+            AliasNameCategoryDescriptor descriptor,
+            AliasNameCategoryState category,
+            QualifiedName aliasName,
+            string name,
+            List<NodeState> created,
+            CancellationToken cancellationToken)
+        {
+            var mintedId = new NodeId(
+                Utils.Format("{0}.{1}", descriptor.NodeId, name),
+                m_host.MaterializationNamespaceIndex);
+
+            if (m_host.TryGetNode(mintedId, out NodeState? existing))
+            {
+                if (existing is AliasNameState existingAlias &&
+                    existingAlias.BrowseName.Name == name)
+                {
+                    LinkAliasToCategory(category, existingAlias);
+                    return existingAlias;
+                }
+
+                m_logger.AliasNameNodeIdCollision(mintedId, name);
+                mintedId = NodeId.Null;
+            }
+
+            AliasNameState aliasNode =
+                m_host.SystemContext.CreateInstanceOfAliasNameType();
+
+            aliasNode.NodeId = mintedId.IsNull
+                ? m_host.MintNodeId(aliasNode)
+                : mintedId;
+            aliasNode.BrowseName = RehomeServerDefinedName(aliasName);
+            aliasNode.DisplayName = new LocalizedText(string.Empty, name);
+            aliasNode.SymbolicName = name;
+            aliasNode.TypeDefinitionId = ObjectTypeIds.AliasNameType;
+            aliasNode.ReferenceTypeId = ReferenceTypeIds.Organizes;
+
+            LinkAliasToCategory(category, aliasNode);
+
+            await m_host.RegisterNodeAsync(aliasNode, cancellationToken)
+                .ConfigureAwait(false);
+            created.Add(aliasNode);
+            return aliasNode;
+        }
+
+        /// <summary>
+        /// Adds the forward and inverse <c>Organizes</c> pair between a
+        /// category and an alias node, tolerating either half already
+        /// being present.
+        /// </summary>
+        private static void LinkAliasToCategory(
+            AliasNameCategoryState category,
+            AliasNameState aliasNode)
+        {
+            if (!category.ReferenceExists(ReferenceTypeIds.Organizes, false, aliasNode.NodeId))
+            {
+                category.AddReference(ReferenceTypeIds.Organizes, false, aliasNode.NodeId);
+            }
+            if (!aliasNode.ReferenceExists(ReferenceTypeIds.Organizes, true, category.NodeId))
+            {
+                aliasNode.AddReference(ReferenceTypeIds.Organizes, true, category.NodeId);
+            }
+        }
+
+        /// <summary>
+        /// Adds the forward <c>AliasFor</c> reference to a target and — for
+        /// targets on this server — the inverse <c>HasAlias</c> reference
+        /// back through the host.
+        /// </summary>
+        private void AddAliasForReference(
+            AliasNameState aliasNode,
+            ExpandedNodeId target,
+            string? serverUri,
+            IDictionary<NodeId, IList<IReference>> externalReferences)
+        {
+            if (target.IsNull)
+            {
+                return;
+            }
+
+            if (!string.IsNullOrEmpty(serverUri))
+            {
+                // A target on a remote server has no local node to carry
+                // the inverse reference. Register the URI in the server
+                // table and stamp its index onto the reference target, so
+                // clients can resolve which server owns the node via the
+                // ServerArray — an ExpandedNodeId with ServerIndex 0 would
+                // misreport the target as local.
+                uint serverIndex = m_host.ServerUris.GetIndexOrAppend(serverUri!);
+                ExpandedNodeId remoteTarget = target.WithServerIndex(serverIndex);
+                if (!aliasNode.ReferenceExists(ReferenceTypeIds.AliasFor, false, remoteTarget))
+                {
+                    aliasNode.AddReference(ReferenceTypeIds.AliasFor, false, remoteTarget);
+                }
+                return;
+            }
+
+            // Resolve the namespace-uri form a store may have been seeded
+            // with, so the reference carries a plain local NodeId. The
+            // duplicate check runs on the RESOLVED id — the same target
+            // seeded once in URI form and once in index form must produce
+            // one reference, and AddReference throws on duplicates.
+            var localTarget = ExpandedNodeId.ToNodeId(target, m_host.NamespaceUris);
+            if (localTarget.IsNull)
+            {
+                if (!aliasNode.ReferenceExists(ReferenceTypeIds.AliasFor, false, target))
+                {
+                    aliasNode.AddReference(ReferenceTypeIds.AliasFor, false, target);
+                }
+                return;
+            }
+
+            if (aliasNode.ReferenceExists(ReferenceTypeIds.AliasFor, false, localTarget))
+            {
+                return;
+            }
+
+            aliasNode.AddReference(ReferenceTypeIds.AliasFor, false, localTarget);
+
+            // The inverse reference travels only with a newly added
+            // forward reference, so repeat materializations do not queue
+            // duplicate external references for the target's manager.
+            m_host.AddInverseAliasReference(
+                localTarget, aliasNode.NodeId, externalReferences);
+        }
+
+        /// <summary>
+        /// Moves a server-defined name out of namespace 0, which Part 3
+        /// reserves for OPC-Foundation-defined names. Store descriptors
+        /// commonly inherit namespace 0 from the well-known categories'
+        /// BrowseNames; publishing server-specific aliases there is a
+        /// conformance violation and can even duplicate a standard child
+        /// name (an alias literally called "FindAlias"). Part 17 §6.2
+        /// clients compare alias names ignoring the namespace, so
+        /// re-homing is transparent to them.
+        /// </summary>
+        private QualifiedName RehomeServerDefinedName(QualifiedName name)
+        {
+            return name.NamespaceIndex == 0 && !string.IsNullOrEmpty(name.Name)
+                ? new QualifiedName(name.Name, m_host.MaterializationNamespaceIndex)
+                : name;
+        }
+    }
+
+    /// <summary>
+    /// The reserved NodeIds of one optional method and its two argument
+    /// properties. <see cref="Method"/> is <see cref="NodeId.Null"/> for
+    /// a category with no reserved allocation, which makes the generated
+    /// <c>Add…</c> helper fall back to the node-id factory.
+    /// </summary>
+    internal readonly record struct AliasNameReservedMethodIds(
+        NodeId Method,
+        NodeId InputArguments,
+        NodeId OutputArguments);
+
+    /// <summary>
+    /// The NodeIds the OPC Foundation reserves for the optional Part 17
+    /// children of the three well-known categories.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// These identifiers are allocated in the standard identifier
+    /// registry — <c>StandardTypes.csv</c>, rows <c>Aliases_FindAliasVerbose,24054</c>
+    /// through <c>Topics_DeleteAliasesFromCategory_OutputArguments,24080</c>,
+    /// plus <c>TagVariables_LastChange,32854</c> and
+    /// <c>Topics_LastChange,32856</c> — so a server that instantiates
+    /// one of these optional children has a canonical NodeId for it.
+    /// </para>
+    /// <para>
+    /// They are deliberately absent from both the ModelDesign and the
+    /// published NodeSet: the standard address space does not
+    /// instantiate optional children, so the source generator has no
+    /// parent-to-instance mapping to emit and no <c>MethodIds</c>
+    /// constant exists for them. The argument properties do have
+    /// generated <c>VariableIds</c> constants and are referenced through
+    /// those; only the nine method identifiers and the two
+    /// <c>LastChange</c> identifiers are spelled out here, each
+    /// traceable to its registry row.
+    /// </para>
+    /// </remarks>
+    internal readonly record struct AliasNameReservedChildIds(
+        AliasNameReservedMethodIds FindAliasVerbose,
+        AliasNameReservedMethodIds AddAliasesToCategory,
+        AliasNameReservedMethodIds DeleteAliasesFromCategory,
+        NodeId LastChange)
+    {
+        /// <summary>
+        /// Returns the reserved child ids for a well-known category, or a
+        /// default (all-null) set for any other category id.
+        /// </summary>
+        public static AliasNameReservedChildIds For(NodeId categoryId)
+        {
+            return s_reserved.TryGetValue(categoryId, out AliasNameReservedChildIds ids)
+                ? ids
+                : default;
+        }
+
+        // One row per well-known category; the numeric literals are the
+        // Method rows of StandardTypes.csv, the VariableIds constants
+        // its Variable rows.
+        private static readonly Dictionary<NodeId, AliasNameReservedChildIds> s_reserved = new()
+        {
+            [ObjectIds.Aliases] = new AliasNameReservedChildIds(
+                new AliasNameReservedMethodIds(
+                    new NodeId(24054u),
+                    VariableIds.Aliases_FindAliasVerbose_InputArguments,
+                    VariableIds.Aliases_FindAliasVerbose_OutputArguments),
+                new AliasNameReservedMethodIds(
+                    new NodeId(24057u),
+                    VariableIds.Aliases_AddAliasesToCategory_InputArguments,
+                    VariableIds.Aliases_AddAliasesToCategory_OutputArguments),
+                new AliasNameReservedMethodIds(
+                    new NodeId(24060u),
+                    VariableIds.Aliases_DeleteAliasesFromCategory_InputArguments,
+                    VariableIds.Aliases_DeleteAliasesFromCategory_OutputArguments),
+                VariableIds.Aliases_LastChange),
+            [ObjectIds.TagVariables] = new AliasNameReservedChildIds(
+                new AliasNameReservedMethodIds(
+                    new NodeId(24063u),
+                    VariableIds.TagVariables_FindAliasVerbose_InputArguments,
+                    VariableIds.TagVariables_FindAliasVerbose_OutputArguments),
+                new AliasNameReservedMethodIds(
+                    new NodeId(24066u),
+                    VariableIds.TagVariables_AddAliasesToCategory_InputArguments,
+                    VariableIds.TagVariables_AddAliasesToCategory_OutputArguments),
+                new AliasNameReservedMethodIds(
+                    new NodeId(24069u),
+                    VariableIds.TagVariables_DeleteAliasesFromCategory_InputArguments,
+                    VariableIds.TagVariables_DeleteAliasesFromCategory_OutputArguments),
+                new NodeId(32854u)),
+            [ObjectIds.Topics] = new AliasNameReservedChildIds(
+                new AliasNameReservedMethodIds(
+                    new NodeId(24072u),
+                    VariableIds.Topics_FindAliasVerbose_InputArguments,
+                    VariableIds.Topics_FindAliasVerbose_OutputArguments),
+                new AliasNameReservedMethodIds(
+                    new NodeId(24075u),
+                    VariableIds.Topics_AddAliasesToCategory_InputArguments,
+                    VariableIds.Topics_AddAliasesToCategory_OutputArguments),
+                new AliasNameReservedMethodIds(
+                    new NodeId(24078u),
+                    VariableIds.Topics_DeleteAliasesFromCategory_InputArguments,
+                    VariableIds.Topics_DeleteAliasesFromCategory_OutputArguments),
+                new NodeId(32856u))
+        };
+    }
+
+    /// <summary>
+    /// Source-generated log messages for the shared Part 17
+    /// materializer.
+    /// </summary>
+    internal static partial class AliasNameNodeMaterializerLog
+    {
+        [LoggerMessage(EventId = ServerEventIds.AliasNameNodeManager + 1, Level = LogLevel.Warning,
+            Message = "Skipped alias category {CategoryId}: its NodeId is outside the materialization namespace, so it belongs to another node manager or is a mis-seeded well-known id.")]
+        public static partial void SkippedAliasCategoryOutsideNamespace(this ILogger logger, NodeId categoryId);
+
+        [LoggerMessage(EventId = ServerEventIds.AliasNameNodeManager + 2, Level = LogLevel.Warning,
+            Message = "Skipped alias category {CategoryId}: the NodeId is already registered by a node of type {OccupantType}.")]
+        public static partial void SkippedAliasCategoryOccupiedNodeId(this ILogger logger, NodeId categoryId, string occupantType);
+
+        [LoggerMessage(EventId = ServerEventIds.AliasNameNodeManager + 3, Level = LogLevel.Warning,
+            Message = "Alias name NodeId {MintedId} for alias '{AliasName}' collides with an existing node; a factory-minted NodeId is used instead.")]
+        public static partial void AliasNameNodeIdCollision(this ILogger logger, NodeId mintedId, string aliasName);
+
+        [LoggerMessage(EventId = ServerEventIds.AliasNameNodeManager + 4, Level = LogLevel.Information,
+            Message = "Materialized {Count} Part 17 alias name nodes from the alias store(s).")]
+        public static partial void MaterializedAliasNameNodes(this ILogger logger, int count);
+    }
+}

--- a/src/Opc.Ua.Server/AliasNames/InMemoryAliasNameStore.cs
+++ b/src/Opc.Ua.Server/AliasNames/InMemoryAliasNameStore.cs
@@ -266,6 +266,7 @@ namespace Opc.Ua.Server.AliasNames
             }
 
             bool changed = false;
+            List<AliasStoreChangedEventArgs>? notifications = null;
             await m_semaphore.WaitAsync(ct).ConfigureAwait(false);
             try
             {
@@ -309,7 +310,7 @@ namespace Opc.Ua.Server.AliasNames
 
                 if (changed)
                 {
-                    entry.LastChange = unchecked(entry.LastChange + 1);
+                    notifications = BumpLastChangeWithAncestors(categoryId);
                 }
             }
             finally
@@ -317,11 +318,7 @@ namespace Opc.Ua.Server.AliasNames
                 m_semaphore.Release();
             }
 
-            if (changed)
-            {
-                Changed?.Invoke(this,
-                    new AliasStoreChangedEventArgs(categoryId, entry.LastChange));
-            }
+            RaiseChanged(notifications);
             return results;
         }
 
@@ -357,6 +354,7 @@ namespace Opc.Ua.Server.AliasNames
             }
 
             bool changed = false;
+            List<AliasStoreChangedEventArgs>? notifications = null;
             await m_semaphore.WaitAsync(ct).ConfigureAwait(false);
             try
             {
@@ -411,7 +409,7 @@ namespace Opc.Ua.Server.AliasNames
 
                 if (changed)
                 {
-                    entry.LastChange = unchecked(entry.LastChange + 1);
+                    notifications = BumpLastChangeWithAncestors(categoryId);
                 }
             }
             finally
@@ -419,12 +417,25 @@ namespace Opc.Ua.Server.AliasNames
                 m_semaphore.Release();
             }
 
-            if (changed)
-            {
-                Changed?.Invoke(this,
-                    new AliasStoreChangedEventArgs(categoryId, entry.LastChange));
-            }
+            RaiseChanged(notifications);
             return results;
+        }
+
+        /// <summary>
+        /// Raises <see cref="Changed"/> for every bumped category, mutated
+        /// child first, ancestors after — outside the store lock so
+        /// handlers can call back into the store.
+        /// </summary>
+        private void RaiseChanged(List<AliasStoreChangedEventArgs>? notifications)
+        {
+            if (notifications == null)
+            {
+                return;
+            }
+            foreach (AliasStoreChangedEventArgs notification in notifications)
+            {
+                Changed?.Invoke(this, notification);
+            }
         }
 
         /// <inheritdoc/>
@@ -433,7 +444,9 @@ namespace Opc.Ua.Server.AliasNames
             m_semaphore.Dispose();
         }
 
-        private void RegisterCategoryRecursive(AliasNameCategoryDescriptor descriptor)
+        private void RegisterCategoryRecursive(
+            AliasNameCategoryDescriptor descriptor,
+            NodeId? parentId = null)
         {
             if (!m_categories.TryAdd(descriptor.NodeId, new CategoryEntry(descriptor)))
             {
@@ -441,10 +454,42 @@ namespace Opc.Ua.Server.AliasNames
                     "Duplicate category NodeId: " + descriptor.NodeId,
                     nameof(descriptor));
             }
+            if (parentId != null)
+            {
+                m_parentByCategory[descriptor.NodeId] = parentId.Value;
+            }
             foreach (AliasNameCategoryDescriptor child in descriptor.SubCategories)
             {
-                RegisterCategoryRecursive(child);
+                RegisterCategoryRecursive(child, descriptor.NodeId);
             }
+        }
+
+        /// <summary>
+        /// Bumps the mutated category's <c>LastChange</c> and — per Part 17
+        /// §6.3.1/§9.2, where a category's <c>LastChange</c> reflects the
+        /// most recent change anywhere in its subtree and the root
+        /// <c>Aliases</c> value reflects any change at all — every ancestor
+        /// category's too. Returns one notification per bumped category;
+        /// the caller raises them outside the store lock.
+        /// </summary>
+        private List<AliasStoreChangedEventArgs> BumpLastChangeWithAncestors(
+            NodeId categoryId)
+        {
+            var notifications = new List<AliasStoreChangedEventArgs>();
+            NodeId current = categoryId;
+            while (m_categories.TryGetValue(current, out CategoryEntry? entry))
+            {
+                entry.LastChange = unchecked(entry.LastChange + 1);
+                notifications.Add(
+                    new AliasStoreChangedEventArgs(current, entry.LastChange));
+
+                if (!m_parentByCategory.TryGetValue(current, out NodeId parent))
+                {
+                    break;
+                }
+                current = parent;
+            }
+            return notifications;
         }
 
         private void CollectMatches(
@@ -578,6 +623,14 @@ namespace Opc.Ua.Server.AliasNames
         }
 
         private readonly Dictionary<NodeId, CategoryEntry> m_categories = [];
+
+        /// <summary>
+        /// Child-to-parent category map used to propagate
+        /// <c>LastChange</c> bumps to ancestors (Part 17 §6.3.1/§9.2).
+        /// Categories form a strict tree within one store — registration
+        /// rejects duplicate ids.
+        /// </summary>
+        private readonly Dictionary<NodeId, NodeId> m_parentByCategory = [];
         private readonly SemaphoreSlim m_semaphore = new(1, 1);
 
         private readonly record struct MappingKey(

--- a/src/Opc.Ua.Server/Diagnostics/DiagnosticsNodeManager.AliasNames.cs
+++ b/src/Opc.Ua.Server/Diagnostics/DiagnosticsNodeManager.AliasNames.cs
@@ -259,37 +259,47 @@ namespace Opc.Ua.Server
             }
         }
 
+        /// <inheritdoc/>
         ISystemContext IAliasNameMaterializerHost.SystemContext => SystemContext;
 
+        /// <inheritdoc/>
         ITypeTable IAliasNameMaterializerHost.TypeTree => Server.TypeTree;
 
+        /// <inheritdoc/>
         NamespaceTable IAliasNameMaterializerHost.NamespaceUris => Server.NamespaceUris;
 
+        /// <inheritdoc/>
         StringTable IAliasNameMaterializerHost.ServerUris => Server.ServerUris;
 
+        /// <inheritdoc/>
         ushort IAliasNameMaterializerHost.MaterializationNamespaceIndex => m_namespaceIndex;
 
+        /// <inheritdoc/>
         AliasNameCategoryState? IAliasNameMaterializerHost.FindCategoryNode(NodeId nodeId)
         {
             return FindPredefinedNode<AliasNameCategoryState>(nodeId);
         }
 
+        /// <inheritdoc/>
         bool IAliasNameMaterializerHost.TryGetNode(NodeId nodeId, out NodeState? node)
         {
             return PredefinedNodes.TryGetValue(nodeId, out node);
         }
 
+        /// <inheritdoc/>
         ValueTask IAliasNameMaterializerHost.RegisterNodeAsync(
             NodeState node, CancellationToken cancellationToken)
         {
             return AddPredefinedNodeAsync(SystemContext, node, cancellationToken);
         }
 
+        /// <inheritdoc/>
         NodeId IAliasNameMaterializerHost.MintNodeId(NodeState node)
         {
             return New(SystemContext, node);
         }
 
+        /// <inheritdoc/>
         void IAliasNameMaterializerHost.LinkRootCategory(
             AliasNameCategoryState root,
             IDictionary<NodeId, IList<IReference>> externalReferences)
@@ -311,6 +321,7 @@ namespace Opc.Ua.Server
             }
         }
 
+        /// <inheritdoc/>
         void IAliasNameMaterializerHost.AddInverseAliasReference(
             NodeId targetId,
             NodeId aliasNodeId,
@@ -324,6 +335,7 @@ namespace Opc.Ua.Server
                 externalReferences);
         }
 
+        /// <inheritdoc/>
         void IAliasNameMaterializerHost.OnLastChangeBound(
             NodeId categoryId, PropertyState<uint> lastChange)
         {

--- a/src/Opc.Ua.Server/Diagnostics/DiagnosticsNodeManager.AliasNames.cs
+++ b/src/Opc.Ua.Server/Diagnostics/DiagnosticsNodeManager.AliasNames.cs
@@ -32,7 +32,6 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Extensions.Logging;
 using Opc.Ua.Server.AliasNames;
 
 namespace Opc.Ua.Server
@@ -59,14 +58,15 @@ namespace Opc.Ua.Server
     /// are instantiated by the standard NodeSet on these well-known nodes,
     /// so the always-on binder — <see cref="WireStandardAliasMethods"/> —
     /// wires <c>FindAlias</c> and (for <c>Aliases</c>) <c>LastChange</c>
-    /// only. A server that wants the optional methods calls
-    /// <see cref="MaterializeRegisteredAliasNameNodesAsync"/>, which adds
-    /// them through the generated optional-child helpers — at the reserved
-    /// NodeIds, see <see cref="ReservedChildIds"/> — for every category
-    /// whose store descriptor declares the matching
-    /// <see cref="AliasNameCapabilities"/>.
+    /// only. A server that wants the optional methods and browsable alias
+    /// nodes calls <see cref="MaterializeRegisteredAliasNameNodesAsync"/>,
+    /// which delegates to the shared
+    /// <see cref="AliasNameNodeMaterializer"/> — the same walker
+    /// <see cref="AliasNameNodeManager"/> uses for application-defined
+    /// namespaces — for every category whose store descriptor declares the
+    /// matching <see cref="AliasNameCapabilities"/>.
     /// </remarks>
-    public partial class DiagnosticsNodeManager
+    public partial class DiagnosticsNodeManager : IAliasNameMaterializerHost
     {
         /// <summary>
         /// Resolves the server's <see cref="IAliasNameStoreRegistry"/>
@@ -104,62 +104,18 @@ namespace Opc.Ua.Server
                 return;
             }
 
-            WireFindAlias(categoryId, category, m_aliasRegistry!);
+            AliasNameNodeMaterializer.WireFindAlias(
+                category, categoryId, m_aliasRegistry!, Server.TypeTree);
 
             if (includeLastChange)
             {
-                BindLastChange(categoryId, category, m_aliasRegistry!);
+                AliasNameNodeMaterializer.SeedLastChange(
+                    category,
+                    categoryId,
+                    m_aliasRegistry!,
+                    SystemContext,
+                    (id, lastChange) => m_lastChangeNodes[id] = lastChange);
             }
-        }
-
-        /// <summary>
-        /// Seeds a category's <c>LastChange</c> property from the store that
-        /// owns it and remembers the node so
-        /// <see cref="OnAliasRegistryChanged"/> can keep it current. No-op
-        /// for a category that does not expose the property.
-        /// </summary>
-        private void BindLastChange(
-            NodeId categoryId,
-            AliasNameCategoryState category,
-            IAliasNameStoreRegistry registry)
-        {
-            if (category.LastChange == null)
-            {
-                return;
-            }
-
-            // The registry's ownership map is authoritative — asking every
-            // store in turn would seed from whichever store happens to
-            // answer first for a category it does not own.
-            uint? seed = registry.GetStoreForCategory(categoryId)?.GetLastChange(categoryId);
-            if (seed.HasValue)
-            {
-                category.LastChange.Value = seed.Value;
-                category.LastChange.ClearChangeMasks(SystemContext, false);
-            }
-
-            m_lastChangeNodes[categoryId] = category.LastChange;
-        }
-
-        /// <summary>
-        /// Points a category's mandatory <c>FindAlias</c> method at the
-        /// supplied registry. Shared by the standard well-known categories
-        /// and by the categories materialized from a store's descriptor
-        /// tree.
-        /// </summary>
-        private void WireFindAlias(
-            NodeId categoryId,
-            AliasNameCategoryState category,
-            IAliasNameStoreRegistry registry)
-        {
-            category.FindAlias?.OnCallAsync = (ctx, method, objId, pattern, refType, ct) =>
-                    AliasNameMethodDispatcher.FindAliasAsync(
-                        registry,
-                        Server.TypeTree,
-                        objId.IsNull ? categoryId : objId,
-                        pattern,
-                        refType,
-                        ct);
         }
 
         /// <summary>
@@ -224,628 +180,28 @@ namespace Opc.Ua.Server
                 return [];
             }
 
+            var materializer = new AliasNameNodeMaterializer(
+                this,
+                registry,
+                AliasNameMethodDispatcher.HasSecureAdminAccess,
+                m_logger);
+
             var created = new List<NodeState>();
             var visited = new HashSet<NodeId>();
 
             foreach (IAliasNameStore store in registry.Stores)
             {
-                foreach (AliasNameCategoryDescriptor root in store.RootCategories)
-                {
-                    // One recursive query per root — every alias in the
-                    // subtree comes back tagged with its home category, so
-                    // per-category re-queries (each of which would scan the
-                    // whole subtree again) are unnecessary. The query is
-                    // restricted to AliasFor and its subtypes because that
-                    // is the reference the materialized nodes carry;
-                    // entries a store holds under unrelated reference
-                    // types are not Part 17 §6.2 alias associations and
-                    // are served by FindAlias only.
-                    IReadOnlyList<AliasNameVerboseDataType> aliases = await store
-                        .FindAliasVerboseAsync(
-                            root.NodeId,
-                            AllAliasesPattern,
-                            ReferenceTypeIds.AliasFor,
-                            Server.TypeTree,
-                            cancellationToken).ConfigureAwait(false);
-
-                    var aliasesByCategory =
-                        new Dictionary<NodeId, List<AliasNameVerboseDataType>>();
-                    foreach (AliasNameVerboseDataType alias in aliases)
-                    {
-                        if (!aliasesByCategory.TryGetValue(
-                                alias.AliasNameCategoryId,
-                                out List<AliasNameVerboseDataType>? bucket))
-                        {
-                            bucket = [];
-                            aliasesByCategory[alias.AliasNameCategoryId] = bucket;
-                        }
-                        bucket.Add(alias);
-                    }
-
-                    await MaterializeCategoryAsync(
-                        registry,
-                        root,
-                        parent: null,
-                        aliasesByCategory,
-                        visited,
-                        externalReferences,
-                        created,
-                        cancellationToken).ConfigureAwait(false);
-                }
+                await materializer.MaterializeStoreAsync(
+                    store,
+                    externalReferences,
+                    created,
+                    visited,
+                    materializeAliasNodes: true,
+                    cancellationToken).ConfigureAwait(false);
             }
 
             m_logger.MaterializedAliasNameNodes(created.Count);
             return created.ToArrayOf();
-        }
-
-        /// <summary>
-        /// Materializes one category — reusing the predefined node when the
-        /// standard NodeSet ships it — then its aliases and sub-categories.
-        /// </summary>
-        private async ValueTask MaterializeCategoryAsync(
-            IAliasNameStoreRegistry registry,
-            AliasNameCategoryDescriptor descriptor,
-            AliasNameCategoryState? parent,
-            IReadOnlyDictionary<NodeId, List<AliasNameVerboseDataType>> aliasesByCategory,
-            HashSet<NodeId> visited,
-            IDictionary<NodeId, IList<IReference>> externalReferences,
-            List<NodeState> created,
-            CancellationToken cancellationToken)
-        {
-            AliasNameCategoryState? category =
-                FindPredefinedNode<AliasNameCategoryState>(descriptor.NodeId);
-
-            if (!visited.Add(descriptor.NodeId))
-            {
-                // Reached a second time — a descriptor shared by two
-                // parents, or a repeat materialization call. The node and
-                // its aliases already exist; only this parent's linkage
-                // can be missing.
-                if (category != null && parent != null)
-                {
-                    LinkOrganizes(parent, category);
-                }
-                return;
-            }
-
-            bool isNewCategory = category == null;
-
-            if (category == null)
-            {
-                bool creatable;
-                if (descriptor.NodeId.NamespaceIndex != m_namespaceIndex)
-                {
-                    // Only nodes in this manager's own namespace may be
-                    // minted here. Anything else is either a namespace
-                    // owned by another node manager (typically an
-                    // AliasNameNodeManager building its own nodes) or a
-                    // mis-seeded well-known id — e.g. a ns=0 descriptor
-                    // pointing at a node that is not an alias category,
-                    // which creating would silently replace.
-                    m_logger.SkippedAliasCategoryOutsideNamespace(descriptor.NodeId);
-                    creatable = false;
-                }
-                else if (PredefinedNodes.TryGetValue(descriptor.NodeId, out NodeState? occupant))
-                {
-                    // The id exists but is not an AliasNameCategoryState —
-                    // creating the category would replace the occupant.
-                    m_logger.SkippedAliasCategoryOccupiedNodeId(
-                        descriptor.NodeId, occupant.GetType().Name);
-                    creatable = false;
-                }
-                else
-                {
-                    creatable = true;
-                }
-
-                if (!creatable)
-                {
-                    // The category itself cannot be materialized, but its
-                    // sub-tree may still hold categories this manager owns
-                    // — do not swallow them. With no parent node to hang
-                    // off, they link under the standard Aliases root via
-                    // the organizer fallback below.
-                    foreach (AliasNameCategoryDescriptor child in descriptor.SubCategories)
-                    {
-                        await MaterializeCategoryAsync(
-                            registry,
-                            child,
-                            parent: null,
-                            aliasesByCategory,
-                            visited,
-                            externalReferences,
-                            created,
-                            cancellationToken).ConfigureAwait(false);
-                    }
-                    return;
-                }
-
-                category = SystemContext.CreateInstanceOfAliasNameCategoryType();
-                category.BrowseName = RehomeServerDefinedName(descriptor.BrowseName);
-                category.DisplayName = new LocalizedText(descriptor.BrowseName.Name);
-                category.SymbolicName = descriptor.BrowseName.Name!;
-                category.TypeDefinitionId = ObjectTypeIds.AliasNameCategoryType;
-                category.ReferenceTypeId = ReferenceTypeIds.Organizes;
-
-                // Mint ids for the mandatory children first — New() does not
-                // preserve a caller-assigned id — then pin the category to
-                // the descriptor's NodeId, which is the key the store and
-                // the registry dispatch on.
-                category.AssignNodeIds(SystemContext, []);
-                category.NodeId = descriptor.NodeId;
-            }
-
-            // The mandatory FindAlias is wired for every materialized
-            // category — including one that pre-existed as a predefined
-            // node (from a companion NodeSet) without a handler; without
-            // this a client would see the optional methods succeed while
-            // the mandatory one returns BadNotImplemented.
-            WireFindAlias(descriptor.NodeId, category, registry);
-
-            // Add and wire the optional Part 17 children the store's
-            // descriptor declares. For a category created above this only
-            // grows the subtree before it is registered; for a standard
-            // predefined category the new children are registered
-            // individually.
-            await ApplyCategoryCapabilitiesAsync(
-                descriptor,
-                category,
-                registry,
-                registerNewChildren: !isNewCategory,
-                created,
-                cancellationToken).ConfigureAwait(false);
-
-            if (isNewCategory)
-            {
-                // A root category from the store has no parent in the
-                // descriptor tree — link it under the standard Aliases
-                // (i=23470) object so it is discoverable by browsing (the
-                // same default AliasNameNodeManager applies via
-                // LinkToStandardAliasesObject). Without an incoming
-                // hierarchical reference the node would exist but be
-                // reachable only by NodeId, defeating the Part 17 §6.2
-                // browse-discovery purpose of materialization.
-                AliasNameCategoryState? organizer = parent ??
-                    (category.NodeId != ObjectIds.Aliases
-                        ? FindPredefinedNode<AliasNameCategoryState>(ObjectIds.Aliases)
-                        : null);
-                if (organizer != null)
-                {
-                    LinkOrganizes(organizer, category);
-                }
-
-                await AddPredefinedNodeAsync(SystemContext, category, cancellationToken)
-                    .ConfigureAwait(false);
-                created.Add(category);
-            }
-            else if (parent != null)
-            {
-                LinkOrganizes(parent, category);
-            }
-
-            await MaterializeAliasesAsync(
-                descriptor,
-                category,
-                aliasesByCategory.TryGetValue(
-                    descriptor.NodeId, out List<AliasNameVerboseDataType>? bucket)
-                    ? bucket
-                    : null,
-                externalReferences,
-                created,
-                cancellationToken).ConfigureAwait(false);
-
-            foreach (AliasNameCategoryDescriptor child in descriptor.SubCategories)
-            {
-                await MaterializeCategoryAsync(
-                    registry,
-                    child,
-                    category,
-                    aliasesByCategory,
-                    visited,
-                    externalReferences,
-                    created,
-                    cancellationToken).ConfigureAwait(false);
-            }
-        }
-
-        /// <summary>
-        /// Adds the forward and inverse <c>Organizes</c> pair between two
-        /// category nodes, tolerating either half already being present —
-        /// <c>NodeState.AddReference</c> throws on duplicates.
-        /// </summary>
-        private static void LinkOrganizes(
-            AliasNameCategoryState parent,
-            AliasNameCategoryState child)
-        {
-            if (!parent.ReferenceExists(ReferenceTypeIds.Organizes, false, child.NodeId))
-            {
-                parent.AddReference(ReferenceTypeIds.Organizes, false, child.NodeId);
-            }
-            if (!child.ReferenceExists(ReferenceTypeIds.Organizes, true, parent.NodeId))
-            {
-                child.AddReference(ReferenceTypeIds.Organizes, true, parent.NodeId);
-            }
-        }
-
-        /// <summary>
-        /// Moves a server-defined name out of namespace 0, which Part 3
-        /// reserves for OPC-Foundation-defined names. Store descriptors
-        /// commonly inherit namespace 0 from the well-known categories'
-        /// BrowseNames; publishing server-specific aliases there is a
-        /// conformance violation and can even duplicate a standard child
-        /// name (an alias literally called "FindAlias"). Part 17 §6.2
-        /// clients compare alias names ignoring the namespace, so
-        /// re-homing is transparent to them.
-        /// </summary>
-        private QualifiedName RehomeServerDefinedName(QualifiedName name)
-        {
-            return name.NamespaceIndex == 0 && !string.IsNullOrEmpty(name.Name)
-                ? new QualifiedName(name.Name, m_namespaceIndex)
-                : name;
-        }
-
-        /// <summary>
-        /// Instantiates and wires the optional Part 17 children a category
-        /// declares through <see cref="AliasNameCategoryDescriptor.Capabilities"/>:
-        /// <c>FindAliasVerbose</c> (§6.3.3), <c>AddAliasesToCategory</c>
-        /// (§6.3.4), <c>DeleteAliasesFromCategory</c> (§6.3.5) and
-        /// <c>LastChange</c> (§6.3.1).
-        /// </summary>
-        /// <remarks>
-        /// The standard NodeSet instantiates none of these on the
-        /// well-known <c>Aliases</c>/<c>TagVariables</c>/<c>Topics</c>
-        /// objects (only <c>FindAlias</c>, plus <c>LastChange</c> on
-        /// <c>Aliases</c>), so the generated <c>Add…</c> helpers create them
-        /// here — at the NodeIds
-        /// <see cref="ReservedChildIds"/> supplies for the well-known
-        /// parents, and at factory-minted ids for an application-defined
-        /// category.
-        /// </remarks>
-        private async ValueTask ApplyCategoryCapabilitiesAsync(
-            AliasNameCategoryDescriptor descriptor,
-            AliasNameCategoryState category,
-            IAliasNameStoreRegistry registry,
-            bool registerNewChildren,
-            List<NodeState> created,
-            CancellationToken cancellationToken)
-        {
-            AliasNameCapabilities capabilities = descriptor.Capabilities;
-            ReservedChildIds reserved = ReservedChildIds.For(descriptor.NodeId);
-            NodeId categoryId = descriptor.NodeId;
-            var addedChildren = new List<NodeState>();
-
-            // Each optional child is created AND wired only under its
-            // capability flag: a child that already exists on the node (a
-            // companion NodeSet may ship one) but that the descriptor did
-            // not declare stays unwired — otherwise a category declared
-            // read-only would silently accept mutations.
-            if ((capabilities & AliasNameCapabilities.FindAliasVerbose) != 0)
-            {
-                if (category.FindAliasVerbose == null)
-                {
-                    category.AddFindAliasVerbose(
-                        SystemContext, reserved.FindAliasVerbose.Method);
-                    ApplyReservedArgumentIds(
-                        category.FindAliasVerbose, reserved.FindAliasVerbose);
-                    addedChildren.Add(category.FindAliasVerbose!);
-                }
-
-                category.FindAliasVerbose!.OnCallAsync =
-                    (ctx, method, objId, pattern, refType, ct) =>
-                        AliasNameMethodDispatcher.FindAliasVerboseAsync(
-                            registry,
-                            Server.TypeTree,
-                            objId.IsNull ? categoryId : objId,
-                            pattern,
-                            refType,
-                            ct);
-            }
-
-            if ((capabilities & AliasNameCapabilities.AddAliasesToCategory) != 0)
-            {
-                if (category.AddAliasesToCategory == null)
-                {
-                    category.AddAddAliasesToCategory(
-                        SystemContext, reserved.AddAliasesToCategory.Method);
-                    ApplyReservedArgumentIds(
-                        category.AddAliasesToCategory, reserved.AddAliasesToCategory);
-                    addedChildren.Add(category.AddAliasesToCategory!);
-                }
-
-                category.AddAliasesToCategory!.OnCallAsync =
-                    (ctx, method, objId, names, targets, servers, refType, ct) =>
-                        !AliasNameMethodDispatcher.HasSecureAdminAccess(ctx)
-                            ? new ValueTask<AddAliasesToCategoryMethodStateResult>(
-                                new AddAliasesToCategoryMethodStateResult
-                                {
-                                    ServiceResult = new ServiceResult(StatusCodes.BadUserAccessDenied),
-                                    ErrorCodes = default
-                                })
-                            : AliasNameMethodDispatcher.AddAliasesAsync(
-                                registry,
-                                objId.IsNull ? categoryId : objId,
-                                names,
-                                targets,
-                                servers,
-                                refType,
-                                ct);
-            }
-
-            if ((capabilities & AliasNameCapabilities.DeleteAliasesFromCategory) != 0)
-            {
-                if (category.DeleteAliasesFromCategory == null)
-                {
-                    category.AddDeleteAliasesFromCategory(
-                        SystemContext, reserved.DeleteAliasesFromCategory.Method);
-                    ApplyReservedArgumentIds(
-                        category.DeleteAliasesFromCategory, reserved.DeleteAliasesFromCategory);
-                    addedChildren.Add(category.DeleteAliasesFromCategory!);
-                }
-
-                category.DeleteAliasesFromCategory!.OnCallAsync =
-                    (ctx, method, objId, names, targets, ct) =>
-                        !AliasNameMethodDispatcher.HasSecureAdminAccess(ctx)
-                            ? new ValueTask<DeleteAliasesFromCategoryMethodStateResult>(
-                                new DeleteAliasesFromCategoryMethodStateResult
-                                {
-                                    ServiceResult = new ServiceResult(StatusCodes.BadUserAccessDenied),
-                                    ErrorCodes = default
-                                })
-                            : AliasNameMethodDispatcher.DeleteAliasesAsync(
-                                registry,
-                                objId.IsNull ? categoryId : objId,
-                                names,
-                                targets,
-                                ct);
-            }
-
-            if ((capabilities & AliasNameCapabilities.LastChange) != 0)
-            {
-                if (category.LastChange == null)
-                {
-                    category.AddLastChange(SystemContext, reserved.LastChange);
-                    addedChildren.Add(category.LastChange!);
-                }
-
-                BindLastChange(categoryId, category, registry);
-            }
-
-            // Every added child is reported to the caller; only children
-            // of an already-registered category also need individual
-            // registration — a category not yet registered covers its
-            // whole subtree when it is.
-            created.AddRange(addedChildren);
-            if (registerNewChildren)
-            {
-                foreach (NodeState child in addedChildren)
-                {
-                    await AddPredefinedNodeAsync(SystemContext, child, cancellationToken)
-                        .ConfigureAwait(false);
-                }
-            }
-        }
-
-        /// <summary>
-        /// Pins a method's argument properties to their reserved NodeIds.
-        /// The generated <c>Add…</c> helper rebases the arguments through
-        /// the node-id factory when it is handed an explicit method NodeId,
-        /// so they have to be re-pinned afterwards. A no-op when the
-        /// category has no reserved allocation.
-        /// </summary>
-        private static void ApplyReservedArgumentIds(
-            MethodState? method,
-            ReservedMethodIds reserved)
-        {
-            if (method == null || reserved.Method.IsNull)
-            {
-                return;
-            }
-            if (method.InputArguments != null)
-            {
-                method.InputArguments.NodeId = reserved.InputArguments;
-            }
-            if (method.OutputArguments != null)
-            {
-                method.OutputArguments.NodeId = reserved.OutputArguments;
-            }
-        }
-
-        /// <summary>
-        /// Creates one <c>AliasNameType</c> instance per alias whose home
-        /// category is <paramref name="descriptor"/> — the bucket handed in
-        /// holds exactly those. Aliases contributed by sub-categories are
-        /// materialized under their own category.
-        /// </summary>
-        private async ValueTask MaterializeAliasesAsync(
-            AliasNameCategoryDescriptor descriptor,
-            AliasNameCategoryState category,
-            List<AliasNameVerboseDataType>? aliases,
-            IDictionary<NodeId, IList<IReference>> externalReferences,
-            List<NodeState> created,
-            CancellationToken cancellationToken)
-        {
-            if (aliases == null || aliases.Count == 0)
-            {
-                return;
-            }
-
-            // One node per alias name; the store reports a separate record
-            // per reference type, and a name may carry several targets.
-            // Duplicate targets — including the same node seeded once in
-            // namespace-URI form and once in index form — are absorbed by
-            // the ReferenceExists guards in AddAliasForReference.
-            var byName = new Dictionary<string, AliasNameState>();
-
-            foreach (AliasNameVerboseDataType alias in aliases)
-            {
-                if (string.IsNullOrEmpty(alias.AliasName.Name))
-                {
-                    continue;
-                }
-
-                string name = alias.AliasName.Name!;
-                if (!byName.TryGetValue(name, out AliasNameState? aliasNode))
-                {
-                    aliasNode = await GetOrCreateAliasNodeAsync(
-                        descriptor, category, alias.AliasName, name, created,
-                        cancellationToken).ConfigureAwait(false);
-                    byName[name] = aliasNode;
-                }
-
-                for (int ii = 0; ii < alias.ReferencedNodes.Count; ii++)
-                {
-                    AddAliasForReference(
-                        aliasNode,
-                        alias.ReferencedNodes[ii],
-                        ii < alias.ServerUris.Count ? alias.ServerUris[ii] : null,
-                        externalReferences);
-                }
-            }
-        }
-
-        /// <summary>
-        /// Resolves or builds the <c>AliasNameType</c> instance for one
-        /// alias. Per Part 17 §6.2 the BrowseName carries the alias name
-        /// and the DisplayName repeats it with an empty locale.
-        /// </summary>
-        /// <remarks>
-        /// The deterministic string id minted from category id + alias name
-        /// is ambiguous — <c>"…s=A"</c> with alias <c>"B.C"</c> and
-        /// <c>"…s=A.B"</c> with alias <c>"C"</c> concatenate identically —
-        /// and a repeat materialization revisits ids it minted before. A
-        /// node already registered under the minted id is therefore reused
-        /// when it is the same alias, and a different occupant makes this
-        /// alias fall back to a factory-minted id instead of silently
-        /// replacing the occupant (<c>AddPredefinedNode</c> overwrites).
-        /// </remarks>
-        private async ValueTask<AliasNameState> GetOrCreateAliasNodeAsync(
-            AliasNameCategoryDescriptor descriptor,
-            AliasNameCategoryState category,
-            QualifiedName aliasName,
-            string name,
-            List<NodeState> created,
-            CancellationToken cancellationToken)
-        {
-            var mintedId = new NodeId(
-                Utils.Format("{0}.{1}", descriptor.NodeId, name),
-                m_namespaceIndex);
-
-            if (PredefinedNodes.TryGetValue(mintedId, out NodeState? existing))
-            {
-                if (existing is AliasNameState existingAlias &&
-                    existingAlias.BrowseName.Name == name)
-                {
-                    LinkAliasToCategory(category, existingAlias);
-                    return existingAlias;
-                }
-
-                m_logger.AliasNameNodeIdCollision(mintedId, name);
-                mintedId = NodeId.Null;
-            }
-
-            AliasNameState aliasNode = SystemContext.CreateInstanceOfAliasNameType();
-
-            aliasNode.NodeId = mintedId.IsNull
-                ? New(SystemContext, aliasNode)
-                : mintedId;
-            aliasNode.BrowseName = RehomeServerDefinedName(aliasName);
-            aliasNode.DisplayName = new LocalizedText(string.Empty, name);
-            aliasNode.SymbolicName = name;
-            aliasNode.TypeDefinitionId = ObjectTypeIds.AliasNameType;
-            aliasNode.ReferenceTypeId = ReferenceTypeIds.Organizes;
-
-            LinkAliasToCategory(category, aliasNode);
-
-            await AddPredefinedNodeAsync(SystemContext, aliasNode, cancellationToken)
-                .ConfigureAwait(false);
-            created.Add(aliasNode);
-            return aliasNode;
-        }
-
-        /// <summary>
-        /// Adds the forward and inverse <c>Organizes</c> pair between a
-        /// category and an alias node, tolerating either half already
-        /// being present.
-        /// </summary>
-        private static void LinkAliasToCategory(
-            AliasNameCategoryState category,
-            AliasNameState aliasNode)
-        {
-            if (!category.ReferenceExists(ReferenceTypeIds.Organizes, false, aliasNode.NodeId))
-            {
-                category.AddReference(ReferenceTypeIds.Organizes, false, aliasNode.NodeId);
-            }
-            if (!aliasNode.ReferenceExists(ReferenceTypeIds.Organizes, true, category.NodeId))
-            {
-                aliasNode.AddReference(ReferenceTypeIds.Organizes, true, category.NodeId);
-            }
-        }
-
-        /// <summary>
-        /// Adds the forward <c>AliasFor</c> reference to a target and — for
-        /// targets on this server — the inverse <c>HasAlias</c> reference
-        /// back, which usually lands in another node manager and therefore
-        /// travels through <paramref name="externalReferences"/>.
-        /// </summary>
-        private void AddAliasForReference(
-            AliasNameState aliasNode,
-            ExpandedNodeId target,
-            string? serverUri,
-            IDictionary<NodeId, IList<IReference>> externalReferences)
-        {
-            if (target.IsNull)
-            {
-                return;
-            }
-
-            if (!string.IsNullOrEmpty(serverUri))
-            {
-                // A target on a remote server has no local node to carry
-                // the inverse reference. Register the URI in the server
-                // table and stamp its index onto the reference target, so
-                // clients can resolve which server owns the node via the
-                // ServerArray — an ExpandedNodeId with ServerIndex 0 would
-                // misreport the target as local.
-                uint serverIndex = Server.ServerUris.GetIndexOrAppend(serverUri!);
-                ExpandedNodeId remoteTarget = target.WithServerIndex(serverIndex);
-                if (!aliasNode.ReferenceExists(ReferenceTypeIds.AliasFor, false, remoteTarget))
-                {
-                    aliasNode.AddReference(ReferenceTypeIds.AliasFor, false, remoteTarget);
-                }
-                return;
-            }
-
-            // Resolve the namespace-uri form a store may have been seeded
-            // with, so the reference carries a plain local NodeId. The
-            // duplicate check runs on the RESOLVED id — the same target
-            // seeded once in URI form and once in index form must produce
-            // one reference, and AddReference throws on duplicates.
-            var localTarget = ExpandedNodeId.ToNodeId(target, Server.NamespaceUris);
-            if (localTarget.IsNull)
-            {
-                if (!aliasNode.ReferenceExists(ReferenceTypeIds.AliasFor, false, target))
-                {
-                    aliasNode.AddReference(ReferenceTypeIds.AliasFor, false, target);
-                }
-                return;
-            }
-
-            if (aliasNode.ReferenceExists(ReferenceTypeIds.AliasFor, false, localTarget))
-            {
-                return;
-            }
-
-            aliasNode.AddReference(ReferenceTypeIds.AliasFor, false, localTarget);
-
-            // The inverse reference travels only with a newly added
-            // forward reference, so repeat materializations do not queue
-            // duplicate external references for the target's manager.
-            AddExternalReference(
-                localTarget,
-                ReferenceTypeIds.AliasFor,
-                true,
-                aliasNode.NodeId,
-                externalReferences);
         }
 
         private void OnAliasRegistryChanged(object? sender, AliasStoreChangedEventArgs e)
@@ -903,108 +259,75 @@ namespace Opc.Ua.Server
             }
         }
 
-        /// <summary>
-        /// The Part 4 §7.40 Like-pattern that matches every alias name.
-        /// </summary>
-        private const string AllAliasesPattern = "%";
+        ISystemContext IAliasNameMaterializerHost.SystemContext => SystemContext;
 
-        /// <summary>
-        /// The reserved NodeIds of one optional method and its two argument
-        /// properties. <see cref="Method"/> is <see cref="NodeId.Null"/> for
-        /// a category with no reserved allocation, which makes the generated
-        /// <c>Add…</c> helper fall back to the node-id factory.
-        /// </summary>
-        private readonly record struct ReservedMethodIds(
-            NodeId Method,
-            NodeId InputArguments,
-            NodeId OutputArguments);
+        ITypeTable IAliasNameMaterializerHost.TypeTree => Server.TypeTree;
 
-        /// <summary>
-        /// The NodeIds the OPC Foundation reserves for the optional Part 17
-        /// children of the three well-known categories.
-        /// </summary>
-        /// <remarks>
-        /// <para>
-        /// These identifiers are allocated in the standard identifier
-        /// registry — <c>StandardTypes.csv</c>, rows <c>Aliases_FindAliasVerbose,24054</c>
-        /// through <c>Topics_DeleteAliasesFromCategory_OutputArguments,24080</c>,
-        /// plus <c>TagVariables_LastChange,32854</c> and
-        /// <c>Topics_LastChange,32856</c> — so a server that instantiates
-        /// one of these optional children has a canonical NodeId for it.
-        /// </para>
-        /// <para>
-        /// They are deliberately absent from both the ModelDesign and the
-        /// published NodeSet: the standard address space does not
-        /// instantiate optional children, so the source generator has no
-        /// parent-to-instance mapping to emit and no <c>MethodIds</c>
-        /// constant exists for them. The argument properties do have
-        /// generated <c>VariableIds</c> constants and are referenced through
-        /// those; only the nine method identifiers and the two
-        /// <c>LastChange</c> identifiers are spelled out here, each
-        /// traceable to its registry row.
-        /// </para>
-        /// </remarks>
-        private readonly record struct ReservedChildIds(
-            ReservedMethodIds FindAliasVerbose,
-            ReservedMethodIds AddAliasesToCategory,
-            ReservedMethodIds DeleteAliasesFromCategory,
-            NodeId LastChange)
+        NamespaceTable IAliasNameMaterializerHost.NamespaceUris => Server.NamespaceUris;
+
+        StringTable IAliasNameMaterializerHost.ServerUris => Server.ServerUris;
+
+        ushort IAliasNameMaterializerHost.MaterializationNamespaceIndex => m_namespaceIndex;
+
+        AliasNameCategoryState? IAliasNameMaterializerHost.FindCategoryNode(NodeId nodeId)
         {
-            public static ReservedChildIds For(NodeId categoryId)
+            return FindPredefinedNode<AliasNameCategoryState>(nodeId);
+        }
+
+        bool IAliasNameMaterializerHost.TryGetNode(NodeId nodeId, out NodeState? node)
+        {
+            return PredefinedNodes.TryGetValue(nodeId, out node);
+        }
+
+        ValueTask IAliasNameMaterializerHost.RegisterNodeAsync(
+            NodeState node, CancellationToken cancellationToken)
+        {
+            return AddPredefinedNodeAsync(SystemContext, node, cancellationToken);
+        }
+
+        NodeId IAliasNameMaterializerHost.MintNodeId(NodeState node)
+        {
+            return New(SystemContext, node);
+        }
+
+        void IAliasNameMaterializerHost.LinkRootCategory(
+            AliasNameCategoryState root,
+            IDictionary<NodeId, IList<IReference>> externalReferences)
+        {
+            // The standard Aliases (i=23470) object is one of this
+            // manager's own predefined nodes, so the linkage is direct —
+            // no external references needed. A root that IS the standard
+            // Aliases node is the hierarchy root itself.
+            if (root.NodeId == ObjectIds.Aliases)
             {
-                return s_reserved.TryGetValue(categoryId, out ReservedChildIds ids)
-                    ? ids
-                    : default;
+                return;
             }
 
-            // One row per well-known category; the numeric literals are the
-            // Method rows of StandardTypes.csv, the VariableIds constants
-            // its Variable rows.
-            private static readonly Dictionary<NodeId, ReservedChildIds> s_reserved = new()
+            AliasNameCategoryState? aliasesRoot =
+                FindPredefinedNode<AliasNameCategoryState>(ObjectIds.Aliases);
+            if (aliasesRoot != null)
             {
-                [ObjectIds.Aliases] = new ReservedChildIds(
-                    new ReservedMethodIds(
-                        new NodeId(24054u),
-                        VariableIds.Aliases_FindAliasVerbose_InputArguments,
-                        VariableIds.Aliases_FindAliasVerbose_OutputArguments),
-                    new ReservedMethodIds(
-                        new NodeId(24057u),
-                        VariableIds.Aliases_AddAliasesToCategory_InputArguments,
-                        VariableIds.Aliases_AddAliasesToCategory_OutputArguments),
-                    new ReservedMethodIds(
-                        new NodeId(24060u),
-                        VariableIds.Aliases_DeleteAliasesFromCategory_InputArguments,
-                        VariableIds.Aliases_DeleteAliasesFromCategory_OutputArguments),
-                    VariableIds.Aliases_LastChange),
-                [ObjectIds.TagVariables] = new ReservedChildIds(
-                    new ReservedMethodIds(
-                        new NodeId(24063u),
-                        VariableIds.TagVariables_FindAliasVerbose_InputArguments,
-                        VariableIds.TagVariables_FindAliasVerbose_OutputArguments),
-                    new ReservedMethodIds(
-                        new NodeId(24066u),
-                        VariableIds.TagVariables_AddAliasesToCategory_InputArguments,
-                        VariableIds.TagVariables_AddAliasesToCategory_OutputArguments),
-                    new ReservedMethodIds(
-                        new NodeId(24069u),
-                        VariableIds.TagVariables_DeleteAliasesFromCategory_InputArguments,
-                        VariableIds.TagVariables_DeleteAliasesFromCategory_OutputArguments),
-                    new NodeId(32854u)),
-                [ObjectIds.Topics] = new ReservedChildIds(
-                    new ReservedMethodIds(
-                        new NodeId(24072u),
-                        VariableIds.Topics_FindAliasVerbose_InputArguments,
-                        VariableIds.Topics_FindAliasVerbose_OutputArguments),
-                    new ReservedMethodIds(
-                        new NodeId(24075u),
-                        VariableIds.Topics_AddAliasesToCategory_InputArguments,
-                        VariableIds.Topics_AddAliasesToCategory_OutputArguments),
-                    new ReservedMethodIds(
-                        new NodeId(24078u),
-                        VariableIds.Topics_DeleteAliasesFromCategory_InputArguments,
-                        VariableIds.Topics_DeleteAliasesFromCategory_OutputArguments),
-                    new NodeId(32856u))
-            };
+                AliasNameNodeMaterializer.LinkOrganizes(aliasesRoot, root);
+            }
+        }
+
+        void IAliasNameMaterializerHost.AddInverseAliasReference(
+            NodeId targetId,
+            NodeId aliasNodeId,
+            IDictionary<NodeId, IList<IReference>> externalReferences)
+        {
+            AddExternalReference(
+                targetId,
+                ReferenceTypeIds.AliasFor,
+                true,
+                aliasNodeId,
+                externalReferences);
+        }
+
+        void IAliasNameMaterializerHost.OnLastChangeBound(
+            NodeId categoryId, PropertyState<uint> lastChange)
+        {
+            m_lastChangeNodes[categoryId] = lastChange;
         }
 
         private IAliasNameStoreRegistry? m_aliasRegistry;
@@ -1023,28 +346,5 @@ namespace Opc.Ua.Server
         /// it during disposal.
         /// </summary>
         private readonly ConcurrentDictionary<NodeId, PropertyState<uint>> m_lastChangeNodes = [];
-    }
-
-    /// <summary>
-    /// Source-generated log messages for the Part 17 parts of
-    /// DiagnosticsNodeManager.
-    /// </summary>
-    internal static partial class DiagnosticsNodeManagerAliasNamesLog
-    {
-        [LoggerMessage(EventId = ServerEventIds.DiagnosticsNodeManager + 1, Level = LogLevel.Information,
-            Message = "Materialized {Count} Part 17 alias name nodes from the registered alias stores.")]
-        public static partial void MaterializedAliasNameNodes(this ILogger logger, int count);
-
-        [LoggerMessage(EventId = ServerEventIds.DiagnosticsNodeManager + 2, Level = LogLevel.Warning,
-            Message = "Skipped alias category {CategoryId}: its NodeId is outside the diagnostics namespace, so it belongs to another node manager or is a mis-seeded well-known id.")]
-        public static partial void SkippedAliasCategoryOutsideNamespace(this ILogger logger, NodeId categoryId);
-
-        [LoggerMessage(EventId = ServerEventIds.DiagnosticsNodeManager + 3, Level = LogLevel.Warning,
-            Message = "Skipped alias category {CategoryId}: the NodeId is already registered by a node of type {OccupantType}.")]
-        public static partial void SkippedAliasCategoryOccupiedNodeId(this ILogger logger, NodeId categoryId, string occupantType);
-
-        [LoggerMessage(EventId = ServerEventIds.DiagnosticsNodeManager + 4, Level = LogLevel.Warning,
-            Message = "Alias name NodeId {MintedId} for alias '{AliasName}' collides with an existing node; a factory-minted NodeId is used instead.")]
-        public static partial void AliasNameNodeIdCollision(this ILogger logger, NodeId mintedId, string aliasName);
     }
 }

--- a/src/Opc.Ua.Server/Diagnostics/DiagnosticsNodeManager.AliasNames.cs
+++ b/src/Opc.Ua.Server/Diagnostics/DiagnosticsNodeManager.AliasNames.cs
@@ -128,15 +128,14 @@ namespace Opc.Ua.Server
                 return;
             }
 
-            foreach (IAliasNameStore store in registry.Stores)
+            // The registry's ownership map is authoritative — asking every
+            // store in turn would seed from whichever store happens to
+            // answer first for a category it does not own.
+            uint? seed = registry.GetStoreForCategory(categoryId)?.GetLastChange(categoryId);
+            if (seed.HasValue)
             {
-                uint? seed = store.GetLastChange(categoryId);
-                if (seed.HasValue)
-                {
-                    category.LastChange.Value = seed.Value;
-                    category.LastChange.ClearChangeMasks(SystemContext, false);
-                    break;
-                }
+                category.LastChange.Value = seed.Value;
+                category.LastChange.ClearChangeMasks(SystemContext, false);
             }
 
             m_lastChangeNodes[categoryId] = category.LastChange;
@@ -196,8 +195,10 @@ namespace Opc.Ua.Server
         /// Call from an overridden <c>CreateAddressSpaceAsync</c> after
         /// <c>base.CreateAddressSpaceAsync</c> — the standard categories
         /// must already be loaded and the stores registered. The created
-        /// nodes are imported into the <c>CoreNodeManager</c> so they are
-        /// reachable by Browse, and are also returned for inspection.
+        /// nodes are registered as predefined nodes of this manager, which
+        /// serves Browse and Call for them; they are also returned for
+        /// inspection. The method is idempotent: a repeat call (after
+        /// another store registered, say) only adds what is missing.
         /// </para>
         /// </remarks>
         /// <param name="externalReferences">The dictionary supplied to
@@ -206,45 +207,75 @@ namespace Opc.Ua.Server
         /// managers.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>The nodes created by this call.</returns>
-        protected async ValueTask<IReadOnlyList<NodeState>> MaterializeRegisteredAliasNameNodesAsync(
+        protected async ValueTask<ArrayOf<NodeState>> MaterializeRegisteredAliasNameNodesAsync(
             IDictionary<NodeId, IList<IReference>> externalReferences,
             CancellationToken cancellationToken = default)
         {
-            var created = new List<NodeState>();
-
-            IAliasNameStoreRegistry? registry = m_aliasRegistry ??
-                (Server as IAliasNameStoreRegistryProvider)?.AliasNameStoreRegistry;
+            // Materialization requires the registry wiring performed by
+            // WireStandardAliasMethods — without it the categories'
+            // LastChange would never update and the standard FindAlias
+            // methods would stay unwired, a half-functional Part 17
+            // surface. That method ran from base.CreateAddressSpaceAsync,
+            // so a null here means the server does not implement
+            // IAliasNameStoreRegistryProvider at all.
+            IAliasNameStoreRegistry? registry = m_aliasRegistry;
             if (registry == null)
             {
-                return created;
+                return [];
             }
+
+            var created = new List<NodeState>();
+            var visited = new HashSet<NodeId>();
 
             foreach (IAliasNameStore store in registry.Stores)
             {
                 foreach (AliasNameCategoryDescriptor root in store.RootCategories)
                 {
+                    // One recursive query per root — every alias in the
+                    // subtree comes back tagged with its home category, so
+                    // per-category re-queries (each of which would scan the
+                    // whole subtree again) are unnecessary. The query is
+                    // restricted to AliasFor and its subtypes because that
+                    // is the reference the materialized nodes carry;
+                    // entries a store holds under unrelated reference
+                    // types are not Part 17 §6.2 alias associations and
+                    // are served by FindAlias only.
+                    IReadOnlyList<AliasNameVerboseDataType> aliases = await store
+                        .FindAliasVerboseAsync(
+                            root.NodeId,
+                            AllAliasesPattern,
+                            ReferenceTypeIds.AliasFor,
+                            Server.TypeTree,
+                            cancellationToken).ConfigureAwait(false);
+
+                    var aliasesByCategory =
+                        new Dictionary<NodeId, List<AliasNameVerboseDataType>>();
+                    foreach (AliasNameVerboseDataType alias in aliases)
+                    {
+                        if (!aliasesByCategory.TryGetValue(
+                                alias.AliasNameCategoryId,
+                                out List<AliasNameVerboseDataType>? bucket))
+                        {
+                            bucket = [];
+                            aliasesByCategory[alias.AliasNameCategoryId] = bucket;
+                        }
+                        bucket.Add(alias);
+                    }
+
                     await MaterializeCategoryAsync(
-                        store,
                         registry,
                         root,
                         parent: null,
+                        aliasesByCategory,
+                        visited,
                         externalReferences,
                         created,
                         cancellationToken).ConfigureAwait(false);
                 }
             }
 
-            if (created.Count > 0)
-            {
-                await Server.CoreNodeManager.ImportNodesAsync(
-                    SystemContext,
-                    created,
-                    true,
-                    cancellationToken).ConfigureAwait(false);
-            }
-
             m_logger.MaterializedAliasNameNodes(created.Count);
-            return created;
+            return created.ToArrayOf();
         }
 
         /// <summary>
@@ -252,31 +283,85 @@ namespace Opc.Ua.Server
         /// standard NodeSet ships it — then its aliases and sub-categories.
         /// </summary>
         private async ValueTask MaterializeCategoryAsync(
-            IAliasNameStore store,
             IAliasNameStoreRegistry registry,
             AliasNameCategoryDescriptor descriptor,
             AliasNameCategoryState? parent,
+            IReadOnlyDictionary<NodeId, List<AliasNameVerboseDataType>> aliasesByCategory,
+            HashSet<NodeId> visited,
             IDictionary<NodeId, IList<IReference>> externalReferences,
             List<NodeState> created,
             CancellationToken cancellationToken)
         {
             AliasNameCategoryState? category =
                 FindPredefinedNode<AliasNameCategoryState>(descriptor.NodeId);
-            bool isNewCategory = category == null;
 
-            if (category == null && !IsNodeIdInNamespace(descriptor.NodeId))
+            if (!visited.Add(descriptor.NodeId))
             {
-                // The category belongs to another node manager — typically an
-                // AliasNameNodeManager that registered its store with the
-                // server-wide registry and builds these nodes itself.
-                // Creating them here would claim its NodeIds a second time.
+                // Reached a second time — a descriptor shared by two
+                // parents, or a repeat materialization call. The node and
+                // its aliases already exist; only this parent's linkage
+                // can be missing.
+                if (category != null && parent != null)
+                {
+                    LinkOrganizes(parent, category);
+                }
                 return;
             }
 
+            bool isNewCategory = category == null;
+
             if (category == null)
             {
+                bool creatable;
+                if (descriptor.NodeId.NamespaceIndex != m_namespaceIndex)
+                {
+                    // Only nodes in this manager's own namespace may be
+                    // minted here. Anything else is either a namespace
+                    // owned by another node manager (typically an
+                    // AliasNameNodeManager building its own nodes) or a
+                    // mis-seeded well-known id — e.g. a ns=0 descriptor
+                    // pointing at a node that is not an alias category,
+                    // which creating would silently replace.
+                    m_logger.SkippedAliasCategoryOutsideNamespace(descriptor.NodeId);
+                    creatable = false;
+                }
+                else if (PredefinedNodes.TryGetValue(descriptor.NodeId, out NodeState? occupant))
+                {
+                    // The id exists but is not an AliasNameCategoryState —
+                    // creating the category would replace the occupant.
+                    m_logger.SkippedAliasCategoryOccupiedNodeId(
+                        descriptor.NodeId, occupant.GetType().Name);
+                    creatable = false;
+                }
+                else
+                {
+                    creatable = true;
+                }
+
+                if (!creatable)
+                {
+                    // The category itself cannot be materialized, but its
+                    // sub-tree may still hold categories this manager owns
+                    // — do not swallow them. With no parent node to hang
+                    // off, they link under the standard Aliases root via
+                    // the organizer fallback below.
+                    foreach (AliasNameCategoryDescriptor child in descriptor.SubCategories)
+                    {
+                        await MaterializeCategoryAsync(
+                            registry,
+                            child,
+                            parent: null,
+                            aliasesByCategory,
+                            visited,
+                            externalReferences,
+                            created,
+                            cancellationToken).ConfigureAwait(false);
+                    }
+                    return;
+                }
+
                 category = SystemContext.CreateInstanceOfAliasNameCategoryType();
-                category.BrowseName = descriptor.BrowseName;
+                category.BrowseName = RehomeServerDefinedName(descriptor.BrowseName);
                 category.DisplayName = new LocalizedText(descriptor.BrowseName.Name);
                 category.SymbolicName = descriptor.BrowseName.Name!;
                 category.TypeDefinitionId = ObjectTypeIds.AliasNameCategoryType;
@@ -288,9 +373,14 @@ namespace Opc.Ua.Server
                 // the registry dispatch on.
                 category.AssignNodeIds(SystemContext, []);
                 category.NodeId = descriptor.NodeId;
-
-                WireFindAlias(descriptor.NodeId, category, registry);
             }
+
+            // The mandatory FindAlias is wired for every materialized
+            // category — including one that pre-existed as a predefined
+            // node (from a companion NodeSet) without a handler; without
+            // this a client would see the optional methods succeed while
+            // the mandatory one returns BadNotImplemented.
+            WireFindAlias(descriptor.NodeId, category, registry);
 
             // Add and wire the optional Part 17 children the store's
             // descriptor declares. For a category created above this only
@@ -307,32 +397,91 @@ namespace Opc.Ua.Server
 
             if (isNewCategory)
             {
-                if (parent != null)
+                // A root category from the store has no parent in the
+                // descriptor tree — link it under the standard Aliases
+                // (i=23470) object so it is discoverable by browsing (the
+                // same default AliasNameNodeManager applies via
+                // LinkToStandardAliasesObject). Without an incoming
+                // hierarchical reference the node would exist but be
+                // reachable only by NodeId, defeating the Part 17 §6.2
+                // browse-discovery purpose of materialization.
+                AliasNameCategoryState? organizer = parent ??
+                    (category.NodeId != ObjectIds.Aliases
+                        ? FindPredefinedNode<AliasNameCategoryState>(ObjectIds.Aliases)
+                        : null);
+                if (organizer != null)
                 {
-                    parent.AddReference(ReferenceTypeIds.Organizes, false, category.NodeId);
-                    category.AddReference(ReferenceTypeIds.Organizes, true, parent.NodeId);
+                    LinkOrganizes(organizer, category);
                 }
 
                 await AddPredefinedNodeAsync(SystemContext, category, cancellationToken)
                     .ConfigureAwait(false);
                 created.Add(category);
             }
+            else if (parent != null)
+            {
+                LinkOrganizes(parent, category);
+            }
 
             await MaterializeAliasesAsync(
-                store, descriptor, category, externalReferences, created, cancellationToken)
-                .ConfigureAwait(false);
+                descriptor,
+                category,
+                aliasesByCategory.TryGetValue(
+                    descriptor.NodeId, out List<AliasNameVerboseDataType>? bucket)
+                    ? bucket
+                    : null,
+                externalReferences,
+                created,
+                cancellationToken).ConfigureAwait(false);
 
             foreach (AliasNameCategoryDescriptor child in descriptor.SubCategories)
             {
                 await MaterializeCategoryAsync(
-                    store,
                     registry,
                     child,
                     category,
+                    aliasesByCategory,
+                    visited,
                     externalReferences,
                     created,
                     cancellationToken).ConfigureAwait(false);
             }
+        }
+
+        /// <summary>
+        /// Adds the forward and inverse <c>Organizes</c> pair between two
+        /// category nodes, tolerating either half already being present —
+        /// <c>NodeState.AddReference</c> throws on duplicates.
+        /// </summary>
+        private static void LinkOrganizes(
+            AliasNameCategoryState parent,
+            AliasNameCategoryState child)
+        {
+            if (!parent.ReferenceExists(ReferenceTypeIds.Organizes, false, child.NodeId))
+            {
+                parent.AddReference(ReferenceTypeIds.Organizes, false, child.NodeId);
+            }
+            if (!child.ReferenceExists(ReferenceTypeIds.Organizes, true, parent.NodeId))
+            {
+                child.AddReference(ReferenceTypeIds.Organizes, true, parent.NodeId);
+            }
+        }
+
+        /// <summary>
+        /// Moves a server-defined name out of namespace 0, which Part 3
+        /// reserves for OPC-Foundation-defined names. Store descriptors
+        /// commonly inherit namespace 0 from the well-known categories'
+        /// BrowseNames; publishing server-specific aliases there is a
+        /// conformance violation and can even duplicate a standard child
+        /// name (an alias literally called "FindAlias"). Part 17 §6.2
+        /// clients compare alias names ignoring the namespace, so
+        /// re-homing is transparent to them.
+        /// </summary>
+        private QualifiedName RehomeServerDefinedName(QualifiedName name)
+        {
+            return name.NamespaceIndex == 0 && !string.IsNullOrEmpty(name.Name)
+                ? new QualifiedName(name.Name, m_namespaceIndex)
+                : name;
         }
 
         /// <summary>
@@ -362,98 +511,118 @@ namespace Opc.Ua.Server
         {
             AliasNameCapabilities capabilities = descriptor.Capabilities;
             ReservedChildIds reserved = ReservedChildIds.For(descriptor.NodeId);
-
-            if ((capabilities & AliasNameCapabilities.FindAliasVerbose) != 0 &&
-                category.FindAliasVerbose == null)
-            {
-                category.AddFindAliasVerbose(SystemContext, reserved.FindAliasVerbose.Method);
-                ApplyReservedArgumentIds(
-                    category.FindAliasVerbose, reserved.FindAliasVerbose);
-                await RegisterAddedChildAsync(
-                    category.FindAliasVerbose, registerNewChildren, created, cancellationToken)
-                    .ConfigureAwait(false);
-            }
-
-            if ((capabilities & AliasNameCapabilities.AddAliasesToCategory) != 0 &&
-                category.AddAliasesToCategory == null)
-            {
-                category.AddAddAliasesToCategory(
-                    SystemContext, reserved.AddAliasesToCategory.Method);
-                ApplyReservedArgumentIds(
-                    category.AddAliasesToCategory, reserved.AddAliasesToCategory);
-                await RegisterAddedChildAsync(
-                    category.AddAliasesToCategory, registerNewChildren, created, cancellationToken)
-                    .ConfigureAwait(false);
-            }
-
-            if ((capabilities & AliasNameCapabilities.DeleteAliasesFromCategory) != 0 &&
-                category.DeleteAliasesFromCategory == null)
-            {
-                category.AddDeleteAliasesFromCategory(
-                    SystemContext, reserved.DeleteAliasesFromCategory.Method);
-                ApplyReservedArgumentIds(
-                    category.DeleteAliasesFromCategory, reserved.DeleteAliasesFromCategory);
-                await RegisterAddedChildAsync(
-                    category.DeleteAliasesFromCategory, registerNewChildren, created,
-                    cancellationToken).ConfigureAwait(false);
-            }
-
-            if ((capabilities & AliasNameCapabilities.LastChange) != 0 &&
-                category.LastChange == null)
-            {
-                category.AddLastChange(SystemContext, reserved.LastChange);
-                await RegisterAddedChildAsync(
-                    category.LastChange, registerNewChildren, created, cancellationToken)
-                    .ConfigureAwait(false);
-            }
-
             NodeId categoryId = descriptor.NodeId;
+            var addedChildren = new List<NodeState>();
 
-            category.FindAliasVerbose?.OnCallAsync =
-                (ctx, method, objId, pattern, refType, ct) =>
-                    AliasNameMethodDispatcher.FindAliasVerboseAsync(
-                        registry,
-                        Server.TypeTree,
-                        objId.IsNull ? categoryId : objId,
-                        pattern,
-                        refType,
-                        ct);
+            // Each optional child is created AND wired only under its
+            // capability flag: a child that already exists on the node (a
+            // companion NodeSet may ship one) but that the descriptor did
+            // not declare stays unwired — otherwise a category declared
+            // read-only would silently accept mutations.
+            if ((capabilities & AliasNameCapabilities.FindAliasVerbose) != 0)
+            {
+                if (category.FindAliasVerbose == null)
+                {
+                    category.AddFindAliasVerbose(
+                        SystemContext, reserved.FindAliasVerbose.Method);
+                    ApplyReservedArgumentIds(
+                        category.FindAliasVerbose, reserved.FindAliasVerbose);
+                    addedChildren.Add(category.FindAliasVerbose!);
+                }
 
-            category.AddAliasesToCategory?.OnCallAsync =
-                (ctx, method, objId, names, targets, servers, refType, ct) =>
-                    !AliasNameMethodDispatcher.HasSecureAdminAccess(ctx)
-                        ? new ValueTask<AddAliasesToCategoryMethodStateResult>(
-                            new AddAliasesToCategoryMethodStateResult
-                            {
-                                ServiceResult = new ServiceResult(StatusCodes.BadUserAccessDenied),
-                                ErrorCodes = default
-                            })
-                        : AliasNameMethodDispatcher.AddAliasesAsync(
+                category.FindAliasVerbose!.OnCallAsync =
+                    (ctx, method, objId, pattern, refType, ct) =>
+                        AliasNameMethodDispatcher.FindAliasVerboseAsync(
                             registry,
+                            Server.TypeTree,
                             objId.IsNull ? categoryId : objId,
-                            names,
-                            targets,
-                            servers,
+                            pattern,
                             refType,
                             ct);
+            }
 
-            category.DeleteAliasesFromCategory?.OnCallAsync =
-                (ctx, method, objId, names, targets, ct) =>
-                    !AliasNameMethodDispatcher.HasSecureAdminAccess(ctx)
-                        ? new ValueTask<DeleteAliasesFromCategoryMethodStateResult>(
-                            new DeleteAliasesFromCategoryMethodStateResult
-                            {
-                                ServiceResult = new ServiceResult(StatusCodes.BadUserAccessDenied),
-                                ErrorCodes = default
-                            })
-                        : AliasNameMethodDispatcher.DeleteAliasesAsync(
-                            registry,
-                            objId.IsNull ? categoryId : objId,
-                            names,
-                            targets,
-                            ct);
+            if ((capabilities & AliasNameCapabilities.AddAliasesToCategory) != 0)
+            {
+                if (category.AddAliasesToCategory == null)
+                {
+                    category.AddAddAliasesToCategory(
+                        SystemContext, reserved.AddAliasesToCategory.Method);
+                    ApplyReservedArgumentIds(
+                        category.AddAliasesToCategory, reserved.AddAliasesToCategory);
+                    addedChildren.Add(category.AddAliasesToCategory!);
+                }
 
-            BindLastChange(categoryId, category, registry);
+                category.AddAliasesToCategory!.OnCallAsync =
+                    (ctx, method, objId, names, targets, servers, refType, ct) =>
+                        !AliasNameMethodDispatcher.HasSecureAdminAccess(ctx)
+                            ? new ValueTask<AddAliasesToCategoryMethodStateResult>(
+                                new AddAliasesToCategoryMethodStateResult
+                                {
+                                    ServiceResult = new ServiceResult(StatusCodes.BadUserAccessDenied),
+                                    ErrorCodes = default
+                                })
+                            : AliasNameMethodDispatcher.AddAliasesAsync(
+                                registry,
+                                objId.IsNull ? categoryId : objId,
+                                names,
+                                targets,
+                                servers,
+                                refType,
+                                ct);
+            }
+
+            if ((capabilities & AliasNameCapabilities.DeleteAliasesFromCategory) != 0)
+            {
+                if (category.DeleteAliasesFromCategory == null)
+                {
+                    category.AddDeleteAliasesFromCategory(
+                        SystemContext, reserved.DeleteAliasesFromCategory.Method);
+                    ApplyReservedArgumentIds(
+                        category.DeleteAliasesFromCategory, reserved.DeleteAliasesFromCategory);
+                    addedChildren.Add(category.DeleteAliasesFromCategory!);
+                }
+
+                category.DeleteAliasesFromCategory!.OnCallAsync =
+                    (ctx, method, objId, names, targets, ct) =>
+                        !AliasNameMethodDispatcher.HasSecureAdminAccess(ctx)
+                            ? new ValueTask<DeleteAliasesFromCategoryMethodStateResult>(
+                                new DeleteAliasesFromCategoryMethodStateResult
+                                {
+                                    ServiceResult = new ServiceResult(StatusCodes.BadUserAccessDenied),
+                                    ErrorCodes = default
+                                })
+                            : AliasNameMethodDispatcher.DeleteAliasesAsync(
+                                registry,
+                                objId.IsNull ? categoryId : objId,
+                                names,
+                                targets,
+                                ct);
+            }
+
+            if ((capabilities & AliasNameCapabilities.LastChange) != 0)
+            {
+                if (category.LastChange == null)
+                {
+                    category.AddLastChange(SystemContext, reserved.LastChange);
+                    addedChildren.Add(category.LastChange!);
+                }
+
+                BindLastChange(categoryId, category, registry);
+            }
+
+            // Every added child is reported to the caller; only children
+            // of an already-registered category also need individual
+            // registration — a category not yet registered covers its
+            // whole subtree when it is.
+            created.AddRange(addedChildren);
+            if (registerNewChildren)
+            {
+                foreach (NodeState child in addedChildren)
+                {
+                    await AddPredefinedNodeAsync(SystemContext, child, cancellationToken)
+                        .ConfigureAwait(false);
+                }
+            }
         }
 
         /// <summary>
@@ -482,63 +651,34 @@ namespace Opc.Ua.Server
         }
 
         /// <summary>
-        /// Registers a child added to an already-loaded category. Children
-        /// of a category that has not been registered yet are covered by
-        /// the registration of their parent.
-        /// </summary>
-        private async ValueTask RegisterAddedChildAsync(
-            NodeState? child,
-            bool registerNewChildren,
-            List<NodeState> created,
-            CancellationToken cancellationToken)
-        {
-            if (child == null || !registerNewChildren)
-            {
-                return;
-            }
-            await AddPredefinedNodeAsync(SystemContext, child, cancellationToken)
-                .ConfigureAwait(false);
-            created.Add(child);
-        }
-
-        /// <summary>
         /// Creates one <c>AliasNameType</c> instance per alias whose home
-        /// category is <paramref name="descriptor"/>. Aliases contributed by
-        /// sub-categories are skipped here — they are materialized under
-        /// their own category — even though <c>FindAliasVerbose</c> reports
-        /// them recursively.
+        /// category is <paramref name="descriptor"/> — the bucket handed in
+        /// holds exactly those. Aliases contributed by sub-categories are
+        /// materialized under their own category.
         /// </summary>
         private async ValueTask MaterializeAliasesAsync(
-            IAliasNameStore store,
             AliasNameCategoryDescriptor descriptor,
             AliasNameCategoryState category,
+            List<AliasNameVerboseDataType>? aliases,
             IDictionary<NodeId, IList<IReference>> externalReferences,
             List<NodeState> created,
             CancellationToken cancellationToken)
         {
-            // Restrict the query to AliasFor and its subtypes: the reference
-            // the materialized node carries is AliasFor, and
-            // AliasNameVerboseDataType does not report which reference type
-            // an entry was stored under. Without the filter an alias
-            // registered under an unrelated reference type would be
-            // published as an AliasFor association it does not have.
-            IReadOnlyList<AliasNameVerboseDataType> aliases = await store
-                .FindAliasVerboseAsync(
-                    descriptor.NodeId,
-                    AllAliasesPattern,
-                    ReferenceTypeIds.AliasFor,
-                    Server.TypeTree,
-                    cancellationToken).ConfigureAwait(false);
+            if (aliases == null || aliases.Count == 0)
+            {
+                return;
+            }
 
             // One node per alias name; the store reports a separate record
             // per reference type, and a name may carry several targets.
+            // Duplicate targets — including the same node seeded once in
+            // namespace-URI form and once in index form — are absorbed by
+            // the ReferenceExists guards in AddAliasForReference.
             var byName = new Dictionary<string, AliasNameState>();
-            var seenTargets = new HashSet<(string Name, ExpandedNodeId Target)>();
 
             foreach (AliasNameVerboseDataType alias in aliases)
             {
-                if (alias.AliasNameCategoryId != descriptor.NodeId ||
-                    string.IsNullOrEmpty(alias.AliasName.Name))
+                if (string.IsNullOrEmpty(alias.AliasName.Name))
                 {
                     continue;
                 }
@@ -546,64 +686,99 @@ namespace Opc.Ua.Server
                 string name = alias.AliasName.Name!;
                 if (!byName.TryGetValue(name, out AliasNameState? aliasNode))
                 {
-                    aliasNode = CreateAliasNode(descriptor, category, alias.AliasName, name);
+                    aliasNode = await GetOrCreateAliasNodeAsync(
+                        descriptor, category, alias.AliasName, name, created,
+                        cancellationToken).ConfigureAwait(false);
                     byName[name] = aliasNode;
-                    created.Add(aliasNode);
                 }
 
                 for (int ii = 0; ii < alias.ReferencedNodes.Count; ii++)
                 {
-                    ExpandedNodeId target = alias.ReferencedNodes[ii];
-
-                    // The same target may arrive once per AliasFor subtype
-                    // the store grouped it under; the node carries one
-                    // reference per target.
-                    if (!seenTargets.Add((name, target)))
-                    {
-                        continue;
-                    }
-
                     AddAliasForReference(
                         aliasNode,
-                        target,
+                        alias.ReferencedNodes[ii],
                         ii < alias.ServerUris.Count ? alias.ServerUris[ii] : null,
                         externalReferences);
                 }
             }
-
-            foreach (AliasNameState aliasNode in byName.Values)
-            {
-                await AddPredefinedNodeAsync(SystemContext, aliasNode, cancellationToken)
-                    .ConfigureAwait(false);
-            }
         }
 
         /// <summary>
-        /// Builds the <c>AliasNameType</c> instance for one alias. Per
-        /// Part 17 §6.2 the BrowseName carries the alias name and the
-        /// DisplayName repeats it with an empty locale.
+        /// Resolves or builds the <c>AliasNameType</c> instance for one
+        /// alias. Per Part 17 §6.2 the BrowseName carries the alias name
+        /// and the DisplayName repeats it with an empty locale.
         /// </summary>
-        private AliasNameState CreateAliasNode(
+        /// <remarks>
+        /// The deterministic string id minted from category id + alias name
+        /// is ambiguous — <c>"…s=A"</c> with alias <c>"B.C"</c> and
+        /// <c>"…s=A.B"</c> with alias <c>"C"</c> concatenate identically —
+        /// and a repeat materialization revisits ids it minted before. A
+        /// node already registered under the minted id is therefore reused
+        /// when it is the same alias, and a different occupant makes this
+        /// alias fall back to a factory-minted id instead of silently
+        /// replacing the occupant (<c>AddPredefinedNode</c> overwrites).
+        /// </remarks>
+        private async ValueTask<AliasNameState> GetOrCreateAliasNodeAsync(
             AliasNameCategoryDescriptor descriptor,
             AliasNameCategoryState category,
             QualifiedName aliasName,
-            string name)
+            string name,
+            List<NodeState> created,
+            CancellationToken cancellationToken)
         {
-            AliasNameState aliasNode = SystemContext.CreateInstanceOfAliasNameType();
-
-            aliasNode.NodeId = new NodeId(
+            var mintedId = new NodeId(
                 Utils.Format("{0}.{1}", descriptor.NodeId, name),
                 m_namespaceIndex);
-            aliasNode.BrowseName = aliasName;
+
+            if (PredefinedNodes.TryGetValue(mintedId, out NodeState? existing))
+            {
+                if (existing is AliasNameState existingAlias &&
+                    existingAlias.BrowseName.Name == name)
+                {
+                    LinkAliasToCategory(category, existingAlias);
+                    return existingAlias;
+                }
+
+                m_logger.AliasNameNodeIdCollision(mintedId, name);
+                mintedId = NodeId.Null;
+            }
+
+            AliasNameState aliasNode = SystemContext.CreateInstanceOfAliasNameType();
+
+            aliasNode.NodeId = mintedId.IsNull
+                ? New(SystemContext, aliasNode)
+                : mintedId;
+            aliasNode.BrowseName = RehomeServerDefinedName(aliasName);
             aliasNode.DisplayName = new LocalizedText(string.Empty, name);
             aliasNode.SymbolicName = name;
             aliasNode.TypeDefinitionId = ObjectTypeIds.AliasNameType;
             aliasNode.ReferenceTypeId = ReferenceTypeIds.Organizes;
 
-            category.AddReference(ReferenceTypeIds.Organizes, false, aliasNode.NodeId);
-            aliasNode.AddReference(ReferenceTypeIds.Organizes, true, category.NodeId);
+            LinkAliasToCategory(category, aliasNode);
 
+            await AddPredefinedNodeAsync(SystemContext, aliasNode, cancellationToken)
+                .ConfigureAwait(false);
+            created.Add(aliasNode);
             return aliasNode;
+        }
+
+        /// <summary>
+        /// Adds the forward and inverse <c>Organizes</c> pair between a
+        /// category and an alias node, tolerating either half already
+        /// being present.
+        /// </summary>
+        private static void LinkAliasToCategory(
+            AliasNameCategoryState category,
+            AliasNameState aliasNode)
+        {
+            if (!category.ReferenceExists(ReferenceTypeIds.Organizes, false, aliasNode.NodeId))
+            {
+                category.AddReference(ReferenceTypeIds.Organizes, false, aliasNode.NodeId);
+            }
+            if (!aliasNode.ReferenceExists(ReferenceTypeIds.Organizes, true, category.NodeId))
+            {
+                aliasNode.AddReference(ReferenceTypeIds.Organizes, true, category.NodeId);
+            }
         }
 
         /// <summary>
@@ -626,22 +801,45 @@ namespace Opc.Ua.Server
             if (!string.IsNullOrEmpty(serverUri))
             {
                 // A target on a remote server has no local node to carry
-                // the inverse reference.
-                aliasNode.AddReference(ReferenceTypeIds.AliasFor, false, target);
+                // the inverse reference. Register the URI in the server
+                // table and stamp its index onto the reference target, so
+                // clients can resolve which server owns the node via the
+                // ServerArray — an ExpandedNodeId with ServerIndex 0 would
+                // misreport the target as local.
+                uint serverIndex = Server.ServerUris.GetIndexOrAppend(serverUri!);
+                ExpandedNodeId remoteTarget = target.WithServerIndex(serverIndex);
+                if (!aliasNode.ReferenceExists(ReferenceTypeIds.AliasFor, false, remoteTarget))
+                {
+                    aliasNode.AddReference(ReferenceTypeIds.AliasFor, false, remoteTarget);
+                }
                 return;
             }
 
             // Resolve the namespace-uri form a store may have been seeded
-            // with, so the reference carries a plain local NodeId.
+            // with, so the reference carries a plain local NodeId. The
+            // duplicate check runs on the RESOLVED id — the same target
+            // seeded once in URI form and once in index form must produce
+            // one reference, and AddReference throws on duplicates.
             var localTarget = ExpandedNodeId.ToNodeId(target, Server.NamespaceUris);
             if (localTarget.IsNull)
             {
-                aliasNode.AddReference(ReferenceTypeIds.AliasFor, false, target);
+                if (!aliasNode.ReferenceExists(ReferenceTypeIds.AliasFor, false, target))
+                {
+                    aliasNode.AddReference(ReferenceTypeIds.AliasFor, false, target);
+                }
+                return;
+            }
+
+            if (aliasNode.ReferenceExists(ReferenceTypeIds.AliasFor, false, localTarget))
+            {
                 return;
             }
 
             aliasNode.AddReference(ReferenceTypeIds.AliasFor, false, localTarget);
 
+            // The inverse reference travels only with a newly added
+            // forward reference, so repeat materializations do not queue
+            // duplicate external references for the target's manager.
             AddExternalReference(
                 localTarget,
                 ReferenceTypeIds.AliasFor,
@@ -659,8 +857,15 @@ namespace Opc.Ua.Server
             if (m_lastChangeNodes.TryGetValue(
                     e.CategoryId, out PropertyState<uint>? lastChange))
             {
-                lastChange.Value = e.LastChange;
-                lastChange.ClearChangeMasks(SystemContext, false);
+                // The store raises Changed synchronously on the mutating
+                // caller's thread; serialize concurrent mutations so two
+                // clients updating the same category cannot interleave the
+                // value write and the change-mask notification.
+                lock (m_lastChangeSync)
+                {
+                    lastChange.Value = e.LastChange;
+                    lastChange.ClearChangeMasks(SystemContext, false);
+                }
             }
         }
 
@@ -680,6 +885,22 @@ namespace Opc.Ua.Server
                 m_aliasRegistry = null;
             }
             m_lastChangeNodes.Clear();
+
+            // Detach the dispatch handlers too — the OnCallAsync closures
+            // capture the registry, so a call racing disposal would
+            // otherwise still dispatch into stores this manager no longer
+            // tracks. Without a handler the method reports itself as not
+            // implemented instead.
+            foreach (NodeState node in PredefinedNodes.Values)
+            {
+                if (node is AliasNameCategoryState category)
+                {
+                    category.FindAlias?.OnCallAsync = null;
+                    category.FindAliasVerbose?.OnCallAsync = null;
+                    category.AddAliasesToCategory?.OnCallAsync = null;
+                    category.DeleteAliasesFromCategory?.OnCallAsync = null;
+                }
+            }
         }
 
         /// <summary>
@@ -731,62 +952,68 @@ namespace Opc.Ua.Server
         {
             public static ReservedChildIds For(NodeId categoryId)
             {
-                if (categoryId == ObjectIds.Aliases)
-                {
-                    return new ReservedChildIds(
-                        new ReservedMethodIds(
-                            new NodeId(24054u),
-                            VariableIds.Aliases_FindAliasVerbose_InputArguments,
-                            VariableIds.Aliases_FindAliasVerbose_OutputArguments),
-                        new ReservedMethodIds(
-                            new NodeId(24057u),
-                            VariableIds.Aliases_AddAliasesToCategory_InputArguments,
-                            VariableIds.Aliases_AddAliasesToCategory_OutputArguments),
-                        new ReservedMethodIds(
-                            new NodeId(24060u),
-                            VariableIds.Aliases_DeleteAliasesFromCategory_InputArguments,
-                            VariableIds.Aliases_DeleteAliasesFromCategory_OutputArguments),
-                        VariableIds.Aliases_LastChange);
-                }
-                if (categoryId == ObjectIds.TagVariables)
-                {
-                    return new ReservedChildIds(
-                        new ReservedMethodIds(
-                            new NodeId(24063u),
-                            VariableIds.TagVariables_FindAliasVerbose_InputArguments,
-                            VariableIds.TagVariables_FindAliasVerbose_OutputArguments),
-                        new ReservedMethodIds(
-                            new NodeId(24066u),
-                            VariableIds.TagVariables_AddAliasesToCategory_InputArguments,
-                            VariableIds.TagVariables_AddAliasesToCategory_OutputArguments),
-                        new ReservedMethodIds(
-                            new NodeId(24069u),
-                            VariableIds.TagVariables_DeleteAliasesFromCategory_InputArguments,
-                            VariableIds.TagVariables_DeleteAliasesFromCategory_OutputArguments),
-                        new NodeId(32854u));
-                }
-                if (categoryId == ObjectIds.Topics)
-                {
-                    return new ReservedChildIds(
-                        new ReservedMethodIds(
-                            new NodeId(24072u),
-                            VariableIds.Topics_FindAliasVerbose_InputArguments,
-                            VariableIds.Topics_FindAliasVerbose_OutputArguments),
-                        new ReservedMethodIds(
-                            new NodeId(24075u),
-                            VariableIds.Topics_AddAliasesToCategory_InputArguments,
-                            VariableIds.Topics_AddAliasesToCategory_OutputArguments),
-                        new ReservedMethodIds(
-                            new NodeId(24078u),
-                            VariableIds.Topics_DeleteAliasesFromCategory_InputArguments,
-                            VariableIds.Topics_DeleteAliasesFromCategory_OutputArguments),
-                        new NodeId(32856u));
-                }
-                return default;
+                return s_reserved.TryGetValue(categoryId, out ReservedChildIds ids)
+                    ? ids
+                    : default;
             }
+
+            // One row per well-known category; the numeric literals are the
+            // Method rows of StandardTypes.csv, the VariableIds constants
+            // its Variable rows.
+            private static readonly Dictionary<NodeId, ReservedChildIds> s_reserved = new()
+            {
+                [ObjectIds.Aliases] = new ReservedChildIds(
+                    new ReservedMethodIds(
+                        new NodeId(24054u),
+                        VariableIds.Aliases_FindAliasVerbose_InputArguments,
+                        VariableIds.Aliases_FindAliasVerbose_OutputArguments),
+                    new ReservedMethodIds(
+                        new NodeId(24057u),
+                        VariableIds.Aliases_AddAliasesToCategory_InputArguments,
+                        VariableIds.Aliases_AddAliasesToCategory_OutputArguments),
+                    new ReservedMethodIds(
+                        new NodeId(24060u),
+                        VariableIds.Aliases_DeleteAliasesFromCategory_InputArguments,
+                        VariableIds.Aliases_DeleteAliasesFromCategory_OutputArguments),
+                    VariableIds.Aliases_LastChange),
+                [ObjectIds.TagVariables] = new ReservedChildIds(
+                    new ReservedMethodIds(
+                        new NodeId(24063u),
+                        VariableIds.TagVariables_FindAliasVerbose_InputArguments,
+                        VariableIds.TagVariables_FindAliasVerbose_OutputArguments),
+                    new ReservedMethodIds(
+                        new NodeId(24066u),
+                        VariableIds.TagVariables_AddAliasesToCategory_InputArguments,
+                        VariableIds.TagVariables_AddAliasesToCategory_OutputArguments),
+                    new ReservedMethodIds(
+                        new NodeId(24069u),
+                        VariableIds.TagVariables_DeleteAliasesFromCategory_InputArguments,
+                        VariableIds.TagVariables_DeleteAliasesFromCategory_OutputArguments),
+                    new NodeId(32854u)),
+                [ObjectIds.Topics] = new ReservedChildIds(
+                    new ReservedMethodIds(
+                        new NodeId(24072u),
+                        VariableIds.Topics_FindAliasVerbose_InputArguments,
+                        VariableIds.Topics_FindAliasVerbose_OutputArguments),
+                    new ReservedMethodIds(
+                        new NodeId(24075u),
+                        VariableIds.Topics_AddAliasesToCategory_InputArguments,
+                        VariableIds.Topics_AddAliasesToCategory_OutputArguments),
+                    new ReservedMethodIds(
+                        new NodeId(24078u),
+                        VariableIds.Topics_DeleteAliasesFromCategory_InputArguments,
+                        VariableIds.Topics_DeleteAliasesFromCategory_OutputArguments),
+                    new NodeId(32856u))
+            };
         }
 
         private IAliasNameStoreRegistry? m_aliasRegistry;
+
+        /// <summary>
+        /// Serializes the <c>LastChange</c> node updates raised by store
+        /// mutations, which arrive on arbitrary client-call threads.
+        /// </summary>
+        private readonly object m_lastChangeSync = new();
 
         /// <summary>
         /// The <c>LastChange</c> property of every category that exposes
@@ -807,5 +1034,17 @@ namespace Opc.Ua.Server
         [LoggerMessage(EventId = ServerEventIds.DiagnosticsNodeManager + 1, Level = LogLevel.Information,
             Message = "Materialized {Count} Part 17 alias name nodes from the registered alias stores.")]
         public static partial void MaterializedAliasNameNodes(this ILogger logger, int count);
+
+        [LoggerMessage(EventId = ServerEventIds.DiagnosticsNodeManager + 2, Level = LogLevel.Warning,
+            Message = "Skipped alias category {CategoryId}: its NodeId is outside the diagnostics namespace, so it belongs to another node manager or is a mis-seeded well-known id.")]
+        public static partial void SkippedAliasCategoryOutsideNamespace(this ILogger logger, NodeId categoryId);
+
+        [LoggerMessage(EventId = ServerEventIds.DiagnosticsNodeManager + 3, Level = LogLevel.Warning,
+            Message = "Skipped alias category {CategoryId}: the NodeId is already registered by a node of type {OccupantType}.")]
+        public static partial void SkippedAliasCategoryOccupiedNodeId(this ILogger logger, NodeId categoryId, string occupantType);
+
+        [LoggerMessage(EventId = ServerEventIds.DiagnosticsNodeManager + 4, Level = LogLevel.Warning,
+            Message = "Alias name NodeId {MintedId} for alias '{AliasName}' collides with an existing node; a factory-minted NodeId is used instead.")]
+        public static partial void AliasNameNodeIdCollision(this ILogger logger, NodeId mintedId, string aliasName);
     }
 }

--- a/src/Opc.Ua.Server/Diagnostics/DiagnosticsNodeManager.AliasNames.cs
+++ b/src/Opc.Ua.Server/Diagnostics/DiagnosticsNodeManager.AliasNames.cs
@@ -27,6 +27,12 @@
  * http://opcfoundation.org/License/MIT/1.00/
  * ======================================================================*/
 
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Opc.Ua.Server.AliasNames;
 
 namespace Opc.Ua.Server
@@ -51,10 +57,14 @@ namespace Opc.Ua.Server
     /// None of the optional Part 17 children
     /// (<c>FindAliasVerbose</c>/<c>AddAliasesToCategory</c>/<c>DeleteAliasesFromCategory</c>)
     /// are instantiated by the standard NodeSet on these well-known nodes,
-    /// so this binder only wires <c>FindAlias</c> and (for
-    /// <c>Aliases</c>) <c>LastChange</c>. Optional methods on
-    /// application-defined categories are wired by
-    /// <see cref="AliasNameNodeManager"/> instead.
+    /// so the always-on binder — <see cref="WireStandardAliasMethods"/> —
+    /// wires <c>FindAlias</c> and (for <c>Aliases</c>) <c>LastChange</c>
+    /// only. A server that wants the optional methods calls
+    /// <see cref="MaterializeRegisteredAliasNameNodesAsync"/>, which adds
+    /// them through the generated optional-child helpers — at the reserved
+    /// NodeIds, see <see cref="ReservedChildIds"/> — for every category
+    /// whose store descriptor declares the matching
+    /// <see cref="AliasNameCapabilities"/>.
     /// </remarks>
     public partial class DiagnosticsNodeManager
     {
@@ -94,45 +104,563 @@ namespace Opc.Ua.Server
                 return;
             }
 
+            WireFindAlias(categoryId, category, m_aliasRegistry!);
+
+            if (includeLastChange)
+            {
+                BindLastChange(categoryId, category, m_aliasRegistry!);
+            }
+        }
+
+        /// <summary>
+        /// Seeds a category's <c>LastChange</c> property from the store that
+        /// owns it and remembers the node so
+        /// <see cref="OnAliasRegistryChanged"/> can keep it current. No-op
+        /// for a category that does not expose the property.
+        /// </summary>
+        private void BindLastChange(
+            NodeId categoryId,
+            AliasNameCategoryState category,
+            IAliasNameStoreRegistry registry)
+        {
+            if (category.LastChange == null)
+            {
+                return;
+            }
+
+            foreach (IAliasNameStore store in registry.Stores)
+            {
+                uint? seed = store.GetLastChange(categoryId);
+                if (seed.HasValue)
+                {
+                    category.LastChange.Value = seed.Value;
+                    category.LastChange.ClearChangeMasks(SystemContext, false);
+                    break;
+                }
+            }
+
+            m_lastChangeNodes[categoryId] = category.LastChange;
+        }
+
+        /// <summary>
+        /// Points a category's mandatory <c>FindAlias</c> method at the
+        /// supplied registry. Shared by the standard well-known categories
+        /// and by the categories materialized from a store's descriptor
+        /// tree.
+        /// </summary>
+        private void WireFindAlias(
+            NodeId categoryId,
+            AliasNameCategoryState category,
+            IAliasNameStoreRegistry registry)
+        {
             category.FindAlias?.OnCallAsync = (ctx, method, objId, pattern, refType, ct) =>
                     AliasNameMethodDispatcher.FindAliasAsync(
-                        m_aliasRegistry!,
+                        registry,
+                        Server.TypeTree,
+                        objId.IsNull ? categoryId : objId,
+                        pattern,
+                        refType,
+                        ct);
+        }
+
+        /// <summary>
+        /// Materializes the alias hierarchy described by every registered
+        /// <see cref="IAliasNameStore"/> as browsable address-space nodes:
+        /// an <c>AliasNameType</c> (i=23455) instance per alias — carrying
+        /// the <c>AliasFor</c> (i=23469) references to its targets — and an
+        /// <c>AliasNameCategoryType</c> (i=23456) instance for every store
+        /// category that the standard NodeSet does not already ship.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Opt-in: servers that only need the well-known <c>FindAlias</c>
+        /// methods to answer from their store — the default wired by
+        /// <see cref="WireStandardAliasMethods"/> — do not have to call
+        /// this. Servers under conformance test do, because Part 17 §6.2
+        /// clients discover aliases by browsing, not only by calling
+        /// <c>FindAlias</c>.
+        /// </para>
+        /// <para>
+        /// The materialized nodes are a snapshot taken at address-space
+        /// creation time. Aliases added or removed through
+        /// <c>AddAliasesToCategory</c>/<c>DeleteAliasesFromCategory</c>
+        /// afterwards change what <c>FindAlias</c> returns and advance
+        /// <c>LastChange</c>, but do not add or remove
+        /// <c>AliasNameType</c> nodes — so a mutated category's browse view
+        /// and its query results diverge until the next restart. This
+        /// applies to the standard well-known categories too whenever their
+        /// descriptor declares the mutation capabilities, because this
+        /// method instantiates those methods for them.
+        /// </para>
+        /// <para>
+        /// Call from an overridden <c>CreateAddressSpaceAsync</c> after
+        /// <c>base.CreateAddressSpaceAsync</c> — the standard categories
+        /// must already be loaded and the stores registered. The created
+        /// nodes are imported into the <c>CoreNodeManager</c> so they are
+        /// reachable by Browse, and are also returned for inspection.
+        /// </para>
+        /// </remarks>
+        /// <param name="externalReferences">The dictionary supplied to
+        /// <c>CreateAddressSpaceAsync</c>; used to add the inverse
+        /// <c>HasAlias</c> reference on target nodes owned by other node
+        /// managers.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The nodes created by this call.</returns>
+        protected async ValueTask<IReadOnlyList<NodeState>> MaterializeRegisteredAliasNameNodesAsync(
+            IDictionary<NodeId, IList<IReference>> externalReferences,
+            CancellationToken cancellationToken = default)
+        {
+            var created = new List<NodeState>();
+
+            IAliasNameStoreRegistry? registry = m_aliasRegistry ??
+                (Server as IAliasNameStoreRegistryProvider)?.AliasNameStoreRegistry;
+            if (registry == null)
+            {
+                return created;
+            }
+
+            foreach (IAliasNameStore store in registry.Stores)
+            {
+                foreach (AliasNameCategoryDescriptor root in store.RootCategories)
+                {
+                    await MaterializeCategoryAsync(
+                        store,
+                        registry,
+                        root,
+                        parent: null,
+                        externalReferences,
+                        created,
+                        cancellationToken).ConfigureAwait(false);
+                }
+            }
+
+            if (created.Count > 0)
+            {
+                await Server.CoreNodeManager.ImportNodesAsync(
+                    SystemContext,
+                    created,
+                    true,
+                    cancellationToken).ConfigureAwait(false);
+            }
+
+            m_logger.MaterializedAliasNameNodes(created.Count);
+            return created;
+        }
+
+        /// <summary>
+        /// Materializes one category — reusing the predefined node when the
+        /// standard NodeSet ships it — then its aliases and sub-categories.
+        /// </summary>
+        private async ValueTask MaterializeCategoryAsync(
+            IAliasNameStore store,
+            IAliasNameStoreRegistry registry,
+            AliasNameCategoryDescriptor descriptor,
+            AliasNameCategoryState? parent,
+            IDictionary<NodeId, IList<IReference>> externalReferences,
+            List<NodeState> created,
+            CancellationToken cancellationToken)
+        {
+            AliasNameCategoryState? category =
+                FindPredefinedNode<AliasNameCategoryState>(descriptor.NodeId);
+            bool isNewCategory = category == null;
+
+            if (category == null && !IsNodeIdInNamespace(descriptor.NodeId))
+            {
+                // The category belongs to another node manager — typically an
+                // AliasNameNodeManager that registered its store with the
+                // server-wide registry and builds these nodes itself.
+                // Creating them here would claim its NodeIds a second time.
+                return;
+            }
+
+            if (category == null)
+            {
+                category = SystemContext.CreateInstanceOfAliasNameCategoryType();
+                category.BrowseName = descriptor.BrowseName;
+                category.DisplayName = new LocalizedText(descriptor.BrowseName.Name);
+                category.SymbolicName = descriptor.BrowseName.Name!;
+                category.TypeDefinitionId = ObjectTypeIds.AliasNameCategoryType;
+                category.ReferenceTypeId = ReferenceTypeIds.Organizes;
+
+                // Mint ids for the mandatory children first — New() does not
+                // preserve a caller-assigned id — then pin the category to
+                // the descriptor's NodeId, which is the key the store and
+                // the registry dispatch on.
+                category.AssignNodeIds(SystemContext, []);
+                category.NodeId = descriptor.NodeId;
+
+                WireFindAlias(descriptor.NodeId, category, registry);
+            }
+
+            // Add and wire the optional Part 17 children the store's
+            // descriptor declares. For a category created above this only
+            // grows the subtree before it is registered; for a standard
+            // predefined category the new children are registered
+            // individually.
+            await ApplyCategoryCapabilitiesAsync(
+                descriptor,
+                category,
+                registry,
+                registerNewChildren: !isNewCategory,
+                created,
+                cancellationToken).ConfigureAwait(false);
+
+            if (isNewCategory)
+            {
+                if (parent != null)
+                {
+                    parent.AddReference(ReferenceTypeIds.Organizes, false, category.NodeId);
+                    category.AddReference(ReferenceTypeIds.Organizes, true, parent.NodeId);
+                }
+
+                await AddPredefinedNodeAsync(SystemContext, category, cancellationToken)
+                    .ConfigureAwait(false);
+                created.Add(category);
+            }
+
+            await MaterializeAliasesAsync(
+                store, descriptor, category, externalReferences, created, cancellationToken)
+                .ConfigureAwait(false);
+
+            foreach (AliasNameCategoryDescriptor child in descriptor.SubCategories)
+            {
+                await MaterializeCategoryAsync(
+                    store,
+                    registry,
+                    child,
+                    category,
+                    externalReferences,
+                    created,
+                    cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
+        /// Instantiates and wires the optional Part 17 children a category
+        /// declares through <see cref="AliasNameCategoryDescriptor.Capabilities"/>:
+        /// <c>FindAliasVerbose</c> (§6.3.3), <c>AddAliasesToCategory</c>
+        /// (§6.3.4), <c>DeleteAliasesFromCategory</c> (§6.3.5) and
+        /// <c>LastChange</c> (§6.3.1).
+        /// </summary>
+        /// <remarks>
+        /// The standard NodeSet instantiates none of these on the
+        /// well-known <c>Aliases</c>/<c>TagVariables</c>/<c>Topics</c>
+        /// objects (only <c>FindAlias</c>, plus <c>LastChange</c> on
+        /// <c>Aliases</c>), so the generated <c>Add…</c> helpers create them
+        /// here — at the NodeIds
+        /// <see cref="ReservedChildIds"/> supplies for the well-known
+        /// parents, and at factory-minted ids for an application-defined
+        /// category.
+        /// </remarks>
+        private async ValueTask ApplyCategoryCapabilitiesAsync(
+            AliasNameCategoryDescriptor descriptor,
+            AliasNameCategoryState category,
+            IAliasNameStoreRegistry registry,
+            bool registerNewChildren,
+            List<NodeState> created,
+            CancellationToken cancellationToken)
+        {
+            AliasNameCapabilities capabilities = descriptor.Capabilities;
+            ReservedChildIds reserved = ReservedChildIds.For(descriptor.NodeId);
+
+            if ((capabilities & AliasNameCapabilities.FindAliasVerbose) != 0 &&
+                category.FindAliasVerbose == null)
+            {
+                category.AddFindAliasVerbose(SystemContext, reserved.FindAliasVerbose.Method);
+                ApplyReservedArgumentIds(
+                    category.FindAliasVerbose, reserved.FindAliasVerbose);
+                await RegisterAddedChildAsync(
+                    category.FindAliasVerbose, registerNewChildren, created, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+
+            if ((capabilities & AliasNameCapabilities.AddAliasesToCategory) != 0 &&
+                category.AddAliasesToCategory == null)
+            {
+                category.AddAddAliasesToCategory(
+                    SystemContext, reserved.AddAliasesToCategory.Method);
+                ApplyReservedArgumentIds(
+                    category.AddAliasesToCategory, reserved.AddAliasesToCategory);
+                await RegisterAddedChildAsync(
+                    category.AddAliasesToCategory, registerNewChildren, created, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+
+            if ((capabilities & AliasNameCapabilities.DeleteAliasesFromCategory) != 0 &&
+                category.DeleteAliasesFromCategory == null)
+            {
+                category.AddDeleteAliasesFromCategory(
+                    SystemContext, reserved.DeleteAliasesFromCategory.Method);
+                ApplyReservedArgumentIds(
+                    category.DeleteAliasesFromCategory, reserved.DeleteAliasesFromCategory);
+                await RegisterAddedChildAsync(
+                    category.DeleteAliasesFromCategory, registerNewChildren, created,
+                    cancellationToken).ConfigureAwait(false);
+            }
+
+            if ((capabilities & AliasNameCapabilities.LastChange) != 0 &&
+                category.LastChange == null)
+            {
+                category.AddLastChange(SystemContext, reserved.LastChange);
+                await RegisterAddedChildAsync(
+                    category.LastChange, registerNewChildren, created, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+
+            NodeId categoryId = descriptor.NodeId;
+
+            category.FindAliasVerbose?.OnCallAsync =
+                (ctx, method, objId, pattern, refType, ct) =>
+                    AliasNameMethodDispatcher.FindAliasVerboseAsync(
+                        registry,
                         Server.TypeTree,
                         objId.IsNull ? categoryId : objId,
                         pattern,
                         refType,
                         ct);
 
-            if (includeLastChange && category.LastChange != null)
+            category.AddAliasesToCategory?.OnCallAsync =
+                (ctx, method, objId, names, targets, servers, refType, ct) =>
+                    !AliasNameMethodDispatcher.HasSecureAdminAccess(ctx)
+                        ? new ValueTask<AddAliasesToCategoryMethodStateResult>(
+                            new AddAliasesToCategoryMethodStateResult
+                            {
+                                ServiceResult = new ServiceResult(StatusCodes.BadUserAccessDenied),
+                                ErrorCodes = default
+                            })
+                        : AliasNameMethodDispatcher.AddAliasesAsync(
+                            registry,
+                            objId.IsNull ? categoryId : objId,
+                            names,
+                            targets,
+                            servers,
+                            refType,
+                            ct);
+
+            category.DeleteAliasesFromCategory?.OnCallAsync =
+                (ctx, method, objId, names, targets, ct) =>
+                    !AliasNameMethodDispatcher.HasSecureAdminAccess(ctx)
+                        ? new ValueTask<DeleteAliasesFromCategoryMethodStateResult>(
+                            new DeleteAliasesFromCategoryMethodStateResult
+                            {
+                                ServiceResult = new ServiceResult(StatusCodes.BadUserAccessDenied),
+                                ErrorCodes = default
+                            })
+                        : AliasNameMethodDispatcher.DeleteAliasesAsync(
+                            registry,
+                            objId.IsNull ? categoryId : objId,
+                            names,
+                            targets,
+                            ct);
+
+            BindLastChange(categoryId, category, registry);
+        }
+
+        /// <summary>
+        /// Pins a method's argument properties to their reserved NodeIds.
+        /// The generated <c>Add…</c> helper rebases the arguments through
+        /// the node-id factory when it is handed an explicit method NodeId,
+        /// so they have to be re-pinned afterwards. A no-op when the
+        /// category has no reserved allocation.
+        /// </summary>
+        private static void ApplyReservedArgumentIds(
+            MethodState? method,
+            ReservedMethodIds reserved)
+        {
+            if (method == null || reserved.Method.IsNull)
             {
-                uint? seed = null;
-                foreach (IAliasNameStore store in m_aliasRegistry!.Stores)
-                {
-                    uint? v = store.GetLastChange(categoryId);
-                    if (v.HasValue)
-                    {
-                        seed = v;
-                        break;
-                    }
-                }
-                if (seed.HasValue)
-                {
-                    category.LastChange.Value = seed.Value;
-                    category.LastChange.ClearChangeMasks(SystemContext, false);
-                }
-                m_aliasesLastChangeNode = category.LastChange;
+                return;
             }
+            if (method.InputArguments != null)
+            {
+                method.InputArguments.NodeId = reserved.InputArguments;
+            }
+            if (method.OutputArguments != null)
+            {
+                method.OutputArguments.NodeId = reserved.OutputArguments;
+            }
+        }
+
+        /// <summary>
+        /// Registers a child added to an already-loaded category. Children
+        /// of a category that has not been registered yet are covered by
+        /// the registration of their parent.
+        /// </summary>
+        private async ValueTask RegisterAddedChildAsync(
+            NodeState? child,
+            bool registerNewChildren,
+            List<NodeState> created,
+            CancellationToken cancellationToken)
+        {
+            if (child == null || !registerNewChildren)
+            {
+                return;
+            }
+            await AddPredefinedNodeAsync(SystemContext, child, cancellationToken)
+                .ConfigureAwait(false);
+            created.Add(child);
+        }
+
+        /// <summary>
+        /// Creates one <c>AliasNameType</c> instance per alias whose home
+        /// category is <paramref name="descriptor"/>. Aliases contributed by
+        /// sub-categories are skipped here — they are materialized under
+        /// their own category — even though <c>FindAliasVerbose</c> reports
+        /// them recursively.
+        /// </summary>
+        private async ValueTask MaterializeAliasesAsync(
+            IAliasNameStore store,
+            AliasNameCategoryDescriptor descriptor,
+            AliasNameCategoryState category,
+            IDictionary<NodeId, IList<IReference>> externalReferences,
+            List<NodeState> created,
+            CancellationToken cancellationToken)
+        {
+            // Restrict the query to AliasFor and its subtypes: the reference
+            // the materialized node carries is AliasFor, and
+            // AliasNameVerboseDataType does not report which reference type
+            // an entry was stored under. Without the filter an alias
+            // registered under an unrelated reference type would be
+            // published as an AliasFor association it does not have.
+            IReadOnlyList<AliasNameVerboseDataType> aliases = await store
+                .FindAliasVerboseAsync(
+                    descriptor.NodeId,
+                    AllAliasesPattern,
+                    ReferenceTypeIds.AliasFor,
+                    Server.TypeTree,
+                    cancellationToken).ConfigureAwait(false);
+
+            // One node per alias name; the store reports a separate record
+            // per reference type, and a name may carry several targets.
+            var byName = new Dictionary<string, AliasNameState>();
+            var seenTargets = new HashSet<(string Name, ExpandedNodeId Target)>();
+
+            foreach (AliasNameVerboseDataType alias in aliases)
+            {
+                if (alias.AliasNameCategoryId != descriptor.NodeId ||
+                    string.IsNullOrEmpty(alias.AliasName.Name))
+                {
+                    continue;
+                }
+
+                string name = alias.AliasName.Name!;
+                if (!byName.TryGetValue(name, out AliasNameState? aliasNode))
+                {
+                    aliasNode = CreateAliasNode(descriptor, category, alias.AliasName, name);
+                    byName[name] = aliasNode;
+                    created.Add(aliasNode);
+                }
+
+                for (int ii = 0; ii < alias.ReferencedNodes.Count; ii++)
+                {
+                    ExpandedNodeId target = alias.ReferencedNodes[ii];
+
+                    // The same target may arrive once per AliasFor subtype
+                    // the store grouped it under; the node carries one
+                    // reference per target.
+                    if (!seenTargets.Add((name, target)))
+                    {
+                        continue;
+                    }
+
+                    AddAliasForReference(
+                        aliasNode,
+                        target,
+                        ii < alias.ServerUris.Count ? alias.ServerUris[ii] : null,
+                        externalReferences);
+                }
+            }
+
+            foreach (AliasNameState aliasNode in byName.Values)
+            {
+                await AddPredefinedNodeAsync(SystemContext, aliasNode, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
+        /// Builds the <c>AliasNameType</c> instance for one alias. Per
+        /// Part 17 §6.2 the BrowseName carries the alias name and the
+        /// DisplayName repeats it with an empty locale.
+        /// </summary>
+        private AliasNameState CreateAliasNode(
+            AliasNameCategoryDescriptor descriptor,
+            AliasNameCategoryState category,
+            QualifiedName aliasName,
+            string name)
+        {
+            AliasNameState aliasNode = SystemContext.CreateInstanceOfAliasNameType();
+
+            aliasNode.NodeId = new NodeId(
+                Utils.Format("{0}.{1}", descriptor.NodeId, name),
+                m_namespaceIndex);
+            aliasNode.BrowseName = aliasName;
+            aliasNode.DisplayName = new LocalizedText(string.Empty, name);
+            aliasNode.SymbolicName = name;
+            aliasNode.TypeDefinitionId = ObjectTypeIds.AliasNameType;
+            aliasNode.ReferenceTypeId = ReferenceTypeIds.Organizes;
+
+            category.AddReference(ReferenceTypeIds.Organizes, false, aliasNode.NodeId);
+            aliasNode.AddReference(ReferenceTypeIds.Organizes, true, category.NodeId);
+
+            return aliasNode;
+        }
+
+        /// <summary>
+        /// Adds the forward <c>AliasFor</c> reference to a target and — for
+        /// targets on this server — the inverse <c>HasAlias</c> reference
+        /// back, which usually lands in another node manager and therefore
+        /// travels through <paramref name="externalReferences"/>.
+        /// </summary>
+        private void AddAliasForReference(
+            AliasNameState aliasNode,
+            ExpandedNodeId target,
+            string? serverUri,
+            IDictionary<NodeId, IList<IReference>> externalReferences)
+        {
+            if (target.IsNull)
+            {
+                return;
+            }
+
+            if (!string.IsNullOrEmpty(serverUri))
+            {
+                // A target on a remote server has no local node to carry
+                // the inverse reference.
+                aliasNode.AddReference(ReferenceTypeIds.AliasFor, false, target);
+                return;
+            }
+
+            // Resolve the namespace-uri form a store may have been seeded
+            // with, so the reference carries a plain local NodeId.
+            var localTarget = ExpandedNodeId.ToNodeId(target, Server.NamespaceUris);
+            if (localTarget.IsNull)
+            {
+                aliasNode.AddReference(ReferenceTypeIds.AliasFor, false, target);
+                return;
+            }
+
+            aliasNode.AddReference(ReferenceTypeIds.AliasFor, false, localTarget);
+
+            AddExternalReference(
+                localTarget,
+                ReferenceTypeIds.AliasFor,
+                true,
+                aliasNode.NodeId,
+                externalReferences);
         }
 
         private void OnAliasRegistryChanged(object? sender, AliasStoreChangedEventArgs e)
         {
-            // Only the standard Aliases (i=23470) node carries a LastChange
-            // property in the shipped NodeSet; mirror its store value.
-            if (m_aliasesLastChangeNode != null &&
-                e.CategoryId == ObjectIds.Aliases)
+            // Mirror the store value onto whichever categories expose a
+            // LastChange property: the standard Aliases (i=23470) node from
+            // the shipped NodeSet, plus any category that declared the
+            // capability and had one added during materialization.
+            if (m_lastChangeNodes.TryGetValue(
+                    e.CategoryId, out PropertyState<uint>? lastChange))
             {
-                m_aliasesLastChangeNode.Value = e.LastChange;
-                m_aliasesLastChangeNode.ClearChangeMasks(SystemContext, false);
+                lastChange.Value = e.LastChange;
+                lastChange.ClearChangeMasks(SystemContext, false);
             }
         }
 
@@ -151,10 +679,133 @@ namespace Opc.Ua.Server
                 registry.Changed -= OnAliasRegistryChanged;
                 m_aliasRegistry = null;
             }
-            m_aliasesLastChangeNode = null;
+            m_lastChangeNodes.Clear();
+        }
+
+        /// <summary>
+        /// The Part 4 §7.40 Like-pattern that matches every alias name.
+        /// </summary>
+        private const string AllAliasesPattern = "%";
+
+        /// <summary>
+        /// The reserved NodeIds of one optional method and its two argument
+        /// properties. <see cref="Method"/> is <see cref="NodeId.Null"/> for
+        /// a category with no reserved allocation, which makes the generated
+        /// <c>Add…</c> helper fall back to the node-id factory.
+        /// </summary>
+        private readonly record struct ReservedMethodIds(
+            NodeId Method,
+            NodeId InputArguments,
+            NodeId OutputArguments);
+
+        /// <summary>
+        /// The NodeIds the OPC Foundation reserves for the optional Part 17
+        /// children of the three well-known categories.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// These identifiers are allocated in the standard identifier
+        /// registry — <c>StandardTypes.csv</c>, rows <c>Aliases_FindAliasVerbose,24054</c>
+        /// through <c>Topics_DeleteAliasesFromCategory_OutputArguments,24080</c>,
+        /// plus <c>TagVariables_LastChange,32854</c> and
+        /// <c>Topics_LastChange,32856</c> — so a server that instantiates
+        /// one of these optional children has a canonical NodeId for it.
+        /// </para>
+        /// <para>
+        /// They are deliberately absent from both the ModelDesign and the
+        /// published NodeSet: the standard address space does not
+        /// instantiate optional children, so the source generator has no
+        /// parent-to-instance mapping to emit and no <c>MethodIds</c>
+        /// constant exists for them. The argument properties do have
+        /// generated <c>VariableIds</c> constants and are referenced through
+        /// those; only the nine method identifiers and the two
+        /// <c>LastChange</c> identifiers are spelled out here, each
+        /// traceable to its registry row.
+        /// </para>
+        /// </remarks>
+        private readonly record struct ReservedChildIds(
+            ReservedMethodIds FindAliasVerbose,
+            ReservedMethodIds AddAliasesToCategory,
+            ReservedMethodIds DeleteAliasesFromCategory,
+            NodeId LastChange)
+        {
+            public static ReservedChildIds For(NodeId categoryId)
+            {
+                if (categoryId == ObjectIds.Aliases)
+                {
+                    return new ReservedChildIds(
+                        new ReservedMethodIds(
+                            new NodeId(24054u),
+                            VariableIds.Aliases_FindAliasVerbose_InputArguments,
+                            VariableIds.Aliases_FindAliasVerbose_OutputArguments),
+                        new ReservedMethodIds(
+                            new NodeId(24057u),
+                            VariableIds.Aliases_AddAliasesToCategory_InputArguments,
+                            VariableIds.Aliases_AddAliasesToCategory_OutputArguments),
+                        new ReservedMethodIds(
+                            new NodeId(24060u),
+                            VariableIds.Aliases_DeleteAliasesFromCategory_InputArguments,
+                            VariableIds.Aliases_DeleteAliasesFromCategory_OutputArguments),
+                        VariableIds.Aliases_LastChange);
+                }
+                if (categoryId == ObjectIds.TagVariables)
+                {
+                    return new ReservedChildIds(
+                        new ReservedMethodIds(
+                            new NodeId(24063u),
+                            VariableIds.TagVariables_FindAliasVerbose_InputArguments,
+                            VariableIds.TagVariables_FindAliasVerbose_OutputArguments),
+                        new ReservedMethodIds(
+                            new NodeId(24066u),
+                            VariableIds.TagVariables_AddAliasesToCategory_InputArguments,
+                            VariableIds.TagVariables_AddAliasesToCategory_OutputArguments),
+                        new ReservedMethodIds(
+                            new NodeId(24069u),
+                            VariableIds.TagVariables_DeleteAliasesFromCategory_InputArguments,
+                            VariableIds.TagVariables_DeleteAliasesFromCategory_OutputArguments),
+                        new NodeId(32854u));
+                }
+                if (categoryId == ObjectIds.Topics)
+                {
+                    return new ReservedChildIds(
+                        new ReservedMethodIds(
+                            new NodeId(24072u),
+                            VariableIds.Topics_FindAliasVerbose_InputArguments,
+                            VariableIds.Topics_FindAliasVerbose_OutputArguments),
+                        new ReservedMethodIds(
+                            new NodeId(24075u),
+                            VariableIds.Topics_AddAliasesToCategory_InputArguments,
+                            VariableIds.Topics_AddAliasesToCategory_OutputArguments),
+                        new ReservedMethodIds(
+                            new NodeId(24078u),
+                            VariableIds.Topics_DeleteAliasesFromCategory_InputArguments,
+                            VariableIds.Topics_DeleteAliasesFromCategory_OutputArguments),
+                        new NodeId(32856u));
+                }
+                return default;
+            }
         }
 
         private IAliasNameStoreRegistry? m_aliasRegistry;
-        private PropertyState<uint>? m_aliasesLastChangeNode;
+
+        /// <summary>
+        /// The <c>LastChange</c> property of every category that exposes
+        /// one, keyed by category NodeId. Concurrent because
+        /// <see cref="OnAliasRegistryChanged"/> reads it on client-call
+        /// threads while <see cref="UnwireStandardAliasMethods"/> may clear
+        /// it during disposal.
+        /// </summary>
+        private readonly ConcurrentDictionary<NodeId, PropertyState<uint>> m_lastChangeNodes = [];
+    }
+
+    /// <summary>
+    /// Source-generated log messages for the Part 17 parts of
+    /// DiagnosticsNodeManager.
+    /// </summary>
+    internal static partial class DiagnosticsNodeManagerAliasNamesLog
+    {
+        [LoggerMessage(EventId = ServerEventIds.DiagnosticsNodeManager + 1, Level = LogLevel.Information,
+            Message = "Materialized {Count} Part 17 alias name nodes from the registered alias stores.")]
+        public static partial void MaterializedAliasNameNodes(this ILogger logger, int count);
     }
 }

--- a/src/Opc.Ua.Server/Diagnostics/DiagnosticsNodeManager.AliasNames.cs
+++ b/src/Opc.Ua.Server/Diagnostics/DiagnosticsNodeManager.AliasNames.cs
@@ -336,7 +336,7 @@ namespace Opc.Ua.Server
         /// Serializes the <c>LastChange</c> node updates raised by store
         /// mutations, which arrive on arbitrary client-call threads.
         /// </summary>
-        private readonly object m_lastChangeSync = new();
+        private readonly Lock m_lastChangeSync = new();
 
         /// <summary>
         /// The <c>LastChange</c> property of every category that exposes

--- a/tests/Opc.Ua.Features.Tests/AliasNameIntegrationTests.cs
+++ b/tests/Opc.Ua.Features.Tests/AliasNameIntegrationTests.cs
@@ -217,10 +217,10 @@ namespace Opc.Ua.Features.Tests
         [Test]
         public async Task EnumerateSubCategoriesAsyncOnLeafReturnsEmptyAsync()
         {
-            // TagVariables has no sub-categories in the standard NodeSet —
-            // the enumeration must yield zero results without throwing.
+            // Topics organizes only aliases, no sub-categories — the
+            // enumeration must yield zero results without throwing.
             var client = AliasNameClient
-                .OpenStandardTagVariables(m_session);
+                .OpenStandardTopics(m_session);
             int count = 0;
             await foreach (AliasNameSubCategoryInfo _ in
                 client.EnumerateSubCategoriesAsync().ConfigureAwait(false))
@@ -228,6 +228,26 @@ namespace Opc.Ua.Features.Tests
                 count++;
             }
             Assert.That(count, Is.Zero);
+        }
+
+        [Test]
+        public async Task EnumerateSubCategoriesAsyncReturnsNestedCategoryAsync()
+        {
+            // The reference server nests a Devices category under
+            // TagVariables (Part 17 §6.3.1 category nesting).
+            var client = AliasNameClient
+                .OpenStandardTagVariables(m_session);
+
+            var names = new HashSet<string>();
+            await foreach (AliasNameSubCategoryInfo info in
+                client.EnumerateSubCategoriesAsync().ConfigureAwait(false))
+            {
+                Assert.That(info.NodeId.IsNull, Is.False);
+                names.Add(info.BrowseName.Name);
+            }
+
+            Assert.That(names, Does.Contain("Devices"),
+                "TagVariables must Organize-link to the nested Devices category.");
         }
     }
 }

--- a/tests/Opc.Ua.History.Tests/AlarmsAndConditionsAlarmTests.cs
+++ b/tests/Opc.Ua.History.Tests/AlarmsAndConditionsAlarmTests.cs
@@ -172,6 +172,7 @@ namespace Opc.Ua.History.Tests
             Assert.That(StatusCode.IsGood(confirm.StatusCode), Is.True,
                 $"Confirm should succeed: {confirm.StatusCode}");
 
+            await collector.ConditionRefreshAsync().ConfigureAwait(false);
             EventFieldList confirmEvent = await collector.WaitForEventAsync(
                 alarmId,
                 e => AlarmEventCollector.TryGetBoolean(

--- a/tests/Opc.Ua.InformationModel.Tests/AliasNameExtendedTests.cs
+++ b/tests/Opc.Ua.InformationModel.Tests/AliasNameExtendedTests.cs
@@ -165,7 +165,9 @@ namespace Opc.Ua.InformationModel.Tests
         [Test]
         public Task AliasNameSecurityAdminNotRequired()
         {
-            Assert.Ignore("AliasName SecurityAdmin CU is optional.");
+            Assert.Ignore(
+                "AliasName SecurityAdmin CU is optional; the mutation methods it " +
+                "covers are exercised by AliasnameOptionalMethodsTests.");
             return Task.CompletedTask;
         }
 

--- a/tests/Opc.Ua.InformationModel.Tests/AliasNameTestHelpers.cs
+++ b/tests/Opc.Ua.InformationModel.Tests/AliasNameTestHelpers.cs
@@ -295,6 +295,139 @@ namespace Opc.Ua.InformationModel.Tests
         }
 
         /// <summary>
+        /// Locates a method by BrowseName and fails the test when the server
+        /// does not expose it. The optional Part 17 methods carry no
+        /// well-known NodeIds, so they are always resolved by browsing.
+        /// </summary>
+        public static async Task<NodeId> RequireMethodAsync(
+            ISession session, NodeId parent, string methodBrowseName)
+        {
+            NodeId methodId = await FindMethodAsync(session, parent, methodBrowseName)
+                .ConfigureAwait(false);
+            Assert.That(methodId.IsNull, Is.False,
+                $"Expected a '{methodBrowseName}' method under {parent}.");
+            return methodId;
+        }
+
+        /// <summary>
+        /// Calls a method with the given input arguments and returns the raw
+        /// <see cref="CallMethodResult"/> without asserting on its status —
+        /// callers that expect a failure inspect it themselves.
+        /// </summary>
+        public static async Task<CallMethodResult> CallMethodAsync(
+            ISession session,
+            NodeId objectId,
+            NodeId methodId,
+            params Variant[] inputArguments)
+        {
+            CallResponse response = await session.CallAsync(
+                null,
+                new CallMethodRequest[]
+                {
+                    new() {
+                        ObjectId = objectId,
+                        MethodId = methodId,
+                        InputArguments = inputArguments.ToArrayOf()
+                    }
+                }.ToArrayOf(),
+                CancellationToken.None).ConfigureAwait(false);
+
+            Assert.That(response.Results.Count, Is.EqualTo(1));
+            return response.Results[0];
+        }
+
+        /// <summary>
+        /// Decodes the AliasNameVerboseDataType[] returned by
+        /// FindAliasVerbose from the first output argument.
+        /// </summary>
+        public static IList<AliasNameVerboseDataType> DecodeVerboseAliasResults(
+            ISession session, CallMethodResult result)
+        {
+            var records = new List<AliasNameVerboseDataType>();
+            if (result == null || result.OutputArguments.Count == 0)
+            {
+                return records;
+            }
+            if (!result.OutputArguments[0].TryGetValue(out ArrayOf<ExtensionObject> aliasArray))
+            {
+                return records;
+            }
+
+            for (int i = 0; i < aliasArray.Count; i++)
+            {
+                ExtensionObject ext = aliasArray.Span[i];
+                if (!ext.IsNull &&
+                    ext.TryGetValue(out AliasNameVerboseDataType typed, session.MessageContext) &&
+                    typed != null)
+                {
+                    records.Add(typed);
+                }
+            }
+            return records;
+        }
+
+        /// <summary>
+        /// Returns true when the referenced node is an instance of
+        /// <c>PublishedDataSetType</c> (i=14509) or one of its subtypes —
+        /// the "is a Dataset" check the Topics conformance unit applies to
+        /// every alias target.
+        /// </summary>
+        public static async Task<bool> IsPublishedDataSetAsync(
+            ISession session, ReferenceDescription target)
+        {
+            var typeDefinition = ExpandedNodeId.ToNodeId(
+                target.TypeDefinition, session.NamespaceUris);
+            if (typeDefinition.IsNull)
+            {
+                return false;
+            }
+            if (typeDefinition == ObjectTypeIds.PublishedDataSetType)
+            {
+                return true;
+            }
+
+            // Walk HasSubtype inverse references up to PublishedDataSetType.
+            NodeId current = typeDefinition;
+            for (int depth = 0; depth < MaxTypeHierarchyDepth; depth++)
+            {
+                BrowseResponse response = await session.BrowseAsync(
+                    null, null, 0,
+                    new BrowseDescription[]
+                    {
+                        new() {
+                            NodeId = current,
+                            BrowseDirection = BrowseDirection.Inverse,
+                            ReferenceTypeId = ReferenceTypeIds.HasSubtype,
+                            IncludeSubtypes = false,
+                            NodeClassMask = 0,
+                            ResultMask = (uint)BrowseResultMask.All
+                        }
+                    }.ToArrayOf(),
+                    CancellationToken.None).ConfigureAwait(false);
+
+                if (response.Results.Count != 1 ||
+                    response.Results[0].References.Count == 0)
+                {
+                    return false;
+                }
+
+                current = ExpandedNodeId.ToNodeId(
+                    response.Results[0].References[0].NodeId, session.NamespaceUris);
+                if (current == ObjectTypeIds.PublishedDataSetType)
+                {
+                    return true;
+                }
+                if (current.IsNull || current == ObjectTypeIds.BaseObjectType)
+                {
+                    return false;
+                }
+            }
+            return false;
+        }
+
+        private const int MaxTypeHierarchyDepth = 16;
+
+        /// <summary>
         /// Plain record describing a single alias entry returned by FindAlias.
         /// </summary>
         internal sealed record AliasRecord(QualifiedName AliasName, NodeId[] ReferencedNodes);

--- a/tests/Opc.Ua.InformationModel.Tests/AliasNameTestHelpers.cs
+++ b/tests/Opc.Ua.InformationModel.Tests/AliasNameTestHelpers.cs
@@ -296,8 +296,11 @@ namespace Opc.Ua.InformationModel.Tests
 
         /// <summary>
         /// Locates a method by BrowseName and fails the test when the server
-        /// does not expose it. The optional Part 17 methods carry no
-        /// well-known NodeIds, so they are always resolved by browsing.
+        /// does not expose it. The optional Part 17 methods do have reserved
+        /// NodeIds (StandardTypes.csv), but no generated <c>MethodIds</c>
+        /// constants exist for them — the ModelDesign does not declare the
+        /// children — so tests resolve them by browsing, as a client
+        /// without prior knowledge would.
         /// </summary>
         public static async Task<NodeId> RequireMethodAsync(
             ISession session, NodeId parent, string methodBrowseName)
@@ -375,57 +378,19 @@ namespace Opc.Ua.InformationModel.Tests
         public static async Task<bool> IsPublishedDataSetAsync(
             ISession session, ReferenceDescription target)
         {
-            var typeDefinition = ExpandedNodeId.ToNodeId(
-                target.TypeDefinition, session.NamespaceUris);
-            if (typeDefinition.IsNull)
+            if (target.TypeDefinition.IsNull)
             {
                 return false;
             }
-            if (typeDefinition == ObjectTypeIds.PublishedDataSetType)
-            {
-                return true;
-            }
 
-            // Walk HasSubtype inverse references up to PublishedDataSetType.
-            NodeId current = typeDefinition;
-            for (int depth = 0; depth < MaxTypeHierarchyDepth; depth++)
-            {
-                BrowseResponse response = await session.BrowseAsync(
-                    null, null, 0,
-                    new BrowseDescription[]
-                    {
-                        new() {
-                            NodeId = current,
-                            BrowseDirection = BrowseDirection.Inverse,
-                            ReferenceTypeId = ReferenceTypeIds.HasSubtype,
-                            IncludeSubtypes = false,
-                            NodeClassMask = 0,
-                            ResultMask = (uint)BrowseResultMask.All
-                        }
-                    }.ToArrayOf(),
-                    CancellationToken.None).ConfigureAwait(false);
-
-                if (response.Results.Count != 1 ||
-                    response.Results[0].References.Count == 0)
-                {
-                    return false;
-                }
-
-                current = ExpandedNodeId.ToNodeId(
-                    response.Results[0].References[0].NodeId, session.NamespaceUris);
-                if (current == ObjectTypeIds.PublishedDataSetType)
-                {
-                    return true;
-                }
-                if (current.IsNull || current == ObjectTypeIds.BaseObjectType)
-                {
-                    return false;
-                }
-            }
-            return false;
+            // The session's node cache walks (and memoizes) the subtype
+            // chain, so repeated targets of the same type cost one lookup
+            // instead of one Browse round trip per hierarchy level.
+            return await session.NodeCache.IsTypeOfAsync(
+                target.TypeDefinition,
+                ObjectTypeIds.PublishedDataSetType,
+                CancellationToken.None).ConfigureAwait(false);
         }
-
-        private const int MaxTypeHierarchyDepth = 16;
 
         /// <summary>
         /// Plain record describing a single alias entry returned by FindAlias.

--- a/tests/Opc.Ua.InformationModel.Tests/AliasnameBaseTests.cs
+++ b/tests/Opc.Ua.InformationModel.Tests/AliasnameBaseTests.cs
@@ -121,6 +121,61 @@ namespace Opc.Ua.InformationModel.Tests
                 "Aliases (i=23470) should expose at least one AliasNameCategory child.");
         }
 
+        [Description("Verify the address space contains at least one AliasNameType instance with an association to a Node.")]
+        [Test]
+        public async Task AddressSpaceContainsAliasNameInstanceAsync()
+        {
+            // The AliasName Base conformance unit is skipped entirely when
+            // no AliasNameType instance can be found, so walk the Aliases
+            // hierarchy and require one that aliases an actual node.
+            var pending = new Queue<NodeId>();
+            pending.Enqueue(AliasesNodeId);
+
+            int aliasInstances = 0;
+            int aliasesWithTarget = 0;
+
+            while (pending.Count > 0)
+            {
+                NodeId current = pending.Dequeue();
+                IList<ReferenceDescription> children =
+                    await BrowseChildrenAsync(Session, current).ConfigureAwait(false);
+
+                foreach (ReferenceDescription child in children)
+                {
+                    var typeDef = ExpandedNodeId.ToNodeId(
+                        child.TypeDefinition, Session.NamespaceUris);
+                    var childId = ExpandedNodeId.ToNodeId(
+                        child.NodeId, Session.NamespaceUris);
+
+                    if (typeDef == AliasNameCategoryTypeNodeId)
+                    {
+                        pending.Enqueue(childId);
+                        continue;
+                    }
+                    if (typeDef != AliasNameTypeNodeId)
+                    {
+                        continue;
+                    }
+
+                    aliasInstances++;
+                    Assert.That(child.BrowseName.Name, Is.Not.Null.And.Not.Empty,
+                        "An AliasName instance carries its alias in the BrowseName.");
+
+                    IList<ReferenceDescription> targets = await BrowseChildrenAsync(
+                        Session, childId, AliasForNodeId).ConfigureAwait(false);
+                    if (targets.Count > 0)
+                    {
+                        aliasesWithTarget++;
+                    }
+                }
+            }
+
+            Assert.That(aliasInstances, Is.GreaterThan(0),
+                "The address space should contain at least one AliasNameType instance.");
+            Assert.That(aliasesWithTarget, Is.GreaterThan(0),
+                "At least one AliasName instance should have an AliasFor association to a Node.");
+        }
+
         [Description("Call the FindAlias method on the Aliases object, passing in the string name part of the name of an AliasName instance. Pass in the AliasFor Reference type.")]
         [Test]
         public async Task FindAliasByExactNameAsync()

--- a/tests/Opc.Ua.InformationModel.Tests/AliasnameCategoryTagsTests.cs
+++ b/tests/Opc.Ua.InformationModel.Tests/AliasnameCategoryTagsTests.cs
@@ -100,12 +100,6 @@ namespace Opc.Ua.InformationModel.Tests
                 }
             }
 
-            if (aliasInstances == 0)
-            {
-                Assert.Ignore(
-                    "TagVariables category exposes no AliasName instances on this server.");
-            }
-
             Assert.That(aliasInstances, Is.GreaterThan(0),
                 "TagVariables should contain at least one AliasName instance.");
             Assert.That(aliasForVariable, Is.GreaterThan(0),

--- a/tests/Opc.Ua.InformationModel.Tests/AliasnameCategoryTopicsTests.cs
+++ b/tests/Opc.Ua.InformationModel.Tests/AliasnameCategoryTopicsTests.cs
@@ -65,7 +65,7 @@ namespace Opc.Ua.InformationModel.Tests
             Assert.That(typeNodeIds, Contains.Item(AliasNameCategoryTypeNodeId));
         }
 
-        [Description("Verify that at least one instance of a Topic is included in the Topics category and that it references a remote Object.")]
+        [Description("Verify that at least one instance of a Topic is included in the category and that the instance is a Dataset.")]
         [Test]
         public async Task TopicsCategoryContainsAliasNameForDatasetAsync()
         {
@@ -76,29 +76,46 @@ namespace Opc.Ua.InformationModel.Tests
                 Session, category).ConfigureAwait(false);
 
             int aliasInstances = 0;
+            int aliasForDataSet = 0;
             var browseNames = new List<string>();
             foreach (ReferenceDescription child in children)
             {
                 var typeDef = ExpandedNodeId.ToNodeId(
                     child.TypeDefinition, Session.NamespaceUris);
-                if (typeDef == AliasNameTypeNodeId)
+                if (typeDef != AliasNameTypeNodeId)
                 {
-                    aliasInstances++;
-                    browseNames.Add(child.BrowseName.Name);
+                    continue;
                 }
-            }
+                aliasInstances++;
+                browseNames.Add(child.BrowseName.Name);
 
-            if (aliasInstances == 0)
-            {
-                Assert.Ignore(
-                    "Topics category exposes no AliasName instances on this server.");
+                // Part 17 §9 requires every alias in the Topics hierarchy to
+                // point at a PublishedDataSetType instance.
+                var aliasId = ExpandedNodeId.ToNodeId(
+                    child.NodeId, Session.NamespaceUris);
+                IList<ReferenceDescription> targets = await BrowseChildrenAsync(
+                    Session, aliasId, AliasForNodeId).ConfigureAwait(false);
+                Assert.That(targets, Is.Not.Empty,
+                    $"Alias '{child.BrowseName.Name}' should have an AliasFor target.");
+
+                foreach (ReferenceDescription target in targets)
+                {
+                    Assert.That(
+                        await IsPublishedDataSetAsync(Session, target).ConfigureAwait(false),
+                        Is.True,
+                        $"Topics alias '{child.BrowseName.Name}' should reference a PublishedDataSetType instance.");
+                    aliasForDataSet++;
+                }
             }
 
             Assert.That(aliasInstances, Is.GreaterThan(0),
                 "Topics should contain at least one AliasName instance.");
-            // ServerEvents and AuditEvents are populated by the
-            // Quickstart reference server's AliasNameNodeManager.
+            Assert.That(aliasForDataSet, Is.GreaterThan(0),
+                "Topics should contain at least one AliasName referencing a dataset.");
+            // The datasets are created by the reference server's
+            // ReferenceServerConfigurationNodeManager under PublishedDataSets.
             Assert.That(browseNames, Contains.Item("ServerEvents"));
+            Assert.That(browseNames, Contains.Item("ReferenceDataSet"));
         }
 
         [Description("Call the FindAlias method on the Topics object, passing in '%' for the filter.")]

--- a/tests/Opc.Ua.InformationModel.Tests/AliasnameHierarchyTests.cs
+++ b/tests/Opc.Ua.InformationModel.Tests/AliasnameHierarchyTests.cs
@@ -28,10 +28,16 @@
  * ======================================================================*/
 
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using Opc.Ua.Client.TestFramework;
 using static Opc.Ua.InformationModel.Tests.AliasNameTestHelpers;
+
+// Conformance tests use inline literal arrays as expected-value
+// assertions; the per-call allocation cost is irrelevant for tests
+// and keeping the literal adjacent to the assertion improves readability.
+#pragma warning disable CA1861 // Avoid constant arrays as arguments
 
 namespace Opc.Ua.InformationModel.Tests
 {
@@ -87,13 +93,94 @@ namespace Opc.Ua.InformationModel.Tests
                 "Expected at least two nested categories under Aliases (TagVariables and Topics).");
             Assert.That(categoryNames, Contains.Item("TagVariables"));
             Assert.That(categoryNames, Contains.Item("Topics"));
-            if (aliasNamesFound == 0)
-            {
-                Assert.Ignore(
-                    "Nested categories expose no AliasName instances on this server.");
-            }
             Assert.That(aliasNamesFound, Is.GreaterThan(0),
                 "Nested categories should expose AliasName instances.");
+        }
+
+        [Description("Verify that an AliasNameCategoryType instance exists under another AliasNameCategoryType instance.")]
+        [Test]
+        public async Task AliasNameCategoryNestedUnderCategoryAsync()
+        {
+            (NodeId tagVariables, _) = await FindCategoryAsync(
+                Session, "TagVariables").ConfigureAwait(false);
+
+            ReferenceDescription nested = await FindNestedCategoryAsync(
+                Session, tagVariables).ConfigureAwait(false);
+
+            Assert.That(nested, Is.Not.Null,
+                "TagVariables should organize a nested AliasNameCategoryType instance.");
+            Assert.That(nested.BrowseName.Name, Is.EqualTo("Devices"));
+
+            // The nested category must carry the mandatory FindAlias method.
+            var nestedId = ExpandedNodeId.ToNodeId(
+                nested.NodeId, Session.NamespaceUris);
+            NodeId methodId = await FindMethodAsync(
+                Session, nestedId, "FindAlias").ConfigureAwait(false);
+            Assert.That(methodId.IsNull, Is.False,
+                "The nested category should expose a FindAlias method.");
+        }
+
+        [Description("Verify FindAlias on a nested category is restricted to that category's hierarchical structure.")]
+        [Test]
+        public async Task FindAliasOnNestedCategoryIsRestrictedToItsSubtreeAsync()
+        {
+            (NodeId tagVariables, NodeId parentMethod) = await FindCategoryAsync(
+                Session, "TagVariables").ConfigureAwait(false);
+
+            ReferenceDescription nested = await FindNestedCategoryAsync(
+                Session, tagVariables).ConfigureAwait(false);
+            Assert.That(nested, Is.Not.Null);
+
+            var nestedId = ExpandedNodeId.ToNodeId(
+                nested.NodeId, Session.NamespaceUris);
+            NodeId nestedMethod = await FindMethodAsync(
+                Session, nestedId, "FindAlias").ConfigureAwait(false);
+            Assert.That(nestedMethod.IsNull, Is.False);
+
+            CallMethodResult nestedResult = await CallFindAliasAsync(
+                Session, nestedId, nestedMethod, "%", AliasForNodeId)
+                .ConfigureAwait(false);
+            Assert.That(StatusCode.IsGood(nestedResult.StatusCode), Is.True,
+                $"FindAlias on the nested category should succeed: {nestedResult.StatusCode}");
+            string[] nestedNames =
+                [.. DecodeAliasResults(Session, nestedResult).Select(r => r.AliasName.Name)];
+
+            Assert.That(nestedNames, Is.EquivalentTo(new[] { "Pump1_Status", "Heater_Power" }),
+                "FindAlias on the nested category should return only its own aliases.");
+
+            // Per Part 17 §6.3.2 the parent search covers the sub-tree too.
+            CallMethodResult parentResult = await CallFindAliasAsync(
+                Session, tagVariables, parentMethod, "%", AliasForNodeId)
+                .ConfigureAwait(false);
+            Assert.That(StatusCode.IsGood(parentResult.StatusCode), Is.True);
+            string[] parentNames =
+                [.. DecodeAliasResults(Session, parentResult).Select(r => r.AliasName.Name)];
+
+            Assert.That(parentNames, Is.SupersetOf(nestedNames),
+                "FindAlias on the parent category should also return the nested aliases.");
+            Assert.That(parentNames, Has.Some.EqualTo("TIC101_Setpoint"),
+                "FindAlias on the parent should still return its own aliases.");
+        }
+
+        /// <summary>
+        /// Returns the first AliasNameCategoryType instance organized under
+        /// <paramref name="categoryId"/>, or null when there is none.
+        /// </summary>
+        private static async Task<ReferenceDescription> FindNestedCategoryAsync(
+            Opc.Ua.Client.ISession session, NodeId categoryId)
+        {
+            IList<ReferenceDescription> children =
+                await BrowseChildrenAsync(session, categoryId).ConfigureAwait(false);
+
+            foreach (ReferenceDescription child in children)
+            {
+                if (ExpandedNodeId.ToNodeId(child.TypeDefinition, session.NamespaceUris) ==
+                    AliasNameCategoryTypeNodeId)
+                {
+                    return child;
+                }
+            }
+            return null;
         }
 
         [Description("Call the FindAlias method on an instance of AliasNameCategoryType (under Aliases), passing in a '%' for the filter. Pass in the AliasFor for the Reference type.")]

--- a/tests/Opc.Ua.InformationModel.Tests/AliasnameOptionalMethodsTests.cs
+++ b/tests/Opc.Ua.InformationModel.Tests/AliasnameOptionalMethodsTests.cs
@@ -60,18 +60,25 @@ namespace Opc.Ua.InformationModel.Tests
     {
         [Description("Verify the optional Part 17 methods are exposed on the well-known categories at their reserved NodeIds.")]
         [Test]
-        [TestCase("Aliases", 24054u, 24057u, 24060u)]
-        [TestCase("TagVariables", 24063u, 24066u, 24069u)]
-        [TestCase("Topics", 24072u, 24075u, 24078u)]
+        [TestCase(23470u, 24054u, 24057u, 24060u)]       // Aliases
+        [TestCase(23479u, 24063u, 24066u, 24069u)]       // TagVariables
+        [TestCase(23488u, 24072u, 24075u, 24078u)]       // Topics
         public async Task StandardCategoryExposesOptionalMethodsAsync(
-            string categoryName, uint verboseId, uint addId, uint deleteId)
+            uint categoryId, uint verboseId, uint addId, uint deleteId)
         {
-            NodeId category = await ResolveCategoryAsync(Session, categoryName)
+            var category = new NodeId(categoryId);
+
+            // One browse serves all three assertions — the returned
+            // ReferenceDescriptions already carry NodeId and BrowseName.
+            IList<ReferenceDescription> children = await BrowseChildrenAsync(
+                Session, category, ReferenceTypeIds.HasComponent)
                 .ConfigureAwait(false);
 
             // Part 17 §9 allocates a NodeId for each optional child of the
-            // three well-known categories, and the source generator assigns
-            // them when the child is added to one of those parents.
+            // three well-known categories. The ModelDesign does not declare
+            // these children, so the source generator cannot assign the ids
+            // — DiagnosticsNodeManager.ReservedChildIds supplies them
+            // explicitly when the children are created.
             (string Name, uint Id)[] expected =
             [
                 ("FindAliasVerbose", verboseId),
@@ -81,32 +88,26 @@ namespace Opc.Ua.InformationModel.Tests
 
             foreach ((string name, uint id) in expected)
             {
-                NodeId methodId = await FindMethodAsync(Session, category, name)
-                    .ConfigureAwait(false);
-                Assert.That(methodId.IsNull, Is.False,
-                    $"{categoryName} should expose the optional {name} method.");
-                Assert.That(methodId, Is.EqualTo(new NodeId(id)),
-                    $"{categoryName}.{name} should use the NodeId Part 17 reserves for it.");
-
-                DataValue browseName = await ReadAttributeAsync(
-                    Session, methodId, Attributes.BrowseName).ConfigureAwait(false);
-                Assert.That(StatusCode.IsGood(browseName.StatusCode), Is.True,
-                    $"{categoryName}.{name} should be readable at {methodId}.");
-                Assert.That(browseName.GetValue<QualifiedName>(default).Name,
-                    Is.EqualTo(name));
+                ReferenceDescription method = children.FirstOrDefault(
+                    c => c.BrowseName.Name == name);
+                Assert.That(method, Is.Not.Null,
+                    $"{category} should expose the optional {name} method.");
+                Assert.That(
+                    ExpandedNodeId.ToNodeId(method.NodeId, Session.NamespaceUris),
+                    Is.EqualTo(new NodeId(id)),
+                    $"{category}.{name} should use the NodeId Part 17 reserves for it.");
             }
         }
 
         [Description("Verify the optional LastChange property is exposed on the well-known categories at its reserved NodeId.")]
         [Test]
-        [TestCase("Aliases", 32852u)]
-        [TestCase("TagVariables", 32854u)]
-        [TestCase("Topics", 32856u)]
+        [TestCase(23470u, 32852u)]       // Aliases
+        [TestCase(23479u, 32854u)]       // TagVariables
+        [TestCase(23488u, 32856u)]       // Topics
         public async Task StandardCategoryExposesLastChangeAsync(
-            string categoryName, uint lastChangeId)
+            uint categoryId, uint lastChangeId)
         {
-            NodeId category = await ResolveCategoryAsync(Session, categoryName)
-                .ConfigureAwait(false);
+            var category = new NodeId(categoryId);
 
             IList<ReferenceDescription> children = await BrowseChildrenAsync(
                 Session, category, ReferenceTypeIds.HasProperty).ConfigureAwait(false);
@@ -114,33 +115,17 @@ namespace Opc.Ua.InformationModel.Tests
             ReferenceDescription lastChange = children.FirstOrDefault(
                 c => c.BrowseName.Name == BrowseNames.LastChange);
             Assert.That(lastChange, Is.Not.Null,
-                $"{categoryName} should expose the LastChange property.");
+                $"{category} should expose the LastChange property.");
             Assert.That(
                 ExpandedNodeId.ToNodeId(lastChange.NodeId, Session.NamespaceUris),
                 Is.EqualTo(new NodeId(lastChangeId)),
-                $"{categoryName}.LastChange should use the NodeId Part 17 reserves for it.");
+                $"{category}.LastChange should use the NodeId Part 17 reserves for it.");
 
             // A VersionTime the client can actually read.
             DataValue value = await ReadAttributeAsync(
                 Session, new NodeId(lastChangeId), Attributes.Value).ConfigureAwait(false);
             Assert.That(StatusCode.IsGood(value.StatusCode), Is.True,
-                $"{categoryName}.LastChange should be readable: {value.StatusCode}");
-        }
-
-        /// <summary>
-        /// Resolves a well-known category by name. Aliases is the root of
-        /// the hierarchy, so it is not a child of itself.
-        /// </summary>
-        private static async Task<NodeId> ResolveCategoryAsync(
-            ISession session, string categoryName)
-        {
-            if (categoryName == "Aliases")
-            {
-                return AliasesNodeId;
-            }
-            (NodeId category, _) = await FindCategoryAsync(session, categoryName)
-                .ConfigureAwait(false);
-            return category;
+                $"{category}.LastChange should be readable: {value.StatusCode}");
         }
 
         [Description("Call FindAliasVerbose on TagVariables and verify the verbose fields are populated.")]
@@ -205,15 +190,91 @@ namespace Opc.Ua.InformationModel.Tests
                 "AddAliasesToCategory requires SecurityAdmin on a SignAndEncrypt channel.");
         }
 
-        [Description("Add an alias as SecurityAdmin, find it, then delete it again.")]
+        [Description("Verify a secure channel alone is not enough — the SecurityAdmin role is also required.")]
         [Test]
-        public async Task AddAndDeleteAliasRoundTripAsync()
+        public async Task AddAliasesWithoutAdminRoleOnSecureChannelIsDeniedAsync()
+        {
+            // The fixture Session runs over SecurityPolicies.None, so the
+            // anonymous test above only exercises the channel half of the
+            // gate. This one connects anonymously over SignAndEncrypt so
+            // the denial can only come from the missing role.
+            ISession secure;
+            try
+            {
+                secure = await OpenAuxSessionAsync(SecurityPolicies.Basic256Sha256)
+                    .ConfigureAwait(false);
+            }
+            catch (ServiceResultException)
+            {
+                Assert.Ignore("Server exposes no Basic256Sha256 endpoint.");
+                return;
+            }
+
+            try
+            {
+                if (secure.ConfiguredEndpoint.Description.SecurityMode !=
+                    MessageSecurityMode.SignAndEncrypt)
+                {
+                    Assert.Ignore("Server exposes no SignAndEncrypt endpoint.");
+                }
+
+                (NodeId category, _) = await FindCategoryAsync(secure, "TagVariables")
+                    .ConfigureAwait(false);
+                NodeId addAliases = await RequireMethodAsync(
+                    secure, category, "AddAliasesToCategory").ConfigureAwait(false);
+
+                CallMethodResult result = await CallMethodAsync(
+                    secure, category, addAliases,
+                    new Variant(new string[] { "NonAdminShouldNotAdd" }.ToArrayOf()),
+                    new Variant(new ExpandedNodeId[] { new(ObjectIds.Server) }.ToArrayOf()),
+                    new Variant(new string[] { string.Empty }.ToArrayOf()),
+                    new Variant(AliasForNodeId)).ConfigureAwait(false);
+
+                Assert.That(
+                    result.StatusCode,
+                    Is.EqualTo((StatusCode)StatusCodes.BadUserAccessDenied),
+                    "A caller without the SecurityAdmin role must be denied even on a secure channel.");
+            }
+            finally
+            {
+                await secure.CloseAsync(default).ConfigureAwait(false);
+                secure.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Connects as the seeded SecurityAdmin user and skips the test when
+        /// the server cannot satisfy the mutation gate's preconditions —
+        /// no username endpoint at all, or none with SignAndEncrypt (the
+        /// fixture helper falls back to Sign and None, which the gate
+        /// rejects, so the test would fail instead of skip).
+        /// </summary>
+        private async Task<ISession> ConnectSecureAdminOrIgnoreAsync()
         {
             ISession admin = await ConnectAsSysAdminAsync().ConfigureAwait(false);
             if (admin == null)
             {
                 Assert.Ignore("Server exposes no username endpoint for the SecurityAdmin user.");
             }
+
+            if (admin.ConfiguredEndpoint.Description.SecurityMode !=
+                MessageSecurityMode.SignAndEncrypt)
+            {
+                await admin.CloseAsync(default).ConfigureAwait(false);
+                admin.Dispose();
+                Assert.Ignore(
+                    "The SecurityAdmin mutation gate requires a SignAndEncrypt endpoint, " +
+                    "which this server does not expose.");
+            }
+
+            return admin;
+        }
+
+        [Description("Add an alias as SecurityAdmin, find it, then delete it again.")]
+        [Test]
+        public async Task AddAndDeleteAliasRoundTripAsync()
+        {
+            ISession admin = await ConnectSecureAdminOrIgnoreAsync().ConfigureAwait(false);
 
             const string aliasName = "RoundTripAlias";
             var target = new ExpandedNodeId(ObjectIds.Server);
@@ -240,6 +301,11 @@ namespace Opc.Ua.InformationModel.Tests
 
                 Assert.That(StatusCode.IsGood(added.StatusCode), Is.True,
                     $"AddAliasesToCategory should succeed for SecurityAdmin: {added.StatusCode}");
+                // A Good method-level status does not mean the entry was
+                // added — per-entry failures travel in the ErrorCodes
+                // output (e.g. a duplicate add), and a false pass here
+                // would let the test delete an alias it did not create.
+                AssertSingleErrorCodeGood(added, "AddAliasesToCategory");
 
                 CallMethodResult found = await CallFindAliasAsync(
                     admin, category, findAlias, aliasName, AliasForNodeId)
@@ -256,12 +322,14 @@ namespace Opc.Ua.InformationModel.Tests
                     new Variant(new ExpandedNodeId[] { target }.ToArrayOf()))
                     .ConfigureAwait(false);
 
-                // Only once the delete actually succeeded is the alias gone
-                // and the finally-block cleanup unnecessary.
-                deleteRequired = !StatusCode.IsGood(deleted.StatusCode);
+                // Only once the delete actually succeeded — method-level
+                // status AND the per-entry ErrorCodes value — is the alias
+                // gone and the finally-block cleanup unnecessary.
+                deleteRequired = !IsSingleErrorCodeGood(deleted);
 
                 Assert.That(StatusCode.IsGood(deleted.StatusCode), Is.True,
                     $"DeleteAliasesFromCategory should succeed: {deleted.StatusCode}");
+                AssertSingleErrorCodeGood(deleted, "DeleteAliasesFromCategory");
 
                 CallMethodResult gone = await CallFindAliasAsync(
                     admin, category, findAlias, aliasName, AliasForNodeId)
@@ -284,6 +352,47 @@ namespace Opc.Ua.InformationModel.Tests
                 await admin.CloseAsync(default).ConfigureAwait(false);
                 admin.Dispose();
             }
+        }
+
+        /// <summary>
+        /// Decodes the per-entry <c>ErrorCodes</c> output argument of an
+        /// <c>AddAliasesToCategory</c>/<c>DeleteAliasesFromCategory</c>
+        /// call (Part 17 §6.3.4/§6.3.5).
+        /// </summary>
+        private static ArrayOf<StatusCode> DecodeErrorCodes(CallMethodResult result)
+        {
+            if (result.OutputArguments.Count == 0 ||
+                !result.OutputArguments[0].TryGetValue(out ArrayOf<StatusCode> codes))
+            {
+                return [];
+            }
+            return codes;
+        }
+
+        /// <summary>
+        /// True when the method-level status and the single per-entry
+        /// <c>ErrorCodes</c> value both report success.
+        /// </summary>
+        private static bool IsSingleErrorCodeGood(CallMethodResult result)
+        {
+            ArrayOf<StatusCode> codes = DecodeErrorCodes(result);
+            return StatusCode.IsGood(result.StatusCode) &&
+                codes.Count == 1 &&
+                StatusCode.IsGood(codes[0]);
+        }
+
+        /// <summary>
+        /// Asserts the mutation's per-entry <c>ErrorCodes</c> output holds
+        /// exactly one Good entry — a Good method-level status alone does
+        /// not mean the entry was applied.
+        /// </summary>
+        private static void AssertSingleErrorCodeGood(CallMethodResult result, string method)
+        {
+            ArrayOf<StatusCode> codes = DecodeErrorCodes(result);
+            Assert.That(codes.Count, Is.EqualTo(1),
+                $"{method} should return one ErrorCodes entry per input entry.");
+            Assert.That(StatusCode.IsGood(codes[0]), Is.True,
+                $"{method} per-entry status should be Good: {codes[0]}");
         }
 
         /// <summary>
@@ -332,11 +441,7 @@ namespace Opc.Ua.InformationModel.Tests
         [Test]
         public async Task MutationAdvancesLastChangeAsync()
         {
-            ISession admin = await ConnectAsSysAdminAsync().ConfigureAwait(false);
-            if (admin == null)
-            {
-                Assert.Ignore("Server exposes no username endpoint for the SecurityAdmin user.");
-            }
+            ISession admin = await ConnectSecureAdminOrIgnoreAsync().ConfigureAwait(false);
 
             const string aliasName = "LastChangeProbeAlias";
             var target = new ExpandedNodeId(ObjectIds.Server);
@@ -366,6 +471,7 @@ namespace Opc.Ua.InformationModel.Tests
                     new Variant(AliasForNodeId)).ConfigureAwait(false);
                 Assert.That(StatusCode.IsGood(added.StatusCode), Is.True,
                     $"AddAliasesToCategory on Aliases should succeed: {added.StatusCode}");
+                AssertSingleErrorCodeGood(added, "AddAliasesToCategory");
 
                 DataValue after = await ReadAttributeAsync(
                     admin, lastChangeNodeId, Attributes.Value).ConfigureAwait(false);

--- a/tests/Opc.Ua.InformationModel.Tests/AliasnameOptionalMethodsTests.cs
+++ b/tests/Opc.Ua.InformationModel.Tests/AliasnameOptionalMethodsTests.cs
@@ -1,0 +1,391 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Opc.Ua.Client;
+using Opc.Ua.Client.TestFramework;
+using static Opc.Ua.InformationModel.Tests.AliasNameTestHelpers;
+
+// Conformance tests use inline literal arrays as expected-value
+// assertions; the per-call allocation cost is irrelevant for tests
+// and keeping the literal adjacent to the assertion improves readability.
+#pragma warning disable CA1861 // Avoid constant arrays as arguments
+
+namespace Opc.Ua.InformationModel.Tests
+{
+    /// <summary>
+    /// Compliance tests for the optional Part 17 methods on the well-known
+    /// alias categories: <c>FindAliasVerbose</c> (§6.3.3),
+    /// <c>AddAliasesToCategory</c> (§6.3.4) and
+    /// <c>DeleteAliasesFromCategory</c> (§6.3.5). The standard NodeSet does
+    /// not instantiate these, so the server adds them through the generated
+    /// optional-child helpers, which place them at the NodeIds Part 17 §9
+    /// reserves.
+    /// </summary>
+    [TestFixture]
+    [Category("Conformance")]
+    [Category("AliasName")]
+    public class AliasnameOptionalMethodsTests : TestFixture
+    {
+        [Description("Verify the optional Part 17 methods are exposed on the well-known categories at their reserved NodeIds.")]
+        [Test]
+        [TestCase("Aliases", 24054u, 24057u, 24060u)]
+        [TestCase("TagVariables", 24063u, 24066u, 24069u)]
+        [TestCase("Topics", 24072u, 24075u, 24078u)]
+        public async Task StandardCategoryExposesOptionalMethodsAsync(
+            string categoryName, uint verboseId, uint addId, uint deleteId)
+        {
+            NodeId category = await ResolveCategoryAsync(Session, categoryName)
+                .ConfigureAwait(false);
+
+            // Part 17 §9 allocates a NodeId for each optional child of the
+            // three well-known categories, and the source generator assigns
+            // them when the child is added to one of those parents.
+            (string Name, uint Id)[] expected =
+            [
+                ("FindAliasVerbose", verboseId),
+                ("AddAliasesToCategory", addId),
+                ("DeleteAliasesFromCategory", deleteId)
+            ];
+
+            foreach ((string name, uint id) in expected)
+            {
+                NodeId methodId = await FindMethodAsync(Session, category, name)
+                    .ConfigureAwait(false);
+                Assert.That(methodId.IsNull, Is.False,
+                    $"{categoryName} should expose the optional {name} method.");
+                Assert.That(methodId, Is.EqualTo(new NodeId(id)),
+                    $"{categoryName}.{name} should use the NodeId Part 17 reserves for it.");
+
+                DataValue browseName = await ReadAttributeAsync(
+                    Session, methodId, Attributes.BrowseName).ConfigureAwait(false);
+                Assert.That(StatusCode.IsGood(browseName.StatusCode), Is.True,
+                    $"{categoryName}.{name} should be readable at {methodId}.");
+                Assert.That(browseName.GetValue<QualifiedName>(default).Name,
+                    Is.EqualTo(name));
+            }
+        }
+
+        [Description("Verify the optional LastChange property is exposed on the well-known categories at its reserved NodeId.")]
+        [Test]
+        [TestCase("Aliases", 32852u)]
+        [TestCase("TagVariables", 32854u)]
+        [TestCase("Topics", 32856u)]
+        public async Task StandardCategoryExposesLastChangeAsync(
+            string categoryName, uint lastChangeId)
+        {
+            NodeId category = await ResolveCategoryAsync(Session, categoryName)
+                .ConfigureAwait(false);
+
+            IList<ReferenceDescription> children = await BrowseChildrenAsync(
+                Session, category, ReferenceTypeIds.HasProperty).ConfigureAwait(false);
+
+            ReferenceDescription lastChange = children.FirstOrDefault(
+                c => c.BrowseName.Name == BrowseNames.LastChange);
+            Assert.That(lastChange, Is.Not.Null,
+                $"{categoryName} should expose the LastChange property.");
+            Assert.That(
+                ExpandedNodeId.ToNodeId(lastChange.NodeId, Session.NamespaceUris),
+                Is.EqualTo(new NodeId(lastChangeId)),
+                $"{categoryName}.LastChange should use the NodeId Part 17 reserves for it.");
+
+            // A VersionTime the client can actually read.
+            DataValue value = await ReadAttributeAsync(
+                Session, new NodeId(lastChangeId), Attributes.Value).ConfigureAwait(false);
+            Assert.That(StatusCode.IsGood(value.StatusCode), Is.True,
+                $"{categoryName}.LastChange should be readable: {value.StatusCode}");
+        }
+
+        /// <summary>
+        /// Resolves a well-known category by name. Aliases is the root of
+        /// the hierarchy, so it is not a child of itself.
+        /// </summary>
+        private static async Task<NodeId> ResolveCategoryAsync(
+            ISession session, string categoryName)
+        {
+            if (categoryName == "Aliases")
+            {
+                return AliasesNodeId;
+            }
+            (NodeId category, _) = await FindCategoryAsync(session, categoryName)
+                .ConfigureAwait(false);
+            return category;
+        }
+
+        [Description("Call FindAliasVerbose on TagVariables and verify the verbose fields are populated.")]
+        [Test]
+        public async Task FindAliasVerboseReturnsCategoryAndServerUrisAsync()
+        {
+            (NodeId category, _) = await FindCategoryAsync(Session, "TagVariables")
+                .ConfigureAwait(false);
+
+            NodeId findAliasVerbose = await RequireMethodAsync(
+                Session, category, "FindAliasVerbose").ConfigureAwait(false);
+
+            CallMethodResult result = await CallMethodAsync(
+                Session, category, findAliasVerbose,
+                new Variant("%"), new Variant(AliasForNodeId)).ConfigureAwait(false);
+
+            Assert.That(StatusCode.IsGood(result.StatusCode), Is.True,
+                $"FindAliasVerbose should succeed: {result.StatusCode}");
+
+            IList<AliasNameVerboseDataType> records =
+                DecodeVerboseAliasResults(Session, result);
+            Assert.That(records, Is.Not.Empty,
+                "FindAliasVerbose('%') should return the TagVariables aliases.");
+
+            foreach (AliasNameVerboseDataType record in records)
+            {
+                Assert.That(record.ReferencedNodes, Is.Not.Empty);
+                Assert.That(record.ServerUris.Count, Is.EqualTo(record.ReferencedNodes.Count),
+                    "ServerUris is parallel to ReferencedNodes (Part 17 §7.3).");
+                Assert.That(record.AliasNameCategoryId.IsNull, Is.False,
+                    "Each record names the category the alias lives in.");
+            }
+
+            // The sub-tree search reports the nested category as the home of
+            // the aliases that live there.
+            var categoryIds = records
+                .Select(r => r.AliasNameCategoryId)
+                .Distinct()
+                .ToList();
+            Assert.That(categoryIds, Has.Count.GreaterThan(1),
+                "TagVariables aggregates aliases from itself and its nested category.");
+        }
+
+        [Description("Verify an anonymous session cannot mutate a category.")]
+        [Test]
+        public async Task AddAliasesFromAnonymousSessionIsDeniedAsync()
+        {
+            (NodeId category, _) = await FindCategoryAsync(Session, "TagVariables")
+                .ConfigureAwait(false);
+
+            NodeId addAliases = await RequireMethodAsync(
+                Session, category, "AddAliasesToCategory").ConfigureAwait(false);
+
+            CallMethodResult result = await CallMethodAsync(
+                Session, category, addAliases,
+                new Variant(new string[] { "AnonymousShouldNotAdd" }.ToArrayOf()),
+                new Variant(new ExpandedNodeId[] { new(ObjectIds.Server) }.ToArrayOf()),
+                new Variant(new string[] { string.Empty }.ToArrayOf()),
+                new Variant(AliasForNodeId)).ConfigureAwait(false);
+
+            Assert.That(result.StatusCode, Is.EqualTo((StatusCode)StatusCodes.BadUserAccessDenied),
+                "AddAliasesToCategory requires SecurityAdmin on a SignAndEncrypt channel.");
+        }
+
+        [Description("Add an alias as SecurityAdmin, find it, then delete it again.")]
+        [Test]
+        public async Task AddAndDeleteAliasRoundTripAsync()
+        {
+            ISession admin = await ConnectAsSysAdminAsync().ConfigureAwait(false);
+            if (admin == null)
+            {
+                Assert.Ignore("Server exposes no username endpoint for the SecurityAdmin user.");
+            }
+
+            const string aliasName = "RoundTripAlias";
+            var target = new ExpandedNodeId(ObjectIds.Server);
+            bool deleteRequired = true;
+            NodeId deleteAliases = NodeId.Null;
+            NodeId categoryForCleanup = NodeId.Null;
+
+            try
+            {
+                (NodeId category, NodeId findAlias) = await FindCategoryAsync(
+                    admin, "TagVariables").ConfigureAwait(false);
+                categoryForCleanup = category;
+                NodeId addAliases = await RequireMethodAsync(
+                    admin, category, "AddAliasesToCategory").ConfigureAwait(false);
+                deleteAliases = await RequireMethodAsync(
+                    admin, category, "DeleteAliasesFromCategory").ConfigureAwait(false);
+
+                CallMethodResult added = await CallMethodAsync(
+                    admin, category, addAliases,
+                    new Variant(new string[] { aliasName }.ToArrayOf()),
+                    new Variant(new ExpandedNodeId[] { target }.ToArrayOf()),
+                    new Variant(new string[] { string.Empty }.ToArrayOf()),
+                    new Variant(AliasForNodeId)).ConfigureAwait(false);
+
+                Assert.That(StatusCode.IsGood(added.StatusCode), Is.True,
+                    $"AddAliasesToCategory should succeed for SecurityAdmin: {added.StatusCode}");
+
+                CallMethodResult found = await CallFindAliasAsync(
+                    admin, category, findAlias, aliasName, AliasForNodeId)
+                    .ConfigureAwait(false);
+                Assert.That(StatusCode.IsGood(found.StatusCode), Is.True);
+                Assert.That(
+                    DecodeAliasResults(admin, found).Select(r => r.AliasName.Name),
+                    Has.Some.EqualTo(aliasName),
+                    "FindAlias should return the alias that was just added.");
+
+                CallMethodResult deleted = await CallMethodAsync(
+                    admin, category, deleteAliases,
+                    new Variant(new string[] { aliasName }.ToArrayOf()),
+                    new Variant(new ExpandedNodeId[] { target }.ToArrayOf()))
+                    .ConfigureAwait(false);
+
+                // Only once the delete actually succeeded is the alias gone
+                // and the finally-block cleanup unnecessary.
+                deleteRequired = !StatusCode.IsGood(deleted.StatusCode);
+
+                Assert.That(StatusCode.IsGood(deleted.StatusCode), Is.True,
+                    $"DeleteAliasesFromCategory should succeed: {deleted.StatusCode}");
+
+                CallMethodResult gone = await CallFindAliasAsync(
+                    admin, category, findAlias, aliasName, AliasForNodeId)
+                    .ConfigureAwait(false);
+                Assert.That(StatusCode.IsGood(gone.StatusCode), Is.True);
+                Assert.That(DecodeAliasResults(admin, gone), Is.Empty,
+                    "FindAlias should no longer return the deleted alias.");
+            }
+            finally
+            {
+                // A failed assertion must not leave the probe alias behind:
+                // the fixture's server is shared with the other alias tests,
+                // several of which assert on exact alias sets.
+                if (deleteRequired && !deleteAliases.IsNull)
+                {
+                    await RemoveAliasAsync(
+                        admin, categoryForCleanup, deleteAliases, aliasName, target)
+                        .ConfigureAwait(false);
+                }
+                await admin.CloseAsync(default).ConfigureAwait(false);
+                admin.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Best-effort removal of a probe alias. This runs while another
+        /// failure may already be unwinding, so it calls the session
+        /// directly rather than through <c>CallMethodAsync</c> — that helper
+        /// asserts on the response shape, and an assertion raised here would
+        /// replace the original failure with a cleanup error.
+        /// </summary>
+        private static async Task RemoveAliasAsync(
+            ISession session,
+            NodeId category,
+            NodeId deleteMethod,
+            string aliasName,
+            ExpandedNodeId target)
+        {
+            try
+            {
+                await session.CallAsync(
+                    null,
+                    new CallMethodRequest[]
+                    {
+                        new() {
+                            ObjectId = category,
+                            MethodId = deleteMethod,
+                            InputArguments = new Variant[]
+                            {
+                                new(new string[] { aliasName }.ToArrayOf()),
+                                new(new ExpandedNodeId[] { target }.ToArrayOf())
+                            }.ToArrayOf()
+                        }
+                    }.ToArrayOf(),
+                    CancellationToken.None).ConfigureAwait(false);
+            }
+            catch (ServiceResultException)
+            {
+                // The alias was never added, or the session is already gone.
+            }
+            catch (ObjectDisposedException)
+            {
+                // The session was torn down before cleanup could run.
+            }
+        }
+
+        [Description("Verify a mutation advances the LastChange property of the Aliases object.")]
+        [Test]
+        public async Task MutationAdvancesLastChangeAsync()
+        {
+            ISession admin = await ConnectAsSysAdminAsync().ConfigureAwait(false);
+            if (admin == null)
+            {
+                Assert.Ignore("Server exposes no username endpoint for the SecurityAdmin user.");
+            }
+
+            const string aliasName = "LastChangeProbeAlias";
+            var target = new ExpandedNodeId(ObjectIds.Server);
+
+            // Aliases.LastChange (i=32852) is the one optional child the
+            // standard NodeSet does ship, so it has a generated constant.
+            NodeId lastChangeNodeId = VariableIds.Aliases_LastChange;
+            NodeId deleteAliases = NodeId.Null;
+
+            try
+            {
+                NodeId addAliases = await RequireMethodAsync(
+                    admin, AliasesNodeId, "AddAliasesToCategory").ConfigureAwait(false);
+                deleteAliases = await RequireMethodAsync(
+                    admin, AliasesNodeId, "DeleteAliasesFromCategory").ConfigureAwait(false);
+
+                DataValue before = await ReadAttributeAsync(
+                    admin, lastChangeNodeId, Attributes.Value).ConfigureAwait(false);
+                Assert.That(StatusCode.IsGood(before.StatusCode), Is.True,
+                    "Aliases.LastChange should be readable.");
+
+                CallMethodResult added = await CallMethodAsync(
+                    admin, AliasesNodeId, addAliases,
+                    new Variant(new string[] { aliasName }.ToArrayOf()),
+                    new Variant(new ExpandedNodeId[] { target }.ToArrayOf()),
+                    new Variant(new string[] { string.Empty }.ToArrayOf()),
+                    new Variant(AliasForNodeId)).ConfigureAwait(false);
+                Assert.That(StatusCode.IsGood(added.StatusCode), Is.True,
+                    $"AddAliasesToCategory on Aliases should succeed: {added.StatusCode}");
+
+                DataValue after = await ReadAttributeAsync(
+                    admin, lastChangeNodeId, Attributes.Value).ConfigureAwait(false);
+                Assert.That(after.GetValue<uint>(0), Is.Not.EqualTo(before.GetValue<uint>(0)),
+                    "LastChange must advance after a successful mutation (Part 17 §6.3.1).");
+            }
+            finally
+            {
+                // Leave the address space as it was found even when an
+                // assertion above failed — the server is shared with the
+                // other alias tests.
+                if (!deleteAliases.IsNull)
+                {
+                    await RemoveAliasAsync(
+                        admin, AliasesNodeId, deleteAliases, aliasName, target)
+                        .ConfigureAwait(false);
+                }
+                await admin.CloseAsync(default).ConfigureAwait(false);
+                admin.Dispose();
+            }
+        }
+    }
+}

--- a/tests/Opc.Ua.Server.Tests/AliasNames/AliasNameMethodDispatcherTests.cs
+++ b/tests/Opc.Ua.Server.Tests/AliasNames/AliasNameMethodDispatcherTests.cs
@@ -101,8 +101,11 @@ namespace Opc.Ua.Server.Tests.AliasNames
         }
 
         [Test]
-        public async Task AddAliasesRejectsTargetServersShorterThanAliasNamesAsync()
+        public async Task AddAliasesAcceptsTargetServersShorterThanAliasNamesAsync()
         {
+            // Part 17 §6.3.4 exempts TargetServers from the equal-length
+            // requirement — a caller with local targets may pass an empty
+            // or shorter array, and a missing entry means "local server".
             (AliasNameStoreRegistry registry, InMemoryAliasNameStore store) =
                 CreateRegistryWithCapableStore();
             using (registry)
@@ -123,9 +126,39 @@ namespace Opc.Ua.Server.Tests.AliasNames
                         CancellationToken.None)
                     .ConfigureAwait(false);
 
+                Assert.That(result.ServiceResult, Is.Null.Or.Property("StatusCode")
+                    .Property("Code").EqualTo(StatusCodes.Good),
+                    "A short TargetServers array is legal per Part 17 §6.3.4.");
+                Assert.That(result.ErrorCodes.Count, Is.EqualTo(2));
+                Assert.That(StatusCode.IsGood(result.ErrorCodes[0]), Is.True);
+                Assert.That(StatusCode.IsGood(result.ErrorCodes[1]), Is.True,
+                    "The entry without a TargetServers value is treated as local.");
+            }
+        }
+
+        [Test]
+        public async Task AddAliasesRejectsAllEmptyArraysAsync()
+        {
+            // Part 17 §6.3.4: Bad_InvalidArgument when all arrays are empty.
+            (AliasNameStoreRegistry registry, InMemoryAliasNameStore store) =
+                CreateRegistryWithCapableStore();
+            using (registry)
+            using (store)
+            {
+                AddAliasesToCategoryMethodStateResult result = await AliasNameMethodDispatcher
+                    .AddAliasesAsync(
+                        registry,
+                        s_categoryId,
+                        default,
+                        default,
+                        default,
+                        ReferenceTypeIds.AliasFor,
+                        CancellationToken.None)
+                    .ConfigureAwait(false);
+
                 Assert.That(result.ServiceResult.StatusCode.Code,
                     Is.EqualTo(StatusCodes.BadInvalidArgument),
-                    "TargetServers shorter than AliasNames must surface as BadInvalidArgument.");
+                    "Empty request arrays must surface as BadInvalidArgument.");
             }
         }
 

--- a/tests/Opc.Ua.Server.Tests/AliasNames/AliasNameNodeManagerTests.cs
+++ b/tests/Opc.Ua.Server.Tests/AliasNames/AliasNameNodeManagerTests.cs
@@ -217,6 +217,86 @@ namespace Opc.Ua.Server.Tests.AliasNames
         }
 
         [Test]
+        public async Task CreateAddressSpaceMaterializesAliasNodesAsync()
+        {
+            // Aliases present in the store BEFORE the address space is
+            // built become browsable AliasNameType nodes (Part 17 §6.2) —
+            // the same materialization DiagnosticsNodeManager applies to
+            // the standard well-known categories.
+            var categoryId = new NodeId("MyCategory", 1);
+            var target = new ExpandedNodeId("Tgt", 1);
+            await m_store.AddAliasesAsync(categoryId,
+                [
+                    new AliasAddRequest("Alpha", target, null, ReferenceTypeIds.AliasFor)
+                ],
+                CancellationToken.None).ConfigureAwait(false);
+
+            using AliasNameNodeManager manager = CreateManager();
+            var externalReferences = new Dictionary<NodeId, IList<IReference>>();
+            await manager.CreateAddressSpaceAsync(externalReferences).ConfigureAwait(false);
+
+            var aliasNodeId = new NodeId(
+                Utils.Format("{0}.{1}", categoryId, "Alpha"), 1);
+            AliasNameState aliasNode = manager
+                .FindPredefinedNode<AliasNameState>(aliasNodeId);
+            Assert.That(aliasNode, Is.Not.Null,
+                "The alias must be materialized as a browsable AliasNameType node.");
+            Assert.That(aliasNode.BrowseName.Name, Is.EqualTo("Alpha"));
+            Assert.That(aliasNode.TypeDefinitionId,
+                Is.EqualTo(ObjectTypeIds.AliasNameType));
+
+            AliasNameCategoryState category = manager
+                .FindPredefinedNode<AliasNameCategoryState>(categoryId);
+            Assert.That(
+                category.ReferenceExists(
+                    ReferenceTypeIds.Organizes, false, aliasNodeId),
+                Is.True,
+                "The category organizes its alias node.");
+            Assert.That(
+                aliasNode.ReferenceExists(
+                    ReferenceTypeIds.AliasFor, false, new NodeId("Tgt", 1)),
+                Is.True,
+                "The alias node carries the AliasFor reference to its target.");
+            Assert.That(externalReferences.ContainsKey(new NodeId("Tgt", 1)),
+                Is.True,
+                "The inverse HasAlias reference is queued for the target's manager.");
+        }
+
+        [Test]
+        public async Task MaterializeAliasNodesCanBeDisabledAsync()
+        {
+            var categoryId = new NodeId("MyCategory", 1);
+            await m_store.AddAliasesAsync(categoryId,
+                [
+                    new AliasAddRequest("Alpha",
+                        new ExpandedNodeId("Tgt", 1),
+                        null,
+                        ReferenceTypeIds.AliasFor)
+                ],
+                CancellationToken.None).ConfigureAwait(false);
+
+            using AliasNameNodeManager manager = CreateManager(
+                new AliasNameNodeManagerOptions
+                {
+                    NamespaceUri = c_namespaceUri,
+                    RegisterWithServerRegistry = false,
+                    MaterializeAliasNodes = false
+                });
+            await manager.CreateAddressSpaceAsync(
+                new Dictionary<NodeId, IList<IReference>>()).ConfigureAwait(false);
+
+            Assert.That(
+                manager.FindPredefinedNode<AliasNameCategoryState>(categoryId),
+                Is.Not.Null,
+                "The category tree is still built.");
+            Assert.That(
+                manager.FindPredefinedNode<AliasNameState>(
+                    new NodeId(Utils.Format("{0}.{1}", categoryId, "Alpha"), 1)),
+                Is.Null,
+                "No alias instance nodes are created when the option is off.");
+        }
+
+        [Test]
         public async Task LastChangeReflectsStoreUpdatesAsync()
         {
             using AliasNameNodeManager manager = CreateManager();

--- a/tests/Opc.Ua.Server.Tests/AliasNames/InMemoryAliasNameStoreTests.cs
+++ b/tests/Opc.Ua.Server.Tests/AliasNames/InMemoryAliasNameStoreTests.cs
@@ -174,6 +174,32 @@ namespace Opc.Ua.Server.Tests.AliasNames
             Assert.That(captured.LastChange, Is.EqualTo(1u));
         }
 
+        [Test]
+        public async Task SubCategoryMutationBumpsAncestorLastChangeAsync()
+        {
+            // Part 17 §6.3.1/§9.2: a category's LastChange reflects the
+            // most recent change anywhere in its subtree, and the root
+            // value reflects any change at all — so a mutation on a nested
+            // category advances the parent's LastChange too, with a
+            // Changed notification per bumped category.
+            using InMemoryAliasNameStore store = CreateStore(withSubCategory: true);
+            var events = new List<AliasStoreChangedEventArgs>();
+            store.Changed += (_, e) => events.Add(e);
+
+            await store.AddAliasesAsync(s_child,
+                [new AliasAddRequest("SubX", s_t1, null, ReferenceTypeIds.AliasFor)],
+                CancellationToken.None).ConfigureAwait(false);
+
+            Assert.That(store.GetLastChange(s_child), Is.EqualTo((uint?)1),
+                "The mutated category bumps.");
+            Assert.That(store.GetLastChange(s_root), Is.EqualTo((uint?)1),
+                "The ancestor category bumps as well.");
+            Assert.That(events, Has.Count.EqualTo(2));
+            Assert.That(events[0].CategoryId, Is.EqualTo(s_child),
+                "The mutated category notifies first.");
+            Assert.That(events[1].CategoryId, Is.EqualTo(s_root));
+        }
+
         private static readonly string[] s_rootAndSub = ["RootA", "SubA"];
 
         [Test]

--- a/tests/Opc.Ua.Sessions.Tests/LeakDetectionSetup.cs
+++ b/tests/Opc.Ua.Sessions.Tests/LeakDetectionSetup.cs
@@ -27,7 +27,7 @@
  * http://opcfoundation.org/License/MIT/1.00/
  * ======================================================================*/
 
-using System;
+using System.Runtime.InteropServices;
 using NUnit.Framework;
 using Opc.Ua.Security.Certificates;
 using Opc.Ua.Tests;
@@ -50,7 +50,10 @@ namespace Opc.Ua.Sessions.Tests
         [OneTimeTearDown]
         public void GlobalTeardown()
         {
-            if (OperatingSystem.IsMacOS())
+            // OperatingSystem.IsMacOS() does not exist on net48 — this
+            // project multi-targets, so use the RuntimeInformation check
+            // the rest of the test tree uses.
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
                 _ = LeakDetectionHelpers.WaitForOutstandingDisposals(maxAttempts: 900);
             }

--- a/tests/Opc.Ua.Sessions.Tests/LeakDetectionSetup.cs
+++ b/tests/Opc.Ua.Sessions.Tests/LeakDetectionSetup.cs
@@ -27,7 +27,6 @@
  * http://opcfoundation.org/License/MIT/1.00/
  * ======================================================================*/
 
-using System.Runtime.InteropServices;
 using NUnit.Framework;
 using Opc.Ua.Security.Certificates;
 using Opc.Ua.Tests;
@@ -50,14 +49,6 @@ namespace Opc.Ua.Sessions.Tests
         [OneTimeTearDown]
         public void GlobalTeardown()
         {
-            // OperatingSystem.IsMacOS() does not exist on net48 — this
-            // project multi-targets, so use the RuntimeInformation check
-            // the rest of the test tree uses.
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-            {
-                _ = LeakDetectionHelpers.WaitForOutstandingDisposals(maxAttempts: 900);
-            }
-
             LeakDetectionHelpers.AssertNoCertificateLeaks();
         }
     }

--- a/tests/Opc.Ua.Sessions.Tests/LeakDetectionSetup.cs
+++ b/tests/Opc.Ua.Sessions.Tests/LeakDetectionSetup.cs
@@ -27,6 +27,7 @@
  * http://opcfoundation.org/License/MIT/1.00/
  * ======================================================================*/
 
+using System;
 using NUnit.Framework;
 using Opc.Ua.Security.Certificates;
 using Opc.Ua.Tests;
@@ -49,6 +50,11 @@ namespace Opc.Ua.Sessions.Tests
         [OneTimeTearDown]
         public void GlobalTeardown()
         {
+            if (OperatingSystem.IsMacOS())
+            {
+                _ = LeakDetectionHelpers.WaitForOutstandingDisposals(maxAttempts: 900);
+            }
+
             LeakDetectionHelpers.AssertNoCertificateLeaks();
         }
     }


### PR DESCRIPTION
# Description

The CTT AliasName conformance units skip or fail against the ConsoleReferenceServer. `AliasName Base` skips with *"No instance of AliasNameType has been found in the address space"*; `Category Tags`, `Category Topics` and `Hierarchy` fail. Part 17 support landed in #3779, but aliases live only inside the `IAliasNameStore` — nothing is browsable, no `AliasNameCategoryType` is nested under another, and the Topics aliases point at the Server object rather than at a `PublishedDataSetType` instance.

Part 17 §6.2 clients — the CTT among them — discover aliases by browsing, not only by calling `FindAlias`. This PR materializes the store contents as real nodes and fills the three gaps.

### SDK — `Opc.Ua.Server`

* **`DiagnosticsNodeManager.MaterializeRegisteredAliasNameNodesAsync`** (new, opt-in) walks every registered `IAliasNameStore` and creates one `AliasNameType` instance per alias — BrowseName carrying the alias name, `AliasFor` references to its targets, and the inverse `HasAlias` reference on each local target (via `externalReferences`, since targets usually live in another node manager) — plus an `AliasNameCategoryType` instance for every store category the standard NodeSet does not already ship. Categories whose NodeId belongs to another node manager are skipped, so an `AliasNameNodeManager` that also registers its store with the server-wide registry does not get its NodeIds claimed twice.

  Opt-in: servers that only need the well-known `FindAlias` to answer from their store pay nothing. The nodes are a snapshot taken at address-space creation — later mutations change what `FindAlias` returns but do not add or remove nodes.

* **Optional Part 17 methods on the well-known categories.** The same pass instantiates whatever a category declares through `AliasNameCapabilities`: `FindAliasVerbose` (§6.3.3), `AddAliasesToCategory` (§6.3.4), `DeleteAliasesFromCategory` (§6.3.5) and `LastChange` (§6.3.1). Mutations require a `SecurityAdmin` caller on a `SignAndEncrypt` channel; the gate previously private to `AliasNameNodeManager` moved to `AliasNameMethodDispatcher` so both paths share one implementation.

* **`LastChange`** is now tracked per category rather than only for the standard `Aliases` node, and the duplicated seeding logic collapsed into one helper.

### Reference server

* A nested **`Devices`** category under `TagVariables` holds `Pump1_Status` and `Heater_Power`. `FindAlias` on `TagVariables` still returns all six names through subtree recursion, while `FindAlias` on `Devices` returns exactly two — which is what the Hierarchy unit checks.
* `ReferenceServerConfigurationNodeManager` creates three **`PublishedDataSet` instances** under `PublishedDataSets` (`i=17371`) and the Topics aliases now target them, satisfying the *"is a Dataset"* check. These are address-space instances only — no PubSub runtime is added, and the CTT only inspects the target's type definition.

## Note for reviewers — the reserved NodeIds

The optional children are created at the NodeIds the OPC Foundation reserves for them (`Aliases.FindAliasVerbose` = `i=24054`, `TagVariables.LastChange` = `i=32854`, …). Those identifiers are allocated in `StandardTypes.csv` but are **not** declared in the ModelDesign and **not** present in the published NodeSet, because the standard address space does not instantiate optional children. The source generator therefore emits no parent-to-instance mapping and no `MethodIds` constants for them, so `DiagnosticsNodeManager.ReservedChildIds` supplies the nine method ids and the two missing `LastChange` ids explicitly, each traceable to its registry row. The 18 argument-property ids do have generated `VariableIds` constants and are referenced through those.

I deliberately did **not** "fix" this by declaring the children in `tools/Opc.Ua.SourceGeneration.Core/Design/StandardTypes.xml`: that file is a verbatim copy of upstream `UA-ModelCompiler/Design.v105/StandardTypes.xml` (the only differences today are upstream being newer), so a local edit is lost on the next sync and the NodeIds would silently revert to factory-minted ones. `docs/AliasNames.md` records this.

Worth raising upstream separately: `StandardTypes.csv` allocates `Aliases_FindAliasVerbose` and siblings while the ModelDesign never declares those children, so the ModelCompiler cannot emit ids it has itself reserved. If that is ever reconciled, `ReservedChildIds` becomes redundant and deletes cleanly.

## Related Issues

- Fixes #4012

## Checklist

- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf) and read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [x] I have added all necessary documentation.
- [x] I have verified that my changes do not introduce (new) build or analyzer warnings.
- [ ] I ran **all** tests locally using the **UA.slnx** solution against at least .net **framework** and .net **10**, and all passed. — **not done: verified on net8.0 only** (Server 4710, InformationModel 1099, Core 4443, plus the client and features alias suites; AOT build clean). Needs a run against net framework and net10 before this leaves draft.
- [ ] I fixed **all** failing and flaky tests in the CI pipelines and **all** CodeQL warnings.
- [ ] I have addressed **all** PR feedback received.

### Tests

`tests/Opc.Ua.InformationModel.Tests/Aliasname*Tests.cs` mirror the four CTT conformance units and no longer `Assert.Ignore` where the CTT reported failures — the alias suite is 37 tests with no skips. New `AliasnameOptionalMethodsTests` covers the optional methods, their reserved NodeIds, the anonymous-caller denial, an add/find/delete round trip and `LastChange` advancing on mutation.

One pre-existing test changed premise: `EnumerateSubCategoriesAsyncOnLeafReturnsEmptyAsync` asserted that `TagVariables` has no sub-categories, which this PR deliberately makes false. It now targets `Topics` (still a leaf) and a new test guards the nesting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
