### PR TITLE
Fully support sub-state machines in the fluent state-machine builder

### DIFF
--- a/docs/StateMachines.md
+++ b/docs/StateMachines.md
@@ -417,18 +417,20 @@ handler — but it does re-arm timed transitions and synchronize
 sub-state machines.)
 
 A state declared with `isInitial: true` is applied automatically when
-the machine is created, so the minimal example above is fully
-functional without an explicit `WithInitialState` call; call
-`WithInitialState` to start in a different state. A sub-state
-machine's declared initial state is applied only while its parent is
-in the attached state — an inactive sub-SM publishes no current
-state.
+the machine is created and its state node is materialized as an
+`InitialStateType` (OPC 10000-16 §4.4.10), so the minimal example
+above is fully functional without an explicit `WithInitialState`
+call; call `WithInitialState` to start in a different state. A
+sub-state machine's declared initial state is applied only while its
+parent is in the attached state.
 
-While suspended, the child FSM's `DoTransition` and `DoCause`
-return `BadInvalidState`. The flag is exposed publicly as
-`FluentFiniteStateMachineState.IsSuspended` for diagnostics.
+While suspended, the child FSM's `CurrentState` and `LastTransition`
+read with `Bad_StateNotActive` (per OPC 10000-16 §4.4.6), and its
+`DoTransition` / `DoCause` return `BadStateNotActive`. The flag is
+exposed publicly as `FluentFiniteStateMachineState.IsSuspended` for
+diagnostics.
 
