### PR TITLE
Fix public IsNodeInView/IsNodeInViewAsync overloads always returning false

### DIFF
--- a/src/Opc.Ua.Server/NodeManager/AsyncCustomNodeManager.cs
+++ b/src/Opc.Ua.Server/NodeManager/AsyncCustomNodeManager.cs
@@ -7441,7 +7441,11 @@ namespace Opc.Ua.Server
         /// <summary>
         /// Returns true if a node is in a view.
         /// </summary>
-        public virtual async ValueTask<bool> IsNodeInViewAsync(
+        /// <remarks>
+        /// Delegates to <see cref="IsNodeInView(ServerSystemContext, NodeId, NodeState)"/>,
+        /// which sub-classes override to implement view membership.
+        /// </remarks>
+        public virtual ValueTask<bool> IsNodeInViewAsync(
             OperationContext context,
             NodeId viewId,
             object nodeHandle,
@@ -7449,15 +7453,16 @@ namespace Opc.Ua.Server
         {
             if (nodeHandle is not NodeHandle handle)
             {
-                return false;
+                return new ValueTask<bool>(false);
             }
 
             if (handle.Node != null)
             {
-                return await IsNodeInViewAsync(context, viewId, handle.Node, cancellationToken).ConfigureAwait(false);
+                return new ValueTask<bool>(
+                    IsNodeInView(SystemContext.Copy(context), viewId, handle.Node));
             }
 
-            return false;
+            return new ValueTask<bool>(false);
         }
 
         /// <summary>

--- a/src/Opc.Ua.Server/NodeManager/CustomNodeManager.cs
+++ b/src/Opc.Ua.Server/NodeManager/CustomNodeManager.cs
@@ -5977,6 +5977,10 @@ namespace Opc.Ua.Server
         /// <summary>
         /// Returns true if a node is in a view.
         /// </summary>
+        /// <remarks>
+        /// Delegates to <see cref="IsNodeInView(ServerSystemContext, NodeId, NodeState)"/>,
+        /// which sub-classes override to implement view membership.
+        /// </remarks>
         public virtual bool IsNodeInView(OperationContext context, NodeId viewId, object nodeHandle)
         {
             if (nodeHandle is not NodeHandle handle)
@@ -5986,7 +5990,7 @@ namespace Opc.Ua.Server
 
             if (handle.Node != null)
             {
-                return IsNodeInView(context, viewId, handle.Node);
+                return IsNodeInView(SystemContext.Copy(context), viewId, handle.Node);
             }
 
             return false;

--- a/tests/Opc.Ua.Server.Tests/AsyncCustomNodeManagerTests.cs
+++ b/tests/Opc.Ua.Server.Tests/AsyncCustomNodeManagerTests.cs
@@ -2490,6 +2490,64 @@ namespace Opc.Ua.Server.Tests
         }
 
         [Test]
+        public async Task IsNodeInViewAsync_HandleWithNodeUsesOverridableIsNodeInViewAsync()
+        {
+            using ITestNodeManager manager = CreateManager();
+            ServerSystemContext systemContext = manager.SystemContext;
+            ushort nsIdx = manager.NamespaceIndexes[0];
+
+            var view = new ViewState();
+            view.CreateAsPredefinedNode(systemContext);
+            view.NodeId = new NodeId("TestView", nsIdx);
+            view.BrowseName = new QualifiedName("TestView", nsIdx);
+            await manager.AddPredefinedNodeAsync(systemContext, view).ConfigureAwait(false);
+
+            var node = new BaseObjectState(null);
+            node.CreateAsPredefinedNode(systemContext);
+            node.NodeId = new NodeId("ViewedNode", nsIdx);
+            node.BrowseName = new QualifiedName("ViewedNode", nsIdx);
+            await manager.AddPredefinedNodeAsync(systemContext, node).ConfigureAwait(false);
+
+            var handle = new NodeHandle(node.NodeId, node);
+            var context = new OperationContext(new RequestHeader(), null, RequestType.Browse, RequestLifetime.None);
+
+            // The default protected IsNodeInView accepts any view that is a predefined node.
+            // Before the fix the public overload recursed into itself and always returned false.
+            bool result = await manager.IsNodeInViewAsync(context, view.NodeId, handle).ConfigureAwait(false);
+            Assert.That(result, Is.True);
+
+            bool unknownView = await manager
+                .IsNodeInViewAsync(context, new NodeId("UnknownView", nsIdx), handle)
+                .ConfigureAwait(false);
+            Assert.That(unknownView, Is.False);
+
+            // A placeholder handle that carries no validated node reports false.
+            var placeholder = new NodeHandle { NodeId = new NodeId("Ghost", nsIdx) };
+            bool placeholderResult = await manager
+                .IsNodeInViewAsync(context, view.NodeId, placeholder)
+                .ConfigureAwait(false);
+            Assert.That(placeholderResult, Is.False);
+
+            // The sync entry point answers from the same logic.
+            var syncManager = (INodeManager2)manager.SyncNodeManager;
+            Assert.That(syncManager.IsNodeInView(context, view.NodeId, handle), Is.True);
+
+            // Sub-classes customize view membership by overriding the protected virtual.
+            NodeState nodeSeenByOverride = null;
+            manager.IsNodeInViewOverride = (overrideContext, overrideViewId, overrideNode) =>
+            {
+                Assert.That(overrideContext, Is.Not.Null);
+                Assert.That(overrideViewId, Is.EqualTo(view.NodeId));
+                nodeSeenByOverride = overrideNode;
+                return false;
+            };
+
+            bool overridden = await manager.IsNodeInViewAsync(context, view.NodeId, handle).ConfigureAwait(false);
+            Assert.That(overridden, Is.False);
+            Assert.That(nodeSeenByOverride, Is.SameAs(node));
+        }
+
+        [Test]
         public async Task GetPermissionMetadataAsync_ReturnsAccessAndRoleInformationAsync()
         {
             using ITestNodeManager manager = CreateManager();
@@ -4705,6 +4763,14 @@ namespace Opc.Ua.Server.Tests
 
         public Func<NodeState, CancellationToken, ValueTask> NodeRemovedCallback { get; set; } = null!;
 
+        public Func<ServerSystemContext, NodeId, NodeState, bool> IsNodeInViewOverride { get; set; }
+
+        protected override bool IsNodeInView(ServerSystemContext context, NodeId viewId, NodeState node)
+        {
+            return IsNodeInViewOverride?.Invoke(context, viewId, node)
+                ?? base.IsNodeInView(context, viewId, node);
+        }
+
         public ValueTask AddRootNotifierPublicAsync(NodeState notifier, CancellationToken cancellationToken = default)
         {
             return AddRootNotifierAsync(notifier, cancellationToken);
@@ -5056,6 +5122,12 @@ namespace Opc.Ua.Server.Tests
         NodeStateCollection? NodesToLoad { get; set; }
 
         /// <summary>
+        /// Optional replacement for the protected IsNodeInView(ServerSystemContext, NodeId, NodeState)
+        /// virtual so tests can verify the public entry points route through it.
+        /// </summary>
+        Func<ServerSystemContext, NodeId, NodeState, bool>? IsNodeInViewOverride { get; set; }
+
+        /// <summary>
         /// Tests whether a NodeId belongs to a managed namespace.
         /// </summary>
         bool IsNodeIdInNamespacePublic(NodeId nodeId);
@@ -5177,6 +5249,14 @@ namespace Opc.Ua.Server.Tests
         public Action<bool> EventSubscriptionCallback { get; set; } = null!;
 
         public Action<NodeState> NodeRemovedCallback { get; set; } = null!;
+
+        public Func<ServerSystemContext, NodeId, NodeState, bool>? IsNodeInViewOverride { get; set; }
+
+        protected override bool IsNodeInView(ServerSystemContext context, NodeId viewId, NodeState node)
+        {
+            return IsNodeInViewOverride?.Invoke(context, viewId, node)
+                ?? base.IsNodeInView(context, viewId, node);
+        }
 
         public void AddPredefinedNodePublic(ISystemContext context, NodeState node)
         {
@@ -5341,6 +5421,12 @@ namespace Opc.Ua.Server.Tests
         {
             get => m_cnm2.NodesToLoad;
             set => m_cnm2.NodesToLoad = value;
+        }
+
+        public Func<ServerSystemContext, NodeId, NodeState, bool>? IsNodeInViewOverride
+        {
+            get => m_cnm2.IsNodeInViewOverride;
+            set => m_cnm2.IsNodeInViewOverride = value;
         }
 
         public bool IsNodeIdInNamespacePublic(NodeId nodeId)

--- a/tests/Opc.Ua.Server.Tests/NodeManager/CustomNodeManagerDeterministicTests.cs
+++ b/tests/Opc.Ua.Server.Tests/NodeManager/CustomNodeManagerDeterministicTests.cs
@@ -1114,17 +1114,14 @@ namespace Opc.Ua.Server.Tests.NodeManager
         }
 
         [Test]
-        public void IsNodeInView_ValidatedHandleReturnsFalseFromPublicOverloadRecursion()
+        public void IsNodeInView_ValidatedHandleDelegatesToProtectedOverload()
         {
-            // FLAGGED PRODUCTION BEHAVIOUR (not fixed here): the public
-            // IsNodeInView(OperationContext, NodeId, object) delegates via
-            // IsNodeInView(context, viewId, handle.Node). Because it forwards an
-            // OperationContext (not a ServerSystemContext), overload resolution binds
-            // back to the same public (OperationContext, NodeId, object) overload rather
-            // than the intended protected (ServerSystemContext, NodeId, NodeState) helper.
-            // The recursive call then receives a NodeState (not a NodeHandle) and returns
-            // false, so the public API reports "not in view" for in-memory nodes even when
-            // the view exists. This characterization test locks in the current behaviour.
+            // Regression test: the public IsNodeInView(OperationContext, NodeId, object)
+            // used to forward the OperationContext unchanged, so overload resolution bound
+            // back to the same public overload instead of the protected
+            // (ServerSystemContext, NodeId, NodeState) helper, and every call reported
+            // "not in view". It now copies the context and delegates to the overridable
+            // protected helper, which accepts any view that is a predefined node.
             using Harness h = CreateHarness();
             var view = new ViewState();
             view.CreateAsPredefinedNode(h.Context);
@@ -1135,14 +1132,17 @@ namespace Opc.Ua.Server.Tests.NodeManager
             h.Manager.AddPredefinedNodePublic(h.Context, node);
             var handle = new NodeHandle(node.NodeId, node);
 
-            // The view genuinely resolves through the protected helper...
             Assert.That(h.Manager.FindPredefinedNode<ViewState>(view.NodeId), Is.SameAs(view));
 
-            // ...yet the public overload returns false because of the recursion described above.
             bool result = h.Manager.IsNodeInView(
                 h.NewContext(RequestType.Browse), view.NodeId, handle);
 
-            Assert.That(result, Is.False);
+            Assert.That(result, Is.True);
+
+            bool unknownView = h.Manager.IsNodeInView(
+                h.NewContext(RequestType.Browse), new NodeId("UnknownView", h.NamespaceIndex), handle);
+
+            Assert.That(unknownView, Is.False);
         }
 
         [Test]


### PR DESCRIPTION
# Description

The public `IsNodeInView(OperationContext, NodeId, object)` in `CustomNodeManager2` and `IsNodeInViewAsync(OperationContext, NodeId, object, CancellationToken)` in `AsyncCustomNodeManager` unwrap the `NodeHandle` and forward `handle.Node` together with the **unchanged** `OperationContext`. Since there is no `NodeState`-taking overload with an `OperationContext`, overload resolution binds the call back to the same public `(object)` overload; the recursive call's `is not NodeHandle` guard then returns false. As a result both entry points always reported "not in view" for a validated handle, regardless of the view. The sync variant has behaved this way since the initial commit; the async port copied the same pattern.

The defect is latent in the SDK today: nothing calls `INodeManager2.IsNodeInView` / `IsNodeInViewAsync` except the sync/async adapters forwarding to each other, and Browse view filtering flows through the protected virtuals directly. External code calling the public API (e.g. node managers ported from the samples) was affected.

Changes:

- Both public overloads now copy the operation context (`SystemContext.Copy(context)`) and delegate to the overridable protected `IsNodeInView(ServerSystemContext, NodeId, NodeState)` helper — the same virtual Browse filtering uses and sub-classes override. Doc remarks name the virtual to override. `IsNodeInViewAsync` drops its now-unneeded `async` keyword (signature unchanged).
- New regression test `IsNodeInViewAsync_HandleWithNodeUsesOverridableIsNodeInViewAsync` runs against the native async manager (both monitored-item manager configurations) and against `CustomNodeManager2` behind `AsyncNodeManagerAdapter`. It covers: known view → true, unknown view → false, placeholder handle without node → false, the sync entry point via `SyncNodeManager`, and — via an override hook on the testable managers — that the public entry points genuinely route through the overridable protected virtual. The test was verified to fail against the unfixed code.
- The characterization test that locked in the broken sync behaviour (`IsNodeInView_ValidatedHandleReturnsFalseFromPublicOverloadRecursion`, flagged "not fixed here") is replaced by `IsNodeInView_ValidatedHandleDelegatesToProtectedOverload`, asserting the fixed behaviour.

Verified locally: all `IsNodeInView*` tests and the full node-manager suites (484 tests) pass on net8.0; `Opc.Ua.Server` builds warning-free on net472.

## Related Issues

Found while migrating the Views sample, whose view filtering uses the protected sync virtuals and is unaffected.

- OPCFoundation/UA-.NETStandard-Samples#758

## Checklist

_Put an `x` in the boxes that apply. You can complete these step by step after opening the PR._

- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf) and read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [x] I have added all necessary documentation.
- [x] I have verified that my changes do not introduce (new) build or analyzer warnings.
- [ ] I ran **all** tests locally using the **UA.slnx** solution against at least .net **framework** and .net **10**, and all passed.
- [ ] I fixed **all** failing and flaky tests in the CI pipelines and **all** CodeQL warnings.
- [ ] I have addressed **all** PR feedback received.

🤖 Generated with [Claude Code](https://claude.com/claude-code)