### PR TITLE
Fix reverse connect hold time when several Servers share one listener

### DIFF
--- a/docs/ReverseConnect.md
+++ b/docs/ReverseConnect.md
@@ -67,6 +67,8 @@ await Task.WhenAll(serverA, serverB).ConfigureAwait(false);
 
 Pass each returned `ITransportWaitingConnection` to the session factory for the corresponding Server.
 
+`HoldTime` controls how long an incoming `ReverseHello` that does not match any registration yet is held open before it is rejected. This matters when several Servers connect before the application has registered a waiting connection for each of them: every held connection waits for the remainder of its own hold time, also when a registration for a different Server arrives in the meantime. A Server whose hold time expires without a matching registration is rejected and reconnects on its next `ReverseHello` interval. A committed stop or dispose releases the held connections immediately.
+
 `StartServiceAsync` validates and prepares the complete listener set before it changes a running service. If activation fails after existing listeners have stopped, the manager recreates and reopens the previous configuration. Cancellation cleans partially initialized candidates and either preserves or restores the prior service. Use `await manager.StopServiceAsync(...)` for an explicit stop and `await manager.DisposeAsync()` (or `await using`) for teardown.
 
 The synchronous `StartService`, `RegisterWaitingConnection`, and `Dispose` APIs remain as obsolete compatibility wrappers. New code should use `StartServiceAsync`, `RegisterWaitingConnectionAsync`, and `DisposeAsync`; the compatibility wrappers may block a caller thread.

--- a/src/Opc.Ua.Client/ReverseConnectManager.cs
+++ b/src/Opc.Ua.Client/ReverseConnectManager.cs
@@ -4556,38 +4556,59 @@ namespace Opc.Ua.Client
                 bool matched = MatchRegistration(sender, e);
                 while (!matched)
                 {
-                    m_logger.HoldingReverseConnectionServerUriEndpointUrl(
-                        e.ServerUri,
-                        e.EndpointUrl);
+                    TimeSpan delay = holdTime - m_timeProvider.GetElapsedTime(startTimestamp);
+                    if (delay <= TimeSpan.Zero)
+                    {
+                        // the hold time expired without a matching registration.
+                        break;
+                    }
+
+                    // A committed Stop/Dispose drains the in-flight callbacks
+                    // before the terminal listener close, and cancels the hold
+                    // token without renewing it. Release the transport instead
+                    // of re-arming the hold on an already cancelled token.
+                    if (IsCallbackDrainPending())
+                    {
+                        break;
+                    }
+
                     CancellationToken ct;
                     lock (m_registrationsLock)
                     {
                         ct = m_cts.Token;
                     }
-                    TimeSpan delay = holdTime - m_timeProvider.GetElapsedTime(startTimestamp);
-                    if (delay > TimeSpan.Zero)
-                    {
-                        await m_timeProvider.Delay(delay, ct)
-                            .ContinueWith(tsk =>
-                            {
-                                if (tsk.IsCanceled)
-                                {
-                                    matched = MatchRegistration(sender, e);
-                                    if (matched && m_logger.IsEnabled(LogLevel.Information))
-                                    {
-                                        m_logger.MatchedReverseConnectionServerUriEndpointUrlAfter(
-                                            e.ServerUri,
-                                            e.EndpointUrl,
-                                            (long)m_timeProvider.GetElapsedTime(startTimestamp).TotalMilliseconds);
-                                    }
-                                }
-                            },
+
+                    m_logger.HoldingReverseConnectionServerUriEndpointUrl(
+                        e.ServerUri,
+                        e.EndpointUrl);
+
+                    bool registrationsChanged = false;
+                    await m_timeProvider.Delay(delay, ct)
+                        .ContinueWith(
+                            tsk => registrationsChanged = tsk.IsCanceled,
                             default,
                             TaskContinuationOptions.None,
                             TaskScheduler.Default)
-                            .ConfigureAwait(false);
+                        .ConfigureAwait(false);
+
+                    if (!registrationsChanged)
+                    {
+                        // the hold time elapsed without a matching registration.
+                        break;
                     }
-                    break;
+
+                    // The registrations changed, try to match again. If the
+                    // registration which caused the wakeup was for another
+                    // Server, keep holding this connection for the remainder
+                    // of its own hold time instead of rejecting it.
+                    matched = MatchRegistration(sender, e);
+                    if (matched && m_logger.IsEnabled(LogLevel.Information))
+                    {
+                        m_logger.MatchedReverseConnectionServerUriEndpointUrlAfter(
+                            e.ServerUri,
+                            e.EndpointUrl,
+                            (long)m_timeProvider.GetElapsedTime(startTimestamp).TotalMilliseconds);
+                    }
                 }
 
                 if (m_logger.IsEnabled(LogLevel.Information))
@@ -4745,6 +4766,23 @@ namespace Opc.Ua.Client
                 }
                 m_activeCallbacks++;
                 return true;
+            }
+        }
+
+        /// <summary>
+        /// Whether a Stop/Dispose is draining the in-flight
+        /// <see cref="OnConnectionWaitingAsync"/> callbacks. A callback that is
+        /// already inside the tracking region must then stop holding its
+        /// transport instead of re-arming the hold: the drain cancels the hold
+        /// token without renewing it, so a renewed hold would spin on an
+        /// already cancelled token until the hold time expires and would block
+        /// the drain until then.
+        /// </summary>
+        private bool IsCallbackDrainPending()
+        {
+            lock (m_callbackLock)
+            {
+                return m_callbacksDrainedSignal != null;
             }
         }
 

