### PR TITLE
Fluent: publish Configure-created nodes' references on foreign-manager nodes (Objects folder placement)

### DIFF
--- a/docs/NodeManagers.md
+++ b/docs/NodeManagers.md
@@ -44,6 +44,7 @@
     - [Project-wide opt-in via MSBuild property (legacy)](#project-wide-opt-in-via-msbuild-property-legacy)
   - [Wiring callbacks: the Configure partial](#wiring-callbacks-the-configure-partial)
     - [Addressing modes](#addressing-modes)
+    - [Creating nodes under other managers' nodes (Objects folder)](#creating-nodes-under-other-managers-nodes-objects-folder)
   - [Typed model-traversal — the Configure(I{Manager}NodeManagerBuilder) partial](#typed-model-traversal--the-configureimanagernodemanagerbuilder-partial)
     - [What the generator emits per model](#what-the-generator-emits-per-model)
     - [Methods with arguments — typed OnCall overloads](#methods-with-arguments--typed-oncall-overloads)
@@ -758,9 +759,13 @@ namespace (legacy MSBuild mode) or the user class's namespace
     `ValueTask<NodeStateCollection>`.
   - `CreateAddressSpaceAsync` `await`s `base.CreateAddressSpaceAsync`,
     then builds a fluent `INodeManagerBuilder`, invokes
-    `Configure(builder)`, calls `builder.Seal()`, and replays
-    `NotifyNodeAdded` for every predefined node so per-node lifecycle
-    hooks fire deterministically.
+    `Configure(builder)`, `await`s `CompleteConfigureAsync` (re-running
+    the reverse-reference pass so nodes created inside `Configure`
+    publish their references to nodes owned by other managers — e.g. an
+    inverse `Organizes` to the ns=0 `Objects` folder — into the
+    `externalReferences` dictionary), calls `builder.Seal()`, and
+    replays `NotifyNodeAdded` for every predefined node so per-node
+    lifecycle hooks fire deterministically.
   - `AddPredefinedNodeAsync` / `RemovePredefinedNodeAsync` overrides
     forward to base and then dispatch the lifecycle notification.
   - `OnMonitoredItemCreated` (still synchronous on the base) dispatches
@@ -825,6 +830,24 @@ or by file stem:
 
 Set `GenerateFactory = false` to suppress factory emission when you want
 to ship a hand-written `IAsyncNodeManagerFactory`.
+
+When the manager also owns namespaces beyond the model's own — most
+commonly a separate *instance* namespace for nodes created at runtime —
+declare them on the attribute:
+
+```csharp
+[NodeManager(
+    NamespaceUri = Namespaces.Boiler,
+    AdditionalNamespaceUris = new[] { Namespaces.Boiler + "Instance" })]
+```
+
+The generated constructor passes them to the base manager together with
+the model namespace and the generated factory advertises them in
+`NamespacesUris`, so the master node manager routes requests for those
+namespaces to this manager from the moment it is built. Calling
+`SetNamespaces` later is not sufficient — the master builds its
+namespace routing from what the manager reported when it was
+constructed.
 
 #### Project-wide opt-in via MSBuild property (legacy)
 
@@ -928,6 +951,47 @@ All resolution happens **once** during `CreateAddressSpaceAsync`,
 against the in-memory predefined-node tree. There is no reflection, no
 `Activator.CreateInstance`, no `Expression.Compile` — the whole pipeline
 is NativeAOT-safe.
+
+#### Creating nodes under other managers' nodes (Objects folder)
+
+Anything a NodeSet can declare, `Configure` can declare identically —
+including references whose target is owned by **another** node manager,
+such as the ns=0 `Objects` folder managed by the `CoreNodeManager`.
+Write the inverse reference on your node; after the `Configure`
+partials return, the manager re-runs its reverse-reference pass
+(`FluentNodeManagerBase.CompleteConfigureAsync`) and publishes the
+matching forward edge into the `externalReferences` dictionary that the
+master node manager distributes once every manager's address space is
+built.
+
+Two helpers make the common placement declarative, and a manager-level
+`CreateInstance<TState>` creates root-level (parentless) instances,
+materializing the subtree from the type model and minting NodeIds
+through the manager's `INodeIdFactory`:
+
+```csharp
+partial void Configure(INodeManagerBuilder builder)
+{
+    // Instantiate a second boiler at runtime and place it under the
+    // ns=0 Objects folder — no LoadPredefinedNodesAsync override, no
+    // manual externalReferences bookkeeping.
+    builder.CreateInstance(
+            new QualifiedName("Boiler #2", NamespaceIndexes[1]),
+            p => new BoilerState(p))
+        .Configure(n => n.UnderObjectsFolder());
+
+    // Arbitrary parents work the same way:
+    //   n.OrganizedBy(parentNodeId)
+    // adds the inverse Organizes reference; the forward edge reaches
+    // the owning manager automatically.
+}
+```
+
+Inverse `HasNotifier` references to external notifiers get root-notifier
+registration through the same pass. This covers **startup-time**
+configuration only — for nodes created after startup use
+`IMasterNodeManager.AddReferencesAsync`, which dispatches to the live
+owning manager.
 
 ### Typed model-traversal — the `Configure(I{Manager}NodeManagerBuilder)` partial
 
@@ -1419,6 +1483,13 @@ builder.Node("Pumps/Pump #1/Operational/MyGroup")
        .HasProperty(metadataNodeId);
 ```
 
+`INodeBuilder.OrganizedBy(parentId)` and `.UnderObjectsFolder()` add
+the *inverse* `Organizes` reference, placing the current node below an
+organizing parent. The parent may be owned by another node manager
+(e.g. the ns=0 `Objects` folder) — the forward edge is published
+automatically when `Configure` completes; see
+[Creating nodes under other managers' nodes](#creating-nodes-under-other-managers-nodes-objects-folder).
+
 `INodeBuilder.AddObject(browseName, typeDefinitionId)` synthesises a
 new `BaseObjectState` child under the current node and returns a typed
 builder for the new object. NodeIds follow the
@@ -1469,6 +1540,22 @@ subtree with the owning node manager. The same registration behaviour
 is used by the fluent state-machine creators, so generated instances
 created from a builder can be browsed, read, and monitored without a
 separate `AddPredefinedNodeAsync` call.
+
+For **root-level** instances (no parent node in this manager),
+`INodeManagerBuilder.CreateInstance<TState>(name, factory)` accepts a
+plain constructor-style factory (`p => new BoilerState(p)`, invoked
+with a `null` parent), fully materialises the instance from its type
+model, and mints per-instance NodeIds for the whole subtree through
+the manager's `INodeIdFactory`. Combine with `.UnderObjectsFolder()`
+(or `.OrganizedBy(parentId)`) to place the instance below a node owned
+by another manager:
+
+```csharp
+builder.CreateInstance(
+        new QualifiedName("Boiler #2", NamespaceIndexes[1]),
+        p => new BoilerState(p))
+    .Configure(n => n.UnderObjectsFolder());
+```
 
 #### Alarm setup (MVP)
 

--- a/src/Opc.Ua.Server/Fluent/FluentNodeManagerBase.cs
+++ b/src/Opc.Ua.Server/Fluent/FluentNodeManagerBase.cs
@@ -27,6 +27,7 @@
  * http://opcfoundation.org/License/MIT/1.00/
  * ======================================================================*/
 
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -226,6 +227,41 @@ namespace Opc.Ua.Server.Fluent
             }
             builder.AttachEventSources(EventSources);
             builder.AttachSimulations(Simulations);
+        }
+
+        /// <summary>
+        /// Re-runs the reverse-reference collection pass after the user's
+        /// <c>Configure</c> callbacks return so that nodes registered
+        /// during <c>Configure</c> publish their references to nodes
+        /// owned by other node managers (e.g. an inverse
+        /// <c>Organizes</c> reference to the Objects folder) into
+        /// <paramref name="externalReferences"/>, exactly like nodes
+        /// declared in a NodeSet do. Inverse <c>HasNotifier</c>
+        /// references to external notifiers additionally register the
+        /// source as a root notifier.
+        /// </summary>
+        /// <remarks>
+        /// The source-generated <c>CreateAddressSpaceAsync</c> and the
+        /// hosting <c>FluentNodeManager</c> invoke this once between the
+        /// <c>Configure</c> callbacks and <see cref="NodeManagerBuilder.Seal"/>;
+        /// hand-written managers that drive
+        /// <see cref="CreateFluentBuilder"/> themselves should do the
+        /// same. Timing is safe because the master node manager
+        /// distributes <paramref name="externalReferences"/> only after
+        /// every manager's <c>CreateAddressSpaceAsync</c> has returned.
+        /// The pass is idempotent, so running it after an earlier
+        /// <c>LoadPredefinedNodesAsync</c> sweep adds no duplicates.
+        /// </remarks>
+        /// <param name="externalReferences">
+        /// The dictionary of references to add to external targets that
+        /// was handed to <c>CreateAddressSpaceAsync</c>.
+        /// </param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        protected ValueTask CompleteConfigureAsync(
+            IDictionary<NodeId, IList<IReference>> externalReferences,
+            CancellationToken cancellationToken = default)
+        {
+            return AddReverseReferencesAsync(externalReferences, cancellationToken);
         }
 
         /// <summary>

--- a/src/Opc.Ua.Server/Fluent/InstanceCreationBuilderExtensions.cs
+++ b/src/Opc.Ua.Server/Fluent/InstanceCreationBuilderExtensions.cs
@@ -146,6 +146,108 @@ namespace Opc.Ua.Server.Fluent
 
             return new InstanceBuilder<TState>(parent, instance);
         }
+
+        /// <summary>
+        /// Creates a new root-level (parentless) instance of
+        /// <typeparamref name="TState"/> and registers it with the
+        /// owning node manager.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Unlike the parent-scoped
+        /// <see cref="CreateInstance{TState}(INodeBuilder, QualifiedName, Func{NodeState, TState})"/>,
+        /// this overload fully materializes the instance from its type
+        /// model (mandatory children, references, default values) via
+        /// <see cref="NodeState.Create(ISystemContext, NodeId, QualifiedName, LocalizedText, bool)"/>
+        /// and mints per-instance NodeIds for the whole subtree through
+        /// the manager's <see cref="INodeIdFactory"/>, so the factory
+        /// delegate should be a plain constructor call:
+        /// </para>
+        /// <code>
+        /// builder.CreateInstance(
+        ///         new QualifiedName("Boiler #2", instanceNamespaceIndex),
+        ///         p => new BoilerState(p))
+        ///     .Configure(n => n.UnderObjectsFolder());
+        /// </code>
+        /// <para>
+        /// Place the new instance below a node owned by another node
+        /// manager (e.g. the Objects folder) by adding an inverse
+        /// hierarchical reference — for example via
+        /// <see cref="ReferenceBuilderExtensions.UnderObjectsFolder(INodeBuilder)"/>
+        /// or <see cref="ReferenceBuilderExtensions.OrganizedBy(INodeBuilder, NodeId)"/>;
+        /// the forward edge is published to the owning manager at the
+        /// end of <c>Configure</c>.
+        /// </para>
+        /// </remarks>
+        /// <typeparam name="TState">Concrete instance state class.</typeparam>
+        /// <param name="builder">The owning node-manager builder.</param>
+        /// <param name="browseName">Browse name of the new instance.</param>
+        /// <param name="factory">
+        /// Factory that constructs the (uninitialized) state instance,
+        /// typically <c>p => new BoilerState(p)</c>. It receives
+        /// <see langword="null"/> as the parent.
+        /// </param>
+        /// <returns>A typed instance builder for further configuration.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="builder"/>, <paramref name="browseName"/>, or
+        /// <paramref name="factory"/> is <c>null</c>.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        /// The builder's context does not supply an
+        /// <see cref="INodeIdFactory"/> to mint instance NodeIds.
+        /// </exception>
+        /// <exception cref="ServiceResultException">
+        /// The factory returned <c>null</c>.
+        /// </exception>
+        public static IInstanceBuilder<TState> CreateInstance<TState>(
+            this INodeManagerBuilder builder,
+            QualifiedName browseName,
+            Func<NodeState?, TState> factory)
+            where TState : BaseInstanceState
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+            if (browseName.IsNull)
+            {
+                throw new ArgumentNullException(nameof(browseName));
+            }
+            if (factory == null)
+            {
+                throw new ArgumentNullException(nameof(factory));
+            }
+
+            // Fail fast: without a NodeIdFactory the subtree would keep
+            // its type-declaration NodeIds and collide with the type
+            // model on registration.
+            builder.Context.RequireNodeIdFactory();
+
+            TState instance = factory(null) ??
+                throw ServiceResultException.Create(
+                    StatusCodes.BadInvalidArgument,
+                    "Factory returned null for instance '{0}'.",
+                    browseName);
+
+            // Materialize the subtree from the type model. The children
+            // carry type-declaration NodeIds at this point.
+            instance.Create(
+                builder.Context,
+                NodeId.Null,
+                browseName,
+                displayName: default,
+                assignNodeIds: false);
+
+            // Rebase the whole subtree onto per-instance NodeIds minted
+            // by the manager's INodeIdFactory (same pass the generated
+            // CreateXxx(parent, browseName) factories run).
+            NodeId previousNodeId = builder.Context.AssignInstanceNodeId(instance);
+            builder.Context.AssignInstanceChildNodeIds(instance, previousNodeId);
+
+            FluentNodeRegistration.RegisterCreatedNode(builder, instance);
+
+            return new InstanceBuilder<TState>(builder, instance);
+        }
     }
 
     /// <summary>
@@ -162,7 +264,11 @@ namespace Opc.Ua.Server.Fluent
         TState Node { get; }
 
         /// <summary>
-        /// The owning parent builder.
+        /// The owning parent builder. For a root-level instance created
+        /// via the manager-scoped
+        /// <see cref="InstanceCreationBuilderExtensions.CreateInstance{TState}(INodeManagerBuilder, QualifiedName, Func{NodeState, TState})"/>
+        /// overload there is no parent node, so this is a builder view
+        /// of the instance itself.
         /// </summary>
         INodeBuilder Parent { get; }
 
@@ -186,6 +292,8 @@ namespace Opc.Ua.Server.Fluent
 
         /// <summary>
         /// Returns control to the parent builder for further chaining.
+        /// For a root-level instance this is a builder view of the
+        /// instance itself; see <see cref="Parent"/>.
         /// </summary>
         INodeBuilder Done();
     }
@@ -204,6 +312,21 @@ namespace Opc.Ua.Server.Fluent
         {
             Parent = parent ?? throw new ArgumentNullException(nameof(parent));
             Node = node ?? throw new ArgumentNullException(nameof(node));
+        }
+
+        /// <summary>
+        /// Root-level (parentless) variant: the instance was created at
+        /// manager scope, so <see cref="Parent"/> is a builder view of
+        /// the instance itself.
+        /// </summary>
+        public InstanceBuilder(INodeManagerBuilder owner, TState node)
+        {
+            if (owner == null)
+            {
+                throw new ArgumentNullException(nameof(owner));
+            }
+            Node = node ?? throw new ArgumentNullException(nameof(node));
+            Parent = new AdHocInstanceNodeBuilder<TState>(owner, node);
         }
 
         public TState Node { get; }

--- a/src/Opc.Ua.Server/Fluent/NodeManagerAttribute.cs
+++ b/src/Opc.Ua.Server/Fluent/NodeManagerAttribute.cs
@@ -82,5 +82,22 @@ namespace Opc.Ua.Server.Fluent
         /// author the factory by hand.
         /// </summary>
         public bool GenerateFactory { get; set; } = true;
+
+        /// <summary>
+        /// Additional namespace URIs the manager owns beyond the model's
+        /// own namespace — typically a separate instance namespace (e.g.
+        /// <c>"http://opcfoundation.org/UA/Boiler/Instance"</c>).
+        /// </summary>
+        /// <remarks>
+        /// The generated constructor passes these to the base node
+        /// manager together with the model namespace, so the master node
+        /// manager routes requests for them to this manager from the
+        /// moment it is built. Reporting an extra namespace later via
+        /// <c>SetNamespaces</c> is not sufficient, because the master
+        /// builds its namespace routing from what the manager reported
+        /// at construction. The generated factory advertises the same
+        /// set through <c>NamespacesUris</c>.
+        /// </remarks>
+        public string[] AdditionalNamespaceUris { get; set; } = null!;
     }
 }

--- a/src/Opc.Ua.Server/Fluent/ReferenceBuilderExtensions.cs
+++ b/src/Opc.Ua.Server/Fluent/ReferenceBuilderExtensions.cs
@@ -42,6 +42,11 @@ namespace Opc.Ua.Server.Fluent
     ///   <item><description><see cref="Organizes(INodeBuilder, NodeId)"/>
     ///     — adds an <c>Organizes</c> reference (DI uses this to gather
     ///     unrelated variables under a FunctionalGroup).</description></item>
+    ///   <item><description><see cref="OrganizedBy(INodeBuilder, NodeId)"/>
+    ///     / <see cref="UnderObjectsFolder(INodeBuilder)"/>
+    ///     — the inverse direction: places the node under an organizing
+    ///     parent, including parents owned by another node manager such
+    ///     as the Objects folder.</description></item>
     ///   <item><description><see cref="HasComponent(INodeBuilder, NodeId)"/>
     ///     / <see cref="HasProperty(INodeBuilder, NodeId)"/>
     ///     — common hierarchical references.</description></item>
@@ -92,6 +97,46 @@ namespace Opc.Ua.Server.Fluent
                 throw new ArgumentNullException(nameof(target));
             }
             return builder.Organizes(target.NodeId);
+        }
+
+        /// <summary>
+        /// Adds an inverse <see cref="ReferenceTypeIds.Organizes"/>
+        /// reference from the current node to
+        /// <paramref name="parentId"/>, declaring that the node is
+        /// organized by that parent.
+        /// </summary>
+        /// <remarks>
+        /// When the parent is owned by another node manager (e.g. the
+        /// Objects folder managed by the CoreNodeManager), the matching
+        /// forward reference is published automatically at the end of
+        /// <c>Configure</c> by the
+        /// <c>FluentNodeManagerBase.CompleteConfigureAsync</c> pass —
+        /// the same mechanism that places NodeSet-declared nodes.
+        /// </remarks>
+        /// <param name="builder">The owning node builder.</param>
+        /// <param name="parentId">NodeId of the organizing parent.</param>
+        /// <returns>The same builder, for chaining.</returns>
+        public static INodeBuilder OrganizedBy(
+            this INodeBuilder builder,
+            NodeId parentId)
+        {
+            return builder.AddReference(ReferenceTypeIds.Organizes, isInverse: true, parentId);
+        }
+
+        /// <summary>
+        /// Places the current node under the standard Objects folder by
+        /// adding an inverse <see cref="ReferenceTypeIds.Organizes"/>
+        /// reference to <see cref="ObjectIds.ObjectsFolder"/>. Shorthand
+        /// for <c>OrganizedBy(ObjectIds.ObjectsFolder)</c>; see
+        /// <see cref="OrganizedBy(INodeBuilder, NodeId)"/> for how the
+        /// forward edge reaches the CoreNodeManager.
+        /// </summary>
+        /// <param name="builder">The owning node builder.</param>
+        /// <returns>The same builder, for chaining.</returns>
+        public static INodeBuilder UnderObjectsFolder(
+            this INodeBuilder builder)
+        {
+            return builder.OrganizedBy(ObjectIds.ObjectsFolder);
         }
 
         /// <summary>

--- a/src/Opc.Ua.Server/Hosting/FluentNodeManagerFactory.cs
+++ b/src/Opc.Ua.Server/Hosting/FluentNodeManagerFactory.cs
@@ -96,15 +96,20 @@ namespace Opc.Ua.Server.Hosting
                 throw new ArgumentNullException(nameof(externalReferences));
             }
             ushort namespaceIndex = (ushort)m_server.NamespaceUris.GetIndex(m_namespaceUri);
+
+            // The root folder's inverse Organizes reference to the Objects
+            // folder is mirrored into externalReferences by the
+            // CompleteConfigureAsync pass below.
             FolderState root = CreateRootFolder(namespaceIndex);
-            if (!externalReferences.TryGetValue(ObjectIds.ObjectsFolder, out IList<IReference>? references))
-            {
-                externalReferences[ObjectIds.ObjectsFolder] = references = [];
-            }
-            references.Add(new NodeStateReference(ReferenceTypeIds.Organizes, false, root.NodeId));
             await AddPredefinedNodeAsync(root, cancellationToken).ConfigureAwait(false);
             NodeManagerBuilder builder = CreateFluentBuilder(namespaceIndex);
             m_build(builder);
+
+            // Mirror references from build-created nodes to nodes owned by
+            // other node managers (e.g. the Objects folder) into the
+            // externalReferences dictionary before sealing the builder.
+            await CompleteConfigureAsync(externalReferences, cancellationToken).ConfigureAwait(false);
+
             builder.Seal();
         }
 

--- a/src/Opc.Ua.Server/NodeManager/AsyncCustomNodeManager.cs
+++ b/src/Opc.Ua.Server/NodeManager/AsyncCustomNodeManager.cs
@@ -2463,7 +2463,11 @@ namespace Opc.Ua.Server
         }
 
         /// <summary>
-        /// Adds an external reference to the dictionary.
+        /// Adds an external reference to the dictionary if it is not
+        /// already present. The if-missing semantics keep the dictionary
+        /// clean when the collection pass runs more than once for the
+        /// same manager (e.g. after fluent <c>Configure</c> callbacks
+        /// register additional nodes).
         /// </summary>
         protected void AddExternalReference(
             NodeId sourceId,
@@ -2476,6 +2480,18 @@ namespace Opc.Ua.Server
             if (!externalReferences.TryGetValue(sourceId, out IList<IReference>? referencesToAdd))
             {
                 externalReferences[sourceId] = referencesToAdd = [];
+            }
+
+            for (int ii = 0; ii < referencesToAdd.Count; ii++)
+            {
+                IReference existingReference = referencesToAdd[ii];
+                if (existingReference.ReferenceTypeId == referenceTypeId &&
+                    existingReference.IsInverse == isInverse &&
+                    !existingReference.TargetId.IsAbsolute &&
+                    (NodeId)existingReference.TargetId == targetId)
+                {
+                    return;
+                }
             }
 
             // add reserve reference from external node.

--- a/src/Opc.Ua.Server/NodeManager/CustomNodeManager.cs
+++ b/src/Opc.Ua.Server/NodeManager/CustomNodeManager.cs
@@ -1339,7 +1339,10 @@ namespace Opc.Ua.Server
         }
 
         /// <summary>
-        /// Adds an external reference to the dictionary.
+        /// Adds an external reference to the dictionary if it is not
+        /// already present. The if-missing semantics keep the dictionary
+        /// clean when the collection pass runs more than once for the
+        /// same manager.
         /// </summary>
         protected void AddExternalReference(
             NodeId sourceId,
@@ -1352,6 +1355,18 @@ namespace Opc.Ua.Server
             if (!externalReferences.TryGetValue(sourceId, out IList<IReference>? referencesToAdd))
             {
                 externalReferences[sourceId] = referencesToAdd = [];
+            }
+
+            for (int ii = 0; ii < referencesToAdd.Count; ii++)
+            {
+                IReference existingReference = referencesToAdd[ii];
+                if (existingReference.ReferenceTypeId == referenceTypeId &&
+                    existingReference.IsInverse == isInverse &&
+                    !existingReference.TargetId.IsAbsolute &&
+                    (NodeId)existingReference.TargetId == targetId)
+                {
+                    return;
+                }
             }
 
             // add reserve reference from external node.

--- a/src/Opc.Ua.Types/Nodes/TypeTable.cs
+++ b/src/Opc.Ua.Types/Nodes/TypeTable.cs
@@ -624,7 +624,8 @@ namespace Opc.Ua
         }
 
         /// <summary>
-        /// Adds an encoding for an existing data type.
+        /// Adds an encoding for an existing data type. Registering the
+        /// same encoding again is a no-op that still succeeds.
         /// </summary>
         public bool AddEncoding(NodeId dataTypeId, ExpandedNodeId encodingId)
         {
@@ -646,7 +647,7 @@ namespace Opc.Ua
                 {
                     typeInfo.Encodings = [localId];
                 }
-                else
+                else if (System.Array.IndexOf(typeInfo.Encodings, localId) < 0)
                 {
                     var encodings = new NodeId[typeInfo.Encodings.Length + 1];
                     System.Array.Copy(typeInfo.Encodings, encodings, typeInfo.Encodings.Length);

--- a/tests/Opc.Ua.Server.Tests/AsyncCustomNodeManagerTests.cs
+++ b/tests/Opc.Ua.Server.Tests/AsyncCustomNodeManagerTests.cs
@@ -3290,6 +3290,73 @@ namespace Opc.Ua.Server.Tests
         }
 
         [Test]
+        public async Task AddReverseReferencesAsyncDoesNotDuplicateExternalReferenceWhenRunTwiceAsync()
+        {
+            using ITestNodeManager manager = CreateManager();
+            ServerSystemContext context = manager.SystemContext;
+            ushort nsIdx = manager.NamespaceIndexes[0];
+
+            var source = new BaseObjectState(null);
+            source.CreateAsPredefinedNode(context);
+            source.NodeId = new NodeId("Source", nsIdx);
+            source.BrowseName = new QualifiedName("Source", nsIdx);
+
+            var externalTarget = new NodeId("ExternalTarget", 0);
+            source.AddReference(ReferenceTypeIds.Organizes, false, externalTarget);
+            await manager.AddNodeAsync(context, default, source).ConfigureAwait(false);
+
+            // The pass runs once after the predefined nodes load and again
+            // after fluent Configure callbacks return; the dictionary must
+            // not accumulate duplicates.
+            var externalReferences = new Dictionary<NodeId, IList<IReference>>();
+            await manager.AddReverseReferencesPublicAsync(externalReferences).ConfigureAwait(false);
+            await manager.AddReverseReferencesPublicAsync(externalReferences).ConfigureAwait(false);
+
+            Assert.That(externalReferences.ContainsKey(externalTarget), Is.True);
+            Assert.That(externalReferences[externalTarget], Has.Count.EqualTo(1));
+        }
+
+        [Test]
+        public async Task AddReverseReferencesAsyncSecondRunAddsReferencesOfNewlyRegisteredNodesAsync()
+        {
+            using ITestNodeManager manager = CreateManager();
+            ServerSystemContext context = manager.SystemContext;
+            ushort nsIdx = manager.NamespaceIndexes[0];
+
+            var first = new BaseObjectState(null);
+            first.CreateAsPredefinedNode(context);
+            first.NodeId = new NodeId("First", nsIdx);
+            first.BrowseName = new QualifiedName("First", nsIdx);
+            first.AddReference(ReferenceTypeIds.Organizes, true, ObjectIds.ObjectsFolder);
+            await manager.AddNodeAsync(context, default, first).ConfigureAwait(false);
+
+            var externalReferences = new Dictionary<NodeId, IList<IReference>>();
+            await manager.AddReverseReferencesPublicAsync(externalReferences).ConfigureAwait(false);
+
+            // A node registered later (like a fluent Configure callback does)
+            // is picked up by the second pass without duplicating the first
+            // node's mirror entry.
+            var second = new BaseObjectState(null);
+            second.CreateAsPredefinedNode(context);
+            second.NodeId = new NodeId("Second", nsIdx);
+            second.BrowseName = new QualifiedName("Second", nsIdx);
+            second.AddReference(ReferenceTypeIds.Organizes, true, ObjectIds.ObjectsFolder);
+            await manager.AddPredefinedNodeAsync(context, second).ConfigureAwait(false);
+
+            await manager.AddReverseReferencesPublicAsync(externalReferences).ConfigureAwait(false);
+
+            Assert.That(externalReferences.ContainsKey(ObjectIds.ObjectsFolder), Is.True);
+            IList<IReference> mirrored = externalReferences[ObjectIds.ObjectsFolder];
+            Assert.That(mirrored, Has.Count.EqualTo(2));
+            Assert.That(
+                mirrored.Count(r =>
+                    r.ReferenceTypeId == ReferenceTypeIds.Organizes &&
+                    !r.IsInverse &&
+                    r.TargetId == new ExpandedNodeId(second.NodeId)),
+                Is.EqualTo(1));
+        }
+
+        [Test]
         public void SetNamespacesUpdatesUrisAndIndexes()
         {
             using ITestNodeManager manager = CreateManager();

--- a/tests/Opc.Ua.Server.Tests/Fluent/InstanceCreationBuilderExtensionsTests.cs
+++ b/tests/Opc.Ua.Server.Tests/Fluent/InstanceCreationBuilderExtensionsTests.cs
@@ -375,5 +375,220 @@ namespace Opc.Ua.Server.Tests.Fluent
 
             Assert.That(captured, Is.SameAs(typed.Node));
         }
+
+        // ── Manager-level (root) CreateInstance ─────────────────────────────
+
+        /// <summary>
+        /// Mirrors the default <c>AsyncCustomNodeManager.New</c>: allocate
+        /// a fresh numeric id only when the node has none.
+        /// </summary>
+        private sealed class CounterNodeIdFactory : INodeIdFactory
+        {
+            private uint m_lastId;
+
+            public NodeId New(ISystemContext context, NodeState node)
+            {
+                return node.NodeId.IsNull
+                    ? new NodeId(++m_lastId, kNs)
+                    : node.NodeId;
+            }
+        }
+
+        /// <summary>
+        /// Instance state whose type model declares one child carrying a
+        /// type-declaration NodeId plus an internal reference to it, so
+        /// the rebasing of the subtree is observable.
+        /// </summary>
+        private sealed class DeclaredChildObjectState : BaseObjectState
+        {
+            public static readonly NodeId DeclarationChildId = new(9999u, 0);
+
+            public DeclaredChildObjectState(NodeState? parent)
+                : base(parent)
+            {
+            }
+
+            protected override void Initialize(ISystemContext context)
+            {
+                base.Initialize(context);
+                var child = new PropertyState(this)
+                {
+                    NodeId = DeclarationChildId,
+                    BrowseName = new QualifiedName("Declared", kNs),
+                    DisplayName = new LocalizedText("Declared"),
+                    TypeDefinitionId = VariableTypeIds.PropertyType,
+                    ReferenceTypeId = ReferenceTypeIds.HasProperty,
+                    DataType = DataTypeIds.Int32,
+                    ValueRank = ValueRanks.Scalar
+                };
+                AddChild(child);
+                AddReference(ReferenceTypeIds.HasOrderedComponent, false, DeclarationChildId);
+            }
+        }
+
+        private static NodeManagerBuilder CreateRootCapableBuilder()
+        {
+            SystemContext ctx = CreateContext();
+            ctx.NodeIdFactory = new CounterNodeIdFactory();
+
+            var builder = new NodeManagerBuilder(
+                ctx,
+                nodeManager: Mock.Of<IAsyncNodeManager>(),
+                defaultNamespaceIndex: kNs,
+                rootResolver: _ => null!,
+                nodeIdResolver: _ => null!,
+                typeIdResolver: _ => []);
+            return builder;
+        }
+
+        [Test]
+        public void ManagerLevelCreateInstanceMaterializesRootInstance()
+        {
+            NodeManagerBuilder b = CreateRootCapableBuilder();
+
+            IInstanceBuilder<BaseObjectState> ib = b.CreateInstance(
+                new QualifiedName("Boiler#2", kNs),
+                p => new BaseObjectState(p));
+
+            Assert.That(ib.Node.Parent, Is.Null);
+            Assert.That(ib.Node.BrowseName, Is.EqualTo(new QualifiedName("Boiler#2", kNs)));
+            Assert.That(ib.Node.SymbolicName, Is.EqualTo("Boiler#2"));
+            Assert.That(ib.Node.DisplayName.Text, Is.EqualTo("Boiler#2"));
+            Assert.That(ib.Node.NodeId.IsNull, Is.False, "NodeId must be minted by the factory");
+            Assert.That(ib.Node.NodeId.NamespaceIndex, Is.EqualTo(kNs));
+        }
+
+        [Test]
+        public void ManagerLevelCreateInstanceFactoryReceivesNullParent()
+        {
+            NodeManagerBuilder b = CreateRootCapableBuilder();
+
+            bool sawNullParent = false;
+            b.CreateInstance(
+                new QualifiedName("Boiler#2", kNs),
+                p =>
+                {
+                    sawNullParent = p == null;
+                    return new BaseObjectState(p);
+                });
+
+            Assert.That(sawNullParent, Is.True);
+        }
+
+        [Test]
+        public void ManagerLevelCreateInstanceRebasesDeclaredChildIds()
+        {
+            NodeManagerBuilder b = CreateRootCapableBuilder();
+
+            IInstanceBuilder<DeclaredChildObjectState> ib = b.CreateInstance(
+                new QualifiedName("Boiler#2", kNs),
+                p => new DeclaredChildObjectState(p));
+
+            var children = new List<BaseInstanceState>();
+            ib.Node.GetChildren(b.Context, children);
+            Assert.That(children, Has.Count.EqualTo(1));
+
+            BaseInstanceState child = children[0];
+            Assert.That(
+                child.NodeId,
+                Is.Not.EqualTo(DeclaredChildObjectState.DeclarationChildId),
+                "Child must be rebased off its type-declaration NodeId");
+            Assert.That(child.NodeId.NamespaceIndex, Is.EqualTo(kNs));
+
+            // The internal reference to the declared child must have been
+            // remapped to the fresh instance id.
+            Assert.That(
+                ib.Node.ReferenceExists(
+                    ReferenceTypeIds.HasOrderedComponent,
+                    isInverse: false,
+                    child.NodeId),
+                Is.True);
+        }
+
+        [Test]
+        public void ManagerLevelCreateInstanceParentAndDoneReturnSelfView()
+        {
+            NodeManagerBuilder b = CreateRootCapableBuilder();
+
+            IInstanceBuilder<BaseObjectState> ib = b.CreateInstance(
+                new QualifiedName("Boiler#2", kNs),
+                p => new BaseObjectState(p));
+
+            Assert.That(ib.Parent.Node, Is.SameAs(ib.Node));
+            Assert.That(ib.Done().Node, Is.SameAs(ib.Node));
+            Assert.That(ib.AsNode().Node, Is.SameAs(ib.Node));
+            Assert.That(ib.AsNode().Builder, Is.SameAs(b));
+        }
+
+        [Test]
+        public void ManagerLevelCreateInstanceConfigureSupportsReferenceSugar()
+        {
+            NodeManagerBuilder b = CreateRootCapableBuilder();
+
+            bool invoked = false;
+            IInstanceBuilder<BaseObjectState> ib = b.CreateInstance(
+                new QualifiedName("Boiler#2", kNs),
+                p => new BaseObjectState(p))
+                .Configure(n =>
+                {
+                    invoked = true;
+                    n.UnderObjectsFolder();
+                });
+
+            Assert.That(invoked, Is.True);
+            Assert.That(
+                ib.Node.ReferenceExists(
+                    ReferenceTypeIds.Organizes,
+                    isInverse: true,
+                    ObjectIds.ObjectsFolder),
+                Is.True);
+        }
+
+        [Test]
+        public void ManagerLevelCreateInstanceWithoutNodeIdFactoryThrows()
+        {
+            SystemContext ctx = CreateContext();
+            var builder = new NodeManagerBuilder(
+                ctx,
+                nodeManager: Mock.Of<IAsyncNodeManager>(),
+                defaultNamespaceIndex: kNs,
+                rootResolver: _ => null!,
+                nodeIdResolver: _ => null!,
+                typeIdResolver: _ => []);
+
+            Assert.Throws<InvalidOperationException>(
+                () => builder.CreateInstance(
+                    new QualifiedName("Boiler#2", kNs),
+                    p => new BaseObjectState(p)));
+        }
+
+        [Test]
+        public void ManagerLevelCreateInstanceNullFactoryReturnThrows()
+        {
+            NodeManagerBuilder b = CreateRootCapableBuilder();
+
+            ServiceResultException ex = Assert.Throws<ServiceResultException>(
+                () => b.CreateInstance<BaseObjectState>(
+                    new QualifiedName("Boiler#2", kNs),
+                    p => null!))!;
+            Assert.That(ex.StatusCode, Is.EqualTo((uint)StatusCodes.BadInvalidArgument));
+        }
+
+        [Test]
+        public void ManagerLevelCreateInstanceNullArgsThrow()
+        {
+            NodeManagerBuilder b = CreateRootCapableBuilder();
+
+            Assert.Throws<ArgumentNullException>(
+                () => ((INodeManagerBuilder)null!).CreateInstance(
+                    new QualifiedName("X", kNs),
+                    p => new BaseObjectState(p)));
+            Assert.Throws<ArgumentNullException>(
+                () => b.CreateInstance(QualifiedName.Null, p => new BaseObjectState(p)));
+            Assert.Throws<ArgumentNullException>(
+                () => b.CreateInstance<BaseObjectState>(
+                    new QualifiedName("X", kNs),
+                    null!));
+        }
     }
 }

--- a/tests/Opc.Ua.Server.Tests/Fluent/InstanceCreationBuilderExtensionsTests.cs
+++ b/tests/Opc.Ua.Server.Tests/Fluent/InstanceCreationBuilderExtensionsTests.cs
@@ -590,5 +590,18 @@ namespace Opc.Ua.Server.Tests.Fluent
                     new QualifiedName("X", kNs),
                     null!));
         }
+
+        [Test]
+        public void RootInstanceBuilderNullArgsThrow()
+        {
+            NodeManagerBuilder b = CreateRootCapableBuilder();
+
+            Assert.Throws<ArgumentNullException>(
+                () => new InstanceBuilder<BaseObjectState>(
+                    (INodeManagerBuilder)null!,
+                    new BaseObjectState(parent: null)));
+            Assert.Throws<ArgumentNullException>(
+                () => new InstanceBuilder<BaseObjectState>(b, null!));
+        }
     }
 }

--- a/tests/Opc.Ua.Server.Tests/Fluent/ReferenceBuilderExtensionsTests.cs
+++ b/tests/Opc.Ua.Server.Tests/Fluent/ReferenceBuilderExtensionsTests.cs
@@ -138,6 +138,37 @@ namespace Opc.Ua.Server.Tests.Fluent
         }
 
         [Test]
+        public void OrganizedByAddsInverseReference()
+        {
+            (NodeManagerBuilder b, BaseObjectState root, BaseDataVariableState t1, _) = CreateBuilder();
+            INodeBuilder nb = b.Node(new NodeId("Root", kNs));
+
+            INodeBuilder chained = nb.OrganizedBy(t1.NodeId);
+
+            Assert.That(chained, Is.SameAs(nb));
+            Assert.That(
+                root.ReferenceExists(ReferenceTypeIds.Organizes, isInverse: true, t1.NodeId),
+                Is.True);
+        }
+
+        [Test]
+        public void UnderObjectsFolderAddsInverseOrganizesToObjectsFolder()
+        {
+            (NodeManagerBuilder b, BaseObjectState root, _, _) = CreateBuilder();
+            INodeBuilder nb = b.Node(new NodeId("Root", kNs));
+
+            INodeBuilder chained = nb.UnderObjectsFolder();
+
+            Assert.That(chained, Is.SameAs(nb));
+            Assert.That(
+                root.ReferenceExists(
+                    ReferenceTypeIds.Organizes,
+                    isInverse: true,
+                    ObjectIds.ObjectsFolder),
+                Is.True);
+        }
+
+        [Test]
         public void HasComponentAddsForwardReference()
         {
             (NodeManagerBuilder b, BaseObjectState root, BaseDataVariableState t1, _) = CreateBuilder();

--- a/tests/Opc.Ua.Server.Tests/Hosting/FluentNodeManagerFactoryCoverageTests.cs
+++ b/tests/Opc.Ua.Server.Tests/Hosting/FluentNodeManagerFactoryCoverageTests.cs
@@ -168,7 +168,7 @@ namespace Opc.Ua.Server.Tests.Hosting
         public async Task BuildCreatedInstanceUnderObjectsFolderIsMirroredToExternalReferencesAsync()
         {
             Mock<IServerInternal> mockServer = BuildMockServer();
-            NodeId? instanceId = null;
+            NodeId instanceId = NodeId.Null;
             var factory = new FluentNodeManagerFactory(
                 TestNamespaceUri,
                 builder => instanceId = builder
@@ -191,14 +191,13 @@ namespace Opc.Ua.Server.Tests.Hosting
             // The forward Organizes edge from the Objects folder to the
             // build-created instance must have been published for the
             // master node manager to distribute (issue #4329).
-            Assert.That(instanceId.HasValue, Is.True);
-            Assert.That(instanceId.Value.IsNull, Is.False);
+            Assert.That(instanceId.IsNull, Is.False);
             Assert.That(externalReferences.ContainsKey(ObjectIds.ObjectsFolder), Is.True);
             Assert.That(
                 externalReferences[ObjectIds.ObjectsFolder].Count(r =>
                     r.ReferenceTypeId == ReferenceTypeIds.Organizes &&
                     !r.IsInverse &&
-                    r.TargetId == new ExpandedNodeId(instanceId.Value)),
+                    r.TargetId == new ExpandedNodeId(instanceId)),
                 Is.EqualTo(1));
 
             ((IDisposable)manager).Dispose();

--- a/tests/Opc.Ua.Server.Tests/Hosting/FluentNodeManagerFactoryCoverageTests.cs
+++ b/tests/Opc.Ua.Server.Tests/Hosting/FluentNodeManagerFactoryCoverageTests.cs
@@ -30,6 +30,8 @@
 #nullable enable
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
@@ -132,6 +134,72 @@ namespace Opc.Ua.Server.Tests.Hosting
             // CreateAsync only instantiates the manager; we verify it completed without error.
             Assert.That(manager, Is.Not.Null);
             Assert.That(buildCalled, Is.False, "Build callback must not be invoked during factory creation.");
+
+            ((IDisposable)manager).Dispose();
+        }
+
+        [Test]
+        public async Task CreateAddressSpaceAsyncMirrorsRootFolderUnderObjectsFolderAsync()
+        {
+            Mock<IServerInternal> mockServer = BuildMockServer();
+            var factory = new FluentNodeManagerFactory(TestNamespaceUri, _ => { });
+
+            IAsyncNodeManager manager = await factory.CreateAsync(
+                mockServer.Object,
+                new ApplicationConfiguration(),
+                CancellationToken.None)
+                .ConfigureAwait(false);
+
+            var externalReferences = new Dictionary<NodeId, IList<IReference>>();
+            await manager.CreateAddressSpaceAsync(externalReferences, CancellationToken.None)
+                .ConfigureAwait(false);
+
+            Assert.That(externalReferences.ContainsKey(ObjectIds.ObjectsFolder), Is.True);
+            Assert.That(
+                externalReferences[ObjectIds.ObjectsFolder].Count(r =>
+                    r.ReferenceTypeId == ReferenceTypeIds.Organizes && !r.IsInverse),
+                Is.EqualTo(1),
+                "The root folder's inverse Organizes reference must be mirrored exactly once");
+
+            ((IDisposable)manager).Dispose();
+        }
+
+        [Test]
+        public async Task BuildCreatedInstanceUnderObjectsFolderIsMirroredToExternalReferencesAsync()
+        {
+            Mock<IServerInternal> mockServer = BuildMockServer();
+            NodeId? instanceId = null;
+            var factory = new FluentNodeManagerFactory(
+                TestNamespaceUri,
+                builder => instanceId = builder
+                    .CreateInstance(
+                        new QualifiedName("Boiler #2", 1),
+                        p => new BaseObjectState(p))
+                    .Configure(n => n.UnderObjectsFolder())
+                    .Node.NodeId);
+
+            IAsyncNodeManager manager = await factory.CreateAsync(
+                mockServer.Object,
+                new ApplicationConfiguration(),
+                CancellationToken.None)
+                .ConfigureAwait(false);
+
+            var externalReferences = new Dictionary<NodeId, IList<IReference>>();
+            await manager.CreateAddressSpaceAsync(externalReferences, CancellationToken.None)
+                .ConfigureAwait(false);
+
+            // The forward Organizes edge from the Objects folder to the
+            // build-created instance must have been published for the
+            // master node manager to distribute (issue #4329).
+            Assert.That(instanceId.HasValue, Is.True);
+            Assert.That(instanceId.Value.IsNull, Is.False);
+            Assert.That(externalReferences.ContainsKey(ObjectIds.ObjectsFolder), Is.True);
+            Assert.That(
+                externalReferences[ObjectIds.ObjectsFolder].Count(r =>
+                    r.ReferenceTypeId == ReferenceTypeIds.Organizes &&
+                    !r.IsInverse &&
+                    r.TargetId == new ExpandedNodeId(instanceId.Value)),
+                Is.EqualTo(1));
 
             ((IDisposable)manager).Dispose();
         }

--- a/tests/Opc.Ua.SourceGeneration.Core.Tests/Generators/NodeManagerGeneratorTests.cs
+++ b/tests/Opc.Ua.SourceGeneration.Core.Tests/Generators/NodeManagerGeneratorTests.cs
@@ -93,15 +93,58 @@ namespace Opc.Ua.SourceGeneration.Generator.Tests
             Assert.That(mgr, Does.Contain("global::Opc.Ua.Server.Fluent.NodeManagerBuilder"));
             Assert.That(mgr, Does.Contain("global::Opc.Ua.Server.Fluent.INodeManagerBuilder"));
 
-            // The Configure/Seal sequence inside CreateAddressSpace must be
-            // wired before any NotifyNodeAdded replays. Order is part of
-            // the contract and is exercised by the hybrid integration test.
+            // The Configure/CompleteConfigure/Seal sequence inside
+            // CreateAddressSpace must be wired before any NotifyNodeAdded
+            // replays. Order is part of the contract and is exercised by
+            // the hybrid integration test. CompleteConfigureAsync re-runs
+            // the reverse-reference pass so configure-created nodes publish
+            // references to nodes owned by other managers (issue #4329).
             int idxConfigure = mgr.IndexOf("Configure(__m_builder)", StringComparison.Ordinal);
+            int idxComplete = mgr.IndexOf(
+                "await CompleteConfigureAsync(externalReferences, cancellationToken)",
+                StringComparison.Ordinal);
             int idxSeal = mgr.IndexOf(".Seal()", StringComparison.Ordinal);
             int idxNotify = mgr.IndexOf("NotifyNodeAdded(", StringComparison.Ordinal);
             Assert.That(idxConfigure, Is.GreaterThan(0), "Configure call must be emitted");
-            Assert.That(idxSeal, Is.GreaterThan(idxConfigure), "Seal must run after Configure");
+            Assert.That(idxComplete, Is.GreaterThan(idxConfigure),
+                "CompleteConfigureAsync must run after Configure");
+            Assert.That(idxSeal, Is.GreaterThan(idxComplete),
+                "Seal must run after CompleteConfigureAsync");
             Assert.That(idxNotify, Is.GreaterThan(idxSeal), "NotifyNodeAdded replay must run after Seal");
+        }
+
+        [Test]
+        public void EmittedNodeManager_WithoutAdditionalNamespaceUris_ReportsModelNamespaceOnly()
+        {
+            Dictionary<string, string> files = GenerateForTestModel(generateNodeManager: true);
+
+            string mgr = files.Single(kv => kv.Key.EndsWith(".NodeManager.g.cs", StringComparison.Ordinal)).Value;
+            string factory = files.Single(kv => kv.Key.EndsWith(".NodeManagerFactory.g.cs", StringComparison.Ordinal)).Value;
+
+            Assert.That(mgr, Does.Not.Contain("/Instance"));
+            Assert.That(factory, Does.Not.Contain("/Instance"));
+        }
+
+        [Test]
+        public void EmittedNodeManager_WithAdditionalNamespaceUris_ReportsThemAtConstruction()
+        {
+            const string instanceUri = "http://test.org/UA/TestModel/Instance";
+            Dictionary<string, string> files = GenerateForTestModel(
+                generateNodeManager: true,
+                additionalNamespaceUris: [instanceUri]);
+
+            string mgr = files.Single(kv => kv.Key.EndsWith(".NodeManager.g.cs", StringComparison.Ordinal)).Value;
+            string factory = files.Single(kv => kv.Key.EndsWith(".NodeManagerFactory.g.cs", StringComparison.Ordinal)).Value;
+
+            // The constructor must pass the extra namespace to the base
+            // manager so the master node manager routes it to this manager
+            // from construction (SetNamespaces after the fact is too late).
+            Assert.That(mgr, Does.Contain(", \"" + instanceUri + "\")"),
+                "Constructor must append the additional namespace URI to the base call");
+
+            // The factory must advertise the same namespace set.
+            Assert.That(factory, Does.Contain(", \"" + instanceUri + "\" })"),
+                "Factory NamespacesUris must include the additional namespace URI");
         }
 
         [Test]
@@ -445,7 +488,9 @@ namespace Opc.Ua.SourceGeneration.Generator.Tests
             return string.Empty;
         }
 
-        private static Dictionary<string, string> GenerateForTestModel(bool generateNodeManager)
+        private static Dictionary<string, string> GenerateForTestModel(
+            bool generateNodeManager,
+            IReadOnlyList<string> additionalNamespaceUris = null)
         {
             const string designFile = "TestModel.xml";
             ITelemetryContext telemetry = NUnitTelemetryContext.Create(logLevel: LogLevel.Error);
@@ -460,7 +505,8 @@ namespace Opc.Ua.SourceGeneration.Generator.Tests
                     Path.GetFileNameWithoutExtension(designFile) + ".csv"),
                 Options = new DesignFileOptions
                 {
-                    GenerateNodeManager = generateNodeManager
+                    GenerateNodeManager = generateNodeManager,
+                    NodeManagerAdditionalNamespaceUris = additionalNamespaceUris
                 }
             }, fileSystem, string.Empty, telemetry);
 

--- a/tests/Opc.Ua.SourceGeneration.Tests/ModelGeneratorTests.cs
+++ b/tests/Opc.Ua.SourceGeneration.Tests/ModelGeneratorTests.cs
@@ -978,6 +978,61 @@ namespace Opc.Ua.SourceGeneration
         }
 
         [Theory]
+        public void NodeManagerWithAdditionalNamespaceUrisReportsThemAtConstruction(
+            LanguageVersion languageVersion)
+        {
+            // Issue #4329 companion: [NodeManager] can declare additional
+            // namespace URIs (e.g. a separate instance namespace) that the
+            // generated constructor passes to the base manager and the
+            // generated factory advertises, so the master node manager
+            // routes them to this manager from construction. SetNamespaces
+            // after the fact is too late for namespace routing.
+            const string bindingSource =
+                """
+                namespace Opc.Ua.Server.Fluent
+                {
+                public sealed class NodeManagerAttribute : global::System.Attribute
+                {
+                public string NamespaceUri { get; set; }
+                public string Design { get; set; }
+                public bool GenerateFactory { get; set; }
+                public string[] AdditionalNamespaceUris { get; set; }
+                }
+                }
+                namespace CrossModelConsumer
+                {
+                [global::Opc.Ua.Server.Fluent.NodeManager(
+                    NamespaceUri = "http://test.org/UA/CrossModel/Types",
+                    AdditionalNamespaceUris = new[] { "http://test.org/UA/CrossModel/Types/Instance" })]
+                public partial class TypesNodeManager
+                {
+                }
+                }
+                """;
+            (ImmutableArray<Diagnostic> diagnostics, GeneratorDriverRunResult runResult) =
+                RunMixedModelGenerator(languageVersion, bindingSource);
+
+            Assert.That(
+                diagnostics.Where(d => d.Id == "MODELGEN010"),
+                Is.Empty,
+                "the binding with additional namespace URIs must still match");
+
+            string generated = string.Join(
+                "\n",
+                runResult.Results[0].GeneratedSources.Select(s => s.SourceText.ToString()));
+            Assert.That(
+                generated,
+                Does.Match(
+                    @": base\(server, configuration, [^)]*""http://test\.org/UA/CrossModel/Types/Instance""\)"),
+                "the generated constructor must append the additional namespace URI to the base call");
+            Assert.That(
+                generated,
+                Does.Match(
+                    @"NamespacesUris[\s\S]{0,200}""http://test\.org/UA/CrossModel/Types/Instance"""),
+                "the generated factory must advertise the additional namespace URI");
+        }
+
+        [Theory]
         public void NodeManagerBoundToModelDesignInstancesIsNotReportedUnmatchedWithNodeSet2(
             LanguageVersion languageVersion)
         {

--- a/tests/Opc.Ua.Types.Tests/Nodes/TypeTableTests.cs
+++ b/tests/Opc.Ua.Types.Tests/Nodes/TypeTableTests.cs
@@ -209,6 +209,20 @@ namespace Opc.Ua.Types.Tests.Nodes
         }
 
         [Test]
+        public void AddEncodingIsIdempotentForSameEncoding()
+        {
+            Assert.That(
+                m_typeTable.AddEncoding(s_dataTypeId, new ExpandedNodeId(s_encodingId1)),
+                Is.True);
+            Assert.That(
+                m_typeTable.AddEncoding(s_dataTypeId, new ExpandedNodeId(s_encodingId1)),
+                Is.True,
+                "Registering the same encoding again must succeed as a no-op");
+
+            Assert.That(m_typeTable.FindDataTypeId(s_encodingId1), Is.EqualTo(s_dataTypeId));
+        }
+
+        [Test]
         public void IsKnownNodeIdReturnsFalseForNull()
         {
             Assert.That(m_typeTable.IsKnown(NodeId.Null), Is.False);

--- a/tools/Opc.Ua.SourceGeneration.Core/DesignFile.cs
+++ b/tools/Opc.Ua.SourceGeneration.Core/DesignFile.cs
@@ -104,6 +104,16 @@ namespace Opc.Ua.SourceGeneration
         /// to author the factory by hand.
         /// </summary>
         public bool EmitNodeManagerFactory { get; init; } = true;
+
+        /// <summary>
+        /// Additional namespace URIs (beyond the model namespace) that
+        /// the generated <c>NodeManager</c> constructor reports to the
+        /// base node manager and the generated factory advertises via
+        /// <c>NamespacesUris</c>. Used by the <c>[NodeManager]</c>
+        /// attribute discovery path
+        /// (<c>AdditionalNamespaceUris</c> named argument).
+        /// </summary>
+        public IReadOnlyList<string> NodeManagerAdditionalNamespaceUris { get; init; }
     }
 
     /// <summary>

--- a/tools/Opc.Ua.SourceGeneration.Core/Generators.cs
+++ b/tools/Opc.Ua.SourceGeneration.Core/Generators.cs
@@ -609,7 +609,8 @@ namespace Opc.Ua.SourceGeneration
                 GenerateNodeManager = true,
                 NodeManagerNamespace = match.TargetNamespace,
                 NodeManagerClassName = match.TargetClassName,
-                EmitNodeManagerFactory = match.GenerateFactory
+                EmitNodeManagerFactory = match.GenerateFactory,
+                NodeManagerAdditionalNamespaceUris = match.AdditionalNamespaceUris
             };
         }
 
@@ -1122,7 +1123,8 @@ namespace Opc.Ua.SourceGeneration
                 {
                     OverrideNamespace = designOptions.NodeManagerNamespace,
                     OverrideClassName = designOptions.NodeManagerClassName,
-                    EmitFactory = designOptions.EmitNodeManagerFactory
+                    EmitFactory = designOptions.EmitNodeManagerFactory,
+                    AdditionalNamespaceUris = designOptions.NodeManagerAdditionalNamespaceUris
                 }.Emit();
             }
 

--- a/tools/Opc.Ua.SourceGeneration.Core/Generators/NodeManagerGenerator.cs
+++ b/tools/Opc.Ua.SourceGeneration.Core/Generators/NodeManagerGenerator.cs
@@ -80,6 +80,14 @@ namespace Opc.Ua.SourceGeneration
         public bool EmitFactory { get; init; } = true;
 
         /// <summary>
+        /// Additional namespace URIs (beyond the model namespace) that
+        /// the generated constructor passes to the base node manager and
+        /// the generated factory advertises via <c>NamespacesUris</c>.
+        /// Typically a sample's separate instance namespace. Optional.
+        /// </summary>
+        public IReadOnlyList<string> AdditionalNamespaceUris { get; init; }
+
+        /// <summary>
         /// Create node manager generator.
         /// </summary>
         public NodeManagerGenerator(IGeneratorContext context)
@@ -137,8 +145,34 @@ namespace Opc.Ua.SourceGeneration
             template.AddReplacement(Tokens.Namespace, typeStem);
             template.AddReplacement(Tokens.NodeManagerClassName, targetClass);
             template.AddReplacement(Tokens.NamespaceUri, nsUriSymbol);
+            template.AddReplacement(
+                Tokens.AdditionalNamespaceUris,
+                FormatAdditionalNamespaceUris());
             template.Render();
             return fileName.AsTextFileResource();
+        }
+
+        /// <summary>
+        /// Renders the additional namespace URIs as a trailing
+        /// <c>, "uri"</c> argument list, or an empty string when none
+        /// were configured.
+        /// </summary>
+        private string FormatAdditionalNamespaceUris()
+        {
+            if (AdditionalNamespaceUris == null || AdditionalNamespaceUris.Count == 0)
+            {
+                return string.Empty;
+            }
+            var buffer = new System.Text.StringBuilder();
+            foreach (string uri in AdditionalNamespaceUris)
+            {
+                if (string.IsNullOrEmpty(uri))
+                {
+                    continue;
+                }
+                buffer.Append(", ").Append(uri.AsStringLiteral());
+            }
+            return buffer.ToString();
         }
 
         private TextFileResource EmitFactoryFile(
@@ -159,6 +193,9 @@ namespace Opc.Ua.SourceGeneration
             template.AddReplacement(Tokens.NodeManagerClassName, targetClass);
             template.AddReplacement(Tokens.NodeManagerFactoryClassName, factoryClass);
             template.AddReplacement(Tokens.NamespaceUri, nsUriSymbol);
+            template.AddReplacement(
+                Tokens.AdditionalNamespaceUris,
+                FormatAdditionalNamespaceUris());
             template.Render();
             return fileName.AsTextFileResource();
         }

--- a/tools/Opc.Ua.SourceGeneration.Core/Generators/NodeManagerTemplates.cs
+++ b/tools/Opc.Ua.SourceGeneration.Core/Generators/NodeManagerTemplates.cs
@@ -68,7 +68,7 @@ namespace Opc.Ua.SourceGeneration
                     public {{Tokens.NodeManagerClassName}}(
                         global::Opc.Ua.Server.IServerInternal server,
                         global::Opc.Ua.ApplicationConfiguration configuration)
-                        : base(server, configuration, {{Tokens.NamespaceUri}})
+                        : base(server, configuration, {{Tokens.NamespaceUri}}{{Tokens.AdditionalNamespaceUris}})
                     {
                         SystemContext.NodeIdFactory = this;
                     }
@@ -122,6 +122,12 @@ namespace Opc.Ua.SourceGeneration
 
                         Configure(__m_builder);
                         Configure(new {{Tokens.NodeManagerClassName}}TypedBuilder(__m_builder));
+
+                        // Mirror references from configure-created nodes to
+                        // nodes owned by other node managers (e.g. the Objects
+                        // folder) into the externalReferences dictionary.
+                        await CompleteConfigureAsync(externalReferences, cancellationToken).ConfigureAwait(false);
+
                         __m_builder.Seal();
 
                         foreach (global::Opc.Ua.NodeState __node in PredefinedNodes.Values)
@@ -299,7 +305,7 @@ namespace Opc.Ua.SourceGeneration
                 {
                     /// <inheritdoc/>
                     public virtual global::Opc.Ua.ArrayOf<string> NamespacesUris
-                        => new global::Opc.Ua.ArrayOf<string>(new string[] { {{Tokens.NamespaceUri}} });
+                        => new global::Opc.Ua.ArrayOf<string>(new string[] { {{Tokens.NamespaceUri}}{{Tokens.AdditionalNamespaceUris}} });
 
                     /// <inheritdoc/>
                     public virtual global::System.Threading.Tasks.ValueTask<global::Opc.Ua.Server.IAsyncNodeManager> CreateAsync(

--- a/tools/Opc.Ua.SourceGeneration.Core/NodeManagerAttributeBinding.cs
+++ b/tools/Opc.Ua.SourceGeneration.Core/NodeManagerAttributeBinding.cs
@@ -27,6 +27,8 @@
  * http://opcfoundation.org/License/MIT/1.00/
  * ======================================================================*/
 
+using System.Collections.Generic;
+
 namespace Opc.Ua.SourceGeneration
 {
     /// <summary>
@@ -68,5 +70,13 @@ namespace Opc.Ua.SourceGeneration
         /// Defaults to <c>true</c>.
         /// </summary>
         public bool GenerateFactory { get; init; } = true;
+
+        /// <summary>
+        /// Additional namespace URIs (beyond the model namespace) that
+        /// the generated constructor reports to the base node manager,
+        /// e.g. a separate instance namespace. <c>null</c> when the
+        /// attribute did not specify any.
+        /// </summary>
+        public IReadOnlyList<string> AdditionalNamespaceUris { get; init; }
     }
 }

--- a/tools/Opc.Ua.SourceGeneration.Core/Templating/Tokens.cs
+++ b/tools/Opc.Ua.SourceGeneration.Core/Templating/Tokens.cs
@@ -31,6 +31,7 @@ namespace Opc.Ua.SourceGeneration
 {
     internal static class Tokens
     {
+        public static string AdditionalNamespaceUris => nameof(AdditionalNamespaceUris);
         public static string ArrayDimensions => nameof(ArrayDimensions);
         public static string BaseClassName => nameof(BaseClassName);
         public static string BaseInterfaces => nameof(BaseInterfaces);

--- a/tools/Opc.Ua.SourceGeneration/Extensions.cs
+++ b/tools/Opc.Ua.SourceGeneration/Extensions.cs
@@ -338,6 +338,35 @@ namespace Opc.Ua.SourceGeneration
         }
 
         /// <summary>
+        /// Get a named string-array argument from the attribute. Returns
+        /// <c>null</c> when the argument is absent or empty; entries
+        /// that are not non-empty strings are skipped.
+        /// </summary>
+        public static string[] GetStringArray(
+            this AttributeData attr,
+            string name)
+        {
+            if (attr == null)
+            {
+                return null;
+            }
+            foreach (KeyValuePair<string, TypedConstant> kvp in attr.NamedArguments)
+            {
+                if (kvp.Key != name ||
+                    kvp.Value.Kind != TypedConstantKind.Array ||
+                    kvp.Value.IsNull)
+                {
+                    continue;
+                }
+                string[] values = [.. kvp.Value.Values
+                    .Select(v => v.Value as string)
+                    .Where(s => !string.IsNullOrEmpty(s))];
+                return values.Length > 0 ? values : null;
+            }
+            return null;
+        }
+
+        /// <summary>
         /// Get a named argument from the attribute
         /// </summary>
         public static int GetInteger(

--- a/tools/Opc.Ua.SourceGeneration/NodeManagerAttributeDiscovery.cs
+++ b/tools/Opc.Ua.SourceGeneration/NodeManagerAttributeDiscovery.cs
@@ -80,6 +80,8 @@ namespace Opc.Ua.SourceGeneration
 
             string namespaceUri = attr.GetValue(nameof(NodeManagerAttributeBinding.NamespaceUri));
             string design = attr.GetValue(nameof(NodeManagerAttributeBinding.Design));
+            string[] additionalNamespaceUris = attr.GetStringArray(
+                nameof(NodeManagerAttributeBinding.AdditionalNamespaceUris));
             bool generateFactory = attr == null ||
                 !attr.NamedArguments
                     .Any(p => p.Key == nameof(NodeManagerAttributeBinding.GenerateFactory) &&
@@ -104,7 +106,8 @@ namespace Opc.Ua.SourceGeneration
                     TargetClassName = targetClassName,
                     NamespaceUri = namespaceUri,
                     Design = design,
-                    GenerateFactory = generateFactory
+                    GenerateFactory = generateFactory,
+                    AdditionalNamespaceUris = additionalNamespaceUris
                 },
                 Location = location,
                 IsPartial = isPartial


### PR DESCRIPTION
# Description

A node created inside the fluent `Configure` hook (source-generated `[NodeManager]` partial, or the hosting `AddNodeManager(uri, build)` route) had no way to appear below the Objects folder — or below any node owned by another node manager. `AsyncCustomNodeManager.AddReverseReferencesAsync` mirrors inverse references into the `externalReferences` dictionary **before** the `Configure` partials run, and the fluent surface never sees the dictionary, so a configure-created node with an inverse `Organizes` reference to `ObjectsFolder` existed and simulated but never showed up under Objects.

This implements the three coordinated pieces proposed in #4329, plus the companion namespace gap:

**1. Idempotent mirroring pass** (independently worthwhile hardening)
- `AddExternalReference` in `AsyncCustomNodeManager` and `CustomNodeManager2` now has if-missing semantics (linear scan of the per-source list).
- `TypeTable.AddEncoding` no longer appends a duplicate encoding id; re-registering the same encoding is a succeeding no-op. (`AddRootNotifierAsync` and the node-side `AddReferenceIfMissing` branch were already idempotent.)

**2. Re-run the pass after `Configure`**
- New protected `FluentNodeManagerBase.CompleteConfigureAsync(externalReferences, ct)` wraps `AddReverseReferencesAsync` so hand-written managers using `CreateFluentBuilder` benefit too.
- The generator-emitted `CreateAddressSpaceAsync` and the hosting `FluentNodeManager` invoke it once between the `Configure` callbacks and `Seal()`. Timing is safe: the master distributes `externalReferences` only after every manager's `CreateAddressSpaceAsync` returns. Side benefit: inverse `HasNotifier` references on configure-created event sources get root-notifier registration for free.
- The hosting `FluentNodeManager`'s hand-rolled `externalReferences` workaround for its root folder is deleted — the root's inverse `Organizes` reference now flows through the shared pass (mirrored exactly once, covered by a test).

**3. Discoverable fluent sugar**
- `OrganizedBy(parentId)` / `UnderObjectsFolder()` on `INodeBuilder` write the inverse `Organizes` reference; with piece 2, placement is just "write the inverse reference".
- A parentless `CreateInstance<TState>` on `INodeManagerBuilder` takes a constructor-style factory (`p => new BoilerState(p)`, keeping the surface reflection-free and AOT-safe), materializes the subtree from the type model via `NodeState.Create`, rebases all NodeIds through the manager's `INodeIdFactory` (`AssignInstanceNodeId`/`AssignInstanceChildNodeIds` — the same pair the generated factories use, so declaration-id children cannot collide with the type model), and registers via `AddPredefinedNodeSynchronously`. The Boiler #2 shape becomes fully fluent:

```csharp
builder.CreateInstance(
        new QualifiedName("Boiler #2", NamespaceIndexes[1]),
        p => new BoilerState(p))
    .Configure(n => n.UnderObjectsFolder());
```

**Companion gap, same theme:** `[NodeManager]` grows `AdditionalNamespaceUris`, flowing through attribute discovery → binding → generator so the generated constructor reports a second (instance) namespace at construction and the generated factory advertises it in `NamespacesUris` — today `SetNamespaces` after construction is not enough because `MasterNodeManager` builds its namespace routing from what the manager reported when it was built.

**Scope boundary** (as discussed in the issue): startup-time configuration only; for nodes created after startup the correct primitive remains `IMasterNodeManager.AddReferencesAsync`.

**Reviewer notes**
- The generated-code change was validated against the real pipeline: a forced fresh compile of `Opc.Ua.Server.Tests` (whose CoverageNodeSet managers are `[NodeManager]`-generated) emits `await CompleteConfigureAsync(externalReferences, cancellationToken)` between `Configure` and `Seal()` and compiles against the real base class.
- The distribution consumer (`AddReferencesAsync`) already used `AddReferenceIfMissing`, so the whole chain is defense-in-depth idempotent.
- 15 new tests: double-run idempotence, second-pass pickup of late-registered nodes, the new reference sugar, root-instance creation incl. child-id rebasing and reference remapping, hosting end-to-end Objects-folder placement, emitted-sequence and `AdditionalNamespaceUris` generator tests, and a full Roslyn-pipeline attribute test. Docs updated in `docs/NodeManagers.md` (new "Creating nodes under other managers' nodes" section, attribute docs, fluent-surface sections).
- Verified locally: all touched projects build with 0 warnings; full `Opc.Ua.Server.Tests` (4,725 passed / 0 failed / 5 skipped, net9.0), `TypeTableTests` (113), `Opc.Ua.SourceGeneration.Core.Tests` (41), `Opc.Ua.SourceGeneration.Tests` (132), and the Quickstarts.Servers sample all pass.

## Related Issues

- Fixes #4329
- Motivating case: OPCFoundation/UA-.NETStandard-Samples#756 / OPCFoundation/UA-.NETStandard-Samples#795 (Workshop/Boiler migration)

## Checklist

- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf) and read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [x] I have added all necessary documentation.
- [x] I have verified that my changes do not introduce (new) build or analyzer warnings.
- [ ] I ran **all** tests locally using the **UA.slnx** solution against at least .net **framework** and .net **10**, and all passed.
- [ ] I fixed **all** failing and flaky tests in the CI pipelines and **all** CodeQL warnings.
- [ ] I have addressed **all** PR feedback received.

🤖 Generated with [Claude Code](https://claude.com/claude-code)