### PR TITLE
Fix instance TypeDefinition across dependency ModelDesign boundaries

### DIFF
--- a/docs/ModelDependencies.md
+++ b/docs/ModelDependencies.md
@@ -145,4 +145,14 @@ payload-materialised data types (base types, field data types, structure /
 enumeration classification), so a local `ModelDesign` structure can subtype
 a structure published only through a referenced assembly's payload.
 
+Design files loaded as dependencies of the current target skip full
+dictionary validation, so the validator links them the same way after
+loading: their data types (as above) and their instances — the
+`TypeDefinition` / `DataType` node references of the types' children,
+variable-type data type restrictions, and method arguments including the
+`InputArguments` / `OutputArguments` argument properties. A target
+`ModelDesign` can therefore declare an `Object` or `Variable` whose
+`TypeDefinition` is a type from another design file and have its inherited
+children generate exactly as if the type were declared locally.
+
 

--- a/tests/Opc.Ua.SourceGeneration.Core.Tests/Generators/CrossModelInstanceTypeDefinitionTests.cs
+++ b/tests/Opc.Ua.SourceGeneration.Core.Tests/Generators/CrossModelInstanceTypeDefinitionTests.cs
@@ -1,0 +1,410 @@
+/* ========================================================================
+ * Copyright (c) 2005-2026 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using Microsoft.Extensions.Logging;
+using NUnit.Framework;
+using Opc.Ua.Schema.Model;
+using Opc.Ua.Tests;
+
+namespace Opc.Ua.SourceGeneration.Generator.Tests
+{
+    /// <summary>
+    /// Regression tests for issue #4353: an Object (or Variable) whose
+    /// TypeDefinition names a type declared in a dependency ModelDesign
+    /// must generate the same node-state factories as it would if the
+    /// type were declared locally. The sibling of the #4332 structure
+    /// subtyping tests on the instance-declaration path: the crash was a
+    /// NullReferenceException in GetNodeStateClassName on the inherited
+    /// children of the cross-model type, whose TypeDefinitionNode /
+    /// DataTypeNode were never linked because dependency designs skip
+    /// dictionary validation.
+    /// </summary>
+    [TestFixture]
+    [Category("Generator")]
+    [SetCulture("en-us")]
+    [SetUICulture("en-us")]
+    [Parallelizable]
+    public class CrossModelInstanceTypeDefinitionTests
+    {
+        private string m_rootPath;
+        private string m_modelAPath;
+        private string m_modelBPath;
+        private string m_modelLocalPath;
+
+        [SetUp]
+        public void SetUp()
+        {
+            m_rootPath = Path.Combine(
+                Path.GetTempPath(),
+                "UA-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(Path.Combine(m_rootPath, "A"));
+            Directory.CreateDirectory(Path.Combine(m_rootPath, "B"));
+            m_modelAPath = Path.Combine(m_rootPath, "A", "ModelA.xml");
+            m_modelBPath = Path.Combine(m_rootPath, "B", "ModelB.xml");
+            m_modelLocalPath = Path.Combine(m_rootPath, "B", "ModelLocal.xml");
+            File.WriteAllText(m_modelAPath, ModelADesign);
+            File.WriteAllText(m_modelBPath, ModelBDesign);
+            File.WriteAllText(m_modelLocalPath, ModelLocalDesign);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            try
+            {
+                Directory.Delete(m_rootPath, true);
+            }
+            catch (IOException)
+            {
+            }
+        }
+
+        /// <summary>
+        /// The primary repro from #4353: an Object instance in the target
+        /// model whose TypeDefinition is an ObjectType with children
+        /// declared in a dependency design file. NodeStateGenerator used
+        /// to throw a NullReferenceException in GetNodeStateClassName on
+        /// the inherited Label property.
+        /// </summary>
+        [Test]
+        public void ObjectInstanceOfDependencyObjectTypeGenerates()
+        {
+            Dictionary<string, string> generated = Generate(
+                targets: [m_modelBPath],
+                dependencies: [m_modelBPath, m_modelAPath]);
+
+            string code = GetNodeStateExtensions(generated);
+            Assert.Multiple(() =>
+            {
+                Assert.That(code, Does.Contain("CreateWidget1("),
+                    "The instance factory must be emitted.");
+                Assert.That(code, Does.Contain("CreateWidget1_Label("),
+                    "The factory for the property inherited from the " +
+                    "dependency type must be emitted.");
+                // The instance is created as the dependency's typed state
+                // class, resolved through the dependency namespace prefix.
+                Assert.That(code, Does.Contain("global::Test.ModelA.WidgetState"),
+                    "The instance must use the typed state class of the " +
+                    "dependency ObjectType.");
+                // The method arguments of the dependency method must
+                // materialise into the InputArguments property value.
+                Assert.That(code, Does.Contain("\"Hard\""),
+                    "The InputArguments value must carry the argument " +
+                    "declared on the dependency method.");
+            });
+        }
+
+        /// <summary>
+        /// The expected behavior stated in #4353: the instance generates
+        /// the same node-state factories as it would if the type were
+        /// declared locally. Compares the full set of factory names of the
+        /// instance subtree between a single-file control model and the
+        /// cross-model variant.
+        /// </summary>
+        [Test]
+        public void InstanceFactoriesMatchLocallyDeclaredType()
+        {
+            Dictionary<string, string> local = Generate(
+                targets: [m_modelLocalPath],
+                dependencies: [m_modelLocalPath]);
+            Dictionary<string, string> crossModel = Generate(
+                targets: [m_modelBPath],
+                dependencies: [m_modelBPath, m_modelAPath]);
+
+            HashSet<string> localFactories = ExtractFactoryNames(
+                GetNodeStateExtensions(local), "Widget1");
+            HashSet<string> crossModelFactories = ExtractFactoryNames(
+                GetNodeStateExtensions(crossModel), "Widget1");
+
+            Assert.That(localFactories, Is.Not.Empty,
+                "The control model did not produce instance factories.");
+            Assert.That(crossModelFactories, Is.EquivalentTo(localFactories),
+                "The cross-model instance must generate the same " +
+                "node-state factories as the locally declared type.");
+        }
+
+        /// <summary>
+        /// The same two design files with the roles flipped: the target is
+        /// the upstream type model and the dependency list contains the
+        /// downstream instance model that imports it (the source generator
+        /// supplies every design file of the compilation as a dependency
+        /// of every other). Loading and linking the downstream instances
+        /// must not fail.
+        /// </summary>
+        [Test]
+        public void UpstreamTargetWithDownstreamInstanceModelGenerates()
+        {
+            Dictionary<string, string> generated = Generate(
+                targets: [m_modelAPath],
+                dependencies: [m_modelAPath, m_modelBPath]);
+
+            string code = GetNodeStateExtensions(generated);
+            Assert.That(code, Does.Contain("CreateWidgetType_Label("),
+                "The type model must generate its own factories.");
+        }
+
+        /// <summary>
+        /// Validator-level checks: the merged hierarchy of the target
+        /// instance must carry linked TypeDefinitionNode / DataTypeNode
+        /// references on the children materialised from the dependency
+        /// type - that is what the generators dereference.
+        /// </summary>
+        [Test]
+        public void DependencyTypeChildrenAreLinkedIntoInstanceHierarchy()
+        {
+            ITelemetryContext telemetry = NUnitTelemetryContext.Create(logLevel: LogLevel.Error);
+            using var virtualFileSystem = new VirtualFileSystem();
+            IFileSystem fileSystem = typeof(ModelDesignValidator).Assembly
+                .AsFileSystem("Opc.Ua.SourceGeneration.Design")
+                .WithFallback(virtualFileSystem);
+            IModelDesign model = fileSystem.OpenModelDesign(
+                new DesignFileCollection
+                {
+                    Targets = [m_modelBPath],
+                    Dependencies = [m_modelAPath],
+                    Options = new DesignFileOptions()
+                },
+                exclusions: null,
+                telemetry,
+                useAllowSubtypes: false);
+
+            ObjectDesign widget = model.Nodes
+                .OfType<ObjectDesign>()
+                .FirstOrDefault(n => n.SymbolicName.Name == "Widget1");
+            Assert.That(widget, Is.Not.Null);
+            Assert.That(widget.TypeDefinitionNode, Is.Not.Null,
+                "The instance's own type definition must resolve to the " +
+                "dependency ObjectType.");
+
+            var label = widget.Hierarchy.Nodes["Label"].Instance as VariableDesign;
+            Assert.That(label, Is.Not.Null);
+            Assert.Multiple(() =>
+            {
+                Assert.That(label.TypeDefinitionNode, Is.Not.Null,
+                    "Label's TypeDefinitionNode must be linked.");
+                Assert.That(label.DataTypeNode, Is.Not.Null,
+                    "Label's DataTypeNode must be linked.");
+                Assert.That(label.DataTypeNode?.SymbolicName.Name, Is.EqualTo("String"));
+            });
+
+            var level = widget.Hierarchy.Nodes["Level"].Instance as VariableDesign;
+            Assert.That(level, Is.Not.Null);
+            Assert.Multiple(() =>
+            {
+                Assert.That(level.TypeDefinitionNode, Is.Not.Null,
+                    "Level's TypeDefinitionNode must be linked.");
+                Assert.That(level.DataTypeNode, Is.Not.Null,
+                    "Level's DataTypeNode must be linked.");
+                // The variable declares no DataType of its own; it has to
+                // inherit the restriction of the dependency VariableType.
+                Assert.That(level.DataTypeNode?.SymbolicName.Name, Is.EqualTo("Double"));
+                Assert.That(
+                    (level.TypeDefinitionNode as VariableTypeDesign)?.DataTypeNode,
+                    Is.Not.Null,
+                    "The dependency VariableType's DataTypeNode must be linked.");
+            });
+        }
+
+        private static string GetNodeStateExtensions(Dictionary<string, string> generated)
+        {
+            string code = generated.Keys
+                .Where(f => f.EndsWith(".NodeStates.ex.g.cs", StringComparison.Ordinal))
+                .Select(f => generated[f])
+                .FirstOrDefault();
+            Assert.That(code, Is.Not.Null, "No node state extensions generated.");
+            return code;
+        }
+
+        /// <summary>
+        /// Collects the names of all emitted factory methods for the
+        /// instance subtree of <paramref name="instanceName"/>. Factory
+        /// names derive from symbolic names only, so they are identical
+        /// for a local and a cross-model type declaration.
+        /// </summary>
+        private static HashSet<string> ExtractFactoryNames(string code, string instanceName)
+        {
+            return Regex.Matches(
+                    code,
+                    @"internal static [^\r\n(]*\b(Create" + Regex.Escape(instanceName) + @"\w*)\(")
+                .Select(m => m.Groups[1].Value)
+                .ToHashSet();
+        }
+
+        private static Dictionary<string, string> Generate(
+            IReadOnlyList<string> targets,
+            IReadOnlyList<string> dependencies)
+        {
+            ITelemetryContext telemetry = NUnitTelemetryContext.Create(logLevel: LogLevel.Error);
+            using var fileSystem = new VirtualFileSystem();
+            Generators.GenerateCode(
+                new DesignFileCollection
+                {
+                    Targets = targets,
+                    Dependencies = dependencies,
+                    Options = new DesignFileOptions()
+                },
+                fileSystem,
+                string.Empty,
+                telemetry,
+                new GeneratorOptions
+                {
+                    OmitFluentApi = true,
+                    OmitEventRecords = true
+                },
+                useAllowSubtypes: false,
+                identifierFiles: null,
+                referencedModels: null,
+                nodeManagerBindings: null,
+                reportBindingDiagnostic: null,
+                sharedUsedBindings: null,
+                bindingModelCount: 0,
+                reportFluentAccessorsOnlyDiagnostic: null,
+                referencedModelProviders: null,
+                referencedAccessorProviders: null);
+            return fileSystem.CreatedFiles
+                .ToDictionary(c => c, c => Encoding.UTF8.GetString(fileSystem.Get(c)));
+        }
+
+        /// <summary>
+        /// The dependency model: an ObjectType with children (the trigger
+        /// of #4353 is precisely the inherited child of a cross-model type
+        /// declaration) and a VariableType with a DataType restriction
+        /// used by one of the children.
+        /// </summary>
+        private const string ModelADesign =
+            """
+            <?xml version="1.0" encoding="utf-8" ?>
+            <opc:ModelDesign
+              xmlns:opc="http://opcfoundation.org/UA/ModelDesign.xsd"
+              xmlns:ua="http://opcfoundation.org/UA/"
+              xmlns="http://test.org/UA/ModelA/"
+              TargetNamespace="http://test.org/UA/ModelA/">
+              <opc:Namespaces>
+                <opc:Namespace Name="OpcUa" Prefix="Opc.Ua" XmlNamespace="http://opcfoundation.org/UA/2008/02/Types.xsd">http://opcfoundation.org/UA/</opc:Namespace>
+                <opc:Namespace Name="ModelA" Prefix="Test.ModelA">http://test.org/UA/ModelA/</opc:Namespace>
+              </opc:Namespaces>
+              <opc:VariableType SymbolicName="WidgetLevelType" BaseType="ua:BaseDataVariableType" DataType="ua:Double" ValueRank="Scalar">
+                <opc:Children>
+                  <opc:Property SymbolicName="HighLimit" DataType="ua:Double" ValueRank="Scalar" />
+                </opc:Children>
+              </opc:VariableType>
+              <opc:ObjectType SymbolicName="WidgetType" BaseType="ua:BaseObjectType">
+                <opc:Children>
+                  <opc:Property SymbolicName="Label" DataType="ua:String" ValueRank="Scalar" />
+                  <opc:Variable SymbolicName="Level" TypeDefinition="WidgetLevelType" />
+                  <opc:Method SymbolicName="Reset">
+                    <opc:InputArguments>
+                      <opc:Argument Name="Hard" DataType="ua:Boolean" ValueRank="Scalar" />
+                    </opc:InputArguments>
+                  </opc:Method>
+                </opc:Children>
+              </opc:ObjectType>
+            </opc:ModelDesign>
+            """;
+
+        /// <summary>
+        /// The target model of the repro: only an instance of the
+        /// dependency ObjectType, organized under the ObjectsFolder.
+        /// </summary>
+        private const string ModelBDesign =
+            """
+            <?xml version="1.0" encoding="utf-8" ?>
+            <opc:ModelDesign
+              xmlns:opc="http://opcfoundation.org/UA/ModelDesign.xsd"
+              xmlns:ua="http://opcfoundation.org/UA/"
+              xmlns:s0="http://test.org/UA/ModelA/"
+              xmlns="http://test.org/UA/ModelB/"
+              TargetNamespace="http://test.org/UA/ModelB/">
+              <opc:Namespaces>
+                <opc:Namespace Name="ModelB" Prefix="Test.ModelB">http://test.org/UA/ModelB/</opc:Namespace>
+                <opc:Namespace Name="ModelA" Prefix="Test.ModelA">http://test.org/UA/ModelA/</opc:Namespace>
+                <opc:Namespace Name="OpcUa" Prefix="Opc.Ua" XmlNamespace="http://opcfoundation.org/UA/2008/02/Types.xsd">http://opcfoundation.org/UA/</opc:Namespace>
+              </opc:Namespaces>
+              <opc:Object SymbolicName="Widget1" TypeDefinition="s0:WidgetType">
+                <opc:References>
+                  <opc:Reference IsInverse="true">
+                    <opc:ReferenceType>ua:Organizes</opc:ReferenceType>
+                    <opc:TargetId>ua:ObjectsFolder</opc:TargetId>
+                  </opc:Reference>
+                </opc:References>
+              </opc:Object>
+            </opc:ModelDesign>
+            """;
+
+        /// <summary>
+        /// The control model: the same type declarations and the same
+        /// instance in a single design file. This is the shape that always
+        /// generated correctly and defines the expected factory set.
+        /// </summary>
+        private const string ModelLocalDesign =
+            """
+            <?xml version="1.0" encoding="utf-8" ?>
+            <opc:ModelDesign
+              xmlns:opc="http://opcfoundation.org/UA/ModelDesign.xsd"
+              xmlns:ua="http://opcfoundation.org/UA/"
+              xmlns="http://test.org/UA/ModelL/"
+              TargetNamespace="http://test.org/UA/ModelL/">
+              <opc:Namespaces>
+                <opc:Namespace Name="ModelL" Prefix="Test.ModelL">http://test.org/UA/ModelL/</opc:Namespace>
+                <opc:Namespace Name="OpcUa" Prefix="Opc.Ua" XmlNamespace="http://opcfoundation.org/UA/2008/02/Types.xsd">http://opcfoundation.org/UA/</opc:Namespace>
+              </opc:Namespaces>
+              <opc:VariableType SymbolicName="WidgetLevelType" BaseType="ua:BaseDataVariableType" DataType="ua:Double" ValueRank="Scalar">
+                <opc:Children>
+                  <opc:Property SymbolicName="HighLimit" DataType="ua:Double" ValueRank="Scalar" />
+                </opc:Children>
+              </opc:VariableType>
+              <opc:ObjectType SymbolicName="WidgetType" BaseType="ua:BaseObjectType">
+                <opc:Children>
+                  <opc:Property SymbolicName="Label" DataType="ua:String" ValueRank="Scalar" />
+                  <opc:Variable SymbolicName="Level" TypeDefinition="WidgetLevelType" />
+                  <opc:Method SymbolicName="Reset">
+                    <opc:InputArguments>
+                      <opc:Argument Name="Hard" DataType="ua:Boolean" ValueRank="Scalar" />
+                    </opc:InputArguments>
+                  </opc:Method>
+                </opc:Children>
+              </opc:ObjectType>
+              <opc:Object SymbolicName="Widget1" TypeDefinition="WidgetType">
+                <opc:References>
+                  <opc:Reference IsInverse="true">
+                    <opc:ReferenceType>ua:Organizes</opc:ReferenceType>
+                    <opc:TargetId>ua:ObjectsFolder</opc:TargetId>
+                  </opc:Reference>
+                </opc:References>
+              </opc:Object>
+            </opc:ModelDesign>
+            """;
+    }
+}

--- a/tests/Opc.Ua.SourceGeneration.Core.Tests/Generators/CrossModelInstanceTypeDefinitionTests.cs
+++ b/tests/Opc.Ua.SourceGeneration.Core.Tests/Generators/CrossModelInstanceTypeDefinitionTests.cs
@@ -235,6 +235,24 @@ namespace Opc.Ua.SourceGeneration.Generator.Tests
                     Is.Not.Null,
                     "The dependency VariableType's DataTypeNode must be linked.");
             });
+
+            var reset = widget.Hierarchy.Nodes["Reset"].Instance as MethodDesign;
+            Assert.That(reset, Is.Not.Null);
+            Parameter hard = reset.InputArguments
+                .FirstOrDefault(a => a.Name == "Hard");
+            Parameter config = reset.InputArguments
+                .FirstOrDefault(a => a.Name == "Config");
+            Assert.Multiple(() =>
+            {
+                Assert.That(hard?.DataTypeNode?.SymbolicName.Name, Is.EqualTo("Boolean"),
+                    "The method argument's DataTypeNode must be linked.");
+                // Mirrors ValidateParameters: without UseAllowSubtypes a
+                // structure argument that allows subtypes degrades to the
+                // abstract Structure.
+                Assert.That(config?.DataTypeNode?.SymbolicName.Name, Is.EqualTo("Structure"),
+                    "The AllowSubTypes structure argument must degrade to " +
+                    "Structure like a locally validated method argument.");
+            });
         }
 
         private static string GetNodeStateExtensions(Dictionary<string, string> generated)
@@ -315,6 +333,11 @@ namespace Opc.Ua.SourceGeneration.Generator.Tests
                 <opc:Namespace Name="OpcUa" Prefix="Opc.Ua" XmlNamespace="http://opcfoundation.org/UA/2008/02/Types.xsd">http://opcfoundation.org/UA/</opc:Namespace>
                 <opc:Namespace Name="ModelA" Prefix="Test.ModelA">http://test.org/UA/ModelA/</opc:Namespace>
               </opc:Namespaces>
+              <opc:DataType SymbolicName="WidgetConfigType" BaseType="ua:Structure">
+                <opc:Fields>
+                  <opc:Field Name="Setting" DataType="ua:String" />
+                </opc:Fields>
+              </opc:DataType>
               <opc:VariableType SymbolicName="WidgetLevelType" BaseType="ua:BaseDataVariableType" DataType="ua:Double" ValueRank="Scalar">
                 <opc:Children>
                   <opc:Property SymbolicName="HighLimit" DataType="ua:Double" ValueRank="Scalar" />
@@ -327,6 +350,7 @@ namespace Opc.Ua.SourceGeneration.Generator.Tests
                   <opc:Method SymbolicName="Reset">
                     <opc:InputArguments>
                       <opc:Argument Name="Hard" DataType="ua:Boolean" ValueRank="Scalar" />
+                      <opc:Argument Name="Config" DataType="WidgetConfigType" ValueRank="Scalar" AllowSubTypes="true" />
                     </opc:InputArguments>
                   </opc:Method>
                 </opc:Children>
@@ -380,6 +404,11 @@ namespace Opc.Ua.SourceGeneration.Generator.Tests
                 <opc:Namespace Name="ModelL" Prefix="Test.ModelL">http://test.org/UA/ModelL/</opc:Namespace>
                 <opc:Namespace Name="OpcUa" Prefix="Opc.Ua" XmlNamespace="http://opcfoundation.org/UA/2008/02/Types.xsd">http://opcfoundation.org/UA/</opc:Namespace>
               </opc:Namespaces>
+              <opc:DataType SymbolicName="WidgetConfigType" BaseType="ua:Structure">
+                <opc:Fields>
+                  <opc:Field Name="Setting" DataType="ua:String" />
+                </opc:Fields>
+              </opc:DataType>
               <opc:VariableType SymbolicName="WidgetLevelType" BaseType="ua:BaseDataVariableType" DataType="ua:Double" ValueRank="Scalar">
                 <opc:Children>
                   <opc:Property SymbolicName="HighLimit" DataType="ua:Double" ValueRank="Scalar" />
@@ -392,6 +421,7 @@ namespace Opc.Ua.SourceGeneration.Generator.Tests
                   <opc:Method SymbolicName="Reset">
                     <opc:InputArguments>
                       <opc:Argument Name="Hard" DataType="ua:Boolean" ValueRank="Scalar" />
+                      <opc:Argument Name="Config" DataType="WidgetConfigType" ValueRank="Scalar" AllowSubTypes="true" />
                     </opc:InputArguments>
                   </opc:Method>
                 </opc:Children>

--- a/tests/Opc.Ua.SourceGeneration.Core.Tests/Generators/CrossModelInstanceTypeDefinitionTests.cs
+++ b/tests/Opc.Ua.SourceGeneration.Core.Tests/Generators/CrossModelInstanceTypeDefinitionTests.cs
@@ -123,6 +123,11 @@ namespace Opc.Ua.SourceGeneration.Generator.Tests
                 Assert.That(code, Does.Contain("\"Hard\""),
                     "The InputArguments value must carry the argument " +
                     "declared on the dependency method.");
+                // The decoded default value of the dependency property must
+                // flow into the generated value code.
+                Assert.That(code, Does.Contain("Unlabeled"),
+                    "The property value must carry the DefaultValue " +
+                    "declared on the dependency type.");
             });
         }
 
@@ -217,6 +222,10 @@ namespace Opc.Ua.SourceGeneration.Generator.Tests
                 Assert.That(label.DataTypeNode, Is.Not.Null,
                     "Label's DataTypeNode must be linked.");
                 Assert.That(label.DataTypeNode?.SymbolicName.Name, Is.EqualTo("String"));
+                // The default value of the dependency property must be
+                // decoded like ValidateInstance does for a local property.
+                Assert.That(label.DecodedValue?.ToString(), Is.EqualTo("Unlabeled"),
+                    "Label's DefaultValue must be decoded.");
             });
 
             var level = widget.Hierarchy.Nodes["Level"].Instance as VariableDesign;
@@ -242,6 +251,8 @@ namespace Opc.Ua.SourceGeneration.Generator.Tests
                 .FirstOrDefault(a => a.Name == "Hard");
             Parameter config = reset.InputArguments
                 .FirstOrDefault(a => a.Name == "Config");
+            Parameter result = reset.OutputArguments
+                .FirstOrDefault(a => a.Name == "Result");
             Assert.Multiple(() =>
             {
                 Assert.That(hard?.DataTypeNode?.SymbolicName.Name, Is.EqualTo("Boolean"),
@@ -250,8 +261,11 @@ namespace Opc.Ua.SourceGeneration.Generator.Tests
                 // structure argument that allows subtypes degrades to the
                 // abstract Structure.
                 Assert.That(config?.DataTypeNode?.SymbolicName.Name, Is.EqualTo("Structure"),
-                    "The AllowSubTypes structure argument must degrade to " +
-                    "Structure like a locally validated method argument.");
+                    "The AllowSubTypes structure input argument must degrade " +
+                    "to Structure like a locally validated method argument.");
+                Assert.That(result?.DataTypeNode?.SymbolicName.Name, Is.EqualTo("Structure"),
+                    "The AllowSubTypes structure output argument must degrade " +
+                    "to Structure like a locally validated method argument.");
             });
         }
 
@@ -328,6 +342,7 @@ namespace Opc.Ua.SourceGeneration.Generator.Tests
             <opc:ModelDesign
               xmlns:opc="http://opcfoundation.org/UA/ModelDesign.xsd"
               xmlns:ua="http://opcfoundation.org/UA/"
+              xmlns:uax="http://opcfoundation.org/UA/2008/02/Types.xsd"
               xmlns="http://test.org/UA/ModelA/"
               TargetNamespace="http://test.org/UA/ModelA/">
               <opc:Namespaces>
@@ -346,13 +361,20 @@ namespace Opc.Ua.SourceGeneration.Generator.Tests
               </opc:VariableType>
               <opc:ObjectType SymbolicName="WidgetType" BaseType="ua:BaseObjectType">
                 <opc:Children>
-                  <opc:Property SymbolicName="Label" DataType="ua:String" ValueRank="Scalar" />
+                  <opc:Property SymbolicName="Label" DataType="ua:String" ValueRank="Scalar">
+                    <opc:DefaultValue>
+                      <uax:String>Unlabeled</uax:String>
+                    </opc:DefaultValue>
+                  </opc:Property>
                   <opc:Variable SymbolicName="Level" TypeDefinition="WidgetLevelType" />
                   <opc:Method SymbolicName="Reset">
                     <opc:InputArguments>
                       <opc:Argument Name="Hard" DataType="ua:Boolean" ValueRank="Scalar" />
                       <opc:Argument Name="Config" DataType="WidgetConfigType" ValueRank="Scalar" AllowSubTypes="true" />
                     </opc:InputArguments>
+                    <opc:OutputArguments>
+                      <opc:Argument Name="Result" DataType="WidgetConfigType" ValueRank="Scalar" AllowSubTypes="true" />
+                    </opc:OutputArguments>
                   </opc:Method>
                 </opc:Children>
               </opc:ObjectType>
@@ -399,6 +421,7 @@ namespace Opc.Ua.SourceGeneration.Generator.Tests
             <opc:ModelDesign
               xmlns:opc="http://opcfoundation.org/UA/ModelDesign.xsd"
               xmlns:ua="http://opcfoundation.org/UA/"
+              xmlns:uax="http://opcfoundation.org/UA/2008/02/Types.xsd"
               xmlns="http://test.org/UA/ModelL/"
               TargetNamespace="http://test.org/UA/ModelL/">
               <opc:Namespaces>
@@ -417,13 +440,20 @@ namespace Opc.Ua.SourceGeneration.Generator.Tests
               </opc:VariableType>
               <opc:ObjectType SymbolicName="WidgetType" BaseType="ua:BaseObjectType">
                 <opc:Children>
-                  <opc:Property SymbolicName="Label" DataType="ua:String" ValueRank="Scalar" />
+                  <opc:Property SymbolicName="Label" DataType="ua:String" ValueRank="Scalar">
+                    <opc:DefaultValue>
+                      <uax:String>Unlabeled</uax:String>
+                    </opc:DefaultValue>
+                  </opc:Property>
                   <opc:Variable SymbolicName="Level" TypeDefinition="WidgetLevelType" />
                   <opc:Method SymbolicName="Reset">
                     <opc:InputArguments>
                       <opc:Argument Name="Hard" DataType="ua:Boolean" ValueRank="Scalar" />
                       <opc:Argument Name="Config" DataType="WidgetConfigType" ValueRank="Scalar" AllowSubTypes="true" />
                     </opc:InputArguments>
+                    <opc:OutputArguments>
+                      <opc:Argument Name="Result" DataType="WidgetConfigType" ValueRank="Scalar" AllowSubTypes="true" />
+                    </opc:OutputArguments>
                   </opc:Method>
                 </opc:Children>
               </opc:ObjectType>

--- a/tests/Opc.Ua.SourceGeneration.Core.Tests/Generators/CrossModelInstanceTypeDefinitionTests.cs
+++ b/tests/Opc.Ua.SourceGeneration.Core.Tests/Generators/CrossModelInstanceTypeDefinitionTests.cs
@@ -276,6 +276,7 @@ namespace Opc.Ua.SourceGeneration.Generator.Tests
             return Regex.Matches(
                     code,
                     @"internal static [^\r\n(]*\b(Create" + Regex.Escape(instanceName) + @"\w*)\(")
+                .Cast<Match>()
                 .Select(m => m.Groups[1].Value)
                 .ToHashSet();
         }

--- a/tests/Opc.Ua.SourceGeneration.Tests/CrossModelInstanceTypeDefinitionGeneratorTests.cs
+++ b/tests/Opc.Ua.SourceGeneration.Tests/CrossModelInstanceTypeDefinitionGeneratorTests.cs
@@ -1,0 +1,163 @@
+/* ========================================================================
+ * Copyright (c) 2005-2026 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using NUnit.Framework;
+
+namespace Opc.Ua.SourceGeneration
+{
+    /// <summary>
+    /// Regression tests for issue #4353 at the source generator driver
+    /// level: an Object whose TypeDefinition is an ObjectType with
+    /// children declared in a sibling AdditionalFile ModelDesign used to
+    /// fail with MODELGEN003 / NullReferenceException in
+    /// NodeStateGenerator while building the node state factories for
+    /// the inherited children.
+    /// </summary>
+    [TestFixture]
+    [Category("SourceGeneration")]
+    [SetCulture("en-us")]
+    [SetUICulture("en-us")]
+    public class CrossModelInstanceTypeDefinitionGeneratorTests
+    {
+        /// <summary>
+        /// Both designs are AdditionalFiles of the same compilation (the
+        /// minimal repro of #4353) in both orderings. The generated
+        /// instance factories reference the typed state classes emitted
+        /// for the dependency model, so the combined output must compile.
+        /// </summary>
+        [TestCase(true)]
+        [TestCase(false)]
+        public void InstanceOfObjectTypeAcrossModelDesignAdditionalFiles(bool instanceModelFirst)
+        {
+            var generator = new ModelSourceGenerator();
+
+            CSharpCompilation compilation = OptimizationLevel.Release.CreateCompilation()
+                .AddCode(
+                    new Dictionary<string, string>().WithOpcUaGeneratedStack(),
+                    LanguageVersion.CSharp11);
+
+            var options = new AnalyzerOptionsProvider(
+                new Dictionary<string, string>
+                {
+                    ["build_property.ModelSourceGeneratorOmitFluentApi"] = "true",
+                    ["build_property.ModelSourceGeneratorOmitEventRecords"] = "true"
+                });
+
+            AdditionalText modelA = EmbeddedText.Create("A/ModelA.xml", ModelADesign);
+            AdditionalText modelB = EmbeddedText.Create("B/ModelB.xml", ModelBDesign);
+
+            GeneratorDriver driver = CSharpGeneratorDriver.Create(generator)
+                .WithUpdatedParseOptions(new CSharpParseOptions()
+                    .WithKind(SourceCodeKind.Regular)
+                    .WithLanguageVersion(LanguageVersion.CSharp11))
+                .AddAdditionalTexts(
+                    instanceModelFirst ? [modelB, modelA] : [modelA, modelB])
+                .WithUpdatedAnalyzerConfigOptions(options);
+
+            driver = driver.RunGeneratorsAndUpdateCompilation(
+                compilation,
+                out Compilation outputCompilation,
+                out ImmutableArray<Diagnostic> diagnostics);
+
+            Assert.That(
+                diagnostics,
+                Is.Empty,
+                string.Join("\n", diagnostics.Select(d => d.ToString())));
+
+            string generated = string.Join(
+                "\n",
+                driver.GetRunResult().Results[0].GeneratedSources
+                    .Select(s => s.SourceText.ToString()));
+            Assert.That(generated, Does.Contain("CreateWidget1("),
+                "The instance factory must be emitted.");
+            Assert.That(generated, Does.Contain("CreateWidget1_Label("),
+                "The factory for the property inherited from the " +
+                "dependency type must be emitted.");
+            Assert.That(generated, Does.Contain("global::Test.ModelA.WidgetState"),
+                "The instance must use the typed state class generated " +
+                "for the dependency ObjectType.");
+
+            outputCompilation.GetDiagnostics().Check(
+                TestContext.Out,
+                out int errors,
+                out _);
+            Assert.That(errors, Is.Zero, $"Compilation produced {errors} errors");
+        }
+
+        private const string ModelADesign =
+            """
+            <?xml version="1.0" encoding="utf-8" ?>
+            <opc:ModelDesign
+              xmlns:opc="http://opcfoundation.org/UA/ModelDesign.xsd"
+              xmlns:ua="http://opcfoundation.org/UA/"
+              xmlns="http://test.org/UA/ModelA/"
+              TargetNamespace="http://test.org/UA/ModelA/">
+              <opc:Namespaces>
+                <opc:Namespace Name="OpcUa" Prefix="Opc.Ua" XmlNamespace="http://opcfoundation.org/UA/2008/02/Types.xsd">http://opcfoundation.org/UA/</opc:Namespace>
+                <opc:Namespace Name="ModelA" Prefix="Test.ModelA">http://test.org/UA/ModelA/</opc:Namespace>
+              </opc:Namespaces>
+              <opc:ObjectType SymbolicName="WidgetType" BaseType="ua:BaseObjectType">
+                <opc:Children>
+                  <opc:Property SymbolicName="Label" DataType="ua:String" ValueRank="Scalar" />
+                </opc:Children>
+              </opc:ObjectType>
+            </opc:ModelDesign>
+            """;
+
+        private const string ModelBDesign =
+            """
+            <?xml version="1.0" encoding="utf-8" ?>
+            <opc:ModelDesign
+              xmlns:opc="http://opcfoundation.org/UA/ModelDesign.xsd"
+              xmlns:ua="http://opcfoundation.org/UA/"
+              xmlns:s0="http://test.org/UA/ModelA/"
+              xmlns="http://test.org/UA/ModelB/"
+              TargetNamespace="http://test.org/UA/ModelB/">
+              <opc:Namespaces>
+                <opc:Namespace Name="ModelB" Prefix="Test.ModelB">http://test.org/UA/ModelB/</opc:Namespace>
+                <opc:Namespace Name="ModelA" Prefix="Test.ModelA">http://test.org/UA/ModelA/</opc:Namespace>
+                <opc:Namespace Name="OpcUa" Prefix="Opc.Ua" XmlNamespace="http://opcfoundation.org/UA/2008/02/Types.xsd">http://opcfoundation.org/UA/</opc:Namespace>
+              </opc:Namespaces>
+              <opc:Object SymbolicName="Widget1" TypeDefinition="s0:WidgetType">
+                <opc:References>
+                  <opc:Reference IsInverse="true">
+                    <opc:ReferenceType>ua:Organizes</opc:ReferenceType>
+                    <opc:TargetId>ua:ObjectsFolder</opc:TargetId>
+                  </opc:Reference>
+                </opc:References>
+              </opc:Object>
+            </opc:ModelDesign>
+            """;
+    }
+}

--- a/tools/Opc.Ua.SourceGeneration.Core/Schema/ModelDesignValidator.cs
+++ b/tools/Opc.Ua.SourceGeneration.Core/Schema/ModelDesignValidator.cs
@@ -6791,7 +6791,7 @@ namespace Opc.Ua.Schema.Model
                 {
                     try
                     {
-                        var decoder = new XmlDecoder(variable.DefaultValue, m_context);
+                        using var decoder = new XmlDecoder(variable.DefaultValue, m_context);
                         Variant variant = decoder.ReadVariantValue(null, default);
                         if (!variant.TypeInfo.IsUnknown)
                         {
@@ -6802,8 +6802,6 @@ namespace Opc.Ua.Schema.Model
                             variable.DecodedValue =
                                 variant.AsBoxedObject(Variant.BoxingBehavior.Legacy);
                         }
-
-                        decoder.Close();
                     }
                     catch (Exception e)
                     {
@@ -6827,9 +6825,34 @@ namespace Opc.Ua.Schema.Model
                 method.OutputArguments = methodDefinition.OutputArguments ?? [];
                 LinkDependencyMethodArguments(method.InputArguments);
                 LinkDependencyMethodArguments(method.OutputArguments);
+
+                if (!UseAllowSubtypes &&
+                    m_nodes.TryGetValue(s_structureQn, out NodeDesign structureNode) &&
+                    structureNode is DataTypeDesign structureDesign)
+                {
+                    foreach (Parameter argument in method.InputArguments)
+                    {
+                        if (argument?.DataTypeNode != null &&
+                            IsTypeOf(argument.DataTypeNode, s_structureQn) &&
+                            argument.AllowSubTypes)
+                        {
+                            argument.DataTypeNode = structureDesign;
+                        }
+                    }
+
+                    foreach (Parameter argument in method.OutputArguments)
+                    {
+                        if (argument?.DataTypeNode != null &&
+                            IsTypeOf(argument.DataTypeNode, s_structureQn) &&
+                            argument.AllowSubTypes)
+                        {
+                            argument.DataTypeNode = structureDesign;
+                        }
+                    }
+                }
+
                 method.HasArguments =
                     MethodDesignArgumentResolver.HasMethodArguments(method);
-
                 // Mirror ValidateInstance: a child method carries the
                 // InputArguments / OutputArguments argument properties as
                 // children, so a target instance of the dependency type

--- a/tools/Opc.Ua.SourceGeneration.Core/Schema/ModelDesignValidator.cs
+++ b/tools/Opc.Ua.SourceGeneration.Core/Schema/ModelDesignValidator.cs
@@ -389,17 +389,20 @@ namespace Opc.Ua.Schema.Model
             // With every upstream model loaded, re-link the payload-imported
             // declarations (their base types may live in a design file that
             // was not loaded when the payloads were applied) and link the
-            // data types of the dependency designs that were loaded without
-            // full dictionary validation. Without this, a target structure
-            // that subtypes a dependency structure inherits fields whose
-            // DataTypeNode is unresolved and whose parent classification is
-            // the BasicDataType enum default, crashing or corrupting the
-            // schema and code generators.
+            // data types and instances of the dependency designs that were
+            // loaded without full dictionary validation. Without this, a
+            // target structure that subtypes a dependency structure inherits
+            // fields whose DataTypeNode is unresolved and whose parent
+            // classification is the BasicDataType enum default, and a target
+            // instance of a dependency-declared type inherits children whose
+            // TypeDefinitionNode / DataTypeNode are unresolved, crashing or
+            // corrupting the schema and code generators.
             LinkDependencyChildren();
             LinkDependencyDataTypes(m_payloadDataTypes);
             foreach (ModelDesign dependency in dependencyModels)
             {
                 LinkDependencyDataTypes(dependency.Items);
+                LinkDependencyInstances(dependency.Items);
             }
 
             int upstreamDependencyCount = dependencyModels.Count;
@@ -417,6 +420,7 @@ namespace Opc.Ua.Schema.Model
             for (int ii = upstreamDependencyCount; ii < dependencyModels.Count; ii++)
             {
                 LinkDependencyDataTypes(dependencyModels[ii].Items);
+                LinkDependencyInstances(dependencyModels[ii].Items);
             }
 
             // set a default xml namespace.
@@ -6693,6 +6697,174 @@ namespace Opc.Ua.Schema.Model
                     m_nodes.TryGetValue(argument.DataType, out NodeDesign dataType))
                 {
                     argument.DataTypeNode = dataType as DataTypeDesign;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Links the instances of a dependency model that did not go
+        /// through <see cref="ValidateDictionary"/> (design files loaded
+        /// as dependencies): resolves the TypeDefinitionNode /
+        /// DataTypeNode of the types' children and standalone instances,
+        /// and the data types of variable types and method arguments, the
+        /// way <see cref="ValidateInstance"/> and <see cref="ValidateType"/>
+        /// do for the target model. A target instance whose TypeDefinition
+        /// is a dependency-declared type inherits these children into its
+        /// hierarchy, and the node state generator dereferences the links.
+        /// Resolution is best effort: references that cannot be resolved
+        /// are left null rather than failing the load.
+        /// </summary>
+        private void LinkDependencyInstances(IEnumerable<NodeDesign> nodes)
+        {
+            if (nodes == null)
+            {
+                return;
+            }
+
+            foreach (NodeDesign node in nodes)
+            {
+                if (node is VariableTypeDesign variableType &&
+                    variableType.DataTypeNode == null &&
+                    !IsNull(variableType.DataType) &&
+                    m_nodes.TryGetValue(variableType.DataType, out NodeDesign dataType))
+                {
+                    variableType.DataTypeNode = dataType as DataTypeDesign;
+                }
+
+                if (node is InstanceDesign instance)
+                {
+                    LinkDependencyInstance(instance);
+                }
+
+                if (node.Children?.Items != null)
+                {
+                    LinkDependencyInstances(node.Children.Items);
+                }
+            }
+        }
+
+        private void LinkDependencyInstance(InstanceDesign instance)
+        {
+            NodeDesign typeDefinition = null;
+
+            if (!IsNull(instance.TypeDefinition))
+            {
+                m_nodes.TryGetValue(instance.TypeDefinition, out typeDefinition);
+            }
+
+            if (instance is ObjectDesign objectDesign &&
+                objectDesign.TypeDefinitionNode == null)
+            {
+                objectDesign.TypeDefinitionNode = typeDefinition as ObjectTypeDesign;
+            }
+
+            if (instance is VariableDesign variable)
+            {
+                if (variable.TypeDefinitionNode == null)
+                {
+                    variable.TypeDefinitionNode = typeDefinition as VariableTypeDesign;
+                }
+
+                // Mirror ValidateInstance: a variable that does not restrict
+                // the data type inherits the restriction of its variable type.
+                if (variable.TypeDefinitionNode is VariableTypeDesign variableType &&
+                    (variable.DataType == null || variable.DataType == s_baseDataTypeQn))
+                {
+                    variable.DataType = variableType.DataType;
+
+                    if (!variable.ValueRankSpecified &&
+                        variableType.ValueRank != ValueRank.ScalarOrArray)
+                    {
+                        variable.ValueRank = variableType.ValueRank;
+                        variable.ValueRankSpecified = true;
+                    }
+                }
+
+                if (variable.DataTypeNode == null &&
+                    !IsNull(variable.DataType) &&
+                    m_nodes.TryGetValue(variable.DataType, out NodeDesign dataType))
+                {
+                    variable.DataTypeNode = dataType as DataTypeDesign;
+                }
+
+                if (variable.DefaultValue != null && variable.DecodedValue == null)
+                {
+                    try
+                    {
+                        var decoder = new XmlDecoder(variable.DefaultValue, m_context);
+                        Variant variant = decoder.ReadVariantValue(null, default);
+                        if (!variant.TypeInfo.IsUnknown)
+                        {
+                            variable.ValueRank =
+                                variant.TypeInfo.ValueRank == ValueRanks.Scalar ?
+                                    ValueRank.Scalar : ValueRank.Array;
+                            variable.ValueRankSpecified = true;
+                            variable.DecodedValue =
+                                variant.AsBoxedObject(Variant.BoxingBehavior.Legacy);
+                        }
+
+                        decoder.Close();
+                    }
+                    catch (Exception e)
+                    {
+                        if (m_logger.IsEnabled(LogLevel.Debug))
+                        {
+                            m_logger.LogDebug(e,
+                                "Could not decode the default value of dependency instance {Name}.",
+                                instance.SymbolicId.Name);
+                        }
+                    }
+                }
+            }
+
+            if (instance is MethodDesign method)
+            {
+                method.MethodType ??= typeDefinition as MethodDesign;
+
+                MethodDesign methodDefinition =
+                    MethodDesignArgumentResolver.ResolveMethodDefinition(method);
+                method.InputArguments = methodDefinition.InputArguments ?? [];
+                method.OutputArguments = methodDefinition.OutputArguments ?? [];
+                LinkDependencyMethodArguments(method.InputArguments);
+                LinkDependencyMethodArguments(method.OutputArguments);
+                method.HasArguments =
+                    MethodDesignArgumentResolver.HasMethodArguments(method);
+
+                // Mirror ValidateInstance: a child method carries the
+                // InputArguments / OutputArguments argument properties as
+                // children, so a target instance of the dependency type
+                // materialises them into its hierarchy. Guarded by the
+                // symbolic id so an already validated or linked method is
+                // not extended twice.
+                if (method.Parent != null &&
+                    !m_nodes.ContainsKey(new XmlQualifiedName(
+                        NodeDesign.CreateSymbolicId(
+                            method.SymbolicId.Name,
+                            "InputArguments"),
+                        method.SymbolicId.Namespace)))
+                {
+                    var children = new List<InstanceDesign>();
+
+                    if (method.Children != null && method.Children.Items != null)
+                    {
+                        children.AddRange(method.Children.Items);
+                    }
+                    if (method.InputArguments != null)
+                    {
+                        children.Add(CreateArgumentProperty(method, "InputArguments"));
+                    }
+                    if (method.OutputArguments != null)
+                    {
+                        children.Add(CreateArgumentProperty(method, "OutputArguments"));
+                    }
+                    if (children.Count > 0)
+                    {
+                        method.Children = new ListOfChildren
+                        {
+                            Items = [.. children]
+                        };
+                        method.HasChildren = true;
+                    }
                 }
             }
         }


### PR DESCRIPTION
# Description

The model source generator crashed with `MODELGEN003` / `NullReferenceException` whenever a `ModelDesign` instantiated an `ObjectType` (or `VariableType`) declared in a **dependency** design file, as soon as that type had children. The sibling of #4332 on the instance-declaration path: #4335 linked dependency *data types*, but an *instance* whose `TypeDefinition` lives in another design still crashed in `NodeStateGenerator` on the type's inherited children.

Root cause: dependency design files load with `validateDictionary: false`, so `ValidateInstance` / `ValidateType` never ran on them and their types' children kept `TypeDefinitionNode` / `DataTypeNode` at `null`. When the target instance merged those children into its hierarchy (`BuildInstanceHierarchy` re-walks the dependency type's `Children.Items`), the null references were copied along, and `GetNodeStateClassName` dereferenced them while building the node state factory list.

Changes:

- A new best-effort `LinkDependencyInstances` pass in `ModelDesignValidator` links dependency-design instances the way `ValidateInstance` / `ValidateType` do for the target model: the `TypeDefinitionNode` / `DataTypeNode` of the types' children and standalone instances (recursively), variable `DataType` / `ValueRank` inheritance from the variable type, `DefaultValue` decoding, `VariableTypeDesign.DataTypeNode` restrictions, and method arguments — including creation of the `InputArguments` / `OutputArguments` argument properties so method children materialise into the target hierarchy exactly like local ones. Resolution is best effort (unresolvable references stay `null`) and NodeSet2 dependencies remain excluded, consistent with `LinkDependencyDataTypes`.
- The pass runs alongside `LinkDependencyDataTypes`: for upstream dependencies after all of them are loaded and before the target validates (so the hierarchy merge picks up the links), and for downstream dependencies after they load.
- `docs/ModelDependencies.md` documents the instance linking.

Tests (all verified to fail with the exact reported NRE stack before the fix):

- `CrossModelInstanceTypeDefinitionTests` (Core, 4 tests): the issue's minimal repro end to end; an equivalence test asserting the cross-model instance emits the **identical node-state factory set** as a locally declared type (this is the issue's stated expectation, and it drove the method-argument-property part of the fix); the flipped upstream/downstream ordering; and validator-level assertions that the merged hierarchy carries linked `TypeDefinitionNode` / `DataTypeNode` references, including the data type inherited from a dependency `VariableType`.
- `CrossModelInstanceTypeDefinitionGeneratorTests` (Roslyn driver, 2 tests): the issue's csproj repro shape — both `AdditionalFiles` orderings, asserting no diagnostics and that the combined generated output of both models **compiles** (the instance factories reference the dependency model's typed state classes).

Verified locally on net10.0: `Opc.Ua.SourceGeneration.Core.Tests` 3800 passed, `Opc.Ua.SourceGeneration.Tests` 141 passed, `Opc.Ua.SourceGeneration.Stack.Tests` 94 passed; 0-warning Release build of `Opc.Ua.SourceGeneration.Core` (all TFMs incl. netstandard2.0); `dotnet format whitespace --verify-no-changes` clean.

This removes the last generator blocker for source generating the instance model of the `Workshop/DataTypes` sample (OPCFoundation/UA-.NETStandard-Samples#814): its `ParkingLot` / `DriverOfTheMonth` are instances of types declared in the other design file.

## Related Issues

- Fixes #4353

## Checklist

_Put an `x` in the boxes that apply. You can complete these step by step after opening the PR._

- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf) and read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [x] I have added all necessary documentation.
- [x] I have verified that my changes do not introduce (new) build or analyzer warnings.
- [ ] I ran **all** tests locally using the **UA.slnx** solution against at least .net **framework** and .net **10**, and all passed.
- [ ] I fixed **all** failing and flaky tests in the CI pipelines and **all** CodeQL warnings.
- [ ] I have addressed **all** PR feedback received.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
