### PR TITLE
Add an async iteration seam to NodeBrowser

### DIFF
--- a/.agents/skills/opcua-v20-migration/references/stack-migration/node-states.md
+++ b/.agents/skills/opcua-v20-migration/references/stack-migration/node-states.md
@@ -315,6 +315,55 @@ that to the browser's own `Next()`.
 
 Analyzer `UA0027` reports every remaining `NodeBrowser.DataLock` reference.
 
+### NodeBrowser gains an async iteration seam
+
+`INodeBrowser` and `NodeBrowser` gain
+`ValueTask<IReference?> NextAsync(CancellationToken cancellationToken = default)`.
+`AsyncCustomNodeManager.BrowseAsync` and `TranslateBrowsePathAsync` iterate a
+browser through it, so a browser whose references depend on I/O — the
+aggregation case, where the references come from another server — can `await`
+the fetch instead of blocking a request worker on it.
+
+**Nothing changes for an existing browser.** The default `NextAsync` completes
+synchronously with the result of `Next()`, so a browser that only overrides
+`Next()` is iterated exactly as before. Only a type that implements
+`INodeBrowser` directly, without deriving from `NodeBrowser`, has to add the
+member.
+
+A browser that was bridging sync-over-async moves the real work into
+`NextAsync` and keeps `Next()` as the bridge for the remaining synchronous
+consumers (`UANodeSetHelpers` export, `CustomNodeManager2`):
+
+```csharp
+// was — the fetch ran under GetResult() on every browse
+public override IReference Next()
+{
+    return NextAsync().GetAwaiter().GetResult();
+}
+
+private async Task<IReference> NextAsync() { ... }
+
+// now — the async server awaits the fetch; Next() is only reached by sync callers
+public override async ValueTask<IReference?> NextAsync(CancellationToken cancellationToken)
+{
+    IReference? reference = base.Next();
+    if (reference != null)
+    {
+        return reference;
+    }
+    ...
+}
+
+public override IReference? Next()
+{
+    return NextAsync(CancellationToken.None).AsTask().GetAwaiter().GetResult();
+}
+```
+
+Browser creation stays synchronous: `OnCreateBrowser` runs under the node's
+browse lock, so a browser does its first fetch lazily in `NextAsync`, not in its
+constructor.
+
 ## `INodeCache` changes
 
 Version 2.0 collapses the two parallel node-cache contracts into a single public interface and removes the remaining synchronous wrappers from the cache surface.

