### PR TITLE
Make certificate leak assertions immune to concurrent test activity

### DIFF
--- a/src/Opc.Ua.Core/Stack/Tcp/UaSCBinaryChannel.Asymmetric.cs
+++ b/src/Opc.Ua.Core/Stack/Tcp/UaSCBinaryChannel.Asymmetric.cs
@@ -1124,6 +1124,19 @@ namespace Opc.Ua.Bindings
         }
 
         /// <summary>
+        /// Test-only hook invoked with the sender certificate chain the moment
+        /// <see cref="ReadAsymmetricMessageHeader"/> parsed it, before any
+        /// validation that can reject the header. It lets the leak regression
+        /// tests observe the disposal of the exact handles the parser allocated
+        /// - the chain is never handed back through the out parameter when the
+        /// method throws - instead of sampling the process-wide
+        /// <see cref="Certificate.InstancesCreated"/> counters, which every
+        /// certificate allocated by a concurrently running test also moves.
+        /// Visible to friend test assemblies via <c>InternalsVisibleTo</c>.
+        /// </summary>
+        internal Action<CertificateCollection>? SenderCertificateChainParsedForTest { get; set; }
+
+        /// <summary>
         /// Reads the asymmetric security header to the buffer.
         /// </summary>
         /// <exception cref="ServiceResultException"></exception>
@@ -1175,6 +1188,7 @@ namespace Opc.Ua.Bindings
                     senderCertificateChain = Utils.ParseCertificateChainBlob(
                         certificateData,
                         Telemetry);
+                    SenderCertificateChainParsedForTest?.Invoke(senderCertificateChain);
 
                     try
                     {

--- a/tests/Opc.Ua.Core.Tests/Security/Certificates/CertificateValidationHelpersTests.cs
+++ b/tests/Opc.Ua.Core.Tests/Security/Certificates/CertificateValidationHelpersTests.cs
@@ -30,6 +30,7 @@
 #nullable enable
 
 using System;
+using System.Collections.Generic;
 using System.Security.Cryptography.X509Certificates;
 using NUnit.Framework;
 using Opc.Ua.Security.Certificates;
@@ -121,9 +122,14 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
         public void ConstructionFailureDisposesAlreadyBuiltCertificates()
         {
             using TestCertificateChain source = TestCertificateChain.Create();
-            long createdBefore = Certificate.InstancesCreated;
-            long disposedBefore = Certificate.InstancesDisposed;
             int calls = 0;
+
+            // Track the handles the factory hands out rather than the
+            // process-wide Certificate.InstancesCreated/InstancesDisposed
+            // counters: certificates allocated elsewhere in the run would move
+            // those counters too, and only these instances are the builder's to
+            // clean up.
+            var built = new List<Certificate>();
 
             InvalidOperationException? exception = Assert.Throws<InvalidOperationException>(
                 () => CertificateValidationHelpers.BuildValidationCertificateCollection(
@@ -137,15 +143,41 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
                             throw new InvalidOperationException("Simulated certificate factory failure.");
                         }
 
-                        return Certificate.FromRawData(certificate.GetRawCertData());
+                        Certificate created = Certificate.FromRawData(certificate.GetRawCertData());
+                        built.Add(created);
+                        return created;
                     }));
 
             Assert.That(exception, Is.Not.Null);
             Assert.That(calls, Is.EqualTo(2));
