### PR TITLE
Fix [DataType] generator Clone() dropping every inherited field of a derived structure

### DIFF
--- a/docs/SourceGeneratedDataTypes.md
+++ b/docs/SourceGeneratedDataTypes.md
@@ -254,7 +254,11 @@ the record's `Equals` implementation.
 
 When a `[DataType]` class derives from another `IEncodeable` base type, the
 generator uses `override` instead of `virtual` and calls `base.Encode()`/
-`base.Decode()` before encoding the derived fields.
+`base.Decode()` before encoding the derived fields. `Clone()` delegates to a
+generated `MemberwiseClone()` that starts from a shallow copy of the whole
+object — carrying the inherited fields — and then deep copies the derived
+class's own reference-typed fields, the same shape the model-based generator
+emits.
 
 ### Internal Class
 

--- a/tests/Opc.Ua.SourceGeneration.Core.Tests/Generators/TypeSourceGeneratorTests.cs
+++ b/tests/Opc.Ua.SourceGeneration.Core.Tests/Generators/TypeSourceGeneratorTests.cs
@@ -190,6 +190,84 @@ namespace Opc.Ua.SourceGeneration.Generator.Tests
         }
 
         [Test]
+        public void GenerateClassCloneUsesMemberwiseClone()
+        {
+            var model = new TypeSourceModel
+            {
+                ClassName = "MyConfig",
+                Namespace = "MyApp.Config",
+                NamespaceUri = "urn:myapp:config",
+                NamespaceSymbol = "MyAppConfig",
+                IsEnum = false,
+                IsRecord = false,
+                Fields =
+                [
+                    CreateField("Name", "String"),
+                    new TypeFieldModel
+                    {
+                        PropertyName = "Child",
+                        FieldName = "Child",
+                        TypeName = "global::Test.Ns.ChildType",
+                        ShortTypeName = "ChildType",
+                        IsEncodeable = true,
+                        Order = 1
+                    }
+                ]
+            };
+
+            string result = TypeSourceGenerator.Generate(model);
+
+            Assert.That(result, Does.Contain("public virtual object Clone()"));
+            Assert.That(result, Does.Contain(
+                "return (MyConfig)this.MemberwiseClone();"));
+            Assert.That(result, Does.Contain(
+                "public new object MemberwiseClone()"));
+            Assert.That(result, Does.Contain(
+                "MyConfig clone = (MyConfig)base.MemberwiseClone();"));
+            Assert.That(result, Does.Contain(
+                "clone.Child = (global::Test.Ns.ChildType)global::Opc.Ua.CoreUtils.Clone(Child);"),
+                "Own reference-typed fields must be deep copied");
+            Assert.That(result, Does.Not.Contain("clone = new MyConfig()"),
+                "Clone must not start from a fresh instance");
+            Assert.That(result, Does.Not.Contain("clone.Name = Name;"),
+                "MemberwiseClone already carries simple fields");
+        }
+
+        [Test]
+        public void GenerateDerivedClassCloneCarriesInheritedState()
+        {
+            var model = new TypeSourceModel
+            {
+                ClassName = "MyDerivedConfig",
+                Namespace = "MyApp.Config",
+                NamespaceUri = "urn:myapp:config",
+                NamespaceSymbol = "MyAppConfig",
+                IsEnum = false,
+                IsRecord = false,
+                IsDerived = true,
+                BaseTypeIsEncodeable = true,
+                Fields =
+                [
+                    CreateField("Count", "UInt32")
+                ]
+            };
+
+            string result = TypeSourceGenerator.Generate(model);
+
+            Assert.That(result, Does.Contain("public override object Clone()"));
+            Assert.That(result, Does.Contain(
+                "return (MyDerivedConfig)this.MemberwiseClone();"));
+            Assert.That(result, Does.Contain(
+                "public new object MemberwiseClone()"));
+            Assert.That(result, Does.Contain(
+                "MyDerivedConfig clone = (MyDerivedConfig)base.MemberwiseClone();"),
+                "The clone must start from base.MemberwiseClone() so " +
+                "inherited fields are not dropped");
+            Assert.That(result, Does.Not.Contain("clone = new MyDerivedConfig()"),
+                "A fresh instance would drop every inherited field");
+        }
+
+        [Test]
         public void GenerateEnumProducesEnumeratedTypeActivator()
         {
             var model = new TypeSourceModel

--- a/tests/Opc.Ua.SourceGeneration.Tests/TypeGeneratorTests.cs
+++ b/tests/Opc.Ua.SourceGeneration.Tests/TypeGeneratorTests.cs
@@ -30,9 +30,12 @@
 using System;
 using System.Collections.Immutable;
 using System.Globalization;
+using System.IO;
 using System.Linq;
+using System.Reflection;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Emit;
 using NUnit.Framework;
 
 namespace Opc.Ua.SourceGeneration
@@ -559,8 +562,85 @@ namespace TestApp.Incremental
                 $"Final incremental compilation produced {errors} errors");
         }
 
