### PR TITLE
Fix typed instance child NodeIds during registration

### DIFF
--- a/.agents/skills/opcua-v20-migration/references/stack-migration/node-states.md
+++ b/.agents/skills/opcua-v20-migration/references/stack-migration/node-states.md
@@ -121,11 +121,14 @@ lifecycle open so callers can finish assembling and configuring the subtree.
 In 2.0, registering the graph through `AddPredefinedNodeAsync`,
 `AddNodeAsync`, or the synchronous predefined-node registration path
 automatically runs `OnBeforeCreate`/`OnAfterCreate` and clears change masks
-before indexing. The asynchronous paths assign or rebase NodeIds before the
-callbacks, so they see the identifiers which enter the address space.
-Synchronous predefined-node registration preserves the caller-assigned
-NodeIds and expects them to be ready. `NodeState.IsCreated` exposes whether
-an individual node has completed that lifecycle.
+before indexing. Asynchronous predefined-node registration repairs typed
+instance subtrees which still carry null, foreign-namespace, or
+type-declaration-colliding NodeIds before the callbacks, so they see the
+identifiers which enter the address space. Explicit NodeIds in a namespace
+owned by the node manager are preserved. Synchronous registration keeps the
+caller's identifiers; fluent helpers which materialise typed subtrees assign
+their instance child NodeIds before registration. `NodeState.IsCreated`
+exposes whether an individual node has completed that lifecycle.
 
 `AddBehaviourToPredefinedNode` and its asynchronous equivalent receive the
 created node. An override which replaces a passive node may therefore observe

--- a/docs/NodeManagers.md
+++ b/docs/NodeManagers.md
@@ -1829,12 +1829,13 @@ await AddPredefinedNodeAsync(SystemContext, pump, cancellationToken);
 The generated factory intentionally returns a graph whose create lifecycle
 has not completed. Node manager registration completes
 `OnBeforeCreate`/`OnAfterCreate` and clears change masks before the graph is
-indexed. The asynchronous registration path performs any required NodeId
-rebasing first, so lifecycle callbacks see the identifiers which enter the
-address space. Synchronous predefined-node registration preserves the
-caller-assigned NodeIds and expects them to be ready. The behavior hook then
-receives a created node. `NodeState.IsCreated` reports whether an individual
-node has completed that lifecycle.
+indexed. Both asynchronous and synchronous predefined-node registration
+repair null, foreign-namespace, or type-declaration-colliding instance
+NodeIds first, so lifecycle callbacks see the identifiers which enter the
+address space. NodeIds explicitly assigned in a namespace owned by the
+manager are preserved. The behavior hook then receives a created node.
+`NodeState.IsCreated` reports whether an individual node has completed that
+lifecycle.
 
 Most callers should configure the graph and then register it as shown above.
 If code must read state established by `OnAfterCreate`, or write state or
@@ -1864,8 +1865,12 @@ Notes:
   automatically.
 * Assignment only happens when the context carries an
   `ISystemContext.NodeIdFactory`. `AsyncCustomNodeManager` supplies one
-  that allocates from the manager's namespace; override `New` to derive
-  ids from the parent chain instead.
+  that allocates null IDs in the manager's default namespace. Registration
+  selectively retries typed-instance descendants which still carry foreign
+  declaration IDs, while preserving explicitly assigned IDs in an owned
+  namespace and well-known namespace-zero roots. Override `New` only when the
+  address space needs a different stable naming strategy, such as deriving
+  IDs from the parent chain.
 * **A node copy never assigns.** `NodeState.Create(context, source)`
   initialises each child from its source right after creating it, which
   overwrites any NodeId minted along the way — so minting one would only

--- a/docs/NodeManagers.md
+++ b/docs/NodeManagers.md
@@ -1829,11 +1829,14 @@ await AddPredefinedNodeAsync(SystemContext, pump, cancellationToken);
 The generated factory intentionally returns a graph whose create lifecycle
 has not completed. Node manager registration completes
 `OnBeforeCreate`/`OnAfterCreate` and clears change masks before the graph is
