### PR TITLE
Bind monitored items to their owning node manager instead of per-call adapter wrappers

### DIFF
--- a/src/Opc.Ua.Server/NodeManager/AsyncCustomNodeManager.cs
+++ b/src/Opc.Ua.Server/NodeManager/AsyncCustomNodeManager.cs
@@ -6233,7 +6233,7 @@ namespace Opc.Ua.Server
 
             bool success = m_monitoredItemManager.RestoreMonitoredItem(
                 Server,
-                m_syncNodeManager.ToAsyncNodeManager(),
+                this,
                 context,
                 handle,
                 storedMonitoredItem,
@@ -6444,7 +6444,7 @@ namespace Opc.Ua.Server
             ISampledDataChangeMonitoredItem dataChangeMonitoredItem =
                 m_monitoredItemManager.CreateMonitoredItem(
                     Server,
-                    m_syncNodeManager.ToAsyncNodeManager(),
+                    this,
                     context,
                     handle,
                     subscriptionId,

--- a/src/Opc.Ua.Server/NodeManager/CustomNodeManager.cs
+++ b/src/Opc.Ua.Server/NodeManager/CustomNodeManager.cs
@@ -166,17 +166,21 @@ namespace Opc.Ua.Server
             m_namespaceUris = namespaceUris;
             m_namespaceIndexes = namespaceIndexes;
 
+            // identity checks against MonitoredItem.NodeManager require every item created by
+            // this NodeManager to share one async adapter instance.
+            m_asyncNodeManager = this.ToAsyncNodeManager();
+
             // create a monitored item manager that owns sampling groups / monitoredNodes
             if (useSamplingGroups)
             {
                 m_monitoredItemManager = new SamplingGroupMonitoredItemManager(
-                    this.ToAsyncNodeManager(),
+                    m_asyncNodeManager,
                     server,
                     configuration!);
             }
             else
             {
-                m_monitoredItemManager = new MonitoredNodeMonitoredItemManager(this.ToAsyncNodeManager(), server);
+                m_monitoredItemManager = new MonitoredNodeMonitoredItemManager(m_asyncNodeManager, server);
             }
 
             PredefinedNodes = [];
@@ -1164,7 +1168,7 @@ namespace Opc.Ua.Server
             if (Server.NodeManager is ISyncNodeManagerMonitoredItemRecovery recovery)
             {
                 recovery.RecoverDetachedMonitoredItems(
-                    this.ToAsyncNodeManager(),
+                    m_asyncNodeManager,
                     [activeNode.NodeId]);
             }
         }
@@ -4864,7 +4868,7 @@ namespace Opc.Ua.Server
 
             bool success = m_monitoredItemManager.RestoreMonitoredItem(
                 Server,
-                this.ToAsyncNodeManager(),
+                m_asyncNodeManager,
                 context,
                 handle,
                 storedMonitoredItem,
@@ -5084,7 +5088,7 @@ namespace Opc.Ua.Server
             ISampledDataChangeMonitoredItem dataChangeMonitoredItem =
                 m_monitoredItemManager.CreateMonitoredItem(
                     Server,
-                    this.ToAsyncNodeManager(),
+                    m_asyncNodeManager,
                     context,
                     handle,
                     subscriptionId,
@@ -6268,6 +6272,7 @@ namespace Opc.Ua.Server
         private IReadOnlyList<string>? m_namespaceUris;
         private ushort[] m_namespaceIndexes;
         private NodeIdDictionary<CacheEntry>? m_componentCache;
+        private readonly IAsyncNodeManager m_asyncNodeManager;
 
         /// <summary>
         /// A logger to use

--- a/tests/Opc.Ua.Server.Tests/AsyncCustomNodeManagerTests.cs
+++ b/tests/Opc.Ua.Server.Tests/AsyncCustomNodeManagerTests.cs
@@ -1680,6 +1680,71 @@ namespace Opc.Ua.Server.Tests
         }
 
         [Test]
+        public async Task CreateMonitoredItemsAsyncBindsOwningNodeManagerAsync()
+        {
+            using ITestNodeManager manager = CreateManager();
+            ServerSystemContext context = manager.SystemContext;
+            ushort nsIdx = manager.NamespaceIndexes[0];
+            var variable = new BaseDataVariableState(null);
+            variable.CreateAsPredefinedNode(context);
+            variable.NodeId = new NodeId("MyVar", nsIdx);
+            variable.BrowseName = new QualifiedName("MyVar", nsIdx);
+            variable.Value = 10;
+            variable.DataType = DataTypeIds.Int32;
+            variable.ValueRank = ValueRanks.Scalar;
+            variable.AccessLevel = AccessLevels.CurrentRead;
+            await manager.AddNodeAsync(context, default, variable).ConfigureAwait(false);
+
+            var itemToCreate = new MonitoredItemCreateRequest
+            {
+                ItemToMonitor = new ReadValueId { NodeId = variable.NodeId, AttributeId = Attributes.Value },
+                MonitoringMode = MonitoringMode.Reporting,
+                RequestedParameters = new MonitoringParameters { ClientHandle = 1, SamplingInterval = 100, QueueSize = 10 }
+            };
+
+            var itemsToCreate = new List<MonitoredItemCreateRequest> { itemToCreate };
+            var errors = new List<ServiceResult> { null };
+            var filterErrors = new List<MonitoringFilterResult> { null };
+            var monitoredItems = new List<IMonitoredItem> { null };
+
+            await manager.CreateMonitoredItemsAsync(
+                CreateMonitoredItemsContext(),
+                1,
+                1000,
+                TimestampsToReturn.Both,
+                itemsToCreate,
+                errors,
+                filterErrors,
+                monitoredItems,
+                false,
+                new MonitoredItemIdFactory()).ConfigureAwait(false);
+
+            Assert.That(ServiceResult.IsGood(errors[0]), Is.True);
+            IMonitoredItem monitoredItem = monitoredItems[0];
+            Assert.That(monitoredItem, Is.Not.Null);
+
+            if (m_managerType == AsyncCustomNodeManagerType.CustomNodeManager2ViaAdapter)
+            {
+                // The sync CustomNodeManager2 binds items through an adapter wrapping it directly.
+                Assert.That(monitoredItem.NodeManager.SyncNodeManager, Is.SameAs(manager.SyncNodeManager));
+            }
+            else
+            {
+                // AsyncCustomNodeManager implements IAsyncNodeManager and must bind items to itself
+                // instead of re-wrapping its sync adapter into a second adapter (issue #4334).
+                Assert.That(monitoredItem.NodeManager, Is.SameAs(manager));
+            }
+
+            // The bound NodeManager must expose the monitored-item lifecycle; a double-wrapped
+            // adapter chain hides it and reports an empty snapshot.
+            Assert.That(monitoredItem.NodeManager, Is.InstanceOf<INodeManagerMonitoredItemLifecycle>());
+            IReadOnlyList<IMonitoredItem> snapshot =
+                await ((INodeManagerMonitoredItemLifecycle)monitoredItem.NodeManager)
+                    .GetMonitoredItemsSnapshotAsync().ConfigureAwait(false);
+            Assert.That(snapshot, Does.Contain(monitoredItem));
+        }
+
+        [Test]
         public async Task ModifyMonitoredItemsAsync_ModifiesItemAsync()
         {
             // Setup manager and node

--- a/tests/Opc.Ua.Server.Tests/AsyncCustomNodeManagerTests.cs
+++ b/tests/Opc.Ua.Server.Tests/AsyncCustomNodeManagerTests.cs
@@ -1701,11 +1701,17 @@ namespace Opc.Ua.Server.Tests
                 MonitoringMode = MonitoringMode.Reporting,
                 RequestedParameters = new MonitoringParameters { ClientHandle = 1, SamplingInterval = 100, QueueSize = 10 }
             };
+            var secondItemToCreate = new MonitoredItemCreateRequest
+            {
+                ItemToMonitor = new ReadValueId { NodeId = variable.NodeId, AttributeId = Attributes.Value },
+                MonitoringMode = MonitoringMode.Reporting,
+                RequestedParameters = new MonitoringParameters { ClientHandle = 2, SamplingInterval = 100, QueueSize = 10 }
+            };
 
-            var itemsToCreate = new List<MonitoredItemCreateRequest> { itemToCreate };
-            var errors = new List<ServiceResult> { null };
-            var filterErrors = new List<MonitoringFilterResult> { null };
-            var monitoredItems = new List<IMonitoredItem> { null };
+            var itemsToCreate = new List<MonitoredItemCreateRequest> { itemToCreate, secondItemToCreate };
+            var errors = new List<ServiceResult> { null, null };
+            var filterErrors = new List<MonitoringFilterResult> { null, null };
+            var monitoredItems = new List<IMonitoredItem> { null, null };
 
             await manager.CreateMonitoredItemsAsync(
                 CreateMonitoredItemsContext(),
@@ -1720,8 +1726,10 @@ namespace Opc.Ua.Server.Tests
                 new MonitoredItemIdFactory()).ConfigureAwait(false);
 
             Assert.That(ServiceResult.IsGood(errors[0]), Is.True);
+            Assert.That(ServiceResult.IsGood(errors[1]), Is.True);
             IMonitoredItem monitoredItem = monitoredItems[0];
             Assert.That(monitoredItem, Is.Not.Null);
+            Assert.That(monitoredItems[1], Is.Not.Null);
 
             if (m_managerType == AsyncCustomNodeManagerType.CustomNodeManager2ViaAdapter)
             {
@@ -1734,6 +1742,10 @@ namespace Opc.Ua.Server.Tests
                 // instead of re-wrapping its sync adapter into a second adapter (issue #4334).
                 Assert.That(monitoredItem.NodeManager, Is.SameAs(manager));
             }
+
+            // All items created by one NodeManager must share the same NodeManager reference;
+            // the sync manager once allocated a fresh adapter per created item.
+            Assert.That(monitoredItems[1].NodeManager, Is.SameAs(monitoredItem.NodeManager));
 
             // The bound NodeManager must expose the monitored-item lifecycle; a double-wrapped
             // adapter chain hides it and reports an empty snapshot.


### PR DESCRIPTION
# Description

`AsyncCustomNodeManager` passed `m_syncNodeManager.ToAsyncNodeManager()` as the owning node manager when creating and restoring monitored items. Since `SyncNodeManagerAdapter` does not implement `IAsyncNodeManager`, every call allocated a fresh `AsyncNodeManagerAdapter` around the `SyncNodeManagerAdapter` around the manager itself. The double-wrapped chain:

- routed async dispatch through the sync adapter's `GetAwaiter().GetResult()` blocking (sync-over-async), defeating the purpose of the async node manager,
- hid `INodeManagerMonitoredItemLifecycle` — the inner sync adapter does not implement it, so detach during monitored-item recovery degraded to `BadNotSupported` and ownership snapshots came back empty,
- broke reference-identity checks against the owning node manager and gave every item a distinct `NodeManager` instance.

The manager implements `IAsyncNodeManager` natively, so it now passes `this` at both call sites — the same reference its constructor already hands to the monitored item managers.

The second commit applies the milder counterpart to the sync `CustomNodeManager2`, which called `this.ToAsyncNodeManager()` at five sites and thereby allocated a fresh single-wrap adapter per created monitored item. The adapter is now created once in the constructor and reused, so the monitored item managers, created and restored items, and detached-item recovery all share one `NodeManager` reference instead of relying on the `SyncNodeManager` fallbacks in `AreSameNodeManager`/`GetVisibleNodeManager`.

The regression test `CreateMonitoredItemsAsyncBindsOwningNodeManagerAsync` runs in all three fixture variants (MonitoredNode, SamplingGroup, CustomNodeManager2 via adapter) and asserts the created items bind to the manager itself, share one `NodeManager` reference, and expose a working monitored-item lifecycle snapshot. Both halves were verified to fail without their respective fix.

## Related Issues

- Fixes #4334

## Checklist

_Put an `x` in the boxes that apply. You can complete these step by step after opening the PR._

- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf) and read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [x] I have added all necessary documentation.
- [x] I have verified that my changes do not introduce (new) build or analyzer warnings.
- [ ] I ran **all** tests locally using the **UA.slnx** solution against at least .net **framework** and .net **10**, and all passed.
- [ ] I fixed **all** failing and flaky tests in the CI pipelines and **all** CodeQL warnings.
- [ ] I have addressed **all** PR feedback received.

🤖 Generated with [Claude Code](https://claude.com/claude-code)