### PR TITLE
Fix transient PublishWorkerCount overshoot in the publish controller

### DIFF
--- a/src/Opc.Ua.Client/Subscription/SubscriptionManager.cs
+++ b/src/Opc.Ua.Client/Subscription/SubscriptionManager.cs
@@ -1619,16 +1619,20 @@ namespace Opc.Ua.Client.Subscriptions
                 try
                 {
                     await m_cts.CancelAsync().ConfigureAwait(false);
-                    if (!Task.IsCompleted)
+                    try
                     {
-                        try
-                        {
-                            await Task.ConfigureAwait(false);
-                        }
-                        catch
-                        {
-                        } // Ignore
+                        //
+                        // Await unconditionally. The controller reaps a
+                        // worker whose task has already completed, and that
+                        // completion is usually a fault or a cancellation -
+                        // skipping the await for completed tasks would leave
+                        // those exceptions unobserved.
+                        //
+                        await Task.ConfigureAwait(false);
                     }
+                    catch
+                    {
+                    } // Ignore
                 }
                 finally
                 {

--- a/src/Opc.Ua.Client/Subscription/SubscriptionManager.cs
+++ b/src/Opc.Ua.Client/Subscription/SubscriptionManager.cs
@@ -1194,6 +1194,10 @@ namespace Opc.Ua.Client.Subscriptions
             {
                 NotifySubscriptionsPaused(paused.Value);
             }
+            // Wake the controller so the pool is sized for the new state.
+            // Resuming is the first point at which a manager that was
+            // constructed paused has a reason to hold workers at all.
+            m_publishControl.Set();
         }
 
         private void SetPublishingQuiesced(bool quiesced)
@@ -1208,6 +1212,9 @@ namespace Opc.Ua.Client.Subscriptions
             {
                 NotifySubscriptionsPaused(paused.Value);
             }
+            // See SetPublishingRequested - leaving quiescence resumes
+            // publishing just like Resume does.
+            m_publishControl.Set();
         }
 
         private bool? UpdatePublishingState()
@@ -1436,6 +1443,58 @@ namespace Opc.Ua.Client.Subscriptions
             {
                 while (!ct.IsCancellationRequested)
                 {
+                    //
+                    // Wait before touching the pool. The controller runs
+                    // synchronously up to this first await, i.e. still inside
+                    // the constructor, where MinPublishWorkerCount and
+                    // MaxPublishWorkerCount are whatever the defaults are —
+                    // the owner has not had a chance to configure them yet.
+                    // Sizing the pool there spins up workers off the default
+                    // minimum only to tear them down again on the first
+                    // resize, and publishes that overshoot through
+                    // PublishWorkerCount. Every path that changes the desired
+                    // count (add/remove, pause/resume, the Min/Max setters,
+                    // Update) signals m_publishControl, so the pool is sized
+                    // exclusively in response to a signal or a worker exit.
+                    //
+                    Task[] waiting = [.. publishWorkers
+                        .Select(w => w.Task)
+                        .Prepend(controlWait)];
+                    await Task.WhenAny(waiting).ConfigureAwait(false);
+                    if (controlWait.IsCompleted)
+                    {
+                        controlWait = m_publishControl.WaitAsync(ct);
+                    }
+                    PublishControlCycles++;
+
+                    // Reap the workers that exited on their own before
+                    // sizing the pool, so a worker that is already gone is
+                    // never counted towards the pool nor kept alongside its
+                    // replacement.
+                    int index = 0;
+                    foreach (Task? item in waiting.Skip(1)) // Skip wait handle
+                    {
+                        if (item.IsCompleted)
+                        {
+                            PublishWorker worker = publishWorkers[index];
+                            m_logger.PublishWorkerExited(worker.Index);
+                            await worker.DisposeAsync().ConfigureAwait(false);
+                            publishWorkers.RemoveAt(index);
+                            continue;
+                        }
+                        index++;
+                    }
+
+                    // Now lower the max publish request if we got any too
+                    // many requests errors
+                    if (publishWorkers.Any(w => w.TooManyPublishRequests))
+                    {
+                        if (MaxPublishWorkerCount > 1)
+                        {
+                            MaxPublishWorkerCount--;
+                        }
+                    }
+
                     int desiredWorkerCount = GetDesiredPublishWorkerCount();
                     if (publishWorkers.Count > desiredWorkerCount)
                     {
@@ -1463,40 +1522,9 @@ namespace Opc.Ua.Client.Subscriptions
                                 desiredWorkerCount - publishWorkers.Count)
                             .Select(index => new PublishWorker(this, index)));
                     }
-                    PublishWorkerCount = publishWorkers.Count;
 