-            Assert.That(Certificate.InstancesCreated - createdBefore, Is.EqualTo(1));
-            Assert.That(
-                Certificate.InstancesDisposed - disposedBefore,
-                Is.EqualTo(Certificate.InstancesCreated - createdBefore));
+            Assert.That(built, Has.Count.EqualTo(1));
+            foreach (Certificate certificate in built)
+            {
+                Assert.That(
+                    IsReleased(certificate),
+                    Is.True,
+                    "a certificate built before the failure must be disposed by the builder.");
+            }
+        }
+
+        /// <summary>
+        /// Whether the last owning handle on the certificate's shared core was
+        /// released. <see cref="Certificate.AddRef"/> is the only observable
+        /// that distinguishes a released core from a live one; the probe handle
+        /// it hands back on a live core is disposed again immediately, so the
+        /// check leaves the refcount untouched.
+        /// </summary>
+        private static bool IsReleased(Certificate certificate)
+        {
+            try
+            {
+                using Certificate probe = certificate.AddRef();
+                return false;
+            }
+            catch (ObjectDisposedException)
+            {
+                return true;
+            }
         }
 
         private static CertificateCollection BuildCollectionFromDisposedSource(

--- a/tests/Opc.Ua.Core.Tests/Stack/Transport/UaSCBinaryClientChannelDeterministicTests.cs
+++ b/tests/Opc.Ua.Core.Tests/Stack/Transport/UaSCBinaryClientChannelDeterministicTests.cs
@@ -805,13 +805,15 @@ namespace Opc.Ua.Core.Tests.Stack.Transport
             /// <summary>
             /// The certificate handles the asymmetric header parser allocated
             /// for the sender chain during the most recent
-            /// <see cref="CallReadAsymmetricMessageHeader"/>. Captured through
-            /// the channel's test hook because the parser disposes the chain
-            /// and clears the out parameter when validation fails, leaving the
-            /// caller no other way to reach those handles. The handles are
-            /// copied out of the collection (which empties itself on disposal)
-            /// without taking a reference, so the snapshot observes their
-            /// release rather than preventing it.
+            /// <see cref="CallReadAsymmetricMessageHeader"/>, or <c>null</c>
+            /// when that call parsed no chain because the header carried no
+            /// sender certificate data. Captured through the channel's test
+            /// hook because the parser disposes the chain and clears the out
+            /// parameter when validation fails, leaving the caller no other way
+            /// to reach those handles. The handles are copied out of the
+            /// collection (which empties itself on disposal) without taking a
+            /// reference, so the snapshot observes their release rather than
+            /// preventing it.
             /// </summary>
             public IReadOnlyList<Certificate>? ParsedSenderChain { get; private set; }
 
@@ -888,6 +890,12 @@ namespace Opc.Ua.Core.Tests.Stack.Transport
                 CallReadAsymmetricMessageHeader(
                     ArraySegment<byte> buffer, Certificate? receiverCertificate)
             {
+                // Cleared up front so the property always describes THIS call:
+                // the hook only fires when the header actually carries sender
+                // certificate data, and a stale chain from an earlier call
+                // would otherwise be asserted against.
+                ParsedSenderChain = null;
+
                 using var decoder = new BinaryDecoder(buffer, Quotas.MessageContext);
                 Certificate? receiver = receiverCertificate;
                 ReadAsymmetricMessageHeader(

--- a/tests/Opc.Ua.Core.Tests/Stack/Transport/UaSCBinaryClientChannelDeterministicTests.cs
+++ b/tests/Opc.Ua.Core.Tests/Stack/Transport/UaSCBinaryClientChannelDeterministicTests.cs
@@ -219,19 +219,13 @@ namespace Opc.Ua.Core.Tests.Stack.Transport
                 sender.RawData,
                 new byte[TcpMessageLimits.CertificateThumbprintSize]);
 
-            // Baseline after the sender/receiver handles already exist: only the
-            // chain the header parser allocates internally may move the counters.
-            long createdBefore = Certificate.InstancesCreated;
-            long disposedBefore = Certificate.InstancesDisposed;
-
             ServiceResultException ex = Assert.Throws<ServiceResultException>(
                 () => channel.CallReadAsymmetricMessageHeader(
                     new ArraySegment<byte>(header), receiver))!;
             Assert.That(ex.StatusCode, Is.EqualTo((uint)StatusCodes.BadCertificateInvalid));
 
-            Assert.That(
-                Certificate.InstancesCreated - createdBefore,
-                Is.EqualTo(Certificate.InstancesDisposed - disposedBefore),
+            AssertParsedSenderChainReleased(
+                channel,
                 "the parsed sender certificate chain must be disposed when asymmetric " +
                 "header validation fails instead of being abandoned as a leaked handle.");
         }
@@ -256,9 +250,6 @@ namespace Opc.Ua.Core.Tests.Stack.Transport
                 sender.RawData,
                 new byte[TcpMessageLimits.CertificateThumbprintSize]);
 
-            long createdBefore = Certificate.InstancesCreated;
-            long disposedBefore = Certificate.InstancesDisposed;
-
             // No receiver certificate and no server certificate registry (client
             // side): the parser reaches the "receiver has no matching certificate"
             // failure after the sender chain is allocated.
@@ -267,9 +258,8 @@ namespace Opc.Ua.Core.Tests.Stack.Transport
                     new ArraySegment<byte>(header), receiverCertificate: null))!;
             Assert.That(ex.StatusCode, Is.EqualTo((uint)StatusCodes.BadCertificateInvalid));
 