+        [Test]
+        public void DerivedClassCloneKeepsInheritedFields()
+        {
+            // Repro from GH issue #4352: Clone() on a derived [DataType]
+            // structure must carry the fields inherited from the base type.
+            const string source = """
+
+using Opc.Ua;
+
+namespace TestApp.CloneRepro
+{
+    [DataType(Namespace = "urn:repro", DataTypeId = "i=1000")]
+    public partial class BaseStruct
+    {
+        public string Name { get; set; }
+    }
+
+    [DataType(Namespace = "urn:repro", DataTypeId = "i=1001")]
+    public partial class DerivedStruct : BaseStruct
+    {
+        public uint Count { get; set; }
+    }
+}
+""";
+            GeneratorRunResult result = RunGenerator(
+                source, out Compilation outputCompilation);
+
+            Assert.That(result.GeneratedSources, Has.Length.EqualTo(1));
+            string generated = result.GeneratedSources[0].SourceText.ToString();
+            Assert.That(generated, Does.Contain("public virtual object Clone()"));
+            Assert.That(generated, Does.Contain("public override object Clone()"));
+            Assert.That(generated, Does.Contain("public new object MemberwiseClone()"));
+            Assert.That(generated, Does.Contain(
+                "BaseStruct clone = (BaseStruct)base.MemberwiseClone();"));
+            Assert.That(generated, Does.Contain(
+                "DerivedStruct clone = (DerivedStruct)base.MemberwiseClone();"));
+            Assert.That(generated, Does.Not.Contain("clone = new DerivedStruct()"),
+                "Clone must not start from a fresh instance");
+
+            // Execute the generated Clone() to prove the inherited
+            // field survives at runtime.
+            using var stream = new MemoryStream();
+            EmitResult emitResult = outputCompilation.Emit(stream);
+            emitResult.Check(TestContext.Out, out int emitErrors, out _);
+            Assert.That(emitResult.Success, Is.True,
+                $"Emit produced {emitErrors} errors");
+
+            Assembly assembly = Assembly.Load(stream.ToArray());
+            Type derivedType = assembly.GetType(
+                "TestApp.CloneRepro.DerivedStruct", throwOnError: true);
+
+            object original = Activator.CreateInstance(derivedType);
+            derivedType.GetProperty("Name").SetValue(original, "kept?");
+            derivedType.GetProperty("Count").SetValue(original, 7u);
+
+            object clone = derivedType.GetMethod("Clone").Invoke(original, null);
+
+            Assert.That(clone, Is.Not.SameAs(original));
+            Assert.That(clone, Is.InstanceOf(derivedType));
+            Assert.That(
+                derivedType.GetProperty("Count").GetValue(clone),
+                Is.EqualTo(7u));
+            Assert.That(
+                derivedType.GetProperty("Name").GetValue(clone),
+                Is.EqualTo("kept?"),
+                "Clone() dropped the inherited field");
+        }
+
         private static GeneratorRunResult RunGenerator(
             string source,
+            bool expectErrors = false,
+            bool expectWarnings = false)
+        {
+            return RunGenerator(source, out _, expectErrors, expectWarnings);
+        }
+
+        private static GeneratorRunResult RunGenerator(
+            string source,
+            out Compilation outputCompilation,
             bool expectErrors = false,
             bool expectWarnings = false)
         {
@@ -581,7 +661,7 @@ namespace TestApp.Incremental
 
             driver = driver.RunGeneratorsAndUpdateCompilation(
                 compilation,
-                out Compilation outputCompilation,
+                out outputCompilation,
                 out ImmutableArray<Diagnostic> diagnostics);
 
             if (!expectErrors)

--- a/tools/Opc.Ua.SourceGeneration.Core/Generators/TypeSourceGenerator.cs
+++ b/tools/Opc.Ua.SourceGeneration.Core/Generators/TypeSourceGenerator.cs
@@ -529,6 +529,11 @@ namespace Opc.Ua.SourceGeneration
                 return null;
             }
 
+            // The clone starts as a shallow copy of the whole object
+            // (base.MemberwiseClone() for classes, 'with { }' for records),
+            // which already carries every field including inherited and
+            // init-only ones. Only fields with reference semantics need an
+            // explicit deep copy on top of that.
             if (NeedsCloning(field))
             {
                 // For init-only properties use the backing field for assignment
@@ -538,17 +543,6 @@ namespace Opc.Ua.SourceGeneration
                 context.Out.WriteLine(
                     "{0} = ({1})global::Opc.Ua.CoreUtils.Clone({2});",
                     target, field.TypeName, field.PropertyName);
-            }
-            else if (field.IsInitOnly)
-            {
-                // Record's 'with' already copies simple init-only fields
-                return null;
-            }
-            else
-            {
-                context.Out.WriteLine(
-                    "clone.{0} = {0};",
-                    field.PropertyName);
             }
             return null;
 