-                    Task[] waiting = [.. publishWorkers
-                        .Select(w => w.Task)
-                        .Prepend(controlWait)];
-                    await Task.WhenAny(waiting).ConfigureAwait(false);
-                    if (controlWait.IsCompleted)
-                    {
-                        controlWait = m_publishControl.WaitAsync(ct);
-                    }
-                    PublishControlCycles++;
-                    int index = 0;
-                    foreach (Task? item in waiting.Skip(1)) // Skip wait handle
-                    {
-                        if (item.IsCompleted)
-                        {
-                            PublishWorker worker = publishWorkers[index];
-                            m_logger.PublishWorkerExited(worker.Index);
-                            await worker.DisposeAsync().ConfigureAwait(false);
-                            publishWorkers.RemoveAt(index);
-                            continue;
-                        }
-                        index++;
-                    }
-
-                    // Now lower the max publish request if we got any too
-                    // many requests errors
-                    if (publishWorkers.Any(w => w.TooManyPublishRequests))
-                    {
-                        if (MaxPublishWorkerCount > 1)
-                        {
-                            MaxPublishWorkerCount--;
-                        }
-                    }
+                    // The pool is settled for this cycle — only now is the
+                    // count observable by callers.
                     PublishWorkerCount = publishWorkers.Count;
                 }
             }
@@ -1572,7 +1600,17 @@ namespace Opc.Ua.Client.Subscriptions
                 m_outer = outer;
                 m_cts = CancellationTokenSource.CreateLinkedTokenSource(outer.m_cts.Token);
                 m_logger = m_outer.m_loggerFactory.CreateLogger<PublishWorker>();
-                Task = PublishWorkerAsync(m_cts.Token);
+                //
+                // Start on the thread pool. Workers are constructed inline by
+                // the publish controller, and the worker loop only yields
+                // where it awaits something that is not already completed. A
+                // transport whose publish completes synchronously would
+                // therefore run the entire worker loop on the controller's
+                // stack, starving the control loop - it could neither resize
+                // the pool nor publish PublishWorkerCount.
+                //
+                CancellationToken token = m_cts.Token;
+                Task = Task.Run(() => PublishWorkerAsync(token), token);
             }
 
             /// <inheritdoc/>

--- a/tests/Opc.Ua.Client.Tests/Subscription/SubscriptionManagerTests.cs
+++ b/tests/Opc.Ua.Client.Tests/Subscription/SubscriptionManagerTests.cs
@@ -1122,11 +1122,15 @@ namespace Opc.Ua.Client.Subscriptions
             await using (sut.ConfigureAwait(false))
             {
                 // Nothing has signalled the controller yet, so the defaults
-                // are still in force - MinPublishWorkerCount is 2 and the
-                // session already reports one subscription.
+                // are still in force. Guard that they still make the
+                // scenario meaningful: the bug only shows when the default
+                // minimum inflates the count the session alone asks for.
                 Assert.Multiple(() =>
                 {
-                    Assert.That(sut.MinPublishWorkerCount, Is.EqualTo(2));
+                    Assert.That(sut.MinPublishWorkerCount,
+                        Is.GreaterThan(session.SessionSubscriptionCount),
+                        "Defaults no longer inflate the pool; pick a scenario " +
+                        "that still exercises constructor-time sizing.");
                     Assert.That(sut.PublishWorkerCount, Is.Zero,
                         "The constructor must not size the publish worker pool.");
                 });

--- a/tests/Opc.Ua.Client.Tests/Subscription/SubscriptionManagerTests.cs
+++ b/tests/Opc.Ua.Client.Tests/Subscription/SubscriptionManagerTests.cs
@@ -1078,6 +1078,7 @@ namespace Opc.Ua.Client.Subscriptions
                 await WaitUntilAsync(
                     () => session.SessionDispatchCount > 0,
                     testCt).ConfigureAwait(false);
+                await WaitForPublishWorkerCountAsync(sut, 1).ConfigureAwait(false);
 
                 Assert.Multiple(() =>
                 {
@@ -1085,6 +1086,68 @@ namespace Opc.Ua.Client.Subscriptions
                     Assert.That(sut.PublishWorkerCount, Is.EqualTo(1));
                     Assert.That(session.DeleteCalls, Is.Empty);
                 });
+            }
+        }
+
+        /// <summary>
+        /// The publish controller must never size the pool from the default
+        /// Min/MaxPublishWorkerCount. It runs synchronously up to its first
+        /// wait, i.e. inside the constructor, so sizing there happened before
+        /// the owner could configure the pool: a session that already carries
+        /// subscriptions got MinPublishWorkerCount (default 2) workers that
+        /// were torn down again by the first resize, and PublishWorkerCount
+        /// transiently reported that overshoot.
+        /// </summary>
+        [Test]
+        [CancelAfter(30_000)]
+        public async Task PublishWorkerPoolIsNeverSizedFromDefaultsBeforeConfigurationAsync(
+            CancellationToken testCt)
+        {
+            ILoggerFactory loggerFactory = m_telemetry.LoggerFactory;
+            var session = new FakeSubscriptionManagerContext();
+            session.SessionOwnedSubscriptionIds.Add(4242u);
+            // Model a transport that does not complete synchronously - the
+            // manager has no created subscription to derive a publish
+            // interval from, so an instantly completing fake would spin the
+            // worker at full speed for the duration of the test.
+            session.OnPublishAsync = async (header, acknowledgements, ct) =>
+            {
+                await Task.Delay(5, ct).ConfigureAwait(false);
+                return CreatePublishResponse(4242u, header.RequestHandle);
+            };
+
+            var sut = new SubscriptionManager(session,
+                loggerFactory, DiagnosticsMasks.None);
+
+            await using (sut.ConfigureAwait(false))
+            {
+                // Nothing has signalled the controller yet, so the defaults
+                // are still in force - MinPublishWorkerCount is 2 and the
+                // session already reports one subscription.
+                Assert.Multiple(() =>
+                {
+                    Assert.That(sut.MinPublishWorkerCount, Is.EqualTo(2));
+                    Assert.That(sut.PublishWorkerCount, Is.Zero,
+                        "The constructor must not size the publish worker pool.");
+                });
+
+                sut.MinPublishWorkerCount = 1;
+                sut.MaxPublishWorkerCount = 1;
+                sut.Resume();
+                sut.Update();
+
+                await WaitForPublishWorkerCountAsync(sut, 1).ConfigureAwait(false);
+
+                // The pool must stay at the configured maximum while the
+                // workers publish - a worker that exits is reaped before its
+                // replacement is created, so the two are never counted
+                // together.
+                var sw = Stopwatch.StartNew();
+                while (sw.Elapsed < TimeSpan.FromSeconds(1))
+                {
+                    Assert.That(sut.PublishWorkerCount, Is.EqualTo(1));
+                    await Task.Delay(10, testCt).ConfigureAwait(false);
+                }
             }
         }
 


