### PR TITLE
[master378] Send the filtered retain trailing event with a client specific Retain = false

### DIFF
--- a/Libraries/Opc.Ua.Server/Subscription/MonitoredItem/FilteredRetainTarget.cs
+++ b/Libraries/Opc.Ua.Server/Subscription/MonitoredItem/FilteredRetainTarget.cs
@@ -1,0 +1,97 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using System.Collections.Generic;
+
+namespace Opc.Ua.Server
+{
+    /// <summary>
+    /// Presents a condition to one client's select clauses with <c>Retain</c> forced to
+    /// <c>false</c>.
+    /// </summary>
+    /// <remarks>
+    /// OPC UA Part 9, 5.5.2 requires the trailing event a condition produces on its way out
+    /// of a client's where clause to carry a client specific <c>Retain = false</c>, whatever
+    /// the server itself retains. The filter target behind that event is shared by every
+    /// monitored item the condition is reported to, so the override cannot be written into
+    /// it; this wrapper applies it while the fields for a single item are read and leaves
+    /// the shared target untouched.
+    /// </remarks>
+    internal sealed class FilteredRetainTarget : IFilterTarget
+    {
+        private readonly IFilterTarget m_target;
+
+        /// <summary>
+        /// Wraps <paramref name="target"/>.
+        /// </summary>
+        /// <exception cref="ArgumentNullException"><paramref name="target"/> is <c>null</c>.</exception>
+        public FilteredRetainTarget(IFilterTarget target)
+        {
+            m_target = target ?? throw new ArgumentNullException(nameof(target));
+        }
+
+        /// <inheritdoc/>
+        public bool IsTypeOf(IFilterContext context, NodeId typeDefinitionId)
+        {
+            return m_target.IsTypeOf(context, typeDefinitionId);
+        }
+
+        /// <inheritdoc/>
+        public object GetAttributeValue(
+            IFilterContext context,
+            NodeId typeDefinitionId,
+            IList<QualifiedName> relativePath,
+            uint attributeId,
+            NumericRange indexRange)
+        {
+            object value = m_target.GetAttributeValue(
+                context,
+                typeDefinitionId,
+                relativePath,
+                attributeId,
+                indexRange);
+
+            // only a Retain the target actually resolves is overridden; a clause the type
+            // check or the browse path rejects stays null so the field list keeps its shape.
+            if (value is bool &&
+                attributeId == Attributes.Value &&
+                relativePath != null &&
+                relativePath.Count == 1 &&
+                relativePath[0] != null &&
+                relativePath[0].NamespaceIndex == 0 &&
+                relativePath[0].Name == BrowseNames.Retain)
+            {
+                return false;
+            }
+
+            return value;
+        }
+    }
+}

--- a/Libraries/Opc.Ua.Server/Subscription/MonitoredItem/MonitoredItem.cs
+++ b/Libraries/Opc.Ua.Server/Subscription/MonitoredItem/MonitoredItem.cs
@@ -1087,13 +1087,22 @@ namespace Opc.Ua.Server
                 }
 
                 // apply filter.
-                if (!bypassFilter && !CanSendFilteredAlarm(context, filter, instance))
+                bool overrideRetain = false;
+                if (!bypassFilter &&
+                    !CanSendFilteredAlarm(context, filter, instance, out overrideRetain))
                 {
                     return;
                 }
 
-                // fetch the event fields.
-                EventFieldList fields = GetEventFields(context, filter, instance);
+                // fetch the event fields. The trailing filtered retain event reads them
+                // through a wrapper that reports Retain = false to this client only. The
+                // queue keeps the original handle: duplicate detection compares handles by
+                // reference, and node managers map the handle back onto the event state.
+                IFilterTarget fieldSource = overrideRetain
+                    ? new FilteredRetainTarget(instance)
+                    : instance;
+                EventFieldList fields = GetEventFields(context, filter, fieldSource);
+                fields.Handle = instance;
                 QueueEvent(fields);
             }
         }
@@ -1114,11 +1123,21 @@ namespace Opc.Ua.Server
         /// <summary>
         /// Determines whether an event can be sent with SupportsFilteredRetain in consideration.
         /// </summary>
