### PR TITLE
Allow partial endpoint filters in RoleManager

### DIFF
--- a/docs/RoleBasedUserManagement.md
+++ b/docs/RoleBasedUserManagement.md
@@ -50,8 +50,8 @@ Every mutator returns a `ServiceResult` that mirrors the spec-defined status cod
 - `X509Subject` - `Name=Value(/Name=Value)*` grammar with names from Part 18 Table 10.
 
 `EndpointType` comparisons in identity resolution honour Part 18 4.4.2: fields set to their default value on the rule
-side act as wildcards. A rule may therefore constrain any non-empty subset of the endpoint fields. For example, this
-rule applies to every endpoint URL that uses `SignAndEncrypt`:
+side act as wildcards. A rule may therefore constrain any subset of endpoint fields by assigning non-default values to
+those fields. For example, this rule applies to every endpoint URL that uses `SignAndEncrypt`:
 
 ```csharp
 IRoleManager roles = server.CurrentInstance.RoleManager;

--- a/docs/RoleBasedUserManagement.md
+++ b/docs/RoleBasedUserManagement.md
@@ -49,7 +49,23 @@ Every mutator returns a `ServiceResult` that mirrors the spec-defined status cod
 - `Thumbprint` - upper-case hexadecimal, no spaces.
 - `X509Subject` - `Name=Value(/Name=Value)*` grammar with names from Part 18 Table 10.
 
-`EndpointType` comparisons in identity resolution honour Part 18 4.4.2: fields set to their default value on the rule side act as wildcards.
+`EndpointType` comparisons in identity resolution honour Part 18 4.4.2: fields set to their default value on the rule
+side act as wildcards. A rule may therefore constrain any non-empty subset of the endpoint fields. For example, this
+rule applies to every endpoint URL that uses `SignAndEncrypt`:
+
+```csharp
+IRoleManager roles = server.CurrentInstance.RoleManager;
+
+roles.AddEndpoint(
+    ObjectIds.WellKnownRole_Engineer,
+    new EndpointType
+    {
+        SecurityMode = MessageSecurityMode.SignAndEncrypt
+    });
+```
+
+At least one field must be non-default; `AddEndpoint` returns `Bad_InvalidArgument` for a null or completely default
+`EndpointType`.
 
 > **Identity-claim criteria support**:
 >

--- a/src/Opc.Ua.Server/RoleBasedUserManagement/EndpointTypeComparer.cs
+++ b/src/Opc.Ua.Server/RoleBasedUserManagement/EndpointTypeComparer.cs
@@ -39,6 +39,19 @@ namespace Opc.Ua.Server
     internal static class EndpointTypeComparer
     {
         /// <summary>
+        /// Returns <c>true</c> if at least one field participates in endpoint
+        /// comparison rather than acting as a wildcard.
+        /// </summary>
+        public static bool HasNonDefaultFields(EndpointType? endpoint)
+        {
+            return endpoint != null &&
+                (!IsDefault(endpoint.EndpointUrl) ||
+                    endpoint.SecurityMode != MessageSecurityMode.Invalid ||
+                    !IsDefault(endpoint.SecurityPolicyUri) ||
+                    !IsDefault(endpoint.TransportProfileUri));
+        }
+
+        /// <summary>
         /// Returns <c>true</c> if the candidate endpoint matches the rule
         /// endpoint per §4.4.2 semantics: a field set to the default value on
         /// the rule side acts as a wildcard.

--- a/src/Opc.Ua.Server/RoleBasedUserManagement/IRoleManager.cs
+++ b/src/Opc.Ua.Server/RoleBasedUserManagement/IRoleManager.cs
@@ -120,13 +120,15 @@ namespace Opc.Ua.Server
         ServiceResult RemoveApplication(NodeId roleId, string applicationUri);
 
         /// <summary>
-        /// Adds an endpoint per Part 18 §4.4.9.
+        /// Adds an endpoint per Part 18 §4.4.9. Default-valued fields act as
+        /// wildcards during endpoint comparison per Part 18 §4.4.2.
         /// </summary>
         /// <returns>
         /// <c>Good</c> on success;
         /// <c>Bad_NodeIdUnknown</c> if the role is unknown;
         /// <c>Bad_RequestNotAllowed</c> if the role is reserved;
-        /// <c>Bad_InvalidArgument</c> if the endpoint is null or its URL is empty;
+        /// <c>Bad_InvalidArgument</c> if the endpoint is null or every field has
+        /// its default value;
         /// <c>Bad_AlreadyExists</c> if an equivalent endpoint already exists.
         /// </returns>
         ServiceResult AddEndpoint(NodeId roleId, EndpointType endpoint);

--- a/src/Opc.Ua.Server/RoleBasedUserManagement/RoleManager.cs
+++ b/src/Opc.Ua.Server/RoleBasedUserManagement/RoleManager.cs
@@ -390,10 +390,10 @@ namespace Opc.Ua.Server
         /// <inheritdoc/>
         public ServiceResult AddEndpoint(NodeId roleId, EndpointType endpoint)
         {
-            if (endpoint == null || string.IsNullOrEmpty(endpoint.EndpointUrl))
+            if (!EndpointTypeComparer.HasNonDefaultFields(endpoint))
             {
                 return new ServiceResult(StatusCodes.BadInvalidArgument,
-                    new LocalizedText("Endpoint or its EndpointUrl must be non-empty."));
+                    new LocalizedText("Endpoint must specify at least one non-default field."));
             }
 
             m_lock.EnterWriteLock();

--- a/tests/Opc.Ua.Server.Tests/RoleManagerTests.cs
+++ b/tests/Opc.Ua.Server.Tests/RoleManagerTests.cs
@@ -253,6 +253,83 @@ namespace Opc.Ua.Server.Tests
         }
 
         [Test]
+        public void AddEndpointAcceptsEverySingleFieldConstraint()
+        {
+            using var manager = new RoleManager();
+            EndpointType[] endpoints =
+            [
+                new() { EndpointUrl = "opc.tcp://srv:4840" },
+                new() { SecurityMode = MessageSecurityMode.SignAndEncrypt },
+                new() { SecurityPolicyUri = SecurityPolicies.Basic256Sha256 },
+                new() { TransportProfileUri = "urn:test:transport-profile" }
+            ];
+
+            foreach (EndpointType endpoint in endpoints)
+            {
+                Assert.That(
+                    ServiceResult.IsGood(
+                        manager.AddEndpoint(ObjectIds.WellKnownRole_Observer, endpoint)),
+                    Is.True);
+            }
+
+            RoleEntry? entry = manager.GetRole(ObjectIds.WellKnownRole_Observer);
+            Assert.That(entry, Is.Not.Null);
+            Assert.That(entry!.Endpoints, Has.Count.EqualTo(endpoints.Length));
+        }
+
+        [Test]
+        public void AddEndpointSecurityModeOnlyRuleSupportsDuplicateDetectionAndRemoval()
+        {
+            using var manager = new RoleManager();
+            var endpoint = new EndpointType
+            {
+                SecurityMode = MessageSecurityMode.SignAndEncrypt
+            };
+
+            ServiceResult add = manager.AddEndpoint(
+                ObjectIds.WellKnownRole_Observer,
+                endpoint);
+            Assert.That(ServiceResult.IsGood(add), Is.True);
+
+            RoleEntry? entry = manager.GetRole(ObjectIds.WellKnownRole_Observer);
+            Assert.That(entry, Is.Not.Null);
+            Assert.That(entry!.Endpoints, Has.Count.EqualTo(1));
+            Assert.That(
+                entry.Endpoints[0].SecurityMode,
+                Is.EqualTo(MessageSecurityMode.SignAndEncrypt));
+            Assert.That(string.IsNullOrEmpty(entry.Endpoints[0].EndpointUrl), Is.True);
+
+            ServiceResult duplicate = manager.AddEndpoint(
+                ObjectIds.WellKnownRole_Observer,
+                endpoint);
+            Assert.That(duplicate.StatusCode, Is.EqualTo(StatusCodes.BadAlreadyExists));
+
+            ServiceResult remove = manager.RemoveEndpoint(
+                ObjectIds.WellKnownRole_Observer,
+                endpoint);
+            Assert.That(ServiceResult.IsGood(remove), Is.True);
+            Assert.That(
+                manager.GetRole(ObjectIds.WellKnownRole_Observer)!.Endpoints,
+                Is.Empty);
+        }
+
+        [Test]
+        public void AddEndpointNullOrAllDefaultRuleReturnsBadInvalidArgument()
+        {
+            using var manager = new RoleManager();
+
+            ServiceResult nullEndpoint = manager.AddEndpoint(
+                ObjectIds.WellKnownRole_Observer,
+                null!);
+            ServiceResult defaultEndpoint = manager.AddEndpoint(
+                ObjectIds.WellKnownRole_Observer,
+                new EndpointType());
+
+            Assert.That(nullEndpoint.StatusCode, Is.EqualTo(StatusCodes.BadInvalidArgument));
+            Assert.That(defaultEndpoint.StatusCode, Is.EqualTo(StatusCodes.BadInvalidArgument));
+        }
+
+        [Test]
         public void RemoveRole_OnUnknownRole_ReturnsBadNodeIdUnknown()
         {
             using var manager = new RoleManager();
@@ -626,6 +703,62 @@ namespace Opc.Ua.Server.Tests
                 TransportProfileUri = "http://example/Profile"
             };
             Assert.That(EndpointTypeComparer.Matches(rule, candidate), Is.True);
+        }
+
+        [Test]
+        public void ResolveGrantedRolesSecurityModeOnlyEndpointRuleMatchesAcrossUrls()
+        {
+            using var manager = new RoleManager();
+            Assert.That(
+                ServiceResult.IsGood(
+                    manager.AddIdentity(
+                        ObjectIds.WellKnownRole_Operator,
+                        AuthenticatedUser())),
+                Is.True);
+            Assert.That(
+                ServiceResult.IsGood(
+                    manager.AddEndpoint(
+                        ObjectIds.WellKnownRole_Operator,
+                        new EndpointType
+                        {
+                            SecurityMode = MessageSecurityMode.SignAndEncrypt
+                        })),
+                Is.True);
+            Assert.That(
+                ServiceResult.IsGood(
+                    manager.SetEndpointsExclude(
+                        ObjectIds.WellKnownRole_Operator,
+                        false)),
+                Is.True);
+
+            var identity = new Mock<IUserIdentity>();
+            identity.Setup(i => i.TokenType).Returns(UserTokenType.UserName);
+            identity.Setup(i => i.DisplayName).Returns("operator");
+            identity.Setup(i => i.GrantedRoleIds).Returns([]);
+
+            IList<NodeId> matchingRoles = manager.ResolveGrantedRoles(
+                identity.Object,
+                clientCertificate: null,
+                new EndpointDescription
+                {
+                    EndpointUrl = "opc.tcp://first-host:4840",
+                    SecurityMode = MessageSecurityMode.SignAndEncrypt
+                });
+            IList<NodeId> nonMatchingRoles = manager.ResolveGrantedRoles(
+                identity.Object,
+                clientCertificate: null,
+                new EndpointDescription
+                {
+                    EndpointUrl = "opc.tcp://second-host:4840",
+                    SecurityMode = MessageSecurityMode.Sign
+                });
+
+            Assert.That(
+                matchingRoles,
+                Has.Member(ObjectIds.WellKnownRole_Operator));
+            Assert.That(
+                nonMatchingRoles,
+                Has.No.Member(ObjectIds.WellKnownRole_Operator));
         }
 
         // ----------------------------------------------------------------

--- a/tests/Opc.Ua.Server.Tests/Roles/RoleStateBindingTests.cs
+++ b/tests/Opc.Ua.Server.Tests/Roles/RoleStateBindingTests.cs
@@ -255,6 +255,41 @@ namespace Opc.Ua.Server.Tests.Roles
                 Is.EqualTo(StatusCodes.BadInvalidArgument));
         }
 
+        [Test]
+        public async Task AddEndpointHandlerAuthorisedCallerAcceptsSecurityModeOnlyRule()
+        {
+            ISystemContext ctx = BuildAdminContext(MessageSecurityMode.SignAndEncrypt);
+            var endpoint = new EndpointType
+            {
+                SecurityMode = MessageSecurityMode.SignAndEncrypt
+            };
+
+            ServiceResult? result = await InvokeAddEndpointAsync(ctx, endpoint)
+                .ConfigureAwait(false);
+
+            Assert.That(ServiceResult.IsGood(result), Is.True);
+            RoleEntry? entry = m_roleManager.GetRole(ObjectIds.WellKnownRole_Observer);
+            Assert.That(entry, Is.Not.Null);
+            Assert.That(entry!.Endpoints, Has.Count.EqualTo(1));
+            Assert.That(
+                entry.Endpoints[0].SecurityMode,
+                Is.EqualTo(MessageSecurityMode.SignAndEncrypt));
+            Assert.That(string.IsNullOrEmpty(entry.Endpoints[0].EndpointUrl), Is.True);
+
+            Assume.That(m_roleState.Endpoints, Is.Not.Null);
+            ArrayOf<EndpointType> syncedEndpoints = m_roleState.Endpoints!.Value;
+            Assert.That(syncedEndpoints, Has.Count.EqualTo(1));
+            Assert.That(
+                syncedEndpoints[0].SecurityMode,
+                Is.EqualTo(MessageSecurityMode.SignAndEncrypt));
+            Assert.That(string.IsNullOrEmpty(syncedEndpoints[0].EndpointUrl), Is.True);
+
+            m_auditServer.Verify(a => a.ReportAuditEvent(
+                It.IsAny<ISystemContext>(),
+                It.IsAny<AuditEventState>()),
+                Times.Once);
+        }
+
         // ----------------------------------------------------------------
         // Audit-event firing (Part 18 §4.5)
         // ----------------------------------------------------------------
@@ -1085,6 +1120,23 @@ namespace Opc.Ua.Server.Tests.Roles
             AddIdentityMethodStateResult result = await method.OnCallAsync!(
                 context, method, m_roleState.NodeId, rule, CancellationToken.None)
                 .ConfigureAwait(false);
+            return result.ServiceResult;
+        }
+
+        private async ValueTask<ServiceResult?> InvokeAddEndpointAsync(
+            ISystemContext context, EndpointType endpoint)
+        {
+            AddEndpointMethodState? method = m_roleState.AddEndpoint;
+            Assume.That(method, Is.Not.Null, "AddEndpoint method state should be attached.");
+            Assume.That(method!.OnCallAsync, Is.Not.Null,
+                "Binding should have wired the typed OnCallAsync delegate.");
+
+            AddEndpointMethodStateResult result = await method.OnCallAsync!(
+                context,
+                method,
+                m_roleState.NodeId,
+                endpoint,
+                CancellationToken.None).ConfigureAwait(false);
             return result.ServiceResult;
         }
 


### PR DESCRIPTION
# Description

Align `RoleManager.AddEndpoint` validation with the Part 18 endpoint comparison semantics already implemented by `EndpointTypeComparer`.

- Accept endpoint mapping rules when any `EndpointType` field is non-default, including security-mode-only wildcard filters.
- Continue rejecting null and completely default endpoint rules.
- Preserve duplicate detection, removal, role-change notifications, and the RoleType `AddEndpoint` method path.
- Document partial endpoint filters and their wildcard behavior.

## Related Issues

- Fixes #4412

## Validation

- `Opc.Ua.Server.Tests` `Roles` category on .NET 10: 171 passed.
- `Opc.Ua.Server.Tests` `Roles` category on .NET Framework 4.8: 171 passed.

## Checklist

- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf) and read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [x] I have added all necessary documentation.
- [x] I have verified that my changes do not introduce (new) build or analyzer warnings.
- [ ] I ran **all** tests locally using the **UA.slnx** solution against at least .net **framework** and .net **10**, and all passed.
- [ ] I fixed **all** failing and flaky tests in the CI pipelines and **all** CodeQL warnings.
- [x] I have addressed **all** PR feedback received.