--- a/docs/AsyncServerSupport.md
+++ b/docs/AsyncServerSupport.md
@@ -71,6 +71,17 @@ server.RegisterNodeManager(context =>
     new MyAsyncNodeManager(server, configuration));
 ```
 
+### Async browse iteration
+
+Every hook a custom node manager overrides is awaitable, and that includes browsing.
+`AsyncCustomNodeManager.BrowseAsync` and `TranslateBrowsePathAsync` iterate an
+`INodeBrowser` through `NextAsync(CancellationToken)` rather than `Next()`, so a browser that
+has to reach an underlying system — the aggregation case, where the references come from
+another server — awaits that fetch on the first `NextAsync` instead of holding a request
+worker on a blocking call. The default `NextAsync` wraps `Next()`, so the browsers the stack
+ships and every existing custom browser keep working untouched. See
+[NodeManagers.md](NodeManagers.md#threading-contract-for-nodes-and-browsers) for the browser contract.
+
 ### Locking strategy vs CustomNodeManager2
 
 `CustomNodeManager2` protects its entire address space with a **single coarse-grained monitor

--- a/docs/MigrationGuide.md
+++ b/docs/MigrationGuide.md
@@ -234,6 +234,13 @@ a node halfway through a change.
 Analyzer `UA0027` flags `NodeBrowser.DataLock`. See
 [migrate/2.0.x/node-states.md](migrate/2.0.x/node-states.md).
 
+`INodeBrowser` also gains `NextAsync(CancellationToken)`, which the async server
+browse and translate-path loops use to iterate a browser. The default completes
+synchronously with `Next()`, so existing browsers are unaffected; a browser whose
+references come from I/O overrides `NextAsync` and awaits there instead of
+blocking inside `Next()`. Details in
+[migrate/2.0.x/node-states.md](migrate/2.0.x/node-states.md#nodebrowser-gains-an-async-iteration-seam).
+
 ## Migrating code that used ApplicationConfiguration.PropertiesLock
 
 `ApplicationConfiguration.PropertiesLock` was removed. It returned the

--- a/docs/NodeManagers.md
+++ b/docs/NodeManagers.md
@@ -341,12 +341,50 @@ does so through the continuation point's `BrowserContext`, `CustomNodeManager2` 
 around the iteration. A derived browser must not add locking of its own; `NodeBrowser` no longer
 exposes one to inherit (see [migration](migrate/2.0.x/node-states.md)).
 
-Two rules follow for node types that customise browsing:
+An **`INodeBrowser` is iterated through `NextAsync`** by the async server paths. `Next()` and
+`NextAsync(CancellationToken)` drain the same sequence, and the default `NextAsync` simply wraps
+`Next()`, so a browser that only overrides `Next()` works unchanged. `AsyncCustomNodeManager`
+drives both `BrowseAsync` and `TranslateBrowsePathAsync` through `NextAsync`, which gives a
+browser whose references come from I/O — an aggregating server that browses another server, a
+device, a file system — a place to `await` instead of holding a request worker on a blocking
+call. Creation stays synchronous: `OnCreateBrowser` and `CreateBrowser` build the browser under
+the node's browse lock, so the fetch happens lazily on the first `NextAsync`, not in the
+constructor.
+
+```csharp
+public sealed class RemoteBrowser : NodeBrowser
+{
+    public override async ValueTask<IReference?> NextAsync(CancellationToken cancellationToken)
+    {
+        // In-memory references first, exactly as the base class hands them out.
+        IReference? reference = base.Next();
+        if (reference != null)
+        {
+            return reference;
+        }
+
+        m_remote ??= await m_session.BrowseAsync(..., cancellationToken).ConfigureAwait(false);
+        return m_remote.Count > 0 ? m_remote.Dequeue() : null;
+    }
+
+    // Synchronous consumers still exist (the nodeset exporter, CustomNodeManager2);
+    // bridge them rather than duplicating the fetch.
+    public override IReference? Next()
+    {
+        return NextAsync(CancellationToken.None).AsTask().GetAwaiter().GetResult();
+    }
+}
+```
+
+Three rules follow for node types that customise browsing:
 
 * An override of `PopulateBrowser` runs with the node's browse lock held. Keep it to in-memory
   work — the lock is held for its duration, so blocking on I/O there stalls every other browse of
   that node. A browser that has to reach an underlying system does that lazily in its own
-  `Next()`, outside every node lock, as `DirectoryBrowser` does for the file-system provider.
+  `NextAsync`, outside every node lock, as `DirectoryBrowser` does for the file-system provider.
+* A browser that overrides `NextAsync` also overrides `Next()`, because the base `Next()` only
+  sees the in-memory references. Bridging `Next()` to `NextAsync` is the usual shape; the async
+  server never calls it, so the blocking only ever happens on a synchronous caller's own thread.
 * An override of `CreateBrowser` that builds its own browser instead of delegating to
   `base.CreateBrowser` must fill it through `PopulateBrowserSynchronized`. Calling
   `PopulateBrowser` directly leaves construction unserialized against other browses of the same

--- a/docs/migrate/2.0.x/node-states.md
+++ b/docs/migrate/2.0.x/node-states.md
@@ -315,6 +315,55 @@ that to the browser's own `Next()`.
 
 Analyzer `UA0027` reports every remaining `NodeBrowser.DataLock` reference.
 
+### NodeBrowser gains an async iteration seam
+
+`INodeBrowser` and `NodeBrowser` gain
+`ValueTask<IReference?> NextAsync(CancellationToken cancellationToken = default)`.
+`AsyncCustomNodeManager.BrowseAsync` and `TranslateBrowsePathAsync` iterate a
+browser through it, so a browser whose references depend on I/O — the
+aggregation case, where the references come from another server — can `await`
+the fetch instead of blocking a request worker on it.
+
+**Nothing changes for an existing browser.** The default `NextAsync` completes
+synchronously with the result of `Next()`, so a browser that only overrides
+`Next()` is iterated exactly as before. Only a type that implements
+`INodeBrowser` directly, without deriving from `NodeBrowser`, has to add the
+member.
+
+A browser that was bridging sync-over-async moves the real work into
+`NextAsync` and keeps `Next()` as the bridge for the remaining synchronous
+consumers (`UANodeSetHelpers` export, `CustomNodeManager2`):
+
+```csharp
+// was — the fetch ran under GetResult() on every browse
+public override IReference Next()
+{
+    return NextAsync().GetAwaiter().GetResult();
+}
+
+private async Task<IReference> NextAsync() { ... }
+
+// now — the async server awaits the fetch; Next() is only reached by sync callers
+public override async ValueTask<IReference?> NextAsync(CancellationToken cancellationToken)
+{
+    IReference? reference = base.Next();
+    if (reference != null)
+    {
+        return reference;
+    }
+    ...
+}
+
+public override IReference? Next()
+{
+    return NextAsync(CancellationToken.None).AsTask().GetAwaiter().GetResult();
+}
+```
+
+Browser creation stays synchronous: `OnCreateBrowser` runs under the node's
+browse lock, so a browser does its first fetch lazily in `NextAsync`, not in its
+constructor.
+
 ## `INodeCache` changes
 
 Version 2.0 collapses the two parallel node-cache contracts into a single public interface and removes the remaining synchronous wrappers from the cache surface.

--- a/src/Opc.Ua.Server/FileSystem/DirectoryBrowser.cs
+++ b/src/Opc.Ua.Server/FileSystem/DirectoryBrowser.cs
@@ -27,8 +27,10 @@
  * http://opcfoundation.org/License/MIT/1.00/
  * ======================================================================*/
 
+using System;
 using System.Collections.Generic;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace Opc.Ua.Server.FileSystem
 {
@@ -54,6 +56,39 @@ namespace Opc.Ua.Server.FileSystem
             m_stage = Stage.Begin;
         }
 
+        /// <summary>
+        /// Asynchronous iteration is the primary path: the server browse and
+        /// translate-path loops drive it, so the provider enumeration is awaited
+        /// rather than blocked on.
+        /// </summary>
+        public override async ValueTask<IReference?> NextAsync(
+            CancellationToken cancellationToken = default)
+        {
+            IReference? reference = base.Next();
+            if (reference != null)
+            {
+                return reference;
+            }
+
+            if (!NeedsProviderEntries())
+            {
+                return null;
+            }
+
+            if (m_stage == Stage.Begin)
+            {
+                m_pending = await LoadEntriesAsync(cancellationToken).ConfigureAwait(false);
+                m_stage = Stage.Children;
+            }
+
+            return NextPendingChild();
+        }
+
+        /// <summary>
+        /// Synchronous bridge for the consumers that still iterate with
+        /// <see cref="NodeBrowser.Next"/> (the nodeset exporter, the legacy
+        /// <c>CustomNodeManager2</c>). It blocks on the provider enumeration.
+        /// </summary>
         public override IReference? Next()
         {
             IReference? reference = base.Next();
@@ -62,24 +97,31 @@ namespace Opc.Ua.Server.FileSystem
                 return reference;
             }
 
-            if (InternalOnly)
-            {
-                return null;
-            }
-            if (!IsRequired(ReferenceTypeIds.HasComponent, false))
+            if (!NeedsProviderEntries())
             {
                 return null;
             }
 
             if (m_stage == Stage.Begin)
             {
-                m_pending = LoadEntries();
+                m_pending = LoadEntriesAsync(CancellationToken.None)
+                    .AsTask().GetAwaiter().GetResult();
                 m_stage = Stage.Children;
             }
 
+            return NextPendingChild();
+        }
+
+        private bool NeedsProviderEntries()
+        {
+            return !InternalOnly && IsRequired(ReferenceTypeIds.HasComponent, false);
+        }
+
+        private IReference? NextPendingChild()
+        {
             if (m_stage == Stage.Children)
             {
-                reference = NextChild();
+                IReference? reference = NextChild();
                 if (reference != null)
                 {
                     return reference;
@@ -90,25 +132,25 @@ namespace Opc.Ua.Server.FileSystem
             return null;
         }
 
-        private List<FileSystemEntry> LoadEntries()
+        private async ValueTask<List<FileSystemEntry>> LoadEntriesAsync(
+            CancellationToken cancellationToken)
         {
             var list = new List<FileSystemEntry>();
             try
             {
-                IAsyncEnumerator<FileSystemEntry> enumerator = m_host.Provider
-                    .EnumerateAsync(m_source.ProviderPath, CancellationToken.None)
-                    .GetAsyncEnumerator(CancellationToken.None);
-                try
+                await foreach (FileSystemEntry entry in m_host.Provider
+                    .EnumerateAsync(m_source.ProviderPath, cancellationToken)
+                    .WithCancellation(cancellationToken)
+                    .ConfigureAwait(false))
                 {
-                    while (enumerator.MoveNextAsync().AsTask().GetAwaiter().GetResult())
-                    {
-                        list.Add(enumerator.Current);
-                    }
+                    list.Add(entry);
                 }
-                finally
-                {
-                    enumerator.DisposeAsync().AsTask().GetAwaiter().GetResult();
-                }
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                // The caller cancelled the browse; surface it rather than
+                // answering with an empty directory.
+                throw;
             }
             catch
             {

--- a/src/Opc.Ua.Server/NodeManager/AsyncCustomNodeManager.cs
+++ b/src/Opc.Ua.Server/NodeManager/AsyncCustomNodeManager.cs
@@ -3298,9 +3298,11 @@ namespace Opc.Ua.Server
                 // apply filters to references.
                 var cache = new Dictionary<NodeId, NodeState>();
 
-                for (IReference? reference = browser.Next();
+                // Iterate through the async seam so a browser that fetches its references
+                // from I/O awaits that work instead of blocking this request worker.
+                for (IReference? reference = await browser.NextAsync(cancellationToken).ConfigureAwait(false);
                     reference != null;
-                    reference = browser.Next())
+                    reference = await browser.NextAsync(cancellationToken).ConfigureAwait(false))
                 {
                     // validate Browse permission
                     ServiceResult serviceResult = await ValidateRolePermissionsAsync(
@@ -3562,9 +3564,9 @@ namespace Opc.Ua.Server
             // check the browse names.
             try
             {
-                for (IReference? reference = browser.Next();
+                for (IReference? reference = await browser.NextAsync(cancellationToken).ConfigureAwait(false);
                     reference != null;
-                    reference = browser.Next())
+                    reference = await browser.NextAsync(cancellationToken).ConfigureAwait(false))
                 {
                     // ignore unknown external references.
                     if (reference.TargetId.IsAbsolute)

--- a/src/Opc.Ua.Types/State/NodeBrowser.cs
+++ b/src/Opc.Ua.Types/State/NodeBrowser.cs
@@ -29,6 +29,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Opc.Ua
 {
@@ -36,10 +38,19 @@ namespace Opc.Ua
     /// An interface to an object that browses the references of an node.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// A browser is single-consumer: it is owned by whoever created it and must not be used
     /// from more than one thread at a time. A browser that outlives a single service call -
     /// one parked in a continuation point for <c>BrowseNext</c>, for example - is serialized
     /// by its owner, not by the browser itself.
+    /// </para>
+    /// <para>
+    /// <see cref="Next"/> and <see cref="NextAsync"/> drain the same sequence, and a caller
+    /// picks one of them for the lifetime of the browser rather than mixing the two. The
+    /// asynchronous server browse path iterates through <see cref="NextAsync"/>, so a browser
+    /// whose references come from I/O - another server, a device, a file system - does that
+    /// work there and never has to block a request worker on it.
+    /// </para>
     /// </remarks>
     public interface INodeBrowser : IDisposable
     {
@@ -47,6 +58,13 @@ namespace Opc.Ua
         /// Returns the next reference.
         /// </summary>
         IReference? Next();
+
+        /// <summary>
+        /// Returns the next reference, awaiting any I/O the browser needs to produce it.
+        /// </summary>
+        /// <param name="cancellationToken">Cancels a pending fetch.</param>
+        /// <returns>The next reference, or <c>null</c> when the browser is exhausted.</returns>
+        ValueTask<IReference?> NextAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Pushes a previously returned reference back into the browser.
@@ -71,7 +89,18 @@ namespace Opc.Ua
     /// afterwards do not appear in it. It is not an atomic snapshot across the node's
     /// collections - see <see cref="NodeState.CreateBrowser"/> for what is and is not
     /// guaranteed. A derived browser that reaches an underlying system does so lazily in
-    /// <see cref="Next"/>, outside any node lock.
+    /// <see cref="NextAsync"/>, outside any node lock.
+    /// </para>
+    /// <para>
+    /// The two iteration members are one seam with two shapes. <see cref="Next"/> is the
+    /// synchronous, in-memory one; <see cref="NextAsync"/> defaults to wrapping it, so a
+    /// browser that only overrides <see cref="Next"/> is iterated correctly by both. A browser
+    /// whose references depend on I/O overrides <see cref="NextAsync"/> and does the fetch
+    /// there - the asynchronous server browse and translate paths iterate through it, so the
+    /// fetch is awaited rather than blocked on. Such a browser also overrides <see cref="Next"/>
+    /// for the remaining synchronous consumers (the nodeset exporter, the legacy
+    /// <c>CustomNodeManager2</c>), typically by bridging to <see cref="NextAsync"/>; the base
+    /// <see cref="Next"/> only ever sees the in-memory references.
     /// </para>
     /// </remarks>
     public class NodeBrowser : INodeBrowser
@@ -153,6 +182,22 @@ namespace Opc.Ua
             }
 
             return null;
+        }
+
+        /// <summary>
+        /// Returns the next reference, awaiting any I/O needed to produce it. Null if no
+        /// more references.
+        /// </summary>
+        /// <remarks>
+        /// The default implementation completes synchronously with the result of
+        /// <see cref="Next"/>, so an existing browser that only overrides <see cref="Next"/>
+        /// keeps working unchanged. A browser that has to reach an underlying system
+        /// overrides this member and awaits the fetch here, outside every node lock.
+        /// </remarks>
+        public virtual ValueTask<IReference?> NextAsync(
+            CancellationToken cancellationToken = default)
+        {
+            return new ValueTask<IReference?>(Next());
         }
 
         /// <summary>

--- a/tests/Opc.Ua.Server.Tests/AsyncCustomNodeManagerTests.cs
+++ b/tests/Opc.Ua.Server.Tests/AsyncCustomNodeManagerTests.cs
@@ -1651,6 +1651,250 @@ namespace Opc.Ua.Server.Tests
         }
 
         /// <summary>
+        /// Issue #4415: the async node manager iterates a browser through
+        /// <see cref="INodeBrowser.NextAsync"/>, so a browser whose references
+        /// come from I/O can await that work. The browser here refuses the
+        /// synchronous <see cref="INodeBrowser.Next"/> outright, and the
+        /// continuation point round trip proves the push-back still works on the
+        /// async path.
+        /// </summary>
+        [Test]
+        public async Task BrowseAsync_IteratesBrowserThroughNextAsyncAsync()
+        {
+            using ITestNodeManager manager = CreateManager();
+            Assume.That(
+                manager is TestableAsyncCustomNodeManager,
+                "Only the async node manager can drive INodeBrowser.NextAsync");
+
+            ServerSystemContext context = manager.SystemContext;
+            ushort nsIdx = manager.NamespaceIndexes[0];
+
+            NodeState[] children = await AddAsyncBrowseTargetsAsync(manager, context, nsIdx).ConfigureAwait(false);
+            AsyncOnlyBrowser browser = null;
+            NodeState parent = await AddAsyncBrowseParentAsync(
+                manager,
+                context,
+                nsIdx,
+                children,
+                created => browser = created).ConfigureAwait(false);
+
+            object handle = await manager.GetManagerHandleAsync(parent.NodeId).ConfigureAwait(false);
+            var continuationPoint = new ContinuationPoint
+            {
+                NodeToBrowse = handle,
+                Manager = manager,
+                View = new ViewDescription(),
+                BrowseDirection = BrowseDirection.Forward,
+                IncludeSubtypes = true,
+                ResultMask = BrowseResultMask.All,
+                MaxResultsToReturn = 1
+            };
+
+            var references = new List<ReferenceDescription>();
+            var operationContext = new OperationContext(
+                new RequestHeader(), null, RequestType.Browse, RequestLifetime.None);
+
+            ContinuationPoint firstResult = await manager.BrowseAsync(
+                operationContext,
+                continuationPoint,
+                references).ConfigureAwait(false);
+
+            Assert.That(firstResult, Is.Not.Null, "second reference must be parked in a continuation point");
+            Assert.That(references, Has.Count.EqualTo(1));
+
+            // BrowseNext hands the node manager a fresh result list per call.
+            var moreReferences = new List<ReferenceDescription>();
+            ContinuationPoint secondResult = await manager.BrowseAsync(
+                operationContext,
+                firstResult,
+                moreReferences).ConfigureAwait(false);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(secondResult, Is.Null);
+                Assert.That(references.Concat(moreReferences).Select(r => r.NodeId), Is.EqualTo(
+                    children.Select(c => new ExpandedNodeId(c.NodeId))));
+                Assert.That(browser, Is.Not.Null);
+                Assert.That(browser.NextCalls, Is.Zero, "the async manager must not fall back to Next()");
+                Assert.That(browser.NextAsyncCalls, Is.GreaterThanOrEqualTo(3));
+            });
+        }
+
+        /// <summary>
+        /// Issue #4415: translate-path resolution iterates the browser through
+        /// <see cref="INodeBrowser.NextAsync"/> as well.
+        /// </summary>
+        [Test]
+        public async Task TranslateBrowsePathAsync_IteratesBrowserThroughNextAsyncAsync()
+        {
+            using ITestNodeManager manager = CreateManager();
+            Assume.That(
+                manager is TestableAsyncCustomNodeManager,
+                "Only the async node manager can drive INodeBrowser.NextAsync");
+
+            ServerSystemContext context = manager.SystemContext;
+            ushort nsIdx = manager.NamespaceIndexes[0];
+
+            NodeState[] children = await AddAsyncBrowseTargetsAsync(manager, context, nsIdx).ConfigureAwait(false);
+            AsyncOnlyBrowser browser = null;
+            NodeState parent = await AddAsyncBrowseParentAsync(
+                manager,
+                context,
+                nsIdx,
+                children,
+                created => browser = created).ConfigureAwait(false);
+
+            object handle = await manager.GetManagerHandleAsync(parent.NodeId).ConfigureAwait(false);
+            var targetIds = new List<ExpandedNodeId>();
+            var unresolved = new List<NodeId>();
+            var relativePath = new RelativePathElement
+            {
+                IncludeSubtypes = true,
+                IsInverse = false,
+                TargetName = children[1].BrowseName
+            };
+
+            await manager.TranslateBrowsePathAsync(
+                new OperationContext(new RequestHeader(), null, RequestType.TranslateBrowsePathsToNodeIds, RequestLifetime.None),
+                handle,
+                relativePath,
+                targetIds,
+                unresolved).ConfigureAwait(false);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(targetIds, Is.EqualTo(new[] { new ExpandedNodeId(children[1].NodeId) }));
+                Assert.That(unresolved, Is.Empty);
+                Assert.That(browser, Is.Not.Null);
+                Assert.That(browser.NextCalls, Is.Zero, "the async manager must not fall back to Next()");
+                Assert.That(browser.NextAsyncCalls, Is.GreaterThanOrEqualTo(3));
+            });
+        }
+
+        private static async Task<NodeState[]> AddAsyncBrowseTargetsAsync(
+            ITestNodeManager manager,
+            ServerSystemContext context,
+            ushort nsIdx)
+        {
+            var children = new NodeState[2];
+            for (int i = 0; i < children.Length; i++)
+            {
+                var child = new BaseObjectState(null);
+                child.CreateAsPredefinedNode(context);
+                child.NodeId = new NodeId("AsyncBrowseChild" + i, nsIdx);
+                child.BrowseName = new QualifiedName("AsyncBrowseChild" + i, nsIdx);
+                await manager.AddNodeAsync(context, default, child).ConfigureAwait(false);
+                children[i] = child;
+            }
+            return children;
+        }
+
+        private static async Task<NodeState> AddAsyncBrowseParentAsync(
+            ITestNodeManager manager,
+            ServerSystemContext context,
+            ushort nsIdx,
+            NodeState[] children,
+            Action<AsyncOnlyBrowser> onCreated)
+        {
+            var parent = new BaseObjectState(null);
+            parent.CreateAsPredefinedNode(context);
+            parent.NodeId = new NodeId("AsyncBrowseParent", nsIdx);
+            parent.BrowseName = new QualifiedName("AsyncBrowseParent", nsIdx);
+            parent.OnCreateBrowser = (
+                browserContext,
+                node,
+                view,
+                referenceType,
+                includeSubtypes,
+                browseDirection,
+                browseName,
+                additionalReferences,
+                internalOnly) =>
+            {
+                var browser = new AsyncOnlyBrowser(
+                    browserContext,
+                    view,
+                    referenceType,
+                    includeSubtypes,
+                    browseDirection,
+                    browseName,
+                    additionalReferences,
+                    internalOnly,
+                    children);
+                onCreated(browser);
+                return browser;
+            };
+            await manager.AddNodeAsync(context, default, parent).ConfigureAwait(false);
+            return parent;
+        }
+
+        /// <summary>
+        /// A browser that produces its references only through
+        /// <see cref="NodeBrowser.NextAsync"/>, after a genuine asynchronous hop,
+        /// the way an aggregating browser that queries another server would. The
+        /// synchronous <see cref="NodeBrowser.Next"/> throws so a caller that still
+        /// drives it is caught by the test.
+        /// </summary>
+        private sealed class AsyncOnlyBrowser : NodeBrowser
+        {
+            private readonly Queue<IReference> m_pending;
+            private IReference m_pushBack;
+
+            public AsyncOnlyBrowser(
+                ISystemContext context,
+                ViewDescription view,
+                NodeId referenceType,
+                bool includeSubtypes,
+                BrowseDirection browseDirection,
+                QualifiedName browseName,
+                IEnumerable<IReference> additionalReferences,
+                bool internalOnly,
+                IEnumerable<NodeState> targets)
+                : base(context, view, referenceType, includeSubtypes, browseDirection,
+                    browseName, additionalReferences, internalOnly)
+            {
+                m_pending = new Queue<IReference>();
+                foreach (NodeState target in targets)
+                {
+                    m_pending.Enqueue(new NodeStateReference(
+                        ReferenceTypeIds.Organizes, false, target.NodeId));
+                }
+            }
+
+            public int NextCalls { get; private set; }
+
+            public int NextAsyncCalls { get; private set; }
+
+            public override IReference Next()
+            {
+                NextCalls++;
+                throw new InvalidOperationException(
+                    "This browser fetches its references asynchronously; iterate it through NextAsync.");
+            }
+
+            public override async ValueTask<IReference> NextAsync(
+                CancellationToken cancellationToken = default)
+            {
+                NextAsyncCalls++;
+                await Task.Yield();
+
+                if (m_pushBack != null)
+                {
+                    IReference reference = m_pushBack;
+                    m_pushBack = null;
+                    return reference;
+                }
+
+                return m_pending.Count > 0 ? m_pending.Dequeue() : null;
+            }
+
+            public override void Push(IReference reference)
+            {
+                m_pushBack = reference;
+            }
+        }
+
+        /// <summary>
         /// Regression for issue #4061: when a node that has been cached (e.g.
         /// because it was subscribed/registered) is deleted at runtime, it must
         /// no longer be resolvable through the component cache, otherwise a

--- a/tests/Opc.Ua.Server.Tests/AsyncCustomNodeManagerTests.cs
+++ b/tests/Opc.Ua.Server.Tests/AsyncCustomNodeManagerTests.cs
@@ -1828,6 +1828,7 @@ namespace Opc.Ua.Server.Tests
             return parent;
         }
 
+#nullable enable
         /// <summary>
         /// A browser that produces its references only through
         /// <see cref="NodeBrowser.NextAsync"/>, after a genuine asynchronous hop,
@@ -1838,16 +1839,16 @@ namespace Opc.Ua.Server.Tests
         private sealed class AsyncOnlyBrowser : NodeBrowser
         {
             private readonly Queue<IReference> m_pending;
-            private IReference m_pushBack;
+            private IReference? m_pushBack;
 
             public AsyncOnlyBrowser(
                 ISystemContext context,
-                ViewDescription view,
+                ViewDescription? view,
                 NodeId referenceType,
                 bool includeSubtypes,
                 BrowseDirection browseDirection,
                 QualifiedName browseName,
-                IEnumerable<IReference> additionalReferences,
+                IEnumerable<IReference>? additionalReferences,
                 bool internalOnly,
                 IEnumerable<NodeState> targets)
                 : base(context, view, referenceType, includeSubtypes, browseDirection,
@@ -1865,14 +1866,14 @@ namespace Opc.Ua.Server.Tests
 
             public int NextAsyncCalls { get; private set; }
 
-            public override IReference Next()
+            public override IReference? Next()
             {
                 NextCalls++;
                 throw new InvalidOperationException(
                     "This browser fetches its references asynchronously; iterate it through NextAsync.");
             }
 
-            public override async ValueTask<IReference> NextAsync(
+            public override async ValueTask<IReference?> NextAsync(
                 CancellationToken cancellationToken = default)
             {
                 NextAsyncCalls++;
@@ -1893,6 +1894,7 @@ namespace Opc.Ua.Server.Tests
                 m_pushBack = reference;
             }
         }
+#nullable restore
 
         /// <summary>
         /// Regression for issue #4061: when a node that has been cached (e.g.

--- a/tests/Opc.Ua.Server.Tests/FileSystem/DirectoryObjectStateTests.cs
+++ b/tests/Opc.Ua.Server.Tests/FileSystem/DirectoryObjectStateTests.cs
@@ -601,10 +601,73 @@ namespace Opc.Ua.Server.Tests.FileSystem
             Assert.That(GetTargetIds(browser), Is.Empty);
         }
 
+        [Test]
+        public async Task NextAsyncEnumeratesImmediateFilesAndDirectoriesAsync()
+        {
+            Directory.CreateDirectory(Path.Combine(m_root, "folder"));
+            File.WriteAllText(Path.Combine(m_root, "a.txt"), "content");
+            DirectoryObjectState state = CreateRootDirectory();
+
+            using INodeBrowser browser = state.CreateBrowser(
+                m_context, null, ReferenceTypeIds.HasComponent, true,
+                BrowseDirection.Forward, QualifiedName.Null, null, false);
+
+            List<ExpandedNodeId> targets = await GetTargetIdsAsync(browser).ConfigureAwait(false);
+
+            Assert.That(targets, Does.Contain(new ExpandedNodeId(
+                FileSystemNodeId.BuildDirectory("folder", m_manager.NamespaceIndex))));
+            Assert.That(targets, Does.Contain(new ExpandedNodeId(
+                FileSystemNodeId.BuildFile("a.txt", m_manager.NamespaceIndex))));
+        }
+
+        [Test]
+        public async Task NextAsyncReturnsNoChildrenWhenProviderEnumerationThrowsAsync()
+        {
+            UseProvider(new ThrowingEnumerateProvider());
+            DirectoryObjectState state = CreateRootDirectory();
+
+            using INodeBrowser browser = state.CreateBrowser(
+                m_context, null, ReferenceTypeIds.HasComponent, true,
+                BrowseDirection.Forward, QualifiedName.Null, null, false);
+
+            Assert.That(await GetTargetIdsAsync(browser).ConfigureAwait(false), Is.Empty);
+        }
+
+        [Test]
+        public void NextAsyncPropagatesCancellationOfTheProviderEnumeration()
+        {
+            UseProvider(new ThrowingEnumerateProvider());
+            DirectoryObjectState state = CreateRootDirectory();
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            using INodeBrowser browser = state.CreateBrowser(
+                m_context, null, ReferenceTypeIds.HasComponent, true,
+                BrowseDirection.Forward, QualifiedName.Null, null, false);
+
+            Assert.ThrowsAsync<OperationCanceledException>(
+                async () => await browser.NextAsync(cts.Token).ConfigureAwait(false));
+        }
+
         private static List<ExpandedNodeId> GetTargetIds(INodeBrowser browser)
         {
             var targets = new List<ExpandedNodeId>();
             for (IReference? reference = browser.Next(); reference != null; reference = browser.Next())
+            {
+                if (!reference.IsInverse)
+                {
+                    targets.Add(reference.TargetId);
+                }
+            }
+            return targets;
+        }
+
+        private static async Task<List<ExpandedNodeId>> GetTargetIdsAsync(INodeBrowser browser)
+        {
+            var targets = new List<ExpandedNodeId>();
+            for (IReference? reference = await browser.NextAsync().ConfigureAwait(false);
+                reference != null;
+                reference = await browser.NextAsync().ConfigureAwait(false))
             {
                 if (!reference.IsInverse)
                 {
@@ -630,11 +693,11 @@ namespace Opc.Ua.Server.Tests.FileSystem
                 [EnumeratorCancellation] CancellationToken ct)
             {
                 await Task.CompletedTask.ConfigureAwait(false);
-                if (!ct.IsCancellationRequested)
-                {
-                    throw new IOException("enumeration failed");
-                }
+                ct.ThrowIfCancellationRequested();
+                throw new IOException("enumeration failed");
+#pragma warning disable CS0162 // unreachable: the iterator must still be an iterator
                 yield break;
+#pragma warning restore CS0162
             }
 
             public ValueTask<Stream> OpenReadAsync(string path, CancellationToken ct)

--- a/tests/Opc.Ua.Types.Tests/State/NodeBrowserTests.cs
+++ b/tests/Opc.Ua.Types.Tests/State/NodeBrowserTests.cs
@@ -1,0 +1,281 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Opc.Ua.Tests;
+
+namespace Opc.Ua.Types.Tests.State
+{
+    /// <summary>
+    /// Tests the iteration seam of <see cref="NodeBrowser"/>: the synchronous
+    /// <see cref="NodeBrowser.Next"/> and the asynchronous
+    /// <see cref="NodeBrowser.NextAsync"/> drain the same sequence, and a derived
+    /// browser may take over either one.
+    /// </summary>
+    [TestFixture]
+    [Category("NodeState")]
+    [SetCulture("en-us")]
+    [SetUICulture("en-us")]
+    [Parallelizable]
+    public class NodeBrowserTests
+    {
+        private SystemContext m_context = null!;
+
+        [OneTimeSetUp]
+        public void OneTimeSetUp()
+        {
+            ITelemetryContext telemetry = NUnitTelemetryContext.Create();
+            ServiceMessageContext messageContext = ServiceMessageContext.CreateEmpty(telemetry);
+            m_context = new SystemContext(telemetry)
+            {
+                NamespaceUris = messageContext.NamespaceUris,
+                ServerUris = messageContext.ServerUris,
+                EncodeableFactory = messageContext.Factory
+            };
+        }
+
+        [Test]
+        public async Task NextAsyncDefaultsToTheSynchronousSequenceAsync()
+        {
+            IReference[] references = CreateReferences(3);
+
+            using NodeBrowser syncBrowser = CreateBrowser(references);
+            using NodeBrowser asyncBrowser = CreateBrowser(references);
+
+            var viaNext = new List<IReference>();
+            for (IReference? reference = syncBrowser.Next();
+                reference != null;
+                reference = syncBrowser.Next())
+            {
+                viaNext.Add(reference);
+            }
+
+            var viaNextAsync = new List<IReference>();
+            for (IReference? reference = await asyncBrowser.NextAsync().ConfigureAwait(false);
+                reference != null;
+                reference = await asyncBrowser.NextAsync().ConfigureAwait(false))
+            {
+                viaNextAsync.Add(reference);
+            }
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(viaNext, Is.EqualTo(references));
+                Assert.That(viaNextAsync, Is.EqualTo(references));
+            });
+        }
+
+        [Test]
+        public void DefaultNextAsyncCompletesSynchronously()
+        {
+            using NodeBrowser browser = CreateBrowser(CreateReferences(1));
+
+            ValueTask<IReference?> pending = browser.NextAsync();
+
+            Assert.That(pending.IsCompletedSuccessfully, Is.True);
+            Assert.That(pending.Result, Is.Not.Null);
+        }
+
+        [Test]
+        public async Task NextAsyncReturnsPushedReferenceFirstAsync()
+        {
+            IReference[] references = CreateReferences(2);
+            using NodeBrowser browser = CreateBrowser(references);
+
+            IReference? first = await browser.NextAsync().ConfigureAwait(false);
+            Assert.That(first, Is.SameAs(references[0]));
+
+            browser.Push(first!);
+
+            IReference? again = await browser.NextAsync().ConfigureAwait(false);
+            IReference? second = await browser.NextAsync().ConfigureAwait(false);
+            IReference? end = await browser.NextAsync().ConfigureAwait(false);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(again, Is.SameAs(references[0]));
+                Assert.That(second, Is.SameAs(references[1]));
+                Assert.That(end, Is.Null);
+            });
+        }
+
+        [Test]
+        public async Task NextAsyncObservesADerivedNextOverrideAsync()
+        {
+            IReference[] references = CreateReferences(1);
+            var extra = new NodeStateReference(
+                ReferenceTypeIds.HasComponent,
+                false,
+                new ExpandedNodeId("extra", 0));
+
+            using var browser = new AppendingBrowser(m_context, references, extra);
+
+            var seen = new List<IReference>();
+            for (IReference? reference = await browser.NextAsync().ConfigureAwait(false);
+                reference != null;
+                reference = await browser.NextAsync().ConfigureAwait(false))
+            {
+                seen.Add(reference);
+            }
+
+            Assert.That(seen, Is.EqualTo(new[] { references[0], extra }));
+        }
+
+        [Test]
+        public async Task ADerivedNextAsyncOverrideIsAwaitedAsync()
+        {
+            IReference[] references = CreateReferences(2);
+            using var browser = new AsyncOnlyBrowser(m_context, references);
+
+            var seen = new List<IReference>();
+            for (IReference? reference = await browser.NextAsync().ConfigureAwait(false);
+                reference != null;
+                reference = await browser.NextAsync().ConfigureAwait(false))
+            {
+                seen.Add(reference);
+            }
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(seen, Is.EqualTo(references));
+                Assert.That(browser.NextAsyncCalls, Is.EqualTo(3));
+                Assert.That(browser.NextCalls, Is.Zero);
+            });
+        }
+
+        [Test]
+        public void ADerivedNextAsyncOverrideHonorsCancellation()
+        {
+            using var browser = new AsyncOnlyBrowser(m_context, CreateReferences(1));
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            Assert.ThrowsAsync<TaskCanceledException>(
+                async () => await browser.NextAsync(cts.Token).ConfigureAwait(false));
+        }
+
+        private NodeBrowser CreateBrowser(IEnumerable<IReference> references)
+        {
+            return new NodeBrowser(
+                m_context,
+                null,
+                NodeId.Null,
+                true,
+                BrowseDirection.Both,
+                QualifiedName.Null,
+                references,
+                false);
+        }
+
+        private static IReference[] CreateReferences(int count)
+        {
+            var references = new IReference[count];
+            for (int i = 0; i < count; i++)
+            {
+                references[i] = new NodeStateReference(
+                    ReferenceTypeIds.HasComponent,
+                    false,
+                    new ExpandedNodeId("target" + i, 0));
+            }
+            return references;
+        }
+
+        /// <summary>
+        /// Overrides only <see cref="NodeBrowser.Next"/>, as every pre-2.0 browser does,
+        /// appending one reference once the in-memory set is exhausted.
+        /// </summary>
+        private sealed class AppendingBrowser : NodeBrowser
+        {
+            private IReference? m_extra;
+
+            public AppendingBrowser(
+                ISystemContext context,
+                IEnumerable<IReference> references,
+                IReference extra)
+                : base(context, null, NodeId.Null, true, BrowseDirection.Both,
+                    QualifiedName.Null, references, false)
+            {
+                m_extra = extra;
+            }
+
+            public override IReference? Next()
+            {
+                IReference? reference = base.Next();
+                if (reference != null)
+                {
+                    return reference;
+                }
+
+                reference = m_extra;
+                m_extra = null;
+                return reference;
+            }
+        }
+
+        /// <summary>
+        /// Produces its references only through <see cref="NodeBrowser.NextAsync"/>, with
+        /// a real asynchronous hop per call, and counts how each member is driven.
+        /// </summary>
+        private sealed class AsyncOnlyBrowser : NodeBrowser
+        {
+            private readonly Queue<IReference> m_pending;
+
+            public AsyncOnlyBrowser(ISystemContext context, IEnumerable<IReference> references)
+                : base(context, null, NodeId.Null, true, BrowseDirection.Both,
+                    QualifiedName.Null, null, false)
+            {
+                m_pending = new Queue<IReference>(references);
+            }
+
+            public int NextAsyncCalls { get; private set; }
+
+            public int NextCalls { get; private set; }
+
+            public override IReference? Next()
+            {
+                NextCalls++;
+                return NextAsync(CancellationToken.None).AsTask().GetAwaiter().GetResult();
+            }
+
+            public override async ValueTask<IReference?> NextAsync(
+                CancellationToken cancellationToken = default)
+            {
+                NextAsyncCalls++;
+                await Task.Delay(1, cancellationToken).ConfigureAwait(false);
+                return m_pending.Count > 0 ? m_pending.Dequeue() : null;
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Description

`NodeBrowser` was synchronous end to end, so a node manager whose browse result depends on I/O had nowhere to `await`. The aggregation server sample is the concrete case: its browser has to browse the aggregated server, and the only way to write it was `Next() => NextAsync().GetAwaiter().GetResult()`, which holds a request worker for the full remote round trip on every browse.

This is option (1) from the issue, the small non-breaking step:

- `INodeBrowser` and `NodeBrowser` gain `ValueTask<IReference?> NextAsync(CancellationToken cancellationToken = default)`. The default completes synchronously with the result of `Next()`, so every existing browser that only overrides `Next()` keeps working unchanged (the samples' `MemoryBufferBrowser` and the migration-analyzer test snippets compile untouched).
- `AsyncCustomNodeManager.BrowseAsync` and `TranslateBrowsePathAsync` iterate browsers through `NextAsync` with the request's cancellation token. The loop bodies already awaited; only the iteration could not.
- `DirectoryBrowser` was the one browser the stack ships that blocked on async I/O. It now awaits the file-system provider enumeration in `NextAsync` and keeps `Next()` as the bridge for the remaining synchronous consumers (`UANodeSetHelpers` export, `CustomNodeManager2`). Cancellation now propagates instead of being reported as an empty directory.
- The synchronous paths (`CustomNodeManager2`, `CoreNodeManager` diagnostics, nodeset export) are unchanged on purpose; they have no place to await.

**Not done, by design.** Browser creation stays synchronous. `OnCreateBrowser` runs under the node's browse lock, so the documented contract is that a browser fetches lazily on its first `NextAsync`. The issue itself notes the async creation seam is not needed for the aggregation case. `IAsyncEnumerable` (option 3) is not attempted.

**Compatibility note.** A type that implements `INodeBrowser` directly without deriving from `NodeBrowser` has to add the member. Nothing in this repo or the samples does that; derived browsers are unaffected.

**Docs** updated in `NodeManagers.md`, `AsyncServerSupport.md`, `MigrationGuide.md` and `migrate/2.0.x/node-states.md`, with a was/now example for a browser that previously bridged sync-over-async.

**Tests**
- `NodeBrowserTests` (new): default wrapper completes synchronously and yields the same sequence as `Next()`, push-back through `NextAsync`, a `Next`-only override observed through `NextAsync`, an awaited `NextAsync` override with cancellation.
- `AsyncCustomNodeManagerTests`: a browser whose `Next()` throws is driven entirely through `NextAsync` by browse, by the continuation-point round trip (push-back on the async path), and by translate-path.
- `DirectoryObjectStateTests`: the async path of the directory browser, including the throwing provider and cancellation.

Verified locally: `Opc.Ua.Server` builds on net10.0 and net48 with 0 errors; the browser-related server suites (1342 tests) and the new unit tests pass on net10.0; `dotnet format whitespace --verify-no-changes` is clean on the changed files.

## Related Issues

- Fixes #4415

## Checklist

- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf) and read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [x] I have added all necessary documentation.
- [x] I have verified that my changes do not introduce (new) build or analyzer warnings.
- [ ] I ran **all** tests locally using the **UA.slnx** solution against at least .net **framework** and .net **10**, and all passed.
- [ ] I fixed **all** failing and flaky tests in the CI pipelines and **all** CodeQL warnings.
- [ ] I have addressed **all** PR feedback received.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