+        /// <remarks>
+        /// <paramref name="overrideRetain"/> is <c>true</c> only for the trailing event a
+        /// condition produces as it leaves this client's where clause. Part 9, 5.5.2 requires
+        /// that event to carry a client specific <c>Retain = false</c> whatever the server
+        /// retains, so the caller has to substitute that value into the delivered fields
+        /// without touching the shared filter target.
+        /// </remarks>
         protected bool CanSendFilteredAlarm(
             IFilterContext context,
             EventFilter filter,
-            IFilterTarget instance)
+            IFilterTarget instance,
+            out bool overrideRetain)
         {
+            overrideRetain = false;
+
             bool passedFilter = filter.WhereClause.Evaluate(context, instance);
 
             ConditionState alarmCondition = null;
@@ -1163,7 +1182,10 @@ namespace Opc.Ua.Server
                 }
                 else if (saved)
                 {
+                    // out of scope now: send the trailing event and tell this client
+                    // that it no longer retains the condition.
                     canSend = true;
+                    overrideRetain = true;
                 }
             }
 

--- a/Tests/Opc.Ua.Server.Tests/FilterRetainTests.cs
+++ b/Tests/Opc.Ua.Server.Tests/FilterRetainTests.cs
@@ -287,14 +287,21 @@ namespace Opc.Ua.Server.Tests
             bool expected = true;
             CanSendFilteredAlarm(monitoredItem, filterContext, filter, alarm, expected, telemetry);
 
-            // 2 Placed Out of Service
+            // 2 Placed Out of Service - the trailing event, "Retain sent" = False
             Debug.WriteLine("// 2 Placed Out of Service");
             alarm.OutOfServiceState.Value = OutOfService;
             if (!supportsFilteredRetain)
             {
                 expected = false;
             }
-            CanSendFilteredAlarm(monitoredItem, filterContext, filter, alarm, expected, telemetry);
+            CanSendFilteredAlarm(
+                monitoredItem,
+                filterContext,
+                filter,
+                alarm,
+                expected,
+                telemetry,
+                expectedOverrideRetain: supportsFilteredRetain);
 
             // 3 Alarm Suppressed; No event since OutOfService
             Debug.WriteLine("// 3 Alarm Suppressed; No event since OutOfService");
@@ -325,7 +332,8 @@ namespace Opc.Ua.Server.Tests
             expected = true;
             CanSendFilteredAlarm(monitoredItem, filterContext, filter, alarm, expected, telemetry);
 
-            // 8 Alarm goes inactive
+            // 8 Alarm goes inactive - with the ActiveState clause this is the trailing
+            // event, "Retain sent" = False
             Debug.WriteLine("// 8 Alarm goes inactive");
             alarm.SetLimitState(systemContext, LimitAlarmStates.Inactive);
             alarm.Retain.Value = false;
@@ -333,7 +341,14 @@ namespace Opc.Ua.Server.Tests
             {
                 expected = false;
             }
-            CanSendFilteredAlarm(monitoredItem, filterContext, filter, alarm, expected, telemetry);
+            CanSendFilteredAlarm(
+                monitoredItem,
+                filterContext,
+                filter,
+                alarm,
+                expected,
+                telemetry,
+                expectedOverrideRetain: supportsFilteredRetain);
 
             // 9 Alarm Suppressed; No event since not active
             Debug.WriteLine("// 9 Alarm Suppressed; No event since not active");
@@ -381,13 +396,233 @@ namespace Opc.Ua.Server.Tests
             CanSendFilteredAlarm(monitoredItem, filterContext, filter, alarm, expected, telemetry);
         }
 
