### PR TITLE
Fix reverse connect hold time when several Servers share one listener

### DIFF
--- a/Docs/ReverseConnect.md
+++ b/Docs/ReverseConnect.md
@@ -34,6 +34,36 @@ If the Client accepts the connection, a secure connection requires that the Clie
 
 The auto-reconnect behavior on the Server is essential to any real application, because Clients close the Socket when the SecureChannel is closed. According to the specification a Server needs to abort the auto-reconnect if it receives a *BadTcpMessageTypeInvalid* code, because that is the error it will receive from peers that have not been upgraded to support the *ReverseHello*. Because of this a Client can use the same error code to tell the Server to stop reconnecting, if a user has rejected the connection. However, in this implementation, only if the Server is configured for a single connection it applies an extended timeout before reconnecting to the Client to reduce the overall traffic. In other configurations the Server keeps sending the *ReverseHello* messages at the configured time interval.
 
+## Sharing a listener across multiple Servers
+
+A reverse connect listener stays bound for the lifetime of its *ReverseConnectManager*. Seeing the listener port remain in the `LISTENING` state after a Session was established is expected and required: the listening socket has to stay open so that further Servers, and the automatic re-connects of the Servers which are already connected, can reach the Client. The port is released when the manager is disposed.
+
+Use **one shared** *ReverseConnectManager* for all Servers which connect to the same Client Url. A separate manager per Server cannot reuse the same host and port. Register or wait for every Server separately, using the *EndpointUrl* of that Server and, preferably, its *ServerUri*:
+
+``` csharp
+using var reverseConnectManager = new ReverseConnectManager(telemetry);
+reverseConnectManager.AddEndpoint(new Uri("opc.tcp://client-host:65300"));
+reverseConnectManager.StartService(
+    new ReverseConnectClientConfiguration {
+        HoldTime = 15000,
+        WaitTimeout = 20000
+    });
+
+ITransportWaitingConnection connectionA = await reverseConnectManager.WaitForConnectionAsync(
+    new Uri("opc.tcp://server-a:62541/Server"),
+    "urn:server-a:UA:Server").ConfigureAwait(false);
+
+ITransportWaitingConnection connectionB = await reverseConnectManager.WaitForConnectionAsync(
+    new Uri("opc.tcp://server-b:62541/Server"),
+    "urn:server-b:UA:Server").ConfigureAwait(false);
+```
+
+Each returned *ITransportWaitingConnection* is passed to the session factory of the corresponding Server.
+
+*HoldTime* controls how long an incoming *ReverseHello* which does not match any registration yet is held open before it is rejected. This matters when several Servers connect before the application has registered a waiting connection for each of them: every held connection waits for the remainder of its own hold time, also when a registration for a different Server arrives in the meantime. A Server whose hold time expires without a matching registration is rejected and reconnects on its next *ReverseHello* interval.
+
+*WaitTimeout* is the default timeout of `WaitForConnectionAsync` when no cancellation token is passed. Choose it large enough to cover the *ReverseHello* interval of the Server.
+
 ## Configuration Extensions
 
 This configuration sample shows the configuration setting for a reverse connection on port 65300.

--- a/Libraries/Opc.Ua.Client/ReverseConnectManager.cs
+++ b/Libraries/Opc.Ua.Client/ReverseConnectManager.cs
@@ -232,6 +232,19 @@ namespace Opc.Ua.Client
             }
             if (m_cts != null)
             {
+                // release the connections which are held by OnConnectionWaitingAsync
+                // before the token source is disposed.
+                lock (m_registrationsLock)
+                {
+                    m_shutdown = true;
+                    try
+                    {
+                        m_cts.Cancel();
+                    }
+                    catch (ObjectDisposedException)
+                    {
+                    }
+                }
                 Utils.SilentDispose(m_cts);
             }
             DisposeHosts();
@@ -480,6 +493,10 @@ namespace Opc.Ua.Client
                 {
                     m_configurationWatcher = null;
                     OnUpdateConfiguration(configuration);
+                    lock (m_registrationsLock)
+                    {
+                        m_shutdown = false;
+                    }
                     OpenHosts();
                     m_state = ReverseConnectManagerState.Started;
                 }
