### PR TITLE
[master378] Fix Publish with maximum TimeoutHint

### DIFF
--- a/Libraries/Opc.Ua.Server/Subscription/SessionPublishQueue.cs
+++ b/Libraries/Opc.Ua.Server/Subscription/SessionPublishQueue.cs
@@ -571,6 +571,12 @@ namespace Opc.Ua.Server
                     () => Tcs.TrySetCanceled());
                 // Cancel publish request if it times out
                 TimeSpan timeOut = operationTimeout < DateTime.MaxValue ? operationTimeout.AddMilliseconds(500) - DateTime.UtcNow : TimeSpan.Zero;
+                // uint.MaxValue is reserved by the underlying timer for an infinite delay.
+                TimeSpan maximumTimerDelay = TimeSpan.FromMilliseconds(uint.MaxValue - 1);
+                if (timeOut > maximumTimerDelay)
+                {
+                    timeOut = maximumTimerDelay;
+                }
                 if (operationTimeout < DateTime.MaxValue && timeOut.TotalMilliseconds > 0)
                 {
                     m_cancellationTokenSource = new CancellationTokenSource(timeOut);

--- a/Libraries/Opc.Ua.Server/Subscription/SessionPublishQueue.cs
+++ b/Libraries/Opc.Ua.Server/Subscription/SessionPublishQueue.cs
@@ -571,18 +571,72 @@ namespace Opc.Ua.Server
                     () => Tcs.TrySetCanceled());
                 // Cancel publish request if it times out
                 TimeSpan timeOut = operationTimeout < DateTime.MaxValue ? operationTimeout.AddMilliseconds(500) - DateTime.UtcNow : TimeSpan.Zero;
-                // uint.MaxValue is reserved by the underlying timer for an infinite delay.
-                TimeSpan maximumTimerDelay = TimeSpan.FromMilliseconds(uint.MaxValue - 1);
-                if (timeOut > maximumTimerDelay)
-                {
-                    timeOut = maximumTimerDelay;
-                }
                 if (operationTimeout < DateTime.MaxValue && timeOut.TotalMilliseconds > 0)
                 {
-                    m_cancellationTokenSource = new CancellationTokenSource(timeOut);
+                    m_cancellationTokenSource = CreateCancellationTokenSource(timeOut);
                     m_cancellationTokenRegistration2 = m_cancellationTokenSource.Token.Register(
                     () => Tcs.TrySetException(new ServiceResultException(StatusCodes.BadTimeout)));
                 }
+            }
+
+            private static CancellationTokenSource CreateCancellationTokenSource(TimeSpan delay)
+            {
+                // uint.MaxValue is reserved by the underlying timer for an infinite delay.
+                TimeSpan maximumTimerDelay = TimeSpan.FromMilliseconds(uint.MaxValue - 1u);
+                if (delay > maximumTimerDelay)
+                {
+                    delay = maximumTimerDelay;
+                }
+
+                // The .NET Framework CancellationTokenSource constructor only accepts
+                // delays up to int.MaxValue milliseconds. Timer supports the full range.
+                if (delay.TotalMilliseconds > int.MaxValue)
+                {
+                    return new TimerCancellationTokenSource(delay);
+                }
+
+                return new CancellationTokenSource(delay);
+            }
+
+            private sealed class TimerCancellationTokenSource : CancellationTokenSource
+            {
+                public TimerCancellationTokenSource(TimeSpan delay)
+                {
+                    Timer timer = new Timer(
+                        state =>
+                        {
+                            var source = (TimerCancellationTokenSource)state;
+                            try
+                            {
+                                source.Cancel();
+                            }
+                            catch (ObjectDisposedException)
+                            {
+                            }
+                        },
+                        this,
+                        delay,
+                        Timeout.InfiniteTimeSpan);
+                    m_timer = timer;
+                    m_timerRegistration = Token.Register(
+                        state => ((Timer)state).Dispose(),
+                        timer);
+                }
+
+                protected override void Dispose(bool disposing)
+                {
+                    if (disposing)
+                    {
+                        m_timerRegistration.Dispose();
+                        m_timer?.Dispose();
+                        m_timer = null;
+                    }
+
+                    base.Dispose(disposing);
+                }
+
+                private Timer m_timer;
+                private CancellationTokenRegistration m_timerRegistration;
             }
 
             public void Dispose()