-indexed. Both asynchronous and synchronous predefined-node registration
-repair null, foreign-namespace, or type-declaration-colliding instance
-NodeIds first, so lifecycle callbacks see the identifiers which enter the
-address space. NodeIds explicitly assigned in a namespace owned by the
-manager are preserved. The behavior hook then receives a created node.
+indexed. Asynchronous predefined-node registration repairs typed instance
+subtrees which still carry null, foreign-namespace, or
+type-declaration-colliding NodeIds first, so lifecycle callbacks see the
+identifiers which enter the address space. NodeIds explicitly assigned in a
+namespace owned by the manager are preserved. Synchronous registration keeps
+the caller's identifiers; fluent helpers which materialise typed subtrees,
+such as the state-machine creators, assign their instance child NodeIds before
+registration. The behavior hook then receives a created node.
 `NodeState.IsCreated` reports whether an individual node has completed that
 lifecycle.
 
@@ -1866,11 +1869,12 @@ Notes:
 * Assignment only happens when the context carries an
   `ISystemContext.NodeIdFactory`. `AsyncCustomNodeManager` supplies one
   that allocates null IDs in the manager's default namespace. Registration
-  selectively retries typed-instance descendants which still carry foreign
-  declaration IDs, while preserving explicitly assigned IDs in an owned
-  namespace and well-known namespace-zero roots. Override `New` only when the
-  address space needs a different stable naming strategy, such as deriving
-  IDs from the parent chain.
+  selectively retries descendants when an asynchronously registered,
+  manager-owned instance subtree still carries foreign declaration IDs, while
+  preserving explicitly assigned IDs in an owned namespace and well-known
+  namespace-zero roots. Synchronous creators must assign typed child IDs before
+  registration. Override `New` only when the address space needs a different
+  stable naming strategy, such as deriving IDs from the parent chain.
 * **A node copy never assigns.** `NodeState.Create(context, source)`
   initialises each child from its source right after creating it, which
   overwrites any NodeId minted along the way — so minting one would only

--- a/docs/migrate/2.0.x/node-states.md
+++ b/docs/migrate/2.0.x/node-states.md
@@ -121,12 +121,14 @@ lifecycle open so callers can finish assembling and configuring the subtree.
 In 2.0, registering the graph through `AddPredefinedNodeAsync`,
 `AddNodeAsync`, or the synchronous predefined-node registration path
 automatically runs `OnBeforeCreate`/`OnAfterCreate` and clears change masks
-before indexing. Both asynchronous and synchronous predefined-node
-registration repair null, foreign-namespace, or type-declaration-colliding
-instance NodeIds before the callbacks, so they see the identifiers which
-enter the address space. Explicit NodeIds in a namespace owned by the node
-manager are preserved. `NodeState.IsCreated` exposes whether an individual
-node has completed that lifecycle.
+before indexing. Asynchronous predefined-node registration repairs typed
+instance subtrees which still carry null, foreign-namespace, or
+type-declaration-colliding NodeIds before the callbacks, so they see the
+identifiers which enter the address space. Explicit NodeIds in a namespace
+owned by the node manager are preserved. Synchronous registration keeps the
+caller's identifiers; fluent helpers which materialise typed subtrees assign
+their instance child NodeIds before registration. `NodeState.IsCreated`
+exposes whether an individual node has completed that lifecycle.
 
 `AddBehaviourToPredefinedNode` and its asynchronous equivalent receive the
 created node. An override which replaces a passive node may therefore observe

--- a/docs/migrate/2.0.x/node-states.md
+++ b/docs/migrate/2.0.x/node-states.md
@@ -121,11 +121,12 @@ lifecycle open so callers can finish assembling and configuring the subtree.
 In 2.0, registering the graph through `AddPredefinedNodeAsync`,
 `AddNodeAsync`, or the synchronous predefined-node registration path
 automatically runs `OnBeforeCreate`/`OnAfterCreate` and clears change masks
