### PR TITLE
Add federated OpenUSD site demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,72 +73,14 @@ Official public 2.0 preview releases are also on nuget.org. Enable prerelease
 packages and use `2.0.0-preview.*` to float to the latest published
 `2.0.0-preview.N` release.
 
-### Sample applications
+### Samples
 
-Each sample has its own `README.md` with build and run instructions.
-
-**Reference applications**
-
-- [Console Reference Server](samples/Reference/ConsoleReferenceServer/README.md) —
-  the certified reference server (with Quickstarts, CTT, and Mono
-  configs). Also ships as a
-  [Docker container](docs/ContainerReferenceServer.md).
-- [Console Reference Client](samples/Reference/ConsoleReferenceClient/README.md) —
-  cross-platform reference client demonstrating sessions, subscriptions,
-  browsing, and method calls.
-- [Console LDS Server](samples/Lds/ConsoleLdsServer) — a standalone
-  Local Discovery Server built on `Opc.Ua.Lds.Server`.
-
-**PubSub samples**
-
-- [Console Reference PubSub Client](samples/PubSub/ConsoleReferencePubSubClient/README.md) —
-  one executable with `publisher`, `subscriber`, and `external` (external-server
-  adapter) modes across the supported transport profiles.
-
-**Minimal / Device-Integration samples**
-
-- [Minimal Calc Server](samples/MinimalApi/MinimalCalcServer) — minimal
-  server built on the source-generated NodeManager pipeline (Calc
-  model).
-- [Minimal Boiler Server](samples/MinimalApi/MinimalBoilerServer) — minimal
-  Boiler-model server with the fluent state-machine builder;
-  Native-AOT publishable.
-- [Pump Device Integration Server](samples/DI/PumpDeviceIntegrationServer/README.md) —
-  minimal Device Integration (Part 100) server using
-  `Opc.Ua.Di.Server`'s fluent builder.
-- [Minimal Robot Server](samples/Robotics/MinimalRobotServer/README.md) — OPC 40010
-  Robotics with independently configurable RSL/GPOS motion and live OpenUSD
-  transforms.
-- [Intent Enabled Robot](samples/Robotics/IntentEnabledRobot/README.md) —
-  one collaborative arm exposing the Robot Intent command surface: task-level
-  motion verbs tracked on a Part 10 program lifecycle, with missions, command
-  authority and safety-aware refusal.
-- [Intent Viewer Client](samples/Robotics/IntentViewerClient/README.md) — click a
-  target in an OpenUSD viewport and watch the arm execute the resulting intent;
-  also runs headless.
-- [Bin Picking Cell](samples/Robotics/BinPickingCell/README.md) — Robot Intent,
-  Vision, an eye-in-hand camera, and an in-address-space OpenUSD scene in one
-  reference cell.
-- [Bin Picking Client](samples/Robotics/BinPickingClient/README.md) — closes the
-  Vision-to-Robot-Intent loop, with optional MCP hosting and an OpenUSD viewport.
-- [Visual Inspection Cell](samples/Vision/VisualInspectionCell/README.md) — hosts
-  Vision, AI Model Management, ISA-95 Job Control V2, and an operator dialog for
-  deterministic machined-bracket inspection.
-- [Visual Inspection Agent](samples/Vision/VisualInspectionAgent/README.md) — drives
-  the inspection loop with typed clients, routes inference through deployment
-  `Invoke`, applies recipe verdicts, schedules allowlisted jobs, and records
-  operator ground truth.
-- [AI Model Management sample](samples/AI/README.md) — `ModelManagementServer`
-  publishes the draft AI Model Management catalogue and routes inference;
-  `ModelManagementClient` discovers deployments and exercises the Methods.
-- [Minimal ISA-95 Server](samples/Isa95/MinimalIsa95Server/README.md) —
-  minimal server hosting the OPC-10030 ISA-95 Common Model together
-  with OPC-10031-4 Job Control V1 and V2, using the typed common-model
-  builder and the in-memory Job Control provider.
-
-More sample projects are maintained in the companion
-[OPC UA .NET Samples](https://github.com/OPCFoundation/UA-.NETStandard-Samples)
-repository.
+The stack also includes a large collection of
+[platform-independent sample applications](docs/samples.md) that turn its
+core services and companion models into runnable client/server workflows.
+More applications, including platform-specific examples, are available in
+the companion
+[OPC UA .NET Samples repository](https://github.com/OPCFoundation/UA-.NETStandard-Samples).
 
 ### Developer tools
 
@@ -206,7 +148,5 @@ vulnerabilities via the process documented in
   [`docs/migrate/2.0.x/`](docs/migrate/2.0.x/README.md)).
 - [OPC UA Online Reference](https://reference.opcfoundation.org/) —
   the official OPC 10000 series specification index.
-- [OPC UA .NET Samples](https://github.com/OPCFoundation/UA-.NETStandard-Samples) —
-  companion repository with more sample applications.
 - [Preview Nuget package feed](https://nuget.pkg.github.com/OPCFoundation/index.json) —
   prerelease builds from every successful `master` build.

--- a/docs/OpenUsd.md
+++ b/docs/OpenUsd.md
@@ -253,6 +253,10 @@ dotnet run --project tools/Opc.Ua.OpenUsd.Connector -- \
 Without `--fetch-assets` or `--stage`, `--view` fetches the asset closure into a temporary directory, because a
 renderer needs geometry it can resolve. Closing the window stops the session; `--seconds` closes it automatically.
 
+For fetched stages, the connector resolves and writes structural component composition before the viewport opens.
+Live streaming then updates values in the rendered stage while continuing to persist later structural changes in
+`live.usda`; reload the viewport to apply a structural model change that occurs after startup.
+
 The renderer itself lives in a separate, optional assembly, `Opc.Ua.OpenUsd.Connector.Viewer`
 (`OPCFoundation.NetStandard.Opc.Ua.OpenUsd.Connector.Viewer`), which the connector loads on demand from its own
 directory. That keeps the connector package free of a UI framework and a native OpenUSD payload, and lets it keep

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,8 @@ Here is a list of available documentation for different topics:
 
 > **New contributor?** Start with the **[Developer Guide](DeveloperGuide.md)** — prerequisites, building, testing, coding standards, and how-to recipes (including how to add logging).
 
+* [Sample applications](samples.md) - Platform-independent reference, PubSub, minimal API, companion-model, robotics, Vision, AI, ISA-95, and OpenUSD demos included in this repository.
+
 ## UA Core stack related
 
 * [OPC UA Profiles and Facets](Profiles.md) - Overview of supported OPC UA profiles, facets, security policies, and transport protocols.

--- a/docs/samples.md
+++ b/docs/samples.md
@@ -74,8 +74,5 @@ instructions.
 Run the complete site demo from the repository root:
 
 ```powershell
-pwsh samples/OpenUsd/run-site-composition-demo.ps1
+pwsh samples/OpenUsd/SiteCompositionServer/run-site-composition-demo.ps1
 ```
-
-More sample projects are maintained in the companion
-[OPC UA .NET Samples repository](https://github.com/OPCFoundation/UA-.NETStandard-Samples).

--- a/docs/samples.md
+++ b/docs/samples.md
@@ -1,0 +1,81 @@
+# Sample applications
+
+This repository contains a large collection of platform-independent samples
+that demonstrate the stack's client, server, PubSub, companion-model, and
+developer-tooling APIs. Each sample has its own `README.md` with build and run
+instructions.
+
+## Reference applications
+
+- [Console Reference Server](../samples/Reference/ConsoleReferenceServer/README.md) —
+  the certified reference server with Quickstarts, CTT, and Mono
+  configurations. It also ships as a
+  [Docker container](ContainerReferenceServer.md).
+- [Console Reference Client](../samples/Reference/ConsoleReferenceClient/README.md) —
+  cross-platform reference client demonstrating sessions, subscriptions,
+  browsing, and method calls.
+- [Console LDS Server](../samples/Lds/ConsoleLdsServer) — a standalone
+  Local Discovery Server built on `Opc.Ua.Lds.Server`.
+
+## PubSub samples
+
+- [Console Reference PubSub Client](../samples/PubSub/ConsoleReferencePubSubClient/README.md) —
+  one executable with `publisher`, `subscriber`, and `external`
+  external-server-adapter modes across the supported transport profiles.
+
+## Minimal and companion-model samples
+
+- [Minimal Calc Server](../samples/MinimalApi/MinimalCalcServer) — minimal
+  server built on the source-generated NodeManager pipeline and Calc model.
+- [Minimal Boiler Server](../samples/MinimalApi/MinimalBoilerServer) — minimal
+  Boiler-model server with the fluent state-machine builder; Native-AOT
+  publishable.
+- [Pump Device Integration Server](../samples/DI/PumpDeviceIntegrationServer/README.md) —
+  Device Integration Part 100 server using `Opc.Ua.Di.Server`'s fluent
+  builder.
+- [Minimal Robot Server](../samples/Robotics/MinimalRobotServer/README.md) —
+  OPC 40010 Robotics with independently configurable RSL/GPOS motion and
+  live OpenUSD transforms.
+- [Intent Enabled Robot](../samples/Robotics/IntentEnabledRobot/README.md) —
+  collaborative arm exposing task-level Robot Intent motion verbs, Part 10
+  program lifecycle, missions, command authority, and safety-aware refusal.
+- [Intent Viewer Client](../samples/Robotics/IntentViewerClient/README.md) —
+  click a target in an OpenUSD viewport and watch the arm execute the
+  resulting intent; it also runs headless.
+- [Bin Picking Cell](../samples/Robotics/BinPickingCell/README.md) — Robot
+  Intent, Vision, an eye-in-hand camera, and an in-address-space OpenUSD scene
+  in one reference cell.
+- [Bin Picking Client](../samples/Robotics/BinPickingClient/README.md) — closes
+  the Vision-to-Robot-Intent loop, with optional MCP hosting and an OpenUSD
+  viewport.
+- [Visual Inspection Cell](../samples/Vision/VisualInspectionCell/README.md) —
+  hosts Vision, AI Model Management, ISA-95 Job Control V2, and an operator
+  dialog for deterministic machined-bracket inspection.
+- [Visual Inspection Agent](../samples/Vision/VisualInspectionAgent/README.md) —
+  drives the inspection loop with typed clients, routes inference through
+  deployment `Invoke`, applies recipe verdicts, schedules allowlisted jobs,
+  and records operator ground truth.
+- [AI Model Management sample](../samples/AI/README.md) —
+  `ModelManagementServer` publishes the draft AI Model Management catalogue
+  and routes inference; `ModelManagementClient` discovers deployments and
+  exercises the Methods.
+- [Minimal ISA-95 Server](../samples/Isa95/MinimalIsa95Server/README.md) —
+  hosts the OPC-10030 ISA-95 Common Model with OPC-10031-4 Job Control V1 and
+  V2, using the typed common-model builder and in-memory Job Control provider.
+
+## OpenUSD site composition
+
+- [Generator Server](../samples/OpenUsd/GeneratorServer/README.md) — simulated
+  generating sets with datasheet-driven behavior and independent OpenUSD
+  twins.
+- [Site Composition Server](../samples/OpenUsd/SiteCompositionServer/README.md) —
+  federates the pump and generator servers into one live OpenUSD site.
+
+Run the complete site demo from the repository root:
+
+```powershell
+pwsh samples/OpenUsd/run-site-composition-demo.ps1
+```
+
+More sample projects are maintained in the companion
+[OPC UA .NET Samples repository](https://github.com/OPCFoundation/UA-.NETStandard-Samples).

--- a/samples/OpenUsd/README.md
+++ b/samples/OpenUsd/README.md
@@ -5,5 +5,12 @@ Runnable samples that publish OpenUSD representations from OPC UA servers.
 | Sample | What it is | What it shows |
 |---|---|---|
 | [`GeneratorServer`](GeneratorServer) | A server for simulated generating sets | Generators companion modelling, datasheet-driven simulation, and one independent OpenUSD twin per configured set |
+| [`SiteCompositionServer`](SiteCompositionServer) | A supervisory server composing remote machines | Cross-server federation of the pump and generator twins into one live site |
+
+Run the complete site demo with:
+
+```powershell
+pwsh samples/OpenUsd/run-site-composition-demo.ps1
+```
 
 See [OpenUSD](../../docs/OpenUsd.md) for the binding model, connector tool and viewport.

--- a/samples/OpenUsd/README.md
+++ b/samples/OpenUsd/README.md
@@ -10,7 +10,7 @@ Runnable samples that publish OpenUSD representations from OPC UA servers.
 Run the complete site demo with:
 
 ```powershell
-pwsh samples/OpenUsd/run-site-composition-demo.ps1
+pwsh samples/OpenUsd/SiteCompositionServer/run-site-composition-demo.ps1
 ```
 
 See [OpenUSD](../../docs/OpenUsd.md) for the binding model, connector tool and viewport.

--- a/samples/OpenUsd/SiteCompositionServer/Assets/Site.usda
+++ b/samples/OpenUsd/SiteCompositionServer/Assets/Site.usda
@@ -66,18 +66,17 @@ def Xform "Site"
         float inputs:intensity = 620
     }
 
-    # An operator walking up to the plant: eye-level-ish, standing off the front
-    # corner so the pump row is on the left and the generator row fills the
-    # right, both receding away. Framed to fill the viewport with machines
-    # rather than ground - this is the first frame a viewport shows, so it has
-    # to work without anyone touching the camera.
+    # An elevated front-left three-quarter view keeps all three pumps distinct
+    # from both generator sets instead of looking straight down either row.
+    # This is the first frame a viewport shows, so it has to work without anyone
+    # touching the camera.
     def Camera "SiteCamera"
     {
         float focalLength = 28
         float horizontalAperture = 24
         float verticalAperture = 13.5
-        double3 xformOp:translate = (1.5, -17, 8.5)
-        double3 xformOp:rotateXYZ = (74, 0, -8)
+        double3 xformOp:translate = (-22, -24, 14)
+        double3 xformOp:rotateXYZ = (71, 0, -35)
         uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:rotateXYZ"]
     }
 }

--- a/samples/OpenUsd/SiteCompositionServer/README.md
+++ b/samples/OpenUsd/SiteCompositionServer/README.md
@@ -38,6 +38,19 @@ directly, so there is no cache to invalidate and no second copy of the truth.
 
 ## Running it
 
+The demo script builds the three servers, publishes the connector and viewport
+side by side, waits for every endpoint, and cleans up when the viewer closes:
+
+```powershell
+pwsh samples/OpenUsd/run-site-composition-demo.ps1
+```
+
+Use `-Renderer D3D12`, `-PumpCount`, `-GeneratorCount`, or `-Keep` to override
+the defaults. `-ViewerBundlePath` can point at an already published connector
+and viewport directory.
+
+To start each process manually, run:
+
 Start the two device servers, then the site server:
 
 ```

--- a/samples/OpenUsd/SiteCompositionServer/README.md
+++ b/samples/OpenUsd/SiteCompositionServer/README.md
@@ -42,7 +42,7 @@ The demo script builds the three servers, publishes the connector and viewport
 side by side, waits for every endpoint, and cleans up when the viewer closes:
 
 ```powershell
-pwsh samples/OpenUsd/run-site-composition-demo.ps1
+pwsh samples/OpenUsd/SiteCompositionServer/run-site-composition-demo.ps1
 ```
 
 Use `-Renderer D3D12`, `-PumpCount`, `-GeneratorCount`, or `-Keep` to override

--- a/samples/OpenUsd/SiteCompositionServer/run-site-composition-demo.ps1
+++ b/samples/OpenUsd/SiteCompositionServer/run-site-composition-demo.ps1
@@ -43,10 +43,11 @@
     Leaves the three servers running and keeps logs, stage assets, and publish output.
 
 .EXAMPLE
-    pwsh samples/OpenUsd/run-site-composition-demo.ps1
+    pwsh samples/OpenUsd/SiteCompositionServer/run-site-composition-demo.ps1
 
 .EXAMPLE
-    pwsh samples/OpenUsd/run-site-composition-demo.ps1 -Renderer D3D12 -Keep
+    pwsh samples/OpenUsd/SiteCompositionServer/run-site-composition-demo.ps1 `
+        -Renderer D3D12 -Keep
 #>
 [CmdletBinding()]
 param(
@@ -72,7 +73,7 @@ param(
 
 $ErrorActionPreference = 'Stop'
 $here = Split-Path -Parent $MyInvocation.MyCommand.Path
-$repoRoot = (Resolve-Path (Join-Path $here '..' '..')).Path
+$repoRoot = (Resolve-Path ([IO.Path]::Combine($here, '..', '..', '..'))).Path
 $runRoot = Join-Path ([IO.Path]::GetTempPath()) "opcua-openusd-site-demo-$PID"
 $viewerPublish = Join-Path $runRoot 'viewer'
 $stageCache = Join-Path $runRoot 'stage'
@@ -85,13 +86,13 @@ $pumpProject = [IO.Path]::Combine(
     'DI',
     'PumpDeviceIntegrationServer',
     'PumpDeviceIntegrationServer.csproj')
-$generatorProject = [IO.Path]::Combine(
+$generatorProject = [IO.Path]::GetFullPath([IO.Path]::Combine(
     $here,
+    '..',
     'GeneratorServer',
-    'GeneratorServer.csproj')
+    'GeneratorServer.csproj'))
 $siteProject = [IO.Path]::Combine(
     $here,
-    'SiteCompositionServer',
     'SiteCompositionServer.csproj')
 $connectorProject = [IO.Path]::Combine(
     $repoRoot,

--- a/samples/OpenUsd/run-site-composition-demo.ps1
+++ b/samples/OpenUsd/run-site-composition-demo.ps1
@@ -79,11 +79,30 @@ $stageCache = Join-Path $runRoot 'stage'
 $previousCustomTestTarget = $env:CustomTestTarget
 $processes = [Collections.Generic.List[Diagnostics.Process]]::new()
 
-$pumpProject = Join-Path $repoRoot 'samples\DI\PumpDeviceIntegrationServer\PumpDeviceIntegrationServer.csproj'
-$generatorProject = Join-Path $here 'GeneratorServer\GeneratorServer.csproj'
-$siteProject = Join-Path $here 'SiteCompositionServer\SiteCompositionServer.csproj'
-$connectorProject = Join-Path $repoRoot 'tools\Opc.Ua.OpenUsd.Connector\Opc.Ua.OpenUsd.Connector.csproj'
-$viewerProject = Join-Path $repoRoot 'tools\Opc.Ua.OpenUsd.Connector.Viewer\Opc.Ua.OpenUsd.Connector.Viewer.csproj'
+$pumpProject = [IO.Path]::Combine(
+    $repoRoot,
+    'samples',
+    'DI',
+    'PumpDeviceIntegrationServer',
+    'PumpDeviceIntegrationServer.csproj')
+$generatorProject = [IO.Path]::Combine(
+    $here,
+    'GeneratorServer',
+    'GeneratorServer.csproj')
+$siteProject = [IO.Path]::Combine(
+    $here,
+    'SiteCompositionServer',
+    'SiteCompositionServer.csproj')
+$connectorProject = [IO.Path]::Combine(
+    $repoRoot,
+    'tools',
+    'Opc.Ua.OpenUsd.Connector',
+    'Opc.Ua.OpenUsd.Connector.csproj')
+$viewerProject = [IO.Path]::Combine(
+    $repoRoot,
+    'tools',
+    'Opc.Ua.OpenUsd.Connector.Viewer',
+    'Opc.Ua.OpenUsd.Connector.Viewer.csproj')
 
 $pumpEndpoint = "opc.tcp://localhost:$PumpPort/PumpDeviceIntegrationServer"
 $generatorEndpoint = "opc.tcp://localhost:$GeneratorPort/GeneratorServer"
@@ -245,15 +264,24 @@ try {
         throw "The viewer bundle is incomplete: $viewerPublish"
     }
 
-    $pumpDll = Join-Path `
-        (Split-Path $pumpProject -Parent) `
-        "bin\$Configuration\net10.0\PumpDeviceIntegrationServer.dll"
-    $generatorDll = Join-Path `
-        (Split-Path $generatorProject -Parent) `
-        "bin\$Configuration\net10.0\GeneratorServer.dll"
-    $siteDll = Join-Path `
-        (Split-Path $siteProject -Parent) `
-        "bin\$Configuration\net10.0\SiteCompositionServer.dll"
+    $pumpDll = [IO.Path]::Combine(
+        (Split-Path $pumpProject -Parent),
+        'bin',
+        $Configuration,
+        'net10.0',
+        'PumpDeviceIntegrationServer.dll')
+    $generatorDll = [IO.Path]::Combine(
+        (Split-Path $generatorProject -Parent),
+        'bin',
+        $Configuration,
+        'net10.0',
+        'GeneratorServer.dll')
+    $siteDll = [IO.Path]::Combine(
+        (Split-Path $siteProject -Parent),
+        'bin',
+        $Configuration,
+        'net10.0',
+        'SiteCompositionServer.dll')
 
     Step "Starting the pump server at $pumpEndpoint"
     Start-Server -Name 'pump' -Dll $pumpDll -Arguments @(

--- a/samples/OpenUsd/run-site-composition-demo.ps1
+++ b/samples/OpenUsd/run-site-composition-demo.ps1
@@ -1,0 +1,335 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Runs the federated pump and generator OpenUSD site-composition demo.
+
+.DESCRIPTION
+    Builds and starts the pump, generator, and site OPC UA servers, publishes the
+    connector and optional viewport side by side, and opens the composed live site.
+    Closing the viewer stops the servers and removes the isolated run directory unless
+    -Keep is supplied.
+
+.PARAMETER PumpCount
+    Number of simulated pumps.
+
+.PARAMETER GeneratorCount
+    Number of simulated generator sets.
+
+.PARAMETER PumpPort
+    Local OPC UA TCP port used by the pump server.
+
+.PARAMETER GeneratorPort
+    Local OPC UA TCP port used by the generator server.
+
+.PARAMETER SitePort
+    Local OPC UA TCP port used by the site-composition server.
+
+.PARAMETER Renderer
+    Viewer renderer preference: Auto, Storm, D3D12, Vulkan, or Metal.
+
+.PARAMETER Configuration
+    Build configuration used for the sample servers and locally published viewer.
+
+.PARAMETER ViewerBundlePath
+    Optional existing directory containing Opc.Ua.OpenUsd.Connector.dll and
+    Opc.Ua.OpenUsd.Connector.Viewer.dll. When omitted, both projects are published
+    side by side into the isolated run directory.
+
+.PARAMETER Seconds
+    Closes the viewer automatically after this many seconds. Zero waits until the
+    viewer window is closed.
+
+.PARAMETER Keep
+    Leaves the three servers running and keeps logs, stage assets, and publish output.
+
+.EXAMPLE
+    pwsh samples/OpenUsd/run-site-composition-demo.ps1
+
+.EXAMPLE
+    pwsh samples/OpenUsd/run-site-composition-demo.ps1 -Renderer D3D12 -Keep
+#>
+[CmdletBinding()]
+param(
+    [ValidateRange(1, 100)]
+    [int]$PumpCount = 3,
+    [ValidateRange(1, 100)]
+    [int]$GeneratorCount = 2,
+    [ValidateRange(1, 65535)]
+    [int]$PumpPort = 62542,
+    [ValidateRange(1, 65535)]
+    [int]$GeneratorPort = 62543,
+    [ValidateRange(1, 65535)]
+    [int]$SitePort = 62544,
+    [ValidateSet('Auto', 'Storm', 'D3D12', 'Vulkan', 'Metal')]
+    [string]$Renderer = 'Auto',
+    [ValidateSet('Debug', 'Release')]
+    [string]$Configuration = 'Release',
+    [string]$ViewerBundlePath,
+    [ValidateRange(0, 86400)]
+    [int]$Seconds = 0,
+    [switch]$Keep
+)
+
+$ErrorActionPreference = 'Stop'
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+$repoRoot = (Resolve-Path (Join-Path $here '..' '..')).Path
+$runRoot = Join-Path ([IO.Path]::GetTempPath()) "opcua-openusd-site-demo-$PID"
+$viewerPublish = Join-Path $runRoot 'viewer'
+$stageCache = Join-Path $runRoot 'stage'
+$previousCustomTestTarget = $env:CustomTestTarget
+$processes = [Collections.Generic.List[Diagnostics.Process]]::new()
+
+$pumpProject = Join-Path $repoRoot 'samples\DI\PumpDeviceIntegrationServer\PumpDeviceIntegrationServer.csproj'
+$generatorProject = Join-Path $here 'GeneratorServer\GeneratorServer.csproj'
+$siteProject = Join-Path $here 'SiteCompositionServer\SiteCompositionServer.csproj'
+$connectorProject = Join-Path $repoRoot 'tools\Opc.Ua.OpenUsd.Connector\Opc.Ua.OpenUsd.Connector.csproj'
+$viewerProject = Join-Path $repoRoot 'tools\Opc.Ua.OpenUsd.Connector.Viewer\Opc.Ua.OpenUsd.Connector.Viewer.csproj'
+
+$pumpEndpoint = "opc.tcp://localhost:$PumpPort/PumpDeviceIntegrationServer"
+$generatorEndpoint = "opc.tcp://localhost:$GeneratorPort/GeneratorServer"
+$siteEndpoint = "opc.tcp://localhost:$SitePort/SiteCompositionServer"
+
+function Step([string]$message) {
+    Write-Host ''
+    Write-Host "==> $message" -ForegroundColor Cyan
+}
+
+function Require([string]$tool) {
+    if (-not (Get-Command $tool -ErrorAction SilentlyContinue)) {
+        throw "$tool is required and was not found on PATH."
+    }
+}
+
+function Assert-PortAvailable([int]$port) {
+    $listener = [Net.Sockets.TcpListener]::new([Net.IPAddress]::Loopback, $port)
+    try {
+        $listener.Start()
+    }
+    catch {
+        throw "TCP port $port is already in use."
+    }
+    finally {
+        $listener.Stop()
+    }
+}
+
+function Invoke-DotNet([string[]]$arguments, [string]$failure) {
+    & dotnet @arguments
+    if ($LASTEXITCODE -ne 0) {
+        throw $failure
+    }
+}
+
+function Start-Server(
+    [string]$name,
+    [string]$dll,
+    [string[]]$arguments,
+    [string]$readyMarker
+) {
+    $stdout = Join-Path $runRoot "$name.out.log"
+    $stderr = Join-Path $runRoot "$name.err.log"
+    $processArguments = @("`"$dll`"") + $arguments
+    $process = Start-Process dotnet `
+        -ArgumentList $processArguments `
+        -RedirectStandardOutput $stdout `
+        -RedirectStandardError $stderr `
+        -PassThru
+    $processes.Add($process)
+
+    $deadline = [DateTime]::UtcNow.AddSeconds(90)
+    while ([DateTime]::UtcNow -lt $deadline) {
+        $process.Refresh()
+        if ($process.HasExited) {
+            throw "$name exited before becoming ready."
+        }
+        if ((Test-Path $stdout) -and
+            (Get-Content -Raw $stdout) -match [regex]::Escape($readyMarker)) {
+            return
+        }
+        Start-Sleep -Milliseconds 250
+    }
+    throw "$name did not become ready within 90 seconds."
+}
+
+function Show-ServerLogs {
+    foreach ($name in @('pump', 'generator', 'site')) {
+        foreach ($stream in @('out', 'err')) {
+            $path = Join-Path $runRoot "$name.$stream.log"
+            if (Test-Path $path) {
+                Write-Host ''
+                Write-Host "$name $stream log:" -ForegroundColor Yellow
+                Get-Content $path
+            }
+        }
+    }
+}
+
+function Get-RuntimeIdentifier {
+    $architecture = [Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture
+    if ($IsWindows -and $architecture -eq [Runtime.InteropServices.Architecture]::X64) {
+        return 'win-x64'
+    }
+    if ($IsLinux -and $architecture -eq [Runtime.InteropServices.Architecture]::X64) {
+        return 'linux-x64'
+    }
+    if ($IsMacOS -and $architecture -eq [Runtime.InteropServices.Architecture]::Arm64) {
+        return 'osx-arm64'
+    }
+    throw "The OpenUSD viewport does not provide a runtime for this platform and architecture."
+}
+
+Require dotnet
+
+try {
+    Assert-PortAvailable $PumpPort
+    Assert-PortAvailable $GeneratorPort
+    Assert-PortAvailable $SitePort
+    New-Item -ItemType Directory -Force -Path $runRoot, $stageCache | Out-Null
+    $env:CustomTestTarget = 'net10.0'
+
+    Step 'Building the pump, generator, and site servers'
+    Invoke-DotNet -Arguments @(
+        'build', $pumpProject,
+        '-c', $Configuration,
+        '-f', 'net10.0',
+        '--nologo',
+        '--verbosity', 'quiet'
+    ) -Failure 'The pump server build failed.'
+    Invoke-DotNet -Arguments @(
+        'build', $generatorProject,
+        '-c', $Configuration,
+        '-f', 'net10.0',
+        '--nologo',
+        '--verbosity', 'quiet'
+    ) -Failure 'The generator server build failed.'
+    Invoke-DotNet -Arguments @(
+        'build', $siteProject,
+        '-c', $Configuration,
+        '-f', 'net10.0',
+        '--nologo',
+        '--verbosity', 'quiet'
+    ) -Failure 'The site-composition server build failed.'
+
+    if ([string]::IsNullOrWhiteSpace($ViewerBundlePath)) {
+        $rid = Get-RuntimeIdentifier
+        New-Item -ItemType Directory -Force -Path $viewerPublish | Out-Null
+        Step "Publishing the connector and viewport for $rid"
+        Invoke-DotNet -Arguments @(
+            'publish', $connectorProject,
+            '-c', $Configuration,
+            '-f', 'net10.0',
+            '-r', $rid,
+            '--self-contained', 'false',
+            '-o', $viewerPublish,
+            '--nologo',
+            '--verbosity', 'quiet'
+        ) -Failure 'The OpenUSD connector publish failed.'
+        Invoke-DotNet -Arguments @(
+            'publish', $viewerProject,
+            '-c', $Configuration,
+            '-f', 'net10.0',
+            '-r', $rid,
+            '--self-contained', 'false',
+            '-o', $viewerPublish,
+            '--nologo',
+            '--verbosity', 'quiet'
+        ) -Failure 'The OpenUSD viewport publish failed.'
+    }
+    else {
+        $viewerPublish = [IO.Path]::GetFullPath($ViewerBundlePath)
+    }
+
+    $connectorDll = Join-Path $viewerPublish 'Opc.Ua.OpenUsd.Connector.dll'
+    $viewportDll = Join-Path $viewerPublish 'Opc.Ua.OpenUsd.Connector.Viewer.dll'
+    if (-not (Test-Path $connectorDll) -or -not (Test-Path $viewportDll)) {
+        throw "The viewer bundle is incomplete: $viewerPublish"
+    }
+
+    $pumpDll = Join-Path `
+        (Split-Path $pumpProject -Parent) `
+        "bin\$Configuration\net10.0\PumpDeviceIntegrationServer.dll"
+    $generatorDll = Join-Path `
+        (Split-Path $generatorProject -Parent) `
+        "bin\$Configuration\net10.0\GeneratorServer.dll"
+    $siteDll = Join-Path `
+        (Split-Path $siteProject -Parent) `
+        "bin\$Configuration\net10.0\SiteCompositionServer.dll"
+
+    Step "Starting the pump server at $pumpEndpoint"
+    Start-Server -Name 'pump' -Dll $pumpDll -Arguments @(
+        '--host', 'localhost',
+        '--port', $PumpPort,
+        '--pumps', $PumpCount
+    ) -ReadyMarker "OPC UA server listening at $pumpEndpoint"
+
+    Step "Starting the generator server at $generatorEndpoint"
+    Start-Server -Name 'generator' -Dll $generatorDll -Arguments @(
+        '--host', 'localhost',
+        '--port', $GeneratorPort,
+        '--generators', $GeneratorCount
+    ) -ReadyMarker "OPC UA server listening at $generatorEndpoint"
+
+    Step "Starting the site-composition server at $siteEndpoint"
+    Start-Server -Name 'site' -Dll $siteDll -Arguments @(
+        '--host', 'localhost',
+        '--port', $SitePort,
+        '--pump-server', $pumpEndpoint,
+        '--generator-server', $generatorEndpoint
+    ) -ReadyMarker "OPC UA server listening at $siteEndpoint"
+
+    Step 'Opening the federated live site'
+    $viewerArguments = @(
+        $connectorDll,
+        '--server', $siteEndpoint,
+        '--insecure',
+        '--federate',
+        '--view',
+        '--renderer', $Renderer,
+        '--camera', '/Site/SiteCamera',
+        '--fetch-assets', $stageCache
+    )
+    if ($Seconds -gt 0) {
+        $viewerArguments += @('--seconds', $Seconds)
+    }
+    & dotnet @viewerArguments
+    if ($LASTEXITCODE -ne 0) {
+        throw "The OpenUSD connector exited with code $LASTEXITCODE."
+    }
+
+    Write-Host ''
+    Write-Host 'The OpenUSD site-composition demo completed.' -ForegroundColor Green
+}
+catch {
+    Show-ServerLogs
+    throw
+}
+finally {
+    if ($previousCustomTestTarget -eq $null) {
+        Remove-Item Env:\CustomTestTarget -ErrorAction SilentlyContinue
+    }
+    else {
+        $env:CustomTestTarget = $previousCustomTestTarget
+    }
+
+    if ($Keep) {
+        Write-Host ''
+        Write-Host "Demo artifacts kept at $runRoot" -ForegroundColor Yellow
+        foreach ($process in $processes) {
+            if (-not $process.HasExited) {
+                Write-Host "  PID $($process.Id): $($process.StartInfo.Arguments)"
+            }
+        }
+    }
+    else {
+        for ($index = $processes.Count - 1; $index -ge 0; $index--) {
+            $process = $processes[$index]
+            if (-not $process.HasExited) {
+                Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue
+                $process.WaitForExit()
+            }
+        }
+        if (Test-Path $runRoot) {
+            Remove-Item -LiteralPath $runRoot -Recurse -Force
+        }
+    }
+}

--- a/src/Opc.Ua.OpenUsd.Client/UsdFileSink.cs
+++ b/src/Opc.Ua.OpenUsd.Client/UsdFileSink.cs
@@ -581,9 +581,34 @@ namespace Opc.Ua.OpenUsd.Client
                 frame,
                 out TransformComponents existing)
                 ? existing
-                : TransformComponents.Identity;
+                : GetTransformBaseline(samples, frame);
             samples[frame] = transform.With(propertyName, vector);
             return true;
+        }
+
+        private static TransformComponents GetTransformBaseline(
+            SortedList<double, TransformComponents> samples,
+            double frame)
+        {
+            int low = 0;
+            int high = samples.Count - 1;
+            int prior = -1;
+            while (low <= high)
+            {
+                int middle = low + ((high - low) / 2);
+                if (samples.Keys[middle] < frame)
+                {
+                    prior = middle;
+                    low = middle + 1;
+                }
+                else
+                {
+                    high = middle - 1;
+                }
+            }
+            return prior >= 0
+                ? samples.Values[prior]
+                : TransformComponents.Identity;
         }
 
         private static bool IsTransformProperty(string propertyName)

--- a/src/Opc.Ua.OpenUsd.Client/UsdFileSink.cs
+++ b/src/Opc.Ua.OpenUsd.Client/UsdFileSink.cs
@@ -45,6 +45,10 @@ namespace Opc.Ua.OpenUsd.Client
     /// </summary>
     public sealed class UsdFileSink : IUsdSink
     {
+        private const string TranslateOp = "xformOp:translate";
+        private const string RotateOp = "xformOp:rotateXYZ";
+        private const string ScaleOp = "xformOp:scale";
+
         private static readonly char[] s_pathSeparator = ['/'];
 
         private static readonly DateTime s_epoch =
@@ -54,11 +58,17 @@ namespace Opc.Ua.OpenUsd.Client
         private readonly Lock m_gate = new();
         private readonly Dictionary<string, Variant> m_values = new(StringComparer.Ordinal);
         private readonly List<(string Prim, string Prop)> m_order = [];
+        private readonly Dictionary<string, TransformComponents> m_transforms =
+            new(StringComparer.Ordinal);
+        private readonly List<string> m_transformOrder = [];
 
         private readonly Dictionary<string, SortedList<double, Variant>> m_timeSamples =
             new(StringComparer.Ordinal);
 
         private readonly List<(string Prim, string Prop)> m_tsOrder = [];
+        private readonly Dictionary<string, SortedList<double, TransformComponents>>
+            m_transformTimeSamples = new(StringComparer.Ordinal);
+        private readonly List<string> m_transformTsOrder = [];
 
         private readonly Dictionary<string, (OpenUsdCompositionArc Arc, string? Asset, bool Active)> m_prims =
             new(StringComparer.Ordinal);
@@ -105,6 +115,11 @@ namespace Opc.Ua.OpenUsd.Client
             }
             lock (m_gate)
             {
+                if (TrySetTransform(m_transforms, m_transformOrder, primPath, propertyName, value))
+                {
+                    WriteOrDefer();
+                    return;
+                }
                 string key = primPath + "|" + propertyName;
                 if (!m_values.ContainsKey(key))
                 {
@@ -125,6 +140,11 @@ namespace Opc.Ua.OpenUsd.Client
             double frame = (time.ToUniversalTime() - s_epoch).TotalSeconds;
             lock (m_gate)
             {
+                if (TrySetTransformTimeSample(primPath, propertyName, frame, value))
+                {
+                    WriteOrDefer();
+                    return;
+                }
                 string key = primPath + "|" + propertyName;
                 if (!m_timeSamples.TryGetValue(key, out SortedList<double, Variant>? samples))
                 {
@@ -314,6 +334,11 @@ namespace Opc.Ua.OpenUsd.Client
                 (string usdType, string formatted) = FormatValue(prop, value);
                 node.Props.Add((prop, usdType, formatted));
             }
+            foreach (string prim in m_transformOrder)
+            {
+                Node node = NavigateTo(root, rootOrder, prim);
+                node.Props.Add(("xformOp:transform", "matrix4d", FormatTransform(m_transforms[prim])));
+            }
             foreach ((string prim, string prop) in m_tsOrder)
             {
                 SortedList<double, Variant> samples = m_timeSamples[prim + "|" + prop];
@@ -331,6 +356,23 @@ namespace Opc.Ua.OpenUsd.Client
                 }
                 block.Append("            }");
                 node.TimeSamples.Add((prop, usdType, block.ToString()));
+            }
+            foreach (string prim in m_transformTsOrder)
+            {
+                SortedList<double, TransformComponents> samples = m_transformTimeSamples[prim];
+                Node node = NavigateTo(root, rootOrder, prim);
+                var block = new StringBuilder();
+                block.Append("{\n");
+                foreach (KeyValuePair<double, TransformComponents> sample in samples)
+                {
+                    block.Append("                ")
+                        .Append(sample.Key.ToString("0.000", CultureInfo.InvariantCulture))
+                        .Append(": ")
+                        .Append(FormatTransform(sample.Value))
+                        .Append(",\n");
+                }
+                block.Append("            }");
+                node.TimeSamples.Add(("xformOp:transform", "matrix4d", block.ToString()));
             }
             foreach (string prim in m_primOrder)
             {
@@ -493,6 +535,136 @@ namespace Opc.Ua.OpenUsd.Client
                 return ("double", F(d));
             }
             return ("double", F(0.0));
+        }
+
+        private static bool TrySetTransform(
+            Dictionary<string, TransformComponents> transforms,
+            List<string> order,
+            string primPath,
+            string propertyName,
+            in Variant value)
+        {
+            if (!IsTransformProperty(propertyName) ||
+                !TryGetVector3(value, out Vector3 vector))
+            {
+                return false;
+            }
+            if (!transforms.TryGetValue(primPath, out TransformComponents transform))
+            {
+                transform = TransformComponents.Identity;
+                order.Add(primPath);
+            }
+            transforms[primPath] = transform.With(propertyName, vector);
+            return true;
+        }
+
+        private bool TrySetTransformTimeSample(
+            string primPath,
+            string propertyName,
+            double frame,
+            in Variant value)
+        {
+            if (!IsTransformProperty(propertyName) ||
+                !TryGetVector3(value, out Vector3 vector))
+            {
+                return false;
+            }
+            if (!m_transformTimeSamples.TryGetValue(
+                    primPath,
+                    out SortedList<double, TransformComponents>? samples))
+            {
+                samples = [];
+                m_transformTimeSamples[primPath] = samples;
+                m_transformTsOrder.Add(primPath);
+            }
+            TransformComponents transform = samples.TryGetValue(
+                frame,
+                out TransformComponents existing)
+                ? existing
+                : TransformComponents.Identity;
+            samples[frame] = transform.With(propertyName, vector);
+            return true;
+        }
+
+        private static bool IsTransformProperty(string propertyName)
+        {
+            return string.Equals(propertyName, TranslateOp, StringComparison.Ordinal) ||
+                string.Equals(propertyName, RotateOp, StringComparison.Ordinal) ||
+                string.Equals(propertyName, ScaleOp, StringComparison.Ordinal);
+        }
+
+        private static bool TryGetVector3(in Variant value, out Vector3 vector)
+        {
+            if (value.TryGetValue(out ArrayOf<double> doubles) && doubles.Count == 3)
+            {
+                vector = new Vector3(doubles[0], doubles[1], doubles[2]);
+                return true;
+            }
+            if (value.TryGetValue(out ArrayOf<float> floats) && floats.Count == 3)
+            {
+                vector = new Vector3(floats[0], floats[1], floats[2]);
+                return true;
+            }
+            vector = default;
+            return false;
+        }
+
+        private static string FormatTransform(in TransformComponents transform)
+        {
+            const double toRadians = Math.PI / 180.0;
+            double cx = Math.Cos(transform.Rotation.X * toRadians);
+            double sx = Math.Sin(transform.Rotation.X * toRadians);
+            double cy = Math.Cos(transform.Rotation.Y * toRadians);
+            double sy = Math.Sin(transform.Rotation.Y * toRadians);
+            double cz = Math.Cos(transform.Rotation.Z * toRadians);
+            double sz = Math.Sin(transform.Rotation.Z * toRadians);
+
+            double r00 = cy * cz;
+            double r01 = cy * sz;
+            double r02 = -sy;
+            double r10 = (sx * sy * cz) - (cx * sz);
+            double r11 = (sx * sy * sz) + (cx * cz);
+            double r12 = sx * cy;
+            double r20 = (cx * sy * cz) + (sx * sz);
+            double r21 = (cx * sy * sz) - (sx * cz);
+            double r22 = cx * cy;
+
+            var result = new StringBuilder();
+            result.Append("( (")
+                .Append(F(transform.Scale.X * r00)).Append(", ")
+                .Append(F(transform.Scale.X * r01)).Append(", ")
+                .Append(F(transform.Scale.X * r02)).Append(", 0.0000), (")
+                .Append(F(transform.Scale.Y * r10)).Append(", ")
+                .Append(F(transform.Scale.Y * r11)).Append(", ")
+                .Append(F(transform.Scale.Y * r12)).Append(", 0.0000), (")
+                .Append(F(transform.Scale.Z * r20)).Append(", ")
+                .Append(F(transform.Scale.Z * r21)).Append(", ")
+                .Append(F(transform.Scale.Z * r22)).Append(", 0.0000), (")
+                .Append(F(transform.Translation.X)).Append(", ")
+                .Append(F(transform.Translation.Y)).Append(", ")
+                .Append(F(transform.Translation.Z)).Append(", 1.0000) )");
+            return result.ToString();
+        }
+
+        private readonly record struct Vector3(double X, double Y, double Z);
+
+        private readonly record struct TransformComponents(
+            Vector3 Translation,
+            Vector3 Rotation,
+            Vector3 Scale)
+        {
+            public static TransformComponents Identity =>
+                new(default, default, new Vector3(1, 1, 1));
+
+            public TransformComponents With(string propertyName, Vector3 value)
+            {
+                return propertyName switch
+                {
+                    TranslateOp => this with { Translation = value },
+                    RotateOp => this with { Rotation = value },
+                    _ => this with { Scale = value }
+                };
+            }
         }
     }
 }

--- a/tests/Opc.Ua.OpenUsd.Tests/OpenUsdConnectorRunnerTests.cs
+++ b/tests/Opc.Ua.OpenUsd.Tests/OpenUsdConnectorRunnerTests.cs
@@ -148,7 +148,7 @@ namespace Opc.Ua.OpenUsd.Client.Tests
         }
 
         [Test]
-        public void WriteStageUsdaComposesLiveLayerBeforeFetchedRootLayer()
+        public void WriteStageUsdaComposesLiveLayerBeforeEveryFetchedRootLayer()
         {
             string cacheDir = Path.Combine(
                 Environment.CurrentDirectory,
@@ -171,6 +171,12 @@ namespace Opc.Ua.OpenUsd.Client.Tests
                         Identifier = "robot.usda",
                         Kind = OpenUsdAssetKind.RootLayer,
                         LocalPath = Path.Combine(cacheDir, "robot.usda")
+                    },
+                    new()
+                    {
+                        Identifier = "plant.usda",
+                        Kind = OpenUsdAssetKind.RootLayer,
+                        LocalPath = Path.Combine(cacheDir, "plant.usda")
                     }
                 };
 
@@ -178,16 +184,69 @@ namespace Opc.Ua.OpenUsd.Client.Tests
 
                 string stage = File.ReadAllText(Path.Combine(cacheDir, "stage.usda"));
                 int liveIndex = stage.IndexOf("@./live.usda@", StringComparison.Ordinal);
-                int rootIndex = stage.IndexOf("@./robot.usda@", StringComparison.Ordinal);
+                int robotIndex = stage.IndexOf("@./robot.usda@", StringComparison.Ordinal);
+                int plantIndex = stage.IndexOf("@./plant.usda@", StringComparison.Ordinal);
 
                 Assert.That(liveIndex, Is.GreaterThanOrEqualTo(0));
-                Assert.That(rootIndex, Is.GreaterThan(liveIndex));
+                Assert.That(robotIndex, Is.GreaterThan(liveIndex));
+                Assert.That(plantIndex, Is.GreaterThan(robotIndex));
                 Assert.That(File.Exists(Path.Combine(cacheDir, "live.usda")), Is.True);
             }
             finally
             {
                 Directory.Delete(cacheDir, recursive: true);
             }
+        }
+
+        [Test]
+        public void ViewportValueSinkForwardsValuesButNotComposition()
+        {
+            var inner = new MockUsdSink();
+            var sink = new UsdViewportValueSink(inner);
+
+            sink.SetAttribute("/Plant/Pump", "speed", Variant.From(42.0));
+            sink.SetTimeSample(
+                "/Plant/Pump",
+                "speed",
+                DateTime.UtcNow,
+                Variant.From(43.0));
+            sink.ComposePrim(
+                "/Plant/Pump",
+                OpenUsdCompositionArc.Reference,
+                "@pump.usda@</Pump>",
+                active: true);
+
+            Assert.That(inner.TotalWrites, Is.EqualTo(1));
+            Assert.That(inner.TimeSampleWrites, Is.EqualTo(1));
+            Assert.That(inner.ComposedPrimCount, Is.Zero);
+        }
+
+        [Test]
+        public void ViewportValueSinkRejectsNullInnerSink()
+        {
+            Assert.That(
+                () => new UsdViewportValueSink(null!),
+                Throws.ArgumentNullException);
+        }
+
+        [Test]
+        public void SiteCameraUsesProvenThreeQuarterFraming()
+        {
+            string stagePath = Path.Combine(
+                FindRepositoryRoot(),
+                "samples",
+                "OpenUsd",
+                "SiteCompositionServer",
+                "Assets",
+                "Site.usda");
+            string stage = File.ReadAllText(stagePath);
+
+            Assert.That(
+                stage,
+                Does.Contain("double3 xformOp:translate = (-22, -24, 14)"));
+            Assert.That(
+                stage,
+                Does.Contain("double3 xformOp:rotateXYZ = (71, 0, -35)"));
         }
 
         [Test]
@@ -245,6 +304,21 @@ namespace Opc.Ua.OpenUsd.Client.Tests
             await canceled.CancelAsync();
 
             await wait;
+        }
+
+        private static string FindRepositoryRoot()
+        {
+            DirectoryInfo? directory = new(TestContext.CurrentContext.WorkDirectory);
+            while (directory is not null)
+            {
+                if (File.Exists(Path.Combine(directory.FullName, "UA.slnx")))
+                {
+                    return directory.FullName;
+                }
+                directory = directory.Parent;
+            }
+            throw new DirectoryNotFoundException(
+                "Could not locate the repository root from the test directory.");
         }
     }
 }

--- a/tests/Opc.Ua.OpenUsd.Tests/UsdFileSinkTests.cs
+++ b/tests/Opc.Ua.OpenUsd.Tests/UsdFileSinkTests.cs
@@ -218,14 +218,16 @@ namespace Opc.Ua.OpenUsd.Client.Tests
         }
 
         [Test]
-        public void SetAttributeVectorAuthorsDouble3Property()
+        public void SetAttributeStructuredTransformAuthorsMatrixProperty()
         {
             var sink = new UsdFileSink(m_path);
             sink.SetAttribute("/Pump", "xformOp:translate",
                 new Variant((ArrayOf<double>)[1.0, 2.0, 3.0]));
 
             string layer = ReadLayer();
-            Assert.That(layer, Does.Contain("double3 xformOp:translate = (1.0000, 2.0000, 3.0000)"));
+            Assert.That(layer, Does.Contain("matrix4d xformOp:transform ="));
+            Assert.That(layer, Does.Contain("(1.0000, 2.0000, 3.0000, 1.0000)"));
+            Assert.That(layer, Does.Not.Contain("double3 xformOp:translate"));
         }
 
         [Test]
@@ -240,7 +242,7 @@ namespace Opc.Ua.OpenUsd.Client.Tests
         }
 
         [Test]
-        public void TimeSamplesAuthorDouble3FrameBlock()
+        public void TimeSamplesAuthorMatrixTransformFrameBlock()
         {
             var sink = new UsdFileSink(m_path);
             var t0 = new DateTime(1970, 1, 1, 0, 0, 1, DateTimeKind.Utc);
@@ -254,9 +256,12 @@ namespace Opc.Ua.OpenUsd.Client.Tests
             }
 
             string layer = ReadLayer();
-            Assert.That(layer, Does.Contain("double3 xformOp:translate.timeSamples = {"));
-            Assert.That(layer, Does.Contain("1.000: (1.0000, 2.0000, 3.0000)"));
-            Assert.That(layer, Does.Contain("2.000: (4.0000, 5.0000, 6.0000)"));
+            Assert.That(layer, Does.Contain("matrix4d xformOp:transform.timeSamples = {"));
+            Assert.That(layer, Does.Contain("1.000:"));
+            Assert.That(layer, Does.Contain("(1.0000, 2.0000, 3.0000, 1.0000)"));
+            Assert.That(layer, Does.Contain("2.000:"));
+            Assert.That(layer, Does.Contain("(4.0000, 5.0000, 6.0000, 1.0000)"));
+            Assert.That(layer, Does.Not.Contain("double3 xformOp:translate.timeSamples"));
         }
 
         [Test]

--- a/tests/Opc.Ua.OpenUsd.Tests/UsdFileSinkTests.cs
+++ b/tests/Opc.Ua.OpenUsd.Tests/UsdFileSinkTests.cs
@@ -265,6 +265,34 @@ namespace Opc.Ua.OpenUsd.Client.Tests
         }
 
         [Test]
+        public void TimeSampleTransformUsesLatestPriorComponents()
+        {
+            var sink = new UsdFileSink(m_path);
+            var translationTime = new DateTime(1970, 1, 1, 0, 0, 1, DateTimeKind.Utc);
+            var rotationTime = new DateTime(1970, 1, 1, 0, 0, 2, DateTimeKind.Utc);
+            using (sink.BeginBatch())
+            {
+                sink.SetTimeSample(
+                    "/Pump",
+                    "xformOp:translate",
+                    translationTime,
+                    new Variant((ArrayOf<double>)[1.0, 2.0, 3.0]));
+                sink.SetTimeSample(
+                    "/Pump",
+                    "xformOp:rotateXYZ",
+                    rotationTime,
+                    new Variant((ArrayOf<double>)[0.0, 0.0, 90.0]));
+            }
+
+            string rotationSample = Array.Find(
+                ReadLayer().Split('\n'),
+                line => line.Contains("2.000:", StringComparison.Ordinal))!;
+
+            Assert.That(rotationSample, Does.Contain("(-1.0000, 0.0000, 0.0000, 0.0000)"));
+            Assert.That(rotationSample, Does.Contain("(1.0000, 2.0000, 3.0000, 1.0000)"));
+        }
+
+        [Test]
         public void BatchDefersWriteUntilScopeDisposed()
         {
             var sink = new UsdFileSink(m_path);

--- a/tools/Opc.Ua.OpenUsd.Connector/OpenUsdConnectorRunner.cs
+++ b/tools/Opc.Ua.OpenUsd.Connector/OpenUsdConnectorRunner.cs
@@ -295,6 +295,7 @@ namespace Opc.Ua.OpenUsd.Connector
 
             var fileSink = new UsdFileSink(outPath);
             string? stagePath = stageOption;
+            bool generatedStage = false;
             IUsdViewHost? viewHost = null;
             if (view && !UsdViewHostLoader.TryLoad(out viewHost, out string unavailable))
             {
@@ -330,7 +331,11 @@ namespace Opc.Ua.OpenUsd.Connector
                     if (fetched.Count > 0)
                     {
                         WriteStageUsda(cacheDir!, fetched);
-                        stagePath ??= Path.Combine(cacheDir!, "stage.usda");
+                        if (string.IsNullOrEmpty(stagePath))
+                        {
+                            stagePath = Path.Combine(cacheDir!, "stage.usda");
+                            generatedStage = true;
+                        }
                         cameraPath ??= FindStageCamera(fetched);
                         Console.WriteLine(
                             $"Fetched {fetched.Count} server-delivered USD layer(s) into {cacheDir}; " +
@@ -351,6 +356,13 @@ namespace Opc.Ua.OpenUsd.Connector
                 {
                     await fetcher.DisposeAsync().ConfigureAwait(false);
                 }
+            }
+
+            if (view && generatedStage)
+            {
+                await PrecomposeViewportStageAsync(
+                    session, fileSink, enableCommands, connectorOptions, telemetry)
+                    .ConfigureAwait(false);
             }
 
             int exit = view
@@ -446,16 +458,38 @@ namespace Opc.Ua.OpenUsd.Connector
         }
 
         // Writes a self-contained stage.usda that composes the connector's live override
-        // layer over the server-delivered root layer (both now local in the cache dir).
+        // over every server-delivered root layer, all now local in the cache directory.
         internal static void WriteStageUsda(string cacheDir, List<OpenUsdConnector.FetchedAsset> fetched)
         {
-            OpenUsdConnector.FetchedAsset? root = fetched.Find(a => a.Kind == OpenUsdAssetKind.RootLayer);
-            string rootName = root != null ? Path.GetFileName(root.LocalPath) : "base.usda";
+            var rootNames = new List<string>();
+            foreach (OpenUsdConnector.FetchedAsset asset in fetched)
+            {
+                if (asset.Kind != OpenUsdAssetKind.RootLayer)
+                {
+                    continue;
+                }
+                string rootName = Path.GetFileName(asset.LocalPath);
+                if (!rootNames.Exists(
+                    name => string.Equals(name, rootName, StringComparison.Ordinal)))
+                {
+                    rootNames.Add(rootName);
+                }
+            }
+            if (rootNames.Count == 0)
+            {
+                rootNames.Add("base.usda");
+            }
+
             var sb = new StringBuilder();
             sb.Append("#usda 1.0\n(\n");
             sb.Append("    doc = \"Self-contained OpenUSD stage: server-delivered base layers " +
                 "+ the live OPC UA override.\"\n");
-            sb.Append("    subLayers = [\n        @./live.usda@,\n        @./").Append(rootName).Append("@\n    ]\n");
+            sb.Append("    subLayers = [\n        @./live.usda@");
+            foreach (string rootName in rootNames)
+            {
+                sb.Append(",\n        @./").Append(rootName).Append('@');
+            }
+            sb.Append("\n    ]\n");
             sb.Append(")\n");
             File.WriteAllText(Path.Combine(cacheDir, "stage.usda"), sb.ToString());
 
@@ -468,6 +502,29 @@ namespace Opc.Ua.OpenUsd.Connector
                 File.WriteAllText(
                     livePath,
                     "#usda 1.0\n(\n    doc = \"OPC UA -> OpenUSD live bindings (override layer)\"\n)\n");
+            }
+        }
+
+        [ExcludeFromCodeCoverage]
+        private static async Task PrecomposeViewportStageAsync(
+            ISession session,
+            IUsdSink fileSink,
+            bool enableCommands,
+            OpenUsdConnectorOptions? connectorOptions,
+            ITelemetryContext telemetry)
+        {
+            var connector = connectorOptions != null
+                ? new OpenUsdConnector(session, fileSink, connectorOptions, telemetry)
+                : new OpenUsdConnector(session, fileSink, enableCommands);
+            try
+            {
+                await connector.StartAsync(CancellationToken.None).ConfigureAwait(false);
+                Console.WriteLine(
+                    "Prepared the viewport stage with its discovered component composition.");
+            }
+            finally
+            {
+                await connector.DisposeAsync().ConfigureAwait(false);
             }
         }
 
@@ -660,7 +717,9 @@ namespace Opc.Ua.OpenUsd.Connector
             ITelemetryContext telemetry,
             CancellationToken cancellationToken)
         {
-            var sink = new CompositeUsdSink(fileSink, stageSink);
+            var sink = new CompositeUsdSink(
+                fileSink,
+                new UsdViewportValueSink(stageSink));
             var connector = connectorOptions != null
                 ? new OpenUsdConnector(session, sink, connectorOptions, telemetry)
                 : new OpenUsdConnector(session, sink, enableCommands);

--- a/tools/Opc.Ua.OpenUsd.Connector/UsdViewportValueSink.cs
+++ b/tools/Opc.Ua.OpenUsd.Connector/UsdViewportValueSink.cs
@@ -1,0 +1,77 @@
+/* ========================================================================
+ * Copyright (c) 2005-2026 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using Opc.Ua.OpenUsd.Client;
+
+namespace Opc.Ua.OpenUsd.Connector
+{
+    /// <summary>
+    /// Forwards live values to a viewport stage whose structural composition was
+    /// prepared before its retained renderer was created.
+    /// </summary>
+    internal sealed class UsdViewportValueSink : IUsdSink
+    {
+        public UsdViewportValueSink(IUsdSink inner)
+        {
+            m_inner = inner ?? throw new ArgumentNullException(nameof(inner));
+        }
+
+        public void SetAttribute(string primPath, string propertyName, Variant value)
+        {
+            m_inner.SetAttribute(primPath, propertyName, value);
+        }
+
+        public void SetTimeSample(
+            string primPath,
+            string propertyName,
+            DateTime time,
+            Variant value)
+        {
+            m_inner.SetTimeSample(primPath, propertyName, time, value);
+        }
+
+        public void ComposePrim(
+            string primPath,
+            OpenUsdCompositionArc arc,
+            string? assetReference,
+            bool active)
+        {
+            // OpenUSD 0.12 retained renderers do not rebuild reliably after live
+            // composition edits. The file sink still persists these changes.
+        }
+
+        public IDisposable BeginBatch()
+        {
+            return m_inner.BeginBatch();
+        }
+
+        private readonly IUsdSink m_inner;
+    }
+}


### PR DESCRIPTION
# Description

Adds a one-command federated OpenUSD site demo and fixes the composition path
that previously produced an empty, overlapping, or poorly framed viewport.

- Add
  `samples/OpenUsd/SiteCompositionServer/run-site-composition-demo.ps1` to
  build and start the pump, generator, and site servers, wait for every
  endpoint, publish the connector and viewer side by side, launch the
  federated viewport, and clean up child processes and artifacts.
- Include every fetched root layer in the generated stage and prepare
  structural component composition before the retained renderer starts.
- Continue persisting structural changes while forwarding value-only updates
  into the live viewport, avoiding renderer topology invalidation.
- Fold structured translation, rotation, and scale values into
  `xformOp:transform` matrices in `UsdFileSink`, including time samples, so
  multiple pump and generator instances remain distinct when the stage is
  reopened.
- Preserve the latest prior transform components when independently sampled
  translation, rotation, or scale history adds a new matrix sample.
- Reframe the site camera to show all three default pumps and both generator
  sets.
- Move the detailed root sample catalog to `docs/samples.md` and replace it
  with a concise link to the platform-independent samples and companion sample
  repository.

Validation performed:

- Ran the demo script through both its existing-viewer-bundle path and its
  default side-by-side publish path on isolated ports.
- Ran the focused OpenUSD connector and file-sink tests: 30 passed.
- Ran the full `Opc.Ua.OpenUsd.Tests` project: 919 passed; the remaining local
  failure is the existing culture-sensitive decimal formatting assertion on
  this host's `en-DE` culture.
- Ran the focused review-feedback file-sink tests: 19 passed.

## Related Issues

- Fixes #4392

## Checklist

- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf) and read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [x] I have added all necessary documentation.
- [x] I have verified that my changes do not introduce (new) build or analyzer warnings.
- [ ] I ran **all** tests locally using the **UA.slnx** solution against at least .net **framework** and .net **10**, and all passed.
- [ ] I fixed **all** failing and flaky tests in the CI pipelines and **all** CodeQL warnings.
- [x] I have addressed **all** PR feedback received.