--- a/Tests/Opc.Ua.Client.Tests/ClientTest.cs
+++ b/Tests/Opc.Ua.Client.Tests/ClientTest.cs
@@ -187,6 +187,46 @@ namespace Opc.Ua.Client.Tests
         }
 
         [Test]
+        [Order(101)]
+        public async Task PublishWithUInt32MaxTimeoutHintAsync()
+        {
+            CreateSubscriptionResponse createResponse = await Session.CreateSubscriptionAsync(
+                null,
+                100,
+                100,
+                1,
+                0,
+                true,
+                0,
+                CancellationToken.None).ConfigureAwait(false);
+
+            try
+            {
+                var requestHeader = new RequestHeader
+                {
+                    Timestamp = DateTime.UtcNow,
+                    TimeoutHint = uint.MaxValue
+                };
+
+                PublishResponse response = await Session.PublishAsync(
+                    requestHeader,
+                    new SubscriptionAcknowledgementCollection(),
+                    CancellationToken.None).ConfigureAwait(false);
+
+                Assert.NotNull(response);
+                Assert.AreEqual((StatusCode)StatusCodes.Good, response.ResponseHeader.ServiceResult);
+                Assert.AreEqual(createResponse.SubscriptionId, response.SubscriptionId);
+            }
+            finally
+            {
+                await Session.DeleteSubscriptionsAsync(
+                    null,
+                    new UInt32Collection { createResponse.SubscriptionId },
+                    CancellationToken.None).ConfigureAwait(false);
+            }
+        }
+
+        [Test]
         [Order(100)]
         public async Task FindServersAsync()
         {

--- a/Tests/Opc.Ua.Server.Tests/SessionPublishQueueRaceTests.cs
+++ b/Tests/Opc.Ua.Server.Tests/SessionPublishQueueRaceTests.cs
@@ -122,6 +122,33 @@ namespace Opc.Ua.Server.Tests
         }
 
         [Test]
+        public void PublishWithMaximumTimeoutQueuesRequest()
+        {
+            ITelemetryContext telemetry = NUnitTelemetryContext.Create();
+            var subscriptionManager = new Mock<ISubscriptionManager>();
+            var server = new Mock<IServerInternal>();
+            server.Setup(s => s.Telemetry).Returns(telemetry);
+            server.Setup(s => s.SubscriptionManager).Returns(subscriptionManager.Object);
+
+            var session = new Mock<ISession>();
+            session.Setup(s => s.Id).Returns(new NodeId(Guid.NewGuid()));
+            session.Setup(s => s.IsSecureChannelValid(It.IsAny<string>())).Returns(true);
+
+            using var queue = new SessionPublishQueue(server.Object, session.Object, 10);
+            var subscription = new Mock<ISubscription>();
+            subscription.Setup(s => s.Id).Returns(1);
+            queue.Add(subscription.Object);
+
+            Task<ISubscription> publishTask = queue.PublishAsync(
+                "channel1",
+                DateTime.UtcNow.AddMilliseconds(uint.MaxValue),
+                false,
+                CancellationToken.None);
+
+            Assert.That(publishTask.IsCompleted, Is.False);
+        }
+
+        [Test]
         [CancelAfter(10000)]
         public async Task PublishTimerPreservesReadySubscriptionTimestampOrderAsync()
         {


### PR DESCRIPTION
# Description

Fixes server side handling of PublishRequests with  maximum TimeoutHint on master378 branch.

## Related Issues


- Fixes master378 coresponding 4371 issue

## Checklist

_Put an `x` in the boxes that apply. You can complete these step by step after opening the PR._

- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf) and read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added all necessary documentation.
- [ ] I have verified that my changes do not introduce (new) build or analyzer warnings.
- [ ] I ran **all** tests locally using the **UA.slnx** solution against at least .net **framework** and .net **10**, and all passed.
- [ ] I fixed **all** failing and flaky tests in the CI pipelines and **all** CodeQL warnings.
- [ ] I have addressed **all** PR feedback received.
