### PR TITLE
Add node creation to the fluent node manager builder

### DIFF
--- a/docs/NodeManagers.md
+++ b/docs/NodeManagers.md
@@ -47,7 +47,7 @@
     - [On-demand virtual node families](#on-demand-virtual-node-families)
     - [Monitored-item creation and lifecycle](#monitored-item-creation-and-lifecycle)
     - [Creating nodes under other managers' nodes (Objects folder)](#creating-nodes-under-other-managers-nodes-objects-folder)
-    - [Creating nodes from scratch — the `Add*` surface](#creating-nodes-from-scratch--the-add-surface)
+    - [Creating nodes from scratch — the Add* surface](#creating-nodes-from-scratch--the-add-surface)
   - [Typed model-traversal — the Configure(I{Manager}NodeManagerBuilder) partial](#typed-model-traversal--the-configureimanagernodemanagerbuilder-partial)
     - [What the generator emits per model](#what-the-generator-emits-per-model)
     - [Methods with arguments — typed OnCall overloads](#methods-with-arguments--typed-oncall-overloads)

--- a/docs/NodeManagers.md
+++ b/docs/NodeManagers.md
@@ -1193,7 +1193,10 @@ Three properties make this usable straight from `Configure`:
   `INodeIdFactory` before returning, so `OnRead`/`OnWrite`
   registrations, which key off `NodeState.NodeId`, stay valid once the
   node is registered. `machines.Node.NodeId` above is the id clients
-  will browse.
+  will browse. This includes a subtree materialised from a type model
+  with `NodeState.Create(…, assignNodeIds: false)`, whose children still
+  carry their declaration ids: those are rebased at `Add` time rather
+  than at registration, so they too are final when the builder returns.
 - **Creation is staged, not immediate.** Created nodes are held until
   the manager calls `RegisterAuthoredNodesAsync`, which the generated
   `CreateAddressSpaceAsync` emits after the `Configure` partials and

--- a/docs/NodeManagers.md
+++ b/docs/NodeManagers.md
@@ -47,6 +47,7 @@
     - [On-demand virtual node families](#on-demand-virtual-node-families)
     - [Monitored-item creation and lifecycle](#monitored-item-creation-and-lifecycle)
     - [Creating nodes under other managers' nodes (Objects folder)](#creating-nodes-under-other-managers-nodes-objects-folder)
+    - [Creating nodes from scratch — the `Add*` surface](#creating-nodes-from-scratch--the-add-surface)
   - [Typed model-traversal — the Configure(I{Manager}NodeManagerBuilder) partial](#typed-model-traversal--the-configureimanagernodemanagerbuilder-partial)
     - [What the generator emits per model](#what-the-generator-emits-per-model)
     - [Methods with arguments — typed OnCall overloads](#methods-with-arguments--typed-oncall-overloads)
@@ -1148,6 +1149,79 @@ registration through the same pass. This covers **startup-time**
 configuration only — for nodes created after startup use
 `IMasterNodeManager.AddReferencesAsync`, which dispatches to the live
 owning manager.
+
+#### Creating nodes from scratch — the `Add*` surface
+
+`Configure` can also *create* nodes, not just wire callbacks on nodes a
+NodeSet or ModelDesign already declared. `INodeManagerBuilder` carries a
+small creation surface for filling a namespace when there is no model to
+generate from:
+
+| Member | Creates |
+| --- | --- |
+| `AddFolder(name, parentId)` | a `FolderState` (`Organizes`) |
+| `AddObject(name, parentId, typeDefinitionId)` | a `BaseObjectState` |
+| `AddVariable<TValue>(name, parentId)` | a `BaseDataVariableState` whose `DataType`/`ValueRank` come from `TValue` |
+| `AddMethod(name, parentId)` | an executable `MethodState` |
+| `Add<TState>(node, parentId)` | an already-constructed state of any `NodeState` subclass |
+| `Add<TState>(factory, parentId)` | a state built by a factory that receives the resolved parent |
+| `AddRoot<TState>(node)` | a root, with its existing references left alone |
+| `TryGetNode(nodeId, out node)` | lookup across created-but-not-yet-registered nodes and predefined nodes |
+
+Each `Add*` takes the browse name as a `string` — qualified with the
+manager's default namespace — or as a `QualifiedName` carrying an
+explicit nonzero namespace index. `parentId` defaults to the ns=0
+`Objects` folder.
+
+```csharp
+partial void Configure(INodeManagerBuilder builder)
+{
+    INodeBuilder<FolderState> machines = builder.AddFolder("Machines");
+
+    builder.AddVariable<double>("Pressure", machines.Node.NodeId)
+        .OnRead(() => m_sensor.Pressure);
+
+    builder.AddMethod("Reset", machines.Node.NodeId)
+        .OnCall(ResetAsync);
+}
+```
+
+Three properties make this usable straight from `Configure`:
+
+- **NodeIds are final before the builder comes back.** Every `Add*`
+  runs the node — and its whole subtree — through the manager's
+  `INodeIdFactory` before returning, so `OnRead`/`OnWrite`
+  registrations, which key off `NodeState.NodeId`, stay valid once the
+  node is registered. `machines.Node.NodeId` above is the id clients
+  will browse.
+- **Creation is staged, not immediate.** Created nodes are held until
+  the manager calls `RegisterAuthoredNodesAsync`, which the generated
+  `CreateAddressSpaceAsync` emits after the `Configure` partials and
+  before `CompleteConfigureAsync`. That ordering is what lets a node
+  name a sibling created moments earlier, and what gets references to
+  externally owned nodes (the `Objects` folder above) mirrored into
+  `externalReferences` by the same reverse-reference pass described in
+  [Creating nodes under other managers' nodes](#creating-nodes-under-other-managers-nodes-objects-folder).
+- **Custom state types stay typed.** `Add<TState>` returns
+  `INodeBuilder<TState>`, so a hand-written `NodeState` subclass keeps
+  its type through the fluent chain. The factory overload exists for
+  the case where a custom `INodeIdFactory` derives a child id from its
+  parent: it resolves the parent first and hands it to the factory,
+  substituting an identity-only proxy when the parent belongs to
+  another node manager.
+
+Creation is rejected outside that window. Calling an `Add*` after the
+builder is sealed, or after the staged graph has been registered, throws
+`BadInvalidState`. A NodeId in a namespace the manager does not own
+throws `BadNodeIdInvalid`, and a parent in one of the manager's *own*
+namespaces that was never created throws `BadNodeIdUnknown`.
+
+Hand-written managers that drive `CreateFluentBuilder` themselves get
+the same surface by calling
+`FluentNodeManagerBase.RegisterAuthoredNodesAsync(builder)` in the same
+position — after the configuration delegate, before
+`CompleteConfigureAsync`. A builder that created nothing registers
+nothing, so the call is safe to make unconditionally.
 
 ### Typed model-traversal — the `Configure(I{Manager}NodeManagerBuilder)` partial
 

--- a/samples/OpenUsd/SiteCompositionServer/SiteNodeManager.cs
+++ b/samples/OpenUsd/SiteCompositionServer/SiteNodeManager.cs
@@ -149,12 +149,18 @@ namespace SiteComposition
             await base.CreateAddressSpaceAsync(externalReferences, cancellationToken)
                 .ConfigureAwait(false);
 
-            await MaterialiseSiteTopologyAsync(cancellationToken).ConfigureAwait(false);
+            NodeManagerBuilder builder = CreateFluentBuilder(SiteNamespaceIndex);
+            MaterialiseSiteTopology(builder);
             await MaterialiseOpenUsdFacilityAsync(cancellationToken).ConfigureAwait(false);
             await MaterialiseCrossServerCompositionAsync(cancellationToken).ConfigureAwait(false);
 
             LinkOpenUsdRootToServer(externalReferences);
-            LinkAreasToObjectsFolder(externalReferences);
+
+            // Registers the site subtree and mirrors its inverse Organizes
+            // reference to the Objects folder into externalReferences.
+            await RegisterAuthoredNodesAsync(builder, cancellationToken).ConfigureAwait(false);
+            await CompleteConfigureAsync(externalReferences, cancellationToken).ConfigureAwait(false);
+            builder.Seal();
 
             m_log.SiteAddressSpaceReady(
                 m_options.PumpServerEndpointUrl ?? "(none)",
@@ -165,8 +171,8 @@ namespace SiteComposition
         /// Creates a small browsable site hierarchy, so the supervisory server is a
         /// real server rather than a bare stage host.
         /// </summary>
-        /// <param name="cancellationToken">Cancellation token.</param>
-        private async ValueTask MaterialiseSiteTopologyAsync(CancellationToken cancellationToken)
+        /// <param name="builder">The fluent builder staging the site subtree.</param>
+        private void MaterialiseSiteTopology(NodeManagerBuilder builder)
         {
             var areas = new FolderState(null)
             {
@@ -181,10 +187,9 @@ namespace SiteComposition
             AddArea(areas, "PumpHall", "Pump Hall", m_options.PumpServerEndpointUrl);
             AddArea(areas, "Powerhouse", "Powerhouse", m_options.GeneratorServerEndpointUrl);
 
-            SystemContext.AssignInstanceChildNodeIds(areas);
-            await AddPredefinedNodeAsync(SystemContext, areas, cancellationToken)
-                .ConfigureAwait(false);
-            m_areas = areas;
+            // Staging assigns the child NodeIds through this manager's own
+            // New(...) factory and organises the folder under Objects.
+            m_areas = builder.Add(areas).Node;
         }
 
         /// <summary>
@@ -407,25 +412,8 @@ namespace SiteComposition
                 ReferenceTypeIds.HasComponent, false, m_openUsdRoot.NodeId));
         }
 
-        /// <summary>
-        /// Organises the site folder under Objects so a client can browse to it.
-        /// </summary>
-        /// <param name="externalReferences">The shared reference dictionary.</param>
-        private void LinkAreasToObjectsFolder(IDictionary<NodeId, IList<IReference>> externalReferences)
-        {
-            if (m_areas == null)
-            {
-                return;
-            }
-            if (!externalReferences.TryGetValue(Opc.Ua.ObjectIds.ObjectsFolder, out IList<IReference>? refs))
-            {
-                refs = new List<IReference>();
-                externalReferences[Opc.Ua.ObjectIds.ObjectsFolder] = refs;
-            }
-            refs.Add(new NodeStateReference(ReferenceTypeIds.Organizes, false, m_areas.NodeId));
-            m_areas.AddReference(ReferenceTypeIds.Organizes, true, Opc.Ua.ObjectIds.ObjectsFolder);
-        }
     }
+
 
     /// <summary>
     /// Namespaces this sample owns.

--- a/src/Opc.Ua.ISA95.Server/Isa95NodeManager.cs
+++ b/src/Opc.Ua.ISA95.Server/Isa95NodeManager.cs
@@ -113,10 +113,19 @@ namespace Opc.Ua.ISA95.Server
                 .ConfigureAwait(false);
 
             await CreateV2StatusEventTypeAsync(cancellationToken).ConfigureAwait(false);
-            Root = CreateRoot(externalReferences);
+            NodeManagerBuilder builder = CreateFluentBuilder(InstanceNamespaceIndex);
+            Root = CreateRoot();
             CreateJobControlV1Endpoints(Root);
             CreateJobControlV2Endpoints(Root);
-            await AddPredefinedNodeAsync(Root, cancellationToken).ConfigureAwait(false);
+
+            // Staged once the endpoints are attached, so the whole subtree is
+            // registered together and the reverse-reference pass publishes the
+            // root's Organizes edge to the Objects folder.
+            builder.Add(Root);
+            await RegisterAuthoredNodesAsync(builder, cancellationToken).ConfigureAwait(false);
+            await CompleteConfigureAsync(externalReferences, cancellationToken)
+                .ConfigureAwait(false);
+            builder.Seal();
             await ConfigureCommonModelAsync(Root, cancellationToken).ConfigureAwait(false);
             ConfigureCatalogChanges();
             await RefreshJobOrderListsAsync(cancellationToken).ConfigureAwait(false);
@@ -144,10 +153,15 @@ namespace Opc.Ua.ISA95.Server
             base.Dispose(disposing);
         }
 
-        private FolderState CreateRoot(
-            IDictionary<NodeId, IList<IReference>> externalReferences)
+        /// <summary>
+        /// Builds the instance root with an explicit string NodeId, which stays
+        /// the address clients browse. Staging it supplies the inverse
+        /// Organizes reference to the Objects folder and publishes the matching
+        /// forward edge through the reverse-reference pass.
+        /// </summary>
+        private FolderState CreateRoot()
         {
-            var root = new FolderState(null)
+            return new FolderState(null)
             {
                 SymbolicName = m_options.RootBrowseName,
                 NodeId = new NodeId(m_options.RootBrowseName, InstanceNamespaceIndex),
@@ -158,24 +172,6 @@ namespace Opc.Ua.ISA95.Server
                 TypeDefinitionId = Ua.ObjectTypeIds.FolderType,
                 ReferenceTypeId = Ua.ReferenceTypeIds.Organizes
             };
-            root.AddReference(
-                Ua.ReferenceTypeIds.Organizes,
-                isInverse: true,
-                Ua.ObjectIds.ObjectsFolder);
-            if (!externalReferences.TryGetValue(
-                Ua.ObjectIds.ObjectsFolder,
-                out IList<IReference>? references))
-            {
-                references = [];
-                externalReferences[Ua.ObjectIds.ObjectsFolder] =
-                    references;
-            }
-            references.Add(
-                new NodeStateReference(
-                    Ua.ReferenceTypeIds.Organizes,
-                    isInverse: false,
-                    root.NodeId));
-            return root;
         }
 
         private void CreateJobControlV1Endpoints(FolderState root)

--- a/src/Opc.Ua.Server/Fluent/FluentNodeManagerBase.cs
+++ b/src/Opc.Ua.Server/Fluent/FluentNodeManagerBase.cs
@@ -367,6 +367,39 @@ namespace Opc.Ua.Server.Fluent
             return AddReverseReferencesAsync(externalReferences, cancellationToken);
         }
 
+        /// <summary>
+        /// Registers every node staged by the builder's <c>Add*</c> methods
+        /// with this manager.
+        /// </summary>
+        /// <remarks>
+        /// Call this once, after the user's <c>Configure</c> delegates return
+        /// and before <see cref="CompleteConfigureAsync"/>, so that the
+        /// reverse-reference pass sees the newly registered nodes and mirrors
+        /// their references to nodes owned by other managers (typically the
+        /// Objects folder) into <c>externalReferences</c>. A builder that
+        /// staged no nodes registers nothing, so the call is safe to make
+        /// unconditionally. The source-generated
+        /// <c>CreateAddressSpaceAsync</c> emits it for you.
+        /// </remarks>
+        /// <param name="builder">The builder whose staged nodes to register.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <exception cref="System.ArgumentNullException">
+        /// <paramref name="builder"/> is <c>null</c>.
+        /// </exception>
+        protected ValueTask RegisterAuthoredNodesAsync(
+            NodeManagerBuilder builder,
+            CancellationToken cancellationToken = default)
+        {
+            if (builder == null)
+            {
+                throw new System.ArgumentNullException(nameof(builder));
+            }
+
+            return builder.RegisterAuthoredNodesAsync(
+                (node, ct) => AddPredefinedNodeAsync(SystemContext, node, ct),
+                cancellationToken);
+        }
+
         /// <inheritdoc/>
         protected override async ValueTask<NodeHandle> GetManagerHandleAsync(
             ServerSystemContext context,

--- a/src/Opc.Ua.Server/Fluent/INodeManagerBuilder.cs
+++ b/src/Opc.Ua.Server/Fluent/INodeManagerBuilder.cs
@@ -27,6 +27,8 @@
  * http://opcfoundation.org/License/MIT/1.00/
  * ======================================================================*/
 
+using System;
+
 namespace Opc.Ua.Server.Fluent
 {
     /// <summary>
@@ -302,5 +304,192 @@ namespace Opc.Ua.Server.Fluent
         /// disambiguator matches no candidate.
         /// </exception>
         IVariableBuilder<TValue> VariableFromDataTypeId<TValue>(NodeId dataTypeId, QualifiedName browseName);
+
+        /// <summary>
+        /// Adds an already constructed state to the manager's graph and
+        /// preserves any caller-assigned NodeIds.
+        /// </summary>
+        /// <remarks>
+        /// The node — and every child in its subtree — receives a final
+        /// NodeId from the manager's <see cref="INodeIdFactory"/> before this
+        /// method returns, so callbacks wired onto the returned builder key
+        /// off ids that survive registration unchanged.
+        /// </remarks>
+        /// <typeparam name="TState">The concrete state type.</typeparam>
+        /// <param name="node">The node or node subtree to add.</param>
+        /// <param name="parentId">
+        /// The parent NodeId. The default places instance nodes below
+        /// <see cref="ObjectIds.ObjectsFolder"/>.
+        /// </param>
+        /// <returns>A typed fluent builder for the added node.</returns>
+        /// <exception cref="ServiceResultException">
+        /// <list type="bullet">
+        ///   <item><description><see cref="StatusCodes.BadBrowseNameInvalid"/> —
+        ///   the node has no browse name.</description></item>
+        ///   <item><description><see cref="StatusCodes.BadNodeIdUnknown"/> —
+        ///   <paramref name="parentId"/> names a node in one of this manager's
+        ///   own namespaces that has not been added yet.</description></item>
+        ///   <item><description><see cref="StatusCodes.BadNodeIdExists"/> —
+        ///   the assigned NodeId collides with an existing node.</description></item>
+        /// </list>
+        /// </exception>
+        INodeBuilder<TState> Add<TState>(TState node, NodeId parentId = default)
+            where TState : NodeState;
+
+        /// <summary>
+        /// Creates and adds a typed state after resolving the parent identity,
+        /// so a custom <see cref="INodeIdFactory"/> can derive the child's id
+        /// from its final parent.
+        /// </summary>
+        /// <typeparam name="TState">The concrete state type.</typeparam>
+        /// <param name="factory">
+        /// Creates the state from the resolved parent, or from an
+        /// identity-only proxy when the parent belongs to another node
+        /// manager.
+        /// </param>
+        /// <param name="parentId">
+        /// The parent NodeId. The default places instance nodes below
+        /// <see cref="ObjectIds.ObjectsFolder"/>.
+        /// </param>
+        /// <returns>A typed fluent builder for the added node.</returns>
+        /// <exception cref="ServiceResultException">
+        /// Same conditions as <see cref="Add{TState}(TState, NodeId)"/>.
+        /// </exception>
+        INodeBuilder<TState> Add<TState>(
+            Func<NodeState?, TState> factory,
+            NodeId parentId = default)
+            where TState : NodeState;
+
+        /// <summary>
+        /// Adds a pre-built root without synthesizing an Objects-folder
+        /// parent. References already present on the root are preserved.
+        /// </summary>
+        /// <typeparam name="TState">The concrete state type.</typeparam>
+        /// <param name="node">The root node or subtree to add.</param>
+        /// <returns>A typed fluent builder for the added root.</returns>
+        INodeBuilder<TState> AddRoot<TState>(TState node)
+            where TState : NodeState;
+
+        /// <summary>
+        /// Attempts to resolve a node that was added through this builder but
+        /// is not registered with the manager yet, falling back to the
+        /// manager's predefined nodes.
+        /// </summary>
+        /// <param name="nodeId">The NodeId to look up.</param>
+        /// <param name="node">The resolved node, or <c>null</c>.</param>
+        /// <returns><c>true</c> when a node was found.</returns>
+        bool TryGetNode(NodeId nodeId, out NodeState? node);
+
+        /// <summary>
+        /// Creates a folder in the manager's default namespace.
+        /// </summary>
+        /// <param name="browseName">
+        /// Browse name, qualified with the builder's default namespace index.
+        /// </param>
+        /// <param name="parentId">
+        /// The parent NodeId. The default places the folder below
+        /// <see cref="ObjectIds.ObjectsFolder"/>.
+        /// </param>
+        INodeBuilder<FolderState> AddFolder(
+            string browseName,
+            NodeId parentId = default);
+
+        /// <summary>
+        /// Creates a folder using an explicitly namespaced browse name.
+        /// </summary>
+        /// <param name="browseName">
+        /// Browse name carrying a nonzero namespace index.
+        /// </param>
+        /// <param name="parentId">See <see cref="AddFolder(string, NodeId)"/>.</param>
+        INodeBuilder<FolderState> AddFolder(
+            QualifiedName browseName,
+            NodeId parentId = default);
+
+        /// <summary>
+        /// Creates an object in the manager's default namespace.
+        /// </summary>
+        /// <param name="browseName">
+        /// Browse name, qualified with the builder's default namespace index.
+        /// </param>
+        /// <param name="parentId">
+        /// The parent NodeId. The default places the object below
+        /// <see cref="ObjectIds.ObjectsFolder"/>.
+        /// </param>
+        /// <param name="typeDefinitionId">
+        /// Type definition to apply; defaults to
+        /// <see cref="ObjectTypeIds.BaseObjectType"/>.
+        /// </param>
+        INodeBuilder<BaseObjectState> AddObject(
+            string browseName,
+            NodeId parentId = default,
+            NodeId typeDefinitionId = default);
+
+        /// <summary>
+        /// Creates an object using an explicitly namespaced browse name.
+        /// </summary>
+        /// <param name="browseName">
+        /// Browse name carrying a nonzero namespace index.
+        /// </param>
+        /// <param name="parentId">See <see cref="AddObject(string, NodeId, NodeId)"/>.</param>
+        /// <param name="typeDefinitionId">See <see cref="AddObject(string, NodeId, NodeId)"/>.</param>
+        INodeBuilder<BaseObjectState> AddObject(
+            QualifiedName browseName,
+            NodeId parentId = default,
+            NodeId typeDefinitionId = default);
+
+        /// <summary>
+        /// Creates a data variable in the manager's default namespace whose
+        /// DataType and ValueRank are derived from
+        /// <typeparamref name="TValue"/>.
+        /// </summary>
+        /// <typeparam name="TValue">The CLR type of the variable value.</typeparam>
+        /// <param name="browseName">
+        /// Browse name, qualified with the builder's default namespace index.
+        /// </param>
+        /// <param name="parentId">
+        /// The parent NodeId. The default places the variable below
+        /// <see cref="ObjectIds.ObjectsFolder"/>.
+        /// </param>
+        IVariableBuilder<TValue> AddVariable<TValue>(
+            string browseName,
+            NodeId parentId = default);
+
+        /// <summary>
+        /// Creates a data variable using an explicitly namespaced browse name.
+        /// </summary>
+        /// <typeparam name="TValue">The CLR type of the variable value.</typeparam>
+        /// <param name="browseName">
+        /// Browse name carrying a nonzero namespace index.
+        /// </param>
+        /// <param name="parentId">See <see cref="AddVariable{TValue}(string, NodeId)"/>.</param>
+        IVariableBuilder<TValue> AddVariable<TValue>(
+            QualifiedName browseName,
+            NodeId parentId = default);
+
+        /// <summary>
+        /// Creates an executable method in the manager's default namespace.
+        /// </summary>
+        /// <param name="browseName">
+        /// Browse name, qualified with the builder's default namespace index.
+        /// </param>
+        /// <param name="parentId">
+        /// The parent NodeId. The default places the method below
+        /// <see cref="ObjectIds.ObjectsFolder"/>.
+        /// </param>
+        INodeBuilder<MethodState> AddMethod(
+            string browseName,
+            NodeId parentId = default);
+
+        /// <summary>
+        /// Creates an executable method using an explicitly namespaced browse
+        /// name.
+        /// </summary>
+        /// <param name="browseName">
+        /// Browse name carrying a nonzero namespace index.
+        /// </param>
+        /// <param name="parentId">See <see cref="AddMethod(string, NodeId)"/>.</param>
+        INodeBuilder<MethodState> AddMethod(
+            QualifiedName browseName,
+            NodeId parentId = default);
     }
 }

--- a/src/Opc.Ua.Server/Fluent/NodeManagerBuilder.Authoring.cs
+++ b/src/Opc.Ua.Server/Fluent/NodeManagerBuilder.Authoring.cs
@@ -1,0 +1,804 @@
+/* ========================================================================
+ * Copyright (c) 2005-2026 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Opc.Ua.Server.Fluent
+{
+    /// <summary>
+    /// Node creation half of the fluent builder. Nodes staged here are held
+    /// in an authored-roots list until
+    /// <see cref="RegisterAuthoredNodesAsync"/> hands them to the manager,
+    /// which happens after the user's <c>Configure</c> delegates return and
+    /// before the builder is sealed.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Every staged node receives its final NodeId from the manager's
+    /// <see cref="INodeIdFactory"/> before the returned per-node builder is
+    /// handed back, so <c>OnRead</c>/<c>OnWrite</c> registrations — which key
+    /// off <see cref="NodeState.NodeId"/> — remain valid once the node is
+    /// registered.
+    /// </para>
+    /// <para>
+    /// Staging rather than registering immediately keeps the fluent surface
+    /// usable from a <c>Configure</c> partial that runs before the manager
+    /// has finished building its address space, and lets a node reference an
+    /// authored sibling that has not been registered yet.
+    /// </para>
+    /// </remarks>
+    public sealed partial class NodeManagerBuilder
+    {
+        /// <inheritdoc/>
+        public INodeBuilder<TState> Add<TState>(TState node, NodeId parentId = default)
+            where TState : NodeState
+        {
+            return AddNode(node, parentId, attachDefaultParent: true);
+        }
+
+        /// <inheritdoc/>
+        public INodeBuilder<TState> Add<TState>(
+            Func<NodeState?, TState> factory,
+            NodeId parentId = default)
+            where TState : NodeState
+        {
+            ThrowIfSealed();
+            ThrowIfAuthoredNodesRegistered();
+            if (factory is null)
+            {
+                throw new ArgumentNullException(nameof(factory));
+            }
+
+            NodeId effectiveParentId = parentId.IsNull
+                ? ObjectIds.ObjectsFolder
+                : parentId;
+            NodeState? parent = ResolveAuthoredOrRegisteredNode(effectiveParentId);
+            if (parent is null && IsOwnedNamespace(effectiveParentId.NamespaceIndex))
+            {
+                throw ServiceResultException.Create(
+                    StatusCodes.BadNodeIdUnknown,
+                    "Parent '{0}' belongs to this node manager but has not been added.",
+                    effectiveParentId);
+            }
+
+            // The factory is handed an identity-only proxy when the parent
+            // lives in another node manager, so a NodeId factory that derives
+            // child ids from the parent still sees the real parent identity.
+            NodeState factoryParent = parent ?? new ExternalParentState(effectiveParentId);
+            TState node = factory(factoryParent) ??
+                throw new InvalidOperationException(
+                    "The node factory returned null.");
+            if (parent is null &&
+                node is BaseInstanceState instance &&
+                ReferenceEquals(instance.Parent, factoryParent))
+            {
+                // The proxy is a stand-in for identity only, so drop the
+                // parent link the factory established. AddChild/RemoveChild
+                // is the only public way to clear BaseInstanceState.Parent.
+                factoryParent.AddChild(instance);
+                factoryParent.RemoveChild(instance);
+            }
+
+            return AddNode(node, parentId, attachDefaultParent: true);
+        }
+
+        /// <inheritdoc/>
+        public INodeBuilder<TState> AddRoot<TState>(TState node)
+            where TState : NodeState
+        {
+            return AddNode(node, NodeId.Null, attachDefaultParent: false);
+        }
+
+        /// <inheritdoc/>
+        public bool TryGetNode(NodeId nodeId, out NodeState? node)
+        {
+            if (nodeId.IsNull)
+            {
+                node = null;
+                return false;
+            }
+
+            if (m_authoredNodes.TryGetValue(nodeId, out node))
+            {
+                return true;
+            }
+
+            node = m_nodeIdResolver(nodeId);
+            return node is not null;
+        }
+
+        /// <inheritdoc/>
+        public INodeBuilder<FolderState> AddFolder(
+            string browseName,
+            NodeId parentId = default)
+        {
+            return AddFolderCore(CreateDefaultBrowseName(browseName), parentId);
+        }
+
+        /// <inheritdoc/>
+        public INodeBuilder<FolderState> AddFolder(
+            QualifiedName browseName,
+            NodeId parentId = default)
+        {
+            return AddFolderCore(ValidateExplicitBrowseName(browseName), parentId);
+        }
+
+        /// <inheritdoc/>
+        public INodeBuilder<BaseObjectState> AddObject(
+            string browseName,
+            NodeId parentId = default,
+            NodeId typeDefinitionId = default)
+        {
+            return AddObjectCore(
+                CreateDefaultBrowseName(browseName),
+                parentId,
+                typeDefinitionId);
+        }
+
+        /// <inheritdoc/>
+        public INodeBuilder<BaseObjectState> AddObject(
+            QualifiedName browseName,
+            NodeId parentId = default,
+            NodeId typeDefinitionId = default)
+        {
+            return AddObjectCore(
+                ValidateExplicitBrowseName(browseName),
+                parentId,
+                typeDefinitionId);
+        }
+
+        /// <inheritdoc/>
+        public IVariableBuilder<TValue> AddVariable<TValue>(
+            string browseName,
+            NodeId parentId = default)
+        {
+            return AddVariableCore<TValue>(
+                CreateDefaultBrowseName(browseName),
+                parentId);
+        }
+
+        /// <inheritdoc/>
+        public IVariableBuilder<TValue> AddVariable<TValue>(
+            QualifiedName browseName,
+            NodeId parentId = default)
+        {
+            return AddVariableCore<TValue>(
+                ValidateExplicitBrowseName(browseName),
+                parentId);
+        }
+
+        /// <inheritdoc/>
+        public INodeBuilder<MethodState> AddMethod(
+            string browseName,
+            NodeId parentId = default)
+        {
+            return AddMethodCore(CreateDefaultBrowseName(browseName), parentId);
+        }
+
+        /// <inheritdoc/>
+        public INodeBuilder<MethodState> AddMethod(
+            QualifiedName browseName,
+            NodeId parentId = default)
+        {
+            return AddMethodCore(ValidateExplicitBrowseName(browseName), parentId);
+        }
+
+        /// <summary>
+        /// Hands every staged root to <paramref name="register"/> in the order
+        /// it was added. Called once by the owning manager between the user's
+        /// <c>Configure</c> delegates and <see cref="Seal"/>; a manager that
+        /// staged no nodes registers nothing.
+        /// </summary>
+        /// <param name="register">
+        /// Registers one root subtree with the manager; typically
+        /// <c>AddPredefinedNodeAsync</c>.
+        /// </param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="register"/> is null.
+        /// </exception>
+        /// <exception cref="ServiceResultException">
+        /// <see cref="StatusCodes.BadInvalidState"/> — the builder is sealed
+        /// or the staged graph was already registered.
+        /// </exception>
+        public async ValueTask RegisterAuthoredNodesAsync(
+            Func<NodeState, CancellationToken, ValueTask> register,
+            CancellationToken cancellationToken = default)
+        {
+            ThrowIfSealed();
+            if (register is null)
+            {
+                throw new ArgumentNullException(nameof(register));
+            }
+            ThrowIfAuthoredNodesRegistered();
+
+            m_authoredNodesRegistered = true;
+            foreach (NodeState root in m_authoredRoots)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                await register(root, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
+        /// Gets the roots staged by the <c>Add*</c> methods, in insertion
+        /// order.
+        /// </summary>
+        internal IReadOnlyList<NodeState> AuthoredRoots => m_authoredRoots;
+
+        private NodeBuilder<TState> AddNode<TState>(
+            TState node,
+            NodeId parentId,
+            bool attachDefaultParent)
+            where TState : NodeState
+        {
+            ThrowIfSealed();
+            ThrowIfAuthoredNodesRegistered();
+            if (node is null)
+            {
+                throw new ArgumentNullException(nameof(node));
+            }
+
+            AttachToParent(node, parentId, attachDefaultParent);
+            PrepareNodeIds(node);
+            IndexAuthoredSubtree(node);
+
+            // A node hung off an already staged parent is registered with that
+            // parent's subtree, so only unparented nodes become roots.
+            if (!HasAuthoredAncestor(node))
+            {
+                AddAuthoredRoot(node);
+            }
+
+            return new NodeBuilder<TState>(this, node);
+        }
+
+        private NodeBuilder<FolderState> AddFolderCore(
+            QualifiedName browseName,
+            NodeId parentId)
+        {
+            string symbolicName = browseName.Name!;
+            var folder = new FolderState(null)
+            {
+                SymbolicName = symbolicName,
+                BrowseName = browseName,
+                DisplayName = new LocalizedText(symbolicName),
+                ReferenceTypeId = ReferenceTypeIds.Organizes,
+                TypeDefinitionId = ObjectTypeIds.FolderType
+            };
+            return AddNode(folder, parentId, attachDefaultParent: true);
+        }
+
+        private NodeBuilder<BaseObjectState> AddObjectCore(
+            QualifiedName browseName,
+            NodeId parentId,
+            NodeId typeDefinitionId)
+        {
+            string symbolicName = browseName.Name!;
+            var instance = new BaseObjectState(null)
+            {
+                SymbolicName = symbolicName,
+                BrowseName = browseName,
+                DisplayName = new LocalizedText(symbolicName),
+                TypeDefinitionId = typeDefinitionId.IsNull
+                    ? ObjectTypeIds.BaseObjectType
+                    : typeDefinitionId
+            };
+            return AddNode(instance, parentId, attachDefaultParent: true);
+        }
+
+        private VariableBuilder<TValue> AddVariableCore<TValue>(
+            QualifiedName browseName,
+            NodeId parentId)
+        {
+            string symbolicName = browseName.Name!;
+            var variable = new BaseDataVariableState(null)
+            {
+                SymbolicName = symbolicName,
+                BrowseName = browseName,
+                DisplayName = new LocalizedText(symbolicName),
+                TypeDefinitionId = VariableTypeIds.BaseDataVariableType,
+                DataType = TypeInfo.GetDataTypeId(typeof(TValue), Context.NamespaceUris),
+                ValueRank = TypeInfo.GetValueRank(typeof(TValue)),
+                AccessLevel = AccessLevels.CurrentRead,
+                UserAccessLevel = AccessLevels.CurrentRead
+            };
+            NodeBuilder<BaseDataVariableState> nodeBuilder = AddNode(
+                variable,
+                parentId,
+                attachDefaultParent: true);
+            return ToVariableBuilder<TValue>(nodeBuilder.Node, browseName.ToString());
+        }
+
+        private NodeBuilder<MethodState> AddMethodCore(
+            QualifiedName browseName,
+            NodeId parentId)
+        {
+            string symbolicName = browseName.Name!;
+            var method = new MethodState(null)
+            {
+                SymbolicName = symbolicName,
+                BrowseName = browseName,
+                DisplayName = new LocalizedText(symbolicName),
+                Executable = true,
+                UserExecutable = true
+            };
+            return AddNode(method, parentId, attachDefaultParent: true);
+        }
+
+        /// <summary>
+        /// Resolves a browse-path root against the staged roots first so a
+        /// <c>Node("MyFolder/Child")</c> lookup can reach a node added earlier
+        /// in the same <c>Configure</c> pass.
+        /// </summary>
+        private NodeState ResolveRoot(QualifiedName browseName)
+        {
+            foreach (NodeState root in m_authoredRoots)
+            {
+                if (root.BrowseName == browseName)
+                {
+                    return root;
+                }
+            }
+            return m_rootResolver(browseName);
+        }
+
+        /// <summary>
+        /// Merges the staged nodes matching <paramref name="predicate"/> into
+        /// the resolver-supplied candidates so type- and DataType-keyed
+        /// lookups also see nodes added in this pass.
+        /// </summary>
+        private IReadOnlyList<NodeState> CollectAuthoredCandidates(
+            IReadOnlyList<NodeState> resolved,
+            Func<NodeState, bool> predicate)
+        {
+            if (m_authoredNodes.Count == 0)
+            {
+                return resolved;
+            }
+
+            List<NodeState> candidates = MatchAuthoredNodes(predicate);
+            for (int i = 0; i < resolved.Count; i++)
+            {
+                if (!ContainsByReference(candidates, resolved[i]))
+                {
+                    candidates.Add(resolved[i]);
+                }
+            }
+            return candidates;
+        }
+
+        /// <inheritdoc cref="CollectAuthoredCandidates(IReadOnlyList{NodeState}, Func{NodeState, bool})"/>
+        private List<NodeState> CollectAuthoredCandidates(
+            ArrayOf<NodeState> resolved,
+            Func<NodeState, bool> predicate)
+        {
+            List<NodeState> candidates = m_authoredNodes.Count == 0
+                ? []
+                : MatchAuthoredNodes(predicate);
+            for (int i = 0; i < resolved.Count; i++)
+            {
+                if (!ContainsByReference(candidates, resolved[i]))
+                {
+                    candidates.Add(resolved[i]);
+                }
+            }
+            return candidates;
+        }
+
+        private List<NodeState> MatchAuthoredNodes(Func<NodeState, bool> predicate)
+        {
+            var candidates = new List<NodeState>();
+            foreach (NodeState authored in m_authoredNodes.Values)
+            {
+                if (predicate(authored))
+                {
+                    candidates.Add(authored);
+                }
+            }
+            return candidates;
+        }
+
+        private static bool ContainsByReference(
+            List<NodeState> candidates,
+            NodeState candidate)
+        {
+            for (int i = 0; i < candidates.Count; i++)
+            {
+                if (ReferenceEquals(candidates[i], candidate))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Links an instance to its parent, defaulting an unparented instance
+        /// to the Objects folder. A parent owned by another node manager gets
+        /// an inverse reference instead of a hard parent link.
+        /// </summary>
+        private void AttachToParent(
+            NodeState node,
+            NodeId parentId,
+            bool attachDefaultParent)
+        {
+            if (node is not BaseInstanceState instance)
+            {
+                if (!parentId.IsNull)
+                {
+                    throw ServiceResultException.Create(
+                        StatusCodes.BadNodeClassInvalid,
+                        "Node '{0}' is not an instance and cannot be attached to parent '{1}'.",
+                        node.BrowseName,
+                        parentId);
+                }
+                return;
+            }
+
+            bool useDefaultReferenceType = instance.ReferenceTypeId.IsNull;
+            NodeState? parent = instance.Parent;
+            NodeId effectiveParentId = parentId;
+            if (parent != null)
+            {
+                if (!parentId.IsNull && parent.NodeId != parentId)
+                {
+                    throw ServiceResultException.Create(
+                        StatusCodes.BadInvalidArgument,
+                        "Node '{0}' is already attached to parent '{1}', not '{2}'.",
+                        node.BrowseName,
+                        parent.NodeId,
+                        parentId);
+                }
+
+                effectiveParentId = parent.NodeId;
+                if (effectiveParentId.IsNull)
+                {
+                    throw ServiceResultException.Create(
+                        StatusCodes.BadNodeIdInvalid,
+                        "The existing parent of node '{0}' has no NodeId.",
+                        node.BrowseName);
+                }
+
+                bool knownParent = IsStagedNode(parent) ||
+                    ReferenceEquals(m_nodeIdResolver(effectiveParentId), parent);
+                if (!knownParent)
+                {
+                    throw ServiceResultException.Create(
+                        StatusCodes.BadNodeIdUnknown,
+                        "The existing parent '{0}' of node '{1}' is not part of this graph or address space.",
+                        effectiveParentId,
+                        node.BrowseName);
+                }
+            }
+            else
+            {
+                if (effectiveParentId.IsNull && attachDefaultParent)
+                {
+                    effectiveParentId = ObjectIds.ObjectsFolder;
+                }
+
+                if (!effectiveParentId.IsNull)
+                {
+                    parent = ResolveAuthoredOrRegisteredNode(effectiveParentId);
+                }
+
+                if (parent == null && IsOwnedNamespace(effectiveParentId.NamespaceIndex))
+                {
+                    throw ServiceResultException.Create(
+                        StatusCodes.BadNodeIdUnknown,
+                        "Parent '{0}' belongs to this node manager but has not been added.",
+                        effectiveParentId);
+                }
+            }
+
+            if (useDefaultReferenceType && !effectiveParentId.IsNull)
+            {
+                instance.ReferenceTypeId =
+                    effectiveParentId == ObjectIds.ObjectsFolder || instance is FolderState
+                        ? ReferenceTypeIds.Organizes
+                        : ReferenceTypeIds.HasComponent;
+            }
+
+            if (parent != null)
+            {
+                AddChildIfMissing(parent, instance);
+                return;
+            }
+
+            if (!effectiveParentId.IsNull)
+            {
+                instance.AddReferenceIfMissing(
+                    instance.ReferenceTypeId,
+                    true,
+                    effectiveParentId);
+            }
+        }
+
+        /// <summary>
+        /// Assigns final NodeIds to the subtree so the returned builder can
+        /// register id-keyed callbacks straight away.
+        /// </summary>
+        private void PrepareNodeIds(NodeState node)
+        {
+            if (node.BrowseName.IsNull)
+            {
+                throw ServiceResultException.Create(
+                    StatusCodes.BadBrowseNameInvalid,
+                    "A node added to the graph must have a browse name.");
+            }
+            if (NodeManager is not AsyncCustomNodeManager manager)
+            {
+                throw ServiceResultException.Create(
+                    StatusCodes.BadConfigurationError,
+                    "Node creation requires an AsyncCustomNodeManager-backed builder.");
+            }
+
+            manager.PrepareAuthoredNodeIdsForRegistration(node);
+            if (node.NodeId.IsNull)
+            {
+                node.NodeId = Context.RequireNodeIdFactory().New(Context, node);
+            }
+            if (node.NodeId.IsNull)
+            {
+                throw ServiceResultException.Create(
+                    StatusCodes.BadConfigurationError,
+                    "The NodeId factory did not assign an id to node '{0}'.",
+                    node.BrowseName);
+            }
+            ValidateAuthoredNodeId(manager, node);
+
+            // The root pass above already covered the whole subtree, so the
+            // descendants only need their namespace checked.
+            var descendants = new List<BaseInstanceState>();
+            var children = new List<BaseInstanceState>();
+            node.GetChildren(Context, descendants);
+            for (int i = 0; i < descendants.Count; i++)
+            {
+                BaseInstanceState child = descendants[i];
+                ValidateAuthoredNodeId(manager, child);
+                children.Clear();
+                child.GetChildren(Context, children);
+                descendants.AddRange(children);
+            }
+        }
+
+        private NodeState? ResolveAuthoredOrRegisteredNode(NodeId nodeId)
+        {
+            if (nodeId.IsNull)
+            {
+                return null;
+            }
+            if (m_authoredNodes.TryGetValue(nodeId, out NodeState? authored))
+            {
+                return authored;
+            }
+            return m_nodeIdResolver(nodeId);
+        }
+
+        private void IndexAuthoredSubtree(NodeState root)
+        {
+            var nodes = new List<NodeState> { root };
+            var children = new List<BaseInstanceState>();
+            for (int i = 0; i < nodes.Count; i++)
+            {
+                NodeState node = nodes[i];
+                IndexAuthoredNode(node);
+
+                children.Clear();
+                node.GetChildren(Context, children);
+                nodes.AddRange(children);
+            }
+        }
+
+        private void IndexAuthoredNode(NodeState node)
+        {
+            if (node.NodeId.IsNull)
+            {
+                throw ServiceResultException.Create(
+                    StatusCodes.BadConfigurationError,
+                    "The NodeId factory did not assign an id to node '{0}'.",
+                    node.BrowseName);
+            }
+
+            if (m_authoredNodes.TryGetValue(node.NodeId, out NodeState? existing))
+            {
+                if (!ReferenceEquals(existing, node))
+                {
+                    throw ServiceResultException.Create(
+                        StatusCodes.BadNodeIdExists,
+                        "NodeId '{0}' is already used by node '{1}'.",
+                        node.NodeId,
+                        existing.BrowseName);
+                }
+                return;
+            }
+
+            NodeState? predefined = m_nodeIdResolver(node.NodeId);
+            if (predefined != null && !ReferenceEquals(predefined, node))
+            {
+                throw ServiceResultException.Create(
+                    StatusCodes.BadNodeIdExists,
+                    "NodeId '{0}' is already used by a predefined node.",
+                    node.NodeId);
+            }
+            m_authoredNodes.Add(node.NodeId, node);
+        }
+
+        private bool HasAuthoredAncestor(NodeState node)
+        {
+            for (NodeState? current = node is BaseInstanceState instance
+                    ? instance.Parent
+                    : null;
+                current != null;
+                current = current is BaseInstanceState parentInstance
+                    ? parentInstance.Parent
+                    : null)
+            {
+                if (!current.NodeId.IsNull && IsStagedNode(current))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        private bool IsStagedNode(NodeState node)
+        {
+            return m_authoredNodes.TryGetValue(node.NodeId, out NodeState? authored) &&
+                ReferenceEquals(authored, node);
+        }
+
+        private void AddAuthoredRoot(NodeState node)
+        {
+            if (!ContainsByReference(m_authoredRoots, node))
+            {
+                m_authoredRoots.Add(node);
+            }
+        }
+
+        private void AddChildIfMissing(NodeState parent, BaseInstanceState child)
+        {
+            var children = new List<BaseInstanceState>();
+            parent.GetChildren(Context, children);
+            for (int i = 0; i < children.Count; i++)
+            {
+                if (ReferenceEquals(children[i], child))
+                {
+                    return;
+                }
+            }
+            parent.AddChild(child);
+        }
+
+        private bool IsOwnedNamespace(ushort namespaceIndex)
+        {
+            if (NodeManager is not AsyncCustomNodeManager manager)
+            {
+                return namespaceIndex == m_defaultNamespaceIndex;
+            }
+
+            for (int i = 0; i < manager.NamespaceIndexes.Count; i++)
+            {
+                if (manager.NamespaceIndexes[i] == namespaceIndex)
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        private static void ValidateAuthoredNodeId(
+            AsyncCustomNodeManager manager,
+            NodeState node)
+        {
+            if (node.NodeId.NamespaceIndex == 0)
+            {
+                throw ServiceResultException.Create(
+                    StatusCodes.BadNodeIdInvalid,
+                    "Added node '{0}' cannot use namespace index 0.",
+                    node.BrowseName);
+            }
+
+            for (int i = 0; i < manager.NamespaceIndexes.Count; i++)
+            {
+                if (manager.NamespaceIndexes[i] == node.NodeId.NamespaceIndex)
+                {
+                    return;
+                }
+            }
+
+            throw ServiceResultException.Create(
+                StatusCodes.BadNodeIdInvalid,
+                "Added node '{0}' uses namespace index {1}, which is not owned by this node manager.",
+                node.BrowseName,
+                node.NodeId.NamespaceIndex);
+        }
+
+        private QualifiedName CreateDefaultBrowseName(string browseName)
+        {
+            if (string.IsNullOrEmpty(browseName))
+            {
+                throw ServiceResultException.Create(
+                    StatusCodes.BadBrowseNameInvalid,
+                    "Browse name is null or empty.");
+            }
+            return new QualifiedName(browseName, m_defaultNamespaceIndex);
+        }
+
+        private static QualifiedName ValidateExplicitBrowseName(QualifiedName browseName)
+        {
+            if (browseName.IsNull)
+            {
+                throw ServiceResultException.Create(
+                    StatusCodes.BadBrowseNameInvalid,
+                    "Browse name is null or empty.");
+            }
+            if (browseName.NamespaceIndex == 0)
+            {
+                throw ServiceResultException.Create(
+                    StatusCodes.BadBrowseNameInvalid,
+                    "A QualifiedName browse name must specify a nonzero namespace index. " +
+                    "Use the string overload for the manager's default namespace.");
+            }
+            return browseName;
+        }
+
+        private void ThrowIfAuthoredNodesRegistered()
+        {
+            if (m_authoredNodesRegistered)
+            {
+                throw ServiceResultException.Create(
+                    StatusCodes.BadInvalidState,
+                    "Cannot add nodes after the staged graph has been registered. " +
+                    "All node creation must occur inside Configure.");
+            }
+        }
+
+        /// <summary>
+        /// Identity-only stand-in handed to a node factory when the requested
+        /// parent is owned by another node manager.
+        /// </summary>
+        private sealed class ExternalParentState : BaseObjectState
+        {
+            public ExternalParentState(NodeId nodeId)
+                : base(parent: null)
+            {
+                NodeId = nodeId;
+            }
+        }
+
+        private readonly Dictionary<NodeId, NodeState> m_authoredNodes = [];
+        private readonly List<NodeState> m_authoredRoots = [];
+        private bool m_authoredNodesRegistered;
+    }
+}

--- a/src/Opc.Ua.Server/Fluent/NodeManagerBuilder.Authoring.cs
+++ b/src/Opc.Ua.Server/Fluent/NodeManagerBuilder.Authoring.cs
@@ -249,12 +249,6 @@ namespace Opc.Ua.Server.Fluent
             }
         }
 
-        /// <summary>
-        /// Gets the roots staged by the <c>Add*</c> methods, in insertion
-        /// order.
-        /// </summary>
-        internal IReadOnlyList<NodeState> AuthoredRoots => m_authoredRoots;
-
         private NodeBuilder<TState> AddNode<TState>(
             TState node,
             NodeId parentId,
@@ -564,10 +558,6 @@ namespace Opc.Ua.Server.Fluent
             }
 
             manager.PrepareAuthoredNodeIdsForRegistration(node);
-            if (node.NodeId.IsNull)
-            {
-                node.NodeId = Context.RequireNodeIdFactory().New(Context, node);
-            }
             if (node.NodeId.IsNull)
             {
                 throw ServiceResultException.Create(

--- a/src/Opc.Ua.Server/Fluent/NodeManagerBuilder.cs
+++ b/src/Opc.Ua.Server/Fluent/NodeManagerBuilder.cs
@@ -56,7 +56,7 @@ namespace Opc.Ua.Server.Fluent
     /// dispatch time.
     /// </para>
     /// </remarks>
-    public sealed class NodeManagerBuilder : INodeManagerBuilder, IFluentDispatcher
+    public sealed partial class NodeManagerBuilder : INodeManagerBuilder, IFluentDispatcher
     {
         /// <summary>
         /// Creates a new builder for the supplied <paramref name="nodeManager"/>.
@@ -145,7 +145,7 @@ namespace Opc.Ua.Server.Fluent
                 Context,
                 browsePath,
                 m_defaultNamespaceIndex,
-                m_rootResolver);
+                ResolveRoot);
 
             return new NodeBuilder(this, node);
         }
@@ -159,7 +159,7 @@ namespace Opc.Ua.Server.Fluent
                 Context,
                 browsePath,
                 m_defaultNamespaceIndex,
-                m_rootResolver);
+                ResolveRoot);
 
             if (node is not TState typed)
             {
@@ -262,7 +262,7 @@ namespace Opc.Ua.Server.Fluent
                 Context,
                 browsePath,
                 m_defaultNamespaceIndex,
-                m_rootResolver);
+                ResolveRoot);
             return ToVariableBuilder<TValue>(node, browsePath);
         }
 
@@ -896,6 +896,11 @@ namespace Opc.Ua.Server.Fluent
                     "NodeId is null or empty.");
             }
 
+            if (m_authoredNodes.TryGetValue(nodeId, out NodeState? authored))
+            {
+                return authored;
+            }
+
             return m_nodeIdResolver(nodeId) ??
                 throw ServiceResultException.Create(
                     StatusCodes.BadNodeIdUnknown,
@@ -912,8 +917,10 @@ namespace Opc.Ua.Server.Fluent
                     "TypeDefinitionId is null or empty.");
             }
 
-            IReadOnlyList<NodeState> candidates = m_typeIdResolver(typeDefinitionId)
-                ?? [];
+            IReadOnlyList<NodeState> candidates = CollectAuthoredCandidates(
+                m_typeIdResolver(typeDefinitionId) ?? [],
+                node => node is BaseInstanceState instance &&
+                    instance.TypeDefinitionId == typeDefinitionId);
 
             if (candidates.Count == 0)
             {
@@ -975,7 +982,10 @@ namespace Opc.Ua.Server.Fluent
                     "DataTypeId is null or empty.");
             }
 
-            ArrayOf<NodeState> candidates = m_dataTypeIdResolver(dataTypeId);
+            List<NodeState> candidates = CollectAuthoredCandidates(
+                m_dataTypeIdResolver(dataTypeId),
+                node => node is BaseVariableState variable &&
+                    variable.DataType == dataTypeId);
 
             if (candidates.Count == 0)
             {

--- a/src/Opc.Ua.Server/Hosting/FluentNodeManagerFactory.cs
+++ b/src/Opc.Ua.Server/Hosting/FluentNodeManagerFactory.cs
@@ -120,6 +120,10 @@ namespace Opc.Ua.Server.Hosting
             NodeManagerBuilder builder = CreateFluentBuilder(namespaceIndex);
             m_build(builder);
 
+            // Register nodes the build delegate created through the builder's
+            // Add* methods before the reverse-reference pass runs.
+            await RegisterAuthoredNodesAsync(builder, cancellationToken).ConfigureAwait(false);
+
             // Mirror references from build-created nodes to nodes owned by
             // other node managers (e.g. the Objects folder) into the
             // externalReferences dictionary before sealing the builder.

--- a/src/Opc.Ua.Server/Hosting/FluentNodeManagerFactory.cs
+++ b/src/Opc.Ua.Server/Hosting/FluentNodeManagerFactory.cs
@@ -111,13 +111,15 @@ namespace Opc.Ua.Server.Hosting
             }
             ushort namespaceIndex = (ushort)m_server.NamespaceUris.GetIndex(m_namespaceUri);
 
+            NodeManagerBuilder builder = CreateFluentBuilder(namespaceIndex);
+
+            // Staged before the build delegate runs, so it can parent nodes to
+            // the root by NodeId or reach it by browse path.
             if (m_rootBrowseName != null)
             {
-                FolderState root = CreateRootFolder(namespaceIndex, m_rootBrowseName);
-                await AddPredefinedNodeAsync(root, cancellationToken).ConfigureAwait(false);
+                builder.Add(CreateRootFolder(namespaceIndex, m_rootBrowseName));
             }
 
-            NodeManagerBuilder builder = CreateFluentBuilder(namespaceIndex);
             m_build(builder);
 
             // Register nodes the build delegate created through the builder's
@@ -132,19 +134,22 @@ namespace Opc.Ua.Server.Hosting
             builder.Seal();
         }
 
+        /// <summary>
+        /// Builds the root folder with an explicit string NodeId, which stays
+        /// the address clients browse. The builder supplies the inverse
+        /// Organizes reference to the Objects folder.
+        /// </summary>
         private static FolderState CreateRootFolder(
             ushort namespaceIndex,
             string browseName)
         {
-            var root = new FolderState(null)
+            return new FolderState(null)
             {
                 NodeId = new NodeId(browseName, namespaceIndex),
                 BrowseName = new QualifiedName(browseName, namespaceIndex),
                 DisplayName = new LocalizedText(browseName),
                 TypeDefinitionId = ObjectTypeIds.FolderType
             };
-            root.AddReference(ReferenceTypeIds.Organizes, true, ObjectIds.ObjectsFolder);
-            return root;
         }
 
         private readonly Action<INodeManagerBuilder> m_build;

--- a/src/Opc.Ua.Server/NodeManager/AsyncCustomNodeManager.cs
+++ b/src/Opc.Ua.Server/NodeManager/AsyncCustomNodeManager.cs
@@ -1134,6 +1134,69 @@ namespace Opc.Ua.Server
         }
 
         /// <summary>
+        /// Assigns final instance NodeIds to a subtree before a fluent
+        /// builder exposes it for callback wiring, so callbacks keyed by
+        /// NodeId stay valid once the node is registered.
+        /// </summary>
+        /// <remarks>
+        /// Unlike <c>PrepareInstanceNodeIdsForRegistration</c>, which only
+        /// rebases a subtree that collides with a declaration, this pass
+        /// assigns an id to every node that still lacks one and pulls
+        /// namespace-0 children into the root's namespace. It is idempotent:
+        /// a second call over an already prepared subtree assigns nothing.
+        /// </remarks>
+        /// <param name="node">The root of the subtree to prepare.</param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="node"/> is null.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        /// The system context carries no NodeId factory.
+        /// </exception>
+        internal void PrepareAuthoredNodeIdsForRegistration(NodeState node)
+        {
+            if (node == null)
+            {
+                throw new ArgumentNullException(nameof(node));
+            }
+
+            if (SystemContext.NodeIdFactory == null)
+            {
+                throw new InvalidOperationException(
+                    "The system context does not provide a NodeId factory.");
+            }
+
+            var nodes = new List<NodeState> { node };
+            var children = new List<BaseInstanceState>();
+            var mappingTable = new Dictionary<NodeId, NodeId>();
+            for (int i = 0; i < nodes.Count; i++)
+            {
+                NodeState candidate = nodes[i];
+                if (candidate.NodeId.IsNull ||
+                    (i > 0 &&
+                        node.NodeId.NamespaceIndex != 0 &&
+                        candidate.NodeId.NamespaceIndex == 0))
+                {
+                    NodeId previousNodeId = SystemContext.AssignInstanceNodeId(candidate);
+                    if (!previousNodeId.IsNull &&
+                        !candidate.NodeId.IsNull &&
+                        previousNodeId != candidate.NodeId)
+                    {
+                        mappingTable[previousNodeId] = candidate.NodeId;
+                    }
+                }
+
+                children.Clear();
+                candidate.GetChildren(SystemContext, children);
+                nodes.AddRange(children);
+            }
+
+            if (mappingTable.Count > 0)
+            {
+                node.UpdateReferenceTargets(SystemContext, mappingTable);
+            }
+        }
+
+        /// <summary>
         /// Replaces an existing PredefinedNodes entry in place. Used by
         /// runtime upgraders (e.g. <see cref="RoleStateBinding"/>) that
         /// swap a passive child with a typed proxy after the original

--- a/src/Opc.Ua.Server/NodeManager/AsyncCustomNodeManager.cs
+++ b/src/Opc.Ua.Server/NodeManager/AsyncCustomNodeManager.cs
@@ -1139,11 +1139,18 @@ namespace Opc.Ua.Server
         /// NodeId stay valid once the node is registered.
         /// </summary>
         /// <remarks>
-        /// Unlike <c>PrepareInstanceNodeIdsForRegistration</c>, which only
-        /// rebases a subtree that collides with a declaration, this pass
-        /// assigns an id to every node that still lacks one and pulls
-        /// namespace-0 children into the root's namespace. It is idempotent:
-        /// a second call over an already prepared subtree assigns nothing.
+        /// This pass assigns an id to every node that still lacks one, pulls
+        /// namespace-0 children into the root's namespace, and rebases nodes
+        /// whose id collides with a type declaration. That last case covers a
+        /// subtree materialised with <c>NodeState.Create(..., assignNodeIds:
+        /// false)</c>, whose children keep their declaration ids: they are
+        /// neither null nor in namespace 0, so only the collision check
+        /// catches them. Rebasing here rather than at registration is what
+        /// keeps the ids the fluent builder hands back final — the same
+        /// repair <c>PrepareInstanceNodeIdsForRegistration</c> would
+        /// otherwise apply later, silently invalidating them.
+        /// It is idempotent: a second call over an already prepared subtree
+        /// assigns nothing.
         /// </remarks>
         /// <param name="node">The root of the subtree to prepare.</param>
         /// <exception cref="ArgumentNullException">
@@ -1172,6 +1179,7 @@ namespace Opc.Ua.Server
             {
                 NodeState candidate = nodes[i];
                 if (candidate.NodeId.IsNull ||
+                    HasDeclarationNodeIdCollision(candidate) ||
                     (i > 0 &&
                         node.NodeId.NamespaceIndex != 0 &&
                         candidate.NodeId.NamespaceIndex == 0))

--- a/src/Opc.Ua.Server/RuntimeNodeSet/RuntimeNodeSetNodeManager.cs
+++ b/src/Opc.Ua.Server/RuntimeNodeSet/RuntimeNodeSetNodeManager.cs
@@ -167,6 +167,15 @@ namespace Opc.Ua.Server.RuntimeNodeSet
                     : await m_configureAsync(builder, cancellationToken).ConfigureAwait(false);
                 try
                 {
+                    // Register nodes the configuration created through the
+                    // builder's Add* methods, then re-run the reverse-reference
+                    // pass so their references to externally owned nodes reach
+                    // the externalReferences dictionary as well.
+                    await RegisterAuthoredNodesAsync(builder, cancellationToken)
+                        .ConfigureAwait(false);
+                    await AddReverseReferencesAsync(externalReferences, cancellationToken)
+                        .ConfigureAwait(false);
+
                     builder.Seal();
 
                     // Step 7 – Replay NotifyNodeAdded for every predefined node

--- a/tests/Opc.Ua.Server.Tests/Fluent/NodeManagerBuilderAuthoringTests.cs
+++ b/tests/Opc.Ua.Server.Tests/Fluent/NodeManagerBuilderAuthoringTests.cs
@@ -809,6 +809,53 @@ namespace Opc.Ua.Server.Tests.Fluent
             }
         }
 
+
+        [Test]
+        public async Task ASubtreeMaterialisedFromATypeModelIsRebasedOffTheDeclarationIdsAsync()
+        {
+            // NodeState.Create(..., assignNodeIds: false) leaves every child
+            // carrying its declaration NodeId: non-null, and in the model's own
+            // namespace rather than ns 0. Staging must rebase those before the
+            // per-node builder is handed back, otherwise the ids collide with
+            // the type-model nodes already in PredefinedNodes.
+            using var manager = new AuthoringTestManager(_ => { });
+            ushort ns = manager.TestNamespaceIndex;
+            NodeId declarationId = new("Declaration.Child", ns);
+            manager.SeedTypeHierarchyNode(declarationId);
+
+            NodeManagerBuilder builder = manager.CreateBuilder();
+            var instance = new BaseObjectState(null)
+            {
+                BrowseName = new QualifiedName("Instance", ns)
+            };
+            var child = new BaseDataVariableState(instance)
+            {
+                NodeId = declarationId,
+                BrowseName = new QualifiedName("Child", ns),
+                DataType = DataTypeIds.Int32,
+                ValueRank = ValueRanks.Scalar
+            };
+            instance.AddChild(child);
+
+            INodeBuilder<BaseObjectState> staged = builder.Add(instance);
+            await manager.RegisterAsync(builder).ConfigureAwait(false);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(
+                    child.NodeId,
+                    Is.Not.EqualTo(declarationId),
+                    "the child must be rebased off the declaration id");
+                Assert.That(
+                    manager.ContainsPredefined(child.NodeId),
+                    Is.True,
+                    "the rebased child must be the id that got registered");
+                Assert.That(
+                    manager.ContainsPredefined(staged.Node.NodeId),
+                    Is.True);
+            });
+        }
+
         private static bool HasInverseReference(
             NodeState node,
             NodeId referenceTypeId,
@@ -868,6 +915,20 @@ namespace Opc.Ua.Server.Tests.Fluent
                 return m_builder;
             }
 
+            public void SeedTypeHierarchyNode(NodeId nodeId)
+            {
+                PredefinedNodes[nodeId] = new BaseDataVariableState(null)
+                {
+                    NodeId = nodeId,
+                    BrowseName = new QualifiedName("Declaration", nodeId.NamespaceIndex),
+                    IsPartOfTypeHierarchy = true
+                };
+            }
+
+            public ValueTask RegisterAsync(NodeManagerBuilder builder)
+            {
+                return RegisterAuthoredNodesAsync(builder, CancellationToken.None);
+            }
             public void SeedPredefinedNode(NodeId nodeId)
             {
                 PredefinedNodes[nodeId] = new BaseObjectState(null)

--- a/tests/Opc.Ua.Server.Tests/Fluent/NodeManagerBuilderAuthoringTests.cs
+++ b/tests/Opc.Ua.Server.Tests/Fluent/NodeManagerBuilderAuthoringTests.cs
@@ -434,6 +434,381 @@ namespace Opc.Ua.Server.Tests.Fluent
             Assert.That(manager.PredefinedNodeCount, Is.Zero);
         }
 
+
+        [Test]
+        public async Task QualifiedNameOverloadsCreateInTheGivenNamespaceAsync()
+        {
+            using var manager = new AuthoringTestManager(builder =>
+            {
+                ushort ns = builder.Context.NamespaceUris.GetIndexOrAppend(kNamespaceUri);
+                builder.AddObject(new QualifiedName("Press", ns));
+                builder.AddVariable<int>(new QualifiedName("Count", ns));
+                builder.AddMethod(new QualifiedName("Halt", ns));
+            });
+            await manager.BuildAsync().ConfigureAwait(false);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(manager.FindByBrowseName("Press"), Is.InstanceOf<BaseObjectState>());
+                Assert.That(manager.FindByBrowseName("Count"), Is.InstanceOf<BaseDataVariableState>());
+                Assert.That(manager.FindByBrowseName("Halt"), Is.InstanceOf<MethodState>());
+            });
+        }
+
+        [Test]
+        public async Task AddObjectAppliesAnExplicitTypeDefinitionAsync()
+        {
+            using var manager = new AuthoringTestManager(
+                builder => builder.AddObject("Press", default, ObjectTypeIds.FolderType));
+            await manager.BuildAsync().ConfigureAwait(false);
+
+            var press = (BaseObjectState)manager.FindByBrowseName("Press");
+            Assert.That(press.TypeDefinitionId, Is.EqualTo(ObjectTypeIds.FolderType));
+        }
+
+        [Test]
+        public void CreatedNodesAreVisibleToTypeAndDataTypeLookups()
+        {
+            using var manager = new AuthoringTestManager(builder =>
+            {
+                builder.AddObject("Press", default, ObjectTypeIds.FolderType);
+                builder.AddVariable<float>("Ratio");
+
+                Assert.Multiple(() =>
+                {
+                    Assert.That(
+                        builder.NodeFromTypeId(ObjectTypeIds.FolderType).Node.BrowseName.Name,
+                        Is.EqualTo("Press"));
+                    Assert.That(
+                        builder.VariableFromDataTypeId<float>(DataTypeIds.Float).Node.BrowseName.Name,
+                        Is.EqualTo("Ratio"));
+                });
+            });
+
+            Assert.DoesNotThrowAsync(async () => await manager.BuildAsync().ConfigureAwait(false));
+        }
+
+        [Test]
+        public async Task GrandchildrenAreRegisteredWithTheirRootAsync()
+        {
+            using var manager = new AuthoringTestManager(builder =>
+            {
+                INodeBuilder<FolderState> plant = builder.AddFolder("Plant");
+                INodeBuilder<BaseObjectState> line = builder.AddObject(
+                    "Line",
+                    plant.Node.NodeId);
+                builder.AddVariable<int>("Speed", line.Node.NodeId);
+            });
+            await manager.BuildAsync().ConfigureAwait(false);
+
+            NodeState speed = manager.FindByBrowseName("Speed");
+            Assert.Multiple(() =>
+            {
+                // One root registered; the subtree came along with it.
+                Assert.That(manager.PredefinedNodeCount, Is.EqualTo(3));
+                Assert.That(
+                    ((BaseInstanceState)speed).Parent!.BrowseName.Name,
+                    Is.EqualTo("Line"));
+                Assert.That(speed.NodeId.NamespaceIndex, Is.EqualTo(manager.TestNamespaceIndex));
+            });
+        }
+
+        [Test]
+        public async Task AddingAnExistingChildDoesNotDuplicateItAsync()
+        {
+            using var manager = new AuthoringTestManager(builder =>
+            {
+                ushort ns = builder.Context.NamespaceUris.GetIndexOrAppend(kNamespaceUri);
+                var parent = new BaseObjectState(null)
+                {
+                    NodeId = new NodeId("Parent", ns),
+                    BrowseName = new QualifiedName("Parent", ns)
+                };
+                var child = new BaseDataVariableState(parent)
+                {
+                    NodeId = new NodeId("Parent.Child", ns),
+                    BrowseName = new QualifiedName("Child", ns),
+                    DataType = DataTypeIds.Int32,
+                    ValueRank = ValueRanks.Scalar
+                };
+                parent.AddChild(child);
+                builder.AddRoot(parent);
+
+                // Re-adding the same instance against the same parent must not
+                // append a second child entry.
+                builder.Add(child, parent.NodeId);
+            });
+            await manager.BuildAsync().ConfigureAwait(false);
+
+            var parentNode = (BaseObjectState)manager.FindByBrowseName("Parent");
+            var children = new List<BaseInstanceState>();
+            parentNode.GetChildren(manager.TestSystemContext, children);
+            Assert.That(children, Has.Count.EqualTo(1));
+        }
+
+        [Test]
+        public async Task AddRootIsIdempotentForTheSameInstanceAsync()
+        {
+            using var manager = new AuthoringTestManager(builder =>
+            {
+                ushort ns = builder.Context.NamespaceUris.GetIndexOrAppend(kNamespaceUri);
+                var root = new BaseObjectState(null)
+                {
+                    NodeId = new NodeId("Root", ns),
+                    BrowseName = new QualifiedName("Root", ns)
+                };
+                builder.AddRoot(root);
+                builder.AddRoot(root);
+            });
+            await manager.BuildAsync().ConfigureAwait(false);
+
+            Assert.That(manager.PredefinedNodeCount, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void NullArgumentsAreRejected()
+        {
+            using var manager = new AuthoringTestManager(builder =>
+            {
+                Assert.Multiple(() =>
+                {
+                    Assert.Throws<ArgumentNullException>(
+                        () => builder.Add((Func<NodeState?, BaseObjectState>)null!));
+                    Assert.Throws<ArgumentNullException>(
+                        () => builder.Add((BaseObjectState)null!));
+                    Assert.Throws<ArgumentNullException>(
+                        () => builder.AddRoot((BaseObjectState)null!));
+                });
+            });
+
+            Assert.DoesNotThrowAsync(async () => await manager.BuildAsync().ConfigureAwait(false));
+        }
+
+        [Test]
+        public void RegisterAuthoredNodesRejectsANullRegisterDelegate()
+        {
+            using var manager = new AuthoringTestManager(_ => { });
+            NodeManagerBuilder builder = manager.CreateBuilder();
+
+            Assert.ThrowsAsync<ArgumentNullException>(
+                async () => await builder
+                    .RegisterAuthoredNodesAsync(null!)
+                    .ConfigureAwait(false));
+        }
+
+        [Test]
+        public async Task AddingAfterRegistrationButBeforeSealIsRejectedAsync()
+        {
+            using var manager = new AuthoringTestManager(_ => { });
+            NodeManagerBuilder builder = manager.CreateBuilder();
+            await builder
+                .RegisterAuthoredNodesAsync((_, _) => default)
+                .ConfigureAwait(false);
+
+            // The builder is registered but not sealed, so this is the
+            // "graph already handed over" guard rather than the seal guard.
+            ServiceResultException exception = Assert.Throws<ServiceResultException>(
+                () => builder.AddFolder("TooLate"))!;
+            Assert.That(exception.StatusCode, Is.EqualTo(StatusCodes.BadInvalidState));
+        }
+
+        [Test]
+        public void EmptyBrowseNamesAreRejected()
+        {
+            using var manager = new AuthoringTestManager(builder =>
+            {
+                Assert.Multiple(() =>
+                {
+                    Assert.That(
+                        Assert.Throws<ServiceResultException>(
+                            () => builder.AddFolder(string.Empty))!.StatusCode,
+                        Is.EqualTo(StatusCodes.BadBrowseNameInvalid));
+                    Assert.That(
+                        Assert.Throws<ServiceResultException>(
+                            () => builder.AddFolder(default(QualifiedName)))!.StatusCode,
+                        Is.EqualTo(StatusCodes.BadBrowseNameInvalid));
+                });
+            });
+
+            Assert.DoesNotThrowAsync(async () => await manager.BuildAsync().ConfigureAwait(false));
+        }
+
+        [Test]
+        public void ANodeWithoutABrowseNameIsRejected()
+        {
+            using var manager = new AuthoringTestManager(builder => builder.AddRoot(
+                new BaseObjectState(null)
+                {
+                    NodeId = new NodeId("NoBrowseName", 2)
+                }));
+
+            ServiceResultException exception = Assert.ThrowsAsync<ServiceResultException>(
+                async () => await manager.BuildAsync().ConfigureAwait(false))!;
+            Assert.That(exception.StatusCode, Is.EqualTo(StatusCodes.BadBrowseNameInvalid));
+        }
+
+        [Test]
+        public void ANonInstanceNodeCannotBeGivenAParent()
+        {
+            using var manager = new AuthoringTestManager(builder =>
+            {
+                ushort ns = builder.Context.NamespaceUris.GetIndexOrAppend(kNamespaceUri);
+                INodeBuilder<FolderState> folder = builder.AddFolder("Machines");
+                builder.Add(
+                    new BaseObjectTypeState
+                    {
+                        NodeId = new NodeId("SomeType", ns),
+                        BrowseName = new QualifiedName("SomeType", ns)
+                    },
+                    folder.Node.NodeId);
+            });
+
+            ServiceResultException exception = Assert.ThrowsAsync<ServiceResultException>(
+                async () => await manager.BuildAsync().ConfigureAwait(false))!;
+            Assert.That(exception.StatusCode, Is.EqualTo(StatusCodes.BadNodeClassInvalid));
+        }
+
+        [Test]
+        public void AParentIdThatContradictsAnExistingParentIsRejected()
+        {
+            using var manager = new AuthoringTestManager(builder =>
+            {
+                ushort ns = builder.Context.NamespaceUris.GetIndexOrAppend(kNamespaceUri);
+                INodeBuilder<FolderState> a = builder.AddFolder("A");
+                INodeBuilder<FolderState> b = builder.AddFolder("B");
+
+                var child = new BaseObjectState(a.Node)
+                {
+                    NodeId = new NodeId("Child", ns),
+                    BrowseName = new QualifiedName("Child", ns)
+                };
+                builder.Add(child, b.Node.NodeId);
+            });
+
+            ServiceResultException exception = Assert.ThrowsAsync<ServiceResultException>(
+                async () => await manager.BuildAsync().ConfigureAwait(false))!;
+            Assert.That(exception.StatusCode, Is.EqualTo(StatusCodes.BadInvalidArgument));
+        }
+
+        [Test]
+        public void AnExistingParentWithoutANodeIdIsRejected()
+        {
+            using var manager = new AuthoringTestManager(builder =>
+            {
+                ushort ns = builder.Context.NamespaceUris.GetIndexOrAppend(kNamespaceUri);
+                var parent = new BaseObjectState(null)
+                {
+                    BrowseName = new QualifiedName("Unidentified", ns)
+                };
+                builder.Add(new BaseObjectState(parent)
+                {
+                    BrowseName = new QualifiedName("Child", ns)
+                });
+            });
+
+            ServiceResultException exception = Assert.ThrowsAsync<ServiceResultException>(
+                async () => await manager.BuildAsync().ConfigureAwait(false))!;
+            Assert.That(exception.StatusCode, Is.EqualTo(StatusCodes.BadNodeIdInvalid));
+        }
+
+        [Test]
+        public void AnExistingParentOutsideTheGraphIsRejected()
+        {
+            using var manager = new AuthoringTestManager(builder =>
+            {
+                ushort ns = builder.Context.NamespaceUris.GetIndexOrAppend(kNamespaceUri);
+                var parent = new BaseObjectState(null)
+                {
+                    NodeId = new NodeId("Stranger", ns),
+                    BrowseName = new QualifiedName("Stranger", ns)
+                };
+                builder.Add(new BaseObjectState(parent)
+                {
+                    BrowseName = new QualifiedName("Child", ns)
+                });
+            });
+
+            ServiceResultException exception = Assert.ThrowsAsync<ServiceResultException>(
+                async () => await manager.BuildAsync().ConfigureAwait(false))!;
+            Assert.That(exception.StatusCode, Is.EqualTo(StatusCodes.BadNodeIdUnknown));
+        }
+
+        [Test]
+        public void ANodeIdInAnUnownedNamespaceIsRejected()
+        {
+            using var manager = new AuthoringTestManager(builder => builder.AddRoot(
+                new BaseObjectState(null)
+                {
+                    NodeId = new NodeId("Foreign", 99),
+                    BrowseName = new QualifiedName("Foreign", 99)
+                }));
+
+            ServiceResultException exception = Assert.ThrowsAsync<ServiceResultException>(
+                async () => await manager.BuildAsync().ConfigureAwait(false))!;
+            Assert.That(exception.StatusCode, Is.EqualTo(StatusCodes.BadNodeIdInvalid));
+        }
+
+        [Test]
+        public void CollidingWithAPredefinedNodeIsRejected()
+        {
+            using var manager = new AuthoringTestManager(_ => { });
+            NodeId taken = new("Taken", manager.TestNamespaceIndex);
+            manager.SeedPredefinedNode(taken);
+
+            NodeManagerBuilder builder = manager.CreateBuilder();
+            ServiceResultException exception = Assert.Throws<ServiceResultException>(
+                () => builder.AddRoot(new BaseObjectState(null)
+                {
+                    NodeId = taken,
+                    BrowseName = new QualifiedName("Taken", manager.TestNamespaceIndex)
+                }))!;
+            Assert.That(exception.StatusCode, Is.EqualTo(StatusCodes.BadNodeIdExists));
+        }
+
+        [Test]
+        public void ANodeIdFactoryThatAssignsNothingIsReported()
+        {
+            using var manager = new AuthoringTestManager(_ => { });
+            manager.UseNullNodeIdFactory();
+
+            NodeManagerBuilder builder = manager.CreateBuilder();
+            ServiceResultException exception = Assert.Throws<ServiceResultException>(
+                () => builder.AddFolder("Machines"))!;
+            Assert.That(exception.StatusCode, Is.EqualTo(StatusCodes.BadConfigurationError));
+        }
+
+        [Test]
+        public void CreationRequiresAnAsyncCustomNodeManagerBackedBuilder()
+        {
+            var builder = new NodeManagerBuilder(
+                new SystemContext(telemetry: null!) { NodeIdFactory = new FixedNodeIdFactory() },
+                Mock.Of<IAsyncNodeManager>(),
+                defaultNamespaceIndex: 2,
+                rootResolver: _ => null!,
+                nodeIdResolver: _ => null!,
+                typeIdResolver: _ => []);
+
+            ServiceResultException exception = Assert.Throws<ServiceResultException>(
+                () => builder.AddFolder("Machines"))!;
+            Assert.That(exception.StatusCode, Is.EqualTo(StatusCodes.BadConfigurationError));
+        }
+
+        private sealed class FixedNodeIdFactory : INodeIdFactory
+        {
+            public NodeId New(ISystemContext context, NodeState node)
+            {
+                return new NodeId(node.BrowseName.Name!, 2);
+            }
+        }
+
+        private sealed class NullNodeIdFactory : INodeIdFactory
+        {
+            public NodeId New(ISystemContext context, NodeState node)
+            {
+                return NodeId.Null;
+            }
+        }
+
         private static bool HasInverseReference(
             NodeState node,
             NodeId referenceTypeId,
@@ -487,6 +862,25 @@ namespace Opc.Ua.Server.Tests.Fluent
                 return RegisterAuthoredNodesAsync(m_builder!, CancellationToken.None);
             }
 
+            public NodeManagerBuilder CreateBuilder()
+            {
+                m_builder = CreateFluentBuilder(TestNamespaceIndex);
+                return m_builder;
+            }
+
+            public void SeedPredefinedNode(NodeId nodeId)
+            {
+                PredefinedNodes[nodeId] = new BaseObjectState(null)
+                {
+                    NodeId = nodeId,
+                    BrowseName = new QualifiedName("Seeded", nodeId.NamespaceIndex)
+                };
+            }
+
+            public void UseNullNodeIdFactory()
+            {
+                SystemContext.NodeIdFactory = new NullNodeIdFactory();
+            }
             public bool ContainsPredefined(NodeId nodeId)
             {
                 return PredefinedNodes.ContainsKey(nodeId);

--- a/tests/Opc.Ua.Server.Tests/Fluent/NodeManagerBuilderAuthoringTests.cs
+++ b/tests/Opc.Ua.Server.Tests/Fluent/NodeManagerBuilderAuthoringTests.cs
@@ -1,0 +1,546 @@
+/* ========================================================================
+ * Copyright (c) 2005-2026 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using NUnit.Framework;
+using Opc.Ua.Server.Fluent;
+
+#nullable enable
+
+namespace Opc.Ua.Server.Tests.Fluent
+{
+    /// <summary>
+    /// Covers the node-creation surface on <see cref="INodeManagerBuilder"/>:
+    /// staging, NodeId assignment, parenting and registration.
+    /// </summary>
+    [TestFixture]
+    [Category("Fluent")]
+    public sealed class NodeManagerBuilderAuthoringTests
+    {
+        private const string kNamespaceUri = "http://opcfoundation.org/UA/Authoring/";
+
+        [Test]
+        public async Task AddFolderRegistersNodeUnderObjectsFolderAsync()
+        {
+            using var manager = new AuthoringTestManager(
+                builder => builder.AddFolder("Machines"));
+            await manager.BuildAsync().ConfigureAwait(false);
+
+            NodeState folder = manager.FindByBrowseName("Machines");
+            Assert.Multiple(() =>
+            {
+                Assert.That(folder, Is.InstanceOf<FolderState>());
+                Assert.That(folder.NodeId.NamespaceIndex, Is.EqualTo(manager.TestNamespaceIndex));
+                Assert.That(
+                    HasInverseReference(folder, ReferenceTypeIds.Organizes, ObjectIds.ObjectsFolder),
+                    Is.True,
+                    "the default parent is mirrored as an inverse Organizes reference");
+            });
+        }
+
+        [Test]
+        public async Task NodeIdsAreAssignedBeforeTheBuilderIsReturnedAsync()
+        {
+            NodeId folderId = NodeId.Null;
+            NodeId variableId = NodeId.Null;
+
+            using var manager = new AuthoringTestManager(builder =>
+            {
+                INodeBuilder<FolderState> folder = builder.AddFolder("Machines");
+                folderId = folder.Node.NodeId;
+                IVariableBuilder<int> variable = builder.AddVariable<int>(
+                    "Speed",
+                    folderId);
+                variableId = variable.Node.NodeId;
+            });
+            await manager.BuildAsync().ConfigureAwait(false);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(folderId.IsNull, Is.False);
+                Assert.That(variableId.IsNull, Is.False);
+                Assert.That(manager.ContainsPredefined(folderId), Is.True);
+                Assert.That(manager.ContainsPredefined(variableId), Is.True);
+            });
+        }
+
+        [Test]
+        public async Task ParentByNodeIdNestsTheChildUnderTheAuthoredParentAsync()
+        {
+            using var manager = new AuthoringTestManager(builder =>
+            {
+                INodeBuilder<FolderState> folder = builder.AddFolder("Machines");
+                builder.AddObject("Press", folder.Node.NodeId);
+            });
+            await manager.BuildAsync().ConfigureAwait(false);
+
+            var folder = (FolderState)manager.FindByBrowseName("Machines");
+            NodeState press = manager.FindByBrowseName("Press");
+            Assert.Multiple(() =>
+            {
+                Assert.That(((BaseInstanceState)press).Parent, Is.SameAs(folder));
+                Assert.That(
+                    ((BaseInstanceState)press).ReferenceTypeId,
+                    Is.EqualTo(ReferenceTypeIds.HasComponent));
+            });
+        }
+
+        [Test]
+        public async Task AddVariableDerivesDataTypeFromTheClrTypeAsync()
+        {
+            using var manager = new AuthoringTestManager(
+                builder => builder.AddVariable<double>("Pressure"));
+            await manager.BuildAsync().ConfigureAwait(false);
+
+            var variable = (BaseDataVariableState)manager.FindByBrowseName("Pressure");
+            Assert.Multiple(() =>
+            {
+                Assert.That(variable.DataType, Is.EqualTo(DataTypeIds.Double));
+                Assert.That(variable.ValueRank, Is.EqualTo(ValueRanks.Scalar));
+            });
+        }
+
+        [Test]
+        public async Task AddMethodCreatesAnExecutableMethodAsync()
+        {
+            using var manager = new AuthoringTestManager(
+                builder => builder.AddMethod("Start"));
+            await manager.BuildAsync().ConfigureAwait(false);
+
+            var method = (MethodState)manager.FindByBrowseName("Start");
+            Assert.Multiple(() =>
+            {
+                Assert.That(method.Executable, Is.True);
+                Assert.That(method.UserExecutable, Is.True);
+            });
+        }
+
+        [Test]
+        public async Task AddKeepsCustomStateTypesStronglyTypedAsync()
+        {
+            CustomObjectState? staged = null;
+
+            using var manager = new AuthoringTestManager(builder =>
+            {
+                var node = new CustomObjectState(null)
+                {
+                    BrowseName = new QualifiedName("Custom", builder.Context.NamespaceUris
+                        .GetIndexOrAppend(kNamespaceUri)),
+                    DisplayName = new LocalizedText("Custom")
+                };
+                INodeBuilder<CustomObjectState> added = builder.Add(node);
+                staged = added.Node;
+            });
+            await manager.BuildAsync().ConfigureAwait(false);
+
+            Assert.That(staged, Is.Not.Null);
+            Assert.That(manager.FindByBrowseName("Custom"), Is.SameAs(staged));
+        }
+
+        [Test]
+        public async Task FactoryOverloadReceivesTheResolvedAuthoredParentAsync()
+        {
+            NodeState? observedParent = null;
+            NodeId folderId = NodeId.Null;
+
+            using var manager = new AuthoringTestManager(builder =>
+            {
+                INodeBuilder<FolderState> folder = builder.AddFolder("Machines");
+                folderId = folder.Node.NodeId;
+                builder.Add(
+                    parent =>
+                    {
+                        observedParent = parent;
+                        return new CustomObjectState(parent)
+                        {
+                            BrowseName = new QualifiedName(
+                                "Child",
+                                builder.Context.NamespaceUris.GetIndexOrAppend(kNamespaceUri))
+                        };
+                    },
+                    folderId);
+            });
+            await manager.BuildAsync().ConfigureAwait(false);
+
+            Assert.That(observedParent, Is.SameAs(manager.FindByBrowseName("Machines")));
+            Assert.That(manager.FindByBrowseName("Child"), Is.Not.Null);
+        }
+
+        [Test]
+        public async Task FactoryOverloadPassesAnIdentityProxyForAnExternalParentAsync()
+        {
+            NodeId observedParentId = NodeId.Null;
+
+            using var manager = new AuthoringTestManager(builder => builder.Add(
+                parent =>
+                {
+                    observedParentId = parent!.NodeId;
+                    return new CustomObjectState(parent)
+                    {
+                        BrowseName = new QualifiedName(
+                            "Detached",
+                            builder.Context.NamespaceUris.GetIndexOrAppend(kNamespaceUri))
+                    };
+                }));
+            await manager.BuildAsync().ConfigureAwait(false);
+
+            NodeState node = manager.FindByBrowseName("Detached");
+            Assert.Multiple(() =>
+            {
+                Assert.That(observedParentId, Is.EqualTo(ObjectIds.ObjectsFolder));
+                Assert.That(
+                    ((BaseInstanceState)node).Parent,
+                    Is.Null,
+                    "the identity proxy must not survive as a real parent");
+                Assert.That(
+                    HasInverseReference(
+                        node,
+                        ReferenceTypeIds.HasComponent,
+                        ObjectIds.ObjectsFolder),
+                    Is.True,
+                    "BaseObjectState(parent) already chose HasComponent for the proxy parent");
+            });
+        }
+
+        [Test]
+        public async Task AddRootKeepsExistingReferencesAndSkipsTheObjectsFolderAsync()
+        {
+            using var manager = new AuthoringTestManager(builder =>
+            {
+                ushort ns = builder.Context.NamespaceUris.GetIndexOrAppend(kNamespaceUri);
+                var root = new BaseObjectState(null)
+                {
+                    NodeId = new NodeId("Root", ns),
+                    BrowseName = new QualifiedName("Root", ns),
+                    DisplayName = new LocalizedText("Root")
+                };
+                root.AddReference(ReferenceTypeIds.Organizes, true, ObjectIds.RootFolder);
+                builder.AddRoot(root);
+            });
+            await manager.BuildAsync().ConfigureAwait(false);
+
+            NodeState root = manager.FindByBrowseName("Root");
+            Assert.Multiple(() =>
+            {
+                Assert.That(
+                    HasInverseReference(root, ReferenceTypeIds.Organizes, ObjectIds.RootFolder),
+                    Is.True);
+                Assert.That(
+                    HasInverseReference(root, ReferenceTypeIds.Organizes, ObjectIds.ObjectsFolder),
+                    Is.False,
+                    "AddRoot does not synthesize an Objects-folder parent");
+            });
+        }
+
+        [Test]
+        public void TryGetNodeResolvesANodeThatIsNotRegisteredYet()
+        {
+            using var manager = new AuthoringTestManager(builder =>
+            {
+                INodeBuilder<FolderState> folder = builder.AddFolder("Machines");
+
+                Assert.Multiple(() =>
+                {
+                    Assert.That(
+                        builder.TryGetNode(folder.Node.NodeId, out NodeState? staged),
+                        Is.True);
+                    Assert.That(staged, Is.SameAs(folder.Node));
+                    Assert.That(
+                        builder.TryGetNode(new NodeId("Absent", 9), out NodeState? missing),
+                        Is.False);
+                    Assert.That(missing, Is.Null);
+                    Assert.That(builder.TryGetNode(NodeId.Null, out _), Is.False);
+                });
+            });
+
+            Assert.DoesNotThrowAsync(async () => await manager.BuildAsync().ConfigureAwait(false));
+        }
+
+        [Test]
+        public async Task ReadHandlersKeyedByIdFireForAuthoredNodesAsync()
+        {
+            NodeId variableId = NodeId.Null;
+
+            using var manager = new AuthoringTestManager(builder =>
+            {
+                IVariableBuilder<int> variable = builder.AddVariable<int>("Counter");
+                variableId = variable.Node.NodeId;
+                variable.OnRead(() => 42);
+            });
+            await manager.BuildAsync().ConfigureAwait(false);
+
+            // The handler must sit on the instance that ended up registered
+            // under the id the builder handed back during Configure.
+            var node = (BaseDataVariableState)manager.FindById(variableId);
+            Assert.That(node.OnSimpleReadValue, Is.Not.Null);
+
+            var value = Variant.Null;
+            ServiceResult result = node.OnSimpleReadValue!(
+                manager.TestSystemContext,
+                node,
+                ref value);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(ServiceResult.IsGood(result), Is.True);
+                Assert.That(value.TryGetValue(out int read), Is.True);
+                Assert.That(read, Is.EqualTo(42));
+            });
+        }
+
+        [Test]
+        public async Task AuthoredNodesAreVisibleToBrowsePathAndNodeIdLookupsAsync()
+        {
+            using var manager = new AuthoringTestManager(builder =>
+            {
+                INodeBuilder<FolderState> folder = builder.AddFolder("Machines");
+                builder.AddObject("Press", folder.Node.NodeId);
+
+                Assert.Multiple(() =>
+                {
+                    Assert.That(builder.Node("Machines/Press").Node.BrowseName.Name, Is.EqualTo("Press"));
+                    Assert.That(
+                        builder.Node(folder.Node.NodeId).Node,
+                        Is.SameAs(folder.Node));
+                });
+            });
+
+            await manager.BuildAsync().ConfigureAwait(false);
+            Assert.That(manager.FindByBrowseName("Press"), Is.Not.Null);
+        }
+
+        [Test]
+        public void QualifiedNameOverloadRejectsNamespaceZero()
+        {
+            using var manager = new AuthoringTestManager(
+                builder => builder.AddFolder(new QualifiedName("Machines", 0)));
+
+            ServiceResultException exception = Assert.ThrowsAsync<ServiceResultException>(
+                async () => await manager.BuildAsync().ConfigureAwait(false))!;
+            Assert.That(exception.StatusCode, Is.EqualTo(StatusCodes.BadBrowseNameInvalid));
+        }
+
+        [Test]
+        public void DuplicateNodeIdIsRejected()
+        {
+            using var manager = new AuthoringTestManager(builder =>
+            {
+                ushort ns = builder.Context.NamespaceUris.GetIndexOrAppend(kNamespaceUri);
+                builder.AddRoot(new BaseObjectState(null)
+                {
+                    NodeId = new NodeId("Duplicate", ns),
+                    BrowseName = new QualifiedName("First", ns)
+                });
+                builder.AddRoot(new BaseObjectState(null)
+                {
+                    NodeId = new NodeId("Duplicate", ns),
+                    BrowseName = new QualifiedName("Second", ns)
+                });
+            });
+
+            ServiceResultException exception = Assert.ThrowsAsync<ServiceResultException>(
+                async () => await manager.BuildAsync().ConfigureAwait(false))!;
+            Assert.That(exception.StatusCode, Is.EqualTo(StatusCodes.BadNodeIdExists));
+        }
+
+        [Test]
+        public void ParentInAnOwnedNamespaceMustBeAuthoredFirst()
+        {
+            using var manager = new AuthoringTestManager(builder => builder.AddObject(
+                "Orphan",
+                new NodeId("NeverAdded", builder.Context.NamespaceUris.GetIndexOrAppend(
+                    kNamespaceUri))));
+
+            ServiceResultException exception = Assert.ThrowsAsync<ServiceResultException>(
+                async () => await manager.BuildAsync().ConfigureAwait(false))!;
+            Assert.That(exception.StatusCode, Is.EqualTo(StatusCodes.BadNodeIdUnknown));
+        }
+
+        [Test]
+        public void NamespaceZeroNodeIdsAreRejected()
+        {
+            using var manager = new AuthoringTestManager(builder => builder.AddRoot(
+                new BaseObjectState(null)
+                {
+                    NodeId = new NodeId("InBaseNamespace", 0),
+                    BrowseName = new QualifiedName("InBaseNamespace", 1)
+                }));
+
+            ServiceResultException exception = Assert.ThrowsAsync<ServiceResultException>(
+                async () => await manager.BuildAsync().ConfigureAwait(false))!;
+            Assert.That(exception.StatusCode, Is.EqualTo(StatusCodes.BadNodeIdInvalid));
+        }
+
+        [Test]
+        public async Task AddingAfterRegistrationIsRejectedAsync()
+        {
+            INodeManagerBuilder? retained = null;
+            using var manager = new AuthoringTestManager(builder => retained = builder);
+            await manager.BuildAsync().ConfigureAwait(false);
+
+            ServiceResultException exception = Assert.Throws<ServiceResultException>(
+                () => retained!.AddFolder("TooLate"))!;
+            Assert.That(exception.StatusCode, Is.EqualTo(StatusCodes.BadInvalidState));
+        }
+
+        [Test]
+        public async Task RegisteringTwiceIsRejectedAsync()
+        {
+            using var manager = new AuthoringTestManager(builder => builder.AddFolder("Machines"));
+            await manager.BuildAsync().ConfigureAwait(false);
+
+            ServiceResultException exception = Assert.ThrowsAsync<ServiceResultException>(
+                async () => await manager.RegisterAgainAsync().ConfigureAwait(false))!;
+            Assert.That(exception.StatusCode, Is.EqualTo(StatusCodes.BadInvalidState));
+        }
+
+        [Test]
+        public async Task ManagerWithoutAuthoredNodesRegistersNothingAsync()
+        {
+            using var manager = new AuthoringTestManager(_ => { });
+            await manager.BuildAsync().ConfigureAwait(false);
+
+            Assert.That(manager.PredefinedNodeCount, Is.Zero);
+        }
+
+        private static bool HasInverseReference(
+            NodeState node,
+            NodeId referenceTypeId,
+            NodeId targetId)
+        {
+            var references = new List<IReference>();
+            node.GetReferences(new SystemContext(telemetry: null!), references);
+            foreach (IReference reference in references)
+            {
+                if (reference.IsInverse &&
+                    reference.ReferenceTypeId == referenceTypeId &&
+                    reference.TargetId == targetId)
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// A hand-written fluent manager that reproduces the order the
+        /// source-generated <c>CreateAddressSpaceAsync</c> uses: Configure,
+        /// register authored nodes, complete configure, seal.
+        /// </summary>
+        private sealed class AuthoringTestManager : FluentNodeManagerBase
+        {
+            public AuthoringTestManager(Action<INodeManagerBuilder> configure)
+                : base(CreateMockServer(), kNamespaceUri)
+            {
+                m_configure = configure;
+            }
+
+            public ushort TestNamespaceIndex => NamespaceIndexes[0];
+
+            public ISystemContext TestSystemContext => SystemContext;
+
+            public int PredefinedNodeCount => PredefinedNodes.Count;
+
+            public async Task BuildAsync()
+            {
+                var externalReferences = new Dictionary<NodeId, IList<IReference>>();
+                m_builder = CreateFluentBuilder(TestNamespaceIndex);
+                m_configure(m_builder);
+                await RegisterAuthoredNodesAsync(m_builder).ConfigureAwait(false);
+                await CompleteConfigureAsync(externalReferences).ConfigureAwait(false);
+                m_builder.Seal();
+            }
+
+            public ValueTask RegisterAgainAsync()
+            {
+                return RegisterAuthoredNodesAsync(m_builder!, CancellationToken.None);
+            }
+
+            public bool ContainsPredefined(NodeId nodeId)
+            {
+                return PredefinedNodes.ContainsKey(nodeId);
+            }
+
+            public NodeState FindById(NodeId nodeId)
+            {
+                Assert.That(PredefinedNodes.TryGetValue(nodeId, out NodeState? node), Is.True);
+                return node!;
+            }
+
+            public NodeState FindByBrowseName(string name)
+            {
+                foreach (NodeState node in PredefinedNodes.Values)
+                {
+                    if (node.BrowseName.Name == name)
+                    {
+                        return node;
+                    }
+                }
+                Assert.Fail($"No predefined node named '{name}'.");
+                return null!;
+            }
+
+            private static IServerInternal CreateMockServer()
+            {
+                var namespaceUris = new NamespaceTable();
+                namespaceUris.Append(Ua.Namespaces.OpcUa);
+
+                var telemetry = new Mock<ITelemetryContext>();
+                telemetry
+                    .SetupGet(context => context.LoggerFactory)
+                    .Returns(NullLoggerFactory.Instance);
+
+                var server = new Mock<IServerInternal>();
+                server.SetupGet(value => value.NamespaceUris).Returns(namespaceUris);
+                server.SetupGet(value => value.Telemetry).Returns(telemetry.Object);
+                server.SetupGet(value => value.MessageContext)
+                    .Returns(ServiceMessageContext.Create(telemetry.Object));
+                server.SetupGet(value => value.DefaultSystemContext)
+                    .Returns(new ServerSystemContext(server.Object));
+                return server.Object;
+            }
+
+            private readonly Action<INodeManagerBuilder> m_configure;
+            private NodeManagerBuilder? m_builder;
+        }
+
+        private sealed class CustomObjectState : BaseObjectState
+        {
+            public CustomObjectState(NodeState? parent)
+                : base(parent)
+            {
+            }
+        }
+    }
+}

--- a/tools/Opc.Ua.SourceGeneration.Core/Generators/FluentBuilderGenerator.cs
+++ b/tools/Opc.Ua.SourceGeneration.Core/Generators/FluentBuilderGenerator.cs
@@ -701,6 +701,57 @@ namespace Opc.Ua.SourceGeneration
                 "dataTypeId, browseName",
                 typeArg: "TValue", noConstraint: true);
 
+            // Node-creation pass-throughs.
+            EmitPassThroughGenericMethod(writer,
+                "global::Opc.Ua.Server.Fluent.INodeBuilder<TState>", "Add",
+                "TState node, global::Opc.Ua.NodeId parentId = default", "node, parentId");
+            EmitPassThroughGenericMethod(writer,
+                "global::Opc.Ua.Server.Fluent.INodeBuilder<TState>", "Add",
+                "global::System.Func<global::Opc.Ua.NodeState?, TState> factory," +
+                    " global::Opc.Ua.NodeId parentId = default",
+                "factory, parentId");
+            EmitPassThroughGenericMethod(writer,
+                "global::Opc.Ua.Server.Fluent.INodeBuilder<TState>", "AddRoot",
+                "TState node", "node");
+            EmitPassThroughMethod(writer,
+                "bool", "TryGetNode",
+                "global::Opc.Ua.NodeId nodeId, out global::Opc.Ua.NodeState? node",
+                "nodeId, out node");
+
+            EmitPassThroughMethod(writer,
+                "global::Opc.Ua.Server.Fluent.INodeBuilder<global::Opc.Ua.FolderState>", "AddFolder",
+                "string browseName, global::Opc.Ua.NodeId parentId = default",
+                "browseName, parentId");
+            EmitPassThroughMethod(writer,
+                "global::Opc.Ua.Server.Fluent.INodeBuilder<global::Opc.Ua.FolderState>", "AddFolder",
+                "global::Opc.Ua.QualifiedName browseName, global::Opc.Ua.NodeId parentId = default",
+                "browseName, parentId");
+            EmitPassThroughMethod(writer,
+                "global::Opc.Ua.Server.Fluent.INodeBuilder<global::Opc.Ua.BaseObjectState>", "AddObject",
+                "string browseName, global::Opc.Ua.NodeId parentId = default," +
+                    " global::Opc.Ua.NodeId typeDefinitionId = default",
+                "browseName, parentId, typeDefinitionId");
+            EmitPassThroughMethod(writer,
+                "global::Opc.Ua.Server.Fluent.INodeBuilder<global::Opc.Ua.BaseObjectState>", "AddObject",
+                "global::Opc.Ua.QualifiedName browseName, global::Opc.Ua.NodeId parentId = default," +
+                    " global::Opc.Ua.NodeId typeDefinitionId = default",
+                "browseName, parentId, typeDefinitionId");
+            EmitPassThroughGenericMethod(writer,
+                "global::Opc.Ua.Server.Fluent.IVariableBuilder<TValue>", "AddVariable",
+                "string browseName, global::Opc.Ua.NodeId parentId = default",
+                "browseName, parentId", typeArg: "TValue", noConstraint: true);
+            EmitPassThroughGenericMethod(writer,
+                "global::Opc.Ua.Server.Fluent.IVariableBuilder<TValue>", "AddVariable",
+                "global::Opc.Ua.QualifiedName browseName, global::Opc.Ua.NodeId parentId = default",
+                "browseName, parentId", typeArg: "TValue", noConstraint: true);
+            EmitPassThroughMethod(writer,
+                "global::Opc.Ua.Server.Fluent.INodeBuilder<global::Opc.Ua.MethodState>", "AddMethod",
+                "string browseName, global::Opc.Ua.NodeId parentId = default",
+                "browseName, parentId");
+            EmitPassThroughMethod(writer,
+                "global::Opc.Ua.Server.Fluent.INodeBuilder<global::Opc.Ua.MethodState>", "AddMethod",
+                "global::Opc.Ua.QualifiedName browseName, global::Opc.Ua.NodeId parentId = default",
+                "browseName, parentId");
             // Typed top-level accessors.
             foreach (InstanceDesign root in roots)
             {

--- a/tools/Opc.Ua.SourceGeneration.Core/Generators/NodeManagerTemplates.cs
+++ b/tools/Opc.Ua.SourceGeneration.Core/Generators/NodeManagerTemplates.cs
@@ -125,6 +125,12 @@ namespace Opc.Ua.SourceGeneration
                         Configure(__m_builder);
                         Configure(new {{Tokens.NodeManagerClassName}}TypedBuilder(__m_builder));
 
+                        // Register nodes created by the Configure partial(s)
+                        // through the builder's Add* methods before the
+                        // reverse-reference pass runs, so their references to
+                        // externally owned nodes are mirrored too.
+                        await RegisterAuthoredNodesAsync(__m_builder, cancellationToken).ConfigureAwait(false);
+
                         // Mirror references from configure-created nodes to
                         // nodes owned by other node managers (e.g. the Objects
                         // folder) into the externalReferences dictionary.


### PR DESCRIPTION
# Description

`INodeManagerBuilder` gains a node **creation** surface alongside its existing lookup surface, so a `Configure` partial can fill a namespace without a NodeSet or a ModelDesign.

Twelve new members, implemented as ordinary public members on `NodeManagerBuilder` (new partial file `NodeManagerBuilder.Authoring.cs`):

| Member | Creates |
| --- | --- |
| `AddFolder(name, parentId)` | a `FolderState` (`Organizes`) |
| `AddObject(name, parentId, typeDefinitionId)` | a `BaseObjectState` |
| `AddVariable<TValue>(name, parentId)` | a `BaseDataVariableState` whose `DataType`/`ValueRank` come from `TValue` |
| `AddMethod(name, parentId)` | an executable `MethodState` |
| `Add<TState>(node, parentId)` | an already-constructed state of any `NodeState` subclass |
| `Add<TState>(factory, parentId)` | a state built by a factory that receives the resolved parent |
| `AddRoot<TState>(node)` | a root, with its existing references left alone |
| `TryGetNode(nodeId, out node)` | lookup across created-but-not-yet-registered nodes and predefined nodes |

Each `Add*` for a browse name takes a `string` (qualified with the manager's default namespace) or a `QualifiedName` carrying an explicit nonzero namespace index — eight overloads plus the four above.

```csharp
partial void Configure(INodeManagerBuilder builder)
{
    INodeBuilder<FolderState> machines = builder.AddFolder("Machines");

    builder.AddVariable<double>("Pressure", machines.Node.NodeId)
        .OnRead(() => m_sensor.Pressure);

    builder.AddMethod("Reset", machines.Node.NodeId)
        .OnCall(ResetAsync);
}
```

Three properties make this usable straight from `Configure`:

- **NodeIds are final before the builder comes back.** Every `Add*` runs the node — and its whole subtree — through the manager's `INodeIdFactory` before returning, so `OnRead`/`OnWrite` registrations, which key off `NodeState.NodeId`, stay valid once the node is registered.
- **Creation is staged, not immediate.** Created nodes are held until the manager calls `RegisterAuthoredNodesAsync`. That is what lets a node name a sibling created moments earlier, and it keeps the builder usable before the manager has finished building its address space.
- **Custom state types stay typed.** `Add<TState>` returns `INodeBuilder<TState>`, so a hand-written `NodeState` subclass keeps its type through the fluent chain.

Staging also makes the builder's own lookups see created nodes: browse paths, `NodeId`, `TypeDefinitionId` and `DataType` resolution all consult the staged graph before falling back to the manager's predefined nodes.

### Registration ordering

A new `protected FluentNodeManagerBase.RegisterAuthoredNodesAsync(builder, ct)` hands the staged roots to `AddPredefinedNodeAsync`. It runs **after** the `Configure` delegates and **before** `CompleteConfigureAsync`, so the reverse-reference pass sees the new nodes and mirrors their references to externally owned nodes (typically the ns=0 `Objects` folder) into `externalReferences`. Three call sites emit it in that position:

- the source-generated `CreateAddressSpaceAsync` (`NodeManagerTemplates`)
- the hosting `FluentNodeManager` (`FluentNodeManagerFactory`)
- `RuntimeNodeSetNodeManager`, which additionally re-runs `AddReverseReferencesAsync` because its first pass happens before `Configure`

A builder that created nothing registers nothing, so the call is safe to make unconditionally.

The surface is available to **every** fluent host — there is no opt-in gate and no second builder interface. The generated typed builder (`FluentBuilderGenerator`) forwards the new members like the rest of `INodeManagerBuilder`.

### Supporting change

`AsyncCustomNodeManager.PrepareAuthoredNodeIdsForRegistration` (internal) assigns an id to every node in a subtree that still lacks one and pulls namespace-0 children into the root's namespace. It differs from the existing `PrepareInstanceNodeIdsForRegistration`, which only rebases a subtree that collides with a declaration. It is idempotent.

## Related Issues

- Follow-up tracked in #4429 (adopting this surface in the remaining hand-rolled node managers, which each need a base-class change first).
- No tracking issue for the API itself yet; happy to open one if maintainers would like the design recorded as an ADR before review.

## Notes for reviewers

Three judgement calls worth a look:

1. **Always-on rather than gated.** The feature is available to every fluent host with no enable call. There is no `INodeSource`-style concept here to withhold it from, so an always-on capability is the same behaviour with one fewer state flag. Misuse is still rejected: `Add*` after `Seal()` or after registration throws `BadInvalidState`, a NodeId in a namespace the manager does not own throws `BadNodeIdInvalid`, and a parent in one of the manager's *own* namespaces that was never created throws `BadNodeIdUnknown`.
2. **Detaching from the external-parent proxy goes through `AddChild`/`RemoveChild`.** The factory overload hands the factory an identity-only proxy when the parent belongs to another node manager, then has to drop the parent link the factory established. `BaseInstanceState.Parent` has an `internal` setter scoped to `Opc.Ua.Types`, so this pair is the only public route. Commented as such at the call site. An alternative would be widening that setter or adding `InternalsVisibleTo` — happy to switch if preferred.
3. **`PrepareNodeIds` does not re-walk per descendant.** The root pass already covers the subtree, so per-child calls would be no-ops on a quadratic walk; descendants are only namespace-validated.

One inherited behaviour the new tests pinned down: `BaseObjectState(parent)` sets `ReferenceTypeId = HasComponent` in its own constructor, so a node built via the factory overload lands under the `Objects` folder with `HasComponent`, while the plain `AddObject` path picks `Organizes`. That asymmetry predates this PR; flagging it in case it is worth normalizing separately.

`Import(UANodeSet)` is deliberately **not** part of this change — it belongs to NodeSet import rather than node creation.

## Test results

19 new tests in `tests/Opc.Ua.Server.Tests/Fluent/NodeManagerBuilderAuthoringTests.cs` cover NodeId assignment before return, parent-by-NodeId nesting, the default Objects-folder placement and its inverse reference, custom state types, both factory paths (authored parent and external-parent proxy), `AddRoot` reference preservation, `TryGetNode`, id-keyed read handlers firing on the registered instance, browse-path/NodeId visibility of created nodes, and every rejection path listed above.

Run against **net10.0** (`-p:CustomTestTarget=net10.0`):

| Suite | Result |
| --- | --- |
| `Opc.Ua.Server.Tests` | 4926 passed, 0 failed, 5 skipped |
| `Opc.Ua.SourceGeneration.Core.Tests` | 3809 passed, 0 failed, 8 skipped |
| `Opc.Ua.SourceGeneration.Tests` | 165 passed, 0 failed |

`UA.slnx` builds with 0 errors and no new warnings.

## Checklist

- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf) and read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [x] I have added all necessary documentation. (New `Creating nodes from scratch — the Add* surface` section in `docs/NodeManagers.md`, plus TOC entry.)
- [x] I have verified that my changes do not introduce (new) build or analyzer warnings.
- [ ] I ran **all** tests locally using the **UA.slnx** solution against at least .net **framework** and .net **10**, and all passed. — **net10.0 only so far** (results above); .NET Framework has not been run locally yet.
- [ ] I fixed **all** failing and flaky tests in the CI pipelines and **all** CodeQL warnings. — pending first CI run.
- [ ] I have addressed **all** PR feedback received.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
