### PR TITLE
[master] Fix maximum Publish TimeoutHint on .NET Framework

### DIFF
--- a/src/Opc.Ua.Core/Types/Utils/TimeProviderExtensions.cs
+++ b/src/Opc.Ua.Core/Types/Utils/TimeProviderExtensions.cs
@@ -181,6 +181,54 @@ namespace Opc.Ua
             public ITimer? Timer { get; set; }
             public CancellationTokenRegistration Registration { get; set; }
         }
+
+        private sealed class TimeProviderCancellationTokenSource : CancellationTokenSource
+        {
+            public TimeProviderCancellationTokenSource(
+                TimeProvider timeProvider,
+                TimeSpan delay)
+            {
+                if (delay == Timeout.InfiniteTimeSpan)
+                {
+                    return;
+                }
+
+                ITimer timer = timeProvider.CreateTimer(
+                    static state =>
+                    {
+                        var source = (TimeProviderCancellationTokenSource)state!;
+                        try
+                        {
+                            source.Cancel();
+                        }
+                        catch (ObjectDisposedException)
+                        {
+                        }
+                    },
+                    this,
+                    delay,
+                    Timeout.InfiniteTimeSpan);
+                m_timer = timer;
+                m_timerRegistration = Token.Register(
+                    static state => ((ITimer)state!).Dispose(),
+                    timer);
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                if (disposing)
+                {
+                    m_timerRegistration.Dispose();
+                    m_timer?.Dispose();
+                    m_timer = null;
+                }
+
+                base.Dispose(disposing);
+            }
+
+            private ITimer? m_timer;
+            private CancellationTokenRegistration m_timerRegistration;
+        }
 #endif
 
         /// <summary>
@@ -195,6 +243,8 @@ namespace Opc.Ua
         /// .NET 8+ this delegates to the built-in BCL constructor; on older
         /// targets it is implemented manually using
         /// <see cref="TimeProvider.CreateTimer"/>.
+        /// On older targets, <see cref="CancellationTokenSource.CancelAfter(TimeSpan)"/>
+        /// does not replace the initial timer used by the manual implementation.
         /// </remarks>
         /// <exception cref="ArgumentNullException">
         /// <paramref name="timeProvider"/> is <c>null</c>.</exception>
@@ -210,36 +260,16 @@ namespace Opc.Ua
 #if NET8_0_OR_GREATER
             return new CancellationTokenSource(delay, timeProvider);
 #else
-            if (timeProvider == TimeProvider.System)
-            {
-                return new CancellationTokenSource(delay);
-            }
             if (delay != Timeout.InfiniteTimeSpan && delay < TimeSpan.Zero)
             {
                 throw new ArgumentOutOfRangeException(nameof(delay));
             }
-            var cts = new CancellationTokenSource();
-            if (delay == Timeout.InfiniteTimeSpan)
+            if (timeProvider == TimeProvider.System &&
+                delay.TotalMilliseconds <= int.MaxValue)
             {
-                return cts;
+                return new CancellationTokenSource(delay);
             }
-            ITimer? timer = timeProvider.CreateTimer(
-                static state =>
-                {
-                    var inner = (CancellationTokenSource)state!;
-                    try
-                    {
-                        inner.Cancel();
-                    }
-                    catch (ObjectDisposedException)
-                    {
-                    }
-                },
-                cts,
-                delay,
-                Timeout.InfiniteTimeSpan);
-            cts.Token.Register(static t => ((ITimer)t!).Dispose(), timer);
-            return cts;
+            return new TimeProviderCancellationTokenSource(timeProvider, delay);
 #endif
         }
     }

--- a/src/Opc.Ua.Core/Types/Utils/TimeProviderExtensions.cs
+++ b/src/Opc.Ua.Core/Types/Utils/TimeProviderExtensions.cs
@@ -243,6 +243,8 @@ namespace Opc.Ua
         /// .NET 8+ this delegates to the built-in BCL constructor; on older
         /// targets it is implemented manually using
         /// <see cref="TimeProvider.CreateTimer"/>.
+        /// Delays greater than the maximum timer interval are clamped to
+        /// <c>uint.MaxValue - 1</c> milliseconds.
         /// On older targets, <see cref="CancellationTokenSource.CancelAfter(TimeSpan)"/>
         /// does not replace the initial timer used by the manual implementation.
         /// </remarks>
