### PR TITLE
Remove the implicit fluent ReferenceServer root

### DIFF
--- a/docs/DependencyInjection.md
+++ b/docs/DependencyInjection.md
@@ -762,13 +762,23 @@ Custom server types that need session, subscription, or durable-subscription DI 
 Fluent node managers can be registered without a factory class:
 
 ```csharp
+const string namespaceUri = "urn:example:line";
+
 services.AddOpcUa()
-    .AddReferenceServer()
-    .AddNodeManager("urn:example:line", nodes =>
+    .AddServer(options => { /* endpoint and application options */ })
+    .AddNodeManager(namespaceUri, nodes =>
     {
-        nodes.Node("ReferenceServer");
+        ushort namespaceIndex =
+            (ushort)nodes.Context.NamespaceUris.GetIndex(namespaceUri);
+        nodes.CreateInstance(
+                new QualifiedName("Line", namespaceIndex),
+                parent => new FolderState(parent))
+            .Configure(node => node.UnderObjectsFolder());
     });
 ```
+
+The callback owns the complete address space contributed by this node manager.
+`AddNodeManager(namespaceUri, build)` does not create an implicit root folder.
 
 `AddHistorianFileStore(provider, path)` combines the historian provider registration with a Part 20
 file-system mount for demo and lab servers.

