### PR TITLE
Keep application certificates which do not name a CertificateType

### DIFF
--- a/src/Opc.Ua.Core/Schema/ApplicationConfiguration.cs
+++ b/src/Opc.Ua.Core/Schema/ApplicationConfiguration.cs
@@ -594,6 +594,7 @@ namespace Opc.Ua
                 if (value.IsEmpty)
                 {
                     m_applicationCertificates = [];
+                    m_rejectedCertificateTypes = [];
                     return;
                 }
 
@@ -603,16 +604,32 @@ namespace Opc.Ua
                 // deprecated flag when we process the collection below.
 
                 var newCertificates = new List<CertificateIdentifier>(value.ToArray() ?? []);
+                var rejectedCertificateTypes = new List<string>();
 
                 // Remove unsupported certificate types
                 for (int i = newCertificates.Count - 1; i >= 0; i--)
                 {
-                    if (!Utils.IsSupportedCertificateType(newCertificates[i].CertificateType))
+                    NodeId certificateType = newCertificates[i].CertificateType;
+
+                    // An identifier which does not name a certificate type means the default
+                    // application certificate type, the same assumption the legacy single
+                    // ApplicationCertificate element carries.
+                    if (certificateType.IsNull)
                     {
-                        // TODO: Log when ITelemetry instance is available
+                        newCertificates[i].CertificateType = ObjectTypeIds
+                            .RsaSha256ApplicationCertificateType;
+                        continue;
+                    }
+
+                    if (!Utils.IsSupportedCertificateType(certificateType))
+                    {
+                        // remember what was dropped, Validate reports it once telemetry is available
+                        rejectedCertificateTypes.Insert(0, certificateType.ToString());
                         newCertificates.RemoveAt(i);
                     }
                 }
+
+                m_rejectedCertificateTypes = rejectedCertificateTypes;
 
                 // Remove any duplicates based on thumbprint
                 for (int i = 0; i < newCertificates.Count; i++)
@@ -823,6 +840,7 @@ namespace Opc.Ua
         public bool IsDeprecatedConfiguration { get; set; }
 
         private ArrayOf<CertificateIdentifier> m_applicationCertificates;
+        private List<string> m_rejectedCertificateTypes = [];
         private CertificateTrustList m_trustedIssuerCertificates;
         private CertificateTrustList m_trustedPeerCertificates;
         private CertificateTrustList? m_httpsIssuerCertificates;

--- a/src/Opc.Ua.Core/Schema/ApplicationConfiguration.cs
+++ b/src/Opc.Ua.Core/Schema/ApplicationConfiguration.cs
@@ -595,6 +595,7 @@ namespace Opc.Ua
                 {
                     m_applicationCertificates = [];
                     m_rejectedCertificateTypes = [];
+                    SupportedSecurityPolicies = BuildSupportedSecurityPolicies();
                     return;
                 }
 

--- a/src/Opc.Ua.Core/Security/Certificates/SecurityConfiguration.cs
+++ b/src/Opc.Ua.Core/Security/Certificates/SecurityConfiguration.cs
@@ -69,8 +69,26 @@ namespace Opc.Ua
         /// <exception cref="ServiceResultException"></exception>
         public void Validate(ITelemetryContext telemetry)
         {
+            if (m_rejectedCertificateTypes.Count > 0)
+            {
+                ILogger<SecurityConfiguration> logger = telemetry
+                    .CreateLogger<SecurityConfiguration>();
+                logger.UnsupportedApplicationCertificateTypes(
+                    m_rejectedCertificateTypes.Count,
+                    string.Join(", ", m_rejectedCertificateTypes));
+            }
+
             if (m_applicationCertificates.IsNull || m_applicationCertificates.Count == 0)
             {
+                if (m_rejectedCertificateTypes.Count > 0)
+                {
+                    throw ServiceResultException.ConfigurationError(
+                        "No supported application certificate configured: {0} certificate identifier(s) " +
+                        "were rejected because their CertificateType is not supported ({1}).",
+                        m_rejectedCertificateTypes.Count,
+                        string.Join(", ", m_rejectedCertificateTypes));
+                }
+
                 throw ServiceResultException.ConfigurationError(
                     "ApplicationCertificate must be specified.");
             }
@@ -298,5 +316,13 @@ namespace Opc.Ua
             this ILogger logger,
             Exception? exception,
             string storeName);
