### PR TITLE
Fix alias startup ordering and retained translation fallbacks

### DIFF
--- a/docs/AliasNames.md
+++ b/docs/AliasNames.md
@@ -74,7 +74,9 @@ services.AddOpcUa()
 ```
 
 `AddAliasNameStore(...)` and `AddAliasNameStoreRegistry(...)` register
-their stores before address-space startup. The opt-in
+their stores before address-space startup, after application
+`IServerPreStartupTask` registrations have finished initializing source
+registries. The opt-in
 `ConfigureAliasNames(Action<AliasNameServerOptions>)` extension is on
 `IOpcUaServerBuilder` in `Microsoft.Extensions.DependencyInjection`.
 `AliasNameServerOptions` is in `Opc.Ua.Server.AliasNames`, and its

--- a/docs/DependencyInjection.md
+++ b/docs/DependencyInjection.md
@@ -536,6 +536,9 @@ overriding the published capabilities in a task.
 
 `AddAliasNameStore(store)` and `AddAliasNameStoreRegistry(registry)`
 make registered stores available before address-space startup.
+Application `IServerPreStartupTask` registrations run first, in their
+registration order, so they can initialize source registries before the
+stores are copied into the server's registry.
 `ConfigureAliasNames(Action<AliasNameServerOptions>)` controls whether
 the normal `ConfigurationNodeManager` also materializes their aliases
 and declared optional capabilities under the standard `TagVariables`
@@ -583,6 +586,10 @@ The server creates, retains, and disposes its own resource manager.
 These callbacks do not register a live `Opc.Ua.Server.ResourceManager`
 service for injection. Resolve supporting services from `sp` and use the
 manager passed to the callback.
+
+Translated text retains its original `TranslationInfo` fallback locale,
+template, and arguments. A retained result can therefore be translated for
+another session without losing its original fallback.
 
 ### Migrating with an existing configuration XML file
 

--- a/src/Opc.Ua.Server/Hosting/OpcUaServerManagerRegistrations.cs
+++ b/src/Opc.Ua.Server/Hosting/OpcUaServerManagerRegistrations.cs
@@ -170,14 +170,15 @@ namespace Opc.Ua.Server.Hosting
                     registration.Resolve(services),
                     registration.OwnsProvider);
             }
-            server.AddPreStartupTask(
-                services.GetService<OpcUaServerAliasNameStartupTask>() ??
-                    new OpcUaServerAliasNameStartupTask(services));
             foreach (IServerPreStartupTask task in
                 services.GetServices<IServerPreStartupTask>())
             {
                 server.AddPreStartupTask(task);
             }
+            // Application tasks may populate source registries used by address-space materialization.
+            server.AddPreStartupTask(
+                services.GetService<OpcUaServerAliasNameStartupTask>() ??
+                    new OpcUaServerAliasNameStartupTask(services));
         }
     }
 

--- a/src/Opc.Ua.Server/NodeManager/ResourceManager.cs
+++ b/src/Opc.Ua.Server/NodeManager/ResourceManager.cs
@@ -414,13 +414,14 @@ namespace Opc.Ua.Server
                     // use the default if no translation available.
                     if (translatedText == null)
                     {
-                        return defaultText.FilterByPreferredLocales(preferredLocales);
+                        return preferredLocales.Count > 0 && defaultText.Translations == null && info.Text != null
+                            ? new LocalizedText(info)
+                            : defaultText.FilterByPreferredLocales(preferredLocales);
                     }
                 }
 
                 // construct translated localized text.
-                return new LocalizedText(new TranslationInfo(
-                    info.Key, culture.Name, translatedText, info.Args));
+                return new LocalizedText(culture.Name, translatedText, info);
             }
         }
 

--- a/src/Opc.Ua.Types/BuiltIn/LocalizedText.cs
+++ b/src/Opc.Ua.Types/BuiltIn/LocalizedText.cs
@@ -168,8 +168,11 @@ namespace Opc.Ua
         }
 
         /// <summary>
-        /// Creates text from a TranslationInfo object.
+        /// Creates selected text while retaining the original translation fallback.
         /// </summary>
+        /// <param name="locale">The locale used to display and format the selected text.</param>
+        /// <param name="text">The selected text or format template.</param>
+        /// <param name="translationInfo">The original fallback and formatting arguments, retained unchanged.</param>
         public LocalizedText(string locale, string text, TranslationInfo translationInfo)
             : this(locale, text, LocalizedTextFormatAndTranslation.Create(translationInfo))
         {
@@ -210,14 +213,14 @@ namespace Opc.Ua
         {
             m_translation = translation;
             m_locale = translation?.GetLocale();
-            m_text = translation?.FormatText();
+            m_text = translation?.GetText(m_locale);
         }
 
         /// <summary>
         /// Initializes the object with a locale and text and translation object.
         /// </summary>
         /// <param name="locale">The locale code applicable for the specified text</param>
-        /// <param name="text">The text to store</param>
+        /// <param name="text">The unformatted template, or encoded text for a multi-language value.</param>
         /// <param name="translation">The translation information</param>
         internal LocalizedText(string? locale, string? text, LocalizedTextFormatAndTranslation? translation)
         {
@@ -230,13 +233,13 @@ namespace Opc.Ua
         /// The locale used to create the text.
         /// </summary>
         public string? Locale
-            => IsMultiLanguage ? m_locale : m_translation?.GetLocale() ?? m_locale;
+            => m_locale ?? m_translation?.GetLocale();
 
         /// <summary>
         /// The localized text.
         /// </summary>
         public string? Text
-            => IsMultiLanguage ? m_text : m_translation?.FormatText() ?? m_text;
+            => IsMultiLanguage ? m_text : m_translation?.FormatText(Locale, m_text) ?? m_text;
 
         /// <summary>
         /// Translations
@@ -265,7 +268,7 @@ namespace Opc.Ua
         public LocalizedText AsMultiLanguage()
         {
             return
-                m_translation?.AsMultiLanguage(false) ??
+                m_translation?.AsMultiLanguage(false, m_locale, m_text) ??
                 LocalizedTextFormatAndTranslation.EncodeAsMulLocale(this);
         }
 
@@ -448,7 +451,7 @@ namespace Opc.Ua
             return m_locale is null && m_translation is null;
         }
 
-        private readonly string? m_text;
+        private readonly string? m_text; // Raw template; formatting must never consume an already formatted value.
         private readonly string? m_locale; // TODO: make union with m_translation?
         private readonly LocalizedTextFormatAndTranslation? m_translation;
     }
@@ -612,33 +615,39 @@ namespace Opc.Ua
         }
 
         /// <summary>
-        /// Format the translation info text with args and locale
+        /// Returns the unformatted template for the locale, or the original fallback.
+        /// </summary>
+        public string? GetText(string? locale)
+        {
+            return locale != null &&
+                Translations != null &&
+                Translations.TryGetValue(locale, out string? text)
+                    ? text
+                    : TranslationInfo.Text;
+        }
+
+        /// <summary>
+        /// Formats the selected template with the retained arguments and selected locale.
         /// </summary>
         /// <returns></returns>
-        public string? FormatText(string? locale = null, string? fallbackText = null)
+        public string? FormatText(string? locale = null, string? text = null)
         {
-            string? text = TranslationInfo.Text;
             locale ??= TranslationInfo.Locale;
-            if (Translations != null &&
-                locale != null &&
-                Translations.TryGetValue(locale, out string? localizedText))
-            {
-                text = localizedText;
-            }
+            text ??= GetText(locale);
 
             if (string.IsNullOrWhiteSpace(text) ||
                 TranslationInfo.Args == null ||
                 TranslationInfo.Args.Length == 0)
             {
-                return text ?? fallbackText;
+                return text;
             }
 
             CultureInfo culture = CultureInfo.InvariantCulture;
-            if (!string.IsNullOrEmpty(TranslationInfo.Locale))
+            if (!string.IsNullOrEmpty(locale))
             {
                 try
                 {
-                    culture = new CultureInfo(TranslationInfo.Locale);
+                    culture = new CultureInfo(locale);
                 }
                 catch
                 {
@@ -712,7 +721,7 @@ namespace Opc.Ua
             {
                 if (Translations.TryGetValue(locale, out string? text))
                 {
-                    return new LocalizedText(locale, FormatText(locale, text));
+                    return new LocalizedText(locale, text, this);
                 }
             }
 
@@ -725,14 +734,14 @@ namespace Opc.Ua
                     if (kvp.Key.StartsWith(language + "-", StringComparison.OrdinalIgnoreCase) ||
                         string.Equals(kvp.Key, language, StringComparison.OrdinalIgnoreCase))
                     {
-                        return new LocalizedText(kvp.Key, FormatText(kvp.Key, kvp.Value));
+                        return new LocalizedText(kvp.Key, kvp.Value, this);
                     }
                 }
             }
 
             // Return the first entry instead
             KeyValuePair<string, string> first = Translations.First();
-            return new LocalizedText(first.Key, FormatText(first.Key, first.Value));
+            return new LocalizedText(first.Key, first.Value, this);
         }
 
         /// <summary>
@@ -750,7 +759,10 @@ namespace Opc.Ua
         /// in https://reference.opcfoundation.org/Core/Part3/v105/docs/8.5
         /// </summary>
         [Pure]
-        public LocalizedText AsMultiLanguage(bool force = false)
+        public LocalizedText AsMultiLanguage(
+            bool force = false,
+            string? selectedLocale = null,
+            string? selectedText = null)
         {
             var t = new List<string[]>();
             if (Translations == null || Translations.Count == 0)
@@ -760,9 +772,13 @@ namespace Opc.Ua
                 {
                     return LocalizedText.Null;
                 }
-                t.Add([
-                    TranslationInfo.Locale ?? "en-US",
-                    FormatText(TranslationInfo.Text, string.Empty)!]);
+                string locale = selectedLocale ?? TranslationInfo.Locale ?? "en-US";
+                string? text = selectedText ?? TranslationInfo.Text;
+                if (!force)
+                {
+                    return new LocalizedText(locale, text, this);
+                }
+                t.Add([locale, FormatText(locale, text)!]);
             }
             else
             {
@@ -774,7 +790,7 @@ namespace Opc.Ua
             if (t.Count == 1 && !force)
             {
                 // No need to encode as mul locale if only one entry
-                return new LocalizedText(t[0][0], t[0][1], this);
+                return new LocalizedText(t[0][0], GetText(t[0][0]), this);
             }
             return new LocalizedText(kMulLocale, Serialize(t), this);
         }

--- a/tests/Opc.Ua.Aot.Tests/HostingAotTests.cs
+++ b/tests/Opc.Ua.Aot.Tests/HostingAotTests.cs
@@ -284,6 +284,7 @@ namespace Opc.Ua.Aot.Tests
                 [new Server.AliasNames.AliasNameCategoryDescriptor(
                     ObjectIds.TagVariables, QualifiedName.From(BrowseNames.TagVariables),
                     Server.AliasNames.AliasNameCapabilities.All)]);
+            using var aliasRegistry = new Server.AliasNames.AliasNameStoreRegistry();
             aliases.Seed(ObjectIds.TagVariables, "AotBuildName",
                 VariableIds.Server_ServerStatus_BuildInfo_ProductName, null, ReferenceTypeIds.AliasFor);
             var host = new AotCompositionHost(fixture.Telemetry, observations, builder =>
@@ -304,6 +305,7 @@ namespace Opc.Ua.Aot.Tests
                 {
                     observations.ResourceDependency = services.GetRequiredService<AotCompositionObservations>();
                     resources.Add("AotComposition.Greeting", "de-DE", "Hallo aus AOT");
+                    resources.Add("AotComposition.Fallback", "de-DE", "Hallo {0}");
                 });
                 builder.AddIdentityAuthenticator<AnonymousAuthenticator>();
                 builder.AddIdentityAuthenticator(usernameAuthenticator);
@@ -330,7 +332,9 @@ namespace Opc.Ua.Aot.Tests
                     observations.EmptyFactoryCalls++;
                     return [];
                 });
-                builder.AddAliasNameStore(aliases);
+                builder.AddAliasNameStoreRegistry(aliasRegistry);
+                builder.Services.AddSingleton<IServerPreStartupTask>(
+                    new AotAliasInitializationTask(aliasRegistry, aliases, observations));
                 builder.ConfigureAliasNames(options => options.MaterializeAliasNodes = true);
                 builder.AddStartupTask<AotCompositionStartupTask>();
                 builder.AddStartupTask<AotCompositionStartupTask>();
@@ -350,6 +354,7 @@ namespace Opc.Ua.Aot.Tests
 
             await Assert.That(observations.FactoryConstructions).IsEqualTo(0);
             await Assert.That(observations.AuthenticatorFactoryCalls).IsEqualTo(0);
+            await Assert.That(aliasRegistry.Stores.Count).IsEqualTo(0);
             await host.StartAsync().ConfigureAwait(false);
 
             await Assert.That(host.Context.CurrentState).IsEqualTo(ServerState.Running);
@@ -370,6 +375,7 @@ namespace Opc.Ua.Aot.Tests
             await Assert.That(ReadAotCompositionMarker(host.Context, "urn:aot:composition:instance")).IsEqualTo(23);
             await Assert.That(ReadAotCompositionMarker(host.Context, "urn:aot:composition:deferred")).IsEqualTo(37);
             await Assert.That(observations.StartupCalls).IsEqualTo(1);
+            await Assert.That(observations.AliasInitializationCalls).IsEqualTo(1);
             await Assert.That(observations.Events.SequenceEqual(["generic", "delegate"])).IsTrue();
             await Assert.That(observations.DelegateDependency).IsSameReferenceAs(observations);
             await Assert.That(observations.DelegateContext).IsSameReferenceAs(host.Context);
@@ -383,6 +389,14 @@ namespace Opc.Ua.Aot.Tests
             await Assert.That(greeting.Locale).IsEqualTo("de-DE");
             await Assert.That(observations.Server.ResourceManager.Translate(
                 ["en-US"], "AotComposition.Greeting", "fallback").Text).IsEqualTo("Hello from AOT");
+            var fallback = new LocalizedText("AotComposition.Fallback", "en-US", "Hello {0}", "AOT");
+            LocalizedText german = observations.Server.ResourceManager.Translate(["de-DE"], fallback);
+            LocalizedText english = observations.Server.ResourceManager.Translate(["en-US"], german);
+            await Assert.That(german.Locale).IsEqualTo("de-DE");
+            await Assert.That(german.Text).IsEqualTo("Hallo AOT");
+            await Assert.That(german.TranslationInfo).IsEqualTo(fallback.TranslationInfo);
+            await Assert.That(english.Locale).IsEqualTo("en-US");
+            await Assert.That(english.Text).IsEqualTo("Hello AOT");
             await Assert.That(observations.AuthenticatorFactoryCalls).IsEqualTo(1);
             await Assert.That(observations.AuthenticatorDependency).IsSameReferenceAs(observations);
             await Assert.That(observations.CertificateValidator)
@@ -506,6 +520,7 @@ namespace Opc.Ua.Aot.Tests
             public int AuthenticatorFactoryCalls { get; set; }
             public int AuthenticationCalls { get; set; }
             public int StartupCalls { get; set; }
+            public int AliasInitializationCalls { get; set; }
             public int MarkerAtFailure { get; set; }
             public uint HistoryLimitAtDelegate { get; set; }
             public bool DelegateCancellationCanBeCanceled { get; set; }
@@ -521,6 +536,22 @@ namespace Opc.Ua.Aot.Tests
             public AotCompositionObservations DelegateDependency { get; set; }
             public AotValueNodeManager GenericManager { get; set; }
             public List<string> Events { get; } = [];
+        }
+
+        private sealed class AotAliasInitializationTask(
+            Server.AliasNames.IAliasNameStoreRegistry registry,
+            Server.AliasNames.IAliasNameStore store,
+            AotCompositionObservations observations) : IServerPreStartupTask
+        {
+            public ValueTask OnServerStartingAsync(
+                IServerContext server,
+                CancellationToken cancellationToken = default)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                registry.Register(store);
+                observations.AliasInitializationCalls++;
+                return default;
+            }
         }
 
         public sealed class AotCompositionStartupTask(AotCompositionObservations observations) : IServerStartupTask

--- a/tests/Opc.Ua.Server.Tests/Hosting/ServerCompositionHostingTests.cs
+++ b/tests/Opc.Ua.Server.Tests/Hosting/ServerCompositionHostingTests.cs
@@ -998,6 +998,177 @@ namespace Opc.Ua.Server.Tests.Hosting
             Assert.That(identity.Identity.TokenType, Is.EqualTo(UserTokenType.Anonymous));
         }
 
+        [TestCase(false, false, false)]
+        [TestCase(true, false, false)]
+        [TestCase(false, true, false)]
+        [TestCase(true, true, false)]
+        [TestCase(false, false, true)]
+        [TestCase(false, true, true)]
+        public async Task PreStartupInitializedAliasesAreRegisteredBeforeAddressSpaceAsync(
+            bool materialize,
+            bool topics,
+            bool plainServer)
+        {
+            NodeId categoryId = topics ? ObjectIds.Topics : ObjectIds.TagVariables;
+            using var store = new InMemoryAliasNameStore(
+                [new AliasNameCategoryDescriptor(
+                    categoryId,
+                    QualifiedName.From(topics ? BrowseNames.Topics : BrowseNames.TagVariables),
+                    AliasNameCapabilities.All)]);
+            using var registry = new AliasNameStoreRegistry();
+            var entered = NewSignal<bool>();
+            var release = NewSignal<bool>();
+            int initializerResolutions = 0;
+            var initializer = new Mock<IServerPreStartupTask>(MockBehavior.Strict);
+            initializer.Setup(task => task.OnServerStartingAsync(
+                It.IsAny<IServerContext>(), It.IsAny<CancellationToken>()))
+                .Returns((IServerContext _, CancellationToken ct) => InitializeAsync(ct));
+            var followingTask = new Mock<IServerPreStartupTask>(MockBehavior.Strict);
+            followingTask.Setup(task => task.OnServerStartingAsync(
+                It.IsAny<IServerContext>(), It.IsAny<CancellationToken>()))
+                .Returns(() =>
+                {
+                    Assert.That(registry.Stores, Does.Contain(store));
+                    return default;
+                });
+            var fixture = new HostedFixture((services, root) =>
+            {
+                services.AddTransient<IServerPreStartupTask>(_ =>
+                {
+                    initializerResolutions++;
+                    return initializer.Object;
+                });
+                services.AddSingleton(followingTask.Object);
+                IOpcUaBuilder builder = services.AddOpcUa();
+                IOpcUaServerBuilder server = plainServer
+                    ? builder.AddServer<StandardServer>(options => ConfigureOptions(options, root))
+                    : builder.AddServer(options => ConfigureOptions(options, root));
+                server.AddAliasNameStoreRegistry(registry);
+                if (materialize)
+                {
+                    server.ConfigureAliasNames(options => options.MaterializeAliasNodes = true);
+                }
+                return server;
+            });
+            await using var cleanup = fixture.ConfigureAwait(false);
+
+            Task starting = fixture.StartAsync();
+            try
+            {
+                await AwaitBoundedAsync(entered.Task).ConfigureAwait(false);
+                Assert.That(starting.IsCompleted, Is.False);
+                Assert.That(registry.Stores, Is.Empty);
+            }
+            finally
+            {
+                release.TrySetResult(true);
+            }
+            await AwaitBoundedAsync(starting).ConfigureAwait(false);
+
+            Assert.That(initializerResolutions, Is.EqualTo(1));
+            initializer.Verify(task => task.OnServerStartingAsync(
+                It.IsAny<IServerContext>(), It.IsAny<CancellationToken>()), Times.Once);
+            followingTask.Verify(task => task.OnServerStartingAsync(
+                It.IsAny<IServerContext>(), It.IsAny<CancellationToken>()), Times.Once);
+            AliasNameCategoryState category = fixture.Context
+                .FindPredefinedNode<AliasNameCategoryState>(categoryId);
+            ArrayOf<AliasNameDataType> aliases = await FindAliasesAsync(fixture.Context, category)
+                .ConfigureAwait(false);
+            Assert.That(aliases.Count, Is.EqualTo(1));
+            Assert.That(aliases[0].AliasName.Name, Is.EqualTo("InitializedAlias"));
+            Assert.That(aliases[0].ReferencedNodes[0],
+                Is.EqualTo((ExpandedNodeId)VariableIds.Server_ServerStatus_BuildInfo_ProductName));
+
+            var references = new List<IReference>();
+            category.GetReferences(fixture.Context.DefaultSystemContext, references);
+            IReference[] browseAliases = references.Where(reference =>
+                reference.ReferenceTypeId == ReferenceTypeIds.Organizes && !reference.IsInverse).ToArray();
+            Assert.That(browseAliases, Has.Length.EqualTo(materialize ? 1 : 0));
+            if (materialize)
+            {
+                var aliasId = ExpandedNodeId.ToNodeId(
+                    browseAliases[0].TargetId, fixture.Context.DefaultSystemContext.NamespaceUris);
+                AliasNameState alias = fixture.Context.FindPredefinedNode<AliasNameState>(aliasId);
+                Assert.That(alias.BrowseName.Name, Is.EqualTo("InitializedAlias"));
+                Assert.That(alias.ReferenceExists(ReferenceTypeIds.AliasFor, false,
+                    VariableIds.Server_ServerStatus_BuildInfo_ProductName), Is.True);
+                Assert.That(category.FindAliasVerbose, Is.Not.Null);
+            }
+
+            async ValueTask InitializeAsync(CancellationToken ct)
+            {
+                Assert.That(ct.CanBeCanceled, Is.True);
+                entered.TrySetResult(true);
+                await release.Task.ConfigureAwait(false);
+                ct.ThrowIfCancellationRequested();
+                store.Seed(categoryId, "InitializedAlias",
+                    VariableIds.Server_ServerStatus_BuildInfo_ProductName, null, ReferenceTypeIds.AliasFor);
+                registry.Register(store);
+            }
+        }
+
+        [TestCase(false)]
+        [TestCase(true)]
+        public async Task FailedPreStartupInitializationDoesNotCopyAliasStoresAsync(bool cancel)
+        {
+            using var store = new InMemoryAliasNameStore(
+                [new AliasNameCategoryDescriptor(
+                    ObjectIds.TagVariables,
+                    QualifiedName.From(BrowseNames.TagVariables),
+                    AliasNameCapabilities.All)]);
+            var registry = new Mock<IAliasNameStoreRegistry>(MockBehavior.Strict);
+            registry.SetupGet(source => source.Stores).Returns([store]);
+            var entered = NewSignal<bool>();
+            var initializer = new Mock<IServerPreStartupTask>(MockBehavior.Strict);
+            initializer.Setup(task => task.OnServerStartingAsync(
+                It.IsAny<IServerContext>(), It.IsAny<CancellationToken>()))
+                .Returns((IServerContext _, CancellationToken ct) => InitializeAsync(ct));
+            var followingTask = new Mock<IServerPreStartupTask>(MockBehavior.Strict);
+            HostedFixture fixture = HostedFixture.Create(builder =>
+            {
+                builder.Services.AddSingleton(initializer.Object);
+                builder.Services.AddSingleton(followingTask.Object);
+                builder.AddAliasNameStoreRegistry(registry.Object);
+                builder.ConfigureAliasNames(options => options.MaterializeAliasNodes = true);
+            });
+            await using var cleanup = fixture.ConfigureAwait(false);
+
+            Task<Exception> failure = fixture.StartAndCaptureFailureAsync();
+            await AwaitBoundedAsync(entered.Task).ConfigureAwait(false);
+            if (cancel)
+            {
+                await fixture.StopAsync().ConfigureAwait(false);
+            }
+            await AwaitBoundedAsync(failure).ConfigureAwait(false);
+            Exception actual = await failure.ConfigureAwait(false);
+
+            Assert.That(fixture.ExecuteTask.IsCanceled, Is.EqualTo(cancel));
+            Assert.That(fixture.ExecuteTask.IsFaulted, Is.EqualTo(!cancel));
+            if (cancel)
+            {
+                Assert.That(actual, Is.InstanceOf<OperationCanceledException>());
+            }
+            else
+            {
+                Assert.That(actual, Is.InstanceOf<ServiceResultException>());
+            }
+            initializer.Verify(task => task.OnServerStartingAsync(
+                It.IsAny<IServerContext>(), It.IsAny<CancellationToken>()), Times.Once);
+            followingTask.Verify(task => task.OnServerStartingAsync(
+                It.IsAny<IServerContext>(), It.IsAny<CancellationToken>()), Times.Never);
+            registry.VerifyGet(source => source.Stores, Times.Never);
+
+            async ValueTask InitializeAsync(CancellationToken ct)
+            {
+                entered.TrySetResult(true);
+                if (cancel)
+                {
+                    await Task.Delay(Timeout.Infinite, ct).ConfigureAwait(false);
+                }
+                throw new InvalidOperationException("Alias initialization failed.");
+            }
+        }
+
         [TestCase(false, false)]
         [TestCase(true, false)]
         [TestCase(false, true)]

--- a/tests/Opc.Ua.Server.Tests/ResourceManagerTests.cs
+++ b/tests/Opc.Ua.Server.Tests/ResourceManagerTests.cs
@@ -1,3 +1,32 @@
+/* ========================================================================
+ * Copyright (c) 2005-2026 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
 using System.Collections.Generic;
 using NUnit.Framework;
 using Opc.Ua.Tests;
@@ -247,6 +276,85 @@ namespace Opc.Ua.Server.Tests
         }
 
         [Test]
+        public void TranslateRetainsOriginalFallbackForAnotherLocale()
+        {
+            var configuration = new ApplicationConfiguration(NUnitTelemetryContext.Create());
+            using var resources = new ResourceManager(configuration);
+            resources.Add("greeting", "de-DE", "Hallo {0}");
+            var original = new LocalizedText("greeting", "en-US", "Hello {0}", "User");
+
+            LocalizedText german = resources.Translate(["de-DE"], original);
+            LocalizedText english = resources.Translate(["en-US"], german);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(german.Locale, Is.EqualTo("de-DE"));
+                Assert.That(german.Text, Is.EqualTo("Hallo User"));
+                Assert.That(german.TranslationInfo, Is.EqualTo(original.TranslationInfo));
+                Assert.That(english.Locale, Is.EqualTo("en-US"));
+                Assert.That(english.Text, Is.EqualTo("Hello User"));
+                Assert.That(english.TranslationInfo, Is.EqualTo(original.TranslationInfo));
+                Assert.That(original.Locale, Is.EqualTo("en-US"));
+                Assert.That(original.Text, Is.EqualTo("Hello User"));
+            });
+        }
+
+        [Test]
+        public void MissingLocaleUsesOriginalFallbackAfterTranslation()
+        {
+            var configuration = new ApplicationConfiguration(NUnitTelemetryContext.Create());
+            using var resources = new ResourceManager(configuration);
+            resources.Add("greeting", "de-DE", "Hallo");
+            var original = new LocalizedText("greeting", "en-US", "Hello");
+            LocalizedText german = resources.Translate(["de-DE"], original);
+
+            LocalizedText result = resources.Translate(["fr-FR"], german);
+
+            Assert.That(result.Locale, Is.EqualTo("en-US"));
+            Assert.That(result.Text, Is.EqualTo("Hello"));
+            Assert.That(result.TranslationInfo, Is.EqualTo(original.TranslationInfo));
+        }
+
+        [Test]
+        public void NoLocalePreferencePreservesTheSelectedTranslation()
+        {
+            var configuration = new ApplicationConfiguration(NUnitTelemetryContext.Create());
+            using var resources = new ResourceManager(configuration);
+            resources.Add("greeting", "de-DE", "Hallo");
+            var original = new LocalizedText("greeting", "en-US", "Hello");
+            LocalizedText german = resources.Translate(["de-DE"], original);
+
+            LocalizedText result = resources.Translate([], german);
+
+            Assert.That(result.Locale, Is.EqualTo("de-DE"));
+            Assert.That(result.Text, Is.EqualTo("Hallo"));
+            Assert.That(result.TranslationInfo, Is.EqualTo(original.TranslationInfo));
+        }
+
+        [Test]
+        public void RetainedServiceResultCanBeTranslatedForAnotherSession()
+        {
+            var configuration = new ApplicationConfiguration(NUnitTelemetryContext.Create());
+            using var resources = new ResourceManager(configuration);
+            resources.Add("timeout", "de-DE", "Zeitlimit {0}");
+            var original = new ServiceResult(
+                StatusCodes.BadTimeout,
+                new LocalizedText("timeout", "en-US", "Timeout {0}", "Pump"));
+
+            ServiceResult german = resources.Translate(["de-DE"], original);
+            ServiceResult english = resources.Translate(["en-US"], german);
+
+            Assert.That(german.StatusCode, Is.EqualTo(StatusCodes.BadTimeout));
+            Assert.That(german.LocalizedText.Text, Is.EqualTo("Zeitlimit Pump"));
+            Assert.That(german.LocalizedText.Locale, Is.EqualTo("de-DE"));
+            Assert.That(english.StatusCode, Is.EqualTo(StatusCodes.BadTimeout));
+            Assert.That(english.LocalizedText.Text, Is.EqualTo("Timeout Pump"));
+            Assert.That(english.LocalizedText.Locale, Is.EqualTo("en-US"));
+            Assert.That(english.LocalizedText.TranslationInfo, Is.EqualTo(original.LocalizedText.TranslationInfo));
+            Assert.That(original.LocalizedText.Text, Is.EqualTo("Timeout Pump"));
+        }
+
+        [Test]
         public void TranslateUsesRegisteredTextAndLocaleInsteadOfFallback()
         {
             var configuration = new ApplicationConfiguration(NUnitTelemetryContext.Create());
@@ -258,7 +366,7 @@ namespace Opc.Ua.Server.Tests
             Assert.That(translated.Text, Is.EqualTo("Hallo User"));
             Assert.That(translated.Locale, Is.EqualTo("de-DE"));
             Assert.That(translated.TranslationInfo.Key, Is.EqualTo("greeting"));
-            Assert.That(translated.TranslationInfo.Text, Is.EqualTo("Hallo {0}"));
+            Assert.That(translated.TranslationInfo.Text, Is.EqualTo("Hello {0}"));
         }
 
         [TestCase(null)]

--- a/tests/Opc.Ua.Types.Tests/BuiltIn/LocalizedTextTranslationTests.cs
+++ b/tests/Opc.Ua.Types.Tests/BuiltIn/LocalizedTextTranslationTests.cs
@@ -1,0 +1,195 @@
+/* ========================================================================
+ * Copyright (c) 2005-2026 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System.Collections.Generic;
+using NUnit.Framework;
+
+namespace Opc.Ua.Types.Tests
+{
+    /// <summary>
+    /// Covers selected display text that retains a different original translation fallback.
+    /// </summary>
+    [TestFixture]
+    [Parallelizable]
+    public sealed class LocalizedTextTranslationTests
+    {
+        [Test]
+        public void SelectedTextRetainsOriginalFallback()
+        {
+            var fallback = new TranslationInfo("greeting", "en-US", "Hello");
+
+            var selected = new LocalizedText("de-DE", "Hallo", fallback);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(selected.Locale, Is.EqualTo("de-DE"));
+                Assert.That(selected.Text, Is.EqualTo("Hallo"));
+                Assert.That(selected.TranslationInfo, Is.EqualTo(fallback));
+            });
+        }
+
+        [Test]
+        public void SelectedTemplateUsesSelectedCultureAndRetainsFallbackArguments()
+        {
+            var fallback = new TranslationInfo("measurement", "en-US", "Value {0:N1}", 1234.5);
+
+            var selected = new LocalizedText("de-DE", "Messwert {0:N1}", fallback);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(selected.Locale, Is.EqualTo("de-DE"));
+                Assert.That(selected.Text, Is.EqualTo("Messwert 1.234,5"));
+                Assert.That(selected.TranslationInfo, Is.EqualTo(fallback));
+                Assert.That(selected.TranslationInfo.Args, Is.SameAs(fallback.Args));
+                Assert.That(new LocalizedText(fallback).Text, Is.EqualTo("Value 1,234.5"));
+            });
+        }
+
+        [Test]
+        public void FilteringRetainsFallbackAcrossLocaleSelections()
+        {
+            var fallback = new TranslationInfo("greeting", "en-US", "Hello {0}", "User");
+            var original = new LocalizedText(new Dictionary<string, string>
+            {
+                ["en-US"] = "Hello {0}",
+                ["de-DE"] = "Hallo {0}",
+                ["fr-FR"] = "Bonjour {0}"
+            }, fallback);
+
+            LocalizedText german = original.FilterByPreferredLocales(["de-DE"]);
+            LocalizedText french = german.FilterByPreferredLocales(["fr-FR"]);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(german.Text, Is.EqualTo("Hallo User"));
+                Assert.That(german.Locale, Is.EqualTo("de-DE"));
+                Assert.That(german.TranslationInfo, Is.EqualTo(fallback));
+                Assert.That(french.Text, Is.EqualTo("Bonjour User"));
+                Assert.That(french.Locale, Is.EqualTo("fr-FR"));
+                Assert.That(french.TranslationInfo, Is.EqualTo(fallback));
+                Assert.That(original.Text, Is.EqualTo("Hello User"));
+                Assert.That(original.Translations, Has.Count.EqualTo(3));
+            });
+        }
+
+        [Test]
+        public void SelectedTextKeepsItsDisplayWhenConvertedToMultiLanguage()
+        {
+            var fallback = new TranslationInfo("greeting", "en-US", "Hello {0}", "User");
+            var selected = new LocalizedText("de-DE", "Hallo {0}", fallback);
+
+            LocalizedText result = selected.AsMultiLanguage();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.Locale, Is.EqualTo("de-DE"));
+                Assert.That(result.Text, Is.EqualTo("Hallo User"));
+                Assert.That(result.TranslationInfo, Is.EqualTo(fallback));
+            });
+        }
+
+        [Test]
+        public void SingleTranslationFormatsBracesExactlyOnce()
+        {
+            var fallback = new TranslationInfo("braces", "en-US", "Fallback {0}", "0");
+            var original = new LocalizedText(new Dictionary<string, string>
+            {
+                ["de-DE"] = "{{{0}}}"
+            }, fallback);
+
+            LocalizedText result = original.AsMultiLanguage();
+
+            Assert.That(result.Locale, Is.EqualTo("de-DE"));
+            Assert.That(result.Text, Is.EqualTo("{0}"));
+            Assert.That(result.TranslationInfo, Is.EqualTo(fallback));
+        }
+
+        [TestCase("de-DE", "de-DE", "Hallo")]
+        [TestCase("de-AT", "de-DE", "Hallo")]
+        [TestCase("ja-JP", "en-US", "Hello")]
+        public void FilteringRetainsMetadataForExactRegionalAndMissingLocales(
+            string requestedLocale,
+            string expectedLocale,
+            string expectedText)
+        {
+            var fallback = new TranslationInfo("greeting", "en-US", "Hello");
+            var original = new LocalizedText(new Dictionary<string, string>
+            {
+                ["en-US"] = "Hello",
+                ["de-DE"] = "Hallo"
+            }, fallback);
+
+            LocalizedText selected = original.FilterByPreferredLocales([requestedLocale]);
+
+            Assert.That(selected.Locale, Is.EqualTo(expectedLocale));
+            Assert.That(selected.Text, Is.EqualTo(expectedText));
+            Assert.That(selected.TranslationInfo, Is.EqualTo(fallback));
+            Assert.That(selected.Translations, Is.SameAs(original.Translations));
+        }
+
+        [TestCase("mul")]
+        [TestCase("qst")]
+        public void MultiLanguageSelectionKeepsFallbackAndFormatsEachLocale(string requestedLocale)
+        {
+            var fallback = new TranslationInfo("measurement", "en-US", "Value {0:N1}", 1234.5);
+            var original = new LocalizedText(new Dictionary<string, string>
+            {
+                ["en-US"] = "Value {0:N1}",
+                ["de-DE"] = "Messwert {0:N1}"
+            }, fallback);
+
+            LocalizedText multiple = original.FilterByPreferredLocales([requestedLocale, "de-DE", "en-US"]);
+            LocalizedText german = multiple.FilterByPreferredLocales(["de-DE"]);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(multiple.IsMultiLanguage, Is.True);
+                Assert.That(multiple.Translations, Has.Count.EqualTo(2));
+                Assert.That(multiple.Text, Does.Contain("[\"de-DE\",\"Messwert 1.234,5\"]"));
+                Assert.That(multiple.Text, Does.Contain("[\"en-US\",\"Value 1,234.5\"]"));
+                Assert.That(multiple.TranslationInfo, Is.EqualTo(fallback));
+                Assert.That(german.Text, Is.EqualTo("Messwert 1.234,5"));
+                Assert.That(german.Locale, Is.EqualTo("de-DE"));
+                Assert.That(german.TranslationInfo, Is.EqualTo(fallback));
+            });
+        }
+
+        [Test]
+        public void EmptySelectedTextDoesNotBecomeFallbackText()
+        {
+            var fallback = new TranslationInfo("greeting", "en-US", "Hello");
+
+            var selected = new LocalizedText("de-DE", string.Empty, fallback);
+
+            Assert.That(selected.Locale, Is.EqualTo("de-DE"));
+            Assert.That(selected.Text, Is.Empty);
+            Assert.That(selected.TranslationInfo, Is.EqualTo(fallback));
+        }
+    }
+}


### PR DESCRIPTION
# Description

Complete the two P2 follow-up fixes identified during review of #4456.

- Copy alias stores after application `IServerPreStartupTask` registrations finish, but before address-space creation. This preserves stores initialized asynchronously during startup, for both the default DI server and compatible custom servers. Task ordering, once-only execution, failure/cancellation behavior, and opt-in snapshot materialization remain intact.
- Preserve the original `TranslationInfo` fallback locale, template, key, and arguments while rendering the selected translation. Retained values and service results can be translated for another session without losing their original fallback.
- Keep selected templates unformatted until rendering, use the selected locale for formatting, retain metadata through locale filtering, and avoid double-formatting escaped braces during single-language conversion.
- Add deterministic alias initialization and translation regressions, extend native hosting coverage, and update the feature documentation.

Public signatures and `LocalizedText` struct layout are unchanged. No dependencies, migration-guide changes, CI settings, or coverage-threshold changes are introduced.

## Related Issues

- Related to #4410.
- Follow-up to the two P2 review findings in #4456.

## Validation

The new regressions failed before the relevant fixes and pass afterward.

| Scope | net10.0 | net48 |
| --- | --- | --- |
| Complete Types test project | 10,265 passed; 1 existing skip | 10,255 passed; 1 existing skip |
| Affected hosting, aliases, resources, and configuration tests | 561 passed | 561 passed |
| Existing real-session alias integration tests | 11 passed | 11 passed |

- Built the affected libraries across all configured target frameworks with **0 warnings and 0 errors**.
- Published and ran the actual Windows NativeAOT test executable: **7 HostingAotTests passed**, including initialized alias registries and English-to-German-to-English fallback preservation. Local compilation used `IlcSingleThreaded=true` after a parallel compiler attempt exhausted host memory; repository settings are unchanged.
- Focused coverage: **28/29 changed executable production lines (96.55%)**.
- Changed-file formatting and diff checks pass.

The results above are the stated local project/filtered runs, not a complete local `UA.slnx` test run. Remote CI and CodeQL results are pending.

## Checklist

- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf) and read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [x] I have added all necessary documentation.
- [x] I have verified that my changes do not introduce (new) build or analyzer warnings.
- [ ] I ran **all** tests locally using the **UA.slnx** solution against at least .net **framework** and .net **10**, and all passed.
- [ ] I fixed **all** failing and flaky tests in the CI pipelines and **all** CodeQL warnings.
- [ ] I have addressed **all** PR feedback received.