-before indexing. The asynchronous paths assign or rebase NodeIds before the
-callbacks, so they see the identifiers which enter the address space.
-Synchronous predefined-node registration preserves the caller-assigned
-NodeIds and expects them to be ready. `NodeState.IsCreated` exposes whether
-an individual node has completed that lifecycle.
+before indexing. Both asynchronous and synchronous predefined-node
+registration repair null, foreign-namespace, or type-declaration-colliding
+instance NodeIds before the callbacks, so they see the identifiers which
+enter the address space. Explicit NodeIds in a namespace owned by the node
+manager are preserved. `NodeState.IsCreated` exposes whether an individual
+node has completed that lifecycle.
 
 `AddBehaviourToPredefinedNode` and its asynchronous equivalent receive the
 created node. An override which replaces a passive node may therefore observe

--- a/src/Opc.Ua.Server/Fluent/StateMachineBuilderExtensions.cs
+++ b/src/Opc.Ua.Server/Fluent/StateMachineBuilderExtensions.cs
@@ -167,6 +167,7 @@ namespace Opc.Ua.Server.Fluent
                 displayName: new LocalizedText(symbolicName),
                 assignNodeIds: false);
 
+            parent.Builder.Context.AssignInstanceChildNodeIds(machine);
             machine.ReferenceTypeId = ReferenceTypeIds.HasComponent;
             parent.Node.AddChild(machine);
             FluentNodeRegistration.RegisterCreatedNode(parent.Builder, machine);

--- a/src/Opc.Ua.Server/NodeManager/AsyncCustomNodeManager.cs
+++ b/src/Opc.Ua.Server/NodeManager/AsyncCustomNodeManager.cs
@@ -2117,8 +2117,13 @@ namespace Opc.Ua.Server
 
             var children = new List<BaseInstanceState>();
             node.GetChildren(context, children);