-            Assert.That(
-                Certificate.InstancesCreated - createdBefore,
-                Is.EqualTo(Certificate.InstancesDisposed - disposedBefore),
+            AssertParsedSenderChainReleased(
+                channel,
                 "the parsed sender chain must be disposed when the receiver certificate is missing.");
         }
 
@@ -297,17 +287,13 @@ namespace Opc.Ua.Core.Tests.Stack.Transport
                 sender.RawData,
                 Array.Empty<byte>());
 
-            long createdBefore = Certificate.InstancesCreated;
-            long disposedBefore = Certificate.InstancesDisposed;
-
             ServiceResultException ex = Assert.Throws<ServiceResultException>(
                 () => channel.CallReadAsymmetricMessageHeader(
                     new ArraySegment<byte>(header), receiver))!;
             Assert.That(ex.StatusCode, Is.EqualTo((uint)StatusCodes.BadCertificateInvalid));
 
-            Assert.That(
-                Certificate.InstancesCreated - createdBefore,
-                Is.EqualTo(Certificate.InstancesDisposed - disposedBefore),
+            AssertParsedSenderChainReleased(
+                channel,
                 "the parsed sender chain must be disposed when the receiver thumbprint is absent.");
         }
 
@@ -736,6 +722,60 @@ namespace Opc.Ua.Core.Tests.Stack.Transport
             return Certificate.From(x509);
         }
 
