### PR TITLE
Expose the client configuration provider and add an opt-in eager load on host start

### DIFF
--- a/docs/DependencyInjection.md
+++ b/docs/DependencyInjection.md
@@ -942,6 +942,54 @@ both file and stream is rejected with a clear
 `InvalidOperationException` at registration. DI-registered
 `ICertificateManager` / `ICertificatePasswordProvider` are honored.
 
+### Client: loading the configuration eagerly
+
+Hosted applications whose user interface needs the
+`ApplicationConfiguration` before any session exists — a WinForms or WPF
+client whose main form takes the configuration in its constructor, for
+instance — can opt into an eager load with
+`OpcUaClientOptions.LoadConfigurationOnStart` (bindable from
+`OpcUa:Client:LoadConfigurationOnStart`). It registers an
+`IHostedService` that awaits the load while the host starts, the
+client-side twin of the reverse-connect hosted service:
+
+```csharp
+services
+    .AddOpcUa()
+    .AddClient("MyClient.Config.xml", opt => opt.LoadConfigurationOnStart = true);
+
+using IHost host = builder.Build();
+await host.StartAsync();
+
+// The document is loaded and validated and the application instance
+// certificate is ensured; a failure has already failed host.StartAsync().
+ApplicationConfiguration configuration = host.Services
+    .GetRequiredService<OpcUaClientOptions>()
+    .ConfigurationProvider!
+    .Configuration;
+```
+
+`OpcUaClientOptions.ConfigurationProvider` is the public
+`IOpcUaApplicationConfigurationProvider` resolved for the client — the
+supplied-document provider when `ConfigurationFile` / `ConfigurationStream`
+was set, and otherwise the shared `ConfigureApplication(...)` provider.
+It is available on the options instance resolved from the service
+provider, not on the instance passed to the `AddClient(...)` callback,
+and it exposes everything a hosted client needs: `GetAsync(ct)` as an
+explicit load trigger without connecting a session, `Configuration` to
+read the loaded document back, and `Application`
+(`IApplicationInstance`) for applications that manage their own instance
+certificate. Applications that do not use the Generic Host can call
+`GetAsync` directly instead of setting `LoadConfigurationOnStart`; both
+routes share the provider's single-flight load, so the configuration is
+never loaded twice.
+
+`LoadConfigurationOnStart` applies to every provider source and is a
+no-op when an explicit `Configuration` was supplied, which is already
+complete. Because it decides a service registration, set it within the
+`AddClient(...)` callback or bind it from the configuration section;
+setting it on the resolved options afterwards has no effect.
+
 ### Fluent shortcuts
 
 The returned `IOpcUaClientBuilder` can compose client features without