+
+        [LoggerMessage(EventId = CoreEventIds.SecurityConfiguration + 1, Level = LogLevel.Warning,
+            Message = "{Count} application certificate identifier(s) were dropped from " +
+                "ApplicationCertificates because their CertificateType is not supported: {CertificateTypes}")]
+        public static partial void UnsupportedApplicationCertificateTypes(
+            this ILogger logger,
+            int count,
+            string certificateTypes);
     }
 }

--- a/tests/Opc.Ua.Configuration.Tests/ApplicationConfigurationBuilderTests.cs
+++ b/tests/Opc.Ua.Configuration.Tests/ApplicationConfigurationBuilderTests.cs
@@ -855,6 +855,50 @@ namespace Opc.Ua.Configuration.Tests
             }
         }
 
+        /// <summary>
+        /// The certificate identifier overload of AddSecurityConfiguration must accept an
+        /// identifier which does not name a certificate type, the same way the obsolete
+        /// subject name overload does. See https://github.com/OPCFoundation/UA-.NETStandard/issues/4315.
+        /// </summary>
+        [Test]
+        public async Task AddSecurityConfigurationWithoutCertificateTypeKeepsTheCertificateAsync()
+        {
+            ITelemetryContext telemetry = NUnitTelemetryContext.Create();
+            var appInstance = new ApplicationInstance(telemetry)
+            {
+                ApplicationName = ApplicationName,
+                ApplicationType = ApplicationType.Client
+            };
+            await using (appInstance.ConfigureAwait(false))
+            {
+                ApplicationConfiguration configuration = await appInstance
+                    .Build(ApplicationUri, ProductUri)
+                    .AsClient()
+                    .AddSecurityConfiguration(
+                        [
+                            new CertificateIdentifier
+                            {
+                                StoreType = CertificateStoreType.Directory,
+                                StorePath = Path.Combine(m_pkiRoot, "own"),
+                                SubjectName = SubjectName
+                                // CertificateType deliberately not set
+                            }
+                        ],
+                        m_pkiRoot)
+                    .SetAutoAcceptUntrustedCertificates(true)
+                    .CreateAsync();
+
+                SecurityConfiguration securityConfiguration = configuration.SecurityConfiguration;
+                Assert.That(securityConfiguration.ApplicationCertificates, Has.Count.EqualTo(1));
+                Assert.That(
+                    securityConfiguration.ApplicationCertificates[0].CertificateType,
+                    Is.EqualTo(ObjectTypeIds.RsaSha256ApplicationCertificateType));
+                Assert.That(
+                    securityConfiguration.SupportedSecurityPolicies.ToArray(),
+                    Contains.Item(SecurityPolicies.Basic256Sha256));
+            }
+        }
+
         [Test]
         public async Task AddUnsecurePolicyNoneAddsPolicyWhenTrueAsync()
         {

--- a/tests/Opc.Ua.Configuration.Tests/SecurityConfigurationTests.cs
+++ b/tests/Opc.Ua.Configuration.Tests/SecurityConfigurationTests.cs
@@ -75,6 +75,107 @@ namespace Opc.Ua.Configuration.Tests
         }
 
         [Test]
