### PR TITLE
Fix reverse connect test timeout race

### DIFF
--- a/tests/Opc.Ua.Sessions.Tests/ReverseConnectTest.cs
+++ b/tests/Opc.Ua.Sessions.Tests/ReverseConnectTest.cs
@@ -93,6 +93,12 @@ namespace Opc.Ua.Sessions.Tests
             ClientFixture = new ClientFixture(telemetry: Telemetry);
 
             await ClientFixture.LoadClientConfigurationAsync(PkiRoot).ConfigureAwait(false);
+            var clientConfiguration = ClientFixture.Config.ClientConfiguration ??
+                throw new InvalidOperationException("Client configuration is missing.");
+            ReverseConnectClientConfiguration reverseConnect =
+                clientConfiguration.ReverseConnect ??= new ReverseConnectClientConfiguration();
+            // Release unmatched sockets before the server's reverse-connect timeout can close them.
+            reverseConnect.HoldTime = MaxTimeout / 2;
             await ClientFixture.StartReverseConnectHostAsync().ConfigureAwait(false);
             m_endpointUrl = new Uri(
                 Utils.ReplaceLocalhost(
@@ -277,15 +283,7 @@ namespace Opc.Ua.Sessions.Tests
         /// <summary>
         /// Creates a reverse-connect session with each endpoint-refresh and domain-check combination.
         /// </summary>
-        /// <remarks>
-        /// [Retry(2)]: a reverse connection held before the client registers its wait can reach
-        /// the server's hold-time boundary between being matched and starting the secure-channel
-        /// handshake. Azure build 17554 observed that transient as <c>BadConnectionClosed</c>.
-        /// Retrying the complete case obtains a fresh reverse connection; two consecutive failures
-        /// still fail and preserve detection of persistent regressions.
-        /// </remarks>
         [Theory]
-        [Retry(2)]
         [Order(301)]
         public async Task ReverseConnect2Async(
             bool updateBeforeConnect,


### PR DESCRIPTION
# Description

Fix the flaky `ReverseConnect2Async(True,True,...)` failure reported by Azure DevOps as `BadConnectionClosed`.

The fixture configured the server to close unclaimed reverse connections after 10 seconds while the client retained unmatched sockets for the 15-second default hold time. Under delayed CI execution, a newly registered waiter could therefore receive a socket the server had already closed.

Configure the test client's hold time to 5 seconds, preserving a safe margin before the server timeout, and remove the `[Retry(2)]` workaround. The test now waits for a live reverse connection instead of masking stale-socket failures with a retry.

## Related Issues

- [Azure DevOps build 17573 test result](https://opcfoundation.visualstudio.com/opcua-netstandard/_build/results?buildId=17573&view=ms.vss-test-web.build-test-results-tab&runId=1606445&resultId=100071&paneView=debug)
- No GitHub issue.

## Validation

- `ReverseConnect2Async`: 11 consecutive Release/net10.0 runs, 88 tests passed.
- Complete `ReverseConnectTest` fixture: 50 tests passed.

## Checklist

- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf) and read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [x] I have added all necessary documentation.
- [x] I have verified that my changes do not introduce (new) build or analyzer warnings.
- [ ] I ran **all** tests locally using the **UA.slnx** solution against at least .net **framework** and .net **10**, and all passed.
- [ ] I fixed **all** failing and flaky tests in the CI pipelines and **all** CodeQL warnings.
- [ ] I have addressed **all** PR feedback received.