--- a/src/Opc.Ua.Client/Fluent/ClientConfigurationLoaderHostedService.cs
+++ b/src/Opc.Ua.Client/Fluent/ClientConfigurationLoaderHostedService.cs
@@ -1,0 +1,91 @@
+/* ========================================================================
+ * Copyright (c) 2005-2026 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+
+namespace Opc.Ua.Client
+{
+    /// <summary>
+    /// Loads the client <see cref="ApplicationConfiguration"/> eagerly
+    /// during host start when
+    /// <see cref="OpcUaClientOptions.LoadConfigurationOnStart"/> is set,
+    /// the client-side twin of
+    /// <see cref="ReverseConnectManagerHostedService"/>. Awaiting
+    /// <c>GetAsync</c> here guarantees that when <c>host.StartAsync()</c>
+    /// returns, the configuration document is loaded and validated, the
+    /// application-instance certificate is ensured, and
+    /// <see cref="OpcUaClientOptions.Configuration"/> is readable - which
+    /// user-interface hosts need before any session exists. A load failure
+    /// fails the host start instead of surfacing on the first connect.
+    /// </summary>
+    internal sealed class ClientConfigurationLoaderHostedService : IHostedService
+    {
+        /// <summary>
+        /// Initializes the hosted service with the resolved client options.
+        /// </summary>
+        /// <param name="options">The resolved client options carrying the
+        /// configuration provider.</param>
+        public ClientConfigurationLoaderHostedService(OpcUaClientOptions options)
+        {
+            m_options = options ?? throw new ArgumentNullException(nameof(options));
+        }
+
+        /// <inheritdoc/>
+        public async Task StartAsync(CancellationToken cancellationToken)
+        {
+            if (m_options.ConfigurationProvider is not { } provider)
+            {
+                // An explicit Configuration was supplied; there is nothing
+                // left to load.
+                return;
+            }
+
+            // Completes validation and application-instance certificate
+            // setup; a lazily loaded supplied configuration document
+            // (ConfigurationFile / ConfigurationStream) also becomes
+            // available here, so publish it on the resolved options exactly
+            // as the session connect path does.
+            ApplicationConfiguration configuration = await provider
+                .GetAsync(cancellationToken)
+                .ConfigureAwait(false);
+            m_options.Configuration ??= configuration;
+        }
+
+        /// <inheritdoc/>
+        public Task StopAsync(CancellationToken cancellationToken)
+        {
+            return Task.CompletedTask;
+        }
+
+        private readonly OpcUaClientOptions m_options;
+    }
+}

--- a/src/Opc.Ua.Client/Fluent/OpcUaClientBuilderExtensions.cs
+++ b/src/Opc.Ua.Client/Fluent/OpcUaClientBuilderExtensions.cs
@@ -1079,6 +1079,16 @@ namespace Microsoft.Extensions.DependencyInjection
                 }
                 return resolvedOptions;
             });
+
+            if (options.LoadConfigurationOnStart)
+            {
+                // Registered before the reverse-connect hosted service in
+                // RegisterCoreServices, so the configuration is loaded and
+                // validated before anything consumes it on host start.
+                services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService,
+                    ClientConfigurationLoaderHostedService>());
+            }
+
             RegisterOptionsValidation(services, options);
         }
 
@@ -1099,7 +1109,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// the supplied configuration document
         /// (<see cref="OpcUaClientOptions.ConfigurationFile"/> /
         /// <see cref="OpcUaClientOptions.ConfigurationStream"/> /
-        /// <see cref="OpcUaClientOptions.ConfigureLoadedConfiguration"/>),
+        /// <see cref="OpcUaClientOptions.ConfigureLoadedConfiguration"/> /
+        /// <see cref="OpcUaClientOptions.LoadConfigurationOnStart"/>),
         /// <see cref="OpcUaClientOptions.Session"/>, <see cref="OpcUaClientOptions.Identity"/>
         /// and <see cref="OpcUaClientOptions.ReverseConnect"/>) into
         /// <paramref name="target"/>.
@@ -1110,6 +1121,7 @@ namespace Microsoft.Extensions.DependencyInjection
             target.ConfigurationFile = source.ConfigurationFile;
             target.ConfigurationStream = source.ConfigurationStream;
             target.ConfigureLoadedConfiguration = source.ConfigureLoadedConfiguration;
+            target.LoadConfigurationOnStart = source.LoadConfigurationOnStart;
             target.ApplicationName = source.ApplicationName;
             target.ApplicationUri = source.ApplicationUri;
             target.ProductUri = source.ProductUri;

--- a/src/Opc.Ua.Client/Fluent/OpcUaClientOptions.cs
+++ b/src/Opc.Ua.Client/Fluent/OpcUaClientOptions.cs
@@ -109,6 +109,45 @@ namespace Opc.Ua.Client
         public Action<ApplicationConfiguration>? ConfigureLoadedConfiguration { get; set; }
 
         /// <summary>
+        /// When <c>true</c>, the client configuration is loaded and
+        /// validated during host start instead of on first use.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Registers an <c>IHostedService</c> that awaits
+        /// <see cref="IOpcUaApplicationConfigurationProvider.GetAsync"/> on
+        /// <see cref="ConfigurationProvider"/> while the .NET Generic Host
+        /// starts. When <c>host.StartAsync()</c> returns, the configuration
+        /// document is loaded and validated, the application-instance
+        /// certificate is ensured, <see cref="Configuration"/> is filled in,
+        /// and a failure fails the host start rather than surfacing on the
+        /// first session connect. This is what user-interface hosts need,
+        /// which must hand the <see cref="ApplicationConfiguration"/> to
+        /// their views before any session exists.
+        /// </para>
+        /// <para>
+        /// Applies to every configuration-provider source: a document
+        /// supplied via <see cref="ConfigurationFile"/> or
+        /// <see cref="ConfigurationStream"/>, and a shared application
+        /// registered with <c>ConfigureApplication(...)</c>. It is a no-op
+        /// when an explicit <see cref="Configuration"/> was set, which is
+        /// already complete, and when no host is present - the
+        /// configuration then still loads lazily on first use. Applications
+        /// without a host call
+        /// <see cref="IOpcUaApplicationConfigurationProvider.GetAsync"/> on
+        /// <see cref="ConfigurationProvider"/> instead; both routes share
+        /// the provider's single-flight load.
+        /// </para>
+        /// <para>
+        /// Because it decides a service registration, this must be set
+        /// within the <c>AddClient(...)</c> callback or bound from the
+        /// <c>OpcUa:Client</c> configuration section; setting it on the
+        /// resolved options afterwards has no effect.
+        /// </para>
+        /// </remarks>
+        public bool LoadConfigurationOnStart { get; set; }
+
+        /// <summary>
         /// The application name. When set (and <see cref="Configuration"/>
         /// is omitted), the root <c>ConfigureApplication(...)</c>
         /// infrastructure is used internally to build and validate the
@@ -196,7 +235,33 @@ namespace Opc.Ua.Client
         /// </summary>
         public ClientReverseConnectOptions? ReverseConnect { get; set; }
 
-        internal IOpcUaApplicationConfigurationProvider? ConfigurationProvider { get; set; }
+        /// <summary>
+        /// The configuration provider resolved for this client, or
+        /// <c>null</c> when an explicit <see cref="Configuration"/> was set
+        /// and no provider is involved.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Only available on the <see cref="OpcUaClientOptions"/> instance
+        /// resolved from the service provider, not on the instance passed to
+        /// the <c>AddClient(...)</c> callback. It is the supplied-document
+        /// provider when <see cref="ConfigurationFile"/> or
+        /// <see cref="ConfigurationStream"/> was set, and otherwise the
+        /// shared provider registered by <c>ConfigureApplication(...)</c>.
+        /// </para>
+        /// <para>
+        /// Use <see cref="IOpcUaApplicationConfigurationProvider.GetAsync"/>
+        /// to trigger the load explicitly without connecting a session,
+        /// <see cref="IOpcUaApplicationConfigurationProvider.Configuration"/>
+        /// to read the loaded document back, and
+        /// <see cref="IOpcUaApplicationConfigurationProvider.Application"/>
+        /// for the <see cref="IApplicationInstance"/> that owns the
+        /// application-instance certificate. Set
+        /// <see cref="LoadConfigurationOnStart"/> to have a hosted
+        /// application await the load during host start instead.
+        /// </para>
+        /// </remarks>
+        public IOpcUaApplicationConfigurationProvider? ConfigurationProvider { get; internal set; }
 
         /// <summary>
         /// <c>true</c> when any application identity or security property

--- a/src/Opc.Ua.Client/NugetREADME.md
+++ b/src/Opc.Ua.Client/NugetREADME.md
@@ -47,7 +47,10 @@ ManagedSession session = await sessionFactory(ct);
 Applications that already own a classic configuration XML file can pass
 it directly — `AddClient("MyClient.Config.xml", ...)`, or as a `Stream`
 for embedded resources — and keep every setting from the file while
-adopting dependency injection.
+adopting dependency injection. The document loads on first use; set
+`OpcUaClientOptions.LoadConfigurationOnStart` to have the host load and
+validate it during `StartAsync`, and read it back through the public
+`OpcUaClientOptions.ConfigurationProvider`.
 
 ## Reverse connect lifecycle
 

--- a/tests/Opc.Ua.Client.Tests/ClientBuilder/ClientConfigurationFileTests.cs
+++ b/tests/Opc.Ua.Client.Tests/ClientBuilder/ClientConfigurationFileTests.cs
@@ -32,11 +32,14 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Configuration.Memory;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using NUnit.Framework;
@@ -57,7 +60,9 @@ namespace Opc.Ua.Client.Tests.ClientBuilder
     /// provider (including the application-instance certificate bootstrap
     /// and the <see cref="OpcUaClientOptions.ConfigureLoadedConfiguration"/>
     /// override callback), precedence over <c>ConfigureApplication(...)</c>,
-    /// ambiguous-combination validation, and load failures.
+    /// the <see cref="OpcUaClientOptions.LoadConfigurationOnStart"/> eager
+    /// load of a supplied document, ambiguous-combination validation, and
+    /// load failures.
     /// </summary>
     [TestFixture]
     [Category("Client")]
@@ -301,6 +306,95 @@ namespace Opc.Ua.Client.Tests.ClientBuilder
 
             Assert.That(options.ConfigurationFile, Is.EqualTo("Legacy/Client.Config.xml"));
             Assert.That(options.ConfigurationProvider, Is.Not.Null);
+        }
+
+        [Test]
+        public async Task LoadConfigurationOnStartLoadsSuppliedDocumentOnHostStartAsync()
+        {
+            const string applicationName = "CfgXmlEagerClient";
+            string testRoot = CreateTestRoot();
+            string configurationFile = WriteConfigurationFile(testRoot, applicationName);
+
+            var services = new ServiceCollection();
+            services.AddLogging();
+            services.AddOpcUa().AddClient(
+                configurationFile,
+                options => options.LoadConfigurationOnStart = true);
+
+            await using ServiceProvider provider = services.BuildServiceProvider();
+            OpcUaClientOptions resolvedOptions =
+                provider.GetRequiredService<OpcUaClientOptions>();
+
+            // Still lazy before the host starts.
+            Assert.That(resolvedOptions.Configuration, Is.Null);
+
+            IHostedService loader = provider.GetServices<IHostedService>()
+                .Single(service => service is ClientConfigurationLoaderHostedService);
+            await loader.StartAsync(CancellationToken.None).ConfigureAwait(false);
+
+            // The document is loaded, validated and published on the options,
+            // so a user interface can consume it without a session.
+            Assert.That(resolvedOptions.Configuration, Is.Not.Null);
+            Assert.That(
+                resolvedOptions.Configuration!.ApplicationName,
+                Is.EqualTo(applicationName));
+            Assert.That(
+                resolvedOptions.ConfigurationProvider!.Configuration,
+                Is.SameAs(resolvedOptions.Configuration));
+            Assert.That(
+                resolvedOptions.ConfigurationProvider.Application.ApplicationName,
+                Is.EqualTo(applicationName));
+
+            // The application-instance certificate was ensured during start.
+            Assert.That(
+                Directory.Exists(Path.Combine(testRoot, "pki", "own")) &&
+                Directory.GetFiles(
+                    Path.Combine(testRoot, "pki", "own"),
+                    "*",
+                    SearchOption.AllDirectories).Length > 0,
+                Is.True,
+                "The application instance certificate was not created.");
+
+            await loader.StopAsync(CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Test]
+        public async Task LoadConfigurationOnStartSurfacesLoadFailureOnHostStartAsync()
+        {
+            string missingFile = Path.Combine(
+                CreateTestRoot(),
+                "DoesNotExist.Config.xml");
+
+            var services = new ServiceCollection();
+            services.AddLogging();
+            services.AddOpcUa().AddClient(
+                missingFile,
+                options => options.LoadConfigurationOnStart = true);
+
+            await using ServiceProvider provider = services.BuildServiceProvider();
+            IHostedService loader = provider.GetServices<IHostedService>()
+                .Single(service => service is ClientConfigurationLoaderHostedService);
+
+            // The failure fails the host start instead of surfacing on the
+            // first session connect.
+            Assert.That(
+                () => loader.StartAsync(CancellationToken.None),
+                Throws.InstanceOf<ServiceResultException>());
+        }
+
+        [Test]
+        public async Task WithoutLoadConfigurationOnStartNoLoaderIsRegisteredAsync()
+        {
+            var services = new ServiceCollection();
+            services.AddLogging();
+            services.AddOpcUa().AddClient("Client.Config.xml");
+
+            await using ServiceProvider provider = services.BuildServiceProvider();
+
+            Assert.That(
+                provider.GetServices<IHostedService>()
+                    .Any(service => service is ClientConfigurationLoaderHostedService),
+                Is.False);
         }
 
         [Test]

--- a/tests/Opc.Ua.Client.Tests/ClientBuilder/ClientEagerConfigurationLoadTests.cs
+++ b/tests/Opc.Ua.Client.Tests/ClientBuilder/ClientEagerConfigurationLoadTests.cs
@@ -1,0 +1,252 @@
+/* ========================================================================
+ * Copyright (c) 2005-2026 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration.Memory;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NUnit.Framework;
+using Opc.Ua.Configuration;
+
+namespace Opc.Ua.Client.Tests.ClientBuilder
+{
+    /// <summary>
+    /// Exercises the provider-agnostic part of the eager client
+    /// configuration load: the public
+    /// <see cref="OpcUaClientOptions.ConfigurationProvider"/> surface and
+    /// the <see cref="OpcUaClientOptions.LoadConfigurationOnStart"/> hosted
+    /// service that awaits
+    /// <see cref="IOpcUaApplicationConfigurationProvider.GetAsync"/> during
+    /// host start. The supplied-document (<c>AddClient(configurationFile)</c>)
+    /// cases live in <see cref="ClientConfigurationFileTests"/>.
+    /// </summary>
+    [TestFixture]
+    [Category("Client")]
+    [Category("ClientBuilder")]
+    [SetCulture("en-us")]
+    [SetUICulture("en-us")]
+    [Parallelizable]
+    public sealed class ClientEagerConfigurationLoadTests
+    {
+        [Test]
+        public async Task LoadConfigurationOnStartAwaitsSharedProviderAsync()
+        {
+            ApplicationConfiguration configuration = CreateConfiguration();
+            Mock<IOpcUaApplicationConfigurationProvider> configurationProvider =
+                CreateProviderMock(configuration);
+
+            var services = new ServiceCollection();
+            services.AddLogging();
+            services.AddSingleton(configurationProvider.Object);
+            services.AddOpcUa().AddClient(options => options.LoadConfigurationOnStart = true);
+
+            await using ServiceProvider provider = services.BuildServiceProvider();
+            OpcUaClientOptions options = provider.GetRequiredService<OpcUaClientOptions>();
+
+            // The shared provider is exposed publicly, so an application can
+            // load and read the configuration back without a session.
+            Assert.That(
+                options.ConfigurationProvider,
+                Is.SameAs(configurationProvider.Object));
+
+            IHostedService loader = GetLoader(provider);
+            await loader.StartAsync(CancellationToken.None).ConfigureAwait(false);
+
+            configurationProvider.Verify(
+                p => p.GetAsync(It.IsAny<CancellationToken>()),
+                Times.Once);
+            Assert.That(options.Configuration, Is.SameAs(configuration));
+
+            await loader.StopAsync(CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Test]
+        public async Task LoadConfigurationOnStartIsNoOpForExplicitConfigurationAsync()
+        {
+            ApplicationConfiguration configuration = CreateConfiguration();
+
+            var services = new ServiceCollection();
+            services.AddLogging();
+            services.AddOpcUa().AddClient(options =>
+            {
+                options.Configuration = configuration;
+                options.LoadConfigurationOnStart = true;
+            });
+
+            await using ServiceProvider provider = services.BuildServiceProvider();
+            OpcUaClientOptions options = provider.GetRequiredService<OpcUaClientOptions>();
+
+            // Nothing to load: an explicit configuration is already complete.
+            Assert.That(options.ConfigurationProvider, Is.Null);
+
+            IHostedService loader = GetLoader(provider);
+            Assert.That(
+                () => loader.StartAsync(CancellationToken.None),
+                Throws.Nothing);
+            Assert.That(options.Configuration, Is.SameAs(configuration));
+        }
+
+        [Test]
+        public async Task LoadConfigurationOnStartCancellationAbortsHostStartAsync()
+        {
+            ApplicationConfiguration configuration = CreateConfiguration();
+            var started = new TaskCompletionSource<bool>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            var configurationProvider =
+                new Mock<IOpcUaApplicationConfigurationProvider>();
+            configurationProvider.Setup(p => p.Configuration).Returns(configuration);
+            configurationProvider
+                .Setup(p => p.GetAsync(It.IsAny<CancellationToken>()))
+                .Returns(async (CancellationToken ct) =>
+                {
+                    started.TrySetResult(true);
+                    await Task.Delay(Timeout.Infinite, ct).ConfigureAwait(false);
+                    return configuration;
+                });
+
+            var services = new ServiceCollection();
+            services.AddLogging();
+            services.AddSingleton(configurationProvider.Object);
+            services.AddOpcUa().AddClient(options => options.LoadConfigurationOnStart = true);
+
+            await using ServiceProvider provider = services.BuildServiceProvider();
+            IHostedService loader = GetLoader(provider);
+
+            using var cts = new CancellationTokenSource();
+            Task start = loader.StartAsync(cts.Token);
+            await started.Task.ConfigureAwait(false);
+            cts.Cancel();
+
+            // The host's startup token is passed through to the load.
+            Assert.That(
+                async () => await start.ConfigureAwait(false),
+                Throws.InstanceOf<OperationCanceledException>());
+        }
+
+        [Test]
+        public async Task LoadConfigurationOnStartBindsFromConfigurationSectionAsync()
+        {
+            IConfiguration configurationRoot = new ConfigurationBuilder()
+                .Add(new MemoryConfigurationSource
+                {
+                    InitialData = new Dictionary<string, string?>
+                    {
+                        ["OpcUa:Client:LoadConfigurationOnStart"] = "true"
+                    }
+                })
+                .Build();
+
+            var services = new ServiceCollection();
+            services.AddLogging();
+            services.AddSingleton(CreateProviderMock(CreateConfiguration()).Object);
+            services.AddOpcUa().AddClient(configurationRoot);
+
+            await using ServiceProvider provider = services.BuildServiceProvider();
+
+            Assert.That(
+                provider.GetRequiredService<OpcUaClientOptions>().LoadConfigurationOnStart,
+                Is.True);
+            Assert.That(GetLoader(provider), Is.Not.Null);
+        }
+
+#if NET8_0_OR_GREATER
+        [Test]
+        public async Task HostStartAsyncCompletesTheConfigurationLoadAsync()
+        {
+            ApplicationConfiguration configuration = CreateConfiguration();
+            Mock<IOpcUaApplicationConfigurationProvider> configurationProvider =
+                CreateProviderMock(configuration);
+
+            using IHost host = new HostBuilder()
+                .ConfigureServices((_, services) =>
+                {
+                    services.AddLogging();
+                    services.AddSingleton(configurationProvider.Object);
+                    services.AddOpcUa().AddClient(
+                        options => options.LoadConfigurationOnStart = true);
+                })
+                .Build();
+
+            await host.StartAsync().ConfigureAwait(false);
+            try
+            {
+                // When StartAsync returns the configuration is loaded and
+                // readable through the public options surface, which is what
+                // user-interface hosts need before any session exists.
+                OpcUaClientOptions options =
+                    host.Services.GetRequiredService<OpcUaClientOptions>();
+                Assert.That(
+                    options.ConfigurationProvider!.Configuration,
+                    Is.SameAs(configuration));
+                Assert.That(options.Configuration, Is.SameAs(configuration));
+                configurationProvider.Verify(
+                    p => p.GetAsync(It.IsAny<CancellationToken>()),
+                    Times.Once);
+            }
+            finally
+            {
+                await host.StopAsync().ConfigureAwait(false);
+            }
+        }
+#endif
+
+        private static IHostedService GetLoader(IServiceProvider provider)
+        {
+            return provider.GetServices<IHostedService>()
+                .Single(service => service is ClientConfigurationLoaderHostedService);
+        }
+
+        private static Mock<IOpcUaApplicationConfigurationProvider> CreateProviderMock(
+            ApplicationConfiguration configuration)
+        {
+            var configurationProvider =
+                new Mock<IOpcUaApplicationConfigurationProvider>();
+            configurationProvider.Setup(p => p.Configuration).Returns(configuration);
+            configurationProvider
+                .Setup(p => p.GetAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(configuration);
+            return configurationProvider;
+        }
+
+        private static ApplicationConfiguration CreateConfiguration()
+        {
+            return new ApplicationConfiguration(
+                Opc.Ua.Tests.NUnitTelemetryContext.Create());
+        }
+    }
+}


### PR DESCRIPTION
# Description

`AddClient(configurationFile)` (#4328) loads the supplied configuration XML lazily on the first DI session connect, and the `ClientSuppliedConfigurationProvider` behind it was reachable only through internals. Hosted clients whose user interface needs the `ApplicationConfiguration` **before any session exists** therefore had no public way to trigger the load or to read the configuration back — the concrete blocker for moving the 14 WinForms sample clients and the GDS client off the classic eager `ApplicationInstance` path (OPCFoundation/UA-.NETStandard-Samples#794 / OPCFoundation/UA-.NETStandard-Samples#808).

Two small additions, exactly as designed in #4340:

**1. `OpcUaClientOptions.ConfigurationProvider` is now public** (`get`; the setter stays `internal`).

It is already typed as the public `IOpcUaApplicationConfigurationProvider`, so consumers get everything they need with **no new types**: `GetAsync(ct)` as an explicit load trigger that does not connect a session, `Configuration` for the loaded document, and `Application` (`IApplicationInstance`) for the applications that manage their own instance certificate. Registering the supplied provider as `IOpcUaApplicationConfigurationProvider` in DI was deliberately *not* done — `OpcUaServerHostedService` binds to the last registered interface when it has no document of its own, so in a combined client+server host a client-only document would silently capture the server.

**2. `OpcUaClientOptions.LoadConfigurationOnStart` — an opt-in eager load for hosted applications.**

It registers an internal `ClientConfigurationLoaderHostedService` that awaits `GetAsync` during host start, the client-side twin of `ReverseConnectManagerHostedService`. When `host.StartAsync()` returns, the document is loaded and validated, the application-instance certificate is ensured, `Configuration` is published onto the resolved options (exactly as the connect path does), and a load failure fails the host start instead of surfacing on the first connect. It is registered ahead of the reverse-connect hosted service, so the configuration is complete before anything consumes it.

The flag applies to every provider source — a document supplied via `ConfigurationFile` / `ConfigurationStream` and a shared `ConfigureApplication(...)` provider alike — and is a no-op for an explicit `Configuration`, which is already complete. It is bindable from `OpcUa:Client:LoadConfigurationOnStart`. Applications without a Generic Host call `GetAsync` on the provider directly instead; both routes share the provider's single-flight load, so the configuration is never loaded twice.

A WinForms client then becomes:

```csharp
services.AddOpcUa().AddClient("MyClient.Config.xml", o => o.LoadConfigurationOnStart = true);

await host.StartAsync();

ApplicationConfiguration configuration = host.Services
    .GetRequiredService<OpcUaClientOptions>()
    .ConfigurationProvider!.Configuration;
```

**Reviewer note:** because the flag decides a *service registration*, it must be set inside the `AddClient(...)` callback or bound from the configuration section — setting it on the resolved options afterwards has no effect. This is called out in the XML docs and in `DependencyInjection.md`.

**Coverage:** three tests added to `ClientConfigurationFileTests` for the supplied-document path (eager load on start including the certificate bootstrap and `Application` surface, load failure surfacing on start, no hosted service registered without the flag) and a new `ClientEagerConfigurationLoadTests` fixture for the provider-agnostic behavior (shared `ConfigureApplication(...)` provider awaited exactly once, explicit-`Configuration` no-op, host-startup-token cancellation aborting the load, configuration-section binding, and an end-to-end `host.StartAsync()` test). All 331 `ClientBuilder` tests pass (8 new), as do the 185 server hosting tests including the combined client+server fixtures. `Opc.Ua.Client` builds warning-free on all target frameworks; the test project builds clean on net10.0 and net472.

**Docs:** new "Client: loading the configuration eagerly" section in `docs/DependencyInjection.md` and a pointer in the `Opc.Ua.Client` NuGet README.

With these in place the sample clients can switch in a follow-up to OPCFoundation/UA-.NETStandard-Samples#808.

## Related Issues

- Fixes #4340
- Builds on #4328

## Checklist

_Put an `x` in the boxes that apply. You can complete these step by step after opening the PR._

- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf) and read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [x] I have added all necessary documentation.
- [x] I have verified that my changes do not introduce (new) build or analyzer warnings.
- [ ] I ran **all** tests locally using the **UA.slnx** solution against at least .net **framework** and .net **10**, and all passed.
- [ ] I fixed **all** failing and flaky tests in the CI pipelines and **all** CodeQL warnings.
- [ ] I have addressed **all** PR feedback received.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