-            bool requiresRebase = RequiresInstanceNodeIdRepair(node) ||
-                children.Any(RequiresInstanceNodeIdRepair);
+            bool requiresRebase = rootCollision ||
+                node.NodeId.IsNull ||
+                children.Any(child =>
+                    child.NodeId.IsNull ||
+                    (IsNodeIdInNamespace(node.NodeId) &&
+                        !IsNodeIdInNamespace(child.NodeId)) ||
+                    HasDeclarationNodeIdCollision(child));
             if (!requiresRebase)
             {
                 return;
@@ -2254,7 +2259,6 @@ namespace Opc.Ua.Server
 
         private void AddPredefinedNodeSynchronously(ISystemContext context, NodeState node)
         {
-            PrepareInstanceNodeIdsForRegistration(context, node);
             CompleteCreateLifecycleForRegistration(context, node);
             IndexPredefinedNode(node);
 

--- a/src/Opc.Ua.Server/NodeManager/AsyncCustomNodeManager.cs
+++ b/src/Opc.Ua.Server/NodeManager/AsyncCustomNodeManager.cs
@@ -2117,45 +2117,60 @@ namespace Opc.Ua.Server
 
             var children = new List<BaseInstanceState>();
             node.GetChildren(context, children);
-            bool requiresRebase = rootCollision ||
-                node.NodeId.IsNull ||
-                children.Any(child =>
-                    child.NodeId.IsNull ||
-                    (node.NodeId.NamespaceIndex != 0 &&
-                        child.NodeId.NamespaceIndex == 0) ||
-                    HasDeclarationNodeIdCollision(child));
+            bool requiresRebase = RequiresInstanceNodeIdRepair(node) ||
+                children.Any(RequiresInstanceNodeIdRepair);
             if (!requiresRebase)
             {
                 return;
             }
 
             var subtree = new List<NodeState> { node };
+            var mappingTable = new Dictionary<NodeId, NodeId>();
             for (int ii = 0; ii < subtree.Count; ii++)
             {
+                NodeState candidate = subtree[ii];
+                if (candidate.IsPartOfTypeHierarchy)
+                {
+                    continue;
+                }
+
+                if (RequiresInstanceNodeIdRepair(candidate))
+                {
+                    if (!candidate.NodeId.IsNull &&
+                        PredefinedNodes.TryGetValue(
+                            candidate.NodeId,
+                            out NodeState? indexedNode) &&
+                        ReferenceEquals(indexedNode, candidate))
+                    {
+                        PredefinedNodes.TryRemove(candidate.NodeId, out _);
+                    }
+
+                    NodeId previousNodeId = context.AssignInstanceNodeId(candidate);
+                    if (!previousNodeId.IsNull &&
+                        !candidate.NodeId.IsNull &&
+                        !previousNodeId.Equals(candidate.NodeId))
+                    {
+                        mappingTable[previousNodeId] = candidate.NodeId;
+                    }
+                }
+
                 children.Clear();
-                subtree[ii].GetChildren(context, children);
+                candidate.GetChildren(context, children);
                 subtree.AddRange(children);
             }
 
-            foreach (NodeState candidate in subtree)
+            if (mappingTable.Count > 0)
             {
-                if (!candidate.NodeId.IsNull &&
-                    PredefinedNodes.TryGetValue(
-                        candidate.NodeId,
-                        out NodeState? indexedNode) &&
-                    ReferenceEquals(indexedNode, candidate))
-                {
-                    PredefinedNodes.TryRemove(candidate.NodeId, out _);
-                }
+                (instance.Parent ?? node).UpdateReferenceTargets(context, mappingTable);
             }
+        }
 
-            NodeId previousNodeId = node.NodeId.IsNull || rootCollision
-                ? context.AssignInstanceNodeId(node)
-                : NodeId.Null;
-            context.AssignInstanceChildNodeIds(
-                node,
-                previousNodeId,
-                instance.Parent ?? node);
+        private bool RequiresInstanceNodeIdRepair(NodeState node)
+        {
+            return !node.IsPartOfTypeHierarchy &&
+                (node.NodeId.IsNull ||
+                    !IsNodeIdInNamespace(node.NodeId) ||
+                    HasDeclarationNodeIdCollision(node));
         }
 
         private bool HasDeclarationNodeIdCollision(NodeState node)
@@ -2239,6 +2254,7 @@ namespace Opc.Ua.Server
 
         private void AddPredefinedNodeSynchronously(ISystemContext context, NodeState node)
         {
+            PrepareInstanceNodeIdsForRegistration(context, node);
             CompleteCreateLifecycleForRegistration(context, node);
             IndexPredefinedNode(node);
 

--- a/tests/Opc.Ua.Server.Tests/AsyncCustomNodeManagerTests.cs
+++ b/tests/Opc.Ua.Server.Tests/AsyncCustomNodeManagerTests.cs
@@ -433,15 +433,13 @@ namespace Opc.Ua.Server.Tests
                 "Requires AsyncCustomNodeManager NodeId preparation");
             var root = new BaseObjectState(null)
             {
-                NodeId = ObjectIds.ServerConfiguration,
-                BrowseName = new QualifiedName(BrowseNames.ServerConfiguration)
+                NodeId = ObjectIds.Server,
+                BrowseName = new QualifiedName(BrowseNames.Server)
             };
-            var childNodeId = new NodeId(11715u);
-            var child = new BaseDataVariableState(root)
+            var child = new BaseObjectState(root)
             {
-                NodeId = childNodeId,
-                BrowseName = new QualifiedName(BrowseNames.ServerCapabilities),
-                DataType = DataTypeIds.BaseDataType
+                NodeId = ObjectIds.Server_ServerCapabilities,
+                BrowseName = new QualifiedName(BrowseNames.ServerCapabilities)
             };
             root.AddChild(child);
 
@@ -451,8 +449,8 @@ namespace Opc.Ua.Server.Tests
 
             Assert.Multiple(() =>
             {
-                Assert.That(root.NodeId, Is.EqualTo(ObjectIds.ServerConfiguration));
-                Assert.That(child.NodeId, Is.EqualTo(childNodeId));
+                Assert.That(root.NodeId, Is.EqualTo(ObjectIds.Server));
+                Assert.That(child.NodeId, Is.EqualTo(ObjectIds.Server_ServerCapabilities));
             });
         }
 