+        public void ApplicationCertificateWithoutCertificateTypeIsKeptAsRsaSha256()
+        {
+            ITelemetryContext telemetry = NUnitTelemetryContext.Create();
+
+            var configuration = new SecurityConfiguration
+            {
+                ApplicationCertificates =
+                [
+                    new CertificateIdentifier
+                    {
+                        StoreType = CertificateStoreType.Directory,
+                        StorePath = "pki/own",
+                        SubjectName = "CN=Test"
+                        // CertificateType deliberately not set
+                    }
+                ],
+                TrustedPeerCertificates = new CertificateTrustList { StorePath = "Test" },
+                TrustedIssuerCertificates = new CertificateTrustList { StorePath = "Test" }
+            };
+
+            Assert.That(configuration.ApplicationCertificates, Has.Count.EqualTo(1));
+            Assert.That(
+                configuration.ApplicationCertificates[0].CertificateType,
+                Is.EqualTo(ObjectTypeIds.RsaSha256ApplicationCertificateType));
+            Assert.That(
+                configuration.SupportedSecurityPolicies.ToArray(),
+                Contains.Item(SecurityPolicies.Basic256Sha256));
+
+            configuration.Validate(telemetry);
+        }
+
+        [Test]
+        public void UnsupportedApplicationCertificateTypeIsRemovedAndReportedByValidate()
+        {
+            ITelemetryContext telemetry = NUnitTelemetryContext.Create();
+
+            var configuration = new SecurityConfiguration
+            {
+                ApplicationCertificates =
+                [
+                    new CertificateIdentifier
+                    {
+                        StoreType = CertificateStoreType.Directory,
+                        StorePath = "pki/own",
+                        SubjectName = "CN=Test",
+                        CertificateType = ObjectTypeIds.EccCurve25519ApplicationCertificateType
+                    }
+                ],
+                TrustedPeerCertificates = new CertificateTrustList { StorePath = "Test" },
+                TrustedIssuerCertificates = new CertificateTrustList { StorePath = "Test" }
+            };
+
+            Assert.That(configuration.ApplicationCertificates, Is.Empty);
+
+            ServiceResultException sre = Assert.Throws<ServiceResultException>(
+                () => configuration.Validate(telemetry));
+
+            Assert.That(sre.Code, Is.EqualTo(StatusCodes.BadConfigurationError));
+            Assert.That(sre.Message, Does.Contain("CertificateType is not supported"));
+            Assert.That(
+                sre.Message,
+                Does.Contain(ObjectTypeIds.EccCurve25519ApplicationCertificateType.ToString()));
+        }
+
+        [Test]
+        public void SupportedApplicationCertificateSurvivesAnUnsupportedSibling()
+        {
+            ITelemetryContext telemetry = NUnitTelemetryContext.Create();
+
+            var configuration = new SecurityConfiguration
+            {
+                ApplicationCertificates =
+                [
+                    new CertificateIdentifier
+                    {
+                        StoreType = CertificateStoreType.Directory,
+                        StorePath = "pki/own",
+                        SubjectName = "CN=Test",
+                        CertificateType = ObjectTypeIds.EccCurve25519ApplicationCertificateType
+                    },
+                    new CertificateIdentifier
+                    {
+                        StoreType = CertificateStoreType.Directory,
+                        StorePath = "pki/own",
+                        SubjectName = "CN=Test"
+                    }
+                ],
+                TrustedPeerCertificates = new CertificateTrustList { StorePath = "Test" },
+                TrustedIssuerCertificates = new CertificateTrustList { StorePath = "Test" }
+            };
+
+            Assert.That(configuration.ApplicationCertificates, Has.Count.EqualTo(1));
+            Assert.That(
+                configuration.ApplicationCertificates[0].CertificateType,
+                Is.EqualTo(ObjectTypeIds.RsaSha256ApplicationCertificateType));
+
+            // the unsupported sibling is only logged, it must not fail validation
+            configuration.Validate(telemetry);
+        }
+
+        [Test]
         public void LoadingConfigurationWithApplicationCertificateShouldMarkItDeprecated()
         {
             string file = Path.Combine(TestContext.CurrentContext.WorkDirectory, "testlegacyconfig.xml");

--- a/tests/Opc.Ua.Configuration.Tests/SecurityConfigurationTests.cs
+++ b/tests/Opc.Ua.Configuration.Tests/SecurityConfigurationTests.cs
@@ -176,6 +176,25 @@ namespace Opc.Ua.Configuration.Tests
         }
 
         [Test]
+        public void EmptyApplicationCertificatesStillReportsTheClassicError()
+        {
+            ITelemetryContext telemetry = NUnitTelemetryContext.Create();
+
+            var configuration = new SecurityConfiguration
+            {
+                ApplicationCertificates = [],
+                TrustedPeerCertificates = new CertificateTrustList { StorePath = "Test" },
+                TrustedIssuerCertificates = new CertificateTrustList { StorePath = "Test" }
+            };
+
+            ServiceResultException sre = Assert.Throws<ServiceResultException>(
+                () => configuration.Validate(telemetry));
+
+            Assert.That(sre.Code, Is.EqualTo(StatusCodes.BadConfigurationError));
+            Assert.That(sre.Message, Does.Contain("ApplicationCertificate must be specified."));
+        }
+
+        [Test]
         public void ClearingApplicationCertificatesRebuildsSupportedSecurityPolicies()
         {
             var configuration = new SecurityConfiguration

--- a/tests/Opc.Ua.Configuration.Tests/SecurityConfigurationTests.cs
+++ b/tests/Opc.Ua.Configuration.Tests/SecurityConfigurationTests.cs
@@ -176,6 +176,35 @@ namespace Opc.Ua.Configuration.Tests
         }
 
         [Test]