@@ -256,6 +258,11 @@ namespace Opc.Ua
             if (timeProvider == null)
             {
                 throw new ArgumentNullException(nameof(timeProvider));
+            }
+            TimeSpan maximumTimerDelay = TimeSpan.FromMilliseconds(uint.MaxValue - 1u);
+            if (delay > maximumTimerDelay)
+            {
+                delay = maximumTimerDelay;
             }
 #if NET8_0_OR_GREATER
             return new CancellationTokenSource(delay, timeProvider);

--- a/src/Opc.Ua.Server/Subscription/SessionPublishQueue.cs
+++ b/src/Opc.Ua.Server/Subscription/SessionPublishQueue.cs
@@ -891,12 +891,6 @@ namespace Opc.Ua.Server
                 TimeSpan timeOut = operationTimeout < DateTime.MaxValue
                     ? operationTimeout.AddMilliseconds(500) - timeProvider.GetUtcNow().UtcDateTime
                     : TimeSpan.Zero;
-                // uint.MaxValue is reserved by the underlying timer for an infinite delay.
-                TimeSpan maximumTimerDelay = TimeSpan.FromMilliseconds(uint.MaxValue - 1);
-                if (timeOut > maximumTimerDelay)
-                {
-                    timeOut = maximumTimerDelay;
-                }
                 if (operationTimeout < DateTime.MaxValue && timeOut.TotalMilliseconds > 0)
                 {
                     m_cancellationTokenSource = timeProvider.CreateCancellationTokenSource(timeOut);

--- a/src/Opc.Ua.Server/Subscription/SessionPublishQueue.cs
+++ b/src/Opc.Ua.Server/Subscription/SessionPublishQueue.cs
@@ -891,6 +891,12 @@ namespace Opc.Ua.Server
                 TimeSpan timeOut = operationTimeout < DateTime.MaxValue
                     ? operationTimeout.AddMilliseconds(500) - timeProvider.GetUtcNow().UtcDateTime
                     : TimeSpan.Zero;
+                // uint.MaxValue is reserved by the underlying timer for an infinite delay.
+                TimeSpan maximumTimerDelay = TimeSpan.FromMilliseconds(uint.MaxValue - 1);
+                if (timeOut > maximumTimerDelay)
+                {
+                    timeOut = maximumTimerDelay;
+                }
                 if (operationTimeout < DateTime.MaxValue && timeOut.TotalMilliseconds > 0)
                 {
                     m_cancellationTokenSource = timeProvider.CreateCancellationTokenSource(timeOut);

--- a/tests/Opc.Ua.Core.Tests/Types/Utils/TimeProviderExtensionsTests.cs
+++ b/tests/Opc.Ua.Core.Tests/Types/Utils/TimeProviderExtensionsTests.cs
@@ -51,6 +51,22 @@ namespace Opc.Ua.Core.Tests.Types.UtilsTests
         }
 
         [Test]
+        public void CreateCancellationTokenSourceClampsDelayAboveMaximumTimerDelay()
+        {
+            var timeProvider = new FakeTimeProvider();
+            TimeSpan maximumTimerDelay = TimeSpan.FromMilliseconds(uint.MaxValue - 1u);
+
+            using CancellationTokenSource cts = timeProvider.CreateCancellationTokenSource(
+                TimeSpan.FromMilliseconds(uint.MaxValue));
+
+            timeProvider.Advance(maximumTimerDelay - TimeSpan.FromTicks(1));
+            Assert.That(cts.IsCancellationRequested, Is.False);
+
+            timeProvider.Advance(TimeSpan.FromTicks(1));
+            Assert.That(cts.IsCancellationRequested, Is.True);
+        }
+
+        [Test]
         public void CreateCancellationTokenSourceUsesProvidedTimeProvider()
         {
             var timeProvider = new FakeTimeProvider();

--- a/tests/Opc.Ua.Core.Tests/Types/Utils/TimeProviderExtensionsTests.cs
+++ b/tests/Opc.Ua.Core.Tests/Types/Utils/TimeProviderExtensionsTests.cs
@@ -1,0 +1,69 @@
+/* ========================================================================
+ * Copyright (c) 2005-2026 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using System.Threading;
+using Microsoft.Extensions.Time.Testing;
+using NUnit.Framework;
+
+namespace Opc.Ua.Core.Tests.Types.UtilsTests
+{
+    [TestFixture]
+    [Category("Utils")]
+    [Parallelizable]
+    public sealed class TimeProviderExtensionsTests
+    {
+        [Test]
+        public void CreateCancellationTokenSourceSupportsMaximumTimerDelay()
+        {
+            TimeSpan delay = TimeSpan.FromMilliseconds(uint.MaxValue - 1u);
+
+            using CancellationTokenSource cts =
+                TimeProvider.System.CreateCancellationTokenSource(delay);
+
+            Assert.That(cts.IsCancellationRequested, Is.False);
+        }
+
+        [Test]
+        public void CreateCancellationTokenSourceUsesProvidedTimeProvider()
+        {
+            var timeProvider = new FakeTimeProvider();
+            TimeSpan delay = TimeSpan.FromMinutes(1);
+
+            using CancellationTokenSource cts =
+                timeProvider.CreateCancellationTokenSource(delay);
+
+            timeProvider.Advance(delay - TimeSpan.FromTicks(1));
+            Assert.That(cts.IsCancellationRequested, Is.False);
+
+            timeProvider.Advance(TimeSpan.FromTicks(1));
+            Assert.That(cts.IsCancellationRequested, Is.True);
+        }
+    }
+}

--- a/tests/Opc.Ua.Sessions.Tests/ClientTest.cs
+++ b/tests/Opc.Ua.Sessions.Tests/ClientTest.cs
@@ -226,6 +226,46 @@ namespace Opc.Ua.Sessions.Tests
         }
 
         [Test]
+        [Order(101)]
+        public async Task PublishWithUInt32MaxTimeoutHintAsync()
+        {
+            CreateSubscriptionResponse createResponse = await Session.CreateSubscriptionAsync(
+                null,
+                100,
+                100,
+                1,
+                0,
+                true,
+                0,
+                CancellationToken.None).ConfigureAwait(false);
+
+            try
+            {
+                var requestHeader = new RequestHeader
+                {
+                    Timestamp = DateTime.UtcNow,
+                    TimeoutHint = uint.MaxValue
+                };
+
+                PublishResponse response = await Session.PublishAsync(
+                    requestHeader,
+                    ArrayOf<SubscriptionAcknowledgement>.Empty,
+                    CancellationToken.None).ConfigureAwait(false);
+
+                Assert.NotNull(response);
+                Assert.AreEqual((StatusCode)StatusCodes.Good, response.ResponseHeader.ServiceResult);
+                Assert.AreEqual(createResponse.SubscriptionId, response.SubscriptionId);
+            }
+            finally
+            {
+                await Session.DeleteSubscriptionsAsync(
+                    null,
+                    new uint[] { createResponse.SubscriptionId }.ToArrayOf(),
+                    CancellationToken.None).ConfigureAwait(false);
+            }
+        }
+
+        [Test]
         [Order(100)]
         public async Task FindServersAsync()
         {

--- a/tests/Opc.Ua.Sessions.Tests/ClientTest.cs
+++ b/tests/Opc.Ua.Sessions.Tests/ClientTest.cs
@@ -252,9 +252,11 @@ namespace Opc.Ua.Sessions.Tests
                     ArrayOf<SubscriptionAcknowledgement>.Empty,
                     CancellationToken.None).ConfigureAwait(false);
 
-                Assert.NotNull(response);
-                Assert.AreEqual((StatusCode)StatusCodes.Good, response.ResponseHeader.ServiceResult);
-                Assert.AreEqual(createResponse.SubscriptionId, response.SubscriptionId);
+                Assert.That(response, Is.Not.Null);
+                Assert.That(
+                    response.ResponseHeader.ServiceResult,
+                    Is.EqualTo((StatusCode)StatusCodes.Good));
+                Assert.That(response.SubscriptionId, Is.EqualTo(createResponse.SubscriptionId));
             }
             finally
             {


### PR DESCRIPTION
## Description

Supersedes #4372 with its integration test and a shared cross-target fix for the .NET Framework failure exposed by Azure build 17743. The original contributor commit and attribution are retained.

On legacy targets, `CancellationTokenSource(TimeSpan)` rejects delays above `int.MaxValue` milliseconds even though `TimeProvider` timers support up to `UInt32.MaxValue - 1` milliseconds. `CreateCancellationTokenSource` now clamps larger delays to the maximum timer interval and uses an owned timer-backed cancellation source when the legacy constructor cannot represent the delay. Normal system delays retain the BCL fast path, and the fallback timer is disposed with its cancellation source.

## Related issues

Fixes #4371
Supersedes #4372

## Coverage

- Publish with `RequestHeader.TimeoutHint = UInt32.MaxValue` across the supported transports
- Maximum and above-maximum timer delays on legacy targets
- Cancellation driven by an injected `TimeProvider`