--- a/src/Opc.Ua.Client/ReverseConnectManager.cs
+++ b/src/Opc.Ua.Client/ReverseConnectManager.cs
@@ -4578,6 +4578,23 @@ namespace Opc.Ua.Client
                         ct = m_cts.Token;
                     }
 
+                    // A registration may have been inserted and the hold token renewed between the
+                    // initial MatchRegistration call and capturing the current token. Re-check before
+                    // waiting so we don't miss a now-available match.
+                    matched = MatchRegistration(sender, e);
+                    if (matched)
+                    {
+                        if (m_logger.IsEnabled(LogLevel.Information))
+                        {
+                            m_logger.MatchedReverseConnectionServerUriEndpointUrlAfter(
+                                e.ServerUri,
+                                e.EndpointUrl,
+                                (long)m_timeProvider.GetElapsedTime(startTimestamp).TotalMilliseconds);
+                        }
+
+                        break;
+                    }
+
                     m_logger.HoldingReverseConnectionServerUriEndpointUrl(
                         e.ServerUri,
                         e.EndpointUrl);

--- a/tests/Opc.Ua.Client.Tests/ClientBuilder/ReverseConnectManagerLifecycleTests.cs
+++ b/tests/Opc.Ua.Client.Tests/ClientBuilder/ReverseConnectManagerLifecycleTests.cs
@@ -2712,6 +2712,67 @@ namespace Opc.Ua.Client.Tests.ClientBuilder
         }
 
         [Test]