@@ -476,31 +474,6 @@ namespace Opc.Ua.Server.Tests
             Assert.That(node.IsCreated, Is.True);
             Assert.That(node.BeforeCreateCount, Is.EqualTo(1));
             Assert.That(node.AfterCreateCount, Is.EqualTo(1));
-        }
-
-        [Test]
-        public void SynchronousRegistrationRebasesTypedChildren()
-        {
-            using ITestNodeManager manager = CreateManager();
-            Assume.That(manager is TestableAsyncCustomNodeManager,
-                "Requires AsyncCustomNodeManager synchronous registration");
-            var asyncManager = (TestableAsyncCustomNodeManager)manager;
-            ushort namespaceIndex = manager.NamespaceIndex;
-            var program = new ProgramStateMachineState(null);
-            program.Create(
-                manager.SystemContext,
-                new NodeId("SynchronousProgram", namespaceIndex),
-                new QualifiedName("SynchronousProgram", namespaceIndex),
-                default,
-                assignNodeIds: false);
-
-            asyncManager.AddPredefinedNodeSynchronouslyPublic(program);
-
-            Assert.That(program.CurrentState, Is.Not.Null);
-            Assert.That(
-                program.CurrentState!.NodeId.NamespaceIndex,
-                Is.EqualTo(namespaceIndex));
-            Assert.That(manager.Find(program.CurrentState.NodeId), Is.SameAs(program.CurrentState));
         }
 
         [Test]

--- a/tests/Opc.Ua.Server.Tests/AsyncCustomNodeManagerTests.cs
+++ b/tests/Opc.Ua.Server.Tests/AsyncCustomNodeManagerTests.cs
@@ -371,6 +371,92 @@ namespace Opc.Ua.Server.Tests
         }
 
         [Test]