-The resulting address space follows Part 16 §B.3 and the standard
+The resulting address space follows Part 16 §4.4.16 and the standard
 NodeSets:
 
 ```
@@ -457,7 +459,7 @@ the optional `AvailableStates` property lists them, so
 `GetAvailableStatesAsync` works against a fluent-built server.
 
 **Transitions** — one `TransitionType` node each, carrying a
-`TransitionNumber` property and the Part 16 §B.4 references:
+`TransitionNumber` property and the Part 16 §4.4.11 references:
 
 * `FromState` / `ToState` to the two state nodes;
 * `HasEffect` to `TransitionEventType`, unless the transition was
@@ -587,7 +589,7 @@ for every Object child it encounters.
 
 Earlier releases attached `HasSubStateMachine` to the state machine
 **root**, because the fluent builder did not materialize state nodes.
-It now sits on the parent **state** node per Part 16 §B.3, and the
+It now sits on the parent **state** node per Part 16 §4.4.16, and the
 root reference is gone.
 
 Callers that passed the state machine's `ObjectId` to

--- a/docs/StateMachines.md
+++ b/docs/StateMachines.md
@@ -409,9 +409,81 @@ parent FSM already declares its sub-state machines as part of the
 type definition. Observe them through the client-side sub-SM
 accessors below.
 
+`WithSubStateMachine` and `WithInitialState` are order-independent:
+whichever is called second brings the sub-SM in line with the
+parent's current state. (`WithInitialState` goes through `SetState`,
+which is not a transition and so still runs no user lifecycle
+handler.)
+
 While suspended, the child FSM's `DoTransition` and `DoCause`
 return `BadInvalidState`. The flag is exposed publicly as
 `FluentFiniteStateMachineState.IsSuspended` for diagnostics.
+
+The resulting address space follows Part 16 §B.3 and the standard
+NodeSets:
+
+```
+LimitAlarm            --HasComponent-->       Active   (StateType)
+Active                --HasSubStateMachine--> LimitState
+LimitAlarm            --HasComponent-->       LimitState
+```
+
+`HasSubStateMachine` is a **non-hierarchical** reference, so it
+cannot double as the parent/child reference — the sub-SM is a
+`HasComponent` child of the state machine and the spec reference
+hangs off the parent *state* node.
+
+### Server side — materialized state and transition nodes
+
+To give `HasSubStateMachine` a state node to hang off — and to make
+`CurrentState/Id` and `LastTransition/Id` resolve to something a
+client can actually browse — `FluentFiniteStateMachineState`
+materializes a node per declared state and transition when the machine
+is created. All of them are `HasComponent` children of the machine.
+
+**States** — one `StateType` node each, carrying a `StateNumber`
+property equal to the numeric state id. `CurrentState/Id` points at
+the node for the current state and tracks it across transitions, and
+the optional `AvailableStates` property lists them, so
+`GetAvailableStatesAsync` works against a fluent-built server.
+
+**Transitions** — one `TransitionType` node each, carrying a
+`TransitionNumber` property and the Part 16 §B.4 references:
+
+* `FromState` / `ToState` to the two state nodes;
+* `HasEffect` to `TransitionEventType`, unless the transition was
+  declared with `hasEffect: false`;
+* `HasCause` to the method node, added by `WithCause(methodNodeId)`
+  for every transition the cause can trigger.
+
+`AvailableTransitions` lists them, and the optional `LastTransition`
+variable is materialized too — without it the base class has nowhere
+to record a completed transition and `ObserveFiniteTransitionsAsync`
+has nothing to subscribe to.
+
+NodeIds are **per instance**, derived from the machine's own NodeId,
+so several machines built from one definition coexist in a single
+address space. Use `sm.GetStateId(nodeId)` / `sm.GetTransitionId(nodeId)`
+and their inverses `sm.GetStateNodeId(stateId)` /
+`sm.GetTransitionNodeId(transitionId)` to move between a NodeId and
+the numeric id used by `AddState` / `AddTransition` / `OnCause` and
+the lifecycle hooks — never parse the NodeId's identifier directly.
+
+Element nodes land in the namespace given to `UseElementNamespace`,
+or in the state machine's own namespace when that was not called or
+the URI is not registered with the server (the element namespace
+defaults to the OPC UA namespace, which must never host vendor
+nodes).
+
+Because element NodeIds are derived from browse names, browse names
+must be unique across states and transitions (and must not shadow the
+standard `CurrentState` / `LastTransition` / `AvailableStates` /
+`AvailableTransitions` children); the builder rejects duplicates when
+the definition freezes.
+
+Cost is one node plus one property per declared state and transition,
+per machine instance — worth weighing for servers that instantiate
+many machines.
 
 ### Client side — sub-SM observation
 
@@ -419,10 +491,16 @@ return `BadInvalidState`. The flag is exposed publicly as
 FiniteStateMachineTypeClient parent =
     new FiniteStateMachineTypeClient(session, alarmId, telemetry);
 
-// Resolve the sub-SM attached to a parent state:
+// The state NodeId comes from AvailableStates ...
+IReadOnlyList<FiniteStateInfo> states =
+    await parent.GetAvailableStatesAsync(ct);
+NodeId activeStateId = states.First(s => s.BrowseName.Name == "Active").NodeId;
+
+// ... or from a snapshot's CurrentStateId, to reach the sub-SM of
+// whatever state the machine is in right now.
 FiniteStateMachineTypeClient? limitSm =
     await parent.GetSubStateMachineAsync(
-        parentStateNodeId: alarmStateNodeId, telemetry, ct);
+        parentStateNodeId: activeStateId, telemetry, ct);
 
 if (limitSm != null)
 {
@@ -494,18 +572,16 @@ Vendor models that add their own `<opc:Object>` children on a custom
 ObjectType benefit automatically; the generator emits the same shape
 for every Object child it encounters.
 
-### Per-spec `HasSubStateMachine` placement (deferred)
+### Breaking change — `HasSubStateMachine` moved to the state node
 
-Part 16 §B.3 places the `HasSubStateMachine` reference on the parent
-state node, not the FSM root. The fluent builder currently attaches
-the reference from the FSM root because `FluentFiniteStateMachineState`
-does not materialize per-state instance NodeStates — state nodes are
-shared across all instances of the type. Browsing
-`HasSubStateMachine` from the FSM root via `GetSubStateMachineAsync`
-and the typed accessors above works against this wiring; clients that
-strictly browse from the state node will not discover the sub-SM. A
-future iteration may materialize per-state instance nodes to align
-with the spec; this is tracked but deliberately deferred.
+Earlier releases attached `HasSubStateMachine` to the state machine
+**root**, because the fluent builder did not materialize state nodes.
+It now sits on the parent **state** node per Part 16 §B.3, and the
+root reference is gone.
+
+Callers that passed the state machine's `ObjectId` to
+`GetSubStateMachineAsync` must pass a state NodeId instead — from
+`GetAvailableStatesAsync` or from a snapshot's `CurrentStateId`.
 
 ## Extensibility recipes
 

--- a/docs/StateMachines.md
+++ b/docs/StateMachines.md
@@ -413,7 +413,16 @@ accessors below.
 whichever is called second brings the sub-SM in line with the
 parent's current state. (`WithInitialState` goes through `SetState`,
 which is not a transition and so still runs no user lifecycle
-handler.)
+handler — but it does re-arm timed transitions and synchronize
+sub-state machines.)
+
+A state declared with `isInitial: true` is applied automatically when
+the machine is created, so the minimal example above is fully
+functional without an explicit `WithInitialState` call; call
+`WithInitialState` to start in a different state. A sub-state
+machine's declared initial state is applied only while its parent is
+in the attached state — an inactive sub-SM publishes no current
+state.
 
 While suspended, the child FSM's `DoTransition` and `DoCause`
 return `BadInvalidState`. The flag is exposed publicly as
@@ -452,7 +461,9 @@ the optional `AvailableStates` property lists them, so
 
 * `FromState` / `ToState` to the two state nodes;
 * `HasEffect` to `TransitionEventType`, unless the transition was
-  declared with `hasEffect: false`;
+  declared with `hasEffect: false` — forward-only, matching how
+  companion NodeSets declare it (the target is a standard node owned
+  by another node manager, so no inverse edge is registered there);
 * `HasCause` to the method node, added by `WithCause(methodNodeId)`
   for every transition the cause can trigger.
 

--- a/docs/StateMachines.md
+++ b/docs/StateMachines.md
@@ -585,9 +585,9 @@ Vendor models that add their own `<opc:Object>` children on a custom
 ObjectType benefit automatically; the generator emits the same shape
 for every Object child it encounters.
 
-### Breaking change — `HasSubStateMachine` moved to the state node
+### Fluent builder behavior — `HasSubStateMachine` is on the state node
 
-Earlier releases attached `HasSubStateMachine` to the state machine
+Earlier fluent-builder implementations attached `HasSubStateMachine` to the state machine
 **root**, because the fluent builder did not materialize state nodes.
 It now sits on the parent **state** node per Part 16 §4.4.16, and the
 root reference is gone.

--- a/docs/WhatsNewIn2.0.md
+++ b/docs/WhatsNewIn2.0.md
@@ -169,7 +169,7 @@ server- and client-side implementations:
   `AvailableTransitions` / `LastTransition` children), so
   `CurrentState/Id` and `LastTransition/Id` resolve to real nodes and
   `HasSubStateMachine` hangs off the parent **state** node per Part 16
-  §B.3 rather than off the machine root. Callers that passed a state
+  §4.4.16 rather than off the machine root. Callers that passed a state
   machine's `ObjectId` to `GetSubStateMachineAsync` must pass a state
   NodeId instead — from `GetAvailableStatesAsync` or a snapshot's
   `CurrentStateId` — and code that read a numeric id out of

--- a/docs/WhatsNewIn2.0.md
+++ b/docs/WhatsNewIn2.0.md
@@ -162,6 +162,23 @@ server- and client-side implementations:
   (`FluentFiniteStateMachineState`) and *lifecycle* (attach behaviour to
   stack-shipped or generator-emitted FSMs) modes, plus client-side
   streaming / read helpers on the generated `*TypeClient` proxies.
+  Definition-mode machines materialize a `StateType` node per declared
+  state and a `TransitionType` node per declared transition (with
+  `StateNumber` / `TransitionNumber`, `FromState` / `ToState` /
+  `HasEffect` / `HasCause`, and the `AvailableStates` /
+  `AvailableTransitions` / `LastTransition` children), so
+  `CurrentState/Id` and `LastTransition/Id` resolve to real nodes and
+  `HasSubStateMachine` hangs off the parent **state** node per Part 16
+  §B.3 rather than off the machine root. Callers that passed a state
+  machine's `ObjectId` to `GetSubStateMachineAsync` must pass a state
+  NodeId instead — from `GetAvailableStatesAsync` or a snapshot's
+  `CurrentStateId` — and code that read a numeric id out of
+  `CurrentState/Id` should call `FiniteStateMachineState.GetStateId`
+  instead of parsing the identifier. Generated state-machine classes
+  now also override `ElementNamespaceUri` with the namespace of the
+  model that declares their states, so `CurrentState/Id` and
+  `LastTransition/Id` are qualified with the companion-spec namespace
+  rather than the OPC UA one.
 - **Part 17 — Alias Names**: full server + client support for
   `AliasNameType`, `AliasNameCategoryType`, `FindAlias`, `FindAliasVerbose`,
   `AddAliasesToCategory`, `DeleteAliasesFromCategory`, and `LastChange`.

--- a/samples/OpenUsd/GeneratorServer/GeneratorStateMachine.cs
+++ b/samples/OpenUsd/GeneratorServer/GeneratorStateMachine.cs
@@ -96,20 +96,20 @@ namespace Generators
         private void PublishState(GeneratorStateMachineState machine, GeneratorRunState state)
         {
             if (machine.CurrentState == null ||
-                !GeneratorStateMap.StateNumbers.TryGetValue(state, out uint number))
+                !GeneratorStateMap.StateIds.TryGetValue(state, out uint stateNodeId))
             {
                 return;
             }
 
             // CurrentState carries the human-readable name; its Id property carries
-            // the state node a client actually compares against, so both are written
-            // or a client sees a name it cannot resolve.
+            // the state NODE the model declares (not the state number — that is the
+            // StateNumber property's value), so a client can browse what it reads.
             machine.CurrentState.Value = new LocalizedText(state.ToString());
             PropertyState<NodeId>? id = machine.CurrentState.CreateOrReplaceId(SystemContext, null!);
             if (id != null)
             {
                 id.Value = NodeId.Create(
-                    number,
+                    stateNodeId,
                     Opc.Ua.Generators.Namespaces.Generators,
                     Server.NamespaceUris);
                 id.ClearChangeMasks(SystemContext, false);

--- a/samples/OpenUsd/GeneratorServer/GeneratorStateMap.cs
+++ b/samples/OpenUsd/GeneratorServer/GeneratorStateMap.cs
@@ -47,6 +47,32 @@ namespace Generators
     internal static class GeneratorStateMap
     {
         /// <summary>
+        /// Gets the model's state <em>node id</em> for every simulated
+        /// state — the identifier of the StateType node the model
+        /// declares, which is what <c>CurrentState/Id</c> must carry
+        /// (the state <em>number</em> is a different value published by
+        /// the StateNumber property).
+        /// </summary>
+        public static IReadOnlyDictionary<GeneratorRunState, uint> StateIds { get; } =
+            new Dictionary<GeneratorRunState, uint>
+            {
+                [GeneratorRunState.Off] = GeneratorStateMachineTypeIds.StateIds.Off,
+                [GeneratorRunState.Ready] = GeneratorStateMachineTypeIds.StateIds.Ready,
+                [GeneratorRunState.Starting] = GeneratorStateMachineTypeIds.StateIds.Starting,
+                [GeneratorRunState.Warmup] = GeneratorStateMachineTypeIds.StateIds.Warmup,
+                [GeneratorRunState.Running] = GeneratorStateMachineTypeIds.StateIds.Running,
+                [GeneratorRunState.Loaded] = GeneratorStateMachineTypeIds.StateIds.Loaded,
+                [GeneratorRunState.Synchronizing] =
+                    GeneratorStateMachineTypeIds.StateIds.Synchronizing,
+                [GeneratorRunState.Paralleled] = GeneratorStateMachineTypeIds.StateIds.Paralleled,
+                [GeneratorRunState.Cooldown] = GeneratorStateMachineTypeIds.StateIds.Cooldown,
+                [GeneratorRunState.Stopping] = GeneratorStateMachineTypeIds.StateIds.Stopping,
+                [GeneratorRunState.Fault] = GeneratorStateMachineTypeIds.StateIds.Fault,
+                [GeneratorRunState.EmergencyStopped] =
+                    GeneratorStateMachineTypeIds.StateIds.EmergencyStopped,
+            };
+
+        /// <summary>
         /// Gets the model's state number for every simulated state.
         /// </summary>
         public static IReadOnlyDictionary<GeneratorRunState, uint> StateNumbers { get; } =

--- a/src/Opc.Ua.Client/StateMachines/FiniteStateMachineTypeClientExtensions.cs
+++ b/src/Opc.Ua.Client/StateMachines/FiniteStateMachineTypeClientExtensions.cs
@@ -593,9 +593,11 @@ namespace Opc.Ua.Client.StateMachines
         /// <param name="parent">The parent finite state-machine
         /// client.</param>
         /// <param name="parentStateNodeId">The NodeId of the parent
-        /// state node (e.g. the <c>StateType</c> instance — for
-        /// servers that wire the reference from the FSM root rather
-        /// than the state node, pass the FSM's <c>ObjectId</c>).</param>
+        /// state node — the <c>StateType</c> node the reference hangs
+        /// off per Part 16 §B.3. Obtain it from
+        /// <see cref="GetAvailableStatesAsync"/> or from a snapshot's
+        /// <c>CurrentStateId</c>; passing the state machine's
+        /// <c>ObjectId</c> resolves nothing.</param>
         /// <param name="telemetry">Telemetry context for the returned
         /// sub-SM client.</param>
         /// <param name="ct">Cancellation token.</param>

--- a/src/Opc.Ua.Client/StateMachines/FiniteStateMachineTypeClientExtensions.cs
+++ b/src/Opc.Ua.Client/StateMachines/FiniteStateMachineTypeClientExtensions.cs
@@ -594,7 +594,7 @@ namespace Opc.Ua.Client.StateMachines
         /// client.</param>
         /// <param name="parentStateNodeId">The NodeId of the parent
         /// state node — the <c>StateType</c> node the reference hangs
-        /// off per Part 16 §B.3. Obtain it from
+        /// off per Part 16 §4.4.16. Obtain it from
         /// <see cref="GetAvailableStatesAsync"/> or from a snapshot's
         /// <c>CurrentStateId</c>; passing the state machine's
         /// <c>ObjectId</c> resolves nothing.</param>

--- a/src/Opc.Ua.Client/StateMachines/StateMachineSnapshot.cs
+++ b/src/Opc.Ua.Client/StateMachines/StateMachineSnapshot.cs
@@ -97,7 +97,7 @@ namespace Opc.Ua.Client.StateMachines
     /// <param name="NodeId">The NodeId of the <c>StateType</c> instance.</param>
     /// <param name="BrowseName">The browse name (e.g. <c>Unshelved</c>).</param>
     /// <param name="StateNumber">The state number declared by the
-    /// type (Part 16 §B.4.3). Zero when the server does not expose
+    /// type (Part 16 §4.4.8). Zero when the server does not expose
     /// the <c>StateNumber</c> property.</param>
     public sealed record FiniteStateInfo(
         NodeId NodeId,

--- a/src/Opc.Ua.Core.Types/State/FiniteStateMachineState.cs
+++ b/src/Opc.Ua.Core.Types/State/FiniteStateMachineState.cs
@@ -196,7 +196,7 @@ namespace Opc.Ua
         }
 
         /// <summary>
-        /// Returns the current state of for the state machine.
+        /// Returns the current state id of the state machine.
         /// </summary>
         protected uint GetCurrentStateId()
         {

--- a/src/Opc.Ua.Core.Types/State/FiniteStateMachineState.cs
+++ b/src/Opc.Ua.Core.Types/State/FiniteStateMachineState.cs
@@ -128,6 +128,74 @@ namespace Opc.Ua
         protected FiniteStateVariableState? LastState { get; set; }
 
         /// <summary>
+        /// Maps a numeric state id onto the NodeId of the
+        /// <c>StateType</c> node representing that state.
+        /// </summary>
+        /// <remarks>
+        /// The default follows the OPC UA convention of qualifying the
+        /// numeric element id with <see cref="ElementNamespaceIndex"/>.
+        /// Subclasses that materialize per-instance state nodes (whose
+        /// NodeIds therefore cannot be derived from the state id alone)
+        /// override this together with <see cref="GetStateId"/> so that
+        /// <c>CurrentState/Id</c> resolves to a node that actually
+        /// exists in the address space.
+        /// </remarks>
+        /// <param name="stateId">The numeric state id. Zero denotes
+        /// "no state" and maps to <see cref="NodeId.Null"/>.</param>
+        public virtual NodeId GetStateNodeId(uint stateId)
+        {
+            return stateId == 0 ? NodeId.Null : new NodeId(stateId, ElementNamespaceIndex);
+        }
+
+        /// <summary>
+        /// The inverse of <see cref="GetStateNodeId"/>. Returns 0 when
+        /// <paramref name="stateNodeId"/> does not identify a state of
+        /// this machine.
+        /// </summary>
+        public virtual uint GetStateId(NodeId stateNodeId)
+        {
+            if (stateNodeId.IsNull ||
+                ElementNamespaceIndex != stateNodeId.NamespaceIndex ||
+                !stateNodeId.TryGetValue(out uint numericId))
+            {
+                return 0;
+            }
+
+            return numericId;
+        }
+
+        /// <summary>
+        /// Maps a numeric transition id onto the NodeId of the
+        /// <c>TransitionType</c> node representing that transition. See
+        /// <see cref="GetStateNodeId"/> for the rationale.
+        /// </summary>
+        /// <param name="transitionId">The numeric transition id. Zero
+        /// denotes "no transition" and maps to <see cref="NodeId.Null"/>.</param>
+        public virtual NodeId GetTransitionNodeId(uint transitionId)
+        {
+            return transitionId == 0
+                ? NodeId.Null
+                : new NodeId(transitionId, ElementNamespaceIndex);
+        }
+
+        /// <summary>
+        /// The inverse of <see cref="GetTransitionNodeId"/>. Returns 0
+        /// when <paramref name="transitionNodeId"/> does not identify a
+        /// transition of this machine.
+        /// </summary>
+        public virtual uint GetTransitionId(NodeId transitionNodeId)
+        {
+            if (transitionNodeId.IsNull ||
+                ElementNamespaceIndex != transitionNodeId.NamespaceIndex ||
+                !transitionNodeId.TryGetValue(out uint numericId))
+            {
+                return 0;
+            }
+
+            return numericId;
+        }
+
+        /// <summary>
         /// Returns the current state of for the state machine.
         /// </summary>
         protected uint GetCurrentStateId()
@@ -139,15 +207,7 @@ namespace Opc.Ua
                 return 0;
             }
 
-            NodeId value = CurrentState.Id.Value;
-
-            if (ElementNamespaceIndex != value.NamespaceIndex ||
-                !value.TryGetValue(out uint numericId))
-            {
-                return 0;
-            }
-
-            return numericId;
+            return GetStateId(CurrentState.Id.Value);
         }
 
         /// <summary>
@@ -310,7 +370,7 @@ namespace Opc.Ua
                 if (state.Id == stateId)
                 {
                     variable.Value = new LocalizedText(state.Name);
-                    variable.Id?.Value = new NodeId(state.Id, ElementNamespaceIndex);
+                    variable.Id?.Value = GetStateNodeId(state.Id);
 
                     variable.Number?.Value = state.Number;
 
@@ -358,7 +418,7 @@ namespace Opc.Ua
                 if (transition.Id == transitionId)
                 {
                     variable.Value = new LocalizedText(transition.Name);
-                    variable.Id?.Value = new NodeId(transition.Id, ElementNamespaceIndex);
+                    variable.Id?.Value = GetTransitionNodeId(transition.Id);
 
                     variable.TransitionTime?.Value = DateTime.UtcNow;
 

--- a/src/Opc.Ua.Di.Server/Builders/SoftwareUpdateFacetWiring.cs
+++ b/src/Opc.Ua.Di.Server/Builders/SoftwareUpdateFacetWiring.cs
@@ -119,16 +119,33 @@ namespace Opc.Ua.Di.Server.Builders
             // State machines — all four are present but only Installation
             // and Confirmation have method handlers wired by default;
             // PrepareForUpdate.Prepare/Abort/Resume also wired.
-            su.PrepareForUpdate = CreatePrepareForUpdate(
+            PrepareForUpdateStateMachineState prepareForUpdate = CreatePrepareForUpdate(
                 context, su, diNs, config, callbackContext, logger);
+            su.PrepareForUpdate = prepareForUpdate;
 
-            su.Installation = CreateInstallation(
+            InstallationStateMachineState installation = CreateInstallation(
                 context, su, diNs, config, callbackContext, logger);
+            su.Installation = installation;
 
-            su.PowerCycle = CreatePowerCycle(context, su, diNs);
+            PowerCycleStateMachineState powerCycle = CreatePowerCycle(context, su, diNs);
+            su.PowerCycle = powerCycle;
 
-            su.Confirmation = CreateConfirmation(
+            ConfirmationStateMachineState confirmation = CreateConfirmation(
                 context, su, diNs, config, callbackContext, logger);
+            su.Confirmation = confirmation;
+
+            // The subtree is fully assembled, so complete the create
+            // lifecycle for it in one pass — the generated CreateInstanceOf
+            // factories build the node graph and assign per-instance NodeIds
+            // but deliberately leave OnBeforeCreate / OnAfterCreate to the
+            // caller (see the generator's "Add predefined node" templates).
+            // Skipping it would leave every state machine below without the
+            // element namespace it resolves in OnAfterCreate, so the state
+            // seeding below has to follow this call.
+            su.CreateAsPredefinedNode(context);
+
+            SeedStateMachines(
+                prepareForUpdate, installation, powerCycle, confirmation, diNs, context);
 
             // Link the SU node into the device subtree and register
             // recursively with the manager. Per-instance NodeIds for the SU
@@ -140,6 +157,45 @@ namespace Opc.Ua.Di.Server.Builders
             manager.RecordSoftwareUpdateFacet(config.LoadingMode);
 
             return su;
+        }
+
+        /// <summary>
+        /// Writes each state machine's initial state. Runs after
+        /// <see cref="NodeState.CreateAsPredefinedNode"/> so that the
+        /// machines have resolved the namespace their element NodeIds
+        /// are qualified with.
+        /// </summary>
+        private static void SeedStateMachines(
+            PrepareForUpdateStateMachineState prepareForUpdate,
+            InstallationStateMachineState installation,
+            PowerCycleStateMachineState powerCycle,
+            ConfirmationStateMachineState confirmation,
+            ushort diNs,
+            ISystemContext context)
+        {
+            SoftwareUpdateStateMachineDispatcher.InitializeToInitialState(
+                prepareForUpdate,
+                SoftwareUpdateStateMachineDispatcher.PrepareForUpdate_Idle,
+                diNs,
+                context);
+
+            SoftwareUpdateStateMachineDispatcher.InitializeToInitialState(
+                installation,
+                SoftwareUpdateStateMachineDispatcher.Installation_Idle,
+                diNs,
+                context);
+
+            SoftwareUpdateStateMachineDispatcher.InitializeToInitialState(
+                powerCycle,
+                SoftwareUpdateStateMachineDispatcher.PowerCycle_NotWaiting,
+                diNs,
+                context);
+
+            SoftwareUpdateStateMachineDispatcher.InitializeToInitialState(
+                confirmation,
+                SoftwareUpdateStateMachineDispatcher.Confirmation_NotWaitingForConfirm,
+                diNs,
+                context);
         }
 
         private const string FileTransferBrowseName = "FileTransfer";
@@ -256,12 +312,6 @@ namespace Opc.Ua.Di.Server.Builders
             sm.Resume?.OnCallMethod2Async = (ctx, m, oid, ins, outs, ct) =>
                     InvokePrepareAsync(config, callbackContext, sm, diNs, logger, ct);
 
-            SoftwareUpdateStateMachineDispatcher.InitializeToInitialState(
-                sm,
-                SoftwareUpdateStateMachineDispatcher.PrepareForUpdate_Idle,
-                diNs,
-                context);
-
             return sm;
         }
 
@@ -320,12 +370,6 @@ namespace Opc.Ua.Di.Server.Builders
                     new QualifiedName("Resume", diNs));
             }
 
-            SoftwareUpdateStateMachineDispatcher.InitializeToInitialState(
-                sm,
-                SoftwareUpdateStateMachineDispatcher.Installation_Idle,
-                diNs,
-                context);
-
             return sm;
         }
 
@@ -338,12 +382,6 @@ namespace Opc.Ua.Di.Server.Builders
             PowerCycleStateMachineState sm =
                 context.CreateInstanceOfPowerCycleStateMachineType(parent, browseName);
             FinaliseChild(context, sm, browseName);
-
-            SoftwareUpdateStateMachineDispatcher.InitializeToInitialState(
-                sm,
-                SoftwareUpdateStateMachineDispatcher.PowerCycle_NotWaiting,
-                diNs,
-                context);
 
             return sm;
         }
@@ -369,12 +407,6 @@ namespace Opc.Ua.Di.Server.Builders
                     (ctx, m, oid, ins, outs, ct) =>
                         InvokeConfirmAsync(config, callbackContext, sm, diNs, logger, ct);
             }
-
-            SoftwareUpdateStateMachineDispatcher.InitializeToInitialState(
-                sm,
-                SoftwareUpdateStateMachineDispatcher.Confirmation_NotWaitingForConfirm,
-                diNs,
-                context);
 
             return sm;
         }

--- a/src/Opc.Ua.Robotics.Server/Builders/OperationBuilders.cs
+++ b/src/Opc.Ua.Robotics.Server/Builders/OperationBuilders.cs
@@ -103,6 +103,13 @@ namespace Opc.Ua.Robotics.Server.Builders
                 (ushort)scope.Context.NamespaceUris.GetIndex(Namespaces.Robotics),
                 states,
                 transitions);
+            // The generated CreateInstanceOf factory builds the node graph
+            // and assigns per-instance NodeIds but leaves OnBeforeCreate /
+            // OnAfterCreate to the caller. A state machine resolves the
+            // namespace qualifying its element NodeIds in OnAfterCreate, so
+            // the create lifecycle has to complete before the initial state
+            // is written.
+            Machine.CreateAsPredefinedNode(scope.Context);
             m_dispatcher.InitializeToInitialState(
                 Machine,
                 StateId(RoboticsOperationState.Idle),

--- a/src/Opc.Ua.Robotics.Server/Builders/TaskControlOperationBuilders.cs
+++ b/src/Opc.Ua.Robotics.Server/Builders/TaskControlOperationBuilders.cs
@@ -294,6 +294,11 @@ namespace Opc.Ua.Robotics.Server.Builders
             Scope.EnsureMutable();
             Machine.AddReadySubstateMachine(Scope.Context);
             Machine.ReadySubstateMachine!.AddResetToProgramStart(Scope.Context);
+            // The parent machine completed its create lifecycle in the
+            // builder constructor, so a child added afterwards has to
+            // complete its own — a state machine resolves the namespace
+            // qualifying its element NodeIds in OnAfterCreate.
+            Machine.ReadySubstateMachine.CreateAsPredefinedNode(Scope.Context);
             Machine.ReadySubstateMachine.ResetToProgramStart!.OnCallAsync = async (_, _, _, cancellationToken) =>
             {
                 RoboticsProgramResult result = await handler(cancellationToken).ConfigureAwait(false);

--- a/src/Opc.Ua.Server/Fluent/StateMachineBuilder.cs
+++ b/src/Opc.Ua.Server/Fluent/StateMachineBuilder.cs
@@ -434,20 +434,11 @@ namespace Opc.Ua.Server.Fluent
                 return 0;
             }
 
-            NodeId value = StateMachine.CurrentState.Id.Value;
-            if (value.IsNull)
-            {
-                return 0;
-            }
-            // The machine's own mapping resolves materialized
-            // (non-numeric) state NodeIds; the numeric fallback keeps
-            // externally-written vendor-namespace ids working.
-            uint stateId = StateMachine.GetStateId(value);
-            if (stateId != 0)
-            {
-                return stateId;
-            }
-            return value.TryGetValue(out uint numericId) ? numericId : 0;
+            // One shared resolve rule: the machine's own mapping first
+            // (materialized state NodeIds), then the namespace-agnostic
+            // numeric fallback for externally-written vendor ids.
+            return StateMachines.StateMachineBuilder.ResolveStateId(
+                StateMachine, StateMachine.CurrentState.Id.Value);
         }
 
         private NodeState? ResolveNode(NodeId nodeId)

--- a/src/Opc.Ua.Server/Fluent/StateMachineBuilder.cs
+++ b/src/Opc.Ua.Server/Fluent/StateMachineBuilder.cs
@@ -439,11 +439,15 @@ namespace Opc.Ua.Server.Fluent
             {
                 return 0;
             }
-            if (!value.TryGetValue(out uint numericId))
+            // The machine's own mapping resolves materialized
+            // (non-numeric) state NodeIds; the numeric fallback keeps
+            // externally-written vendor-namespace ids working.
+            uint stateId = StateMachine.GetStateId(value);
+            if (stateId != 0)
             {
-                return 0;
+                return stateId;
             }
-            return numericId;
+            return value.TryGetValue(out uint numericId) ? numericId : 0;
         }
 
         private NodeState? ResolveNode(NodeId nodeId)

--- a/src/Opc.Ua.Server/StateMachines/FiniteStateMachineDispatcher.cs
+++ b/src/Opc.Ua.Server/StateMachines/FiniteStateMachineDispatcher.cs
@@ -92,7 +92,13 @@ namespace Opc.Ua.Server.StateMachines
             ISystemContext context)
         {
             ApplyState(machine, stateId, context);
-            ClearLastTransition(machine);
+            // Materialize the optional LastTransition now, while the
+            // machine is typically still pre-registration — deferring
+            // it to the first ApplyTransition would mint nodes into an
+            // already-indexed address space, where clients can browse
+            // but not read them.
+            EnsureLastTransition(machine, context);
+            ClearLastTransition(machine, context);
         }
 
         /// <summary>
@@ -226,7 +232,9 @@ namespace Opc.Ua.Server.StateMachines
             return false;
         }
 
-        private static void ClearLastTransition(FiniteStateMachineState machine)
+        private static void ClearLastTransition(
+            FiniteStateMachineState machine,
+            ISystemContext context)
         {
             if (machine?.LastTransition is null)
             {
@@ -247,18 +255,23 @@ namespace Opc.Ua.Server.StateMachines
             {
                 machine.LastTransition.TransitionTime.Value = DateTime.MinValue;
             }
+
+            machine.LastTransition.ClearChangeMasks(context, includeChildren: true);
         }
 
         private static void EnsureLastTransition(
             FiniteStateMachineState machine,
             ISystemContext context)
         {
-            if (machine.LastTransition is not null)
+            if (machine.LastTransition is null)
             {
-                return;
+                machine.AddLastTransition(context);
             }
 
-            machine.AddLastTransition(context);
+            // ApplyTransition writes the optional Number child, so it
+            // has to exist by now too — created later it would land in
+            // an already-indexed address space.
+            machine.LastTransition!.AddNumber(context);
         }
 
         private static FiniteStateMachineEntry Lookup(

--- a/src/Opc.Ua.Server/StateMachines/FiniteStateMachineDispatcher.cs
+++ b/src/Opc.Ua.Server/StateMachines/FiniteStateMachineDispatcher.cs
@@ -52,6 +52,17 @@ namespace Opc.Ua.Server.StateMachines
     /// <remarks>
     /// Source-generated companion state machines do not currently emit StateTable and TransitionTable overrides.
     /// This dispatcher updates the standard state variables directly while preserving the generated node hierarchy.
+    /// <para>
+    /// Element NodeIds come from the machine's own
+    /// <see cref="FiniteStateMachineState.GetStateNodeId"/> /
+    /// <see cref="FiniteStateMachineState.GetTransitionNodeId"/>, so a generated machine writes
+    /// ids in its model namespace and a machine that materializes its own element nodes points
+    /// at the real node. That requires the machine to have completed its create lifecycle —
+    /// <c>ElementNamespaceUri</c> is resolved in <c>OnAfterCreate</c> — so a node assembled by a
+    /// <c>CreateInstanceOf</c> factory must be passed through
+    /// <see cref="NodeState.CreateAsPredefinedNode"/> first. <c>namespaceIndex</c> now only
+    /// backstops reading a state variable some other component wrote.
+    /// </para>
     /// </remarks>
     public sealed class FiniteStateMachineDispatcher
     {
@@ -103,7 +114,11 @@ namespace Opc.Ua.Server.StateMachines
 
             if (machine.CurrentState.Id != null)
             {
-                machine.CurrentState.Id.Value = new NodeId(stateId, m_namespaceIndex);
+                // The machine owns the element-NodeId convention:
+                // generated machines qualify the numeric id with their
+                // model namespace, and machines that materialize their
+                // own state nodes point at the real node.
+                machine.CurrentState.Id.Value = machine.GetStateNodeId(stateId);
             }
             if (machine.CurrentState.Number != null)
             {
@@ -138,7 +153,8 @@ namespace Opc.Ua.Server.StateMachines
 
             if (machine.LastTransition.Id != null)
             {
-                machine.LastTransition.Id.Value = new NodeId(transitionId, m_namespaceIndex);
+                machine.LastTransition.Id.Value =
+                    machine.GetTransitionNodeId(transitionId);
             }
             if (machine.LastTransition.Number != null)
             {
@@ -177,14 +193,27 @@ namespace Opc.Ua.Server.StateMachines
             }
 
             NodeId nodeId = machine.CurrentState.Id.Value;
-            if (nodeId.IsNull || nodeId.NamespaceIndex != m_namespaceIndex)
+            if (nodeId.IsNull)
             {
                 return false;
             }
 
-            if (nodeId.TryGetValue(out uint id))
+            // Ask the machine first — it owns the mapping — then fall
+            // back to the numeric convention for state variables a
+            // caller wrote in some other namespace.
+            uint id = machine.GetStateId(nodeId);
+            if (id != 0)
             {
                 stateId = id;
+                return true;
+            }
+            if (nodeId.NamespaceIndex != m_namespaceIndex)
+            {
+                return false;
+            }
+            if (nodeId.TryGetValue(out uint numericId))
+            {
+                stateId = numericId;
                 return true;
             }
             if (uint.TryParse(nodeId.IdentifierAsString, NumberStyles.Integer, CultureInfo.InvariantCulture,

--- a/src/Opc.Ua.Server/StateMachines/FluentFiniteStateMachineState.cs
+++ b/src/Opc.Ua.Server/StateMachines/FluentFiniteStateMachineState.cs
@@ -71,20 +71,22 @@ namespace Opc.Ua.Server.StateMachines
         private int m_cacheVersion = -1;
 
         /// <summary>
-        /// The materialized <c>StateType</c> nodes, keyed both ways.
-        /// Populated once by <see cref="MaterializeStateNodes"/>; both
-        /// stay <c>null</c> until then, in which case the base
-        /// (numeric) element-NodeId convention applies.
+        /// The materialized <c>StateType</c> nodes by numeric id.
+        /// Populated once by <see cref="MaterializeStateNodes"/>; stays
+        /// <c>null</c> until then, in which case the base (numeric)
+        /// element-NodeId convention applies. The reverse direction is
+        /// resolved by scanning the nodes' <em>live</em> NodeIds — no
+        /// reverse map is kept, so a NodeId reassigned after
+        /// materialization (e.g. by a node manager's per-instance
+        /// NodeId rebase during registration) still resolves.
         /// </summary>
         private Dictionary<uint, BaseObjectState>? m_stateNodesById;
-        private Dictionary<NodeId, uint>? m_stateIdsByNodeId;
 
         /// <summary>
-        /// The materialized <c>TransitionType</c> nodes, keyed both
-        /// ways. See <see cref="MaterializeTransitionNodes"/>.
+        /// The materialized <c>TransitionType</c> nodes by numeric id.
+        /// See <see cref="MaterializeTransitionNodes"/>.
         /// </summary>
         private Dictionary<uint, BaseObjectState>? m_transitionNodesById;
-        private Dictionary<NodeId, uint>? m_transitionIdsByNodeId;
 
         /// <summary>
         /// When <c>true</c>, the state machine rejects all incoming
@@ -287,34 +289,75 @@ namespace Opc.Ua.Server.StateMachines
             string ownerPrefix = ComposeOwnerPrefix();
 
             var nodesById = new Dictionary<uint, BaseObjectState>();
-            var idsByNodeId = new Dictionary<NodeId, uint>();
-            var availableStates = new NodeId[MutableDefinition.States.Count];
 
-            for (int ii = 0; ii < MutableDefinition.States.Count; ii++)
+            foreach (StateMachineStateDefinition state in MutableDefinition.States)
             {
-                StateMachineStateDefinition state = MutableDefinition.States[ii];
-                BaseObjectState stateNode = MaterializeElementNode(
+                nodesById[state.Id] = MaterializeElementNode(
                     ownerPrefix,
                     state.BrowseName,
                     ObjectTypeIds.StateType,
                     BrowseNames.StateNumber,
                     state.Id,
                     elementNamespaceIndex);
-
-                nodesById[state.Id] = stateNode;
-                idsByNodeId[stateNode.NodeId] = state.Id;
-                availableStates[ii] = stateNode.NodeId;
             }
 
             m_stateNodesById = nodesById;
-            m_stateIdsByNodeId = idsByNodeId;
 
+            // The value is served live so it stays correct even if a
+            // node manager reassigns the element NodeIds when the
+            // machine is registered.
             AddAvailableStates(
                 context,
-                available => available.Value = ArrayOf.Wrapped(availableStates),
+                available =>
+                {
+                    available.Value = ReadLiveStateNodeIds();
+                    available.OnSimpleReadValue = (ISystemContext ctx, NodeState node, ref Variant value) =>
+                    {
+                        value = Variant.From(ReadLiveStateNodeIds());
+                        return ServiceResult.Good;
+                    };
+                },
                 new NodeId(
                     ownerPrefix + "_" + BrowseNames.AvailableStates,
                     NodeId.NamespaceIndex));
+        }
+
+        /// <summary>
+        /// Projects the state nodes' current NodeIds in declaration
+        /// order.
+        /// </summary>
+        private ArrayOf<NodeId> ReadLiveStateNodeIds()
+        {
+            if (m_stateNodesById == null)
+            {
+                return default;
+            }
+            var nodeIds = new NodeId[MutableDefinition.States.Count];
+            for (int ii = 0; ii < nodeIds.Length; ii++)
+            {
+                nodeIds[ii] =
+                    m_stateNodesById[MutableDefinition.States[ii].Id].NodeId;
+            }
+            return ArrayOf.Wrapped(nodeIds);
+        }
+
+        /// <summary>
+        /// Projects the transition nodes' current NodeIds in
+        /// declaration order.
+        /// </summary>
+        private ArrayOf<NodeId> ReadLiveTransitionNodeIds()
+        {
+            if (m_transitionNodesById == null)
+            {
+                return default;
+            }
+            var nodeIds = new NodeId[MutableDefinition.Transitions.Count];
+            for (int ii = 0; ii < nodeIds.Length; ii++)
+            {
+                nodeIds[ii] =
+                    m_transitionNodesById[MutableDefinition.Transitions[ii].Id].NodeId;
+            }
+            return ArrayOf.Wrapped(nodeIds);
         }
 
         /// <summary>
@@ -343,13 +386,10 @@ namespace Opc.Ua.Server.StateMachines
             string ownerPrefix = ComposeOwnerPrefix();
 
             var nodesById = new Dictionary<uint, BaseObjectState>();
-            var idsByNodeId = new Dictionary<NodeId, uint>();
-            var availableTransitions = new NodeId[MutableDefinition.Transitions.Count];
 
-            for (int ii = 0; ii < MutableDefinition.Transitions.Count; ii++)
+            foreach (StateMachineTransitionDefinition transition
+                in MutableDefinition.Transitions)
             {
-                StateMachineTransitionDefinition transition =
-                    MutableDefinition.Transitions[ii];
                 BaseObjectState transitionNode = MaterializeElementNode(
                     ownerPrefix,
                     transition.BrowseName,
@@ -374,16 +414,21 @@ namespace Opc.Ua.Server.StateMachines
                 }
 
                 nodesById[transition.Id] = transitionNode;
-                idsByNodeId[transitionNode.NodeId] = transition.Id;
-                availableTransitions[ii] = transitionNode.NodeId;
             }
 
             m_transitionNodesById = nodesById;
-            m_transitionIdsByNodeId = idsByNodeId;
 
             AddAvailableTransitions(
                 context,
-                available => available.Value = ArrayOf.Wrapped(availableTransitions),
+                available =>
+                {
+                    available.Value = ReadLiveTransitionNodeIds();
+                    available.OnSimpleReadValue = (ISystemContext ctx, NodeState node, ref Variant value) =>
+                    {
+                        value = Variant.From(ReadLiveTransitionNodeIds());
+                        return ServiceResult.Good;
+                    };
+                },
                 new NodeId(
                     ownerPrefix + "_" + BrowseNames.AvailableTransitions,
                     NodeId.NamespaceIndex));
@@ -446,23 +491,34 @@ namespace Opc.Ua.Server.StateMachines
 
         /// <summary>
         /// The stable string prefix all of this machine's materialized
-        /// element NodeIds share — the machine's own identifier, or one
-        /// random prefix for a machine created without a NodeId.
+        /// element NodeIds share — the machine's own <em>full</em>
+        /// NodeId string (namespace and id type included, so two
+        /// machines whose identifiers happen to coincide in different
+        /// namespaces cannot mint colliding element ids), or one random
+        /// prefix for a machine created without a NodeId.
         /// </summary>
         private string ComposeOwnerPrefix()
         {
-            return m_ownerPrefix ??= NodeId.IsNull
+            return m_ownerPrefix ??= ComposeOwnerPrefix(NodeId);
+        }
+
+        private static string ComposeOwnerPrefix(NodeId ownerNodeId)
+        {
+            return ownerNodeId.IsNull
                 ? Guid.NewGuid().ToString()
-                : NodeId.IdentifierAsString;
+                : ownerNodeId.ToString();
         }
 
         private string? m_ownerPrefix;
 
         /// <summary>
-        /// Links a transition node to one of its endpoint states.
-        /// Silently skips endpoints the definition does not declare —
-        /// <c>ValidateDefinition</c> already rejects those, and a
-        /// definition built by hand should not throw from create.
+        /// Links a transition node to one of its endpoint states, in
+        /// both directions — so a client can inverse-browse
+        /// <c>FromState</c> / <c>ToState</c> from a state node to find
+        /// its transitions. Silently skips endpoints the definition
+        /// does not declare — <c>ValidateDefinition</c> already rejects
+        /// those, and a definition built by hand should not throw from
+        /// create.
         /// </summary>
         private void AddTransitionEndpointReference(
             BaseObjectState transitionNode,
@@ -473,22 +529,26 @@ namespace Opc.Ua.Server.StateMachines
             if (stateNode != null)
             {
                 transitionNode.AddReference(referenceTypeId, false, stateNode.NodeId);
+                stateNode.AddReference(referenceTypeId, true, transitionNode.NodeId);
             }
         }
 
         /// <summary>
         /// Records a <c>HasCause</c> reference from every transition the
-        /// cause can trigger to the method node that carries it.
+        /// cause can trigger to the method node that carries it, plus
+        /// the inverse on the method so inverse-browsing
+        /// <c>HasCause</c> from the method finds the transitions.
         /// Invoked by <c>StateMachineBuilder.WithCause</c>, the only
         /// place where a numeric cause id is bound to a real method.
         /// </summary>
-        internal void AddCauseReferences(uint causeId, NodeId methodNodeId)
+        internal void AddCauseReferences(uint causeId, MethodState causeMethod)
         {
-            if (m_transitionNodesById == null || methodNodeId.IsNull)
+            if (m_transitionNodesById == null || causeMethod.NodeId.IsNull)
             {
                 return;
             }
 
+            NodeId methodNodeId = causeMethod.NodeId;
             foreach (StateMachineCauseMapping mapping in MutableDefinition.CauseMappings)
             {
                 // The ReferenceExists check keeps repeated WithCause
@@ -501,6 +561,8 @@ namespace Opc.Ua.Server.StateMachines
                 {
                     transitionNode.AddReference(
                         ReferenceTypeIds.HasCause, false, methodNodeId);
+                    causeMethod.AddReference(
+                        ReferenceTypeIds.HasCause, true, transitionNode.NodeId);
                 }
             }
         }
@@ -523,10 +585,14 @@ namespace Opc.Ua.Server.StateMachines
         /// <inheritdoc/>
         public override NodeId GetStateNodeId(uint stateId)
         {
-            if (m_stateNodesById != null &&
-                m_stateNodesById.TryGetValue(stateId, out BaseObjectState? node))
+            if (m_stateNodesById != null)
             {
-                return node.NodeId;
+                // Once nodes are materialized the map is authoritative —
+                // the numeric convention would mint a NodeId pointing
+                // at nothing (or at an unrelated standard node).
+                return m_stateNodesById.TryGetValue(stateId, out BaseObjectState? node)
+                    ? node.NodeId
+                    : NodeId.Null;
             }
             return base.GetStateNodeId(stateId);
         }
@@ -534,15 +600,15 @@ namespace Opc.Ua.Server.StateMachines
         /// <inheritdoc/>
         public override uint GetStateId(NodeId stateNodeId)
         {
-            if (m_stateIdsByNodeId != null)
+            if (m_stateNodesById != null)
             {
-                // Once nodes are materialized the map is authoritative —
-                // falling back to the base numeric convention would let
-                // any numeric NodeId in the element namespace resolve
-                // to a state this machine does not have.
-                return m_stateIdsByNodeId.TryGetValue(stateNodeId, out uint stateId)
-                    ? stateId
-                    : 0;
+                // Authoritative once materialized — falling back to the
+                // base numeric convention would let any numeric NodeId
+                // in the element namespace resolve to a state this
+                // machine does not have. Resolved against the nodes'
+                // LIVE NodeIds (not a snapshot map), so ids reassigned
+                // by a node manager during registration keep resolving.
+                return FindElementId(m_stateNodesById, stateNodeId);
             }
             return base.GetStateId(stateNodeId);
         }
@@ -550,11 +616,13 @@ namespace Opc.Ua.Server.StateMachines
         /// <inheritdoc/>
         public override NodeId GetTransitionNodeId(uint transitionId)
         {
-            if (m_transitionNodesById != null &&
-                m_transitionNodesById.TryGetValue(
-                    transitionId, out BaseObjectState? node))
+            if (m_transitionNodesById != null)
             {
-                return node.NodeId;
+                // Authoritative once materialized — see GetStateNodeId.
+                return m_transitionNodesById.TryGetValue(
+                    transitionId, out BaseObjectState? node)
+                    ? node.NodeId
+                    : NodeId.Null;
             }
             return base.GetTransitionNodeId(transitionId);
         }
@@ -562,15 +630,37 @@ namespace Opc.Ua.Server.StateMachines
         /// <inheritdoc/>
         public override uint GetTransitionId(NodeId transitionNodeId)
         {
-            if (m_transitionIdsByNodeId != null)
+            if (m_transitionNodesById != null)
             {
                 // Authoritative once materialized — see GetStateId.
-                return m_transitionIdsByNodeId.TryGetValue(
-                    transitionNodeId, out uint transitionId)
-                    ? transitionId
-                    : 0;
+                return FindElementId(m_transitionNodesById, transitionNodeId);
             }
             return base.GetTransitionId(transitionNodeId);
+        }
+
+        /// <summary>
+        /// Reverse-resolves an element NodeId by scanning the
+        /// materialized nodes' current NodeIds. Linear in the element
+        /// count (small by construction), allocation-free, and — unlike
+        /// a snapshot dictionary keyed by NodeId — correct even after a
+        /// node manager reassigns the element NodeIds.
+        /// </summary>
+        private static uint FindElementId(
+            Dictionary<uint, BaseObjectState> nodesById,
+            NodeId elementNodeId)
+        {
+            if (elementNodeId.IsNull)
+            {
+                return 0;
+            }
+            foreach (KeyValuePair<uint, BaseObjectState> entry in nodesById)
+            {
+                if (entry.Value.NodeId == elementNodeId)
+                {
+                    return entry.Key;
+                }
+            }
+            return 0;
         }
 
         /// <summary>
@@ -592,19 +682,21 @@ namespace Opc.Ua.Server.StateMachines
 
         /// <summary>
         /// Derives a deterministic, per-instance NodeId for a state
-        /// machine element from the owning node's NodeId and the
-        /// element's name, so repeated builds produce stable ids and
-        /// two machines built from the same definition do not collide.
+        /// machine element from the owning node's full NodeId string
+        /// and the element's name, so repeated builds produce stable
+        /// ids and two machines cannot mint colliding element ids —
+        /// not even machines with the same identifier in different
+        /// namespaces. (A machine with no NodeId gets a random prefix,
+        /// which is stable within one build but not across builds.)
         /// </summary>
         internal static NodeId ComposeElementNodeId(
             NodeId ownerNodeId,
             string elementName,
             ushort namespaceIndex)
         {
-            string owner = ownerNodeId.IsNull
-                ? Guid.NewGuid().ToString()
-                : ownerNodeId.IdentifierAsString;
-            return new NodeId(owner + "_" + elementName, namespaceIndex);
+            return new NodeId(
+                ComposeOwnerPrefix(ownerNodeId) + "_" + elementName,
+                namespaceIndex);
         }
 
         private void RefreshCache()

--- a/src/Opc.Ua.Server/StateMachines/FluentFiniteStateMachineState.cs
+++ b/src/Opc.Ua.Server/StateMachines/FluentFiniteStateMachineState.cs
@@ -156,7 +156,7 @@ namespace Opc.Ua.Server.StateMachines
         public FluentFiniteStateMachineState(
             NodeState parent,
             StateMachineDefinition definition)
-            : this(parent, FromSnapshot(definition), useHolder: true)
+            : this(parent, FromSnapshot(definition))
         {
         }
 
@@ -168,16 +168,14 @@ namespace Opc.Ua.Server.StateMachines
             NodeState parent,
             MutableStateMachineDefinition holder)
         {
-            return new FluentFiniteStateMachineState(parent, holder, useHolder: true);
+            return new FluentFiniteStateMachineState(parent, holder);
         }
 
         private FluentFiniteStateMachineState(
             NodeState parent,
-            MutableStateMachineDefinition holder,
-            bool useHolder)
+            MutableStateMachineDefinition holder)
             : base(parent)
         {
-            _ = useHolder;
             MutableDefinition = holder ?? throw new ArgumentNullException(nameof(holder));
         }
 
@@ -253,8 +251,12 @@ namespace Opc.Ua.Server.StateMachines
             System.Threading.CancellationToken ct = default)
         {
             base.OnAfterCreate(context, node, ct);
-            MaterializeStateNodes(context);
-            MaterializeTransitionNodes(context);
+            // One prefix for everything the machine materializes, so a
+            // machine created without a NodeId still gets a single
+            // (random) prefix shared by all of its element nodes.
+            string ownerPrefix = ComposeOwnerPrefix(NodeId);
+            MaterializeStateNodes(context, ownerPrefix);
+            MaterializeTransitionNodes(context, ownerPrefix);
         }
 
         /// <summary>
@@ -278,84 +280,76 @@ namespace Opc.Ua.Server.StateMachines
         /// machine that is never created keeps the numeric convention.
         /// </para>
         /// </remarks>
-        private void MaterializeStateNodes(ISystemContext context)
+        private void MaterializeStateNodes(ISystemContext context, string ownerPrefix)
         {
             if (m_stateNodesById != null)
             {
                 return;
             }
 
-            ushort elementNamespaceIndex = ElementNodeIdNamespaceIndex;
-            string ownerPrefix = ComposeOwnerPrefix();
+            m_stateNodesById = MaterializeElementNodes(
+                MutableDefinition.States,
+                ObjectTypeIds.StateType,
+                BrowseNames.StateNumber,
+                ownerPrefix);
 
-            var nodesById = new Dictionary<uint, BaseObjectState>();
-
-            foreach (StateMachineStateDefinition state in MutableDefinition.States)
-            {
-                nodesById[state.Id] = MaterializeElementNode(
-                    ownerPrefix,
-                    state.BrowseName,
-                    ObjectTypeIds.StateType,
-                    BrowseNames.StateNumber,
-                    state.Id,
-                    elementNamespaceIndex);
-            }
-
-            m_stateNodesById = nodesById;
-
-            // The value is served live so it stays correct even if a
-            // node manager reassigns the element NodeIds when the
-            // machine is registered.
             AddAvailableStates(
                 context,
-                available =>
-                {
-                    available.Value = ReadLiveStateNodeIds();
-                    available.OnSimpleReadValue = (ISystemContext ctx, NodeState node, ref Variant value) =>
+                ServeLiveNodeIds(
+                    () => ReadLiveNodeIds(MutableDefinition.States, m_stateNodesById)),
+                StandardChildNodeId(ownerPrefix, BrowseNames.AvailableStates));
+        }
+
+        /// <summary>
+        /// Configures an <c>AvailableStates</c> / <c>AvailableTransitions</c>
+        /// variable to serve <paramref name="read"/> live — so the
+        /// published NodeIds stay correct even if a node manager
+        /// reassigns the element NodeIds when the machine is registered.
+        /// </summary>
+        private static Action<BaseDataVariableState<ArrayOf<NodeId>>> ServeLiveNodeIds(
+            Func<ArrayOf<NodeId>> read)
+        {
+            return available =>
+            {
+                available.Value = read();
+                available.OnSimpleReadValue =
+                    (ISystemContext ctx, NodeState node, ref Variant value) =>
                     {
-                        value = Variant.From(ReadLiveStateNodeIds());
+                        value = Variant.From(read());
                         return ServiceResult.Good;
                     };
-                },
-                new NodeId(
-                    ownerPrefix + "_" + BrowseNames.AvailableStates,
-                    NodeId.NamespaceIndex));
+            };
         }
 
         /// <summary>
-        /// Projects the state nodes' current NodeIds in declaration
+        /// The NodeId for a standard FiniteStateMachineType child the
+        /// machine materializes next to its element nodes. These live
+        /// in the machine's own namespace, unlike the element nodes,
+        /// which follow <see cref="ElementNodeIdNamespaceIndex"/>.
+        /// </summary>
+        private NodeId StandardChildNodeId(string ownerPrefix, string browseName)
+        {
+            return new NodeId(ownerPrefix + "_" + browseName, NodeId.NamespaceIndex);
+        }
+
+        /// <summary>
+        /// Projects the element nodes' current NodeIds in declaration
         /// order.
         /// </summary>
-        private ArrayOf<NodeId> ReadLiveStateNodeIds()
+        /// <typeparam name="T">The element definition kind.</typeparam>
+        private static ArrayOf<NodeId> ReadLiveNodeIds<T>(
+            List<T> elements,
+            Dictionary<uint, BaseObjectState>? nodesById)
+            where T : IStateMachineElementDefinition
         {
-            if (m_stateNodesById == null)
+            if (nodesById == null)
             {
                 return default;
             }
-            var nodeIds = new NodeId[MutableDefinition.States.Count];
+            var nodeIds = new NodeId[elements.Count];
             for (int ii = 0; ii < nodeIds.Length; ii++)
             {
-                nodeIds[ii] =
-                    m_stateNodesById[MutableDefinition.States[ii].Id].NodeId;
-            }
-            return ArrayOf.Wrapped(nodeIds);
-        }
-
-        /// <summary>
-        /// Projects the transition nodes' current NodeIds in
-        /// declaration order.
-        /// </summary>
-        private ArrayOf<NodeId> ReadLiveTransitionNodeIds()
-        {
-            if (m_transitionNodesById == null)
-            {
-                return default;
-            }
-            var nodeIds = new NodeId[MutableDefinition.Transitions.Count];
-            for (int ii = 0; ii < nodeIds.Length; ii++)
-            {
-                nodeIds[ii] =
-                    m_transitionNodesById[MutableDefinition.Transitions[ii].Id].NodeId;
+                nodeIds[ii] = nodesById[elements[ii].Id].NodeId;
             }
             return ArrayOf.Wrapped(nodeIds);
         }
@@ -375,28 +369,23 @@ namespace Opc.Ua.Server.StateMachines
         /// <c>StateMachineBuilder.WithCause</c>, which is where the
         /// cause id is tied to a concrete method node.
         /// </remarks>
-        private void MaterializeTransitionNodes(ISystemContext context)
+        private void MaterializeTransitionNodes(ISystemContext context, string ownerPrefix)
         {
             if (m_transitionNodesById != null)
             {
                 return;
             }
 
-            ushort elementNamespaceIndex = ElementNodeIdNamespaceIndex;
-            string ownerPrefix = ComposeOwnerPrefix();
-
-            var nodesById = new Dictionary<uint, BaseObjectState>();
+            m_transitionNodesById = MaterializeElementNodes(
+                MutableDefinition.Transitions,
+                ObjectTypeIds.TransitionType,
+                BrowseNames.TransitionNumber,
+                ownerPrefix);
 
             foreach (StateMachineTransitionDefinition transition
                 in MutableDefinition.Transitions)
             {
-                BaseObjectState transitionNode = MaterializeElementNode(
-                    ownerPrefix,
-                    transition.BrowseName,
-                    ObjectTypeIds.TransitionType,
-                    BrowseNames.TransitionNumber,
-                    transition.Id,
-                    elementNamespaceIndex);
+                BaseObjectState transitionNode = m_transitionNodesById[transition.Id];
 
                 AddTransitionEndpointReference(
                     transitionNode, ReferenceTypeIds.FromState, transition.FromStateId);
@@ -412,26 +401,13 @@ namespace Opc.Ua.Server.StateMachines
                         false,
                         ObjectTypeIds.TransitionEventType);
                 }
-
-                nodesById[transition.Id] = transitionNode;
             }
-
-            m_transitionNodesById = nodesById;
 
             AddAvailableTransitions(
                 context,
-                available =>
-                {
-                    available.Value = ReadLiveTransitionNodeIds();
-                    available.OnSimpleReadValue = (ISystemContext ctx, NodeState node, ref Variant value) =>
-                    {
-                        value = Variant.From(ReadLiveTransitionNodeIds());
-                        return ServiceResult.Good;
-                    };
-                },
-                new NodeId(
-                    ownerPrefix + "_" + BrowseNames.AvailableTransitions,
-                    NodeId.NamespaceIndex));
+                ServeLiveNodeIds(
+                    () => ReadLiveNodeIds(MutableDefinition.Transitions, m_transitionNodesById)),
+                StandardChildNodeId(ownerPrefix, BrowseNames.AvailableTransitions));
 
             // LastTransition is Optional on FiniteStateMachineType and
             // is not created by default, which would leave the base
@@ -442,10 +418,35 @@ namespace Opc.Ua.Server.StateMachines
             {
                 AddLastTransition(
                     context,
-                    new NodeId(
-                        ownerPrefix + "_" + BrowseNames.LastTransition,
-                        NodeId.NamespaceIndex));
+                    StandardChildNodeId(ownerPrefix, BrowseNames.LastTransition));
             }
+        }
+
+        /// <summary>
+        /// Materializes one element node per definition entry and
+        /// returns them keyed by numeric id.
+        /// </summary>
+        /// <typeparam name="T">The element definition kind.</typeparam>
+        private Dictionary<uint, BaseObjectState> MaterializeElementNodes<T>(
+            List<T> elements,
+            NodeId typeDefinitionId,
+            string numberBrowseName,
+            string ownerPrefix)
+            where T : IStateMachineElementDefinition
+        {
+            ushort elementNamespaceIndex = ElementNodeIdNamespaceIndex;
+            var nodesById = new Dictionary<uint, BaseObjectState>(elements.Count);
+            foreach (T element in elements)
+            {
+                nodesById[element.Id] = MaterializeElementNode(
+                    ownerPrefix,
+                    element.BrowseName,
+                    typeDefinitionId,
+                    numberBrowseName,
+                    element.Id,
+                    elementNamespaceIndex);
+            }
+            return nodesById;
         }
 
         /// <summary>
@@ -463,14 +464,14 @@ namespace Opc.Ua.Server.StateMachines
             uint number,
             ushort namespaceIndex)
         {
-            var nodeId = new NodeId(ownerPrefix + "_" + browseName, namespaceIndex);
+            string elementIdentifier = ownerPrefix + "_" + browseName;
 
             var node = new BaseObjectState(this)
             {
                 ReferenceTypeId = ReferenceTypeIds.HasComponent,
                 TypeDefinitionId = typeDefinitionId,
                 SymbolicName = browseName,
-                NodeId = nodeId,
+                NodeId = new NodeId(elementIdentifier, namespaceIndex),
                 BrowseName = new QualifiedName(browseName, namespaceIndex),
                 DisplayName = new LocalizedText(browseName)
             };
@@ -481,7 +482,7 @@ namespace Opc.Ua.Server.StateMachines
                     DataTypeIds.UInt32,
                     ValueRanks.Scalar);
             numberProperty.NodeId = new NodeId(
-                ownerPrefix + "_" + browseName + "_" + numberBrowseName,
+                elementIdentifier + "_" + numberBrowseName,
                 namespaceIndex);
             ((PropertyState<uint>)numberProperty).Value = number;
 
@@ -490,26 +491,19 @@ namespace Opc.Ua.Server.StateMachines
         }
 
         /// <summary>
-        /// The stable string prefix all of this machine's materialized
+        /// The stable string prefix all of a machine's materialized
         /// element NodeIds share — the machine's own <em>full</em>
         /// NodeId string (namespace and id type included, so two
         /// machines whose identifiers happen to coincide in different
-        /// namespaces cannot mint colliding element ids), or one random
+        /// namespaces cannot mint colliding element ids), or a random
         /// prefix for a machine created without a NodeId.
         /// </summary>
-        private string ComposeOwnerPrefix()
-        {
-            return m_ownerPrefix ??= ComposeOwnerPrefix(NodeId);
-        }
-
         private static string ComposeOwnerPrefix(NodeId ownerNodeId)
         {
             return ownerNodeId.IsNull
                 ? Guid.NewGuid().ToString()
                 : ownerNodeId.ToString();
         }
-
-        private string? m_ownerPrefix;
 
         /// <summary>
         /// Links a transition node to one of its endpoint states, in
@@ -590,9 +584,7 @@ namespace Opc.Ua.Server.StateMachines
                 // Once nodes are materialized the map is authoritative —
                 // the numeric convention would mint a NodeId pointing
                 // at nothing (or at an unrelated standard node).
-                return m_stateNodesById.TryGetValue(stateId, out BaseObjectState? node)
-                    ? node.NodeId
-                    : NodeId.Null;
+                return FindStateNode(stateId)?.NodeId ?? NodeId.Null;
             }
             return base.GetStateNodeId(stateId);
         }

--- a/src/Opc.Ua.Server/StateMachines/FluentFiniteStateMachineState.cs
+++ b/src/Opc.Ua.Server/StateMachines/FluentFiniteStateMachineState.cs
@@ -91,13 +91,53 @@ namespace Opc.Ua.Server.StateMachines
         /// <summary>
         /// When <c>true</c>, the state machine rejects all incoming
         /// transitions and cause invocations with
-        /// <see cref="StatusCodes.BadInvalidState"/>. Used to model
+        /// <see cref="StatusCodes.BadStateNotActive"/>. Used to model
         /// the inactive state of a sub-state-machine whose parent
         /// has exited the attached state. Set by
         /// <see cref="StateMachineBuilder{TState}.WithSubStateMachine"/>
-        /// lifecycle hooks.
+        /// lifecycle hooks via <see cref="SetSuspended"/>.
         /// </summary>
-        public bool IsSuspended { get; set; }
+        public bool IsSuspended { get; private set; }
+
+        /// <summary>
+        /// Suspends or resumes the machine. Per OPC 10000-16 §4.4.6, an
+        /// inactive sub-state machine's <c>CurrentState</c> and
+        /// <c>LastTransition</c> shall read with
+        /// <see cref="StatusCodes.BadStateNotActive"/> — this applies
+        /// (and clears) that status alongside the flag.
+        /// </summary>
+        internal void SetSuspended(ISystemContext context, bool suspended)
+        {
+            IsSuspended = suspended;
+
+            StatusCode status = suspended
+                ? StatusCodes.BadStateNotActive
+                : StatusCodes.Good;
+            ApplySuspensionStatus(context, CurrentState, status);
+            ApplySuspensionStatus(context, LastTransition, status);
+        }
+
+        private static void ApplySuspensionStatus(
+            ISystemContext context,
+            BaseVariableState? variable,
+            StatusCode status)
+        {
+            if (variable == null)
+            {
+                return;
+            }
+            variable.StatusCode = status;
+            var children = new List<BaseInstanceState>();
+            variable.GetChildren(context, children);
+            foreach (BaseInstanceState child in children)
+            {
+                if (child is BaseVariableState childVariable)
+                {
+                    childVariable.StatusCode = status;
+                }
+            }
+            variable.ClearChangeMasks(context, includeChildren: true);
+        }
 
         /// <inheritdoc/>
         public override bool IsCausePermitted(
@@ -122,7 +162,7 @@ namespace Opc.Ua.Server.StateMachines
         {
             if (IsSuspended)
             {
-                return StatusCodes.BadInvalidState;
+                return StatusCodes.BadStateNotActive;
             }
             return base.DoCause(context, causeMethod, causeId, inputArguments, outputArguments);
         }
@@ -137,7 +177,7 @@ namespace Opc.Ua.Server.StateMachines
         {
             if (IsSuspended)
             {
-                return StatusCodes.BadInvalidState;
+                return StatusCodes.BadStateNotActive;
             }
             return base.DoTransition(context, transitionId, causeId, inputArguments, outputArguments);
         }
@@ -266,7 +306,7 @@ namespace Opc.Ua.Server.StateMachines
         /// optional <c>AvailableStates</c> variable.
         /// </summary>
         /// <remarks>
-        /// Part 16 §B.3 hangs <c>HasSubStateMachine</c> off the parent
+        /// Part 16 §4.4.16 hangs <c>HasSubStateMachine</c> off the parent
         /// state node, and Part 5 has <c>CurrentState/Id</c> point at
         /// that same node — neither is expressible while the states
         /// exist only as <c>ElementInfo</c> table rows. Nodes are
@@ -292,6 +332,16 @@ namespace Opc.Ua.Server.StateMachines
                 ObjectTypeIds.StateType,
                 BrowseNames.StateNumber,
                 ownerPrefix);
+
+            // OPC 10000-16 §4.4.10: the entry state is an
+            // InitialStateType (a StateType subtype), so a client can
+            // tell which state the machine activates into.
+            if (MutableDefinition.InitialStateId is uint initialStateId &&
+                m_stateNodesById.TryGetValue(
+                    initialStateId, out BaseObjectState? initialStateNode))
+            {
+                initialStateNode.TypeDefinitionId = ObjectTypeIds.InitialStateType;
+            }
 
             AddAvailableStates(
                 context,
@@ -358,7 +408,7 @@ namespace Opc.Ua.Server.StateMachines
         /// Materializes one <c>TransitionType</c> node per declared
         /// transition as a <c>HasComponent</c> child of this state
         /// machine, each with a <c>TransitionNumber</c> property and the
-        /// Part 16 §B.4 <c>FromState</c> / <c>ToState</c> /
+        /// Part 16 §4.4.11 <c>FromState</c> / <c>ToState</c> /
         /// <c>HasEffect</c> references, and publishes them through the
         /// optional <c>AvailableTransitions</c> variable.
         /// </summary>
@@ -394,7 +444,7 @@ namespace Opc.Ua.Server.StateMachines
 
                 if (transition.HasEffect)
                 {
-                    // Part 16 §B.4: HasEffect names the event type the
+                    // Part 16 §4.4.11: HasEffect names the event type the
                     // transition causes the machine to report.
                     transitionNode.AddReference(
                         ReferenceTypeIds.HasEffect,

--- a/src/Opc.Ua.Server/StateMachines/FluentFiniteStateMachineState.cs
+++ b/src/Opc.Ua.Server/StateMachines/FluentFiniteStateMachineState.cs
@@ -28,6 +28,7 @@
  * ======================================================================*/
 
 using System;
+using System.Collections.Generic;
 
 namespace Opc.Ua.Server.StateMachines
 {
@@ -68,6 +69,22 @@ namespace Opc.Ua.Server.StateMachines
         private uint[,]? m_transitionMappings;
         private uint[,]? m_causeMappings;
         private int m_cacheVersion = -1;
+
+        /// <summary>
+        /// The materialized <c>StateType</c> nodes, keyed both ways.
+        /// Populated once by <see cref="MaterializeStateNodes"/>; both
+        /// stay <c>null</c> until then, in which case the base
+        /// (numeric) element-NodeId convention applies.
+        /// </summary>
+        private Dictionary<uint, BaseObjectState>? m_stateNodesById;
+        private Dictionary<NodeId, uint>? m_stateIdsByNodeId;
+
+        /// <summary>
+        /// The materialized <c>TransitionType</c> nodes, keyed both
+        /// ways. See <see cref="MaterializeTransitionNodes"/>.
+        /// </summary>
+        private Dictionary<uint, BaseObjectState>? m_transitionNodesById;
+        private Dictionary<NodeId, uint>? m_transitionIdsByNodeId;
 
         /// <summary>
         /// When <c>true</c>, the state machine rejects all incoming
@@ -219,6 +236,375 @@ namespace Opc.Ua.Server.StateMachines
                 RefreshCache();
                 return m_causeMappings;
             }
+        }
+
+        /// <summary>
+        /// Materializes the state and transition nodes once the base has
+        /// resolved <c>ElementNamespaceIndex</c>. The definition is
+        /// always frozen by this point — the builder freezes before it
+        /// creates the node, and the snapshot constructor freezes on
+        /// construction.
+        /// </summary>
+        protected override void OnAfterCreate(
+            ISystemContext context,
+            NodeState node,
+            System.Threading.CancellationToken ct = default)
+        {
+            base.OnAfterCreate(context, node, ct);
+            MaterializeStateNodes(context);
+            MaterializeTransitionNodes(context);
+        }
+
+        /// <summary>
+        /// Materializes one <c>StateType</c> node per declared state as
+        /// a <c>HasComponent</c> child of this state machine, each with
+        /// a <c>StateNumber</c> property, and publishes them through the
+        /// optional <c>AvailableStates</c> variable.
+        /// </summary>
+        /// <remarks>
+        /// Part 16 §B.3 hangs <c>HasSubStateMachine</c> off the parent
+        /// state node, and Part 5 has <c>CurrentState/Id</c> point at
+        /// that same node — neither is expressible while the states
+        /// exist only as <c>ElementInfo</c> table rows. Nodes are
+        /// per-instance so that several machines built from one
+        /// definition can coexist in a single address space; the
+        /// <see cref="FiniteStateMachineState.GetStateNodeId"/> /
+        /// <see cref="FiniteStateMachineState.GetStateId"/> overrides
+        /// below keep <c>CurrentState/Id</c> in step.
+        /// <para>
+        /// Idempotent — driven from <see cref="OnAfterCreate"/>, so a
+        /// machine that is never created keeps the numeric convention.
+        /// </para>
+        /// </remarks>
+        private void MaterializeStateNodes(ISystemContext context)
+        {
+            if (m_stateNodesById != null)
+            {
+                return;
+            }
+
+            ushort elementNamespaceIndex = ElementNodeIdNamespaceIndex;
+            string ownerPrefix = ComposeOwnerPrefix();
+
+            var nodesById = new Dictionary<uint, BaseObjectState>();
+            var idsByNodeId = new Dictionary<NodeId, uint>();
+            var availableStates = new NodeId[MutableDefinition.States.Count];
+
+            for (int ii = 0; ii < MutableDefinition.States.Count; ii++)
+            {
+                StateMachineStateDefinition state = MutableDefinition.States[ii];
+                BaseObjectState stateNode = MaterializeElementNode(
+                    ownerPrefix,
+                    state.BrowseName,
+                    ObjectTypeIds.StateType,
+                    BrowseNames.StateNumber,
+                    state.Id,
+                    elementNamespaceIndex);
+
+                nodesById[state.Id] = stateNode;
+                idsByNodeId[stateNode.NodeId] = state.Id;
+                availableStates[ii] = stateNode.NodeId;
+            }
+
+            m_stateNodesById = nodesById;
+            m_stateIdsByNodeId = idsByNodeId;
+
+            AddAvailableStates(
+                context,
+                available => available.Value = ArrayOf.Wrapped(availableStates),
+                new NodeId(
+                    ownerPrefix + "_" + BrowseNames.AvailableStates,
+                    NodeId.NamespaceIndex));
+        }
+
+        /// <summary>
+        /// Materializes one <c>TransitionType</c> node per declared
+        /// transition as a <c>HasComponent</c> child of this state
+        /// machine, each with a <c>TransitionNumber</c> property and the
+        /// Part 16 §B.4 <c>FromState</c> / <c>ToState</c> /
+        /// <c>HasEffect</c> references, and publishes them through the
+        /// optional <c>AvailableTransitions</c> variable.
+        /// </summary>
+        /// <remarks>
+        /// The counterpart to <see cref="MaterializeStateNodes"/>, and
+        /// what makes <c>LastTransition/Id</c> resolve to a node a
+        /// client can browse. <c>HasCause</c> is added later, by
+        /// <c>StateMachineBuilder.WithCause</c>, which is where the
+        /// cause id is tied to a concrete method node.
+        /// </remarks>
+        private void MaterializeTransitionNodes(ISystemContext context)
+        {
+            if (m_transitionNodesById != null)
+            {
+                return;
+            }
+
+            ushort elementNamespaceIndex = ElementNodeIdNamespaceIndex;
+            string ownerPrefix = ComposeOwnerPrefix();
+
+            var nodesById = new Dictionary<uint, BaseObjectState>();
+            var idsByNodeId = new Dictionary<NodeId, uint>();
+            var availableTransitions = new NodeId[MutableDefinition.Transitions.Count];
+
+            for (int ii = 0; ii < MutableDefinition.Transitions.Count; ii++)
+            {
+                StateMachineTransitionDefinition transition =
+                    MutableDefinition.Transitions[ii];
+                BaseObjectState transitionNode = MaterializeElementNode(
+                    ownerPrefix,
+                    transition.BrowseName,
+                    ObjectTypeIds.TransitionType,
+                    BrowseNames.TransitionNumber,
+                    transition.Id,
+                    elementNamespaceIndex);
+
+                AddTransitionEndpointReference(
+                    transitionNode, ReferenceTypeIds.FromState, transition.FromStateId);
+                AddTransitionEndpointReference(
+                    transitionNode, ReferenceTypeIds.ToState, transition.ToStateId);
+
+                if (transition.HasEffect)
+                {
+                    // Part 16 §B.4: HasEffect names the event type the
+                    // transition causes the machine to report.
+                    transitionNode.AddReference(
+                        ReferenceTypeIds.HasEffect,
+                        false,
+                        ObjectTypeIds.TransitionEventType);
+                }
+
+                nodesById[transition.Id] = transitionNode;
+                idsByNodeId[transitionNode.NodeId] = transition.Id;
+                availableTransitions[ii] = transitionNode.NodeId;
+            }
+
+            m_transitionNodesById = nodesById;
+            m_transitionIdsByNodeId = idsByNodeId;
+
+            AddAvailableTransitions(
+                context,
+                available => available.Value = ArrayOf.Wrapped(availableTransitions),
+                new NodeId(
+                    ownerPrefix + "_" + BrowseNames.AvailableTransitions,
+                    NodeId.NamespaceIndex));
+
+            // LastTransition is Optional on FiniteStateMachineType and
+            // is not created by default, which would leave the base
+            // class's UpdateTransitionVariable call a no-op and give
+            // clients nothing to subscribe to. Materialize it alongside
+            // the transitions it names.
+            if (MutableDefinition.Transitions.Count > 0)
+            {
+                AddLastTransition(
+                    context,
+                    new NodeId(
+                        ownerPrefix + "_" + BrowseNames.LastTransition,
+                        NodeId.NamespaceIndex));
+            }
+        }
+
+        /// <summary>
+        /// Creates one materialized element node — the shape shared by
+        /// states and transitions: a <c>HasComponent</c>
+        /// <see cref="BaseObjectState"/> child carrying a numeric
+        /// element property, with a NodeId derived from the machine's
+        /// own identifier and the element's browse name.
+        /// </summary>
+        private BaseObjectState MaterializeElementNode(
+            string ownerPrefix,
+            string browseName,
+            NodeId typeDefinitionId,
+            string numberBrowseName,
+            uint number,
+            ushort namespaceIndex)
+        {
+            var nodeId = new NodeId(ownerPrefix + "_" + browseName, namespaceIndex);
+
+            var node = new BaseObjectState(this)
+            {
+                ReferenceTypeId = ReferenceTypeIds.HasComponent,
+                TypeDefinitionId = typeDefinitionId,
+                SymbolicName = browseName,
+                NodeId = nodeId,
+                BrowseName = new QualifiedName(browseName, namespaceIndex),
+                DisplayName = new LocalizedText(browseName)
+            };
+
+            PropertyState numberProperty = node
+                .AddProperty<uint, VariantBuilder>(
+                    numberBrowseName,
+                    DataTypeIds.UInt32,
+                    ValueRanks.Scalar);
+            numberProperty.NodeId = new NodeId(
+                ownerPrefix + "_" + browseName + "_" + numberBrowseName,
+                namespaceIndex);
+            ((PropertyState<uint>)numberProperty).Value = number;
+
+            AddChild(node);
+            return node;
+        }
+
+        /// <summary>
+        /// The stable string prefix all of this machine's materialized
+        /// element NodeIds share — the machine's own identifier, or one
+        /// random prefix for a machine created without a NodeId.
+        /// </summary>
+        private string ComposeOwnerPrefix()
+        {
+            return m_ownerPrefix ??= NodeId.IsNull
+                ? Guid.NewGuid().ToString()
+                : NodeId.IdentifierAsString;
+        }
+
+        private string? m_ownerPrefix;
+
+        /// <summary>
+        /// Links a transition node to one of its endpoint states.
+        /// Silently skips endpoints the definition does not declare —
+        /// <c>ValidateDefinition</c> already rejects those, and a
+        /// definition built by hand should not throw from create.
+        /// </summary>
+        private void AddTransitionEndpointReference(
+            BaseObjectState transitionNode,
+            NodeId referenceTypeId,
+            uint stateId)
+        {
+            BaseObjectState? stateNode = FindStateNode(stateId);
+            if (stateNode != null)
+            {
+                transitionNode.AddReference(referenceTypeId, false, stateNode.NodeId);
+            }
+        }
+
+        /// <summary>
+        /// Records a <c>HasCause</c> reference from every transition the
+        /// cause can trigger to the method node that carries it.
+        /// Invoked by <c>StateMachineBuilder.WithCause</c>, the only
+        /// place where a numeric cause id is bound to a real method.
+        /// </summary>
+        internal void AddCauseReferences(uint causeId, NodeId methodNodeId)
+        {
+            if (m_transitionNodesById == null || methodNodeId.IsNull)
+            {
+                return;
+            }
+
+            foreach (StateMachineCauseMapping mapping in MutableDefinition.CauseMappings)
+            {
+                // The ReferenceExists check keeps repeated WithCause
+                // calls for the same method from stacking duplicates.
+                if (mapping.CauseId == causeId &&
+                    m_transitionNodesById.TryGetValue(
+                        mapping.TransitionId, out BaseObjectState? transitionNode) &&
+                    !transitionNode.ReferenceExists(
+                        ReferenceTypeIds.HasCause, false, methodNodeId))
+                {
+                    transitionNode.AddReference(
+                        ReferenceTypeIds.HasCause, false, methodNodeId);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Returns the materialized <c>StateType</c> node for the given
+        /// state, or <c>null</c> when the states have not been
+        /// materialized or the id is unknown.
+        /// </summary>
+        internal BaseObjectState? FindStateNode(uint stateId)
+        {
+            if (m_stateNodesById != null &&
+                m_stateNodesById.TryGetValue(stateId, out BaseObjectState? node))
+            {
+                return node;
+            }
+            return null;
+        }
+
+        /// <inheritdoc/>
+        public override NodeId GetStateNodeId(uint stateId)
+        {
+            if (m_stateNodesById != null &&
+                m_stateNodesById.TryGetValue(stateId, out BaseObjectState? node))
+            {
+                return node.NodeId;
+            }
+            return base.GetStateNodeId(stateId);
+        }
+
+        /// <inheritdoc/>
+        public override uint GetStateId(NodeId stateNodeId)
+        {
+            if (m_stateIdsByNodeId != null)
+            {
+                // Once nodes are materialized the map is authoritative —
+                // falling back to the base numeric convention would let
+                // any numeric NodeId in the element namespace resolve
+                // to a state this machine does not have.
+                return m_stateIdsByNodeId.TryGetValue(stateNodeId, out uint stateId)
+                    ? stateId
+                    : 0;
+            }
+            return base.GetStateId(stateNodeId);
+        }
+
+        /// <inheritdoc/>
+        public override NodeId GetTransitionNodeId(uint transitionId)
+        {
+            if (m_transitionNodesById != null &&
+                m_transitionNodesById.TryGetValue(
+                    transitionId, out BaseObjectState? node))
+            {
+                return node.NodeId;
+            }
+            return base.GetTransitionNodeId(transitionId);
+        }
+
+        /// <inheritdoc/>
+        public override uint GetTransitionId(NodeId transitionNodeId)
+        {
+            if (m_transitionIdsByNodeId != null)
+            {
+                // Authoritative once materialized — see GetStateId.
+                return m_transitionIdsByNodeId.TryGetValue(
+                    transitionNodeId, out uint transitionId)
+                    ? transitionId
+                    : 0;
+            }
+            return base.GetTransitionId(transitionNodeId);
+        }
+
+        /// <summary>
+        /// The namespace index that qualifies materialized state and
+        /// transition NodeIds. The element namespace defaults to the
+        /// OPC UA namespace (index 0), which must never host vendor
+        /// nodes — so the resolved element namespace is honoured only
+        /// when it is a real, registered non-default namespace, and the
+        /// machine's own namespace is used otherwise. Keying off the
+        /// resolved index (rather than off whether
+        /// <c>UseElementNamespace</c> was called) also keeps a machine
+        /// rebuilt from a <see cref="Definition"/> snapshot consistent
+        /// with the machine the snapshot was taken from.
+        /// </summary>
+        private ushort ElementNodeIdNamespaceIndex
+            => ElementNamespaceIndex != 0
+                ? ElementNamespaceIndex
+                : NodeId.NamespaceIndex;
+
+        /// <summary>
+        /// Derives a deterministic, per-instance NodeId for a state
+        /// machine element from the owning node's NodeId and the
+        /// element's name, so repeated builds produce stable ids and
+        /// two machines built from the same definition do not collide.
+        /// </summary>
+        internal static NodeId ComposeElementNodeId(
+            NodeId ownerNodeId,
+            string elementName,
+            ushort namespaceIndex)
+        {
+            string owner = ownerNodeId.IsNull
+                ? Guid.NewGuid().ToString()
+                : ownerNodeId.IdentifierAsString;
+            return new NodeId(owner + "_" + elementName, namespaceIndex);
         }
 
         private void RefreshCache()

--- a/src/Opc.Ua.Server/StateMachines/StateMachineBuilder.cs
+++ b/src/Opc.Ua.Server/StateMachines/StateMachineBuilder.cs
@@ -87,7 +87,8 @@ namespace Opc.Ua.Server.StateMachines
             ISystemContext context,
             MutableStateMachineDefinition? definition,
             NodeId deferredCreateNodeId = default,
-            QualifiedName deferredCreateBrowseName = default)
+            QualifiedName deferredCreateBrowseName = default,
+            bool suppressInitialStateAutoSeed = false)
         {
             m_stateMachine = stateMachine
                 ?? throw new ArgumentNullException(nameof(stateMachine));
@@ -96,6 +97,7 @@ namespace Opc.Ua.Server.StateMachines
             m_definition = definition;
             m_deferredCreateNodeId = deferredCreateNodeId;
             m_deferredCreateBrowseName = deferredCreateBrowseName;
+            m_suppressInitialStateAutoSeed = suppressInitialStateAutoSeed;
             TimeProvider timeProvider =
                 ((context as ServerSystemContext)?.Server as ITimeProviderProvider)?.TimeProvider
                 ?? TimeProvider.System;
@@ -104,6 +106,14 @@ namespace Opc.Ua.Server.StateMachines
 
         private readonly NodeId m_deferredCreateNodeId;
         private readonly QualifiedName m_deferredCreateBrowseName;
+
+        /// <summary>
+        /// Sub-state-machine child builders suppress the freeze-time
+        /// initial-state auto-seed: a sub-SM only receives its initial
+        /// state when its parent is in the attached state — Part 16
+        /// expects an inactive machine to publish no current state.
+        /// </summary>
+        private readonly bool m_suppressInitialStateAutoSeed;
 
         /// <summary>
         /// The underlying state machine. Reading this property freezes
@@ -141,6 +151,17 @@ namespace Opc.Ua.Server.StateMachines
             MutableStateMachineDefinition def = RequireDefinition();
             def.EnsureNotFrozen();
 
+            if (id == 0)
+            {
+                // 0 is the "no state" sentinel throughout
+                // FiniteStateMachineState (GetCurrentStateId, the
+                // mapping hooks, UpdateStateVariable) — a state with
+                // id 0 could never be entered.
+                throw new ArgumentException(
+                    "State id 0 is reserved as the \"no state\" sentinel.",
+                    nameof(id));
+            }
+
             if (string.IsNullOrEmpty(browseName))
             {
                 throw new ArgumentException("Browse name must not be empty.",
@@ -156,15 +177,19 @@ namespace Opc.Ua.Server.StateMachines
                 }
             }
 
-            def.States.Add(new StateMachineStateDefinition(id, browseName, isInitial));
+            // Validate BEFORE mutating, so a caller that catches the
+            // exception is not left with a phantom state in the holder.
+            if (isInitial &&
+                def.InitialStateId.HasValue &&
+                def.InitialStateId.Value != id)
+            {
+                throw new InvalidOperationException(
+                    "Only one state may be marked as the initial state.");
+            }
 
+            def.States.Add(new StateMachineStateDefinition(id, browseName, isInitial));
             if (isInitial)
             {
-                if (def.InitialStateId.HasValue && def.InitialStateId.Value != id)
-                {
-                    throw new InvalidOperationException(
-                        "Only one state may be marked as the initial state.");
-                }
                 def.InitialStateId = id;
             }
 
@@ -193,6 +218,14 @@ namespace Opc.Ua.Server.StateMachines
         {
             MutableStateMachineDefinition def = RequireDefinition();
             def.EnsureNotFrozen();
+
+            if (id == 0)
+            {
+                // 0 is the "no transition" sentinel — see AddState.
+                throw new ArgumentException(
+                    "Transition id 0 is reserved as the \"no transition\" sentinel.",
+                    nameof(id));
+            }
 
             if (string.IsNullOrEmpty(browseName))
             {
@@ -603,12 +636,12 @@ namespace Opc.Ua.Server.StateMachines
 
         private static uint ExtractCurrentStateId(TState sm)
         {
-            NodeId? id = sm.CurrentState?.Id?.Value;
-            if (id is null || id.Value.IsNull)
+            NodeId id = sm.CurrentState?.Id?.Value ?? NodeId.Null;
+            if (id.IsNull)
             {
                 return 0;
             }
-            return StateMachineBuilder.ResolveStateId(sm, id.Value);
+            return StateMachineBuilder.ResolveStateId(sm, id);
         }
 
         /// <summary>
@@ -697,20 +730,30 @@ namespace Opc.Ua.Server.StateMachines
             // a declared state or transition (or a repeated sub-SM).
             foreach (StateMachineStateDefinition s in m_definition.States)
             {
-                if (string.Equals(s.BrowseName, browseName.Name, StringComparison.Ordinal))
+                if (string.Equals(s.BrowseName, browseName.Name, StringComparison.Ordinal) ||
+                    string.Equals(
+                        s.BrowseName + "_" + BrowseNames.StateNumber,
+                        browseName.Name,
+                        StringComparison.Ordinal))
                 {
                     throw new ArgumentException(
                         $"Sub-state-machine browse name '{browseName.Name}' " +
-                        "collides with a declared state.", nameof(browseName));
+                        "collides with a declared state or its " +
+                        "StateNumber property.", nameof(browseName));
                 }
             }
             foreach (StateMachineTransitionDefinition t in m_definition.Transitions)
             {
-                if (string.Equals(t.BrowseName, browseName.Name, StringComparison.Ordinal))
+                if (string.Equals(t.BrowseName, browseName.Name, StringComparison.Ordinal) ||
+                    string.Equals(
+                        t.BrowseName + "_" + BrowseNames.TransitionNumber,
+                        browseName.Name,
+                        StringComparison.Ordinal))
                 {
                     throw new ArgumentException(
                         $"Sub-state-machine browse name '{browseName.Name}' " +
-                        "collides with a declared transition.", nameof(browseName));
+                        "collides with a declared transition or its " +
+                        "TransitionNumber property.", nameof(browseName));
                 }
             }
 
@@ -742,10 +785,14 @@ namespace Opc.Ua.Server.StateMachines
                 : ComposeChildNodeId(m_stateMachine.NodeId, browseName);
 
             // A repeated sub-SM browse name composes the same child
-            // NodeId — reject it before wiring anything.
+            // NodeId — reject it before wiring anything. The BrowseName
+            // comparison backstops the NodeId one for machines whose
+            // children were renumbered by a NodeId factory (or created
+            // without a NodeId), where the composed id never matches.
             var existingChildren = new List<BaseInstanceState>();
             m_stateMachine.GetChildren(m_context, existingChildren);
-            if (existingChildren.Exists(c => c.NodeId == childNodeId))
+            if (existingChildren.Exists(
+                c => c.NodeId == childNodeId || c.BrowseName == browseName))
             {
                 throw new ArgumentException(
                     $"A child with browse name '{browseName.Name}' already " +
@@ -755,7 +802,8 @@ namespace Opc.Ua.Server.StateMachines
             var childBuilder = new StateMachineBuilder<FluentFiniteStateMachineState>(
                 child, m_context, subHolder,
                 deferredCreateNodeId: childNodeId,
-                deferredCreateBrowseName: browseName);
+                deferredCreateBrowseName: browseName,
+                suppressInitialStateAutoSeed: true);
             configure(childBuilder);
             // Read StateMachine to freeze the child's definition and
             // ensure it is fully constructed.
@@ -776,19 +824,39 @@ namespace Opc.Ua.Server.StateMachines
                 true,
                 parentStateNode.NodeId);
 
-            // The sub-SM is suspended unless the parent is in the
-            // attached state. WithInitialState goes through SetState,
-            // not DoTransition, so it fires no enter handler — the same
-            // sync therefore runs twice: once now (covering
-            // WithInitialState BEFORE this call) and once from
-            // WithInitialState itself (covering it AFTER).
+            // One rule brings the sub-SM in line with the parent's
+            // state, shared by all three activation paths: attach time
+            // (covering WithInitialState BEFORE this call), the
+            // initial-state synchronizer (WithInitialState AFTER — it
+            // goes through SetState, which fires no enter handler), and
+            // the enter-state handler for real transitions. A
+            // preserveOnReentry child keeps its state across
+            // re-activations but is still seeded the first time it
+            // activates with no state at all.
             uint initialChildStateId = subHolder.InitialStateId ?? 0;
 
             void SyncChildToParentState(ISystemContext ctx, uint parentCurrentStateId)
             {
                 bool attached = parentCurrentStateId == parentStateId;
                 materializedChild.IsSuspended = !attached;
-                if (attached && initialChildStateId != 0)
+                if (!attached)
+                {
+                    // Part 16: an inactive sub-SM publishes no current
+                    // state. A preserveOnReentry child keeps it, so the
+                    // state survives until the next activation.
+                    if (!preserveOnReentry)
+                    {
+                        materializedChild.SetState(ctx, 0);
+                    }
+                    return;
+                }
+                if (initialChildStateId == 0)
+                {
+                    return;
+                }
+                bool childHasState =
+                    !(materializedChild.CurrentState?.Value.IsNullOrEmpty ?? true);
+                if (!preserveOnReentry || !childHasState)
                 {
                     materializedChild.SetState(ctx, initialChildStateId);
                 }
@@ -798,19 +866,10 @@ namespace Opc.Ua.Server.StateMachines
             m_dispatcher.AddInitialStateSynchronizer(SyncChildToParentState);
 
             // Wire the lifecycle hooks on the parent.
-            m_dispatcher.AddEnterStateHandler(parentStateId, (ctx, parent) =>
-            {
-                if (!preserveOnReentry && initialChildStateId != 0)
-                {
-                    materializedChild.IsSuspended = false;
-                    materializedChild.SetState(ctx, initialChildStateId);
-                }
-                else
-                {
-                    materializedChild.IsSuspended = false;
-                }
-            });
-            m_dispatcher.AddExitStateHandler(parentStateId, (ctx, parent) => materializedChild.IsSuspended = true);
+            m_dispatcher.AddEnterStateHandler(parentStateId,
+                (ctx, parent) => SyncChildToParentState(ctx, parentStateId));
+            m_dispatcher.AddExitStateHandler(parentStateId,
+                (ctx, parent) => materializedChild.IsSuspended = true);
 
             return this;
         }
@@ -876,7 +935,7 @@ namespace Opc.Ua.Server.StateMachines
             // lifecycle-mode FSMs declare it in their type definition.
             if (m_stateMachine is FluentFiniteStateMachineState fluent)
             {
-                fluent.AddCauseReferences(causeId, methodNodeId);
+                fluent.AddCauseReferences(causeId, method);
             }
             return this;
         }
@@ -1026,6 +1085,21 @@ namespace Opc.Ua.Server.StateMachines
                         new LocalizedText(m_deferredCreateBrowseName.Name),
                         true);
                 }
+
+                // A state declared with isInitial: true is applied as
+                // soon as the machine exists — otherwise a definition
+                // that never calls WithInitialState (the documented
+                // minimal example) is built with no current state and
+                // can never transition. Sub-SM child builders opt out:
+                // their initial state is applied only when the parent
+                // is in the attached state.
+                if (!m_suppressInitialStateAutoSeed &&
+                    m_definition.InitialStateId is uint declaredInitialState)
+                {
+                    m_stateMachine.SetState(m_context, declaredInitialState);
+                    m_dispatcher.SynchronizeInitialState(
+                        m_context, declaredInitialState);
+                }
             }
         }
 
@@ -1044,8 +1118,8 @@ namespace Opc.Ua.Server.StateMachines
                 }
             }
             throw new InvalidOperationException(
-                $"Initial state {stateId} is not declared. Call AddState " +
-                "to declare it before WithInitialState.");
+                $"State {stateId} is not declared. Call AddState to " +
+                "declare it first.");
         }
 
         private static void ValidateDefinition(MutableStateMachineDefinition def)
@@ -1057,17 +1131,22 @@ namespace Opc.Ua.Server.StateMachines
                     "definition is frozen.");
             }
 
-            // Element NodeIds are derived from browse names, so a name
-            // shared by two elements (or shadowing a standard child
-            // materialized next to them) would mint colliding NodeIds.
+            // Element NodeIds are derived from browse names — both the
+            // element node ("{owner}_{name}") and its number property
+            // ("{owner}_{name}_{StateNumber|TransitionNumber}") — so the
+            // full set of derived name suffixes must be unique, or two
+            // nodes would mint the same NodeId (e.g. a state "A" and a
+            // transition "A_StateNumber").
             var elementNames = new HashSet<string>(StringComparer.Ordinal);
             foreach (StateMachineStateDefinition s in def.States)
             {
-                ValidateElementName(elementNames, s.BrowseName, "State");
+                ValidateElementName(
+                    elementNames, s.BrowseName, BrowseNames.StateNumber, "State");
             }
             foreach (StateMachineTransitionDefinition t in def.Transitions)
             {
-                ValidateElementName(elementNames, t.BrowseName, "Transition");
+                ValidateElementName(
+                    elementNames, t.BrowseName, BrowseNames.TransitionNumber, "Transition");
             }
 
             var stateIds = new HashSet<uint>();
@@ -1147,6 +1226,7 @@ namespace Opc.Ua.Server.StateMachines
         private static void ValidateElementName(
             HashSet<string> seenNames,
             string browseName,
+            string numberBrowseName,
             string elementKind)
         {
             if (Array.IndexOf(s_reservedElementNames, browseName) >= 0)
@@ -1158,10 +1238,22 @@ namespace Opc.Ua.Server.StateMachines
             if (!seenNames.Add(browseName))
             {
                 throw new InvalidOperationException(
-                    $"{elementKind} browse name '{browseName}' is used by " +
-                    "more than one state or transition — element NodeIds " +
-                    "are derived from browse names, so names must be " +
-                    "unique across both.");
+                    $"{elementKind} browse name '{browseName}' collides " +
+                    "with another element or an element's number " +
+                    "property — element NodeIds are derived from browse " +
+                    "names, so the derived names must be unique.");
+            }
+            // Reserve the number-property suffix too, so no later
+            // element can claim the NodeId this element's StateNumber /
+            // TransitionNumber property will be minted with.
+            if (!seenNames.Add(browseName + "_" + numberBrowseName))
+            {
+                throw new InvalidOperationException(
+                    $"{elementKind} browse name '{browseName}' derives a " +
+                    $"number-property NodeId ('{browseName}_{numberBrowseName}') " +
+                    "that collides with another element — element NodeIds " +
+                    "are derived from browse names, so the derived names " +
+                    "must be unique.");
             }
         }
 
@@ -1403,13 +1495,28 @@ namespace Opc.Ua.Server.StateMachines
 
         /// <summary>
         /// Runs every registered synchronizer against
-        /// <paramref name="stateId"/>.
+        /// <paramref name="stateId"/>, and re-arms the timed-transition
+        /// timers to match — <c>SetState</c> fires no transition, so
+        /// this is the only chance to arm a timer for a state entered
+        /// that way (and to cancel timers for states left that way).
         /// </summary>
         public void SynchronizeInitialState(ISystemContext context, uint stateId)
         {
             foreach (Action<ISystemContext, uint> synchronizer in m_initialStateSynchronizers)
             {
                 SafeInvoke(() => synchronizer(context, stateId));
+            }
+
+            foreach (KeyValuePair<uint, TimedTransitionEntry> timed in m_timedTransitions)
+            {
+                if (timed.Key == stateId)
+                {
+                    ArmTimer(timed.Key, timed.Value);
+                }
+                else
+                {
+                    CancelTimer(timed.Key);
+                }
             }
         }
 
@@ -1506,7 +1613,7 @@ namespace Opc.Ua.Server.StateMachines
             // (applied via SetState, which doesn't fire OnAfterTransition)
             // would never arm a timer.
             uint currentState = ExtractStateId(
-                m_stateMachine.CurrentState?.Id?.Value);
+                m_stateMachine.CurrentState?.Id?.Value ?? NodeId.Null);
             if (currentState == fromStateId)
             {
                 ArmTimer(fromStateId, entry);
@@ -1537,7 +1644,7 @@ namespace Opc.Ua.Server.StateMachines
             // transitions safely (each DoTransition call is fully
             // synchronous on one thread).
             m_pendingFromByThread[Environment.CurrentManagedThreadId] = ExtractStateId(
-                m_stateMachine.CurrentState?.Id?.Value);
+                m_stateMachine.CurrentState?.Id?.Value ?? NodeId.Null);
 
             // Builder guards run before any pre-existing OnBefore.
             foreach (Func<ISystemContext, TState, uint, uint, ServiceResult> g in m_guards)
@@ -1588,7 +1695,7 @@ namespace Opc.Ua.Server.StateMachines
 
             m_pendingFromByThread.TryRemove(
                 Environment.CurrentManagedThreadId, out uint from);
-            uint to = ExtractStateId(m_stateMachine.CurrentState?.Id?.Value);
+            uint to = ExtractStateId(m_stateMachine.CurrentState?.Id?.Value ?? NodeId.Null);
 
             // Exit handlers fire first, then transition observers, then
             // enter handlers (standard reactive-FSM lifecycle order).
@@ -1689,13 +1796,13 @@ namespace Opc.Ua.Server.StateMachines
             }
         }
 
-        private uint ExtractStateId(NodeId? nodeId)
+        private uint ExtractStateId(NodeId nodeId)
         {
-            if (!nodeId.HasValue || nodeId.Value.IsNull)
+            if (nodeId.IsNull)
             {
                 return 0;
             }
-            return StateMachineBuilder.ResolveStateId(m_stateMachine, nodeId.Value);
+            return StateMachineBuilder.ResolveStateId(m_stateMachine, nodeId);
         }
 
         private static void SafeInvoke(Action action)

--- a/src/Opc.Ua.Server/StateMachines/StateMachineBuilder.cs
+++ b/src/Opc.Ua.Server/StateMachines/StateMachineBuilder.cs
@@ -268,6 +268,11 @@ namespace Opc.Ua.Server.StateMachines
             FreezeDefinition();
             ValidateDefinitionStateExists(stateId);
             m_stateMachine.SetState(m_context, stateId);
+            // SetState is not a transition, so no lifecycle handler
+            // runs — but a sub-state-machine attached to the initial
+            // state still has to activate, whichever order
+            // WithInitialState and WithSubStateMachine were called in.
+            m_dispatcher.SynchronizeInitialState(m_context, stateId);
             return this;
         }
 
@@ -603,14 +608,15 @@ namespace Opc.Ua.Server.StateMachines
             {
                 return 0;
             }
-            return id.Value.TryGetValue(out uint stateId) ? stateId : 0;
+            return StateMachineBuilder.ResolveStateId(sm, id.Value);
         }
 
         /// <summary>
         /// Attaches a sub-state-machine to the parent state identified
-        /// by <paramref name="parentStateId"/>. The sub-SM is added
-        /// as a <c>HasSubStateMachine</c>-referenced child of the
-        /// parent FSM, configured through the nested
+        /// by <paramref name="parentStateId"/>. The sub-SM is added as
+        /// a <c>HasComponent</c> child of the parent FSM and referenced
+        /// by <c>HasSubStateMachine</c> from the parent <em>state</em>
+        /// node per Part 16 §B.3, configured through the nested
         /// <paramref name="configure"/> builder, and managed by the
         /// dispatcher lifecycle:
         /// </summary>
@@ -637,6 +643,11 @@ namespace Opc.Ua.Server.StateMachines
         /// mode (when adopting a stack-shipped or vendor FSM) the
         /// sub-SM is already part of the type definition; observe it
         /// through the client-side sub-SM accessors instead.
+        /// </para>
+        /// <para>
+        /// Order-independent with respect to
+        /// <see cref="WithInitialState"/>: whichever is called second
+        /// brings the sub-SM in line with the parent's current state.
         /// </para>
         /// </remarks>
         /// <param name="parentStateId">The parent state whose entry
@@ -679,47 +690,112 @@ namespace Opc.Ua.Server.StateMachines
             }
 
             FreezeDefinition();
+            ValidateDefinitionStateExists(parentStateId);
+
+            // The sub-SM's NodeId is composed the same way as the
+            // element NodeIds, so its browse name must not collide with
+            // a declared state or transition (or a repeated sub-SM).
+            foreach (StateMachineStateDefinition s in m_definition.States)
+            {
+                if (string.Equals(s.BrowseName, browseName.Name, StringComparison.Ordinal))
+                {
+                    throw new ArgumentException(
+                        $"Sub-state-machine browse name '{browseName.Name}' " +
+                        "collides with a declared state.", nameof(browseName));
+                }
+            }
+            foreach (StateMachineTransitionDefinition t in m_definition.Transitions)
+            {
+                if (string.Equals(t.BrowseName, browseName.Name, StringComparison.Ordinal))
+                {
+                    throw new ArgumentException(
+                        $"Sub-state-machine browse name '{browseName.Name}' " +
+                        "collides with a declared transition.", nameof(browseName));
+                }
+            }
+
+            // The parent state node carries the HasSubStateMachine
+            // reference, so it has to exist. FreezeDefinition creates
+            // the parent, whose OnAfterCreate materializes the states.
+            if (m_stateMachine is not FluentFiniteStateMachineState parentFsm)
+            {
+                throw new InvalidOperationException(
+                    "WithSubStateMachine requires a builder that owns a " +
+                    "FluentFiniteStateMachineState (use StateMachineBuilder.Create).");
+            }
+            BaseObjectState parentStateNode = parentFsm.FindStateNode(parentStateId)
+                ?? throw new InvalidOperationException(
+                    $"No state node was materialized for state {parentStateId}; " +
+                    "the parent state machine must be created before a " +
+                    "sub-state-machine can be attached to one of its states.");
 
             // Configure the sub-SM through a nested builder. The
             // sub-SM's NodeId is derived from the parent's NodeId so
-            // it lives under the parent in the address space.
+            // it lives under the parent in the address space. Creation
+            // is deferred to the child's own FreezeDefinition so its
+            // states are declared by the time they are materialized.
             var subHolder = new MutableStateMachineDefinition();
             var child =
                 FluentFiniteStateMachineState.CreateWithHolder(m_stateMachine, subHolder);
             NodeId childNodeId = m_stateMachine.NodeId.IsNull
                 ? new NodeId(Guid.NewGuid())
                 : ComposeChildNodeId(m_stateMachine.NodeId, browseName);
-            child.Create(
-                m_context,
-                childNodeId,
-                browseName,
-                new LocalizedText(browseName.Name ?? string.Empty),
-                true);
+
+            // A repeated sub-SM browse name composes the same child
+            // NodeId — reject it before wiring anything.
+            var existingChildren = new List<BaseInstanceState>();
+            m_stateMachine.GetChildren(m_context, existingChildren);
+            if (existingChildren.Exists(c => c.NodeId == childNodeId))
+            {
+                throw new ArgumentException(
+                    $"A child with browse name '{browseName.Name}' already " +
+                    "exists on the state machine.", nameof(browseName));
+            }
+
             var childBuilder = new StateMachineBuilder<FluentFiniteStateMachineState>(
-                child, m_context, subHolder);
+                child, m_context, subHolder,
+                deferredCreateNodeId: childNodeId,
+                deferredCreateBrowseName: browseName);
             configure(childBuilder);
             // Read StateMachine to freeze the child's definition and
             // ensure it is fully constructed.
             FluentFiniteStateMachineState materializedChild = childBuilder.StateMachine;
-            // Set the reference type BEFORE adding to the parent so
-            // AddChild does not default it to HasComponent. Then add.
-            materializedChild.ReferenceTypeId = ReferenceTypeIds.HasSubStateMachine;
-            m_stateMachine.AddChild(materializedChild);
 
-            // Initial state of the sub-SM is "suspended" unless the
-            // parent already starts in the attached state.
+            // HasSubStateMachine is non-hierarchical, so it cannot
+            // double as the parent/child reference — the sub-SM is a
+            // HasComponent child (matching the standard NodeSets) and
+            // the spec reference hangs off the parent state node.
+            materializedChild.ReferenceTypeId = ReferenceTypeIds.HasComponent;
+            m_stateMachine.AddChild(materializedChild);
+            parentStateNode.AddReference(
+                ReferenceTypeIds.HasSubStateMachine,
+                false,
+                materializedChild.NodeId);
+            materializedChild.AddReference(
+                ReferenceTypeIds.HasSubStateMachine,
+                true,
+                parentStateNode.NodeId);
+
+            // The sub-SM is suspended unless the parent is in the
+            // attached state. WithInitialState goes through SetState,
+            // not DoTransition, so it fires no enter handler — the same
+            // sync therefore runs twice: once now (covering
+            // WithInitialState BEFORE this call) and once from
+            // WithInitialState itself (covering it AFTER).
             uint initialChildStateId = subHolder.InitialStateId ?? 0;
-            bool parentInAttachedState =
-                ExtractCurrentStateId(m_stateMachine) == parentStateId;
-            materializedChild.IsSuspended = !parentInAttachedState;
-            if (parentInAttachedState && initialChildStateId != 0)
+
+            void SyncChildToParentState(ISystemContext ctx, uint parentCurrentStateId)
             {
-                // Set the child to its initial state immediately —
-                // the parent's OnEnterState handler isn't fired on
-                // WithInitialState (it goes through SetState, not
-                // DoTransition), so we must seed the child here.
-                materializedChild.SetState(m_context, initialChildStateId);
+                bool attached = parentCurrentStateId == parentStateId;
+                materializedChild.IsSuspended = !attached;
+                if (attached && initialChildStateId != 0)
+                {
+                    materializedChild.SetState(ctx, initialChildStateId);
+                }
             }
+
+            SyncChildToParentState(m_context, ExtractCurrentStateId(m_stateMachine));
+            m_dispatcher.AddInitialStateSynchronizer(SyncChildToParentState);
 
             // Wire the lifecycle hooks on the parent.
             m_dispatcher.AddEnterStateHandler(parentStateId, (ctx, parent) =>
@@ -744,12 +820,10 @@ namespace Opc.Ua.Server.StateMachines
             // Derive a deterministic child NodeId from the parent
             // and the child's browse name so multiple
             // WithSubStateMachine calls produce stable, distinct ids.
-            string suffix = browseName.Name ?? "Child";
-            if (parentNodeId.TryGetValue(out string parentStr))
-            {
-                return new NodeId(parentStr + "_" + suffix, parentNodeId.NamespaceIndex);
-            }
-            return new NodeId(parentNodeId + "_" + suffix, parentNodeId.NamespaceIndex);
+            return FluentFiniteStateMachineState.ComposeElementNodeId(
+                parentNodeId,
+                browseName.Name ?? "Child",
+                parentNodeId.NamespaceIndex);
         }
 
         /// <summary>
@@ -795,6 +869,15 @@ namespace Opc.Ua.Server.StateMachines
                     nameof(methodNodeId));
 
             m_dispatcher.InstallCauseMethod(method, causeId);
+
+            // Part 16 §B.4: every transition this cause can trigger
+            // gets a HasCause reference to the method node. Only
+            // definition mode knows the cause-to-transition mapping;
+            // lifecycle-mode FSMs declare it in their type definition.
+            if (m_stateMachine is FluentFiniteStateMachineState fluent)
+            {
+                fluent.AddCauseReferences(causeId, methodNodeId);
+            }
             return this;
         }
 
@@ -974,6 +1057,19 @@ namespace Opc.Ua.Server.StateMachines
                     "definition is frozen.");
             }
 
+            // Element NodeIds are derived from browse names, so a name
+            // shared by two elements (or shadowing a standard child
+            // materialized next to them) would mint colliding NodeIds.
+            var elementNames = new HashSet<string>(StringComparer.Ordinal);
+            foreach (StateMachineStateDefinition s in def.States)
+            {
+                ValidateElementName(elementNames, s.BrowseName, "State");
+            }
+            foreach (StateMachineTransitionDefinition t in def.Transitions)
+            {
+                ValidateElementName(elementNames, t.BrowseName, "Transition");
+            }
+
             var stateIds = new HashSet<uint>();
             foreach (StateMachineStateDefinition s in def.States)
             {
@@ -1032,6 +1128,40 @@ namespace Opc.Ua.Server.StateMachines
                         "subsequent mappings would be silently " +
                         "shadowed by the first.");
                 }
+            }
+        }
+
+        /// <summary>
+        /// The browse names of the standard FiniteStateMachineType
+        /// children the fluent machine materializes alongside its
+        /// element nodes — a state or transition may not shadow them.
+        /// </summary>
+        private static readonly string[] s_reservedElementNames =
+        [
+            BrowseNames.CurrentState,
+            BrowseNames.LastTransition,
+            BrowseNames.AvailableStates,
+            BrowseNames.AvailableTransitions
+        ];
+
+        private static void ValidateElementName(
+            HashSet<string> seenNames,
+            string browseName,
+            string elementKind)
+        {
+            if (Array.IndexOf(s_reservedElementNames, browseName) >= 0)
+            {
+                throw new InvalidOperationException(
+                    $"{elementKind} browse name '{browseName}' shadows a " +
+                    "standard FiniteStateMachineType child.");
+            }
+            if (!seenNames.Add(browseName))
+            {
+                throw new InvalidOperationException(
+                    $"{elementKind} browse name '{browseName}' is used by " +
+                    "more than one state or transition — element NodeIds " +
+                    "are derived from browse names, so names must be " +
+                    "unique across both.");
             }
         }
 
@@ -1147,6 +1277,27 @@ namespace Opc.Ua.Server.StateMachines
             }
             return new StateMachineBuilder<TState>(stateMachine, context, null);
         }
+
+        /// <summary>
+        /// Resolves a <c>CurrentState/Id</c> NodeId to the numeric state
+        /// id: first through the machine's own mapping (so materialized
+        /// state NodeIds resolve), then — for lifecycle-mode machines
+        /// whose state variable is written by an external dispatcher in
+        /// a namespace the machine does not know about — by the
+        /// namespace-agnostic numeric convention the builder has always
+        /// honoured.
+        /// </summary>
+        internal static uint ResolveStateId(
+            FiniteStateMachineState sm,
+            NodeId nodeId)
+        {
+            uint stateId = sm.GetStateId(nodeId);
+            if (stateId != 0)
+            {
+                return stateId;
+            }
+            return nodeId.TryGetValue(out uint numericId) ? numericId : 0;
+        }
     }
 
     /// <summary>
@@ -1166,6 +1317,7 @@ namespace Opc.Ua.Server.StateMachines
         private readonly ISystemContext m_context;
         private readonly TimeProvider m_timeProvider;
         private readonly Dictionary<uint, List<Action<ISystemContext, TState>>> m_enterHandlers = [];
+        private readonly List<Action<ISystemContext, uint>> m_initialStateSynchronizers = [];
         private readonly Dictionary<uint, List<Action<ISystemContext, TState>>> m_exitHandlers = [];
         private readonly List<Action<ISystemContext, TState, uint, uint>> m_transitionObservers = [];
         private readonly List<Func<ISystemContext, TState, uint, uint, ServiceResult>> m_guards = [];
@@ -1234,6 +1386,31 @@ namespace Opc.Ua.Server.StateMachines
             }
             list.Add(handler);
             EnsureInstalled();
+        }
+
+        /// <summary>
+        /// Registers a callback that brings machine-owned state (today:
+        /// sub-state-machine activation) in line with a state the
+        /// machine was placed in by <c>SetState</c> rather than by a
+        /// transition. Deliberately separate from the enter-state
+        /// handlers so that <see cref="StateMachineBuilder{TState}.WithInitialState"/>
+        /// keeps its contract of not running user lifecycle handlers.
+        /// </summary>
+        public void AddInitialStateSynchronizer(Action<ISystemContext, uint> synchronizer)
+        {
+            m_initialStateSynchronizers.Add(synchronizer);
+        }
+
+        /// <summary>
+        /// Runs every registered synchronizer against
+        /// <paramref name="stateId"/>.
+        /// </summary>
+        public void SynchronizeInitialState(ISystemContext context, uint stateId)
+        {
+            foreach (Action<ISystemContext, uint> synchronizer in m_initialStateSynchronizers)
+            {
+                SafeInvoke(() => synchronizer(context, stateId));
+            }
         }
 
         public void AddExitStateHandler(
@@ -1512,13 +1689,13 @@ namespace Opc.Ua.Server.StateMachines
             }
         }
 
-        private static uint ExtractStateId(NodeId? nodeId)
+        private uint ExtractStateId(NodeId? nodeId)
         {
             if (!nodeId.HasValue || nodeId.Value.IsNull)
             {
                 return 0;
             }
-            return nodeId.Value.TryGetValue(out uint id) ? id : 0;
+            return StateMachineBuilder.ResolveStateId(m_stateMachine, nodeId.Value);
         }
 
         private static void SafeInvoke(Action action)

--- a/src/Opc.Ua.Server/StateMachines/StateMachineBuilder.cs
+++ b/src/Opc.Ua.Server/StateMachines/StateMachineBuilder.cs
@@ -649,7 +649,7 @@ namespace Opc.Ua.Server.StateMachines
         /// by <paramref name="parentStateId"/>. The sub-SM is added as
         /// a <c>HasComponent</c> child of the parent FSM and referenced
         /// by <c>HasSubStateMachine</c> from the parent <em>state</em>
-        /// node per Part 16 §B.3, configured through the nested
+        /// node per Part 16 §4.4.16, configured through the nested
         /// <paramref name="configure"/> builder, and managed by the
         /// dispatcher lifecycle:
         /// </summary>
@@ -838,18 +838,21 @@ namespace Opc.Ua.Server.StateMachines
             void SyncChildToParentState(ISystemContext ctx, uint parentCurrentStateId)
             {
                 bool attached = parentCurrentStateId == parentStateId;
-                materializedChild.IsSuspended = !attached;
                 if (!attached)
                 {
-                    // Part 16: an inactive sub-SM publishes no current
-                    // state. A preserveOnReentry child keeps it, so the
-                    // state survives until the next activation.
+                    // Part 16: an inactive sub-SM's state variables read
+                    // Bad_StateNotActive (applied by SetSuspended). A
+                    // preserveOnReentry child additionally keeps its
+                    // internal state for the next activation.
                     if (!preserveOnReentry)
                     {
                         materializedChild.SetState(ctx, 0);
                     }
+                    materializedChild.SetSuspended(ctx, true);
                     return;
                 }
+
+                materializedChild.SetSuspended(ctx, false);
                 if (initialChildStateId == 0)
                 {
                     return;
@@ -869,7 +872,7 @@ namespace Opc.Ua.Server.StateMachines
             m_dispatcher.AddEnterStateHandler(parentStateId,
                 (ctx, parent) => SyncChildToParentState(ctx, parentStateId));
             m_dispatcher.AddExitStateHandler(parentStateId,
-                (ctx, parent) => materializedChild.IsSuspended = true);
+                (ctx, parent) => materializedChild.SetSuspended(ctx, true));
 
             return this;
         }
@@ -929,7 +932,7 @@ namespace Opc.Ua.Server.StateMachines
 
             m_dispatcher.InstallCauseMethod(method, causeId);
 
-            // Part 16 §B.4: every transition this cause can trigger
+            // Part 16 §4.4.11: every transition this cause can trigger
             // gets a HasCause reference to the method node. Only
             // definition mode knows the cause-to-transition mapping;
             // lifecycle-mode FSMs declare it in their type definition.

--- a/src/Opc.Ua.Server/StateMachines/StateMachineDefinition.cs
+++ b/src/Opc.Ua.Server/StateMachines/StateMachineDefinition.cs
@@ -87,6 +87,19 @@ namespace Opc.Ua.Server.StateMachines
     }
 
     /// <summary>
+    /// The shape shared by state and transition definitions — what the
+    /// element-node materialization needs to treat them uniformly.
+    /// </summary>
+    internal interface IStateMachineElementDefinition
+    {
+        /// <summary>The element's numeric id.</summary>
+        uint Id { get; }
+
+        /// <summary>The element's browse name.</summary>
+        string BrowseName { get; }
+    }
+
+    /// <summary>
     /// Definition of a single state in a Part 16 state machine.
     /// </summary>
     /// <param name="Id">The state's numeric id (used as the
@@ -98,7 +111,7 @@ namespace Opc.Ua.Server.StateMachines
     public sealed record StateMachineStateDefinition(
         uint Id,
         string BrowseName,
-        bool IsInitial = false);
+        bool IsInitial = false) : IStateMachineElementDefinition;
 
     /// <summary>
     /// Definition of a transition between two states.
@@ -114,7 +127,7 @@ namespace Opc.Ua.Server.StateMachines
         string BrowseName,
         uint FromStateId,
         uint ToStateId,
-        bool HasEffect = true);
+        bool HasEffect = true) : IStateMachineElementDefinition;
 
     /// <summary>
     /// Maps a cause (method NodeId) plus current state to the

--- a/tests/Opc.Ua.Robotics.Tests/RoboticsOperationBuilderTests.cs
+++ b/tests/Opc.Ua.Robotics.Tests/RoboticsOperationBuilderTests.cs
@@ -134,6 +134,17 @@ namespace Opc.Ua.Robotics.Server.Tests
             Assert.That(
                 systemOperation.Machine.CurrentState.Number!.Value,
                 Is.EqualTo(2u));
+            // The state nodes are declared in the Robotics model, so
+            // CurrentState/Id must be qualified with that namespace and
+            // not the OPC UA one. This only holds because the machine
+            // completed its create lifecycle — OnAfterCreate is where
+            // ElementNamespaceUri is resolved.
+            Assert.That(
+                systemOperation.Machine.CurrentState.Id!.Value,
+                Is.EqualTo(NodeId.Create(
+                    SystemOperationStateMachineTypeIds.StateIds.Ready,
+                    Namespaces.Robotics,
+                    m_fixture.Manager.SystemContext.NamespaceUris)));
             Assert.That(systemOperation.Machine.LastTransition!.Value.Text, Is.EqualTo("ExecutingToReady"));
             Assert.That(
                 systemOperation.Machine.LastTransition.Number!.Value,

--- a/tests/Opc.Ua.Server.Tests/StateMachines/FiniteStateMachineDispatcherTests.cs
+++ b/tests/Opc.Ua.Server.Tests/StateMachines/FiniteStateMachineDispatcherTests.cs
@@ -116,6 +116,38 @@ namespace Opc.Ua.Server.Tests.StateMachines
                 Is.EqualTo(Objects.ExclusiveLimitStateMachineType_Low));
         }
 
+        [Test]
+        public void InitializeToInitialStateMaterializesLastTransition()
+        {
+            // The optional LastTransition (and its Number) must exist
+            // by the time the machine is registered — minted later, at
+            // the first ApplyTransition, the nodes would be browsable
+            // but not readable.
+            var machine = new ExclusiveLimitStateMachineState(null);
+            machine.Create(
+                m_context,
+                new NodeId(4500, 1),
+                new QualifiedName("LimitState", 1),
+                new LocalizedText("LimitState"),
+                true);
+            machine.LastTransition?.Parent?.RemoveChild(machine.LastTransition);
+            var dispatcher = new FiniteStateMachineDispatcher(
+                0,
+                [new FiniteStateMachineEntry(
+                    Objects.ExclusiveLimitStateMachineType_High, 2, "High")],
+                []);
+
+            dispatcher.InitializeToInitialState(
+                machine, Objects.ExclusiveLimitStateMachineType_High, m_context);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(machine.LastTransition, Is.Not.Null);
+                Assert.That(machine.LastTransition!.Number, Is.Not.Null);
+                Assert.That(machine.LastTransition.Value.IsNullOrEmpty, Is.True);
+            });
+        }
+
         private BaseInstanceState FindChild(FluentFiniteStateMachineState parent, string browseName)
         {
             var children = new List<BaseInstanceState>();

--- a/tests/Opc.Ua.Server.Tests/StateMachines/FiniteStateMachineDispatcherTests.cs
+++ b/tests/Opc.Ua.Server.Tests/StateMachines/FiniteStateMachineDispatcherTests.cs
@@ -27,6 +27,7 @@
  * http://opcfoundation.org/License/MIT/1.00/
  * ======================================================================*/
 
+using System.Collections.Generic;
 using NUnit.Framework;
 using Opc.Ua.Server.StateMachines;
 
@@ -62,13 +63,64 @@ namespace Opc.Ua.Server.Tests.StateMachines
             dispatcher.Move(machine, 2, 10, m_context);
 
             Assert.That(machine.CurrentState!.Value.Text, Is.EqualTo("Ready"));
-            Assert.That(machine.CurrentState.Id!.Value, Is.EqualTo(new NodeId(2, 1)));
             Assert.That(machine.CurrentState.Number!.Value, Is.EqualTo(200u));
             Assert.That(machine.LastTransition!.Value.Text, Is.EqualTo("IdleToReady"));
-            Assert.That(machine.LastTransition.Id!.Value, Is.EqualTo(new NodeId(10, 1)));
             Assert.That(machine.LastTransition.Number!.Value, Is.EqualTo(300u));
             Assert.That(dispatcher.TryGetCurrentState(machine, out uint stateId), Is.True);
             Assert.That(stateId, Is.EqualTo(2u));
+
+            // The element NodeIds come from the machine, so for a
+            // machine that materializes its own element nodes they
+            // resolve to real, browsable nodes rather than to the
+            // dispatcher's raw numeric convention.
+            Assert.That(machine.CurrentState.Id!.Value,
+                Is.EqualTo(machine.GetStateNodeId(2)));
+            Assert.That(machine.LastTransition.Id!.Value,
+                Is.EqualTo(machine.GetTransitionNodeId(10)));
+            Assert.That(FindChild(machine, "Ready").NodeId,
+                Is.EqualTo(machine.CurrentState.Id.Value));
+            Assert.That(FindChild(machine, "IdleToReady").NodeId,
+                Is.EqualTo(machine.LastTransition.Id.Value));
+        }
+
+        [Test]
+        public void ApplyStateUsesTheMachinesElementNamespace()
+        {
+            // A machine that does NOT materialize element nodes keeps
+            // the numeric convention, qualified by the namespace its
+            // ElementNamespaceUri resolves to — the shape generated
+            // companion state machines rely on. Create() is what
+            // resolves that namespace, so this machine is created
+            // properly rather than assembled by hand.
+            var machine = new ExclusiveLimitStateMachineState(null);
+            machine.Create(
+                m_context,
+                new NodeId(4400, 1),
+                new QualifiedName("LimitState", 1),
+                new LocalizedText("LimitState"),
+                true);
+            var dispatcher = new FiniteStateMachineDispatcher(
+                0,
+                [new FiniteStateMachineEntry(
+                    Objects.ExclusiveLimitStateMachineType_Low, 3, "Low")],
+                []);
+
+            dispatcher.ApplyState(
+                machine, Objects.ExclusiveLimitStateMachineType_Low, m_context);
+
+            Assert.That(machine.CurrentState!.Id!.Value,
+                Is.EqualTo(new NodeId(Objects.ExclusiveLimitStateMachineType_Low)));
+            Assert.That(
+                dispatcher.TryGetCurrentState(machine, out uint stateId), Is.True);
+            Assert.That(stateId,
+                Is.EqualTo(Objects.ExclusiveLimitStateMachineType_Low));
+        }
+
+        private BaseInstanceState FindChild(FluentFiniteStateMachineState parent, string browseName)
+        {
+            var children = new List<BaseInstanceState>();
+            parent.GetChildren(m_context, children);
+            return children.Find(c => c.BrowseName.Name == browseName)!;
         }
     }
 }

--- a/tests/Opc.Ua.Server.Tests/StateMachines/FiniteStateMachineElementIdTests.cs
+++ b/tests/Opc.Ua.Server.Tests/StateMachines/FiniteStateMachineElementIdTests.cs
@@ -1,0 +1,102 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using NUnit.Framework;
+
+namespace Opc.Ua.Server.Tests.StateMachines
+{
+    /// <summary>
+    /// Guards the default element-NodeId convention on
+    /// <see cref="FiniteStateMachineState"/>. The
+    /// <c>GetStateNodeId</c> / <c>GetStateId</c> /
+    /// <c>GetTransitionNodeId</c> hooks exist so the fluent builder can
+    /// point <c>CurrentState/Id</c> at per-instance state nodes; every
+    /// stack-shipped and generator-emitted machine must keep reporting
+    /// the numeric <c>(elementId, ElementNamespaceIndex)</c> form.
+    /// </summary>
+    [TestFixture]
+    [Category("Server")]
+    [Category("StateMachines")]
+    [Parallelizable]
+    public sealed class FiniteStateMachineElementIdTests
+    {
+        private ServerSystemContext m_context = null!;
+
+        [SetUp]
+        public void SetUp()
+        {
+            m_context = StateMachineTestFixtures.CreateContext();
+        }
+
+        [Test]
+        public void StackStateMachineKeepsTheNumericElementConvention()
+        {
+            var sm = new ExclusiveLimitStateMachineState(null);
+            sm.Create(
+                m_context,
+                new NodeId(4200, 1),
+                new QualifiedName("LimitState", 1),
+                new LocalizedText("LimitState"),
+                true);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(
+                    sm.GetStateNodeId(Objects.ExclusiveLimitStateMachineType_High),
+                    Is.EqualTo(new NodeId(Objects.ExclusiveLimitStateMachineType_High)));
+                Assert.That(
+                    sm.GetTransitionNodeId(
+                        Objects.ExclusiveLimitStateMachineType_HighToHighHigh),
+                    Is.EqualTo(new NodeId(
+                        Objects.ExclusiveLimitStateMachineType_HighToHighHigh)));
+                Assert.That(
+                    sm.GetStateId(new NodeId(Objects.ExclusiveLimitStateMachineType_Low)),
+                    Is.EqualTo(Objects.ExclusiveLimitStateMachineType_Low));
+
+                // OnAfterCreate seeds CurrentState with High.
+                Assert.That(
+                    sm.CurrentState!.Id!.Value,
+                    Is.EqualTo(new NodeId(Objects.ExclusiveLimitStateMachineType_High)));
+            });
+        }
+
+        [Test]
+        public void ZeroElementIdsMapToNull()
+        {
+            var sm = new ExclusiveLimitStateMachineState(null);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(sm.GetStateNodeId(0), Is.EqualTo(NodeId.Null));
+                Assert.That(sm.GetTransitionNodeId(0), Is.EqualTo(NodeId.Null));
+                Assert.That(sm.GetStateId(NodeId.Null), Is.Zero);
+            });
+        }
+    }
+}

--- a/tests/Opc.Ua.Server.Tests/StateMachines/StateMachineBuilderGuardTests.cs
+++ b/tests/Opc.Ua.Server.Tests/StateMachines/StateMachineBuilderGuardTests.cs
@@ -229,13 +229,13 @@ namespace Opc.Ua.Server.Tests.StateMachines
                 .OnCause(200, from: 2, transition: 20);
         }
 
-        private static uint CurrentStateId(FiniteStateMachineState sm)
+        private static uint CurrentStateId(FluentFiniteStateMachineState sm)
         {
-            if (sm.CurrentState?.Id?.Value is { } id &&
-                !id.IsNull &&
-                id.TryGetValue(out uint stateId))
+            if (sm.CurrentState?.Id?.Value is { } id && !id.IsNull)
             {
-                return stateId;
+                // Resolve through the machine's own mapping so
+                // materialized state NodeIds are understood too.
+                return sm.GetStateId(id);
             }
             return 0;
         }

--- a/tests/Opc.Ua.Server.Tests/StateMachines/StateMachineBuilderLifecycleTests.cs
+++ b/tests/Opc.Ua.Server.Tests/StateMachines/StateMachineBuilderLifecycleTests.cs
@@ -226,6 +226,46 @@ namespace Opc.Ua.Server.Tests.StateMachines
         }
 
         [Test]
+        public void WithTimedTransitionArmsWhenInitialStateIsSetAfterwards()
+        {
+            // WithInitialState goes through SetState (no transition),
+            // so the initial-state synchronizer is the only chance to
+            // arm the timer for the state entered that way.
+            using var done = new ManualResetEventSlim(false);
+            _ = BuildOnOffMachine()
+                .OnEnterState(2, (ctx, m) => done.Set())
+                .WithTimedTransition(
+                    fromStateId: 1,
+                    timeout: TimeSpan.FromMilliseconds(50),
+                    transitionId: 10)
+                .WithInitialState(1)
+                .StateMachine;
+
+            Assert.That(done.Wait(TimeSpan.FromSeconds(2)), Is.True,
+                "timed transition should fire when WithInitialState " +
+                "follows WithTimedTransition");
+        }
+
+        [Test]
+        public void AddStateFailureLeavesTheDefinitionUnchanged()
+        {
+            StateMachineBuilder<FluentFiniteStateMachineState> b =
+                StateMachineTestFixtures.NewBuilder(m_context)
+                    .AddState(1, "A", isInitial: true)
+                    .AddState(2, "B")
+                    .AddTransition(10, "AToB", from: 1, to: 2);
+
+            Assert.That(() => b.AddState(3, "C", isInitial: true),
+                Throws.InvalidOperationException);
+
+            // The rejected state must not linger in the definition —
+            // it would be materialized but invisible to the tables.
+            FluentFiniteStateMachineState sm = b.StateMachine;
+            Assert.That(sm.Definition.States, Has.Count.EqualTo(2));
+            Assert.That(sm.GetStateNodeId(3), Is.EqualTo(NodeId.Null));
+        }
+
+        [Test]
         public void WithTimedTransitionRejectsNonPositiveTimeout()
         {
             StateMachineBuilder<FluentFiniteStateMachineState> b = BuildOnOffMachine();

--- a/tests/Opc.Ua.Server.Tests/StateMachines/StateMachineBuilderLifecycleTests.cs
+++ b/tests/Opc.Ua.Server.Tests/StateMachines/StateMachineBuilderLifecycleTests.cs
@@ -471,13 +471,13 @@ namespace Opc.Ua.Server.Tests.StateMachines
                 .OnCause(200, from: 2, transition: 20);
         }
 
-        private static uint CurrentStateId(FiniteStateMachineState sm)
+        private static uint CurrentStateId(FluentFiniteStateMachineState sm)
         {
-            if (sm.CurrentState?.Id?.Value is { } id &&
-                !id.IsNull &&
-                id.TryGetValue(out uint stateId))
+            if (sm.CurrentState?.Id?.Value is { } id && !id.IsNull)
             {
-                return stateId;
+                // Resolve through the machine's own mapping so
+                // materialized state NodeIds are understood too.
+                return sm.GetStateId(id);
             }
             return 0;
         }

--- a/tests/Opc.Ua.Server.Tests/StateMachines/StateMachineBuilderStateNodeTests.cs
+++ b/tests/Opc.Ua.Server.Tests/StateMachines/StateMachineBuilderStateNodeTests.cs
@@ -1,0 +1,276 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using Opc.Ua.Server.StateMachines;
+
+namespace Opc.Ua.Server.Tests.StateMachines
+{
+    /// <summary>
+    /// Unit tests for the <c>StateType</c> nodes that
+    /// <see cref="FluentFiniteStateMachineState"/> materializes for its
+    /// declared states — the address-space representation Part 16 §B.3
+    /// requires so that <c>CurrentState/Id</c> resolves to a real node
+    /// and <c>HasSubStateMachine</c> has a state node to hang off.
+    /// </summary>
+    [TestFixture]
+    [Category("Server")]
+    [Category("StateMachines")]
+    [Parallelizable]
+    public sealed class StateMachineBuilderStateNodeTests
+    {
+        private ServerSystemContext m_context = null!;
+
+        [SetUp]
+        public void SetUp()
+        {
+            m_context = StateMachineTestFixtures.CreateContext();
+        }
+
+        [Test]
+        public void EveryDeclaredStateGetsAStateTypeNode()
+        {
+            FluentFiniteStateMachineState sm = Build().StateMachine;
+
+            BaseInstanceState off = GetChild(sm, "Off");
+            BaseInstanceState on = GetChild(sm, "On");
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(off, Is.InstanceOf<BaseObjectState>());
+                Assert.That(((BaseObjectState)off).TypeDefinitionId,
+                    Is.EqualTo(ObjectTypeIds.StateType));
+                Assert.That(off.ReferenceTypeId,
+                    Is.EqualTo(ReferenceTypeIds.HasComponent));
+                Assert.That(((BaseObjectState)on).TypeDefinitionId,
+                    Is.EqualTo(ObjectTypeIds.StateType));
+            });
+        }
+
+        [Test]
+        public void StateNodeCarriesStateNumberProperty()
+        {
+            FluentFiniteStateMachineState sm = Build().StateMachine;
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(StateNumber(sm, "Off"), Is.EqualTo(1u));
+                Assert.That(StateNumber(sm, "On"), Is.EqualTo(2u));
+            });
+        }
+
+        [Test]
+        public void CurrentStateIdResolvesToTheMaterializedNode()
+        {
+            FluentFiniteStateMachineState sm = Build()
+                .WithInitialState(1)
+                .StateMachine;
+
+            Assert.That(sm.CurrentState!.Id!.Value,
+                Is.EqualTo(GetChild(sm, "Off").NodeId));
+
+            sm.DoTransition(m_context, 10, 0, default, []);
+
+            Assert.That(sm.CurrentState.Id.Value,
+                Is.EqualTo(GetChild(sm, "On").NodeId));
+        }
+
+        [Test]
+        public void GetStateIdRoundTripsThroughGetStateNodeId()
+        {
+            FluentFiniteStateMachineState sm = Build().StateMachine;
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(sm.GetStateId(sm.GetStateNodeId(1)), Is.EqualTo(1u));
+                Assert.That(sm.GetStateId(sm.GetStateNodeId(2)), Is.EqualTo(2u));
+                Assert.That(sm.GetStateId(new NodeId("nonsense", 1)), Is.Zero);
+            });
+        }
+
+        [Test]
+        public void GetStateIdIsAuthoritativeAfterMaterialization()
+        {
+            FluentFiniteStateMachineState sm = Build().StateMachine;
+
+            // A foreign numeric NodeId must not resolve to a state of
+            // this machine once the materialized map exists — the old
+            // numeric fallback would have returned 2930 here.
+            Assert.Multiple(() =>
+            {
+                Assert.That(sm.GetStateId(new NodeId(2930u, 0)), Is.Zero);
+                Assert.That(sm.GetStateId(new NodeId(1u, 0)), Is.Zero);
+                Assert.That(sm.GetTransitionId(new NodeId(10u, 0)), Is.Zero);
+            });
+        }
+
+        [Test]
+        public void LifecycleStateExtractionFallsBackToNumericIds()
+        {
+            // A lifecycle-mode machine whose CurrentState/Id is written
+            // by an external dispatcher in a vendor namespace must still
+            // resolve numerically — the builder has always honoured the
+            // namespace-agnostic numeric convention for adopted FSMs.
+            var sm = new ExclusiveLimitStateMachineState(null);
+            sm.Create(
+                m_context,
+                new NodeId(4300, 1),
+                new QualifiedName("LimitState", 1),
+                new LocalizedText("LimitState"),
+                true);
+            sm.CurrentState!.Id!.Value = new NodeId(
+                Objects.ExclusiveLimitStateMachineType_Low, 5);
+
+            Assert.That(
+                StateMachineBuilder.ResolveStateId(sm, sm.CurrentState.Id.Value),
+                Is.EqualTo(Objects.ExclusiveLimitStateMachineType_Low));
+        }
+
+        [Test]
+        public void DuplicateElementBrowseNamesAreRejected()
+        {
+            Assert.Multiple(() =>
+            {
+                // Two states sharing a browse name would mint the same
+                // materialized NodeId.
+                Assert.That(() => StateMachineTestFixtures.NewBuilder(m_context)
+                        .AddState(1, "Idle", isInitial: true)
+                        .AddState(2, "Idle")
+                        .StateMachine,
+                    Throws.InvalidOperationException);
+
+                // A state and a transition sharing a browse name collide
+                // the same way.
+                Assert.That(() => StateMachineTestFixtures.NewBuilder(m_context)
+                        .AddState(1, "Reset", isInitial: true)
+                        .AddTransition(10, "Reset", from: 1, to: 1)
+                        .StateMachine,
+                    Throws.InvalidOperationException);
+
+                // Standard FiniteStateMachineType children are reserved.
+                Assert.That(() => StateMachineTestFixtures.NewBuilder(m_context)
+                        .AddState(1, BrowseNames.AvailableStates, isInitial: true)
+                        .StateMachine,
+                    Throws.InvalidOperationException);
+            });
+        }
+
+        [Test]
+        public void AvailableStatesListsTheMaterializedStateNodes()
+        {
+            FluentFiniteStateMachineState sm = Build().StateMachine;
+
+            Assert.That(sm.AvailableStates, Is.Not.Null);
+            NodeId[] published = [.. sm.AvailableStates!.Value];
+
+            Assert.That(published, Is.EqualTo(new[]
+            {
+                GetChild(sm, "Off").NodeId,
+                GetChild(sm, "On").NodeId
+            }));
+
+            // The standard NodeSet models AvailableStates as a
+            // HasComponent BaseDataVariable, and that is the reference
+            // type GetAvailableStatesAsync translates the path with.
+            Assert.That(sm.AvailableStates.ReferenceTypeId,
+                Is.EqualTo(ReferenceTypeIds.HasComponent));
+            Assert.That(sm.AvailableStates.BrowseName,
+                Is.EqualTo(new QualifiedName(BrowseNames.AvailableStates)));
+        }
+
+        [Test]
+        public void TwoMachinesFromOneDefinitionGetDistinctStateNodeIds()
+        {
+            FluentFiniteStateMachineState first =
+                Build(nodeIdNumber: 5000).StateMachine;
+            FluentFiniteStateMachineState second =
+                Build(nodeIdNumber: 5001).StateMachine;
+
+            Assert.That(GetChild(first, "Off").NodeId,
+                Is.Not.EqualTo(GetChild(second, "Off").NodeId));
+        }
+
+        [Test]
+        public void StateNodesLandInTheMachineNamespaceByDefault()
+        {
+            // The element namespace defaults to the OPC UA namespace
+            // (index 0), which must never host vendor nodes.
+            FluentFiniteStateMachineState sm = Build().StateMachine;
+
+            Assert.That(GetChild(sm, "Off").NodeId.NamespaceIndex,
+                Is.EqualTo(sm.NodeId.NamespaceIndex));
+            Assert.That(GetChild(sm, "Off").NodeId.NamespaceIndex, Is.Not.Zero);
+        }
+
+        [Test]
+        public void UseElementNamespaceControlsTheStateNodeNamespace()
+        {
+            const string customUri = "urn:test:custom-ns";
+            ushort registeredIndex = m_context.NamespaceUris.GetIndexOrAppend(customUri);
+
+            FluentFiniteStateMachineState sm = StateMachineTestFixtures
+                .NewBuilder(m_context)
+                .UseElementNamespace(customUri)
+                .AddState(1, "Off", isInitial: true)
+                .AddState(2, "On")
+                .StateMachine;
+
+            Assert.That(GetChild(sm, "Off").NodeId.NamespaceIndex,
+                Is.EqualTo(registeredIndex));
+        }
+
+        private StateMachineBuilder<FluentFiniteStateMachineState> Build(
+            uint nodeIdNumber = 5000)
+        {
+            return StateMachineTestFixtures.NewBuilder(m_context, nodeIdNumber)
+                .AddState(1, "Off", isInitial: true)
+                .AddState(2, "On")
+                .AddTransition(10, "OffToOn", from: 1, to: 2)
+                .AddTransition(20, "OnToOff", from: 2, to: 1);
+        }
+
+        private BaseInstanceState GetChild(NodeState parent, string browseName)
+        {
+            var children = new List<BaseInstanceState>();
+            parent.GetChildren(m_context, children);
+            return children.Find(c => c.BrowseName.Name == browseName)!;
+        }
+
+        private uint StateNumber(NodeState sm, string stateBrowseName)
+        {
+            var properties = new List<BaseInstanceState>();
+            GetChild(sm, stateBrowseName).GetChildren(m_context, properties);
+            var number = (PropertyState<uint>)properties
+                .First(p => p.BrowseName.Name == BrowseNames.StateNumber);
+            return number.Value;
+        }
+    }
+}

--- a/tests/Opc.Ua.Server.Tests/StateMachines/StateMachineBuilderStateNodeTests.cs
+++ b/tests/Opc.Ua.Server.Tests/StateMachines/StateMachineBuilderStateNodeTests.cs
@@ -37,7 +37,7 @@ namespace Opc.Ua.Server.Tests.StateMachines
     /// <summary>
     /// Unit tests for the <c>StateType</c> nodes that
     /// <see cref="FluentFiniteStateMachineState"/> materializes for its
-    /// declared states — the address-space representation Part 16 §B.3
+    /// declared states — the address-space representation Part 16 §4.4.16
     /// requires so that <c>CurrentState/Id</c> resolves to a real node
     /// and <c>HasSubStateMachine</c> has a state node to hang off.
     /// </summary>
@@ -66,8 +66,11 @@ namespace Opc.Ua.Server.Tests.StateMachines
             Assert.Multiple(() =>
             {
                 Assert.That(off, Is.InstanceOf<BaseObjectState>());
+                // The declared initial state is an InitialStateType
+                // (OPC 10000-16 §4.4.10); every other state is a plain
+                // StateType.
                 Assert.That(((BaseObjectState)off).TypeDefinitionId,
-                    Is.EqualTo(ObjectTypeIds.StateType));
+                    Is.EqualTo(ObjectTypeIds.InitialStateType));
                 Assert.That(off.ReferenceTypeId,
                     Is.EqualTo(ReferenceTypeIds.HasComponent));
                 Assert.That(((BaseObjectState)on).TypeDefinitionId,

--- a/tests/Opc.Ua.Server.Tests/StateMachines/StateMachineBuilderStateNodeTests.cs
+++ b/tests/Opc.Ua.Server.Tests/StateMachines/StateMachineBuilderStateNodeTests.cs
@@ -180,6 +180,36 @@ namespace Opc.Ua.Server.Tests.StateMachines
                         .AddState(1, BrowseNames.AvailableStates, isInitial: true)
                         .StateMachine,
                     Throws.InvalidOperationException);
+
+                // An element name equal to another element's composed
+                // number-property name would mint the property's NodeId.
+                Assert.That(() => StateMachineTestFixtures.NewBuilder(m_context)
+                        .AddState(1, "A", isInitial: true)
+                        .AddState(2, "A_StateNumber")
+                        .StateMachine,
+                    Throws.InvalidOperationException);
+                Assert.That(() => StateMachineTestFixtures.NewBuilder(m_context)
+                        .AddState(1, "B", isInitial: true)
+                        .AddTransition(10, "B_StateNumber", from: 1, to: 1)
+                        .StateMachine,
+                    Throws.InvalidOperationException);
+            });
+        }
+
+        [Test]
+        public void ZeroElementIdsAreRejectedByTheBuilder()
+        {
+            // 0 is the "no state" / "no transition" sentinel throughout
+            // FiniteStateMachineState, so the builder refuses it.
+            Assert.Multiple(() =>
+            {
+                Assert.That(() => StateMachineTestFixtures.NewBuilder(m_context)
+                        .AddState(0, "Zero"),
+                    Throws.ArgumentException);
+                Assert.That(() => StateMachineTestFixtures.NewBuilder(m_context)
+                        .AddState(1, "One", isInitial: true)
+                        .AddTransition(0, "ZeroT", from: 1, to: 1),
+                    Throws.ArgumentException);
             });
         }
 
@@ -216,6 +246,41 @@ namespace Opc.Ua.Server.Tests.StateMachines
 
             Assert.That(GetChild(first, "Off").NodeId,
                 Is.Not.EqualTo(GetChild(second, "Off").NodeId));
+        }
+
+        [Test]
+        public void MachinesWithEqualIdentifiersInDifferentNamespacesDoNotCollide()
+        {
+            // The owner prefix carries the full NodeId (namespace
+            // included) — two machines whose identifiers coincide in
+            // different namespaces must still mint distinct element ids.
+            FluentFiniteStateMachineState first = StateMachineBuilder
+                .Create(null, m_context, new NodeId("Pump", 1), new QualifiedName("Pump", 1))
+                .AddState(1, "Off", isInitial: true)
+                .StateMachine;
+            FluentFiniteStateMachineState second = StateMachineBuilder
+                .Create(null, m_context, new NodeId("Pump", 2), new QualifiedName("Pump", 2))
+                .AddState(1, "Off", isInitial: true)
+                .StateMachine;
+
+            Assert.That(GetChild(first, "Off").NodeId,
+                Is.Not.EqualTo(GetChild(second, "Off").NodeId));
+        }
+
+        [Test]
+        public void DeclaredInitialStateIsAppliedWithoutWithInitialState()
+        {
+            // The documented minimal example never calls
+            // WithInitialState — the isInitial flag alone must leave
+            // the machine in a workable state.
+            FluentFiniteStateMachineState sm = Build().StateMachine;
+
+            Assert.That(sm.CurrentState!.Id!.Value,
+                Is.EqualTo(GetChild(sm, "Off").NodeId));
+
+            // ... and the machine can transition out of it.
+            ServiceResult result = sm.DoTransition(m_context, 10, 0, default, []);
+            Assert.That(ServiceResult.IsGood(result), Is.True);
         }
 
         [Test]

--- a/tests/Opc.Ua.Server.Tests/StateMachines/StateMachineBuilderSubStateTests.cs
+++ b/tests/Opc.Ua.Server.Tests/StateMachines/StateMachineBuilderSubStateTests.cs
@@ -98,7 +98,7 @@ namespace Opc.Ua.Server.Tests.StateMachines
             BaseInstanceState child = GetChild(parent, "ChildSm");
             BaseInstanceState stateNode = GetChild(parent, "ParentA");
 
-            // Part 16 §B.3: the reference hangs off the parent STATE
+            // Part 16 §4.4.16: the reference hangs off the parent STATE
             // node, not the state machine root.
             var forward = new List<IReference>();
             stateNode.GetReferences(
@@ -270,6 +270,42 @@ namespace Opc.Ua.Server.Tests.StateMachines
                 // current state — its declared initial state is only
                 // applied once the parent enters the attached state.
                 Assert.That(child.CurrentState!.Value.IsNullOrEmpty, Is.True);
+                // ... and OPC 10000-16 §4.4.6: CurrentState and
+                // LastTransition of an inactive sub-SM read with
+                // Bad_StateNotActive.
+                Assert.That(child.CurrentState.StatusCode,
+                    Is.EqualTo((StatusCode)StatusCodes.BadStateNotActive));
+                Assert.That(child.LastTransition!.StatusCode,
+                    Is.EqualTo((StatusCode)StatusCodes.BadStateNotActive));
+            });
+        }
+
+        [Test]
+        public void ResumedSubStateMachineReadsGoodAgain()
+        {
+            FluentFiniteStateMachineState parent = BuildParent()
+                .WithSubStateMachine(
+                    parentStateId: 1,
+                    browseName: new QualifiedName("ChildSm", 1),
+                    configure: c => c
+                        .AddState(10, "ChildIdle", isInitial: true)
+                        .AddTransition(100, "Loop", from: 10, to: 10))
+                .WithInitialState(2)
+                .StateMachine;
+            var child = (FluentFiniteStateMachineState)GetChild(parent, "ChildSm");
+            Assert.That(child.CurrentState!.StatusCode,
+                Is.EqualTo((StatusCode)StatusCodes.BadStateNotActive));
+
+            // Parent enters the attached state → the sub-SM activates
+            // and its state variables read Good with the seeded state.
+            parent.DoTransition(m_context, 21, 0, default, []);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(child.IsSuspended, Is.False);
+                Assert.That(child.CurrentState.StatusCode,
+                    Is.EqualTo((StatusCode)StatusCodes.Good));
+                Assert.That(CurrentStateId(child), Is.EqualTo(10u));
             });
         }
 
@@ -348,7 +384,7 @@ namespace Opc.Ua.Server.Tests.StateMachines
         }
 
         [Test]
-        public void SuspendedSubStateMachineRejectsTransitionsWithBadInvalidState()
+        public void SuspendedSubStateMachineRejectsTransitionsWithBadStateNotActive()
         {
             FluentFiniteStateMachineState parent = BuildParent()
                 .WithInitialState(2) // parent in state 2, sub-SM suspended
@@ -366,7 +402,7 @@ namespace Opc.Ua.Server.Tests.StateMachines
             ServiceResult result = child.DoTransition(m_context, 100, 0, default, []);
 
             Assert.That(ServiceResult.IsBad(result), Is.True);
-            Assert.That(result.Code, Is.EqualTo(StatusCodes.BadInvalidState));
+            Assert.That(result.Code, Is.EqualTo(StatusCodes.BadStateNotActive));
         }
 
         [Test]

--- a/tests/Opc.Ua.Server.Tests/StateMachines/StateMachineBuilderSubStateTests.cs
+++ b/tests/Opc.Ua.Server.Tests/StateMachines/StateMachineBuilderSubStateTests.cs
@@ -27,6 +27,7 @@
  * http://opcfoundation.org/License/MIT/1.00/
  * ======================================================================*/
 
+using System;
 using System.Collections.Generic;
 using NUnit.Framework;
 using Opc.Ua.Server.StateMachines;
@@ -55,7 +56,7 @@ namespace Opc.Ua.Server.Tests.StateMachines
         }
 
         [Test]
-        public void WithSubStateMachineAddsHasSubStateMachineChild()
+        public void WithSubStateMachineAddsHasComponentChild()
         {
             FluentFiniteStateMachineState parent = BuildParent()
                 .WithInitialState(1)
@@ -73,9 +74,196 @@ namespace Opc.Ua.Server.Tests.StateMachines
             BaseInstanceState child = children.Find(c => c.BrowseName.Name == "ChildSm")!;
 
             Assert.That(child, Is.Not.Null);
+            // HasSubStateMachine is non-hierarchical, so the parent /
+            // child relationship uses HasComponent — matching the
+            // standard NodeSets.
             Assert.That(child.ReferenceTypeId,
-                Is.EqualTo(ReferenceTypeIds.HasSubStateMachine));
+                Is.EqualTo(ReferenceTypeIds.HasComponent));
             Assert.That(child, Is.InstanceOf<FluentFiniteStateMachineState>());
+        }
+
+        [Test]
+        public void WithSubStateMachineReferencesSubMachineFromParentStateNode()
+        {
+            FluentFiniteStateMachineState parent = BuildParent()
+                .WithInitialState(1)
+                .WithSubStateMachine(
+                    parentStateId: 1,
+                    browseName: new QualifiedName("ChildSm", 1),
+                    configure: c => c
+                        .AddState(10, "ChildIdle", isInitial: true)
+                        .AddTransition(100, "Loop", from: 10, to: 10))
+                .StateMachine;
+
+            BaseInstanceState child = GetChild(parent, "ChildSm");
+            BaseInstanceState stateNode = GetChild(parent, "ParentA");
+
+            // Part 16 §B.3: the reference hangs off the parent STATE
+            // node, not the state machine root.
+            var forward = new List<IReference>();
+            stateNode.GetReferences(
+                m_context, forward, ReferenceTypeIds.HasSubStateMachine, false);
+            Assert.That(forward, Has.Count.EqualTo(1));
+            Assert.That(forward[0].TargetId, Is.EqualTo((ExpandedNodeId)child.NodeId));
+
+            // ... and the inverse (SubStateMachineOf) browses back.
+            var inverse = new List<IReference>();
+            child.GetReferences(
+                m_context, inverse, ReferenceTypeIds.HasSubStateMachine, true);
+            Assert.That(inverse, Has.Count.EqualTo(1));
+            Assert.That(inverse[0].TargetId, Is.EqualTo((ExpandedNodeId)stateNode.NodeId));
+
+            // The state machine root must NOT carry the reference.
+            var fromRoot = new List<IReference>();
+            parent.GetReferences(
+                m_context, fromRoot, ReferenceTypeIds.HasSubStateMachine, false);
+            Assert.That(fromRoot, Is.Empty);
+        }
+
+        [Test]
+        public void SubStateMachineIsDiscoverableThroughTheNodeBrowser()
+        {
+            // Drives the real NodeBrowser along the exact path a client
+            // takes: hierarchical browse of the machine to reach the
+            // state node and the sub-SM, then HasSubStateMachine from
+            // the state node. HasSubStateMachine is non-hierarchical,
+            // so using it as the parent/child reference would leave the
+            // sub-SM invisible to the first of those browses.
+            //
+            // NodeState.PopulateBrowser only walks children when the
+            // TypeTable can tell it the browsed reference type is
+            // hierarchical, so the bare test table needs that one fact.
+            var typeTable = (TypeTable)m_context.TypeTable;
+            typeTable.AddReferenceSubtype(
+                ReferenceTypeIds.HierarchicalReferences,
+                NodeId.Null,
+                new QualifiedName(BrowseNames.HierarchicalReferences));
+            typeTable.AddReferenceSubtype(
+                ReferenceTypeIds.HasComponent,
+                ReferenceTypeIds.HierarchicalReferences,
+                new QualifiedName(BrowseNames.HasComponent));
+
+            FluentFiniteStateMachineState parent = BuildParent()
+                .WithInitialState(1)
+                .WithSubStateMachine(
+                    parentStateId: 1,
+                    browseName: new QualifiedName("ChildSm", 1),
+                    configure: c => c
+                        .AddState(10, "ChildIdle", isInitial: true)
+                        .AddTransition(100, "Loop", from: 10, to: 10))
+                .StateMachine;
+
+            List<NodeId> components = BrowseTargets(
+                parent, ReferenceTypeIds.HasComponent, BrowseDirection.Forward);
+            NodeId stateNodeId = GetChild(parent, "ParentA").NodeId;
+            NodeId childNodeId = GetChild(parent, "ChildSm").NodeId;
+
+            Assert.That(components, Does.Contain(stateNodeId));
+            Assert.That(components, Does.Contain(childNodeId));
+
+            List<NodeId> subMachines = BrowseTargets(
+                GetChild(parent, "ParentA"),
+                ReferenceTypeIds.HasSubStateMachine,
+                BrowseDirection.Forward);
+
+            Assert.That(subMachines, Is.EqualTo(new[] { childNodeId }));
+        }
+
+        private List<NodeId> BrowseTargets(
+            NodeState node,
+            NodeId referenceTypeId,
+            BrowseDirection direction)
+        {
+            var targets = new List<NodeId>();
+            using INodeBrowser browser = node.CreateBrowser(
+                m_context,
+                null,
+                referenceTypeId,
+                false,
+                direction,
+                default,
+                null,
+                false);
+            for (IReference reference = browser.Next();
+                reference != null;
+                reference = browser.Next())
+            {
+                targets.Add(ExpandedNodeId.ToNodeId(
+                    reference.TargetId, m_context.NamespaceUris));
+            }
+            return targets;
+        }
+
+        [Test]
+        public void WithSubStateMachineRejectsBrowseNameCollidingWithState()
+        {
+            StateMachineBuilder<FluentFiniteStateMachineState> builder =
+                BuildParent().WithInitialState(1);
+
+            // The sub-SM NodeId is composed like the element NodeIds,
+            // so a browse name shared with a state would collide.
+            Assert.Throws<ArgumentException>(() =>
+                builder.WithSubStateMachine(
+                    parentStateId: 1,
+                    browseName: new QualifiedName("ParentA", 1),
+                    configure: c => c.AddState(10, "ChildIdle", isInitial: true)));
+        }
+
+        [Test]
+        public void WithSubStateMachineRejectsUnknownParentState()
+        {
+            StateMachineBuilder<FluentFiniteStateMachineState> builder =
+                BuildParent().WithInitialState(1);
+
+            Assert.Throws<InvalidOperationException>(() =>
+                builder.WithSubStateMachine(
+                    parentStateId: 99,
+                    browseName: new QualifiedName("ChildSm", 1),
+                    configure: c => c.AddState(10, "ChildIdle", isInitial: true)));
+        }
+
+        [Test]
+        public void SubStateMachineActivatesWhenInitialStateIsSetAfterwards()
+        {
+            // WithInitialState goes through SetState, which fires no
+            // enter handler — the sub-SM must still activate, so this
+            // call order behaves the same as the reverse one.
+            FluentFiniteStateMachineState parent = BuildParent()
+                .WithSubStateMachine(
+                    parentStateId: 1,
+                    browseName: new QualifiedName("ChildSm", 1),
+                    configure: c => c
+                        .AddState(10, "ChildIdle", isInitial: true)
+                        .AddState(11, "ChildRunning")
+                        .AddTransition(100, "IdleToRunning", from: 10, to: 11))
+                .WithInitialState(1)
+                .StateMachine;
+
+            var child = (FluentFiniteStateMachineState)GetChild(parent, "ChildSm");
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(child.IsSuspended, Is.False);
+                Assert.That(CurrentStateId(child), Is.EqualTo(10u));
+            });
+        }
+
+        [Test]
+        public void SubStateMachineStaysSuspendedWhenInitialStateIsElsewhere()
+        {
+            FluentFiniteStateMachineState parent = BuildParent()
+                .WithSubStateMachine(
+                    parentStateId: 1,
+                    browseName: new QualifiedName("ChildSm", 1),
+                    configure: c => c
+                        .AddState(10, "ChildIdle", isInitial: true)
+                        .AddTransition(100, "Loop", from: 10, to: 10))
+                .WithInitialState(2)
+                .StateMachine;
+
+            var child = (FluentFiniteStateMachineState)GetChild(parent, "ChildSm");
+
+            Assert.That(child.IsSuspended, Is.True);
         }
 
         [Test]
@@ -238,13 +426,13 @@ namespace Opc.Ua.Server.Tests.StateMachines
             return children.Find(c => c.BrowseName.Name == browseName)!;
         }
 
-        private static uint CurrentStateId(FiniteStateMachineState sm)
+        private static uint CurrentStateId(FluentFiniteStateMachineState sm)
         {
-            if (sm.CurrentState?.Id?.Value is { } id &&
-                !id.IsNull &&
-                id.TryGetValue(out uint stateId))
+            if (sm.CurrentState?.Id?.Value is { } id && !id.IsNull)
             {
-                return stateId;
+                // Resolve through the machine's own mapping so
+                // materialized state NodeIds are understood too.
+                return sm.GetStateId(id);
             }
             return 0;
         }

--- a/tests/Opc.Ua.Server.Tests/StateMachines/StateMachineBuilderSubStateTests.cs
+++ b/tests/Opc.Ua.Server.Tests/StateMachines/StateMachineBuilderSubStateTests.cs
@@ -263,7 +263,42 @@ namespace Opc.Ua.Server.Tests.StateMachines
 
             var child = (FluentFiniteStateMachineState)GetChild(parent, "ChildSm");
 
-            Assert.That(child.IsSuspended, Is.True);
+            Assert.Multiple(() =>
+            {
+                Assert.That(child.IsSuspended, Is.True);
+                // Part 16: an inactive sub-state machine publishes no
+                // current state — its declared initial state is only
+                // applied once the parent enters the attached state.
+                Assert.That(child.CurrentState!.Value.IsNullOrEmpty, Is.True);
+            });
+        }
+
+        [Test]
+        public void PreserveOnReentryChildSurvivesALaterWithInitialState()
+        {
+            StateMachineBuilder<FluentFiniteStateMachineState> builder =
+                BuildParent()
+                    .WithInitialState(1)
+                    .WithSubStateMachine(
+                        parentStateId: 1,
+                        browseName: new QualifiedName("ChildSm", 1),
+                        configure: c => c
+                            .AddState(10, "ChildIdle", isInitial: true)
+                            .AddState(11, "ChildRunning")
+                            .AddTransition(100, "IdleToRunning", from: 10, to: 11),
+                        preserveOnReentry: true);
+            FluentFiniteStateMachineState parent = builder.StateMachine;
+            var child = (FluentFiniteStateMachineState)GetChild(parent, "ChildSm");
+
+            // Move the child off its initial state, then re-apply the
+            // parent's initial state — a preserveOnReentry child must
+            // keep its state instead of being reset.
+            child.DoTransition(m_context, 100, 0, default, []);
+            Assert.That(CurrentStateId(child), Is.EqualTo(11u));
+
+            builder.WithInitialState(1);
+
+            Assert.That(CurrentStateId(child), Is.EqualTo(11u));
         }
 
         [Test]

--- a/tests/Opc.Ua.Server.Tests/StateMachines/StateMachineBuilderTransitionNodeTests.cs
+++ b/tests/Opc.Ua.Server.Tests/StateMachines/StateMachineBuilderTransitionNodeTests.cs
@@ -101,6 +101,32 @@ namespace Opc.Ua.Server.Tests.StateMachines
         }
 
         [Test]
+        public void StateNodesCarryTheInverseFromAndToStateReferences()
+        {
+            FluentFiniteStateMachineState sm = Build().StateMachine;
+
+            // Inverse-browsing FromState/ToState from a state node is
+            // how a §B.4 client discovers the state's transitions.
+            Assert.Multiple(() =>
+            {
+                Assert.That(
+                    InverseTargets(GetChild(sm, "Off"), ReferenceTypeIds.FromState),
+                    Is.EqualTo(new[] { GetChild(sm, "OffToOn").NodeId }));
+                Assert.That(
+                    InverseTargets(GetChild(sm, "On"), ReferenceTypeIds.ToState),
+                    Is.EqualTo(new[] { GetChild(sm, "OffToOn").NodeId }));
+            });
+        }
+
+        private NodeId[] InverseTargets(BaseInstanceState node, NodeId referenceTypeId)
+        {
+            var references = new List<IReference>();
+            node.GetReferences(m_context, references, referenceTypeId, true);
+            return [.. references.Select(r =>
+                ExpandedNodeId.ToNodeId(r.TargetId, m_context.NamespaceUris))];
+        }
+
+        [Test]
         public void HasEffectFollowsTheTransitionDeclaration()
         {
             FluentFiniteStateMachineState sm = StateMachineTestFixtures
@@ -216,6 +242,16 @@ namespace Opc.Ua.Server.Tests.StateMachines
                 // The cause only maps to transition 10.
                 Assert.That(Targets(GetChild(sm, "OnToOff"), ReferenceTypeIds.HasCause),
                     Is.Empty);
+
+                // ... and the method carries the inverse edge, so
+                // inverse-browsing HasCause from the method finds the
+                // transition it triggers.
+                var inverse = new List<IReference>();
+                start.GetReferences(
+                    m_context, inverse, ReferenceTypeIds.HasCause, true);
+                Assert.That(inverse, Has.Count.EqualTo(1));
+                Assert.That(inverse[0].TargetId,
+                    Is.EqualTo((ExpandedNodeId)GetChild(sm, "OffToOn").NodeId));
             });
         }
 

--- a/tests/Opc.Ua.Server.Tests/StateMachines/StateMachineBuilderTransitionNodeTests.cs
+++ b/tests/Opc.Ua.Server.Tests/StateMachines/StateMachineBuilderTransitionNodeTests.cs
@@ -37,7 +37,7 @@ namespace Opc.Ua.Server.Tests.StateMachines
     /// <summary>
     /// Unit tests for the <c>TransitionType</c> nodes that
     /// <see cref="FluentFiniteStateMachineState"/> materializes for its
-    /// declared transitions — the Part 16 §B.4 counterpart to the
+    /// declared transitions — the Part 16 §4.4.11 counterpart to the
     /// <c>StateType</c> nodes, which makes <c>LastTransition/Id</c>
     /// resolve to a real node and populates <c>AvailableTransitions</c>.
     /// </summary>
@@ -106,7 +106,7 @@ namespace Opc.Ua.Server.Tests.StateMachines
             FluentFiniteStateMachineState sm = Build().StateMachine;
 
             // Inverse-browsing FromState/ToState from a state node is
-            // how a §B.4 client discovers the state's transitions.
+            // how a §4.4.11 client discovers the state's transitions.
             Assert.Multiple(() =>
             {
                 Assert.That(

--- a/tests/Opc.Ua.Server.Tests/StateMachines/StateMachineBuilderTransitionNodeTests.cs
+++ b/tests/Opc.Ua.Server.Tests/StateMachines/StateMachineBuilderTransitionNodeTests.cs
@@ -1,0 +1,256 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using Opc.Ua.Server.StateMachines;
+
+namespace Opc.Ua.Server.Tests.StateMachines
+{
+    /// <summary>
+    /// Unit tests for the <c>TransitionType</c> nodes that
+    /// <see cref="FluentFiniteStateMachineState"/> materializes for its
+    /// declared transitions — the Part 16 §B.4 counterpart to the
+    /// <c>StateType</c> nodes, which makes <c>LastTransition/Id</c>
+    /// resolve to a real node and populates <c>AvailableTransitions</c>.
+    /// </summary>
+    [TestFixture]
+    [Category("Server")]
+    [Category("StateMachines")]
+    [Parallelizable]
+    public sealed class StateMachineBuilderTransitionNodeTests
+    {
+        private ServerSystemContext m_context = null!;
+
+        [SetUp]
+        public void SetUp()
+        {
+            m_context = StateMachineTestFixtures.CreateContext();
+        }
+
+        [Test]
+        public void EveryDeclaredTransitionGetsATransitionTypeNode()
+        {
+            FluentFiniteStateMachineState sm = Build().StateMachine;
+
+            var offToOn = (BaseObjectState)GetChild(sm, "OffToOn");
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(offToOn.TypeDefinitionId,
+                    Is.EqualTo(ObjectTypeIds.TransitionType));
+                Assert.That(offToOn.ReferenceTypeId,
+                    Is.EqualTo(ReferenceTypeIds.HasComponent));
+                Assert.That(GetChild(sm, "OnToOff"), Is.Not.Null);
+            });
+        }
+
+        [Test]
+        public void TransitionNodeCarriesTransitionNumberProperty()
+        {
+            FluentFiniteStateMachineState sm = Build().StateMachine;
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(TransitionNumber(sm, "OffToOn"), Is.EqualTo(10u));
+                Assert.That(TransitionNumber(sm, "OnToOff"), Is.EqualTo(20u));
+            });
+        }
+
+        [Test]
+        public void TransitionNodeLinksItsFromAndToStates()
+        {
+            FluentFiniteStateMachineState sm = Build().StateMachine;
+
+            BaseInstanceState offToOn = GetChild(sm, "OffToOn");
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(Targets(offToOn, ReferenceTypeIds.FromState),
+                    Is.EqualTo(new[] { GetChild(sm, "Off").NodeId }));
+                Assert.That(Targets(offToOn, ReferenceTypeIds.ToState),
+                    Is.EqualTo(new[] { GetChild(sm, "On").NodeId }));
+            });
+        }
+
+        [Test]
+        public void HasEffectFollowsTheTransitionDeclaration()
+        {
+            FluentFiniteStateMachineState sm = StateMachineTestFixtures
+                .NewBuilder(m_context)
+                .AddState(1, "Off", isInitial: true)
+                .AddState(2, "On")
+                .AddTransition(10, "OffToOn", from: 1, to: 2)
+                .AddTransition(20, "OnToOff", from: 2, to: 1, hasEffect: false)
+                .StateMachine;
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(
+                    Targets(GetChild(sm, "OffToOn"), ReferenceTypeIds.HasEffect),
+                    Is.EqualTo(new[] { ObjectTypeIds.TransitionEventType }));
+                Assert.That(
+                    Targets(GetChild(sm, "OnToOff"), ReferenceTypeIds.HasEffect),
+                    Is.Empty);
+            });
+        }
+
+        [Test]
+        public void LastTransitionIsMaterializedAlongsideTheTransitions()
+        {
+            FluentFiniteStateMachineState sm = Build().StateMachine;
+
+            // Optional on FiniteStateMachineType, so nothing creates it
+            // by default — but without it the base class has nowhere to
+            // record a transition and clients have nothing to observe.
+            Assert.That(sm.LastTransition, Is.Not.Null);
+            Assert.That(sm.LastTransition!.BrowseName,
+                Is.EqualTo(new QualifiedName(BrowseNames.LastTransition)));
+        }
+
+        [Test]
+        public void LastTransitionIdResolvesToTheMaterializedNode()
+        {
+            FluentFiniteStateMachineState sm = Build()
+                .WithInitialState(1)
+                .StateMachine;
+
+            sm.DoTransition(m_context, 10, 0, default, []);
+
+            Assert.That(sm.LastTransition!.Id!.Value,
+                Is.EqualTo(GetChild(sm, "OffToOn").NodeId));
+        }
+
+        [Test]
+        public void GetTransitionIdRoundTripsThroughGetTransitionNodeId()
+        {
+            FluentFiniteStateMachineState sm = Build().StateMachine;
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(sm.GetTransitionId(sm.GetTransitionNodeId(10)),
+                    Is.EqualTo(10u));
+                Assert.That(sm.GetTransitionId(sm.GetTransitionNodeId(20)),
+                    Is.EqualTo(20u));
+                Assert.That(sm.GetTransitionId(new NodeId("nonsense", 1)), Is.Zero);
+            });
+        }
+
+        [Test]
+        public void AvailableTransitionsListsTheMaterializedTransitionNodes()
+        {
+            FluentFiniteStateMachineState sm = Build().StateMachine;
+
+            Assert.That(sm.AvailableTransitions, Is.Not.Null);
+            NodeId[] published = [.. sm.AvailableTransitions!.Value];
+
+            Assert.That(published, Is.EqualTo(new[]
+            {
+                GetChild(sm, "OffToOn").NodeId,
+                GetChild(sm, "OnToOff").NodeId
+            }));
+
+            // The standard NodeSet models AvailableTransitions as a
+            // HasComponent BaseDataVariable, and that is the reference
+            // type GetAvailableTransitionsAsync translates the path with.
+            Assert.That(sm.AvailableTransitions.ReferenceTypeId,
+                Is.EqualTo(ReferenceTypeIds.HasComponent));
+            Assert.That(sm.AvailableTransitions.BrowseName,
+                Is.EqualTo(new QualifiedName(BrowseNames.AvailableTransitions)));
+        }
+
+        [Test]
+        public void WithCauseLinksTheMethodToEveryTransitionItTriggers()
+        {
+            var methodNodeId = new NodeId(7001u, 1);
+
+            StateMachineBuilder<FluentFiniteStateMachineState> builder = Build();
+            FluentFiniteStateMachineState sm = builder.StateMachine;
+
+            // A cause method has to be a child of the machine before
+            // WithCause can resolve it.
+            var start = new MethodState(sm)
+            {
+                ReferenceTypeId = ReferenceTypeIds.HasComponent,
+                NodeId = methodNodeId,
+                BrowseName = new QualifiedName("Start", 1),
+                DisplayName = new LocalizedText("Start"),
+                Executable = true,
+                UserExecutable = true
+            };
+            sm.AddChild(start);
+
+            builder.WithCause(methodNodeId);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(Targets(GetChild(sm, "OffToOn"), ReferenceTypeIds.HasCause),
+                    Is.EqualTo(new[] { methodNodeId }));
+                // The cause only maps to transition 10.
+                Assert.That(Targets(GetChild(sm, "OnToOff"), ReferenceTypeIds.HasCause),
+                    Is.Empty);
+            });
+        }
+
+        private StateMachineBuilder<FluentFiniteStateMachineState> Build()
+        {
+            return StateMachineTestFixtures.NewBuilder(m_context)
+                .AddState(1, "Off", isInitial: true)
+                .AddState(2, "On")
+                .AddTransition(10, "OffToOn", from: 1, to: 2)
+                .AddTransition(20, "OnToOff", from: 2, to: 1)
+                .OnCause(7001, from: 1, transition: 10);
+        }
+
+        private BaseInstanceState GetChild(NodeState parent, string browseName)
+        {
+            var children = new List<BaseInstanceState>();
+            parent.GetChildren(m_context, children);
+            return children.Find(c => c.BrowseName.Name == browseName)!;
+        }
+
+        private NodeId[] Targets(BaseInstanceState node, NodeId referenceTypeId)
+        {
+            var references = new List<IReference>();
+            node.GetReferences(m_context, references, referenceTypeId, false);
+            return [.. references.Select(r =>
+                ExpandedNodeId.ToNodeId(r.TargetId, m_context.NamespaceUris))];
+        }
+
+        private uint TransitionNumber(NodeState sm, string transitionBrowseName)
+        {
+            var properties = new List<BaseInstanceState>();
+            GetChild(sm, transitionBrowseName).GetChildren(m_context, properties);
+            var number = (PropertyState<uint>)properties
+                .First(p => p.BrowseName.Name == BrowseNames.TransitionNumber);
+            return number.Value;
+        }
+    }
+}

--- a/tests/Opc.Ua.SourceGeneration.Core.Tests/CompilerUtils.cs
+++ b/tests/Opc.Ua.SourceGeneration.Core.Tests/CompilerUtils.cs
@@ -1084,6 +1084,7 @@ namespace Opc.Ua.SourceGeneration
                 public class FiniteStateMachineState : BaseObjectState
                 {
                     public FiniteStateMachineState(NodeState? parent) : base(parent) { }
+                    protected virtual string ElementNamespaceUri => "http://opcfoundation.org/UA/";
                     public void CreateOrReplaceCurrentState(
                         ISystemContext context, BaseInstanceState? replacement, bool assignInstanceNodeIds = true) { }
                 }

--- a/tests/Opc.Ua.SourceGeneration.Core.Tests/Generators/NodeStateGeneratorTests.cs
+++ b/tests/Opc.Ua.SourceGeneration.Core.Tests/Generators/NodeStateGeneratorTests.cs
@@ -144,6 +144,175 @@ namespace Opc.Ua.SourceGeneration.Generator.Tests
         }
 
         /// <summary>
+        /// A subtype that declares its own state elements reports the
+        /// namespace of its declaring model.
+        /// </summary>
+        [TestCase("StateType")]
+        [TestCase("InitialStateType")]
+        [TestCase("TransitionType")]
+        public void FindElementNamespaceUriUsesTheDeclaringTypesNamespace(
+            string elementTypeName)
+        {
+            const string vendorNs = "http://vendor.test/UA/";
+            ObjectTypeDesign machine = CreateFsmSubtype(
+                vendorNs, DeclareElement(elementTypeName));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(
+                    NodeStateGenerator.IsFiniteStateMachineSubtype(machine),
+                    Is.True);
+                Assert.That(
+                    NodeStateGenerator.FindElementNamespaceUri(machine),
+                    Is.EqualTo(vendorNs));
+            });
+        }
+
+        /// <summary>
+        /// A behaviour-only subtype inherits its elements — and their
+        /// namespace — from the nearest base that declares them.
+        /// </summary>
+        [Test]
+        public void FindElementNamespaceUriWalksUpToTheDeclaringBase()
+        {
+            const string baseNs = "http://base.test/UA/";
+            const string derivedNs = "http://derived.test/UA/";
+            ObjectTypeDesign baseMachine = CreateFsmSubtype(
+                baseNs, DeclareElement("StateType"));
+            var derived = new ObjectTypeDesign
+            {
+                SymbolicName = new System.Xml.XmlQualifiedName(
+                    "DerivedMachineType", derivedNs),
+                BaseTypeNode = baseMachine
+            };
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(
+                    NodeStateGenerator.IsFiniteStateMachineSubtype(derived),
+                    Is.True);
+                Assert.That(
+                    NodeStateGenerator.FindElementNamespaceUri(derived),
+                    Is.EqualTo(baseNs));
+            });
+        }
+
+        /// <summary>
+        /// A subtype whose elements are declared by the standard model
+        /// resolves to the OPC UA namespace — for which no override is
+        /// emitted, because the base class already returns it.
+        /// </summary>
+        [Test]
+        public void FindElementNamespaceUriResolvesInheritedStandardElements()
+        {
+            ObjectTypeDesign standardMachine = CreateFsmSubtype(
+                Types.Namespaces.OpcUa, DeclareElement("StateType"));
+            var vendorSubtype = new ObjectTypeDesign
+            {
+                SymbolicName = new System.Xml.XmlQualifiedName(
+                    "VendorProgramType", "http://vendor.test/UA/"),
+                BaseTypeNode = standardMachine
+            };
+
+            Assert.That(
+                NodeStateGenerator.FindElementNamespaceUri(vendorSubtype),
+                Is.EqualTo(Types.Namespaces.OpcUa));
+        }
+
+        /// <summary>
+        /// Types outside the FiniteStateMachineType hierarchy get no
+        /// override, and a hierarchy with no declared elements resolves
+        /// to nothing.
+        /// </summary>
+        [Test]
+        public void FindElementNamespaceUriIgnoresNonStateMachineTypes()
+        {
+            var plainType = new ObjectTypeDesign
+            {
+                SymbolicName = new System.Xml.XmlQualifiedName(
+                    "PlainType", "http://vendor.test/UA/")
+            };
+            ObjectTypeDesign elementFreeMachine = CreateFsmSubtype(
+                "http://vendor.test/UA/", children: null);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(
+                    NodeStateGenerator.IsFiniteStateMachineSubtype(plainType),
+                    Is.False);
+                Assert.That(
+                    NodeStateGenerator.IsFiniteStateMachineSubtype(elementFreeMachine),
+                    Is.True);
+                Assert.That(
+                    NodeStateGenerator.FindElementNamespaceUri(elementFreeMachine),
+                    Is.Null);
+            });
+        }
+
+        /// <summary>
+        /// A subtype that merely re-declares an inherited state (to
+        /// attach a description or modelling rule) is not the type that
+        /// declares the elements — the namespace walk must continue to
+        /// its base.
+        /// </summary>
+        [Test]
+        public void FindElementNamespaceUriSkipsOverriddenElements()
+        {
+            const string baseNs = "http://base.test/UA/";
+            ObjectTypeDesign baseMachine = CreateFsmSubtype(
+                baseNs, DeclareElement("StateType"));
+            ObjectDesign overriddenState = DeclareElement("StateType");
+            overriddenState.OveriddenNode = DeclareElement("StateType");
+            var derived = new ObjectTypeDesign
+            {
+                SymbolicName = new System.Xml.XmlQualifiedName(
+                    "OverridingMachineType", "http://derived.test/UA/"),
+                BaseTypeNode = baseMachine,
+                Children = new ListOfChildren { Items = [overriddenState] }
+            };
+
+            Assert.That(
+                NodeStateGenerator.FindElementNamespaceUri(derived),
+                Is.EqualTo(baseNs));
+        }
+
+        /// <summary>
+        /// Builds a subtype of the standard FiniteStateMachineType in
+        /// <paramref name="namespaceUri"/>, optionally declaring
+        /// state-machine element children.
+        /// </summary>
+        private static ObjectTypeDesign CreateFsmSubtype(
+            string namespaceUri,
+            params InstanceDesign[] children)
+        {
+            var fsmRoot = new ObjectTypeDesign
+            {
+                SymbolicName = new System.Xml.XmlQualifiedName(
+                    "FiniteStateMachineType", Types.Namespaces.OpcUa)
+            };
+            return new ObjectTypeDesign
+            {
+                SymbolicName = new System.Xml.XmlQualifiedName(
+                    "TestMachineType", namespaceUri),
+                BaseTypeNode = fsmRoot,
+                Children = children == null || children.Length == 0
+                    ? null
+                    : new ListOfChildren { Items = children }
+            };
+        }
+
+        private static ObjectDesign DeclareElement(string elementTypeName)
+        {
+            return new ObjectDesign
+            {
+                SymbolicName = new System.Xml.XmlQualifiedName(
+                    "SomeElement", "http://vendor.test/UA/"),
+                TypeDefinition = new System.Xml.XmlQualifiedName(
+                    elementTypeName, Types.Namespaces.OpcUa)
+            };
+        }
+
+        /// <summary>
         /// Tests that Emit returns early without creating files when no node state classes exist.
         /// </summary>
         [Test]

--- a/tools/Opc.Ua.SourceGeneration.Core/Generators/NodeStateGenerator.cs
+++ b/tools/Opc.Ua.SourceGeneration.Core/Generators/NodeStateGenerator.cs
@@ -2119,14 +2119,14 @@ namespace Opc.Ua.SourceGeneration
         /// is not necessarily the machine's own namespace: a subtype
         /// that adds no states of its own keeps reporting the base
         /// type's, and the base class default (the OPC UA namespace) is
-        /// then already right. Returns an empty string for every other
-        /// object type.
+        /// then already right. Returns <c>null</c> (collapsing the
+        /// template line) for every other object type.
         /// </summary>
         private string BuildElementNamespaceOverride(ObjectTypeDesign objectType)
         {
             if (!IsFiniteStateMachineSubtype(objectType))
             {
-                return string.Empty;
+                return null;
             }
 
             string namespaceUri = FindElementNamespaceUri(objectType);
@@ -2134,14 +2134,39 @@ namespace Opc.Ua.SourceGeneration
                 namespaceUri == Namespaces.OpcUa)
             {
                 // The base class already returns the OPC UA namespace.
-                return string.Empty;
+                return null;
             }
 
-            string constant = m_context.ModelDesign.Namespaces
-                .GetConstantSymbolForNamespace(namespaceUri);
+            string constant;
+            try
+            {
+                constant = m_context.ModelDesign.Namespaces
+                    .GetConstantSymbolForNamespace(namespaceUri);
+            }
+            catch (ArgumentException e)
+            {
+                // A namespace entry with a URI but no Name — surface it
+                // instead of failing the whole generation for a
+                // diagnostic-only feature.
+                m_logger.LogWarning(
+                    "Cannot emit ElementNamespaceUri for {Type}: {Error}",
+                    objectType.SymbolicName?.Name,
+                    e.Message);
+                return null;
+            }
             if (string.IsNullOrEmpty(constant))
             {
-                return string.Empty;
+                // Failing open here means the machine keeps the base
+                // default (the OPC UA namespace) and its element ids
+                // land in namespace 0 — say so rather than being silent.
+                m_logger.LogWarning(
+                    "No namespace constant for '{Uri}' — {Type} will " +
+                    "qualify its state and transition ids with the OPC " +
+                    "UA namespace. Add the declaring model to the " +
+                    "design's <Namespaces> to fix this.",
+                    namespaceUri,
+                    objectType.SymbolicName?.Name);
+                return null;
             }
 
             return CoreUtils.Format(
@@ -2157,7 +2182,7 @@ namespace Opc.Ua.SourceGeneration
         /// children. A subtype that only adds behaviour inherits its
         /// elements — and therefore their namespace — from its base.
         /// </summary>
-        private static string FindElementNamespaceUri(ObjectTypeDesign objectType)
+        internal static string FindElementNamespaceUri(ObjectTypeDesign objectType)
         {
             TypeDesign current = objectType;
             while (current != null)
@@ -2171,7 +2196,7 @@ namespace Opc.Ua.SourceGeneration
             return null;
         }
 
-        private static bool DeclaresStateMachineElements(TypeDesign type)
+        internal static bool DeclaresStateMachineElements(TypeDesign type)
         {
             InstanceDesign[] children = type.Children?.Items;
             if (children == null)
@@ -2189,6 +2214,14 @@ namespace Opc.Ua.SourceGeneration
                 {
                     continue;
                 }
+                if (childObject.OveriddenNode != null)
+                {
+                    // Re-declaring an inherited state (to attach a
+                    // description, a modelling rule, ...) does not make
+                    // this type the one that declares the elements —
+                    // the ids still live in the base model's namespace.
+                    continue;
+                }
                 string typeDefName = childObject.TypeDefinition.Name;
                 if (string.Equals(typeDefName, kStateTypeName, StringComparison.Ordinal) ||
                     string.Equals(typeDefName, kInitialStateTypeName, StringComparison.Ordinal) ||
@@ -2204,7 +2237,7 @@ namespace Opc.Ua.SourceGeneration
         /// Whether the type derives, however indirectly, from the
         /// standard <c>FiniteStateMachineType</c>.
         /// </summary>
-        private static bool IsFiniteStateMachineSubtype(ObjectTypeDesign objectType)
+        internal static bool IsFiniteStateMachineSubtype(ObjectTypeDesign objectType)
         {
             TypeDesign current = objectType;
             while (current != null)

--- a/tools/Opc.Ua.SourceGeneration.Core/Generators/NodeStateGenerator.cs
+++ b/tools/Opc.Ua.SourceGeneration.Core/Generators/NodeStateGenerator.cs
@@ -2105,7 +2105,130 @@ namespace Opc.Ua.SourceGeneration
             context.Template.AddReplacement(Tokens.IsAbstract, objectType.IsAbstract);
             context.Template.AddReplacement(Tokens.EventNotifier,
                 objectType.GetEventNotifierAsCode());
+            context.Template.AddReplacement(
+                Tokens.ElementNamespaceOverride,
+                BuildElementNamespaceOverride(objectType));
         }
+
+        /// <summary>
+        /// Emits the <c>ElementNamespaceUri</c> override for
+        /// <c>FiniteStateMachineType</c> subtypes. Part 5 qualifies the
+        /// numeric state and transition NodeIds a machine reports in
+        /// <c>CurrentState/Id</c> and <c>LastTransition/Id</c> with the
+        /// namespace of the model that declares those elements — which
+        /// is not necessarily the machine's own namespace: a subtype
+        /// that adds no states of its own keeps reporting the base
+        /// type's, and the base class default (the OPC UA namespace) is
+        /// then already right. Returns an empty string for every other
+        /// object type.
+        /// </summary>
+        private string BuildElementNamespaceOverride(ObjectTypeDesign objectType)
+        {
+            if (!IsFiniteStateMachineSubtype(objectType))
+            {
+                return string.Empty;
+            }
+
+            string namespaceUri = FindElementNamespaceUri(objectType);
+            if (string.IsNullOrEmpty(namespaceUri) ||
+                namespaceUri == Namespaces.OpcUa)
+            {
+                // The base class already returns the OPC UA namespace.
+                return string.Empty;
+            }
+
+            string constant = m_context.ModelDesign.Namespaces
+                .GetConstantSymbolForNamespace(namespaceUri);
+            if (string.IsNullOrEmpty(constant))
+            {
+                return string.Empty;
+            }
+
+            return CoreUtils.Format(
+                "/// <inheritdoc/>{0}" +
+                "        protected override string ElementNamespaceUri => {1};",
+                Environment.NewLine,
+                constant);
+        }
+
+        /// <summary>
+        /// The namespace of the nearest type in the hierarchy that
+        /// actually declares <c>StateType</c> / <c>TransitionType</c>
+        /// children. A subtype that only adds behaviour inherits its
+        /// elements — and therefore their namespace — from its base.
+        /// </summary>
+        private static string FindElementNamespaceUri(ObjectTypeDesign objectType)
+        {
+            TypeDesign current = objectType;
+            while (current != null)
+            {
+                if (DeclaresStateMachineElements(current))
+                {
+                    return current.SymbolicName?.Namespace;
+                }
+                current = current.BaseTypeNode;
+            }
+            return null;
+        }
+
+        private static bool DeclaresStateMachineElements(TypeDesign type)
+        {
+            InstanceDesign[] children = type.Children?.Items;
+            if (children == null)
+            {
+                return false;
+            }
+            foreach (InstanceDesign child in children)
+            {
+                if (child is not ObjectDesign childObject ||
+                    childObject.TypeDefinition == null ||
+                    !string.Equals(
+                        childObject.TypeDefinition.Namespace,
+                        Namespaces.OpcUa,
+                        StringComparison.Ordinal))
+                {
+                    continue;
+                }
+                string typeDefName = childObject.TypeDefinition.Name;
+                if (string.Equals(typeDefName, kStateTypeName, StringComparison.Ordinal) ||
+                    string.Equals(typeDefName, kInitialStateTypeName, StringComparison.Ordinal) ||
+                    string.Equals(typeDefName, kTransitionTypeName, StringComparison.Ordinal))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Whether the type derives, however indirectly, from the
+        /// standard <c>FiniteStateMachineType</c>.
+        /// </summary>
+        private static bool IsFiniteStateMachineSubtype(ObjectTypeDesign objectType)
+        {
+            TypeDesign current = objectType;
+            while (current != null)
+            {
+                if (string.Equals(
+                        current.SymbolicName?.Name,
+                        kFiniteStateMachineTypeName,
+                        StringComparison.Ordinal) &&
+                    string.Equals(
+                        current.SymbolicName?.Namespace,
+                        Namespaces.OpcUa,
+                        StringComparison.Ordinal))
+                {
+                    return true;
+                }
+                current = current.BaseTypeNode;
+            }
+            return false;
+        }
+
+        private const string kFiniteStateMachineTypeName = "FiniteStateMachineType";
+        private const string kStateTypeName = "StateType";
+        private const string kInitialStateTypeName = "InitialStateType";
+        private const string kTransitionTypeName = "TransitionType";
 
         private void AddNodeStateClassMethodTypeReplacements(
             IWriteContext context,

--- a/tools/Opc.Ua.SourceGeneration.Core/Generators/NodeStateTemplates.cs
+++ b/tools/Opc.Ua.SourceGeneration.Core/Generators/NodeStateTemplates.cs
@@ -126,6 +126,8 @@ namespace Opc.Ua.SourceGeneration
                 {
                 }
 
+                {{Tokens.ElementNamespaceOverride}}
+
                 {{Tokens.ListOfProperties}}
 
                 {{Tokens.ListOfNonMandatoryChildren}}

--- a/tools/Opc.Ua.SourceGeneration.Core/Templating/Tokens.cs
+++ b/tools/Opc.Ua.SourceGeneration.Core/Templating/Tokens.cs
@@ -74,6 +74,7 @@ namespace Opc.Ua.SourceGeneration
         public static string EncodingMaskEncode => nameof(EncodingMaskEncode);
         public static string EncodingMaskDecode => nameof(EncodingMaskDecode);
         public static string EnumerationName => nameof(EnumerationName);
+        public static string ElementNamespaceOverride => nameof(ElementNamespaceOverride);
         public static string EventNotifier => nameof(EventNotifier);
         public static string FieldIndex => nameof(FieldIndex);
         public static string ExtraInterfaces => nameof(ExtraInterfaces);


### PR DESCRIPTION
# Description

Part 16 §B.3 places `HasSubStateMachine` on the parent **state** node, but the fluent builder attached it to the state-machine **root** because `FluentFiniteStateMachineState` never materialized state nodes at all. Investigating #3821 showed the gap was wider than the reference placement:

1. **No state nodes existed.** The NodeId written into `CurrentState/Id` — `new NodeId(stateId, ElementNamespaceIndex)` — was **dangling**: no node with that id was in the address space.
2. **`AvailableStates` was never populated**, so `GetAvailableStatesAsync` returned empty against a fluent-built server.
3. **The whole client discovery chain was therefore dead.** `ObserveEffectiveStateAsync` enumerates `AvailableStates` and browses `HasSubStateMachine` from each state node — it found nothing. The client side was already spec-correct; only the server deviated.
4. **`HasSubStateMachine` is non-hierarchical** (a subtype of `NonHierarchicalReferences`, `i=32`). Using it as the sub-SM's `BaseInstanceState.ReferenceTypeId` left the sub-SM unreachable from a hierarchical browse of the machine.

## What changed

**Element nodes are materialized.** Definition-mode machines now create one `StateType` node per declared state and one `TransitionType` node per declared transition — each a `HasComponent` child carrying `StateNumber` / `TransitionNumber`, with the §B.4 `FromState` / `ToState` / `HasEffect` references and `HasCause` added by `WithCause`. `AvailableStates`, `AvailableTransitions` and `LastTransition` are populated, so `CurrentState/Id` and `LastTransition/Id` resolve to real, browsable nodes. NodeIds are per-instance, so several machines built from one definition coexist.

**`HasSubStateMachine` moved to the state node**, with the inverse `SubStateMachineOf`, and the sub-SM is attached as a `HasComponent` child (fixing 4).

**Core gains element-id mapping hooks.** `GetCurrentStateId` / `UpdateStateVariable` / `UpdateTransitionVariable` hard-coded the numeric form and were non-virtual, so a subclass could not redirect them. They now route through `public virtual` `GetStateNodeId` / `GetStateId` / `GetTransitionNodeId` / `GetTransitionId`, whose defaults reproduce the previous `(elementId, ElementNamespaceIndex)` convention **exactly** — every stack-shipped and generator-emitted machine is unaffected, and there is a regression test asserting that.

**Generated machines report their model namespace.** The generator now emits an `ElementNamespaceUri` override on `FiniteStateMachineType` subtypes, taken from the nearest type that actually *declares* state children — a subtype that only adds behaviour inherits its elements, and their namespace, from its base.

**Ordering and validation fixes.** `WithSubStateMachine` and `WithInitialState` are now order-independent (previously, attaching a sub-SM before setting the initial state left the child suspended until the parent left and re-entered the state — silently). `WithSubStateMachine` validates `parentStateId`, and the builder rejects duplicate element browse names, since element NodeIds are now derived from them.

## A defect this surfaced

Code that assembles nodes with the generated `CreateInstanceOf<Type>` factories never calls `NodeState.CreateAsPredefinedNode`, so `OnBeforeCreate` / `OnAfterCreate` are skipped for the entire subtree — and `OnAfterCreate` is the only place a state machine resolves its element namespace. It is also where `ConditionState` binds its `Enable` / `Disable` / `AddComment` handlers and `AlarmConditionState` binds the shelving methods, so the impact is broader than state machines.

This PR fixes only the two call sites it depends on — DI's `SoftwareUpdateFacetWiring` and Robotics' `RoboticsOperationBuilder`. **The repository-wide audit is deliberately left out of scope and tracked in #4320** (24 files call these factories; none completed the lifecycle).

The Robotics regression had no test coverage at all, so an assertion on `CurrentState/Id` was added and verified to fail without the fix.

## Breaking changes

- Sub-state machines are **no longer browsable from the state-machine root**. Callers passing a machine's `ObjectId` to `GetSubStateMachineAsync` must pass a state NodeId instead — from `GetAvailableStatesAsync` or a snapshot's `CurrentStateId`.
- `CurrentState/Id` for fluent machines changes from the numeric form to the materialized node's id. Code reading a numeric id out of it should call `FiniteStateMachineState.GetStateId` rather than parsing the identifier.
- Generated machines qualify `CurrentState/Id` / `LastTransition/Id` with their companion-spec namespace instead of the OPC UA one.

Documented in `docs/WhatsNewIn2.0.md` and `docs/StateMachines.md`.

## Notes for reviewers

- Adding `virtual` to the `FiniteStateMachineState` members is a binary (not source) breaking change — assumed acceptable on the 2.0 line, but worth confirming against the compatibility policy.
- Address-space cost is one node plus one property per declared state and transition, per machine instance; called out in the docs for servers instantiating many machines.
- `AvailableTransitions` is modelled as a `HasComponent` `BaseDataVariable` (matching the standard NodeSet and what the client's browse path expects), not a Property.

## Related Issues

- Fixes #3821
- Surfaced #4320 (node create lifecycle audit — not addressed here)

## Checklist

- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf) and read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [x] I have added all necessary documentation.
- [x] I have verified that my changes do not introduce (new) build or analyzer warnings.
- [ ] I ran **all** tests locally using the **UA.slnx** solution against at least .net **framework** and .net **10**, and all passed.
- [ ] I fixed **all** failing and flaky tests in the CI pipelines and **all** CodeQL warnings.
- [ ] I have addressed **all** PR feedback received.

### Test runs (net10.0)

| Suite | Result |
|---|---|
| `Opc.Ua.Server.Tests` (full) | 4734 passed, 5 skipped |
| `Opc.Ua.SourceGeneration.Core.Tests` | 3780 passed |
| `Opc.Ua.SourceGeneration.Tests` | 132 passed |
| `Opc.Ua.SourceGeneration.Stack.Tests` | 94 passed |
| `Opc.Ua.Types.Tests` | 8763 passed |
| `Opc.Ua.Robotics.Tests` | 540 passed |
| `Opc.Ua.Robotics.Intent.Tests` | 22 passed |
| `Opc.Ua.Di.Tests` | 424 passed |
| `Opc.Ua.ISA95.Tests` | 136 passed |
| `Opc.Ua.Aas.Tests` | 670 passed |
| `Opc.Ua.Positioning.Tests` | 69 passed |
| `Opc.Ua.Client.Tests` (StateMachines) | 36 passed |

Only net10.0 was run locally; the .NET Framework leg is left to CI, hence the unchecked box above.