+        public async Task HeldConnectionSurvivesRegistrationForAnotherServer()
+        {
+            ITelemetryContext telemetry = CreateTelemetry();
+            var harness = new FakeListenerHarness(Scheme);
+            Uri url = Url(20610);
+            await using var manager = new ReverseConnectManager(telemetry)
+            {
+                TransportBindings = harness.Registry
+            };
+
+            // A hold time far beyond the settle window below, so the assertion
+            // that the second connection is still held cannot pass by timing.
+            ReverseConnectClientConfiguration configuration = ConfigFor(url);
+            configuration.HoldTime = 120000;
+            configuration.WaitTimeout = 60000;
+            await manager.StartServiceAsync(configuration).ConfigureAwait(false);
+
+            const string serverUriA = "urn:server-a:UA:Server";
+            const string serverUriB = "urn:server-b:UA:Server";
+            var endpointUrlA = new Uri(Scheme + "://server-a:62541/Server");
+            var endpointUrlB = new Uri(Scheme + "://server-b:62541/Server");
+            var eventA = new FakeConnectionWaitingEventArgs(serverUriA, endpointUrlA);
+            var eventB = new FakeConnectionWaitingEventArgs(serverUriB, endpointUrlB);
+
+            // Both Servers connect before the application registered a waiting
+            // connection for either of them, so both callbacks park on their hold.
+            Task holdA = manager.InvokeConnectionWaitingForTest(eventA);
+            Task holdB = manager.InvokeConnectionWaitingForTest(eventB);
+            Assert.That(holdA.IsCompleted, Is.False, "the unmatched callback must hold");
+            Assert.That(holdB.IsCompleted, Is.False, "the unmatched callback must hold");
+
+            // Waiting for the first Server cancels the shared hold token, which
+            // wakes up both held callbacks.
+            ITransportWaitingConnection connectionA = await manager
+                .WaitForConnectionAsync(endpointUrlA, serverUriA)
+                .ConfigureAwait(false);
+
+            Assert.That(connectionA, Is.SameAs(eventA));
+            await holdA.ConfigureAwait(false);
+            Assert.That(eventA.Accepted, Is.True);
+
+            // The connection of the second Server did not match that registration
+            // and must keep waiting for the remainder of its own hold time.
+            Task settled = await Task.WhenAny(holdB, Task.Delay(1000)).ConfigureAwait(false);
+            Assert.That(
+                settled,
+                Is.Not.SameAs(holdB),
+                "the reverse connection of the second Server was released before its hold time expired");
+            Assert.That(eventB.Accepted, Is.False);
+
+            // The still held connection is available for the second Server.
+            ITransportWaitingConnection connectionB = await manager
+                .WaitForConnectionAsync(endpointUrlB, serverUriB)
+                .ConfigureAwait(false);
+
+            Assert.That(connectionB, Is.SameAs(eventB));
+            await holdB.ConfigureAwait(false);
+            Assert.That(eventB.Accepted, Is.True);
+        }
+
+        [Test]
         public async Task StopDrainsHeldConnectionCallbackBeforeListenerClose()
         {
             ITelemetryContext telemetry = CreateTelemetry();


### PR DESCRIPTION
# Description

Fixes the reverse connect problem reported in #3985 on `master`. #4009 and #4059 addressed the listener startup diagnostics and the async lifecycle, but the actual hold time defect described in [mrsuciu's comment on the issue](https://github.com/OPCFoundation/UA-.NETStandard/issues/3985) survived both refactors unchanged.

Symptom: a Client which uses one reverse connect listener port for several Servers connects to the first Server, and every following `WaitForConnectionAsync` times out. A separate listener port per Server was the only workaround.

## Root cause

- Servers which send `ReverseHello` before the application registered a waiting connection for them are held in `OnConnectionWaitingAsync` for `HoldTime`.
- All held connections share a single `CancellationTokenSource`, so `RegisterWaitingConnection`/`WaitForConnectionAsync` wakes up **every** held connection, not only the one it was registered for.
- The hold loop was `while (!matched) { ... break; }` with an unconditional `break`, so each woken connection got exactly one re-match attempt. The connections which did not match the new registration fell out of the loop unaccepted, although most of their own hold time was left.
- An unaccepted connection is force faulted by the listener (`TcpReverseConnectChannel`, "The reverse connection was rejected by the client"), so that Server is dropped and only returns on its next `ReverseHello` interval, long after the Client timed out waiting for it.

Separate ports avoid the shared wakeup path, which is exactly why that workaround succeeds.

## Changes

- `OnConnectionWaitingAsync` re-arms the hold after a wakeup: it re-matches, and if the registration which caused the wakeup was for another Server the connection keeps waiting for the remainder of its own hold time. The loop is still bounded by `HoldTime`, so a Server which is never registered for is rejected exactly as before.
- New `IsCallbackDrainPending()` check before the hold is re-armed. `DrainConnectionCallbacksAsync` cancels the hold token without renewing it, so a re-armed hold would spin on the already cancelled token until the hold time expires and would block the drain until then. With the check a held callback releases its transport immediately, which keeps the existing `StopDrainsHeldConnectionCallbackBeforeListenerClose` and `DisposeDrainsHeldConnectionCallbackBeforeListenerDisposal` guarantees intact.
- `docs/ReverseConnect.md`: document the `HoldTime` semantics in the "Sharing a listener across multiple Servers" section.

No public API change.

## Validation

- New `HeldConnectionSurvivesRegistrationForAnotherServer` test in `ReverseConnectManagerLifecycleTests` drives two held callbacks through `InvokeConnectionWaitingForTest` and proves the second Server keeps its connection when the first Server is registered. Verified that it fails against the previous behaviour with "the reverse connection of the second Server was released before its hold time expired".
- `FullyQualifiedName~ReverseConnect` (183 tests, including `ReverseConnectManagerTests`, `ReverseConnectManagerLifecycleTests` and `ReverseConnectHostTests`): all pass on net10.0 and net48.

## Related Issues

- Relates to #3985.
- The same fix for the LTS branch is #4341 (base `master378`).

## Checklist

- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf) and read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [x] I have added all necessary documentation.
- [x] I have verified that my changes do not introduce (new) build or analyzer warnings.
- [ ] I ran **all** tests locally using the **UA.slnx** solution against at least .net **framework** and .net **10**, and all passed.
- [ ] I fixed **all** failing and flaky tests in the CI pipelines and **all** CodeQL warnings.
- [ ] I have addressed **all** PR feedback received.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