### PR DESCRIPTION
Fixes #4339.

## Cause

`PublishControllerAsync` sized the worker pool at the **top** of its loop, before its first `await`. The `SubscriptionManager` constructor calls the controller directly, so that first resize ran *synchronously inside the constructor* — with `MinPublishWorkerCount`/`MaxPublishWorkerCount` still at their defaults (2 / 15), because owners configure them afterwards.

A session that already reports subscriptions — a classic, session-owned subscription counts through `ISubscriptionManagerContext.SessionSubscriptionCount` — therefore had `1` clamped **up** to the default minimum of 2, spun up two workers in the constructor, and published that overshoot through `PublishWorkerCount`. The configured `Min = Max = 1` then shrank the pool back asynchronously.

Confirmed with a probe before changing anything:

```
PROBE right after ctor: 2
```

which reproduces the issue's `Worker #0 STARTED / #0 PAUSED / #1 STARTED` log exactly. `ClassicSessionSubscriptionStartsPublishWorkerAsync` pins the pool to one worker and samples the property directly, so it failed whenever it read it before the controller had shrunk the pool back.

## Fix

The control loop now waits first and sizes the pool afterwards:

```
wait -> reap exited workers -> resize -> publish the count
```

The pool is only ever sized in response to a signal or a worker exit, never from unconfigured defaults, and the count is assigned once the pool has settled — so a worker that has exited is never counted alongside its replacement (the second half of the issue's *Expected Behavior*).

Two supporting changes were required:

- **Publish workers now start on the thread pool.** The controller creates them inline, and the worker loop only yields where it awaits something not already complete. With the resize moved behind the wait, workers are typically created while publishing is already running, which made that starvation reachable: I hit it while testing — 430k publishes in 2 s with `PublishControlCycles` stuck at 1 and `PublishWorkerCount` stuck at 0. The same starvation would hang `DisposeAsync`, which awaits the controller.
- **`Resume()`, and leaving publishing quiescence, now signal the publish control**, so the pool is sized promptly once publishing starts rather than waiting for an unrelated event.

## Tests

- `ClassicSessionSubscriptionStartsPublishWorkerAsync` now settles the pool through the existing `WaitForPublishWorkerCountAsync` helper instead of sampling the property bare.
- New `PublishWorkerPoolIsNeverSizedFromDefaultsBeforeConfigurationAsync` pins the constructor behaviour (count stays 0 while the defaults are in force) and asserts the count never leaves 1 while workers publish.

## Verification

- `Opc.Ua.Client.Tests`: 2151/2151 pass.
- `Opc.Ua.Subscriptions.Tests`: 619 passed, 6 skipped, 0 failed (22 m 18 s).
- The two affected tests stressed 15x in a row: green.
- `dotnet format whitespace --verify-no-changes` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)