+        /// <summary>
+        /// Asserts that every certificate handle the asymmetric header parser
+        /// allocated for the sender chain was released by the time the parse
+        /// failed.
+        /// </summary>
+        /// <remarks>
+        /// The chain is captured through the channel's test hook and probed
+        /// instance by instance. The process-wide
+        /// <see cref="Certificate.InstancesCreated"/> /
+        /// <see cref="Certificate.InstancesDisposed"/> counters cannot be used
+        /// here: this fixture is <see cref="ParallelizableAttribute"/>, so any
+        /// certificate another test allocates inside the measured window shifts
+        /// the created delta without a matching dispose and fails the assertion
+        /// for reasons that have nothing to do with the header parser.
+        /// </remarks>
+        private static void AssertParsedSenderChainReleased(
+            TestClientChannel channel, string because)
+        {
+            IReadOnlyList<Certificate>? parsedChain = channel.ParsedSenderChain;
+
+            // Guards against a vacuous pass: the header must have carried a
+            // sender certificate for there to be anything to leak.
+            Assert.That(
+                parsedChain,
+                Is.Not.Null,
+                "the header parser must have parsed a sender certificate chain.");
+            Assert.That(parsedChain, Is.Not.Empty);
+
+            foreach (Certificate certificate in parsedChain!)
+            {
+                Assert.That(IsReleased(certificate), Is.True, because);
+            }
+        }
+
+        /// <summary>
+        /// Whether the last owning handle on the certificate's shared core was
+        /// released. <see cref="Certificate.AddRef"/> is the only observable
+        /// that distinguishes a released core from a live one; the probe handle
+        /// it hands back on a live core is disposed again immediately, so the
+        /// check leaves the refcount untouched.
+        /// </summary>
+        private static bool IsReleased(Certificate certificate)
+        {
+            try
+            {
+                using Certificate probe = certificate.AddRef();
+                return false;
+            }
+            catch (ObjectDisposedException)
+            {
+                return true;
+            }
+        }
+
         private sealed class TestClientChannel : UaSCUaBinaryClientChannel
         {
             public TestClientChannel(
@@ -758,7 +798,22 @@ namespace Opc.Ua.Core.Tests.Stack.Transport
                     telemetry,
                     timeProvider)
             {
+                SenderCertificateChainParsedForTest =
+                    chain => ParsedSenderChain = new List<Certificate>(chain);
             }
+
+            /// <summary>
+            /// The certificate handles the asymmetric header parser allocated
+            /// for the sender chain during the most recent
+            /// <see cref="CallReadAsymmetricMessageHeader"/>. Captured through
+            /// the channel's test hook because the parser disposes the chain
+            /// and clears the out parameter when validation fails, leaving the
+            /// caller no other way to reach those handles. The handles are
+            /// copied out of the collection (which empties itself on disposal)
+            /// without taking a reference, so the snapshot observes their
+            /// release rather than preventing it.
+            /// </summary>
+            public IReadOnlyList<Certificate>? ParsedSenderChain { get; private set; }
 
             public TcpChannelState CurrentState
             {


### PR DESCRIPTION
# Description

`UaSCBinaryClientChannelDeterministicTests` had a concurrency bug that made the **full** `Opc.Ua.Core.Tests` suite fail on master (e8bec27d5), while the fixture passed 25/25 when run filtered.

```
dotnet test tests/Opc.Ua.Core.Tests/Opc.Ua.Core.Tests.csproj -p:CustomTestTarget=net10.0
=> Failed: 1, Passed: 4391, Skipped: 86, Total: 4478
=> ReadAsymmetricMessageHeaderDisposesSenderChainWhenReceiverCertificateMissing
   Assert.That(Certificate.InstancesCreated - createdBefore,
               Is.EqualTo(Certificate.InstancesDisposed - disposedBefore))
   Expected: 1  But was: 2
```

**Cause.** The three `ReadAsymmetricMessageHeaderDisposesSenderChain*` tests took a baseline of `Certificate.InstancesCreated` / `InstancesDisposed` — static, process-wide counters — ran one parse, then asserted the two deltas were equal. The fixture is `[Parallelizable]`, so any certificate a concurrently running test allocated inside the measured window inflated the created delta without a matching dispose. Which test lost the race varied by environment (locally `...WhenReceiverCertificateMissing`, on GitHub Actions `test-ubuntu-latest-Core` the sibling `...WhenReceiverThumbprintMismatches`), which is itself evidence of a race rather than a product defect. The product path is fine — the assertion passes whenever the window is uncontended.

**Fix.** Observe the exact handles the header parser allocated rather than global counters. `ReadAsymmetricMessageHeader` disposes the sender chain *and* clears the `out` parameter when validation fails, so the chain is unreachable from the caller; an `internal SenderCertificateChainParsedForTest` hook now surfaces it the moment it is parsed. It is reachable through the existing `InternalsVisibleTo Opc.Ua.Core.Tests` and follows the `IsHeldBySomeContextForTest` precedent in `ChannelGate`.

The tests snapshot those handles — a copy without `AddRef`, since a disposed `CertificateCollection` clears itself and throws on enumeration — and probe each one with `AddRef()`, the only observable that distinguishes a released core from a live one. The probe handle is disposed immediately, so the refcount is untouched. Non-null and non-empty assertions guard against a vacuous pass. The fixture stays `[Parallelizable]`; `[NonParallelizable]` was rejected as it only narrows the window and costs suite time.

## Audit of the other counter readers

| Site | Status |
| --- | --- |
| `CertificateValidationHelpersTests.ConstructionFailureDisposesAlreadyBuiltCertificates` | **Converted.** It asserted an *absolute* `created - before == 1`. Its own factory delegate builds the instances, so it now tracks them directly — no product change needed. |
| `CertificateManagerTests` (`GetIssuersAsync`) | Left as-is. Already `[NonParallelizable]` on the test; the window spans a whole trust-list resolve, where instance capture isn't practical. |
| `UaSCBinaryLoopbackTests.FailedReconnectDisposesCandidateCertificateHandlesAsync` | Left as-is. Fixture is `[NonParallelizable]`; measures a full TCP reconnect. |
| `TrustedIssuerStoreResolverTests` (PubSub.Mqtt) | Left as-is. No `[Parallelizable]` on the fixture and no assembly-level attribute, so it runs in NUnit's non-parallel shift. |
| `LeakDetectionSetup` | Left as-is. Assembly-level teardown, where the global counters are the correct observable. |

## Verification

- **Three full (unfiltered) `Opc.Ua.Core.Tests` runs on net10.0: 0 failed, 4392 passed, 86 skipped, 4478 total** — one more pass than the 4391 on master. A filtered run cannot reproduce this failure, so the full suite is the only meaningful check.
- **Negative control:** temporarily removing the product's `senderCertificateChain?.Dispose()` failed all three tests with `Expected: True, But was: False`, then reverted. The new assertions still detect a genuine leak.
- Not run locally: the full **UA.slnx** solution against .NET Framework. Leaving that to CI.

## Related Issues

No tracked issue — this is a test-infrastructure fix for a failure observed on master and in the `test-ubuntu-latest-Core` CI job.

## Checklist

- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf) and read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [x] I have added all necessary documentation.
- [x] I have verified that my changes do not introduce (new) build or analyzer warnings.
- [ ] I ran **all** tests locally using the **UA.slnx** solution against at least .net **framework** and .net **10**, and all passed. _(Opc.Ua.Core.Tests on net10.0 only — see Verification.)_
- [ ] I fixed **all** failing and flaky tests in the CI pipelines and **all** CodeQL warnings.
- [ ] I have addressed **all** PR feedback received.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
