### PR TITLE
Fix certificate leak when rejected-store enqueue races manager disposal

### DIFF
--- a/src/Opc.Ua.Core/Security/Certificates/CertificateManager/RejectedCertificateProcessor.cs
+++ b/src/Opc.Ua.Core/Security/Certificates/CertificateManager/RejectedCertificateProcessor.cs
@@ -100,11 +100,7 @@ namespace Opc.Ua
             // channel is processed in order, this also implies all earlier
             // requests have completed.
             Interlocked.Exchange(ref m_drainTcs, tcs);
-            var request = new WriteRequest(chain.AddRef(), tcs);
-
-            return m_channel.Writer.TryWrite(request)
-                ? default
-                : m_channel.Writer.WriteAsync(request, ct);
+            return WriteRequestAsync(new WriteRequest(chain.AddRef(), tcs), ct);
         }
 
         /// <summary>
@@ -118,11 +114,57 @@ namespace Opc.Ua
             var tcs = new TaskCompletionSource<bool>(
                 TaskCreationOptions.RunContinuationsAsynchronously);
             Interlocked.Exchange(ref m_drainTcs, tcs);
+            return WriteRequestAsync(new WriteRequest(Chain: null, tcs), ct);
+        }
 
-            var request = new WriteRequest(Chain: null, tcs);
+        private ValueTask WriteRequestAsync(WriteRequest request, CancellationToken ct)
+        {
             return m_channel.Writer.TryWrite(request)
                 ? default
-                : m_channel.Writer.WriteAsync(request, ct);
+                : WriteRequestSlowAsync(request, ct);
+        }
+
+        /// <summary>
+        /// Fallback for a refused <c>TryWrite</c>. The channel is bounded with
+        /// <see cref="BoundedChannelFullMode.DropOldest"/>, so a refused
+        /// TryWrite means the writer has been completed by
+        /// <see cref="DisposeAsync"/> and the awaited write below fails rather
+        /// than blocks. The request owns its chain (the per-cert AddRef taken
+        /// on enqueue): once the write cannot commit the request to the
+        /// channel, nothing else references it, so the chain must be disposed
+        /// here — an abandoned request keeps one leaked reference per
+        /// certificate for the life of the process (this was the intermittent
+        /// one-certificate leak reported by the test assemblies' teardown leak
+        /// detector when a late validation raced manager disposal). The
+        /// completion is resolved as "not processed" so a WaitForDrainAsync
+        /// caller is not left waiting on the abandoned request. An enqueue
+        /// after shutdown is a benign teardown race and the store write is
+        /// best-effort, so <see cref="ChannelClosedException"/> is swallowed;
+        /// cancellation still propagates.
+        /// </summary>
+        private async ValueTask WriteRequestSlowAsync(
+            WriteRequest request,
+            CancellationToken ct)
+        {
+            try
+            {
+                await m_channel.Writer.WriteAsync(request, ct).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                try
+                {
+                    request.Chain?.Dispose();
+                }
+                finally
+                {
+                    request.Completion.TrySetResult(false);
+                }
+                if (ex is not ChannelClosedException)
+                {
+                    throw;
+                }
+            }
         }
 
         /// <summary>

--- a/tests/Opc.Ua.Core.Tests/Security/Certificates/CertificateManager/CertificateManagerTests.cs
+++ b/tests/Opc.Ua.Core.Tests/Security/Certificates/CertificateManager/CertificateManagerTests.cs
@@ -669,6 +669,73 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
             return Task.CompletedTask;
         }
 