+        public void ClearingApplicationCertificatesRebuildsSupportedSecurityPolicies()
+        {
+            var configuration = new SecurityConfiguration
+            {
+                ApplicationCertificates =
+                [
+                    new CertificateIdentifier
+                    {
+                        StoreType = CertificateStoreType.Directory,
+                        StorePath = "pki/own",
+                        SubjectName = "CN=Test",
+                        CertificateType = ObjectTypeIds.RsaSha256ApplicationCertificateType
+                    }
+                ]
+            };
+
+            Assert.That(
+                configuration.SupportedSecurityPolicies.ToArray(),
+                Contains.Item(SecurityPolicies.Basic256Sha256));
+
+            configuration.ApplicationCertificates = [];
+
+            Assert.That(configuration.ApplicationCertificates, Is.Empty);
+            Assert.That(
+                configuration.SupportedSecurityPolicies.ToArray(),
+                Is.EqualTo(new[] { SecurityPolicies.None }));
+        }
+
+        [Test]
         public void LoadingConfigurationWithApplicationCertificateShouldMarkItDeprecated()
         {
             string file = Path.Combine(TestContext.CurrentContext.WorkDirectory, "testlegacyconfig.xml");


### PR DESCRIPTION
# Description

`SecurityConfiguration.ApplicationCertificates`'s setter removed every identifier whose certificate type is not supported, and `CertificateIdentifier.CertificateType` defaults to unset. An otherwise correct identifier passed to the recommended `AddSecurityConfiguration(ArrayOf<CertificateIdentifier> certIdList, ...)` overload was therefore dropped silently, and validation then failed with `ApplicationCertificate must be specified.` — pointing at the wrong cause. The obsolete `AddSecurityConfiguration(string subjectName, ...)` overload escaped this because it assigns the legacy singular `ApplicationCertificate` property, whose setter fills in `RsaSha256ApplicationCertificateType` itself. The result: the replacement advertised by the `[Obsolete]` message could not be used without also setting `CertificateType`, which that message does not mention.

**Changes:**

- `SecurityConfiguration.ApplicationCertificates` (`src/Opc.Ua.Core/Schema/ApplicationConfiguration.cs`) now treats an unset `CertificateType` as the default RSA-SHA256 application certificate type instead of dropping the entry — the same assumption the legacy single `ApplicationCertificate` element carries, so both paths agree on what a valid `CertificateIdentifier` is. Fixing the setter also covers callers that assign `ApplicationCertificates` directly, not just the builder overload.
- Identifiers dropped for a genuinely unsupported type are no longer discarded without a trace. They are remembered and reported by `SecurityConfiguration.Validate`, which has an `ITelemetryContext` — this replaces the `// TODO: Log when ITelemetry instance is available` that was exactly this bug:
  - a warning naming the rejected certificate types is logged whenever any were filtered out;
  - when the collection ends up empty *because* of the filtering, the error now reads `No supported application certificate configured: N certificate identifier(s) were rejected because their CertificateType is not supported (...)` instead of `ApplicationCertificate must be specified.`. The original message is kept for the genuinely-empty case.

**Notes for reviewers:**

- Behaviour is unchanged for every configuration that already names a certificate type; all shipped and test config XMLs set `CertificateTypeString`.
- `FindApplicationCertificateAsync` already had a fallback treating a null certificate type as RsaSha256, and `ApplicationInstance` fills in the type from the created/validated certificate when it is null — defaulting in the setter is consistent with both and yields the same RSA certificate.
- The unsupported-type filter itself is untouched; only unset types are now kept.

## Related Issues

- Fixes #4315

## Checklist

- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf) and read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
  - `SecurityConfigurationTests`: an untyped identifier survives as RsaSha256 and contributes `Basic256Sha256` to `SupportedSecurityPolicies`; an unsupported type (`EccCurve25519ApplicationCertificateType`) is removed and reported by `Validate` with `BadConfigurationError`; a supported entry survives alongside an unsupported sibling without failing validation.
  - `ApplicationConfigurationBuilderTests`: end-to-end reproduction from the issue, building a client through `AddSecurityConfiguration(ArrayOf<CertificateIdentifier>, pkiRoot)` + `CreateAsync()`.
- [ ] I have added all necessary documentation.
- [x] I have verified that my changes do not introduce (new) build or analyzer warnings.
- [ ] I ran **all** tests locally using the **UA.slnx** solution against at least .net **framework** and .net **10**, and all passed.
  - Ran on net10.0: `Opc.Ua.Configuration.Tests` 225/225 passed, `Opc.Ua.Core.Tests` 4368 passed / 86 skipped / 0 failed. The full solution across .NET Framework was not run locally — relying on CI for that.
- [ ] I fixed **all** failing and flaky tests in the CI pipelines and **all** CodeQL warnings.
- [ ] I have addressed **all** PR feedback received.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