--- a/docs/NodeManagers.md
+++ b/docs/NodeManagers.md
@@ -381,6 +381,25 @@ services.AddOpcUa()
     .AddNodeManager(sp => new MyNodeManager(sp.GetRequiredService<ITelemetryContext>()));
 ```
 
+For a one-shot fluent node manager, the callback creates and places the
+complete contributed graph. The hosting API does not add an implicit root:
+
+```csharp
+const string namespaceUri = "urn:example:line";
+
+services.AddOpcUa()
+    .AddServer(o => { /* … */ })
+    .AddNodeManager(namespaceUri, builder =>
+    {
+        ushort namespaceIndex =
+            (ushort)builder.Context.NamespaceUris.GetIndex(namespaceUri);
+        builder.CreateInstance(
+                new QualifiedName("Line", namespaceIndex),
+                parent => new FolderState(parent))
+            .Configure(node => node.UnderObjectsFolder());
+    });
+```
+
 ### Runtime registration
 
 A running server exposes `INodeManagerLifecycle`. Resolve it from dependency injection in a hosted

--- a/src/Opc.Ua.Server/Hosting/FluentNodeManagerFactory.cs
+++ b/src/Opc.Ua.Server/Hosting/FluentNodeManagerFactory.cs
@@ -38,14 +38,24 @@ namespace Opc.Ua.Server.Hosting
 {
     internal sealed class FluentNodeManagerFactory : IAsyncNodeManagerFactory
     {
-        public FluentNodeManagerFactory(string namespaceUri, Action<INodeManagerBuilder> build)
+        public FluentNodeManagerFactory(
+            string namespaceUri,
+            Action<INodeManagerBuilder> build,
+            string? rootBrowseName = null)
         {
             if (string.IsNullOrWhiteSpace(namespaceUri))
             {
                 throw new ArgumentException("Namespace URI must not be empty.", nameof(namespaceUri));
             }
+            if (rootBrowseName != null && string.IsNullOrWhiteSpace(rootBrowseName))
+            {
+                throw new ArgumentException(
+                    "Root browse name must not be empty.",
+                    nameof(rootBrowseName));
+            }
             m_namespaceUri = namespaceUri;
             m_build = build ?? throw new ArgumentNullException(nameof(build));
+            m_rootBrowseName = rootBrowseName;
             NamespacesUris = [namespaceUri];
         }
 
@@ -63,13 +73,15 @@ namespace Opc.Ua.Server.Hosting
                 configuration,
                 logger,
                 m_namespaceUri,
-                m_build);
+                m_build,
+                m_rootBrowseName);
 #pragma warning restore CA2000
             return new ValueTask<IAsyncNodeManager>(manager);
         }
 
         private readonly Action<INodeManagerBuilder> m_build;
         private readonly string m_namespaceUri;
+        private readonly string? m_rootBrowseName;
     }
 
     internal sealed class FluentNodeManager : FluentNodeManagerBase
@@ -79,12 +91,14 @@ namespace Opc.Ua.Server.Hosting
             ApplicationConfiguration configuration,
             ILogger logger,
             string namespaceUri,
-            Action<INodeManagerBuilder> build)
+            Action<INodeManagerBuilder> build,
+            string? rootBrowseName)
             : base(server, configuration, logger, namespaceUri)
         {
             m_server = server ?? throw new ArgumentNullException(nameof(server));
             m_namespaceUri = namespaceUri ?? throw new ArgumentNullException(nameof(namespaceUri));
             m_build = build ?? throw new ArgumentNullException(nameof(build));
+            m_rootBrowseName = rootBrowseName;
         }
 
         public override async ValueTask CreateAddressSpaceAsync(
@@ -97,11 +111,12 @@ namespace Opc.Ua.Server.Hosting
             }
             ushort namespaceIndex = (ushort)m_server.NamespaceUris.GetIndex(m_namespaceUri);
 
-            // The root folder's inverse Organizes reference to the Objects
-            // folder is mirrored into externalReferences by the
-            // CompleteConfigureAsync pass below.
-            FolderState root = CreateRootFolder(namespaceIndex);
-            await AddPredefinedNodeAsync(root, cancellationToken).ConfigureAwait(false);
+            if (m_rootBrowseName != null)
+            {
+                FolderState root = CreateRootFolder(namespaceIndex, m_rootBrowseName);
+                await AddPredefinedNodeAsync(root, cancellationToken).ConfigureAwait(false);
+            }
+
             NodeManagerBuilder builder = CreateFluentBuilder(namespaceIndex);
             m_build(builder);
 
@@ -113,9 +128,10 @@ namespace Opc.Ua.Server.Hosting
             builder.Seal();
         }
 
-        private static FolderState CreateRootFolder(ushort namespaceIndex)
+        private static FolderState CreateRootFolder(
+            ushort namespaceIndex,
+            string browseName)
         {
-            const string browseName = "ReferenceServer";
             var root = new FolderState(null)
             {
                 NodeId = new NodeId(browseName, namespaceIndex),
@@ -130,5 +146,6 @@ namespace Opc.Ua.Server.Hosting
         private readonly Action<INodeManagerBuilder> m_build;
         private readonly IServerInternal m_server;
         private readonly string m_namespaceUri;
+        private readonly string? m_rootBrowseName;
     }
 }

--- a/src/Opc.Ua.Server/Hosting/IOpcUaServerBuilder.cs
+++ b/src/Opc.Ua.Server/Hosting/IOpcUaServerBuilder.cs
@@ -50,6 +50,7 @@ namespace Opc.Ua.Server.Hosting
 
         /// <summary>
         /// Registers a fluent node manager built from a namespace URI and configuration callback.
+        /// The callback creates and places every node; no implicit root node is added.
         /// </summary>
         /// <param name="namespaceUri">Namespace URI owned by the fluent node manager.</param>
         /// <param name="build">Callback that wires fluent nodes, alarms, state machines and simulations.</param>

--- a/src/Opc.Ua.Server/Hosting/OpcUaServerBuilderExtensions.cs
+++ b/src/Opc.Ua.Server/Hosting/OpcUaServerBuilderExtensions.cs
@@ -1038,6 +1038,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
         /// <summary>
         /// Registers a fluent node manager built from a namespace URI and configuration callback.
+        /// The callback creates and places every node; no implicit root node is added.
         /// </summary>
         /// <param name="builder">The server builder.</param>
         /// <param name="namespaceUri">Namespace URI owned by the fluent node manager.</param>
@@ -1054,10 +1055,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 throw new ArgumentNullException(nameof(builder));
             }
 
-            var factory = new FluentNodeManagerFactory(namespaceUri, build);
-            builder.Services.AddSingleton<IAsyncNodeManagerFactory>(factory);
-            builder.Services.AddSingleton(new OpcUaServerNodeManagerRegistration(factory));
-            return builder;
+            return RegisterFluentNodeManager(builder, namespaceUri, build);
         }
 
         /// <summary>
@@ -1263,11 +1261,12 @@ namespace Microsoft.Extensions.DependencyInjection
                 options.IncludeUnsecurePolicyNone = false;
                 configure?.Invoke(options);
             });
-            return serverBuilder
-                .AddRoleManager<RoleManager>()
-                .AddNodeManager(
-                    "http://opcfoundation.org/UA/ReferenceServer",
-                    nodeManager => nodeManager.Node("ReferenceServer"));
+            serverBuilder.AddRoleManager<RoleManager>();
+            return RegisterFluentNodeManager(
+                serverBuilder,
+                "http://opcfoundation.org/UA/ReferenceServer",
+                nodeManager => nodeManager.Node("ReferenceServer"),
+                "ReferenceServer");
         }
 
         /// <summary>
@@ -1332,6 +1331,21 @@ namespace Microsoft.Extensions.DependencyInjection
             return builder
                 .AddHistorian(historian)
                 .AddFileSystem(rootDirectory, mountName, isWritable);
+        }
+
+        private static IOpcUaServerBuilder RegisterFluentNodeManager(
+            IOpcUaServerBuilder builder,
+            string namespaceUri,
+            Action<INodeManagerBuilder> build,
+            string? rootBrowseName = null)
+        {
+            var factory = new FluentNodeManagerFactory(
+                namespaceUri,
+                build,
+                rootBrowseName);
+            builder.Services.AddSingleton<IAsyncNodeManagerFactory>(factory);
+            builder.Services.AddSingleton(new OpcUaServerNodeManagerRegistration(factory));
+            return builder;
         }
 
         private static void RegisterDefaultIdentityAuthenticators(
@@ -2117,10 +2131,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
             public IOpcUaServerBuilder AddNodeManager(string namespaceUri, Action<INodeManagerBuilder> build)
             {
-                var factory = new FluentNodeManagerFactory(namespaceUri, build);
-                Services.AddSingleton<IAsyncNodeManagerFactory>(factory);
-                Services.AddSingleton(new OpcUaServerNodeManagerRegistration(factory));
-                return this;
+                return RegisterFluentNodeManager(this, namespaceUri, build);
             }
 
             public IOpcUaServerBuilder AddSyncNodeManager<

--- a/tests/Opc.Ua.Server.Tests/Hosting/FluentNodeManagerFactoryCoverageTests.cs
+++ b/tests/Opc.Ua.Server.Tests/Hosting/FluentNodeManagerFactoryCoverageTests.cs
@@ -89,6 +89,14 @@ namespace Opc.Ua.Server.Tests.Hosting
         }
 
         [Test]
+        public void CtorWithWhitespaceRootBrowseNameThrowsArgumentException()
+        {
+            Assert.That(
+                () => new FluentNodeManagerFactory(TestNamespaceUri, _ => { }, " "),
+                Throws.TypeOf<ArgumentException>());
+        }
+
+        [Test]
         public void CtorWithValidArgumentsSetsNamespacesUris()
         {
             var factory = new FluentNodeManagerFactory(TestNamespaceUri, _ => { });
@@ -139,7 +147,7 @@ namespace Opc.Ua.Server.Tests.Hosting
         }
 
         [Test]
-        public async Task CreateAddressSpaceAsyncMirrorsRootFolderUnderObjectsFolderAsync()
+        public async Task CreateAddressSpaceAsyncDoesNotCreateImplicitRootFolderAsync()
         {
             Mock<IServerInternal> mockServer = BuildMockServer();
             var factory = new FluentNodeManagerFactory(TestNamespaceUri, _ => { });
@@ -154,12 +162,49 @@ namespace Opc.Ua.Server.Tests.Hosting
             await manager.CreateAddressSpaceAsync(externalReferences, CancellationToken.None)
                 .ConfigureAwait(false);
 
+            Assert.That(
+                externalReferences.ContainsKey(ObjectIds.ObjectsFolder),
+                Is.False);
+            Assert.That(
+                await manager.GetManagerHandleAsync(
+                    new NodeId("ReferenceServer", 1),
+                    CancellationToken.None).ConfigureAwait(false),
+                Is.Null);
+
+            ((IDisposable)manager).Dispose();
+        }
+
+        [Test]
+        public async Task ConfiguredRootFolderIsMirroredUnderObjectsFolderAsync()
+        {
+            Mock<IServerInternal> mockServer = BuildMockServer();
+            var factory = new FluentNodeManagerFactory(
+                TestNamespaceUri,
+                builder => builder.Node("ReferenceServer"),
+                "ReferenceServer");
+
+            IAsyncNodeManager manager = await factory.CreateAsync(
+                mockServer.Object,
+                new ApplicationConfiguration(),
+                CancellationToken.None)
+                .ConfigureAwait(false);
+
+            var externalReferences = new Dictionary<NodeId, IList<IReference>>();
+            await manager.CreateAddressSpaceAsync(externalReferences, CancellationToken.None)
+                .ConfigureAwait(false);
+
+            var rootId = new NodeId("ReferenceServer", 1);
             Assert.That(externalReferences.ContainsKey(ObjectIds.ObjectsFolder), Is.True);
             Assert.That(
                 externalReferences[ObjectIds.ObjectsFolder].Count(r =>
-                    r.ReferenceTypeId == ReferenceTypeIds.Organizes && !r.IsInverse),
-                Is.EqualTo(1),
-                "The root folder's inverse Organizes reference must be mirrored exactly once");
+                    r.ReferenceTypeId == ReferenceTypeIds.Organizes &&
+                    !r.IsInverse &&
+                    r.TargetId == new ExpandedNodeId(rootId)),
+                Is.EqualTo(1));
+            Assert.That(
+                await manager.GetManagerHandleAsync(rootId, CancellationToken.None)
+                    .ConfigureAwait(false),
+                Is.Not.Null);
 
             ((IDisposable)manager).Dispose();
         }
@@ -195,10 +240,15 @@ namespace Opc.Ua.Server.Tests.Hosting
             Assert.That(externalReferences.ContainsKey(ObjectIds.ObjectsFolder), Is.True);
             Assert.That(
                 externalReferences[ObjectIds.ObjectsFolder].Count(r =>
-                    r.ReferenceTypeId == ReferenceTypeIds.Organizes &&
-                    !r.IsInverse &&
-                    r.TargetId == new ExpandedNodeId(instanceId)),
+                    r.ReferenceTypeId == ReferenceTypeIds.Organizes && !r.IsInverse),
                 Is.EqualTo(1));
+            Assert.That(
+                externalReferences[ObjectIds.ObjectsFolder]
+                    .Single(r =>
+                        r.ReferenceTypeId == ReferenceTypeIds.Organizes &&
+                        !r.IsInverse)
+                    .TargetId,
+                Is.EqualTo(new ExpandedNodeId(instanceId)));
 
             ((IDisposable)manager).Dispose();
         }
@@ -264,12 +314,56 @@ namespace Opc.Ua.Server.Tests.Hosting
             Assert.That(factory.NamespacesUris[0], Is.EqualTo(TestNamespaceUri));
         }
 
-        // ── Helpers ──────────────────────────────────────────────────────────
+        [Test]
+        public async Task AddReferenceServerConfiguresNamedRootFolderAsync()
+        {
+            const string referenceNamespaceUri =
+                "http://opcfoundation.org/UA/ReferenceServer";
+            var services = new ServiceCollection();
+            services.AddLogging();
+            services.AddOpcUa().AddReferenceServer();
+            using ServiceProvider sp = services.BuildServiceProvider();
+            OpcUaServerNodeManagerRegistration registration = sp
+                .GetServices<OpcUaServerNodeManagerRegistration>()
+                .Single();
+            IAsyncNodeManagerFactory factory = registration.AsyncFactory!;
+            Mock<IServerInternal> mockServer = BuildMockServer(referenceNamespaceUri);
+            IAsyncNodeManager manager = await factory.CreateAsync(
+                mockServer.Object,
+                new ApplicationConfiguration(),
+                CancellationToken.None)
+                .ConfigureAwait(false);
 
-        private static Mock<IServerInternal> BuildMockServer()
+            try
+            {
+                var externalReferences = new Dictionary<NodeId, IList<IReference>>();
+                await manager.CreateAddressSpaceAsync(
+                    externalReferences,
+                    CancellationToken.None).ConfigureAwait(false);
+
+                var rootId = new NodeId("ReferenceServer", 1);
+                Assert.That(
+                    externalReferences[ObjectIds.ObjectsFolder].Count(reference =>
+                        reference.ReferenceTypeId == ReferenceTypeIds.Organizes &&
+                        !reference.IsInverse &&
+                        reference.TargetId == new ExpandedNodeId(rootId)),
+                    Is.EqualTo(1));
+                Assert.That(
+                    await manager.GetManagerHandleAsync(rootId, CancellationToken.None)
+                        .ConfigureAwait(false),
+                    Is.Not.Null);
+            }
+            finally
+            {
+                ((IDisposable)manager).Dispose();
+            }
+        }
+
+        private static Mock<IServerInternal> BuildMockServer(
+            string namespaceUri = TestNamespaceUri)
         {
             var namespaceTable = new NamespaceTable();
-            namespaceTable.Append(TestNamespaceUri);
+            namespaceTable.Append(namespaceUri);
 
             var mockTelemetry = new Mock<ITelemetryContext>();
             mockTelemetry

--- a/tests/Opc.Ua.Server.Tests/Hosting/ServerFluentApiHostingTests.cs
+++ b/tests/Opc.Ua.Server.Tests/Hosting/ServerFluentApiHostingTests.cs
@@ -584,7 +584,7 @@ namespace Opc.Ua.Server.Tests.Hosting
         public void AddNodeManagerRegistersFluentNodeManagerFactory()
         {
             using ServiceProvider sp = CreateServerBuilder()
-                .AddNodeManager("urn:tests:fluent", builder => builder.Node("ReferenceServer"))
+                .AddNodeManager("urn:tests:fluent", _ => { })
                 .Services.BuildServiceProvider();
 
             OpcUaServerNodeManagerRegistration registration = sp


### PR DESCRIPTION
## Summary

- stop `AddNodeManager(namespaceUri, build)` from creating a hidden `ReferenceServer` folder
- keep the named root as an internal opt-in used only by `AddReferenceServer`
- centralize fluent node-manager factory registration so the interface implementation and extension path cannot diverge
- add hosting coverage for the no-root default, explicit callback-created roots, and the reference-server preset
- update hosting API documentation and examples to show explicit root creation and placement

## Relationship to #4389

This is an independent hosting bug in `FluentNodeManagerFactory`; #4389 does not change that factory. Keeping it separate avoids expanding the already large architectural PR. The node-source branch has been rebased over this fix locally without reintroducing the implicit root.

## Validation

| Scope | Result |
| --- | --- |
| Focused hosting tests `net10.0` | 17 passed |
| Focused hosting tests `net48` | 17 passed |
| Full `Opc.Ua.Server.Tests` `net10.0` | 4,861 passed, 5 skipped |
| Full solution build `net10.0` | Succeeded |
| Full `Opc.Ua.Server.Tests` `net48` | 4,855 passed, 6 skipped before the assembly-wide teardown reported four outstanding certificate wrappers; the same teardown result reproduced on the independent #4376 branch |

## Related Issues

Fixes #4388