+        /// <summary>
+        /// Part 9, 5.5.2: the trailing event a condition produces on its way out of a
+        /// client's where clause carries a client specific Retain = false, whatever the
+        /// server retains - otherwise that client keeps an alarm it should drop. The
+        /// snapshot is shared by every item the condition is reported to, so an item whose
+        /// filter still passes has to keep reading the server's real value from it.
+        /// </summary>
+        [Test]
+        public void TrailingEventIsDeliveredWithRetainFalse()
+        {
+            ITelemetryContext telemetry = NUnitTelemetryContext.Create();
+
+            ExclusiveLevelAlarmState alarm = GetExclusiveLevelAlarm(
+                addFilterRetain: true,
+                filterRetainValue: true,
+                telemetry: telemetry);
+
+            SystemContext systemContext = GetSystemContext(telemetry);
+            IFilterContext filterContext = GetFilterContext(telemetry);
+
+            // one client only wants High alarms, the other wants every event.
+            EventFilter highOnly = GetRetainEventFilter(GetHighOnlyFilter(), telemetry);
+            EventFilter everything = GetRetainEventFilter(new ContentFilter(), telemetry);
+            MonitoredItem highOnlyItem = CreateMonitoredItem(highOnly, telemetry);
+            MonitoredItem everythingItem = CreateMonitoredItem(everything, telemetry);
+
+            alarm.SetLimitState(systemContext, LimitAlarmStates.High);
+            alarm.Retain.Value = true;
+
+            InstanceStateSnapshot inScope = CreateSnapshot(alarm, telemetry);
+            highOnlyItem.QueueEvent(inScope);
+            everythingItem.QueueEvent(inScope);
+
+            Assert.That(PublishRetain(highOnlyItem), Is.True, "in scope: the server's value");
+            Assert.That(PublishRetain(everythingItem), Is.True);
+
+            // the alarm leaves the High-only client's scope while the server still retains
+            // it - the shape of an alarm that was acknowledged but is not yet inactive.
+            alarm.SetLimitState(systemContext, LimitAlarmStates.Inactive);
+            alarm.Retain.Value = true;
+
+            InstanceStateSnapshot outOfScope = CreateSnapshot(alarm, telemetry);
+            highOnlyItem.QueueEvent(outOfScope);
+            everythingItem.QueueEvent(outOfScope);
+
+            Assert.That(
+                PublishRetain(highOnlyItem),
+                Is.False,
+                "the trailing event carries the client specific Retain");
+            Assert.That(
+                PublishRetain(everythingItem),
+                Is.True,
+                "an item the condition still passes reads the server's value");
+            Assert.That(
+                ReadRetain(outOfScope, filterContext),
+                Is.True,
+                "the shared snapshot is untouched");
+        }
+
+        /// <summary>
+        /// The override belongs to the single transition out of scope. Once the condition
+        /// passes the where clause again the client is back to the server's value.
+        /// </summary>
+        [Test]
+        public void RetainOverrideAppliesToTheTrailingEventOnly()
+        {
+            ITelemetryContext telemetry = NUnitTelemetryContext.Create();
+
+            ExclusiveLevelAlarmState alarm = GetExclusiveLevelAlarm(
+                addFilterRetain: true,
+                filterRetainValue: true,
+                telemetry: telemetry);
+
+            SystemContext systemContext = GetSystemContext(telemetry);
+            EventFilter highOnly = GetRetainEventFilter(GetHighOnlyFilter(), telemetry);
+            MonitoredItem monitoredItem = CreateMonitoredItem(highOnly, telemetry);
+
+            alarm.SetLimitState(systemContext, LimitAlarmStates.High);
+            alarm.Retain.Value = true;
+            monitoredItem.QueueEvent(CreateSnapshot(alarm, telemetry));
+            Assert.That(PublishRetain(monitoredItem), Is.True);
+
+            alarm.SetLimitState(systemContext, LimitAlarmStates.Inactive);
+            alarm.Retain.Value = true;
+            monitoredItem.QueueEvent(CreateSnapshot(alarm, telemetry));
+            Assert.That(PublishRetain(monitoredItem), Is.False, "trailing event");
+
+            // still out of scope and no longer tracked: nothing is delivered at all.
+            monitoredItem.QueueEvent(CreateSnapshot(alarm, telemetry));
+            Assert.That(monitoredItem.ItemsInQueue, Is.Zero);
+
+            alarm.SetLimitState(systemContext, LimitAlarmStates.High);
+            alarm.Retain.Value = true;
+            monitoredItem.QueueEvent(CreateSnapshot(alarm, telemetry));
+            Assert.That(PublishRetain(monitoredItem), Is.True, "back in scope: the server's value");
+        }
+
+        /// <summary>
+        /// A select clause the wrapper cannot resolve - here Retain asked for on a type the
+        /// condition is not - must stay null rather than be turned into a false.
+        /// </summary>
+        [Test]
+        public void RetainOverrideLeavesUnresolvedClausesAlone()
+        {
+            ITelemetryContext telemetry = NUnitTelemetryContext.Create();
+            IFilterContext filterContext = GetFilterContext(telemetry);
+
+            ExclusiveLevelAlarmState alarm = GetExclusiveLevelAlarm(
+                addFilterRetain: true,
+                filterRetainValue: true,
+                telemetry: telemetry);
+            alarm.Retain.Value = true;
+
+            var wrapped = new FilteredRetainTarget(CreateSnapshot(alarm, telemetry));
+            QualifiedNameCollection retainPath = [.. new QualifiedName[] { BrowseNames.Retain }];
+
+            object overridden = wrapped.GetAttributeValue(
+                filterContext,
+                ObjectTypeIds.ConditionType,
+                retainPath,
+                Attributes.Value,
+                NumericRange.Empty);
+            Assert.That(overridden, Is.EqualTo(false));
+
+            object unresolved = wrapped.GetAttributeValue(
+                filterContext,
+                ObjectTypeIds.AuditEventType,
+                retainPath,
+                Attributes.Value,
+                NumericRange.Empty);
+            Assert.That(unresolved, Is.Null);
+        }
+
+        private const int kRetainFieldIndex = 1;
+
+        /// <summary>
+        /// Select clauses with a known slot for Retain and no localized text, so the item
+        /// does not need a resource manager to build the field list.
+        /// </summary>
+        private EventFilter GetRetainEventFilter(
+            ContentFilter whereClause,
+            ITelemetryContext telemetry)
+        {
+            var selectClauses = new SimpleAttributeOperandCollection
+            {
+                new SimpleAttributeOperand
+                {
+                    AttributeId = Attributes.Value,
+                    TypeDefinitionId = ObjectTypeIds.BaseEventType,
+                    BrowsePath = [.. new QualifiedName[] { BrowseNames.EventId }]
+                },
+                new SimpleAttributeOperand
+                {
+                    AttributeId = Attributes.Value,
+                    TypeDefinitionId = ObjectTypeIds.ConditionType,
+                    BrowsePath = [.. new QualifiedName[] { BrowseNames.Retain }]
+                },
+                new SimpleAttributeOperand
+                {
+                    AttributeId = Attributes.NodeId,
+                    TypeDefinitionId = ObjectTypeIds.ConditionType
+                }
+            };
+
+            var filter = new EventFilter
+            {
+                SelectClauses = selectClauses,
+                WhereClause = whereClause
+            };
+            _ = filter.Validate(GetFilterContext(telemetry));
+            return filter;
+        }
+
+        private InstanceStateSnapshot CreateSnapshot(
+            BaseObjectState alarm,
+            ITelemetryContext telemetry)
+        {
+            var snapshot = new InstanceStateSnapshot();
+            snapshot.Initialize(GetSystemContext(telemetry), alarm);
+            return snapshot;
+        }
+
+        /// <summary>
+        /// Publishes the single queued event and returns the Retain field it carries.
+        /// </summary>
+        private static bool PublishRetain(MonitoredItem monitoredItem)
+        {
+            var notifications = new Queue<EventFieldList>();
+            _ = monitoredItem.Publish(new OperationContext(monitoredItem), notifications, 10);
+
+            Assert.That(notifications, Has.Count.EqualTo(1));
+            EventFieldList fields = notifications.Dequeue();
+            Assert.That(
+                fields.EventFields[kRetainFieldIndex].Value,
+                Is.TypeOf<bool>(),
+                "Retain is a selected field");
+            return (bool)fields.EventFields[kRetainFieldIndex].Value;
+        }
+
+        private static bool ReadRetain(
+            InstanceStateSnapshot target,
+            IFilterContext filterContext)
+        {
+            object value = target.GetAttributeValue(
+                filterContext,
+                ObjectTypeIds.ConditionType,
+                [.. new QualifiedName[] { BrowseNames.Retain }],
+                Attributes.Value,
+                NumericRange.Empty);
+            Assert.That(value, Is.TypeOf<bool>());
+            return (bool)value;
+        }
+
+        /// <summary>
+        /// Evaluates the alarm's current state against the item and asserts whether it is
+        /// sent. When <paramref name="expectedOverrideRetain"/> is given it also asserts
+        /// whether this is the trailing event that carries the client specific
+        /// Retain = false - the "Retain sent" column of Part 9 Table B.3.
+        /// </summary>
         private void CanSendFilteredAlarm(
             MonitoredItem monitoredItem,
             IFilterContext context,
             EventFilter filter,
             BaseObjectState alarm,
             bool expected,
-            ITelemetryContext telemetry)
+            ITelemetryContext telemetry,
+            bool? expectedOverrideRetain = null)
         {
             SystemContext systemContext = GetSystemContext(telemetry);
 
@@ -397,11 +632,22 @@ namespace Opc.Ua.Server.Tests
             const BindingFlags eFlags = BindingFlags.Instance | BindingFlags.NonPublic;
             MethodInfo methodInfo = typeof(MonitoredItem).GetMethod("CanSendFilteredAlarm", eFlags);
             Debug.WriteLine("Expecting " + expected.ToString());
-            object result = methodInfo.Invoke(monitoredItem, [context, filter, eventSnapshot]);
+
+            // the out parameter is read back from the argument array after the call.
+            object[] arguments = [context, filter, eventSnapshot, false];
+            object result = methodInfo.Invoke(monitoredItem, arguments);
 
             Assert.That(result, Is.Not.Null);
             Assert.That(result.GetType().Name, Is.EqualTo("Boolean"));
             Assert.That((bool)result, Is.EqualTo(expected));
+
+            if (expectedOverrideRetain.HasValue)
+            {
+                Assert.That(
+                    (bool)arguments[3],
+                    Is.EqualTo(expectedOverrideRetain.Value),
+                    "Retain sent");
+            }
         }
 
         private ExclusiveLevelAlarmState GetExclusiveLevelAlarm(


### PR DESCRIPTION
# Description

Backport of #4453 to the 1.5.378 line.

When `SupportsFilteredRetain` is true and a condition drops out of a client's where clause, the server sends one trailing event to that client. Before this change the trailing event carried the condition's real `Retain` value, typically `true`, so a spec-following client kept an alarm on its display that it should have dropped. OPC 10000-9, 5.5.2 (Figure 11) and the "Retain sent" column of Table B.3 require that event to be sent with a client specific `Retain = false`.

The value is per client and per filter, so it is applied inside the monitored item:

* `CanSendFilteredAlarm` gains an `out bool overrideRetain` parameter that is `true` only for the trailing out-of-scope event. The protected signature is changed in place rather than overloaded.
* For that event the event fields are read through a new internal `FilteredRetainTarget` decorator. It delegates everything to the original `IFilterTarget` and returns `false` for a `Retain` value clause the target actually resolves. A clause the type check rejects stays null so the field list keeps its shape.
* The shared `InstanceStateSnapshot` that `ReportEvent` fans out to every monitored item is never touched, so other subscriptions whose filter the condition still passes keep receiving the server's real value. The queued `EventFieldList` keeps the original instance as its `Handle`, so reference-based duplicate detection and node manager handle lookups are unaffected.

Differences from the master change: this branch has neither the #4377 filtered-retain rework nor `docs/AlarmsAndConditions.md`, so the decorator is written against the `object`-based `IFilterTarget` of this line, the existing tracking logic is left as it is, and there is no documentation change. The reflection-based test helper reads the new out parameter back from the argument array.

Tests added in `FilterRetainTests`:

* the step-5 event from the issue queued through two monitored items sharing one snapshot: the out-of-scope client receives `Retain = false`, the still-passing client receives `true`, and the snapshot itself still reports `true`;
* the override applies to the single trailing event only and the server value returns once the condition re-enters scope;
* an unresolvable `Retain` clause stays null;
* the existing 16-step Table B.3 test now also asserts the "Retain sent" column for the trailing rows.

## Related Issues

- Fixes #4449 for 1.5.378
- Backport of #4453

## Checklist

- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf) and read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [x] I have added all necessary documentation.
- [x] I have verified that my changes do not introduce (new) build or analyzer warnings.
- [ ] I ran **all** tests locally using the **UA.slnx** solution against at least .net **framework** and .net **10**, and all passed.
- [ ] I fixed **all** failing and flaky tests in the CI pipelines and **all** CodeQL warnings.
- [ ] I have addressed **all** PR feedback received.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