@@ -632,6 +649,12 @@ namespace Opc.Ua.Client
         /// </summary>
         private void StopService()
         {
+            lock (m_registrationsLock)
+            {
+                m_shutdown = true;
+            }
+
+            // releases the connections which are held by OnConnectionWaitingAsync.
             ClearWaitingConnections();
             lock (m_lock)
             {
@@ -645,6 +668,11 @@ namespace Opc.Ua.Client
         /// </summary>
         private void StartService()
         {
+            lock (m_registrationsLock)
+            {
+                m_shutdown = false;
+            }
+
             lock (m_lock)
             {
                 OpenHosts();
@@ -693,6 +721,17 @@ namespace Opc.Ua.Client
         }
 
         /// <summary>
+        /// Invokes the internal <see cref="OnConnectionWaitingAsync"/> callback
+        /// against a supplied waiting connection event, exactly as a listener
+        /// would. Exposed internally so a test can drive a held connection
+        /// without opening a listener.
+        /// </summary>
+        internal Task InvokeConnectionWaitingForTest(ConnectionWaitingEventArgs e)
+        {
+            return OnConnectionWaitingAsync(this, e);
+        }
+
+        /// <summary>
         /// Raised when a reverse connection is waiting,
         /// finds and calls a waiting connection.
         /// </summary>
@@ -704,37 +743,53 @@ namespace Opc.Ua.Client
             bool matched = MatchRegistration(sender, e);
             while (!matched)
             {
-                m_logger.LogInformation("Holding reverse connection: {ServerUri} {EndpointUrl}", e.ServerUri, e.EndpointUrl);
+                int delay = endTime - HiResClock.TickCount;
+                if (delay <= 0)
+                {
+                    // the hold time expired without a matching registration.
+                    break;
+                }
+
                 CancellationToken ct;
                 lock (m_registrationsLock)
                 {
+                    if (m_shutdown)
+                    {
+                        // the manager is stopping, release the connection.
+                        break;
+                    }
                     ct = m_cts.Token;
                 }
-                int delay = endTime - HiResClock.TickCount;
-                if (delay > 0)
-                {
-                    await Task.Delay(delay, ct)
-                        .ContinueWith(tsk =>
-                        {
-                            if (tsk.IsCanceled)
-                            {
-                                matched = MatchRegistration(sender, e);
-                                if (matched)
-                                {
-                                    m_logger.LogInformation(
-                                        "Matched reverse connection {ServerUri} {EndpointUrl} after {Duration}ms",
-                                        e.ServerUri,
-                                        e.EndpointUrl,
-                                        HiResClock.TickCount - startTime);
-                                }
-                            }
-                        },
+
+                m_logger.LogInformation("Holding reverse connection: {ServerUri} {EndpointUrl}", e.ServerUri, e.EndpointUrl);
+
+                bool registrationsChanged = false;
+                await Task.Delay(delay, ct)
+                    .ContinueWith(
+                        tsk => registrationsChanged = tsk.IsCanceled,
                         default,
                         TaskContinuationOptions.None,
                         TaskScheduler.Default)
-                        .ConfigureAwait(false);
+                    .ConfigureAwait(false);
+
+                if (!registrationsChanged)
+                {
+                    // the hold time elapsed without a matching registration.
+                    break;
                 }
-                break;
+
+                // the registrations changed, try to match again. If the registration
+                // which caused the wakeup was for another server, keep holding this
+                // connection for the remainder of its own hold time.
+                matched = MatchRegistration(sender, e);
+                if (matched)
+                {
+                    m_logger.LogInformation(
+                        "Matched reverse connection {ServerUri} {EndpointUrl} after {Duration}ms",
+                        e.ServerUri,
+                        e.EndpointUrl,
+                        HiResClock.TickCount - startTime);
+                }
             }
 
             m_logger.LogInformation(
@@ -847,5 +902,11 @@ namespace Opc.Ua.Client
         private readonly List<Registration> m_registrations;
         private readonly Lock m_registrationsLock = new();
         private CancellationTokenSource m_cts;
+
+        /// <summary>
+        /// Set while the manager is stopped or disposed to release the
+        /// reverse connections which are held by OnConnectionWaitingAsync.
+        /// </summary>
+        private bool m_shutdown;
     }
 }

--- a/Tests/Opc.Ua.Client.Tests/ReverseConnectManagerUnitTests.cs
+++ b/Tests/Opc.Ua.Client.Tests/ReverseConnectManagerUnitTests.cs
@@ -1,0 +1,193 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Opc.Ua.Tests;
+
+namespace Opc.Ua.Client.Tests
+{
+    /// <summary>
+    /// Unit tests for the connection hold time of the reverse connect manager.
+    /// </summary>
+    /// <remarks>
+    /// A single reverse connect listener is intended to serve multiple servers.
+    /// Servers which connect before the application registered a waiting
+    /// connection for them are held for the configured hold time. Registering a
+    /// waiting connection wakes up all held connections, but a connection which
+    /// does not match the new registration must keep waiting for the remainder
+    /// of its own hold time instead of being rejected.
+    /// </remarks>
+    [TestFixture]
+    [Category("Client")]
+    [Parallelizable]
+    public class ReverseConnectManagerUnitTests
+    {
+        private const int kHoldTime = 30000;
+        private const int kSettleTimeout = 1000;
+        private const int kCompletionTimeout = 20000;
+        private const string kServerUriA = "urn:server-a:UA:Server";
+        private const string kServerUriB = "urn:server-b:UA:Server";
+
+        private static readonly Uri s_endpointUrlA = new("opc.tcp://server-a:62541/Server");
+        private static readonly Uri s_endpointUrlB = new("opc.tcp://server-b:62541/Server");
+
+        /// <summary>
+        /// A waiting connection event which can be created without a listener.
+        /// </summary>
+        private sealed class TestConnectionWaitingEventArgs : ConnectionWaitingEventArgs
+        {
+            public TestConnectionWaitingEventArgs(string serverUri, Uri endpointUrl)
+                : base(serverUri, endpointUrl)
+            {
+            }
+        }
+
+        /// <summary>
+        /// A reverse connection which is held must not be rejected when a
+        /// waiting connection for another server is registered.
+        /// </summary>
+        [Test]
+        public async Task HeldConnectionSurvivesRegistrationForAnotherServerAsync()
+        {
+            using ReverseConnectManager manager = CreateManager(kHoldTime);
+
+            var serverA = new TestConnectionWaitingEventArgs(kServerUriA, s_endpointUrlA);
+            var serverB = new TestConnectionWaitingEventArgs(kServerUriB, s_endpointUrlB);
+
+            // both servers connect before the application waits for them
+            Task holdA = manager.InvokeConnectionWaitingForTest(serverA);
+            Task holdB = manager.InvokeConnectionWaitingForTest(serverB);
+
+            Assert.That(holdA.IsCompleted, Is.False);
+            Assert.That(holdB.IsCompleted, Is.False);
+
+            // wait for the first server, this wakes up both held connections
+            ITransportWaitingConnection connectionA = await manager
+                .WaitForConnectionAsync(s_endpointUrlA, kServerUriA)
+                .ConfigureAwait(false);
+
+            Assert.That(connectionA, Is.SameAs(serverA));
+            await WaitForCompletionAsync(holdA).ConfigureAwait(false);
+            Assert.That(serverA.Accepted, Is.True);
+
+            // the connection of the second server must still be held
+            Task settled = await Task.WhenAny(holdB, Task.Delay(kSettleTimeout))
+                .ConfigureAwait(false);
+            Assert.That(
+                settled,
+                Is.Not.SameAs(holdB),
+                "The reverse connection of the second server was released before its hold time expired.");
+            Assert.That(serverB.Accepted, Is.False);
+
+            // the held connection is still available for the second server
+            ITransportWaitingConnection connectionB = await manager
+                .WaitForConnectionAsync(s_endpointUrlB, kServerUriB)
+                .ConfigureAwait(false);
+
+            Assert.That(connectionB, Is.SameAs(serverB));
+            await WaitForCompletionAsync(holdB).ConfigureAwait(false);
+            Assert.That(serverB.Accepted, Is.True);
+        }
+
+        /// <summary>
+        /// A reverse connection which is never registered for is rejected once
+        /// the hold time expired.
+        /// </summary>
+        [Test]
+        public async Task HeldConnectionIsRejectedWhenHoldTimeExpiresAsync()
+        {
+            using ReverseConnectManager manager = CreateManager(1000);
+
+            var server = new TestConnectionWaitingEventArgs(kServerUriA, s_endpointUrlA);
+
+            Task hold = manager.InvokeConnectionWaitingForTest(server);
+            Assert.That(hold.IsCompleted, Is.False);
+
+            await WaitForCompletionAsync(hold).ConfigureAwait(false);
+            Assert.That(server.Accepted, Is.False);
+        }
+
+        /// <summary>
+        /// Disposing the manager releases the connections which are held,
+        /// they are not kept until the hold time expires.
+        /// </summary>
+        [Test]
+        public async Task DisposeReleasesHeldConnectionAsync()
+        {
+            ReverseConnectManager manager = CreateManager(kHoldTime);
+
+            var server = new TestConnectionWaitingEventArgs(kServerUriA, s_endpointUrlA);
+
+            Task hold = manager.InvokeConnectionWaitingForTest(server);
+            Assert.That(hold.IsCompleted, Is.False);
+
+            manager.Dispose();
+
+            await WaitForCompletionAsync(hold).ConfigureAwait(false);
+            Assert.That(server.Accepted, Is.False);
+        }
+
+        /// <summary>
+        /// Create a started manager without a listener, only the hold time and
+        /// the wait timeout of the configuration are used by the tests.
+        /// </summary>
+        private static ReverseConnectManager CreateManager(int holdTime)
+        {
+            var manager = new ReverseConnectManager(NUnitTelemetryContext.Create());
+            try
+            {
+                manager.StartService(
+                    new ReverseConnectClientConfiguration
+                    {
+                        HoldTime = holdTime,
+                        WaitTimeout = kCompletionTimeout
+                    });
+            }
+            catch
+            {
+                manager.Dispose();
+                throw;
+            }
+            return manager;
+        }
+
+        /// <summary>
+        /// Await a task, fail the test if it does not complete in time.
+        /// </summary>
+        private static async Task WaitForCompletionAsync(Task task)
+        {
+            Task completed = await Task.WhenAny(task, Task.Delay(kCompletionTimeout))
+                .ConfigureAwait(false);
+            Assert.That(completed, Is.SameAs(task), "The reverse connection was not released.");
+            await task.ConfigureAwait(false);
+        }
+    }
+}


### PR DESCRIPTION
# Description

Fixes the reverse connect problem reported in #3985: a Client which uses one reverse connect listener port for several Servers connects to the first Server, and every following `WaitForConnectionAsync` times out. A separate listener port per Server was the only workaround.

## Root cause

Confirming the analysis in [mrsuciu's comment on #3985](https://github.com/OPCFoundation/UA-.NETStandard/issues/3985):

- Servers which send `ReverseHello` before the application registered a waiting connection for them are held in `OnConnectionWaitingAsync` for `HoldTime`.
- All held connections share a single `CancellationTokenSource`, so `RegisterWaitingConnection` wakes up **every** held connection, not only the one it was registered for.
- The hold loop was `while (!matched) { ... break; }` with an unconditional `break`, so each woken connection got exactly one re-match attempt. The connections which did not match the new registration fell out of the loop unaccepted, although most of their own hold time was left.
- An unaccepted connection is force faulted by the listener (`TcpReverseConnectChannel`, "The reverse connection was rejected by the client"), so that Server is dropped and only returns on its next `ReverseHello` interval, long after the Client timed out waiting for it.

Separate ports avoid the shared wakeup path, which is exactly why that workaround succeeds.

## Changes

- `ReverseConnectManager.OnConnectionWaitingAsync` re-arms the hold after a wakeup: it re-matches, and if the registration which caused the wakeup was for another Server the connection keeps waiting for the remainder of its own hold time. The loop is still bounded by `HoldTime`, so a Server which is never registered for is rejected exactly as before.
- A shutdown flag set by `StopService`/`Dispose` (cleared by `StartService`) releases held connections immediately during teardown, instead of parking them until the hold time expires. `Dispose` now also cancels the token source before disposing it, so a held callback can no longer read a disposed token.
- `Docs/ReverseConnect.md`: new "Sharing a listener across multiple Servers" section documenting that the listener port staying in `LISTENING` is expected, that one shared `ReverseConnectManager` should serve all Servers on the same Client Url, and the `HoldTime`/`WaitTimeout` semantics.

No public API, signature or serialization change.

## Validation

- New `ReverseConnectManagerUnitTests` (3 tests): the two Server regression, hold time expiry still rejecting, and dispose releasing a held connection. They drive the callback through an internal test hook, so no listener or socket is involved. Verified that the regression test fails against the previous behaviour with "The reverse connection of the second server was released before its hold time expired."
- New tests pass on net10.0 and net48.
- Full reverse connect suite (`FullyQualifiedName~ReverseConnect`, including the existing `ReverseConnectTest` server fixture): 33/33 pass on net10.0.

## Related Issues

- Relates to #3985.
- `master` carries the identical defect: the same `break` survived #4009 and #4059 and is still present in `src/Opc.Ua.Client/ReverseConnectManager.cs`. The equivalent fix for `master` is #4342 (it uses `TimeProvider` and breaks on a pending callback drain instead of a new flag), so the issue is intentionally not auto closed here.

## Checklist

- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf) and read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [x] I have added all necessary documentation.
- [x] I have verified that my changes do not introduce (new) build or analyzer warnings.
- [ ] I ran **all** tests locally using the **UA.slnx** solution against at least .net **framework** and .net **10**, and all passed.
- [ ] I fixed **all** failing and flaky tests in the CI pipelines and **all** CodeQL warnings.
- [ ] I have addressed **all** PR feedback received.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