+        public async Task RegistrationRebasesTypedChildrenAndPreservesExplicitIdsAsync()
+        {
+            using ITestNodeManager manager = CreateManager();
+            Assume.That(manager is TestableAsyncCustomNodeManager,
+                "Requires AsyncCustomNodeManager NodeId preparation");
+            ushort namespaceIndex = manager.NamespaceIndexes[0];
+            var program = new ProgramStateMachineState(null);
+            program.Create(
+                manager.SystemContext,
+                new NodeId("Program", namespaceIndex),
+                new QualifiedName("Program", namespaceIndex),
+                default,
+                assignNodeIds: false);
+            var explicitChildId = new NodeId("Program_Explicit", namespaceIndex);
+            var explicitChild = new BaseDataVariableState(program)
+            {
+                NodeId = explicitChildId,
+                BrowseName = new QualifiedName("Explicit", namespaceIndex),
+                DisplayName = new LocalizedText("Explicit"),
+                DataType = DataTypeIds.UInt32,
+                ValueRank = ValueRanks.Scalar
+            };
+            program.AddChild(explicitChild);
+
+            Assert.That(program.CurrentState, Is.Not.Null);
+            Assert.That(program.CurrentState!.Id, Is.Not.Null);
+            Assert.That(program.CurrentState.NodeId.NamespaceIndex, Is.Zero);
+            Assert.That(program.CurrentState.Id!.NodeId.NamespaceIndex, Is.Zero);
+
+            await manager
+                .AddPredefinedNodeAsync(manager.SystemContext, program)
+                .ConfigureAwait(false);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(
+                    program.CurrentState.NodeId.NamespaceIndex,
+                    Is.EqualTo(namespaceIndex));
+                Assert.That(
+                    program.CurrentState.Id.NodeId.NamespaceIndex,
+                    Is.EqualTo(namespaceIndex));
+                Assert.That(explicitChild.NodeId, Is.EqualTo(explicitChildId));
+                Assert.That(manager.Find(program.CurrentState.NodeId), Is.SameAs(program.CurrentState));
+                Assert.That(manager.Find(program.CurrentState.Id.NodeId), Is.SameAs(program.CurrentState.Id));
+                Assert.That(manager.Find(explicitChildId), Is.SameAs(explicitChild));
+            });
+            Assert.That(
+                await manager.GetManagerHandleAsync(program.CurrentState.NodeId).ConfigureAwait(false),
+                Is.Not.Null);
+            Assert.That(
+                await manager.GetManagerHandleAsync(program.CurrentState.Id.NodeId).ConfigureAwait(false),
+                Is.Not.Null);
+        }
+
+        [Test]
+        public async Task RegistrationPreservesNamespaceZeroRootIdsAsync()
+        {
+            using ITestNodeManager manager = CreateManager();
+            Assume.That(manager is TestableAsyncCustomNodeManager,
+                "Requires AsyncCustomNodeManager NodeId preparation");
+            var root = new BaseObjectState(null)
+            {
+                NodeId = ObjectIds.ServerConfiguration,
+                BrowseName = new QualifiedName(BrowseNames.ServerConfiguration)
+            };
+            var childNodeId = new NodeId(11715u);
+            var child = new BaseDataVariableState(root)
+            {
+                NodeId = childNodeId,
+                BrowseName = new QualifiedName(BrowseNames.ServerCapabilities),
+                DataType = DataTypeIds.BaseDataType
+            };
+            root.AddChild(child);
+
+            await manager
+                .AddPredefinedNodeAsync(manager.SystemContext, root)
+                .ConfigureAwait(false);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(root.NodeId, Is.EqualTo(ObjectIds.ServerConfiguration));
+                Assert.That(child.NodeId, Is.EqualTo(childNodeId));
+            });
+        }
+
+        [Test]
         public void SynchronousPredefinedNodeRegistrationCompletesCreateLifecycle()
         {
             using ITestNodeManager manager = CreateManager();
@@ -390,6 +476,31 @@ namespace Opc.Ua.Server.Tests
             Assert.That(node.IsCreated, Is.True);
             Assert.That(node.BeforeCreateCount, Is.EqualTo(1));
             Assert.That(node.AfterCreateCount, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void SynchronousRegistrationRebasesTypedChildren()
+        {
+            using ITestNodeManager manager = CreateManager();
+            Assume.That(manager is TestableAsyncCustomNodeManager,
+                "Requires AsyncCustomNodeManager synchronous registration");
+            var asyncManager = (TestableAsyncCustomNodeManager)manager;
+            ushort namespaceIndex = manager.NamespaceIndex;
+            var program = new ProgramStateMachineState(null);
+            program.Create(
+                manager.SystemContext,
+                new NodeId("SynchronousProgram", namespaceIndex),
+                new QualifiedName("SynchronousProgram", namespaceIndex),
+                default,
+                assignNodeIds: false);
+
+            asyncManager.AddPredefinedNodeSynchronouslyPublic(program);
+
+            Assert.That(program.CurrentState, Is.Not.Null);
+            Assert.That(
+                program.CurrentState!.NodeId.NamespaceIndex,
+                Is.EqualTo(namespaceIndex));
+            Assert.That(manager.Find(program.CurrentState.NodeId), Is.SameAs(program.CurrentState));
         }
 
         [Test]

--- a/tests/Opc.Ua.Server.Tests/Fluent/FluentAlarmRegistrationIntegrationTests.cs
+++ b/tests/Opc.Ua.Server.Tests/Fluent/FluentAlarmRegistrationIntegrationTests.cs
@@ -152,7 +152,7 @@ namespace Opc.Ua.Server.Tests.Fluent
         }
 
         [Test]
-        public void OtherFluentCreatorsRegisterCreatedNodes()
+        public async Task OtherFluentCreatorsRegisterCreatedNodesAsync()
         {
             using Harness h = CreateHarness();
 
@@ -166,6 +166,25 @@ namespace Opc.Ua.Server.Tests.Fluent
             Assert.That(h.Manager.PredefinedNodes.ContainsKey(group.Node.NodeId), Is.True);
             Assert.That(h.Manager.PredefinedNodes.ContainsKey(instance.Node.NodeId), Is.True);
             Assert.That(h.Manager.PredefinedNodes.ContainsKey(machine.StateMachine.NodeId), Is.True);
+            Assert.That(machine.StateMachine.CurrentState, Is.Not.Null);
+            Assert.That(machine.StateMachine.CurrentState!.Id, Is.Not.Null);
+            Assert.That(
+                machine.StateMachine.CurrentState.NodeId.NamespaceIndex,
+                Is.EqualTo(h.NamespaceIndex));
+            Assert.That(
+                machine.StateMachine.CurrentState.Id!.NodeId.NamespaceIndex,
+                Is.EqualTo(h.NamespaceIndex));
+            Assert.That(
+                h.Manager.PredefinedNodes.ContainsKey(machine.StateMachine.CurrentState.NodeId),
+                Is.True);
+            Assert.That(
+                h.Manager.PredefinedNodes.ContainsKey(machine.StateMachine.CurrentState.Id.NodeId),
+                Is.True);
+            Assert.That(
+                await h.Manager
+                    .GetManagerHandlePublicAsync(machine.StateMachine.CurrentState.NodeId)
+                    .ConfigureAwait(false),
+                Is.Not.Null);
         }
 
         private static async Task<IList<ReferenceDescription>> BrowseAsync(

--- a/tests/Opc.Ua.Server.Tests/Fluent/FluentAlarmRegistrationIntegrationTests.cs
+++ b/tests/Opc.Ua.Server.Tests/Fluent/FluentAlarmRegistrationIntegrationTests.cs
@@ -315,7 +315,7 @@ namespace Opc.Ua.Server.Tests.Fluent
             manager.AddPredefinedNodeSynchronouslyPublic(root);
 
             var builder = new NodeManagerBuilder(
-                serverSystemContext,
+                manager.SystemContext,
                 nodeManager: manager,
                 defaultNamespaceIndex: ns,
                 rootResolver: q => manager.PredefinedNodes.Values


### PR DESCRIPTION
## Summary

- selectively repair typed instance subtrees during asynchronous registration when null, foreign declaration, or type-colliding NodeIds remain
- preserve caller-assigned IDs in manager-owned namespaces, well-known namespace-zero roots, and standalone foreign nodes
- assign `CreateProgramStateMachine` child NodeIds at the fluent creation point without changing generic synchronous registration semantics
- add `ProgramStateMachineState` regressions proving `CurrentState` descendants are manager-owned and reachable
- document the registration contract and synchronize the bundled migration-plugin copy

## Relationship to #4389

This is a compatibility fix for the existing `AsyncCustomNodeManager` and fluent state-machine paths and should land independently. The node-source work in #4389 has been rebased over this change locally and retains its cancellation-aware lifecycle ordering.

## Validation

| Scope | Result |
| --- | --- |
| Focused `net10.0` NodeId/fluent regressions | Passed |
| Focused `net48` NodeId/fluent regressions | Passed |
| Full `Opc.Ua.Server.Tests` `net10.0` | 4,862 passed, 5 skipped |
| `Opc.Ua.Client.ComplexTypes.Tests` `net10.0` / `net48` | 2,773 passed on each |
| `Opc.Ua.Di.Tests` `net10.0` / `net48` | 424 passed on each |
| `Opc.Ua.InformationModel.Tests` `net10.0` / `net48` | 1,080 passed, 20 skipped on each |
| Migration plugin validation | 15 bundled docs synchronized |
| Full solution build `net10.0` | Succeeded |

## Related Issues

Fixes #4376