--- a/tools/Opc.Ua.SourceGeneration.Core/Generators/TypeSourceTemplates.cs
+++ b/tools/Opc.Ua.SourceGeneration.Core/Generators/TypeSourceTemplates.cs
@@ -434,18 +434,30 @@ namespace Opc.Ua.SourceGeneration
             """);
 
         /// <summary>
-        /// Clone method
+        /// Clone/MemberwiseClone methods for a class. Clone delegates to
+        /// MemberwiseClone, which starts from a shallow copy of the whole
+        /// object - carrying every field, including inherited ones - and
+        /// then deep copies this class's own reference-typed fields. A
+        /// derived class hides MemberwiseClone and chains into the base
+        /// implementation via base.MemberwiseClone(), matching the shape
+        /// emitted by the model-based generator.
         /// </summary>
         public static readonly TemplateString CloneMethod = TemplateString.Parse(
             $$"""
             /// <inheritdoc/>
             public {{Tokens.AccessModifier}} object Clone()
             {
-                {{Tokens.ClassName}} clone = new {{Tokens.ClassName}}();
+                return ({{Tokens.ClassName}})this.MemberwiseClone();
+            }
+
+            /// <inheritdoc/>
+            public new object MemberwiseClone()
+            {
+                {{Tokens.ClassName}} clone = ({{Tokens.ClassName}})base.MemberwiseClone();
                 {{Tokens.ListOfClonedFields}}
                 return clone;
             }
-            
+
             """);
 
         /// <summary>


### PR DESCRIPTION
# Description

The `[DataType]` source generator emitted a `Clone()` that created a fresh instance and copied only the fields declared on the annotated type itself, so every field inherited from an `IEncodeable` base was silently dropped. Since the server clones node values while loading an address space, a derived structure served by a node manager came back out of a Read with its inherited fields empty, even though encode/decode was correct.

This PR makes the `[DataType]` path emit the same `MemberwiseClone`-based shape as the model-based generator:

```csharp
/// <inheritdoc/>
public override object Clone()
{
    return (DerivedStruct)this.MemberwiseClone();
}

/// <inheritdoc/>
public new object MemberwiseClone()
{
    DerivedStruct clone = (DerivedStruct)base.MemberwiseClone();
    // deep copy of the own reference-typed fields
    return clone;
}
```

`Clone()` delegates to a generated `public new object MemberwiseClone()` that starts from `base.MemberwiseClone()` — a shallow copy of the whole object, inherited fields included — and then deep copies the type's own reference-typed fields (encodeables, `DataValue`, `Variant`, `ExtensionObject`). Derived classes hide `MemberwiseClone` and chain into the base implementation, so deep-copy semantics compose across the hierarchy, including across assemblies into model-generated base types (the `BicycleType` scenario that surfaced this). The two generator paths now agree.

Because the clone now starts from a full shallow copy (`base.MemberwiseClone()` for classes, `with { }` for records), the per-field clone emitter only writes the deep-copy assignments; the redundant per-field plain copies are gone. This also fixes a latent side bug in the class path: init-only simple fields were silently dropped by the fresh-instance clone as well.

Records were already correct (`with { }` carries every field) and are unchanged in shape.

Tests:

- `GenerateClassCloneUsesMemberwiseClone` / `GenerateDerivedClassCloneCarriesInheritedState` assert the emitted shape for root and derived classes.
- `DerivedClassCloneKeepsInheritedFields` runs the exact repro from the issue through the Roslyn driver, emits the assembly, and executes `Clone()` at runtime to prove the inherited field survives (verified on net10.0 and net48).

Verified locally: `Opc.Ua.SourceGeneration.Core.Tests` (3798 passed), `Opc.Ua.SourceGeneration.Tests` (140 passed), `Opc.Ua.SourceGeneration.Stack.Tests` (94 passed), and `Opc.Ua.Client.Tests` (2161 passed, exercises the regenerated in-tree `[DataType]` record types). The in-tree `[DataType]` consumers (Opc.Ua.Client, both GDS common projects) regenerate and build without warnings.

## Related Issues

- Fixes #4352

## Checklist

_Put an `x` in the boxes that apply. You can complete these step by step after opening the PR._

- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf) and read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [x] I have added all necessary documentation.
- [x] I have verified that my changes do not introduce (new) build or analyzer warnings.
- [ ] I ran **all** tests locally using the **UA.slnx** solution against at least .net **framework** and .net **10**, and all passed.
- [ ] I fixed **all** failing and flaky tests in the CI pipelines and **all** CodeQL warnings.
- [ ] I have addressed **all** PR feedback received.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