+        /// <summary>
+        /// A validation can race manager disposal and enqueue a rejected
+        /// chain after the rejected-certificate processor's channel has been
+        /// completed. The refused enqueue must release the per-certificate
+        /// references it took for the queued request instead of abandoning
+        /// them with it — an abandoned request pins each certificate's core
+        /// for the life of the process and surfaced as an intermittent
+        /// one-certificate leak in the test assemblies' teardown leak
+        /// detector on slow CI agents.
+        /// </summary>
+        [Test]
+        public async Task RejectCertificateAsyncAfterDisposeDoesNotLeakChainAsync()
+        {
+            string rejectedPath = CreateTempDir();
+            var manager = new CertificateManager(m_telemetry);
+            Certificate cert = CertificateBuilder
+                .Create("CN=RejectedAfterDispose")
+                .SetRSAKeySize(2048)
+                .CreateForRSA();
+            try
+            {
+                manager.RegisterTrustList(TrustListIdentifier.Rejected, rejectedPath);
+
+                // Prime the processor so the disposed manager still holds one,
+                // then dispose the manager: DisposeAsync drains the processor
+                // and completes its channel, so later writes are refused.
+                using (var primed = new CertificateCollection { cert })
+                {
+                    await manager.RejectCertificateAsync(primed).ConfigureAwait(false);
+                }
+                await manager.DisposeAsync().ConfigureAwait(false);
+
+                // The late enqueue is refused; it must neither throw for this
+                // benign teardown race nor keep the references taken for the
+                // refused request.
+                using (var late = new CertificateCollection { cert })
+                {
+                    Assert.DoesNotThrowAsync(async () =>
+                        await manager.RejectCertificateAsync(late).ConfigureAwait(false));
+                }
+            }
+            finally
+            {
+                cert.Dispose();
+            }
+
+            // cert held the sole surviving reference. After its Dispose every
+            // owning handle over the core must be gone, so AddRef must refuse.
+            Certificate leakedReference = null;
+            try
+            {
+                leakedReference = cert.AddRef();
+            }
+            catch (ObjectDisposedException)
+            {
+                // expected: no reference survived the refused enqueue.
+            }
+
+            if (leakedReference != null)
+            {
+                leakedReference.Dispose();
+                Assert.Fail(
+                    "The refused enqueue abandoned its request without releasing " +
+                    "the per-certificate references taken for it.");
+            }
+        }
+
         [Test]
         public void FactoryCreateFromSecurityConfiguration()
         {

--- a/tests/Opc.Ua.Core.Tests/Security/Certificates/CertificateManager/CertificateManagerTests.cs
+++ b/tests/Opc.Ua.Core.Tests/Security/Certificates/CertificateManager/CertificateManagerTests.cs
@@ -683,7 +683,7 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
         public async Task RejectCertificateAsyncAfterDisposeDoesNotLeakChainAsync()
         {
             string rejectedPath = CreateTempDir();
-            var manager = new CertificateManager(m_telemetry);
+            await using var manager = new CertificateManager(m_telemetry);
             Certificate cert = CertificateBuilder
                 .Create("CN=RejectedAfterDispose")
                 .SetRSAKeySize(2048)


### PR DESCRIPTION
The macOS legs of the Build and Test workflow intermittently failed the assembly-level teardown of the Sessions (also History and Client) test suites with "Certificate leak detected: 1 instance(s) created but not disposed" while every test passed (master run 33004556144: created=16777, disposed=16776; PR run 33207357247: created=17373, disposed=17372). The count held steady through the teardown's full quiescence window, so the missing disposal was permanent, not a slow in-flight drain.

RejectedCertificateProcessor.EnqueueAsync takes a per-certificate AddRef for the queued WriteRequest before TryWrite. Once CertificateManager.DisposeAsync has completed the channel writer, the bounded DropOldest channel refuses TryWrite and the WriteAsync fallback throws ChannelClosedException, abandoning the request: nothing releases the references it owns, so every certificate in the chain keeps one leaked reference for the life of the process. A validation that races manager disposal — a keep-alive, reconnect or fire-and-forget channel teardown rejecting a certificate while the fixture tears down — lands in exactly this window, and the slower loaded macOS runners make that race likely. The abandoned request also left FlushRejectedAsync waiters hanging on a drain marker that never resolves, and surfaced unobserved ChannelClosedExceptions through the fire-and-forget EnqueueRejectedCertificate discard.

Route both enqueue paths through a fallback that, when the write cannot commit the request to the channel, disposes the request's chain (releasing the per-certificate references), resolves its completion as "not processed" so drain waiters are unblocked, and swallows only the benign ChannelClosedException shutdown race; cancellation still propagates. The teardown leak detector needs no change: its quiescence poll was correctly reporting a genuine leak.

The new regression test reproduces the CI signature deterministically against the previous code (ChannelClosedException plus "Certificate leak detected: 1 instance(s) created but not disposed (created=1, disposed=0)" in the assembly teardown) and passes with the fix.