### PR TITLE
Fix signed builds for Quickstarts.Servers

### DIFF
--- a/Applications/Quickstarts.Servers/Properties/AssemblyInfo.cs
+++ b/Applications/Quickstarts.Servers/Properties/AssemblyInfo.cs
@@ -28,7 +28,5 @@
  * ======================================================================*/
 
 using System;
-using System.Runtime.CompilerServices;
 
 [assembly: CLSCompliant(false)]
-[assembly: InternalsVisibleTo("Opc.Ua.Server.Tests")]

--- a/Applications/Quickstarts.Servers/Quickstarts.Servers.csproj
+++ b/Applications/Quickstarts.Servers/Quickstarts.Servers.csproj
@@ -15,6 +15,9 @@
     <PackageId>$(PackageId).Debug</PackageId>
   </PropertyGroup>
   <ItemGroup>
+    <InternalsVisibleTo Include="Opc.Ua.Server.Tests" />
+  </ItemGroup>
+  <ItemGroup>
     <EmbeddedResource Include="Boiler\Generated\Boiler.PredefinedNodes.uanodes" />
     <EmbeddedResource Include="TestData\Generated\TestData.PredefinedNodes.uanodes" />
     <EmbeddedResource Include="MemoryBuffer\Generated\MemoryBuffer.PredefinedNodes.uanodes" />


### PR DESCRIPTION
# Description

Test assembly permission moved from AssemblyInfo.cs to the project file, matching the other projects and allowing the required public key to be added automatically.

