### PR TITLE
Fix the Opc.Ua.Types defects found by the read-only audit

### DIFF
--- a/src/Opc.Ua.Types/BuiltIn/ArrayOf.cs
+++ b/src/Opc.Ua.Types/BuiltIn/ArrayOf.cs
@@ -580,7 +580,7 @@ namespace Opc.Ua
         [Pure]
         public ArrayOf<T> ReplaceItem(T value, int index)
         {
-            if (index < 0 || index > Count)
+            if (index < 0 || index >= Count)
             {
                 throw new ArgumentOutOfRangeException(nameof(index));
             }

--- a/src/Opc.Ua.Types/BuiltIn/DateTimeUtc.cs
+++ b/src/Opc.Ua.Types/BuiltIn/DateTimeUtc.cs
@@ -330,7 +330,8 @@ namespace Opc.Ua
         /// </summary>
         public DateTimeUtc AddMilliseconds(double milliseconds)
         {
-            return new DateTimeUtc(Value + (long)(milliseconds * TimeSpan.TicksPerMillisecond));
+            return new DateTimeUtc(
+                SaturatingAdd(Value, MillisecondsToTicks(milliseconds)));
         }
 
         /// <summary>
@@ -338,7 +339,8 @@ namespace Opc.Ua
         /// </summary>
         public DateTimeUtc SubtractMilliseconds(double milliseconds)
         {
-            return new DateTimeUtc(Value - (long)(milliseconds * TimeSpan.TicksPerMillisecond));
+            return new DateTimeUtc(
+                SaturatingSubtract(Value, MillisecondsToTicks(milliseconds)));
         }
 
         /// <summary>
@@ -354,7 +356,7 @@ namespace Opc.Ua
         /// </summary>
         public DateTimeUtc Add(TimeSpan value)
         {
-            return new DateTimeUtc(Value + value.Ticks);
+            return new DateTimeUtc(SaturatingAdd(Value, value.Ticks));
         }
 
         /// <summary>
@@ -362,7 +364,7 @@ namespace Opc.Ua
         /// </summary>
         public DateTimeUtc Subtract(TimeSpan value)
         {
-            return new DateTimeUtc(Value - value.Ticks);
+            return new DateTimeUtc(SaturatingSubtract(Value, value.Ticks));
         }
 
         /// <inheritdoc/>
@@ -444,16 +446,16 @@ namespace Opc.Ua
         public static DateTimeUtc Parse(ReadOnlySpan<char> s, IFormatProvider? provider)
         {
 #if NET8_0_OR_GREATER
-            return DateTime.Parse(s, provider);
+            return DateTime.Parse(s, provider, kParseStyles);
 #else
-            return DateTime.Parse(new string(s.ToArray()), provider);
+            return DateTime.Parse(new string(s.ToArray()), provider, kParseStyles);
 #endif
         }
 
         /// <inheritdoc/>
         public static DateTimeUtc Parse(string s, IFormatProvider? provider)
         {
-            return DateTime.Parse(s, provider);
+            return DateTime.Parse(s, provider, kParseStyles);
         }
 
         /// <inheritdoc/>
@@ -465,7 +467,7 @@ namespace Opc.Ua
             if (DateTime.TryParse(
                 s,
                 provider,
-                DateTimeStyles.AssumeUniversal,
+                kParseStyles,
                 out DateTime dt))
             {
                 result = dt;
@@ -488,7 +490,7 @@ namespace Opc.Ua
                 new string(s.ToArray()),
 #endif
                 provider,
-                DateTimeStyles.AssumeUniversal,
+                kParseStyles,
                 out DateTime dt))
             {
                 result = dt;
@@ -558,6 +560,65 @@ namespace Opc.Ua
         }
 
         /// <summary>
+        /// Adds a tick offset without wrapping around. <see cref="Value"/>
+        /// reports <see cref="long.MaxValue"/> for the "no expiry" sentinel, so
+        /// plain addition overflows into a negative file time and the bounds
+        /// check would then clamp it to <see cref="MinValue"/>.
+        /// </summary>
+        private static long SaturatingAdd(long value, long ticks)
+        {
+            long result = unchecked(value + ticks);
+            if (ticks > 0 && result < value)
+            {
+                return long.MaxValue;
+            }
+            if (ticks < 0 && result > value)
+            {
+                return long.MinValue;
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Subtracts a tick offset without wrapping around. Negating
+        /// <see cref="long.MinValue"/> is not representable - unchecked it
+        /// yields <see cref="long.MinValue"/> again - so subtracting the most
+        /// negative offset, which is mathematically a very large addition,
+        /// would saturate to <see cref="MinValue"/> instead of
+        /// <see cref="MaxValue"/>.
+        /// </summary>
+        private static long SaturatingSubtract(long value, long ticks)
+        {
+            return ticks == long.MinValue
+                ? long.MaxValue
+                : SaturatingAdd(value, -ticks);
+        }
+
+        /// <summary>
+        /// Converts a millisecond offset to ticks. A double to long conversion
+        /// saturates on .NET 5 and later but yields <see cref="long.MinValue"/>
+        /// for NaN and for out of range values on .NET Framework, so the
+        /// conversion is done explicitly to keep every target identical.
+        /// </summary>
+        private static long MillisecondsToTicks(double milliseconds)
+        {
+            double ticks = milliseconds * TimeSpan.TicksPerMillisecond;
+            if (double.IsNaN(ticks))
+            {
+                return 0;
+            }
+            if (ticks >= long.MaxValue)
+            {
+                return long.MaxValue;
+            }
+            if (ticks <= long.MinValue)
+            {
+                return long.MinValue;
+            }
+            return (long)ticks;
+        }
+
+        /// <summary>
         /// Ensure the file time is in the correct boundaries defined
         /// by the specification
         /// </summary>
@@ -579,7 +640,11 @@ namespace Opc.Ua
         /// <inheritdoc/>
         public static DateTimeUtc From(string s)
         {
-            return DateTime.ParseExact(s, "yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture);
+            return DateTime.ParseExact(
+                s,
+                "yyyy-MM-dd HH:mm:ss",
+                CultureInfo.InvariantCulture,
+                kParseStyles);
         }
 
         /// <inheritdoc/>
@@ -605,6 +670,14 @@ namespace Opc.Ua
         {
             return ToDateTime().ToString(format, provider);
         }
+
+        /// <summary>
+        /// Text without a time zone designator denotes UTC, not machine local
+        /// time. Without this a zone-less timestamp is shifted by the local
+        /// offset when it is converted into the UTC file time.
+        /// </summary>
+        private const DateTimeStyles kParseStyles =
+            DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal;
 
         private const long kMaxValue = 2650467743990000000;
         private const long kTickOffset = 584388 * TimeSpan.TicksPerDay;

--- a/src/Opc.Ua.Types/BuiltIn/DiagnosticInfo.cs
+++ b/src/Opc.Ua.Types/BuiltIn/DiagnosticInfo.cs
@@ -199,7 +199,12 @@ namespace Opc.Ua
 
             if (!serviceLevel)
             {
-                mask >>= 5;
+                // The operation level bits sit five positions above their
+                // service level counterparts, but UserPermissionAdditionalInfo
+                // is an internal flag outside those pairs and must survive the
+                // shift - otherwise operation level AdditionalInfo is dropped.
+                const uint userPermission = (uint)DiagnosticsMasks.UserPermissionAdditionalInfo;
+                mask = ((mask & ~userPermission) >> 5) | (mask & userPermission);
             }
 
             diagnosticsMask = (DiagnosticsMasks)mask;
@@ -226,7 +231,12 @@ namespace Opc.Ua
 
             if (!serviceLevel)
             {
-                mask >>= 5;
+                // The operation level bits sit five positions above their
+                // service level counterparts, but UserPermissionAdditionalInfo
+                // is an internal flag outside those pairs and must survive the
+                // shift - otherwise operation level AdditionalInfo is dropped.
+                const uint userPermission = (uint)DiagnosticsMasks.UserPermissionAdditionalInfo;
+                mask = ((mask & ~userPermission) >> 5) | (mask & userPermission);
             }
 
             diagnosticsMask = (DiagnosticsMasks)mask;

--- a/src/Opc.Ua.Types/BuiltIn/ExpandedNodeId.cs
+++ b/src/Opc.Ua.Types/BuiltIn/ExpandedNodeId.cs
@@ -452,7 +452,7 @@ namespace Opc.Ua
             // check for null.
             if (obj is null)
             {
-                return IsNull ? 0 : -1;
+                return IsNull ? 0 : 1;
             }
 
             // just compare node ids.
@@ -494,7 +494,8 @@ namespace Opc.Ua
             }
             else
             {
-                nodeId = NodeId.Null;
+                // Not comparable to a foreign type - never report equality.
+                return -1;
             }
 
             // check for null.
@@ -538,6 +539,7 @@ namespace Opc.Ua
             {
                 null => IsNull,
                 ExpandedNodeId e => Equals(e),
+                NodeId n => Equals(n),
                 _ => false
             };
         }
@@ -900,10 +902,12 @@ namespace Opc.Ua
             }
             else
             {
+                // The identifier itself must still be written, otherwise the
+                // result ("nsu=<uri>;i=") cannot be parsed back.
                 Format(
                     formatProvider,
                     buffer,
-                    null!,
+                    "0",
                     IdType.Numeric,
                     0,
                     NamespaceUri,
@@ -1411,14 +1415,25 @@ namespace Opc.Ua
                     return false;
                 }
 
-                if (ushort.TryParse(text[4..index], out ushort ns))
+                if (!uint.TryParse(
+                    text[4..index],
+                    NumberStyles.None,
+                    CultureInfo.InvariantCulture,
+                    out uint svr))
                 {
-                    serverIndex = ns;
+                    // An unparsable or out of range index must not be silently
+                    // dropped - that would turn a remote node id into a local
+                    // one, and TryParse would report success while doing it.
+                    error = NodeIdParseError.InvalidServerIndex;
+                    return false;
+                }
 
-                    if (options?.ServerMappings != null && options.NamespaceMappings != null && options.NamespaceMappings.Length < ns)
-                    {
-                        serverIndex = options.NamespaceMappings[ns];
-                    }
+                serverIndex = (int)svr;
+
+                if (options?.ServerMappings != null &&
+                    svr < (uint)options.ServerMappings.Length)
+                {
+                    serverIndex = options.ServerMappings[svr];
                 }
 
                 text = text[(index + 1)..];
@@ -1461,8 +1476,11 @@ namespace Opc.Ua
                 return false;
             }
 
-            if (namespaceIndex > 0)
+            if (namespaceUri != null && namespaceIndex >= 0)
             {
+                // A resolved nsu= becomes a relative node id, also when it
+                // resolves to namespace zero, so that the result matches what
+                // NodeId.Parse produces for the equivalent ns= form.
                 value = new ExpandedNodeId(
                     WithResolvedNamespace(nodeId, (ushort)namespaceIndex),
                     null,

--- a/src/Opc.Ua.Types/BuiltIn/MatrixOf.cs
+++ b/src/Opc.Ua.Types/BuiltIn/MatrixOf.cs
@@ -140,11 +140,23 @@ namespace Opc.Ua
                     indexes[array.Rank - row - 1] =
                         element / multiplier % dimensions[row];
                 }
-                values[element] = (T)
-                    (array.GetValue(indexes)
-                        ?? throw new ArgumentException(
+                object? item = array.GetValue(indexes);
+                if (item is null)
+                {
+                    // Reference types (and nullable value types) legitimately
+                    // carry unset entries, only value types cannot be null.
+                    if (default(T) is not null)
+                    {
+                        throw new ArgumentException(
                             "array contains null",
-                            nameof(array)));
+                            nameof(array));
+                    }
+                    values[element] = default!;
+                }
+                else
+                {
+                    values[element] = (T)item;
+                }
             }
             m_memory = values;
             m_dimensions =

--- a/src/Opc.Ua.Types/BuiltIn/NodeId.cs
+++ b/src/Opc.Ua.Types/BuiltIn/NodeId.cs
@@ -220,7 +220,7 @@ namespace Opc.Ua
             m_inner.NamespaceIdx = namespaceIndex;
             m_inner.Type = (byte)IdType.Opaque;
             m_identifier = value;
-            m_inner.Numeric = (uint)value.GetHashCode();
+            m_inner.Numeric = value.IsEmpty ? 0 : (uint)value.GetHashCode();
         }
 
         /// <summary>
@@ -409,15 +409,20 @@ namespace Opc.Ua
                     return false;
                 }
 
-                if (ushort.TryParse(text[3..index], out ushort ns))
+                if (!ushort.TryParse(text[3..index], out ushort ns))
                 {
-                    namespaceIndex = ns;
+                    // An unparsable or out of range index must not be silently
+                    // dropped - that would land the node id in namespace zero.
+                    error = NodeIdParseError.InvalidNamespaceFormat;
+                    return false;
+                }
 
-                    if (options?.NamespaceMappings != null &&
-                        ns < options.NamespaceMappings.Length)
-                    {
-                        namespaceIndex = options.NamespaceMappings[ns];
-                    }
+                namespaceIndex = ns;
+
+                if (options?.NamespaceMappings != null &&
+                    ns < options.NamespaceMappings.Length)
+                {
+                    namespaceIndex = options.NamespaceMappings[ns];
                 }
 
                 text = text[(index + 1)..];
@@ -1304,7 +1309,16 @@ namespace Opc.Ua
         {
             if (IsNull)
             {
-                return nodeId.IsNull ? 0 : 1; // nodeId is greater than null
+                return nodeId.IsNull ? 0 : -1; // a null NodeId sorts before any value
+            }
+
+            if (nodeId.IsNull)
+            {
+                // ... and any value sorts after a null NodeId. Without this the
+                // comparisons below answer -1 for everything that is not a
+                // namespace zero numeric id, so both directions report "less
+                // than" and the comparer is not even transitive.
+                return +1;
             }
 
             // check for different namespace.
@@ -1348,7 +1362,7 @@ namespace Opc.Ua
         {
             if (IsNull)
             {
-                return string.IsNullOrEmpty(obj) ? 0 : 1;
+                return string.IsNullOrEmpty(obj) ? 0 : -1;
             }
             if (NamespaceIndex != 0 || IdType != IdType.String)
             {
@@ -1362,7 +1376,7 @@ namespace Opc.Ua
         {
             if (IsNull)
             {
-                return obj == 0 ? 0 : 1;
+                return obj == 0 ? 0 : -1;
             }
             if (NamespaceIndex != 0 || IdType != IdType.Numeric)
             {
@@ -1376,7 +1390,7 @@ namespace Opc.Ua
         {
             if (IsNull)
             {
-                return obj == Guid.Empty ? 0 : 1;
+                return obj == Guid.Empty ? 0 : -1;
             }
             if (NamespaceIndex != 0 || IdType != IdType.Guid)
             {
@@ -1390,7 +1404,7 @@ namespace Opc.Ua
         {
             if (IsNull)
             {
-                return obj.IsEmpty ? 0 : 1;
+                return obj.IsEmpty ? 0 : -1;
             }
             if (NamespaceIndex != 0 || IdType != IdType.Opaque)
             {
@@ -1405,7 +1419,7 @@ namespace Opc.Ua
             // Needed for filter operators - do not remove
             return obj switch
             {
-                null => IsNull ? 0 : -1,
+                null => IsNull ? 0 : 1,
                 int n => n < 0 ? -1 : CompareTo((uint)n),
                 uint n => CompareTo(n),
                 Guid g => CompareTo(g),

--- a/src/Opc.Ua.Types/BuiltIn/NumericRange.cs
+++ b/src/Opc.Ua.Types/BuiltIn/NumericRange.cs
@@ -31,6 +31,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using System.Globalization;
+using System.Text;
 using System.Text.Json.Serialization;
 using Opc.Ua.Types;
 
@@ -361,6 +362,23 @@ namespace Opc.Ua
                     return string.Empty;
                 }
 
+                NumericRange[]? subRanges = m_subRanges;
+                if (subRanges is { Length: > 0 })
+                {
+                    // A multidimensional range must round trip through its text
+                    // form, so every dimension has to be written out.
+                    var builder = new StringBuilder();
+                    for (int ii = 0; ii < subRanges.Length; ii++)
+                    {
+                        if (ii > 0)
+                        {
+                            builder.Append(',');
+                        }
+                        builder.Append(subRanges[ii].ToString(null, formatProvider));
+                    }
+                    return builder.ToString();
+                }
+
                 if (m_end < 0)
                 {
                     return string.Format(formatProvider, "{0}", m_begin);
@@ -413,6 +431,18 @@ namespace Opc.Ua
                         {
                             range = Null;
                             return result;
+                        }
+
+                        // An empty dimension (",1:2" or "1:2,,3:4") is a syntax
+                        // error, not a null range. Reject it here instead of
+                        // letting the constructor below throw.
+                        if (subrange.IsNull)
+                        {
+                            range = Null;
+                            return ServiceResult.Create(
+                                StatusCodes.BadIndexRangeInvalid,
+                                "NumericRange has an empty dimension ({0}).",
+                                textToParse);
                         }
 
                         subranges.Add(subrange);
@@ -2329,7 +2359,8 @@ namespace Opc.Ua
         public StatusCode ApplyRange(ref ArrayOf<ByteString> value)
         {
             StatusCode statusCode = SliceArrayOf(ref value);
-            if (Dimensions == 1)
+            // A null range leaves the value untouched (Dimensions == 0).
+            if (IsNull || Dimensions == 1)
             {
                 return statusCode;
             }
@@ -2368,7 +2399,8 @@ namespace Opc.Ua
             ref ArrayOf<ByteString> value,
             ArrayOf<ByteString> slice)
         {
-            if (Dimensions == 1)
+            // A null range leaves the value untouched (Dimensions == 0).
+            if (IsNull || Dimensions == 1)
             {
                 return UpdateArrayOf(ref value, slice);
             }
@@ -2416,7 +2448,8 @@ namespace Opc.Ua
         public StatusCode ApplyRange(ref ArrayOf<string> value)
         {
             StatusCode statusCode = SliceArrayOf(ref value);
-            if (Dimensions == 1)
+            // A null range leaves the value untouched (Dimensions == 0).
+            if (IsNull || Dimensions == 1)
             {
                 return statusCode;
             }
@@ -2455,7 +2488,8 @@ namespace Opc.Ua
             ref ArrayOf<string> value,
             ArrayOf<string> slice)
         {
-            if (Dimensions == 1)
+            // A null range leaves the value untouched (Dimensions == 0).
+            if (IsNull || Dimensions == 1)
             {
                 return UpdateArrayOf(ref value, slice);
             }
@@ -2504,6 +2538,13 @@ namespace Opc.Ua
         /// <typeparam name="T"></typeparam>
         public StatusCode ApplyRange<T>(ref ArrayOf<T> value)
         {
+            // A null range leaves the value untouched (Dimensions == 0), as in
+            // every sibling overload. Testing the dimension count first rejected
+            // it with BadIndexRangeNoData before SliceArrayOf could say Good.
+            if (IsNull)
+            {
+                return StatusCodes.Good;
+            }
             if (Dimensions != 1)
             {
                 return StatusCodes.BadIndexRangeNoData;
@@ -2521,6 +2562,12 @@ namespace Opc.Ua
         /// <typeparam name="T"></typeparam>
         public StatusCode UpdateRange<T>(ref ArrayOf<T> value, ArrayOf<T> slice)
         {
+            // A null range leaves the value untouched (Dimensions == 0), as in
+            // every sibling overload.
+            if (IsNull)
+            {
+                return StatusCodes.Good;
+            }
             if (Dimensions != 1)
             {
                 return StatusCodes.BadIndexRangeNoData;

--- a/src/Opc.Ua.Types/BuiltIn/QualifiedName.cs
+++ b/src/Opc.Ua.Types/BuiltIn/QualifiedName.cs
@@ -521,26 +521,32 @@ namespace Opc.Ua
 
             var buffer = new StringBuilder();
 
-            if (NamespaceIndex > 0)
+            if (NamespaceIndex == 0)
             {
-                if (useNamespaceUri)
+                // prepend the namespace index if the name contains a colon,
+                // otherwise the text parses back into the wrong namespace.
+                if (Name!.Contains(':', StringComparison.Ordinal))
                 {
-                    string? namespaceUri = context.NamespaceUris.GetString(NamespaceIndex);
-                    if (!string.IsNullOrEmpty(namespaceUri))
-                    {
-                        buffer.Append("nsu=")
-                            .Append(CoreUtils.EscapeUri(namespaceUri!))
-                            .Append(';');
-                    }
-                    else
-                    {
-                        buffer.Append(NamespaceIndex).Append(':');
-                    }
+                    buffer.Append("0:");
+                }
+            }
+            else if (useNamespaceUri)
+            {
+                string? namespaceUri = context.NamespaceUris.GetString(NamespaceIndex);
+                if (!string.IsNullOrEmpty(namespaceUri))
+                {
+                    buffer.Append("nsu=")
+                        .Append(CoreUtils.EscapeUri(namespaceUri!))
+                        .Append(';');
                 }
                 else
                 {
                     buffer.Append(NamespaceIndex).Append(':');
                 }
+            }
+            else
+            {
+                buffer.Append(NamespaceIndex).Append(':');
             }
 
             buffer.Append(Name);

--- a/src/Opc.Ua.Types/BuiltIn/TypeInfo.cs
+++ b/src/Opc.Ua.Types/BuiltIn/TypeInfo.cs
@@ -1411,7 +1411,7 @@ namespace Opc.Ua
                         }
                         break;
                     case DataTypes.Enumeration:
-                        if (typeInfo.BuiltInType == BuiltInType.Int32)
+                        if (typeInfo.BuiltInType is BuiltInType.Int32 or BuiltInType.Enumeration)
                         {
                             return typeInfo;
                         }
@@ -1446,7 +1446,7 @@ namespace Opc.Ua
                 }
 
                 // check for enumerations.
-                if (typeInfo.BuiltInType == BuiltInType.Int32 &&
+                if (typeInfo.BuiltInType is BuiltInType.Int32 or BuiltInType.Enumeration &&
                     typeTree.IsTypeOf(expectedDataTypeId, DataTypeIds.Enumeration))
                 {
                     return typeInfo;

--- a/src/Opc.Ua.Types/BuiltIn/Variant.cs
+++ b/src/Opc.Ua.Types/BuiltIn/Variant.cs
@@ -7432,9 +7432,23 @@ namespace Opc.Ua
             {
                 return 0;
             }
-            TypeInfo ourTypeInfo = IsNull ? other.TypeInfo : TypeInfo;
-            if (!IsNull && !other.IsNull &&
-                (m_typeInfo.BuiltInType != other.m_typeInfo.BuiltInType ||
+            if (IsNull || other.IsNull)
+            {
+                // Order the null versus typed case the way Equals decides it.
+                // Substituting the typed side's type info and then reading the
+                // null variant's zeroed union storage reported equality for
+                // every zero valued scalar, so a SortedSet or a
+                // SortedDictionary collapsed Variant.Null and Variant(0) into
+                // one entry even though Equals tells them apart.
+                Variant typed = IsNull ? other : this;
+                if (!typed.ValueIsValueType && typed.ValueIsDefaultOrNull)
+                {
+                    return 0;
+                }
+                return IsNull ? -1 : +1;
+            }
+            TypeInfo ourTypeInfo = TypeInfo;
+            if ((m_typeInfo.BuiltInType != other.m_typeInfo.BuiltInType ||
                  m_typeInfo.ValueRank != other.m_typeInfo.ValueRank) &&
                 !IsConvertible(TypeInfo, other.TypeInfo))
             {

--- a/src/Opc.Ua.Types/BuiltIn/Variant.cs
+++ b/src/Opc.Ua.Types/BuiltIn/Variant.cs
@@ -648,6 +648,7 @@ namespace Opc.Ua
             m_typeInfo = TypeInfo.Arrays.Variant;
         }
 
+
         /// <summary>
         /// Creates a new variant with a <see cref="bool"/>-matrix value
         /// </summary>
@@ -1074,19 +1075,27 @@ namespace Opc.Ua
                     BuiltInType.UInt16 or
                     BuiltInType.Int32 or
                     BuiltInType.UInt32 or
+                    BuiltInType.StatusCode => m_union.Int32,
+                    // Float and Double must not hash their raw bits: -0.0 equals
+                    // +0.0 and every NaN equals every other NaN under Equals.
+                    BuiltInType.Float => m_union.Float.GetHashCode(),
+                    BuiltInType.Double => m_union.Double.GetHashCode(),
+                    BuiltInType.Enumeration => m_union.Int32,
                     BuiltInType.DateTime or
-                    BuiltInType.StatusCode or
-                    BuiltInType.Float => m_union.Int32,
-                    BuiltInType.Enumeration or
                     BuiltInType.Int64 or
-                    BuiltInType.UInt64 or
-                    BuiltInType.Double => m_union.UInt64.GetHashCode(),
+                    BuiltInType.UInt64 => m_union.UInt64.GetHashCode(),
                     BuiltInType.QualifiedName when IsPackedScalar => GetQualifiedName().GetHashCode(),
                     BuiltInType.NodeId when IsPackedScalar => GetNodeId().GetHashCode(),
                     BuiltInType.ByteString when IsPackedScalar => GetByteString().GetHashCode(),
                     BuiltInType.LocalizedText when IsPackedScalar => GetLocalizedText().GetHashCode(),
                     _ => m_value?.GetHashCode() ?? 0
                 };
+            }
+            if (TypeInfo.IsArray && TypeInfo.BuiltInType == BuiltInType.Byte)
+            {
+                // A byte array compares equal to a ByteString, so it must hash
+                // the same way as ByteString does.
+                return ReadOnlySpan.ComputeHash32(GetByteArray().Span);
             }
             return m_value?.GetHashCode() ?? 0;
         }
@@ -1972,7 +1981,8 @@ namespace Opc.Ua
         /// </param>
         public bool TryGetValue(out EnumValue value)
         {
-            if (TypeInfo.BuiltInType is BuiltInType.Int32 or BuiltInType.Enumeration)
+            if (TypeInfo.IsScalar &&
+                TypeInfo.BuiltInType is BuiltInType.Int32 or BuiltInType.Enumeration)
             {
                 value = new EnumValue(m_union.Int32, m_value);
                 return true;
@@ -2378,6 +2388,12 @@ namespace Opc.Ua
                 value = default;
                 return false;
             }
+            if (v.IsNull)
+            {
+                // Preserve the difference between a null and an empty array.
+                value = default;
+                return true;
+            }
             var buffer = new T[v.Count];
             for (int ii = 0; ii < v.Count; ii++)
             {
@@ -2779,6 +2795,12 @@ namespace Opc.Ua
                 value = default;
                 return false;
             }
+            if (v.IsNull)
+            {
+                // Preserve the difference between a null and an empty matrix.
+                value = default;
+                return true;
+            }
             var buffer = new T[v.Count];
             for (int ii = 0; ii < v.Count; ii++)
             {
@@ -3061,9 +3083,17 @@ namespace Opc.Ua
                 switch (TypeInfo.BuiltInType)
                 {
                     case BuiltInType.SByte:
+                        value = new decimal(m_union.SByte);
+                        return true;
                     case BuiltInType.Byte:
+                        value = new decimal(m_union.Byte);
+                        return true;
                     case BuiltInType.Int16:
+                        value = new decimal(m_union.Int16);
+                        return true;
                     case BuiltInType.UInt16:
+                        value = new decimal(m_union.UInt16);
+                        return true;
                     case BuiltInType.Int32:
                         value = new decimal(m_union.Int32);
                         return true;
@@ -5883,6 +5913,12 @@ namespace Opc.Ua
             {
                 return this;
             }
+            if (TypeInfo.BuiltInType == BuiltInType.Enumeration && TypeInfo.IsScalar)
+            {
+                // An enumeration is an Int32 on the wire, so convert through it
+                // rather than rejecting every target type.
+                return new Variant(GetEnumeration().Value).ConvertTo(targetType);
+            }
             if (TypeInfo.IsScalar)
             {
                 switch (targetType)
@@ -7307,34 +7343,17 @@ namespace Opc.Ua
         /// <inheritdoc/>
         public static Variant operator &(Variant lhs, Variant rhs)
         {
-            if (!lhs.TypeInfo.IsScalar ||
-                !rhs.TypeInfo.IsScalar)
+            if (lhs.TypeInfo.IsScalar &&
+                lhs.TypeInfo.BuiltInType == BuiltInType.Boolean &&
+                rhs.TypeInfo.IsScalar &&
+                rhs.TypeInfo.BuiltInType == BuiltInType.Boolean)
             {
-                return default;
+                return lhs.m_union.Boolean && rhs.m_union.Boolean;
             }
-            Union rhsUnion = rhs.IsPackedScalar ? default : rhs.m_union;
-            switch (lhs.TypeInfo.BuiltInType)
+            if (TryGetIntegerBits(lhs, out ulong lhsBits) &&
+                TryGetIntegerBits(rhs, out ulong rhsBits))
             {
-                case BuiltInType.Boolean:
-                    return lhs.m_union.Boolean && rhsUnion.Boolean;
-                case BuiltInType.Byte:
-                    return lhs.m_union.Byte & rhsUnion.Byte;
-                case BuiltInType.SByte:
-                    return lhs.m_union.SByte & rhsUnion.SByte;
-                case BuiltInType.Int16:
-                    return lhs.m_union.Int16 & rhsUnion.Int16;
-                case BuiltInType.UInt16:
-                    return lhs.m_union.UInt16 & rhsUnion.UInt16;
-                case BuiltInType.Enumeration:
-                    return new EnumValue(lhs.m_union.Int32 & rhsUnion.Int32, lhs.m_value);
-                case BuiltInType.Int32:
-                    return lhs.m_union.Int32 & rhsUnion.Int32;
-                case BuiltInType.UInt32:
-                    return lhs.m_union.UInt32 & rhsUnion.UInt32;
-                case BuiltInType.Int64:
-                    return lhs.m_union.Int64 & rhsUnion.Int64;
-                case BuiltInType.UInt64:
-                    return lhs.m_union.UInt64 & rhsUnion.UInt64;
+                return FromIntegerBits(lhs.m_typeInfo, lhsBits & rhsBits, lhs.m_value);
             }
             return default;
         }
@@ -7342,36 +7361,61 @@ namespace Opc.Ua
         /// <inheritdoc/>
         public static Variant operator |(Variant lhs, Variant rhs)
         {
-            if (!lhs.TypeInfo.IsScalar ||
-                !rhs.TypeInfo.IsScalar)
+            if (lhs.TypeInfo.IsScalar &&
+                lhs.TypeInfo.BuiltInType == BuiltInType.Boolean &&
+                rhs.TypeInfo.IsScalar &&
+                rhs.TypeInfo.BuiltInType == BuiltInType.Boolean)
             {
-                return default;
+                return lhs.m_union.Boolean || rhs.m_union.Boolean;
             }
-            Union rhsUnion = rhs.IsPackedScalar ? default : rhs.m_union;
-            switch (lhs.TypeInfo.BuiltInType)
+            if (TryGetIntegerBits(lhs, out ulong lhsBits) &&
+                TryGetIntegerBits(rhs, out ulong rhsBits))
             {
-                case BuiltInType.Boolean:
-                    return lhs.m_union.Boolean || rhsUnion.Boolean;
-                case BuiltInType.Byte:
-                    return lhs.m_union.Byte | rhsUnion.Byte;
-                case BuiltInType.SByte:
-                    return lhs.m_union.SByte | rhsUnion.SByte;
-                case BuiltInType.Int16:
-                    return lhs.m_union.Int16 | rhsUnion.Int16;
-                case BuiltInType.UInt16:
-                    return lhs.m_union.UInt16 | rhsUnion.UInt16;
-                case BuiltInType.Enumeration:
-                    return new EnumValue(lhs.m_union.Int32 | rhsUnion.Int32, lhs.m_value);
-                case BuiltInType.Int32:
-                    return lhs.m_union.Int32 | rhsUnion.Int32;
-                case BuiltInType.UInt32:
-                    return lhs.m_union.UInt32 | rhsUnion.UInt32;
-                case BuiltInType.Int64:
-                    return lhs.m_union.Int64 | rhsUnion.Int64;
-                case BuiltInType.UInt64:
-                    return lhs.m_union.UInt64 | rhsUnion.UInt64;
+                return FromIntegerBits(lhs.m_typeInfo, lhsBits | rhsBits, lhs.m_value);
             }
             return default;
+        }
+
+        /// <summary>
+        /// Reads the two's complement bits of an integer scalar through the union
+        /// field that matches its built in type, so that the operand's own type
+        /// - not the left hand operand's type - decides how it is read.
+        /// </summary>
+        private static bool TryGetIntegerBits(Variant value, out ulong bits)
+        {
+            bits = 0;
+            switch (value.GetNumericScalar(out long signed, out ulong unsigned, out _))
+            {
+                case NumericKind.Signed:
+                    bits = unchecked((ulong)signed);
+                    return true;
+                case NumericKind.Unsigned:
+                    bits = unsigned;
+                    return true;
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Narrows the result of a bitwise operation back into the type of the
+        /// left hand operand instead of widening it to Int32.
+        /// </summary>
+        private static Variant FromIntegerBits(TypeInfo typeInfo, ulong bits, object? source)
+        {
+            return typeInfo.BuiltInType switch
+            {
+                BuiltInType.SByte => new Variant(unchecked((sbyte)bits)),
+                BuiltInType.Byte => new Variant(unchecked((byte)bits)),
+                BuiltInType.Int16 => new Variant(unchecked((short)bits)),
+                BuiltInType.UInt16 => new Variant(unchecked((ushort)bits)),
+                BuiltInType.Int32 => new Variant(unchecked((int)bits)),
+                BuiltInType.UInt32 => new Variant(unchecked((uint)bits)),
+                BuiltInType.Int64 => new Variant(unchecked((long)bits)),
+                BuiltInType.UInt64 => new Variant(bits),
+                BuiltInType.Enumeration => new Variant(
+                    new EnumValue(unchecked((int)bits), source)),
+                _ => default
+            };
         }
 
         /// <inheritdoc/>
@@ -7382,6 +7426,17 @@ namespace Opc.Ua
                 return 0;
             }
             TypeInfo ourTypeInfo = IsNull ? other.TypeInfo : TypeInfo;
+            if (!IsNull && !other.IsNull &&
+                (m_typeInfo.BuiltInType != other.m_typeInfo.BuiltInType ||
+                 m_typeInfo.ValueRank != other.m_typeInfo.ValueRank) &&
+                !IsConvertible(TypeInfo, other.TypeInfo))
+            {
+                // Values of unrelated built-in types are only comparable when both
+                // sides are numeric scalars. Never compare the raw union payload of
+                // two different representations.
+                return TryCompareNumericTo(other, out int numericResult) ?
+                    numericResult : int.MinValue;
+            }
             Union otherUnion = other.IsPackedScalar ? default : other.m_union;
             if (ourTypeInfo.IsScalar)
             {
@@ -7392,7 +7447,7 @@ namespace Opc.Ua
                     case BuiltInType.Boolean:
                         return m_union.Boolean.CompareTo(otherUnion.Boolean);
                     case BuiltInType.Enumeration:
-                        return m_union.UInt64.CompareTo(otherUnion.UInt64);
+                        return m_union.Int32.CompareTo(otherUnion.Int32);
                     case BuiltInType.Int64:
                     case BuiltInType.DateTime:
                         return m_union.Int64.CompareTo(otherUnion.Int64);
@@ -7441,25 +7496,32 @@ namespace Opc.Ua
         /// <inheritdoc/>
         public static bool operator <(Variant left, Variant right)
         {
-            return left.CompareTo(right) < 0;
+            // int.MinValue is CompareTo's "not comparable" sentinel and must not
+            // be read as an ordinary negative result - it is its own negation,
+            // so both directions would report "less than".
+            int result = left.CompareTo(right);
+            return result is not int.MinValue and < 0;
         }
 
         /// <inheritdoc/>
         public static bool operator <=(Variant left, Variant right)
         {
-            return left.CompareTo(right) <= 0;
+            int result = left.CompareTo(right);
+            return result is not int.MinValue and <= 0;
         }
 
         /// <inheritdoc/>
         public static bool operator >(Variant left, Variant right)
         {
-            return left.CompareTo(right) > 0;
+            int result = left.CompareTo(right);
+            return result is not int.MinValue and > 0;
         }
 
         /// <inheritdoc/>
         public static bool operator >=(Variant left, Variant right)
         {
-            return left.CompareTo(right) >= 0;
+            int result = left.CompareTo(right);
+            return result is not int.MinValue and >= 0;
         }
 
         /// <summary>
@@ -7475,7 +7537,15 @@ namespace Opc.Ua
             }
             if (ValueIsValueType && other.ValueIsValueType)
             {
-                return m_union.UInt64 == other.m_union.UInt64;
+                if (m_typeInfo.BuiltInType == other.m_typeInfo.BuiltInType ||
+                    IsConvertible(TypeInfo, other.TypeInfo))
+                {
+                    // Same representation - use the strict typed comparison so that
+                    // e.g. StatusCode compares its code and not its symbolic id.
+                    return Equals(other);
+                }
+                // Numeric scalars of different widths compare by numeric value.
+                return TryCompareNumericTo(other, out int numericResult) && numericResult == 0;
             }
             if (IsPackedQualifiedName && other.IsPackedQualifiedName)
             {
@@ -7504,10 +7574,26 @@ namespace Opc.Ua
             {
                 return true;
             }
+            if (IsNull || other.IsNull)
+            {
+                // Decide the null versus typed case once, symmetrically.
+                // Comparing a null variant against a typed one used to give a
+                // different answer depending on which side it was written on:
+                // Variant(0).Equals(Null) was true while Null.Equals(Variant(0))
+                // was false, because the accessors hand out default(T) for a
+                // null variant. Only a typed variant whose reference payload is
+                // absent -- such as the null bodied ExtensionObject a null
+                // variant round trips to -- equals the null variant. A numeric,
+                // boolean or status code zero is a value, not an absent one, and
+                // must stay unequal: it hashes to zero like the null variant, so
+                // letting it compare equal collapses both into one bucket of
+                // every Dictionary and HashSet keyed on Variant.
+                Variant typed = IsNull ? other : this;
+                return !typed.ValueIsValueType && typed.ValueIsDefaultOrNull;
+            }
 
-            // Ensure we compare against a null variant correctly below.
-            TypeInfo ourTypeInfo = IsNull ? other.m_typeInfo : m_typeInfo;
-            TypeInfo otherTypeInfo = other.IsNull ? ourTypeInfo : other.m_typeInfo;
+            TypeInfo ourTypeInfo = m_typeInfo;
+            TypeInfo otherTypeInfo = other.m_typeInfo;
 
             if ((ourTypeInfo.ValueRank != otherTypeInfo.ValueRank ||
                 ourTypeInfo.BuiltInType != otherTypeInfo.BuiltInType) &&
@@ -7515,6 +7601,19 @@ namespace Opc.Ua
             {
                 return false;
             }
+            if (ourTypeInfo.ValueRank == 0 || otherTypeInfo.ValueRank == 0)
+            {
+                // A null MatrixOf carries no dimensions, so its type info
+                // reports value rank zero. The accessors below cannot read a
+                // matrix payload out of that, which made such a variant unequal
+                // even to an identical one, so compare the payloads directly.
+                return ourTypeInfo.ValueRank == otherTypeInfo.ValueRank &&
+                    ourTypeInfo.BuiltInType == otherTypeInfo.BuiltInType &&
+                    (m_value is null
+                        ? other.m_value is null
+                        : m_value.Equals(other.m_value));
+            }
+
             if (ourTypeInfo.IsScalar)
             {
                 switch (ourTypeInfo.BuiltInType)
@@ -7817,10 +7916,135 @@ namespace Opc.Ua
                     case BuiltInType.UInt64:
                     case BuiltInType.Int64:
                     case BuiltInType.DateTime:
+                    case BuiltInType.StatusCode:
                         return true;
                 }
                 return false;
             }
+        }
+
+        /// <summary>
+        /// Classification of a numeric scalar payload for cross type comparison.
+        /// </summary>
+        private enum NumericKind
+        {
+            /// <summary> Not a numeric scalar. </summary>
+            None,
+
+            /// <summary> Signed integer payload. </summary>
+            Signed,
+
+            /// <summary> Unsigned integer payload. </summary>
+            Unsigned,
+
+            /// <summary> Floating point payload. </summary>
+            Real
+        }
+
+        /// <summary>
+        /// Reads the numeric payload of a scalar variant through the union field
+        /// that matches its built in type. Reading a narrow value through a wider
+        /// union field zero extends it and turns negative values positive.
+        /// </summary>
+        private NumericKind GetNumericScalar(out long signed, out ulong unsigned, out double real)
+        {
+            signed = 0;
+            unsigned = 0;
+            real = 0;
+            if (!m_typeInfo.IsScalar)
+            {
+                return NumericKind.None;
+            }
+            switch (m_typeInfo.BuiltInType)
+            {
+                case BuiltInType.SByte:
+                    signed = m_union.SByte;
+                    return NumericKind.Signed;
+                case BuiltInType.Int16:
+                    signed = m_union.Int16;
+                    return NumericKind.Signed;
+                case BuiltInType.Enumeration:
+                case BuiltInType.Int32:
+                    signed = m_union.Int32;
+                    return NumericKind.Signed;
+                case BuiltInType.Int64:
+                    signed = m_union.Int64;
+                    return NumericKind.Signed;
+                case BuiltInType.Byte:
+                    unsigned = m_union.Byte;
+                    return NumericKind.Unsigned;
+                case BuiltInType.UInt16:
+                    unsigned = m_union.UInt16;
+                    return NumericKind.Unsigned;
+                case BuiltInType.UInt32:
+                    unsigned = m_union.UInt32;
+                    return NumericKind.Unsigned;
+                case BuiltInType.UInt64:
+                    unsigned = m_union.UInt64;
+                    return NumericKind.Unsigned;
+                case BuiltInType.Float:
+                    real = m_union.Float;
+                    return NumericKind.Real;
+                case BuiltInType.Double:
+                    real = m_union.Double;
+                    return NumericKind.Real;
+            }
+            return NumericKind.None;
+        }
+
+        /// <summary>
+        /// Compares two numeric scalars of unrelated built in types by value.
+        /// Returns false when either side is not a numeric scalar, or when a
+        /// floating point operand is NaN and therefore not ordered.
+        /// </summary>
+        private bool TryCompareNumericTo(Variant other, out int result)
+        {
+            result = 0;
+            NumericKind ours = GetNumericScalar(out long ourSigned, out ulong ourUnsigned, out double ourReal);
+            NumericKind theirs = other.GetNumericScalar(
+                out long theirSigned, out ulong theirUnsigned, out double theirReal);
+            if (ours == NumericKind.None || theirs == NumericKind.None)
+            {
+                return false;
+            }
+            if (ours == NumericKind.Real || theirs == NumericKind.Real)
+            {
+                double lhs = ours switch
+                {
+                    NumericKind.Signed => ourSigned,
+                    NumericKind.Unsigned => ourUnsigned,
+                    _ => ourReal
+                };
+                double rhs = theirs switch
+                {
+                    NumericKind.Signed => theirSigned,
+                    NumericKind.Unsigned => theirUnsigned,
+                    _ => theirReal
+                };
+                if (double.IsNaN(lhs) || double.IsNaN(rhs))
+                {
+                    return false;
+                }
+                result = lhs.CompareTo(rhs);
+                return true;
+            }
+            if (ours == NumericKind.Signed)
+            {
+                if (theirs == NumericKind.Signed)
+                {
+                    result = ourSigned.CompareTo(theirSigned);
+                    return true;
+                }
+                result = ourSigned < 0 ? -1 : ((ulong)ourSigned).CompareTo(theirUnsigned);
+                return true;
+            }
+            if (theirs == NumericKind.Signed)
+            {
+                result = theirSigned < 0 ? 1 : ourUnsigned.CompareTo((ulong)theirSigned);
+                return true;
+            }
+            result = ourUnsigned.CompareTo(theirUnsigned);
+            return true;
         }
 
         /// <summary>
@@ -7987,10 +8211,11 @@ namespace Opc.Ua
                         return GetDataValueArray().ConvertAll(v => new Variant(v));
                     case BuiltInType.DiagnosticInfo:
                         return [];
+                    case BuiltInType.Enumeration:
+                        return GetEnumerationArray().ConvertAll(v => new Variant(v));
                     case BuiltInType.Number:
                     case BuiltInType.Integer:
                     case BuiltInType.UInteger:
-                    case BuiltInType.Enumeration:
                     case BuiltInType.Variant:
                         return GetVariantArray(); // TODO: Variant arrays with variant matrix/arrays
                 }
@@ -8049,10 +8274,11 @@ namespace Opc.Ua
                         return GetDataValueMatrix().ConvertAll(v => new Variant(v)).ToArrayOf();
                     case BuiltInType.DiagnosticInfo:
                         return [];
+                    case BuiltInType.Enumeration:
+                        return GetEnumerationMatrix().ConvertAll(v => new Variant(v)).ToArrayOf();
                     case BuiltInType.Number:
                     case BuiltInType.Integer:
                     case BuiltInType.UInteger:
-                    case BuiltInType.Enumeration:
                     case BuiltInType.Variant:
                         return GetVariantMatrix().ToArrayOf(); // TODO: Variant matrices with variant matrix/arrays
                 }
@@ -8134,10 +8360,11 @@ namespace Opc.Ua
                         return new Variant(items.ConvertAll(v => v.GetDataValue()));
                     case BuiltInType.DiagnosticInfo:
                         return default;
+                    case BuiltInType.Enumeration:
+                        return new Variant(items.ConvertAll(v => v.GetEnumeration()));
                     case BuiltInType.Number:
                     case BuiltInType.Integer:
                     case BuiltInType.UInteger:
-                    case BuiltInType.Enumeration:
                     case BuiltInType.Variant:
                         return new Variant(items);
                 }

--- a/src/Opc.Ua.Types/BuiltIn/Variant.cs
+++ b/src/Opc.Ua.Types/BuiltIn/Variant.cs
@@ -1078,8 +1078,15 @@ namespace Opc.Ua
                     BuiltInType.StatusCode => m_union.Int32,
                     // Float and Double must not hash their raw bits: -0.0 equals
                     // +0.0 and every NaN equals every other NaN under Equals.
-                    BuiltInType.Float => m_union.Float.GetHashCode(),
-                    BuiltInType.Double => m_union.Double.GetHashCode(),
+                    // .NET Framework's own GetHashCode folds the two zeroes
+                    // together but not the NaN payloads, so NaN is canonicalized
+                    // here to keep the hash agreeing with Equals on every target.
+                    BuiltInType.Float => float.IsNaN(m_union.Float)
+                        ? float.NaN.GetHashCode()
+                        : m_union.Float.GetHashCode(),
+                    BuiltInType.Double => double.IsNaN(m_union.Double)
+                        ? double.NaN.GetHashCode()
+                        : m_union.Double.GetHashCode(),
                     BuiltInType.Enumeration => m_union.Int32,
                     BuiltInType.DateTime or
                     BuiltInType.Int64 or

--- a/src/Opc.Ua.Types/BuiltIn/XmlElement.cs
+++ b/src/Opc.Ua.Types/BuiltIn/XmlElement.cs
@@ -188,7 +188,8 @@ namespace Opc.Ua
             {
                 return false;
             }
-            return XNode.DeepEquals(other, AsXElement());
+            XElement? ours = AsXElement();
+            return ours != null && XNode.DeepEquals(other, ours);
         }
 
         /// <inheritdoc/>
@@ -228,7 +229,21 @@ namespace Opc.Ua
             {
                 return IsEmpty;
             }
-            return XNode.DeepEquals(other.AsXElement(), AsXElement());
+            if (IsEmpty)
+            {
+                return false;
+            }
+            XElement? ours = AsXElement();
+            XElement? theirs = other.AsXElement();
+            if (ours == null || theirs == null)
+            {
+                // At least one document is malformed and cannot be compared
+                // structurally. Compare the raw text instead - two different
+                // malformed documents must not report equality while hashing
+                // differently.
+                return string.Equals(m_outerXml, other.m_outerXml, StringComparison.Ordinal);
+            }
+            return XNode.DeepEquals(theirs, ours);
         }
 
         /// <inheritdoc/>
@@ -252,7 +267,27 @@ namespace Opc.Ua
         /// <inheritdoc/>
         public override int GetHashCode()
         {
-            return m_outerXml?.GetHashCode(StringComparison.Ordinal) ?? 0;
+            if (IsEmpty)
+            {
+                return 0;
+            }
+
+            XElement? element = AsXElement();
+            if (element == null)
+            {
+                // A malformed document is compared by its raw text, so hash it
+                // the same way.
+                return m_outerXml!.GetHashCode(StringComparison.Ordinal);
+            }
+
+            // Equals compares structurally through XNode.DeepEquals, which
+            // ignores attribute order and the spelling of an empty element, so
+            // the hash may only use properties DeepEquals requires to match.
+            // Hashing the raw text put two equal elements in different buckets.
+            var hash = new HashCode();
+            hash.Add(element.Name);
+            hash.Add(element.Value, StringComparer.Ordinal);
+            return hash.ToHashCode();
         }
 
         /// <inheritdoc/>

--- a/src/Opc.Ua.Types/Diagnostics/TelemetryContextBase.cs
+++ b/src/Opc.Ua.Types/Diagnostics/TelemetryContextBase.cs
@@ -32,6 +32,7 @@ using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using Microsoft.Extensions.Logging;
 
 namespace Opc.Ua
@@ -57,18 +58,11 @@ namespace Opc.Ua
         }
 
         /// <inheritdoc/>
+        // GetCallingAssembly has to be called from the public entry point:
+        // inside a private helper it only ever reports this assembly, so every
+        // meter and activity source was named after Opc.Ua.Types.
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public Meter CreateMeter()
-        {
-            (string name, string version) = GetAssemblyInfo();
-            return new Meter(name, version);
-        }
-
-        /// <inheritdoc/>
-        public ActivitySource ActivitySource
-            => s_sources.GetOrAdd(GetAssemblyInfo(),
-                    key => new ActivitySource(key.Item1, key.Item2));
-
-        private static (string, string) GetAssemblyInfo()
         {
             Assembly assembly;
             try
@@ -79,6 +73,32 @@ namespace Opc.Ua
             {
                 assembly = typeof(TelemetryContextBase).Assembly;
             }
+            (string name, string version) = GetAssemblyInfo(assembly);
+            return new Meter(name, version);
+        }
+
+        /// <inheritdoc/>
+        public ActivitySource ActivitySource
+        {
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            get
+            {
+                Assembly assembly;
+                try
+                {
+                    assembly = Assembly.GetCallingAssembly();
+                }
+                catch (PlatformNotSupportedException)
+                {
+                    assembly = typeof(TelemetryContextBase).Assembly;
+                }
+                return s_sources.GetOrAdd(GetAssemblyInfo(assembly),
+                    key => new ActivitySource(key.Item1, key.Item2));
+            }
+        }
+
+        private static (string, string) GetAssemblyInfo(Assembly assembly)
+        {
             return s_cache.GetOrAdd(assembly, GetAssemblyInfoCore);
             static (string, string) GetAssemblyInfoCore(Assembly assembly)
             {

--- a/src/Opc.Ua.Types/Encoders/BinaryDecoder.cs
+++ b/src/Opc.Ua.Types/Encoders/BinaryDecoder.cs
@@ -151,6 +151,22 @@ namespace Opc.Ua
         }
 
         /// <summary>
+        /// Adopts already resolved mapping tables and the current nesting depth
+        /// from an outer decoder. Used when an ExtensionObject body is decoded
+        /// from inside another decoder - the nested body is part of the same
+        /// message and must share both.
+        /// </summary>
+        internal void InheritDecodingState(
+            ushort[]? namespaceMappings,
+            ushort[]? serverMappings,
+            uint nestingLevel)
+        {
+            m_namespaceMappings = namespaceMappings;
+            m_serverMappings = serverMappings;
+            m_nestingLevel = nestingLevel;
+        }
+
+        /// <summary>
         /// Completes reading and closes the stream.
         /// </summary>
         public void Close()
@@ -797,6 +813,10 @@ namespace Opc.Ua
                 {
                     XmlElement element = extension.TryGetAsXml(out XmlElement xe) ? xe : default;
                     using var xmlDecoder = new XmlDecoder(element, Context);
+                    xmlDecoder.InheritDecodingState(
+                        m_namespaceMappings,
+                        m_serverMappings,
+                        m_nestingLevel);
                     try
                     {
                         System.Xml.XmlElement? xmlElement = element.AsXmlElement();
@@ -811,8 +831,12 @@ namespace Opc.Ua
 
                         xmlDecoder.Close();
                     }
-                    catch (Exception e)
+                    catch (Exception e) when (
+                        e is not ServiceResultException sre ||
+                        sre.StatusCode != StatusCodes.BadEncodingLimitsExceeded)
                     {
+                        // An encoding limit breach must not be downgraded into a
+                        // successful decode that keeps the over limit raw body.
                         Logger.CouldNotDecodeKnownTypeXml(activator.XmlName, e.Message, element.OuterXml);
                     }
                 }
@@ -983,7 +1007,15 @@ namespace Opc.Ua
                     encodeableTypeId);
             }
 
-            var encodeable = (T)activator.CreateInstance();
+            if (activator.CreateInstance() is not T encodeable)
+            {
+                // The type id comes from the wire and need not name a T at all.
+                throw ServiceResultException.Create(
+                    StatusCodes.BadDecodingError,
+                    "Type '{0}' is not a {1}.",
+                    encodeableTypeId,
+                    typeof(T).Name);
+            }
             CheckAndIncrementNestingLevel();
             try
             {
@@ -2061,7 +2093,7 @@ namespace Opc.Ua
         /// <exception cref="ServiceResultException"></exception>
         private DiagnosticInfo? ReadDiagnosticInfo(int depth)
         {
-            if (depth >= DiagnosticInfo.MaxInnerDepth)
+            if (depth > DiagnosticInfo.MaxInnerDepth)
             {
                 throw ServiceResultException.Create(
                     StatusCodes.BadEncodingLimitsExceeded,

--- a/src/Opc.Ua.Types/Encoders/BinaryEncoder.cs
+++ b/src/Opc.Ua.Types/Encoders/BinaryEncoder.cs
@@ -223,6 +223,12 @@ namespace Opc.Ua
             int position = (int)m_writer.BaseStream.Position;
             m_writer.Flush();
             m_writer.Dispose();
+
+            // Clear the reference so a following Dispose() does not flush a
+            // writer that is already disposed - which throws for every owned
+            // stream that is not a MemoryStream.
+            m_writer = null!;
+            m_closed = true;
             return position;
         }
 
@@ -523,14 +529,10 @@ namespace Opc.Ua
                 return;
             }
 
-            if (Context.MaxStringLength > 0 && Context.MaxStringLength < value.Length)
-            {
-                throw ServiceResultException.Create(
-                    StatusCodes.BadEncodingLimitsExceeded,
-                    "MaxStringLength {0} < {1}",
-                    Context.MaxStringLength,
-                    value.Length);
-            }
+            // The limit applies to the encoded length on the wire, which is what
+            // BinaryDecoder.ReadString checks. Counting UTF-16 chars here would
+            // let a non ASCII string encode and fail to decode.
+            EncodingLimits.CheckStringLength(Context.MaxStringLength, value);
 
             int maxByteCount = Encoding.UTF8.GetMaxByteCount(value.Length);
 
@@ -1037,9 +1039,23 @@ namespace Opc.Ua
             else
             {
                 using var encoder = new BinaryEncoder(Context);
+
+                // The nested encoder writes the same payload the seekable path
+                // writes inline, so it must see the same namespace/server
+                // mappings and continue this encoder's nesting budget.
+                encoder.m_namespaceMappings = m_namespaceMappings;
+                encoder.m_serverMappings = m_serverMappings;
+                encoder.m_nestingLevel = m_nestingLevel;
+
                 encoder.WriteEncodeable(encodeable);
-                bytes = ByteString.From(encoder.CloseAndReturnBuffer());
-                WriteByteString(null, bytes);
+                byte[] body = encoder.CloseAndReturnBuffer() ?? [];
+
+                // The body length is not a ByteString on the wire: the seekable
+                // path above and BinaryDecoder.ReadExtensionObject both write
+                // and read a plain Int32 length without applying
+                // MaxByteStringLength, so do not apply it here either.
+                WriteInt32(null, body.Length);
+                WriteBytes(body);
             }
         }
 

--- a/src/Opc.Ua.Types/Encoders/EncodeableFactory.cs
+++ b/src/Opc.Ua.Types/Encoders/EncodeableFactory.cs
@@ -99,7 +99,7 @@ namespace Opc.Ua
                 encodeableType = null;
                 return false;
             }
-            return m_encodeableTypes.TryGetValue(typeId, out encodeableType);
+            return m_encodeableTypes.TryGetValue(Fix(typeId), out encodeableType);
         }
 
         /// <inheritdoc/>
@@ -112,7 +112,7 @@ namespace Opc.Ua
                 enumeratedType = null;
                 return false;
             }
-            return m_enumeratedTypes.TryGetValue(typeId, out enumeratedType);
+            return m_enumeratedTypes.TryGetValue(Fix(typeId), out enumeratedType);
         }
 
         /// <inheritdoc/>
@@ -143,6 +143,24 @@ namespace Opc.Ua
         public EncodeableFactory Fork()
         {
             return new EncodeableFactory(this);
+        }
+
+        /// <summary>
+        /// Normalizes an encoding id that names namespace zero by its URI into
+        /// the equivalent relative id. Registrations and lookups both apply
+        /// this so that either spelling of a namespace zero id resolves to the
+        /// same entry.
+        /// </summary>
+        private static ExpandedNodeId Fix(ExpandedNodeId nodeId)
+        {
+            // check for default namespace. A server scoped id names a type in a
+            // remote address space and must not collapse onto the local entry.
+            if (nodeId.NamespaceUri == Types.Namespaces.OpcUa &&
+                nodeId.ServerIndex == 0)
+            {
+                return new ExpandedNodeId(nodeId.InnerNodeId);
+            }
+            return nodeId;
         }
 
         /// <summary>
@@ -197,15 +215,15 @@ namespace Opc.Ua
                 {
                     if (!typeId.IsNull)
                     {
-                        m_enumeratedTypes[typeId] = type;
+                        m_enumeratedTypes[Fix(typeId)] = type;
                     }
                     if (!binaryEncodingId.IsNull)
                     {
-                        m_enumeratedTypes[binaryEncodingId] = type;
+                        m_enumeratedTypes[Fix(binaryEncodingId)] = type;
                     }
                     if (!xmlEncodingId.IsNull)
                     {
-                        m_enumeratedTypes[xmlEncodingId] = type;
+                        m_enumeratedTypes[Fix(xmlEncodingId)] = type;
                     }
                 }
                 m_xmlNameToType[type.XmlName] = type;
@@ -219,7 +237,7 @@ namespace Opc.Ua
             {
                 if (!encodingId.IsNull)
                 {
-                    m_encodeableTypes[encodingId] = type ??
+                    m_encodeableTypes[Fix(encodingId)] = type ??
                         throw new ArgumentNullException(nameof(type));
                     m_xmlNameToType[type.XmlName] = type;
                 }
@@ -233,7 +251,7 @@ namespace Opc.Ua
             {
                 if (!encodingId.IsNull)
                 {
-                    m_enumeratedTypes[encodingId] = type ??
+                    m_enumeratedTypes[Fix(encodingId)] = type ??
                         throw new ArgumentNullException(nameof(type));
                     m_xmlNameToType[type.XmlName] = type;
                 }
@@ -252,10 +270,10 @@ namespace Opc.Ua
                     switch (type)
                     {
                         case IEncodeableType encodeableType:
-                            m_encodeableTypes[encodingId] = encodeableType;
+                            m_encodeableTypes[Fix(encodingId)] = encodeableType;
                             break;
                         case IEnumeratedType enumeratedType:
-                            m_enumeratedTypes[encodingId] = enumeratedType;
+                            m_enumeratedTypes[Fix(encodingId)] = enumeratedType;
                             break;
                         case null:
                             return this;
@@ -299,7 +317,7 @@ namespace Opc.Ua
                     encodeableType = null;
                     return false;
                 }
-                return m_encodeableTypes.TryGetValue(typeId, out encodeableType) ||
+                return m_encodeableTypes.TryGetValue(Fix(typeId), out encodeableType) ||
                     m_factory.TryGetEncodeableType(typeId, out encodeableType);
             }
 
@@ -313,7 +331,7 @@ namespace Opc.Ua
                     enumeratedType = null;
                     return false;
                 }
-                return m_enumeratedTypes.TryGetValue(typeId, out enumeratedType) ||
+                return m_enumeratedTypes.TryGetValue(Fix(typeId), out enumeratedType) ||
                     m_factory.TryGetEnumeratedType(typeId, out enumeratedType);
             }
 
@@ -460,16 +478,9 @@ namespace Opc.Ua
                     m_encodeableTypes[Fix(nodeId)] = encodeableType;
                 }
 
-                static ExpandedNodeId Fix(ExpandedNodeId nodeId)
-                {
-                    // check for default namespace.
-                    if (nodeId.NamespaceUri == Types.Namespaces.OpcUa)
-                    {
-                        return new ExpandedNodeId(nodeId.InnerNodeId);
-                    }
-                    return nodeId;
-                }
             }
+
+
 
             private readonly EncodeableFactory m_factory;
             private readonly Dictionary<XmlQualifiedName, IType> m_xmlNameToType = [];

--- a/src/Opc.Ua.Types/Encoders/EncodingLimits.cs
+++ b/src/Opc.Ua.Types/Encoders/EncodingLimits.cs
@@ -1,0 +1,101 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System.Text;
+using Opc.Ua.Types;
+
+namespace Opc.Ua
+{
+    /// <summary>
+    /// The one place that decides what the encoding limits count, shared by
+    /// every codec so that a single <see cref="IServiceMessageContext"/> cannot
+    /// give a different answer over Binary, XML and JSON for the same value.
+    /// </summary>
+    internal static class EncodingLimits
+    {
+        /// <summary>
+        /// Returns true when a string does not fit into MaxStringLength.
+        /// </summary>
+        /// <remarks>
+        /// MaxStringLength counts the <b>bytes</b> of the encoded string
+        /// (OPC 10000-3 5.6.4 and OPC 10000-5 6.3.2), not UTF-16 code units.
+        /// Measuring code units instead lets a peer encode a non ASCII string
+        /// that the receiver then refuses to decode, and makes the limit depend
+        /// on the alphabet the value happens to be written in. Zero, and any
+        /// negative value, mean unlimited as in every other limit check.
+        /// </remarks>
+        /// <param name="maxStringLength">The configured limit.</param>
+        /// <param name="value">The string to measure.</param>
+        /// <param name="byteLength">The measured length, only meaningful when
+        /// this method returns true.</param>
+        public static bool StringExceedsLimit(
+            int maxStringLength,
+            string? value,
+            out int byteLength)
+        {
+            byteLength = 0;
+
+            if (maxStringLength <= 0 || value == null)
+            {
+                return false;
+            }
+
+            // UTF-8 never needs more than three bytes per UTF-16 code unit - a
+            // surrogate pair is two code units and four bytes - so the string
+            // only has to be measured when even that worst case does not fit.
+            if (value.Length <= maxStringLength / 3)
+            {
+                return false;
+            }
+
+            byteLength = Encoding.UTF8.GetByteCount(value);
+            return byteLength > maxStringLength;
+        }
+
+        /// <summary>
+        /// Throws if a string does not fit into MaxStringLength.
+        /// </summary>
+        /// <param name="maxStringLength">The configured limit.</param>
+        /// <param name="value">The string to check.</param>
+        /// <exception cref="ServiceResultException">Thrown with
+        /// <see cref="StatusCodes.BadEncodingLimitsExceeded"/> when the string
+        /// is over the limit.</exception>
+        public static void CheckStringLength(int maxStringLength, string? value)
+        {
+            if (StringExceedsLimit(maxStringLength, value, out int byteLength))
+            {
+                throw ServiceResultException.Create(
+                    StatusCodes.BadEncodingLimitsExceeded,
+                    "MaxStringLength {0} < {1}",
+                    maxStringLength,
+                    byteLength);
+            }
+        }
+    }
+}

--- a/src/Opc.Ua.Types/Encoders/JsonDecoder.cs
+++ b/src/Opc.Ua.Types/Encoders/JsonDecoder.cs
@@ -36,6 +36,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Text;
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using Opc.Ua.Types;
@@ -1103,7 +1104,7 @@ namespace Opc.Ua
         /// <summary>
         /// Get boolean from element
         /// </summary>
-        private static bool TryGetBooleanFromElement(JsonElement element, out bool value)
+        private bool TryGetBooleanFromElement(JsonElement element, out bool value)
         {
             switch (element.ValueKind)
             {
@@ -1122,7 +1123,7 @@ namespace Opc.Ua
         /// <summary>
         /// Get boolean values from element
         /// </summary>
-        private static bool TryGetBooleanArrayFromElement(
+        private bool TryGetBooleanArrayFromElement(
             JsonElement element,
             out ArrayOf<bool> values)
         {
@@ -1154,7 +1155,7 @@ namespace Opc.Ua
         /// <summary>
         /// Get byte from element
         /// </summary>
-        private static bool TryGetByteFromElement(
+        private bool TryGetByteFromElement(
             JsonElement element,
             out byte value)
         {
@@ -1174,7 +1175,7 @@ namespace Opc.Ua
         /// <summary>
         /// Get byte values from element
         /// </summary>
-        private static bool TryGetByteArrayFromElement(
+        private bool TryGetByteArrayFromElement(
             JsonElement element,
             out ArrayOf<byte> values)
         {
@@ -1186,6 +1187,9 @@ namespace Opc.Ua
                 case JsonValueKind.String:
                     if (element.TryGetBytesFromBase64(out byte[]? base64))
                     {
+                        // TryGetArrayElements is the choke point for
+                        // MaxArrayLength, and this branch never goes through it.
+                        CheckArrayLength(base64.Length);
                         values = base64;
                         return true;
                     }
@@ -1221,7 +1225,7 @@ namespace Opc.Ua
         /// <summary>
         /// Get byte string from element
         /// </summary>
-        private static bool TryGetByteStringFromElement(
+        private bool TryGetByteStringFromElement(
             JsonElement element,
             out ByteString value)
         {
@@ -1236,6 +1240,7 @@ namespace Opc.Ua
                         value = default;
                         return false;
                     }
+                    CheckByteStringLength(result.Length);
                     value = ByteString.From(result);
                     return true;
                 case JsonValueKind.Array:
@@ -1246,6 +1251,9 @@ namespace Opc.Ua
                         value = default;
                         return false;
                     }
+                    // The array spelling of a byte string still has to honour
+                    // MaxByteStringLength, like the base64 spelling above.
+                    CheckByteStringLength(array.Count);
                     value = ByteString.From(array.Span);
                     return true;
                 default:
@@ -1257,7 +1265,7 @@ namespace Opc.Ua
         /// <summary>
         /// Get byte string values from element
         /// </summary>
-        private static bool TryGetByteStringArrayFromElement(
+        private bool TryGetByteStringArrayFromElement(
             JsonElement element,
             out ArrayOf<ByteString> values)
         {
@@ -1414,7 +1422,7 @@ namespace Opc.Ua
         /// <summary>
         /// Get date time from json element
         /// </summary>
-        private static bool TryGetDateTimeFromElement(
+        private bool TryGetDateTimeFromElement(
             JsonElement element,
             out DateTimeUtc value)
         {
@@ -1435,7 +1443,7 @@ namespace Opc.Ua
         /// <summary>
         /// Get date time values from element
         /// </summary>
-        private static bool TryGetDateTimeArrayFromElement(
+        private bool TryGetDateTimeArrayFromElement(
             JsonElement element,
             out ArrayOf<DateTimeUtc> values)
         {
@@ -1479,7 +1487,7 @@ namespace Opc.Ua
                     value = default;
                     return true;
                 case JsonValueKind.Object:
-                    if (depth >= DiagnosticInfo.MaxInnerDepth)
+                    if (depth > DiagnosticInfo.MaxInnerDepth)
                     {
                         throw ServiceResultException.Create(
                             StatusCodes.BadEncodingLimitsExceeded,
@@ -1595,7 +1603,7 @@ namespace Opc.Ua
         /// <summary>
         /// Get double from element
         /// </summary>
-        private static bool TryGetDoubleFromElement(JsonElement element, out double value)
+        private bool TryGetDoubleFromElement(JsonElement element, out double value)
         {
             switch (element.ValueKind)
             {
@@ -1618,7 +1626,7 @@ namespace Opc.Ua
         /// <summary>
         /// Get double values from element
         /// </summary>
-        private static bool TryGetDoubleArrayFromElement(JsonElement element,
+        private bool TryGetDoubleArrayFromElement(JsonElement element,
             out ArrayOf<double> values)
         {
             if (TryGetArrayElements(element, out ArrayOf<JsonElement> elements))
@@ -1648,7 +1656,7 @@ namespace Opc.Ua
         /// Get enumeration from element
         /// </summary>
         /// <typeparam name="T"></typeparam>
-        private static bool TryGetEnumerationFromElement<T>(JsonElement element, out T value)
+        private bool TryGetEnumerationFromElement<T>(JsonElement element, out T value)
             where T : struct, Enum
         {
             switch (element.ValueKind)
@@ -1698,7 +1706,7 @@ namespace Opc.Ua
         /// <summary>
         /// Get enumeration from element
         /// </summary>
-        private static bool TryGetEnumerationFromElement(JsonElement element, out EnumValue value)
+        private bool TryGetEnumerationFromElement(JsonElement element, out EnumValue value)
         {
             switch (element.ValueKind)
             {
@@ -1712,10 +1720,15 @@ namespace Opc.Ua
                         value = default;
                         return false;
                     }
+                    // The symbolic name below is kept verbatim from the wire, so
+                    // it is bounded by MaxStringLength like any other string.
+                    CheckStringLength(text);
                     // Verbose encoding
                     // https://reference.opcfoundation.org/Core/Part6/v105/docs/5.4.4.1.2
                     int split = text.LastIndexOf('_');
-                    string? symbol = text;
+                    // Without a separator there is no symbolic name. Taking the
+                    // whole text as the symbol made a bare "5" re-encode as "5_5".
+                    string? symbol = null;
                     if (split >= 0)
                     {
                         symbol = text[..split];
@@ -1743,7 +1756,7 @@ namespace Opc.Ua
         /// Get enumeration values from element
         /// </summary>
         /// <typeparam name="T"></typeparam>
-        private static bool TryGetEnumerationArrayFromElement<T>(
+        private bool TryGetEnumerationArrayFromElement<T>(
             JsonElement element,
             out ArrayOf<T> values) where T : struct, Enum
         {
@@ -1773,7 +1786,7 @@ namespace Opc.Ua
         /// <summary>
         /// Get enumeration values from element
         /// </summary>
-        private static bool TryGetEnumerationArrayFromElement(
+        private bool TryGetEnumerationArrayFromElement(
             JsonElement element,
             out ArrayOf<EnumValue> values)
         {
@@ -1942,7 +1955,7 @@ namespace Opc.Ua
                                             value = new ExtensionObject(typeId, encodeable);
                                             return true;
                                         }
-                                        catch (Exception ex)
+                                        catch (Exception ex) when (!MustRethrowBodyError(ex))
                                         {
                                             m_logger.CannotDeserializeExtensionObjectBody(ex);
                                         }
@@ -1995,6 +2008,19 @@ namespace Opc.Ua
             }
         }
 
+        /// <summary>
+        /// Decides whether a failure while decoding an ExtensionObject body may
+        /// be swallowed in favour of keeping the raw JSON. Strict parsing must
+        /// never fall back, and an encoding limit breach must never be
+        /// downgraded into a successful decode.
+        /// </summary>
+        private bool MustRethrowBodyError(Exception ex)
+        {
+            return m_options.ParseStrict ||
+                (ex is ServiceResultException sre &&
+                    sre.StatusCode == StatusCodes.BadEncodingLimitsExceeded);
+        }
+
         private static bool IsBodylessExtensionObject(JsonElement element)
         {
             foreach (JsonProperty property in element.EnumerateObject())
@@ -2045,7 +2071,7 @@ namespace Opc.Ua
         /// <param name="element"></param>
         /// <param name="value"></param>
         /// <returns></returns>
-        private static bool TryGetFloatFromElement(JsonElement element, out float value)
+        private bool TryGetFloatFromElement(JsonElement element, out float value)
         {
             switch (element.ValueKind)
             {
@@ -2068,7 +2094,7 @@ namespace Opc.Ua
         /// <summary>
         /// Get float values from element
         /// </summary>
-        private static bool TryGetFloatArrayFromElement(JsonElement element,
+        private bool TryGetFloatArrayFromElement(JsonElement element,
             out ArrayOf<float> values)
         {
             if (TryGetArrayElements(element, out ArrayOf<JsonElement> elements))
@@ -2097,7 +2123,7 @@ namespace Opc.Ua
         /// <summary>
         /// Get guid from element
         /// </summary>
-        private static bool TryGetGuidFromElement(JsonElement element, out Uuid value)
+        private bool TryGetGuidFromElement(JsonElement element, out Uuid value)
         {
             switch (element.ValueKind)
             {
@@ -2108,24 +2134,36 @@ namespace Opc.Ua
 #if NET9_0_OR_GREATER
                     ReadOnlySpan<byte> utf8Text =
                         JsonMarshal.GetRawUtf8Value(element).Trim((byte)'"');
-                    Span<char> chars = stackalloc char[78];
-                    if (System.Text.Encoding.UTF8.TryGetChars(utf8Text, chars, out int written))
+
+                    // The raw value is still JSON escaped. Only take the
+                    // allocation free path when there is nothing to unescape,
+                    // otherwise fall through to the decoded string below.
+                    if (utf8Text.IndexOf((byte)'\\') < 0)
                     {
-                        chars = chars[..written];
-                        if (Guid.TryParse(chars, out Guid guid))
+                        Span<char> chars = stackalloc char[78];
+                        if (System.Text.Encoding.UTF8.TryGetChars(
+                            utf8Text,
+                            chars,
+                            out int written))
                         {
-                            value = new Uuid(guid);
-                            return true;
-                        }
-                        Span<byte> bytes = stackalloc byte[16];
-                        if (Convert.TryFromBase64Chars(chars, bytes, out written) &&
-                            written == 16)
-                        {
-                            value = new Uuid(new Guid(bytes));
-                            return true;
+                            chars = chars[..written];
+                            if (Guid.TryParse(chars, out Guid fastGuid))
+                            {
+                                value = new Uuid(fastGuid);
+                                return true;
+                            }
+                            Span<byte> buffer = stackalloc byte[16];
+                            if (Convert.TryFromBase64Chars(chars, buffer, out written) &&
+                                written == 16)
+                            {
+                                value = new Uuid(new Guid(buffer));
+                                return true;
+                            }
+                            value = default;
+                            return false;
                         }
                     }
-#else
+#endif
                     if (Guid.TryParse(element.GetString(), out Guid guid))
                     {
                         value = new Uuid(guid);
@@ -2137,7 +2175,6 @@ namespace Opc.Ua
                         value = new Uuid(new Guid(bytes));
                         return true;
                     }
-#endif
                     value = default;
                     return false;
                 default:
@@ -2149,7 +2186,7 @@ namespace Opc.Ua
         /// <summary>
         /// Get guid values from element
         /// </summary>
-        private static bool TryGetGuidArrayFromElement(
+        private bool TryGetGuidArrayFromElement(
             JsonElement element,
             out ArrayOf<Uuid> values)
         {
@@ -2179,7 +2216,7 @@ namespace Opc.Ua
         /// <summary>
         /// Get signed short from element
         /// </summary>
-        private static bool TryGetInt16FromElement(JsonElement element, out short value)
+        private bool TryGetInt16FromElement(JsonElement element, out short value)
         {
             switch (element.ValueKind)
             {
@@ -2198,7 +2235,7 @@ namespace Opc.Ua
         /// Get short values from element
         /// </summary>
         /// <returns></returns>
-        private static bool TryGetInt16ArrayFromElement(
+        private bool TryGetInt16ArrayFromElement(
             JsonElement element,
             out ArrayOf<short> values)
         {
@@ -2228,7 +2265,7 @@ namespace Opc.Ua
         /// <summary>
         /// Get signed integer from element
         /// </summary>
-        private static bool TryGetInt32FromElement(JsonElement element, out int value)
+        private bool TryGetInt32FromElement(JsonElement element, out int value)
         {
             switch (element.ValueKind)
             {
@@ -2246,7 +2283,7 @@ namespace Opc.Ua
         /// <summary>
         /// Get integer values from element
         /// </summary>
-        private static bool TryGetInt32ArrayFromElement(
+        private bool TryGetInt32ArrayFromElement(
             JsonElement element,
             out ArrayOf<int> values)
         {
@@ -2372,7 +2409,11 @@ namespace Opc.Ua
                         m_stack.Pop();
                     }
                 case JsonValueKind.String:
-                    value = LocalizedText.From(element.GetString()!);
+                    // The shorthand spelling has to honour MaxStringLength too,
+                    // the object form above does so via TryGetStringFromElement.
+                    string? shorthand = element.GetString();
+                    CheckStringLength(shorthand);
+                    value = LocalizedText.From(shorthand!);
                     return true;
                 default:
                     value = LocalizedText.Null;
@@ -2547,7 +2588,7 @@ namespace Opc.Ua
         /// <summary>
         /// Get signed byte from element
         /// </summary>
-        private static bool TryGetSByteFromElement(JsonElement element, out sbyte value)
+        private bool TryGetSByteFromElement(JsonElement element, out sbyte value)
         {
             switch (element.ValueKind)
             {
@@ -2565,7 +2606,7 @@ namespace Opc.Ua
         /// <summary>
         /// Get sbyte values from element
         /// </summary>
-        private static bool TryGetSByteArrayFromElement(
+        private bool TryGetSByteArrayFromElement(
             JsonElement element,
             out ArrayOf<sbyte> values)
         {
@@ -2580,6 +2621,9 @@ namespace Opc.Ua
                         values = default;
                         return false;
                     }
+                    // TryGetArrayElements is the choke point for MaxArrayLength,
+                    // and this branch never goes through it.
+                    CheckArrayLength(bytes.Length);
                     values = MemoryMarshal.Cast<byte, sbyte>(bytes).ToArray();
                     return true;
                 case JsonValueKind.Array:
@@ -2677,7 +2721,7 @@ namespace Opc.Ua
         /// <summary>
         /// Get string from element
         /// </summary>
-        private static bool TryGetStringFromElement(JsonElement element, out string? value)
+        private bool TryGetStringFromElement(JsonElement element, out string? value)
         {
             switch (element.ValueKind)
             {
@@ -2686,6 +2730,7 @@ namespace Opc.Ua
                     return true;
                 case JsonValueKind.String:
                     value = element.GetString();
+                    CheckStringLength(value);
                     return true;
                 default:
                     value = default;
@@ -2699,7 +2744,7 @@ namespace Opc.Ua
         /// <param name="element"></param>
         /// <param name="values"></param>
         /// <returns></returns>
-        private static bool TryGetStringArrayFromElement(JsonElement element,
+        private bool TryGetStringArrayFromElement(JsonElement element,
             out ArrayOf<string?> values)
         {
             if (TryGetArrayElements(element, out ArrayOf<JsonElement> elements))
@@ -2765,6 +2810,10 @@ namespace Opc.Ua
                                     if (TryGetByteStringFromElement(uaBody, out ByteString bytes))
                                     {
                                         using var decoder = new BinaryDecoder(bytes.ToArray(), Context);
+                                        decoder.InheritDecodingState(
+                                            m_namespaceMappings,
+                                            m_serverMappings,
+                                            0);
                                         value = decoder.ReadEncodeable<T>(null, typeId);
                                         return true;
                                     }
@@ -2778,6 +2827,10 @@ namespace Opc.Ua
                                             break;
                                         }
                                         using var decoder = new XmlDecoder(xmlElement, Context);
+                                        decoder.InheritDecodingState(
+                                            m_namespaceMappings,
+                                            m_serverMappings,
+                                            0);
                                         decoder.PushNamespace(xmlElement.NamespaceURI);
                                         value = decoder.ReadEncodeable<T>(xmlElement.LocalName, typeId);
                                         decoder.PopNamespace();
@@ -2790,11 +2843,17 @@ namespace Opc.Ua
                                         typeId,
                                         out IEncodeableType? activator))
                                     {
-                                        value = (T)activator.CreateInstance() ??
+                                        if (activator.CreateInstance() is not T instance)
+                                        {
+                                            // The type id comes from the wire and
+                                            // need not name a T at all.
                                             throw ServiceResultException.Create(
                                                 StatusCodes.BadDecodingError,
-                                                "Type does not support IEncodeable interface: '{0}'",
-                                                typeId);
+                                                "Type '{0}' is not a {1}.",
+                                                typeId,
+                                                typeof(T).Name);
+                                        }
+                                        value = instance;
 
                                         if (!m_options.ParseStrict)
                                         {
@@ -2896,7 +2955,16 @@ namespace Opc.Ua
                     encodeableTypeId);
             }
 
-            value = (T)activator.CreateInstance();
+            if (activator.CreateInstance() is not T instance)
+            {
+                // The type id comes from the wire and need not name a T at all.
+                throw ServiceResultException.Create(
+                    StatusCodes.BadDecodingError,
+                    "Type '{0}' is not a {1}.",
+                    encodeableTypeId,
+                    typeof(T).Name);
+            }
+            value = instance;
             return TryGetEncodeableFromElement(value, element);
         }
 
@@ -3093,7 +3161,7 @@ namespace Opc.Ua
         /// <summary>
         /// Get unsigned short from element
         /// </summary>
-        private static bool TryGetUInt16FromElement(JsonElement element, out ushort value)
+        private bool TryGetUInt16FromElement(JsonElement element, out ushort value)
         {
             switch (element.ValueKind)
             {
@@ -3111,7 +3179,7 @@ namespace Opc.Ua
         /// <summary>
         /// Get unsigned short values from element
         /// </summary>
-        private static bool TryGetUInt16ArrayFromElement(JsonElement element, out ArrayOf<ushort> values)
+        private bool TryGetUInt16ArrayFromElement(JsonElement element, out ArrayOf<ushort> values)
         {
             if (TryGetArrayElements(element, out ArrayOf<JsonElement> elements))
             {
@@ -3139,7 +3207,7 @@ namespace Opc.Ua
         /// <summary>
         /// Get unsigned integer from element
         /// </summary>
-        private static bool TryGetUInt32FromElement(JsonElement element, out uint value)
+        private bool TryGetUInt32FromElement(JsonElement element, out uint value)
         {
             switch (element.ValueKind)
             {
@@ -3157,7 +3225,7 @@ namespace Opc.Ua
         /// <summary>
         /// Get unsigned int values from element
         /// </summary>
-        private static bool TryGetUInt32ArrayFromElement(JsonElement element, out ArrayOf<uint> values)
+        private bool TryGetUInt32ArrayFromElement(JsonElement element, out ArrayOf<uint> values)
         {
             if (TryGetArrayElements(element, out ArrayOf<JsonElement> elements))
             {
@@ -3626,6 +3694,15 @@ namespace Opc.Ua
             }
             else
             {
+                if (element.ValueKind is JsonValueKind.Null or JsonValueKind.Undefined &&
+                    dimensionElement.ValueKind == JsonValueKind.Undefined)
+                {
+                    // An omitted or null matrix field is a null variant. The
+                    // dimension check below would otherwise reject it outright.
+                    value = default;
+                    return true;
+                }
+
                 if (readRawValue)
                 {
                     // If reading raw value, then the eleemnt we are reading is encoded
@@ -3646,22 +3723,25 @@ namespace Opc.Ua
                     m_stack.Push(parent);
                 }
 
-                // Read dimension array. A multi-dimensional Variant must carry
-                // Dimensions with at least two entries, each greater than zero
-                // (Part 6 5.2.2.16); the product-versus-length consistency is
-                // enforced by MatrixOf<T> in the switch below. Reject an absent,
-                // too-short, zero or negative dimension here so an empty matrix
-                // (which would otherwise satisfy the product check) is rejected.
-                if (!TryGetInt32ArrayFromElement(
-                    dimensionElement,
-                    out ArrayOf<int> dims) ||
-                    !MatrixOf.IsValidMatrix(dims.Span))
-                {
-                    value = default;
-                    return false;
-                }
                 try
                 {
+                    // Read dimension array. A multi-dimensional Variant must carry
+                    // Dimensions with at least two entries, each greater than zero
+                    // (Part 6 5.2.2.16); the product-versus-length consistency is
+                    // enforced by MatrixOf<T> in the switch below. Reject an absent,
+                    // too-short, zero or negative dimension here so an empty matrix
+                    // (which would otherwise satisfy the product check) is rejected.
+                    // This sits inside the try so the pushed stack entry is popped
+                    // again by the finally below.
+                    if (!TryGetInt32ArrayFromElement(
+                        dimensionElement,
+                        out ArrayOf<int> dims) ||
+                        !MatrixOf.IsValidMatrix(dims.Span))
+                    {
+                        value = default;
+                        return false;
+                    }
+
                     switch (typeInfo.BuiltInType)
                     {
                         case BuiltInType.Null:
@@ -3877,7 +3957,7 @@ namespace Opc.Ua
         /// <summary>
         /// Get xml element from json element
         /// </summary>
-        private static bool TryGetXmlElementFromElement(
+        private bool TryGetXmlElementFromElement(
             JsonElement element,
             out XmlElement value)
         {
@@ -3893,7 +3973,7 @@ namespace Opc.Ua
         /// <summary>
         /// Get xml element values from element
         /// </summary>
-        private static bool TryGetXmlElementArrayFromElement(
+        private bool TryGetXmlElementArrayFromElement(
             JsonElement element,
             out ArrayOf<XmlElement> values)
         {
@@ -3936,27 +4016,41 @@ namespace Opc.Ua
                     value = default;
                     return true;
                 case JsonValueKind.Object:
+                    fieldName = default;
+
+                    // An absent SwitchField must stay "not present" (-1): reading
+                    // it as selector 0 both indexed switches[-1] and made the
+                    // name based Verbose fallback below unreachable.
                     long index = -1;
-                    if (TryGetUInt32FromElement(
-                        GetPropertyElement(JsonProperties.SwitchField),
-                        out uint switchFieldIndex))
+                    JsonElement switchFieldElement =
+                        GetPropertyElement(JsonProperties.SwitchField);
+                    if (switchFieldElement.ValueKind == JsonValueKind.Number &&
+                        switchFieldElement.TryGetUInt32(out uint switchFieldIndex))
                     {
                         index = switchFieldIndex;
                     }
 
-                    fieldName = default;
                     if (switches == null)
                     {
+                        // No field names to resolve against, but the selector
+                        // itself must still be reported when it was written.
+                        value = index < 0 ? 0 : (uint)index;
+                        return true;
+                    }
+                    if (index == 0)
+                    {
+                        // Selector zero selects no field at all.
                         value = 0;
                         return true;
                     }
-                    if (index >= switches.Count)
+                    if (index > switches.Count)
                     {
+                        // Unknown selector - report it and let the caller reject it.
                         value = (uint)index;
                         return true;
                     }
 
-                    if (index >= 0)
+                    if (index > 0)
                     {
                         // Switch field index found, resolve it
                         JsonElement valueElement = GetPropertyElement("Value");
@@ -4152,7 +4246,7 @@ namespace Opc.Ua
         /// <param name="element"></param>
         /// <param name="values"></param>
         /// <returns></returns>
-        private static bool TryGetArrayElements(
+        private bool TryGetArrayElements(
             JsonElement element,
             out ArrayOf<JsonElement> values)
         {
@@ -4195,12 +4289,55 @@ namespace Opc.Ua
                             }
                         }
                     }
+                    CheckArrayLength(result.Count);
                     values = result;
                     return true;
                 default:
                     values = default;
                     return false;
             }
+        }
+
+        /// <summary>
+        /// The JSON decoder used to enforce no payload limits at all. Zero means
+        /// unlimited, matching every other codec.
+        /// </summary>
+        /// <exception cref="ServiceResultException"></exception>
+        private void CheckArrayLength(int length)
+        {
+            if (Context.MaxArrayLength > 0 && length > Context.MaxArrayLength)
+            {
+                throw ServiceResultException.Create(
+                    StatusCodes.BadEncodingLimitsExceeded,
+                    "MaxArrayLength {0} < {1}",
+                    Context.MaxArrayLength,
+                    length);
+            }
+        }
+
+        /// <summary>
+        /// Checks a decoded byte string against MaxByteStringLength.
+        /// </summary>
+        /// <exception cref="ServiceResultException"></exception>
+        private void CheckByteStringLength(int length)
+        {
+            if (Context.MaxByteStringLength > 0 && length > Context.MaxByteStringLength)
+            {
+                throw ServiceResultException.Create(
+                    StatusCodes.BadEncodingLimitsExceeded,
+                    "MaxByteStringLength {0} < {1}",
+                    Context.MaxByteStringLength,
+                    length);
+            }
+        }
+
+        /// <summary>
+        /// Checks a decoded string against MaxStringLength.
+        /// </summary>
+        /// <exception cref="ServiceResultException"></exception>
+        private void CheckStringLength(string? value)
+        {
+            EncodingLimits.CheckStringLength(Context.MaxStringLength, value);
         }
 
         /// <summary>

--- a/src/Opc.Ua.Types/Encoders/JsonEncoder.cs
+++ b/src/Opc.Ua.Types/Encoders/JsonEncoder.cs
@@ -854,7 +854,7 @@ namespace Opc.Ua
                 WriteNull(fieldName);
                 return;
             }
-            CheckStringLength(value.Length);
+            CheckStringLength(value);
             m_writer.WritePropertyName(fieldName!);
             m_writer.WriteStringValue(value);
         }
@@ -1379,8 +1379,19 @@ namespace Opc.Ua
                         WriteJsonExtensionObjectBody(
                             rawJson,
                             !m_options.SuppressArtifacts && !localTypeId.IsNull);
+                        break;
                     }
-                    break;
+                    if (rawJson.Length == 0)
+                    {
+                        // No body at all.
+                        break;
+                    }
+                    // A non object body cannot be inlined into the envelope.
+                    // Silently dropping it produced an ExtensionObject whose
+                    // body was gone without any error.
+                    throw ServiceResultException.Create(
+                        StatusCodes.BadEncodingError,
+                        "ExtensionObject JSON body must be a JSON object.");
                 case ExtensionObjectEncoding.Binary:
                     WriteByte(JsonProperties.UaEncoding, (byte)ExtensionObjectEncoding.Binary);
                     WriteByteString(
@@ -1856,7 +1867,7 @@ namespace Opc.Ua
                 m_writer.WriteNullValue();
                 return;
             }
-            CheckStringLength(value.Length);
+            CheckStringLength(value);
             m_writer.WriteStringValue(value);
         }
 
@@ -2386,7 +2397,8 @@ namespace Opc.Ua
         /// <exception cref="ServiceResultException"></exception>
         private void CheckArrayLength(int length)
         {
-            if (length > Context.MaxArrayLength)
+            // Zero means unlimited, as in every other codec.
+            if (Context.MaxArrayLength > 0 && length > Context.MaxArrayLength)
             {
                 throw ServiceResultException.Create(
                     StatusCodes.BadEncodingLimitsExceeded,
@@ -2400,7 +2412,8 @@ namespace Opc.Ua
         /// <exception cref="ServiceResultException"></exception>
         private void CheckByteStringLength(int length)
         {
-            if (length > Context.MaxByteStringLength)
+            // Zero means unlimited, as in every other codec.
+            if (Context.MaxByteStringLength > 0 && length > Context.MaxByteStringLength)
             {
                 throw ServiceResultException.Create(
                     StatusCodes.BadEncodingLimitsExceeded,
@@ -2427,14 +2440,9 @@ namespace Opc.Ua
         /// Check string
         /// </summary>
         /// <exception cref="ServiceResultException"></exception>
-        private void CheckStringLength(int length)
+        private void CheckStringLength(string value)
         {
-            if (length > Context.MaxStringLength)
-            {
-                throw ServiceResultException.Create(
-                    StatusCodes.BadEncodingLimitsExceeded,
-                    $"{length} characters > max (= {Context.MaxStringLength})");
-            }
+            EncodingLimits.CheckStringLength(Context.MaxStringLength, value);
         }
 
         private const int kFlushThreshold = 16 * 1024;

--- a/src/Opc.Ua.Types/Encoders/Union.cs
+++ b/src/Opc.Ua.Types/Encoders/Union.cs
@@ -142,13 +142,14 @@ namespace Opc.Ua.Encoders
             bool isJsonDecoder = decoder.EncodingType == EncodingType.Json;
             if (unionSelector == 0 && isJsonDecoder)
             {
+                // The Verbose JSON encoding writes no SwitchField, so the
+                // selector has to be recovered from the member name. Every
+                // union field is a candidate - filtering by IsOptional left the
+                // list empty and every such union decoded as selector 0.
                 var fields = new List<string>();
                 foreach (Field property in PropertyList)
                 {
-                    if (property.IsOptional)
-                    {
-                        fields.Add(property.Name!);
-                    }
+                    fields.Add(property.Name!);
                 }
 
                 unionSelector = decoder.ReadSwitchField(fields, out _);

--- a/src/Opc.Ua.Types/Encoders/XmlDecoder.cs
+++ b/src/Opc.Ua.Types/Encoders/XmlDecoder.cs
@@ -320,6 +320,22 @@ namespace Opc.Ua
             }
         }
 
+        /// <summary>
+        /// Adopts already resolved mapping tables and the current nesting depth
+        /// from an outer decoder. Used when an ExtensionObject with an XML body
+        /// is decoded from inside another decoder - the nested body is part of
+        /// the same message and must share both.
+        /// </summary>
+        internal void InheritDecodingState(
+            ushort[]? namespaceMappings,
+            ushort[]? serverMappings,
+            uint nestingLevel)
+        {
+            m_namespaceMappings = namespaceMappings;
+            m_serverMappings = serverMappings;
+            m_nestingLevel = nestingLevel;
+        }
+
         /// <inheritdoc/>
         public T DecodeMessage<T>() where T : IEncodeable
         {
@@ -352,7 +368,16 @@ namespace Opc.Ua
             PushNamespace(typeName.Namespace);
 
             // read the message.
-            T encodeable = ReadEncodeable(name, (T)activator.CreateInstance());
+            if (activator.CreateInstance() is not T instance)
+            {
+                // The type name comes from the document and need not name a T.
+                throw ServiceResultException.Create(
+                    StatusCodes.BadDecodingError,
+                    "Type '{0}' is not a {1}.",
+                    typeName,
+                    typeof(T).Name);
+            }
+            T encodeable = ReadEncodeable(name, instance);
 
             PopNamespace();
 
@@ -584,10 +609,7 @@ namespace Opc.Ua
                 string? xml = SafeReadString();
 
                 // check the length.
-                if (Context.MaxStringLength > 0 && Context.MaxStringLength < xml!.Length)
-                {
-                    throw new ServiceResultException(StatusCodes.BadEncodingLimitsExceeded);
-                }
+                EncodingLimits.CheckStringLength(Context.MaxStringLength, xml);
 
                 if (!string.IsNullOrEmpty(xml))
                 {
@@ -1047,7 +1069,15 @@ namespace Opc.Ua
                     encodeableTypeId);
             }
 
-            var value = (T)activator.CreateInstance();
+            if (activator.CreateInstance() is not T value)
+            {
+                // The type id comes from the wire and need not name a T at all.
+                throw ServiceResultException.Create(
+                    StatusCodes.BadDecodingError,
+                    "Type '{0}' is not a {1}.",
+                    encodeableTypeId,
+                    typeof(T).Name);
+            }
             return ReadEncodeable(fieldName, value);
         }
 
@@ -1960,7 +1990,7 @@ namespace Opc.Ua
                     int[] dimensions = ReadInt32Array("Dimensions").ToArray() ?? [];
                     if (BeginField("Elements", true))
                     {
-                        value = ReadEncodeableArray<T>(null, encodeableTypeId).ToMatrix(dimensions);
+                        value = ToMatrixOrThrow(ReadEncodeableArray<T>(null, encodeableTypeId), dimensions);
                         EndField("Elements");
                     }
 
@@ -1991,7 +2021,7 @@ namespace Opc.Ua
                     int[] dimensions = ReadInt32Array("Dimensions").ToArray() ?? [];
                     if (BeginField("Elements", true))
                     {
-                        value = ReadEncodeableArray<T>(null).ToMatrix(dimensions);
+                        value = ToMatrixOrThrow(ReadEncodeableArray<T>(null), dimensions);
                         EndField("Elements");
                     }
 
@@ -2005,6 +2035,31 @@ namespace Opc.Ua
                 m_nestingLevel--;
             }
             return value;
+        }
+
+        /// <summary>
+        /// Builds a matrix from decoded elements and wire supplied dimensions.
+        /// MatrixOf throws ArgumentException for invalid dimensions (negative,
+        /// zero rank, overflowing product, or a length mismatch), which must be
+        /// reported through the decoder rejection channel instead of escaping.
+        /// </summary>
+        /// <typeparam name="T">The element type of the matrix.</typeparam>
+        /// <exception cref="ServiceResultException"></exception>
+        private static MatrixOf<T> ToMatrixOrThrow<T>(ArrayOf<T> elements, int[] dimensions)
+        {
+            try
+            {
+                return elements.ToMatrix(dimensions);
+            }
+            catch (ArgumentException ex)
+            {
+                throw ServiceResultException.Create(
+                    StatusCodes.BadDecodingError,
+                    ex,
+                    "Encodeable matrix Dimensions [{0}] are inconsistent with {1} element(s).",
+                    string.Join(",", dimensions),
+                    elements.Count);
+            }
         }
 
         /// <inheritdoc/>
@@ -2138,7 +2193,14 @@ namespace Opc.Ua
             // skip whitespace.
             while (m_reader.NodeType != XmlNodeType.Element)
             {
-                m_reader.Read();
+                if (!m_reader.Read())
+                {
+                    // Read() returns false at the end of the document, leaving
+                    // NodeType at None - without this the loop never ends.
+                    throw ServiceResultException.Create(
+                        StatusCodes.BadDecodingError,
+                        "Error reading variant value. No element found.");
+                }
             }
 
             try
@@ -2385,7 +2447,7 @@ namespace Opc.Ua
         /// <exception cref="ServiceResultException"></exception>
         private DiagnosticInfo? ReadDiagnosticInfo(int depth)
         {
-            if (depth >= DiagnosticInfo.MaxInnerDepth)
+            if (depth > DiagnosticInfo.MaxInnerDepth)
             {
                 throw ServiceResultException.Create(
                     StatusCodes.BadEncodingLimitsExceeded,
@@ -2662,15 +2724,16 @@ namespace Opc.Ua
                 string value = m_reader.ReadContentAsString();
 
                 // check the length.
-                if (value != null &&
-                    Context.MaxStringLength > 0 &&
-                    Context.MaxStringLength < value.Length)
+                if (EncodingLimits.StringExceedsLimit(
+                    Context.MaxStringLength,
+                    value,
+                    out int byteLength))
                 {
                     throw ServiceResultException.Create(
                         StatusCodes.BadEncodingLimitsExceeded,
                         "ReadString in {0} exceeds MaxStringLength: {1} > {2}",
                         functionName ?? string.Empty,
-                        value.Length,
+                        byteLength,
                         Context.MaxStringLength);
                 }
 

--- a/src/Opc.Ua.Types/Encoders/XmlEncoder.cs
+++ b/src/Opc.Ua.Types/Encoders/XmlEncoder.cs
@@ -433,12 +433,11 @@ namespace Opc.Ua
             if (BeginField(fieldName, value == null, true, isArrayElement))
             {
                 // check the length.
-                if (Context.MaxStringLength > 0 && Context.MaxStringLength < value!.Length)
-                {
-                    throw new ServiceResultException(StatusCodes.BadEncodingLimitsExceeded);
-                }
+                EncodingLimits.CheckStringLength(Context.MaxStringLength, value);
 
-                if (!string.IsNullOrWhiteSpace(value))
+                // A whitespace only string is still a value - writing nothing
+                // would turn it into an empty string on the wire.
+                if (!string.IsNullOrEmpty(value))
                 {
                     m_writer.WriteString(value);
                 }
@@ -542,6 +541,15 @@ namespace Opc.Ua
         {
             if (BeginField(fieldName, value.IsEmpty, true, isArrayElement))
             {
+                // WriteRaw bypasses every check the writer would otherwise make,
+                // so validate the body first. Writing unparsable (or injected)
+                // markup would produce a document no decoder can read.
+                if (!value.IsValid)
+                {
+                    throw ServiceResultException.Create(
+                        StatusCodes.BadEncodingError,
+                        "XmlElement body is not well formed XML.");
+                }
                 m_writer.WriteRaw(value.OuterXml ?? string.Empty);
                 EndField(fieldName);
             }
@@ -1650,7 +1658,7 @@ namespace Opc.Ua
         {
             CheckAndIncrementNestingLevel();
 
-            if (BeginField("Matrix", values.IsNull, true, true))
+            if (BeginField(fieldName, values.IsNull, true, true))
             {
                 PushNamespace(Namespaces.OpcUaXsd);
                 if (!values.IsNull)
@@ -1659,7 +1667,7 @@ namespace Opc.Ua
                     WriteEncodeableArray("Elements", values.ToArrayOf(), encodeableTypeId);
                 }
                 PopNamespace();
-                EndField("Matrix");
+                EndField(fieldName);
             }
 
             m_nestingLevel--;

--- a/src/Opc.Ua.Types/Encoders/XmlEncoder.cs
+++ b/src/Opc.Ua.Types/Encoders/XmlEncoder.cs
@@ -33,6 +33,7 @@ using System.Globalization;
 using System.IO;
 using System.Text;
 using System.Xml;
+using System.Xml.Linq;
 using Microsoft.Extensions.Logging;
 using Opc.Ua.Types;
 
@@ -542,15 +543,20 @@ namespace Opc.Ua
             if (BeginField(fieldName, value.IsEmpty, true, isArrayElement))
             {
                 // WriteRaw bypasses every check the writer would otherwise make,
-                // so validate the body first. Writing unparsable (or injected)
-                // markup would produce a document no decoder can read.
-                if (!value.IsValid)
+                // so parse the body first. Writing unparsable (or injected)
+                // markup would produce a document no decoder can read, and an
+                // XML declaration - which parses fine but may only appear at the
+                // start of a document - would be injected into the middle of
+                // this one. Writing the parsed element back drops the prolog and
+                // guarantees a single well formed root.
+                XElement? body = value.AsXElement();
+                if (body == null)
                 {
                     throw ServiceResultException.Create(
                         StatusCodes.BadEncodingError,
                         "XmlElement body is not well formed XML.");
                 }
-                m_writer.WriteRaw(value.OuterXml ?? string.Empty);
+                m_writer.WriteRaw(body.ToString(SaveOptions.DisableFormatting));
                 EndField(fieldName);
             }
         }

--- a/src/Opc.Ua.Types/Encoders/XmlParser.cs
+++ b/src/Opc.Ua.Types/Encoders/XmlParser.cs
@@ -366,7 +366,16 @@ namespace Opc.Ua
             PushNamespace(typeName.Namespace);
 
             // read the message.
-            T encodeable = ReadEncodeable(name, (T)activator.CreateInstance());
+            if (activator.CreateInstance() is not T instance)
+            {
+                // The type name comes from the document and need not name a T.
+                throw ServiceResultException.Create(
+                    StatusCodes.BadDecodingError,
+                    "Type '{0}' is not a {1}.",
+                    typeName,
+                    typeof(T).Name);
+            }
+            T encodeable = ReadEncodeable(name, instance);
 
             PopNamespace();
 
@@ -598,10 +607,7 @@ namespace Opc.Ua
                 string? xml = SafeReadString();
 
                 // check the length.
-                if (Context.MaxStringLength > 0 && Context.MaxStringLength < xml!.Length)
-                {
-                    throw new ServiceResultException(StatusCodes.BadEncodingLimitsExceeded);
-                }
+                EncodingLimits.CheckStringLength(Context.MaxStringLength, xml);
 
                 if (!string.IsNullOrEmpty(xml))
                 {
@@ -652,7 +658,10 @@ namespace Opc.Ua
         {
             if (BeginField(fieldName, true, out bool isNil))
             {
-                string? xml = SafeReadString();
+                // The base64 text is not a String on the wire - gating it by
+                // MaxStringLength would reject blobs that are well within
+                // MaxByteStringLength, which is checked below.
+                string? xml = ReadInnerText();
 
                 ByteString value;
 
@@ -1056,7 +1065,15 @@ namespace Opc.Ua
                     encodeableTypeId);
             }
 
-            var value = (T)activator.CreateInstance();
+            if (activator.CreateInstance() is not T value)
+            {
+                // The type id comes from the wire and need not name a T at all.
+                throw ServiceResultException.Create(
+                    StatusCodes.BadDecodingError,
+                    "Type '{0}' is not a {1}.",
+                    encodeableTypeId,
+                    typeof(T).Name);
+            }
             return ReadEncodeable(fieldName, value);
         }
 
@@ -1572,7 +1589,7 @@ namespace Opc.Ua
                 }
 
                 // check the length.
-                if (Context.MaxArrayLength > 0 && Context.MaxByteStringLength < values.Count)
+                if (Context.MaxArrayLength > 0 && Context.MaxArrayLength < values.Count)
                 {
                     throw new ServiceResultException(StatusCodes.BadEncodingLimitsExceeded);
                 }
@@ -1969,8 +1986,9 @@ namespace Opc.Ua
                     int[] dimensions = ReadInt32Array("Dimensions").ToArray() ?? [];
                     if (BeginField("Elements", true))
                     {
-                        value = ReadEncodeableArray<T>(null, encodeableTypeId)
-                            .ToMatrix(dimensions);
+                        value = ToMatrixOrThrow(
+                            ReadEncodeableArray<T>(null, encodeableTypeId),
+                            dimensions);
                         EndField("Elements");
                     }
 
@@ -2001,8 +2019,7 @@ namespace Opc.Ua
                     int[] dimensions = ReadInt32Array("Dimensions").ToArray() ?? [];
                     if (BeginField("Elements", true))
                     {
-                        value = ReadEncodeableArray<T>(null)
-                            .ToMatrix(dimensions);
+                        value = ToMatrixOrThrow(ReadEncodeableArray<T>(null), dimensions);
                         EndField("Elements");
                     }
 
@@ -2016,6 +2033,31 @@ namespace Opc.Ua
                 m_nestingLevel--;
             }
             return value;
+        }
+
+        /// <summary>
+        /// Builds a matrix from decoded elements and wire supplied dimensions.
+        /// MatrixOf throws ArgumentException for invalid dimensions (negative,
+        /// zero rank, overflowing product, or a length mismatch), which must be
+        /// reported through the decoder rejection channel instead of escaping.
+        /// </summary>
+        /// <typeparam name="T">The element type of the matrix.</typeparam>
+        /// <exception cref="ServiceResultException"></exception>
+        private static MatrixOf<T> ToMatrixOrThrow<T>(ArrayOf<T> elements, int[] dimensions)
+        {
+            try
+            {
+                return elements.ToMatrix(dimensions);
+            }
+            catch (ArgumentException ex)
+            {
+                throw ServiceResultException.Create(
+                    StatusCodes.BadDecodingError,
+                    ex,
+                    "Encodeable matrix Dimensions [{0}] are inconsistent with {1} element(s).",
+                    string.Join(",", dimensions),
+                    elements.Count);
+            }
         }
 
         /// <inheritdoc/>
@@ -2410,7 +2452,7 @@ namespace Opc.Ua
         /// <exception cref="ServiceResultException"></exception>
         private DiagnosticInfo? ReadDiagnosticInfo(int depth)
         {
-            if (depth >= DiagnosticInfo.MaxInnerDepth)
+            if (depth > DiagnosticInfo.MaxInnerDepth)
             {
                 throw ServiceResultException.Create(
                     StatusCodes.BadEncodingLimitsExceeded,
@@ -2679,23 +2721,34 @@ namespace Opc.Ua
         /// <exception cref="ServiceResultException"></exception>
         private string? SafeReadString([CallerMemberName] string? functionName = null)
         {
-            ElementContext context = m_contextStack.Peek();
-            string? value = context.Element?.InnerText;
+            string? value = ReadInnerText();
 
             // check the length.
-            if (value != null &&
-                Context.MaxStringLength > 0 &&
-                Context.MaxStringLength < value.Length)
+            if (EncodingLimits.StringExceedsLimit(
+                Context.MaxStringLength,
+                value,
+                out int byteLength))
             {
                 throw ServiceResultException.Create(
                     StatusCodes.BadEncodingLimitsExceeded,
                     "ReadString in {0} exceeds MaxStringLength: {1} > {2}",
                     functionName ?? string.Empty,
-                    value.Length,
+                    byteLength,
                     Context.MaxStringLength);
             }
 
             return value;
+        }
+
+        /// <summary>
+        /// Reads the InnerText of the current context element without applying
+        /// MaxStringLength. Used for payloads whose text is not a String on the
+        /// wire (base64 byte strings), which are bounded by their own limit.
+        /// </summary>
+        private string? ReadInnerText()
+        {
+            ElementContext context = m_contextStack.Peek();
+            return context.Element?.InnerText;
         }
 
         private static byte[] SafeConvertFromBase64String(string s)

--- a/src/Opc.Ua.Types/Nodes/Node.cs
+++ b/src/Opc.Ua.Types/Nodes/Node.cs
@@ -637,9 +637,12 @@ namespace Opc.Ua
                     break;
             }
 
-            return expectedType ==
-                    TypeInfo.GetBuiltInType(
-                        TypeInfo.GetDataTypeId(value, null)) && // TODO: Pass message context
+            // The value's own built-in type is read directly rather than by way
+            // of its data type id: for a structured value that id is the
+            // concrete structure (StructureDefinition and the like), which is
+            // not a built-in type at all, so the round trip resolved every
+            // DataTypeDefinition write to BuiltInType.Null and rejected it.
+            return expectedType == value.TypeInfo.BuiltInType &&
                 value.TypeInfo.ValueRank == expectedRank;
         }
 

--- a/src/Opc.Ua.Types/Nodes/Node.cs
+++ b/src/Opc.Ua.Types/Nodes/Node.cs
@@ -591,15 +591,56 @@ namespace Opc.Ua
                 case Attributes.NodeClass:
                     return StatusCodes.BadNotWritable;
                 default:
-                    // check data type.
                     if (attributeId != Attributes.Value &&
-                        Attributes.GetDataTypeId(attributeId) !=
-                            TypeInfo.GetDataTypeId(value, null)) // TODO: Pass message context
+                        !IsAssignableToAttribute(attributeId, value.WrappedValue))
                     {
                         return StatusCodes.BadTypeMismatch;
                     }
                     return Write(attributeId, value.WrappedValue);
             }
+        }
+
+        /// <summary>
+        /// Checks whether a value can be written to an attribute.
+        /// </summary>
+        /// <remarks>
+        /// The data type is compared by built-in type rather than by data type
+        /// id, because some attributes are typed by a subtype of a built-in type
+        /// (MinimumSamplingInterval is a Duration, i.e. a Double) which never
+        /// compares equal to the data type id of the value itself. The value rank
+        /// has to match as well: the built-in type alone does not separate a
+        /// Boolean from an array of Boolean, and the write handlers cast the
+        /// value unconditionally, so an array would reach them and throw
+        /// InvalidCastException out of a method that reports failure as a status
+        /// code.
+        /// </remarks>
+        /// <param name="attributeId">The attribute id.</param>
+        /// <param name="value">The value to write.</param>
+        private static bool IsAssignableToAttribute(uint attributeId, Variant value)
+        {
+            BuiltInType expectedType =
+                TypeInfo.GetBuiltInType(Attributes.GetDataTypeId(attributeId));
+            int expectedRank = ValueRanks.Scalar;
+
+            switch (attributeId)
+            {
+                case Attributes.RolePermissions:
+                case Attributes.UserRolePermissions:
+                    // RolePermissionType is not a built-in type, so the data
+                    // type id above yields BuiltInType.Null. The permissions
+                    // travel as an array of ExtensionObject.
+                    expectedType = BuiltInType.ExtensionObject;
+                    expectedRank = ValueRanks.OneDimension;
+                    break;
+                case Attributes.ArrayDimensions:
+                    expectedRank = ValueRanks.OneDimension;
+                    break;
+            }
+
+            return expectedType ==
+                    TypeInfo.GetBuiltInType(
+                        TypeInfo.GetDataTypeId(value, null)) && // TODO: Pass message context
+                value.TypeInfo.ValueRank == expectedRank;
         }
 
         /// <summary>

--- a/src/Opc.Ua.Types/Nodes/NodeSet.cs
+++ b/src/Opc.Ua.Types/Nodes/NodeSet.cs
@@ -954,8 +954,8 @@ namespace Opc.Ua
             {
                 argument.DataType = Translate(
                     argument.DataType,
-                    sourceNamespaceUris,
-                    targetNamespaceUris);
+                    targetNamespaceUris,
+                    sourceNamespaceUris);
                 return new ExtensionObject(argument);
             }
 #pragma warning restore CS8602, CS8600

--- a/src/Opc.Ua.Types/Nodes/NodeTable.cs
+++ b/src/Opc.Ua.Types/Nodes/NodeTable.cs
@@ -516,7 +516,9 @@ namespace Opc.Ua
                 serializedNode.ReferenceTable.Count == 0)
             {
                 // index references.
-                foreach (ReferenceNode reference in node.References.OfType<ReferenceNode>())
+                // node.References resolves to the (still empty) ReferenceTable,
+                // so the unindexed list has to be read from the Node itself.
+                foreach (ReferenceNode reference in serializedNode.References)
                 {
                     // ignore invalid references.
                     if (reference.ReferenceTypeId.IsNull ||
@@ -541,8 +543,9 @@ namespace Opc.Ua
                     }
                 }
 
-                // clear unindexed reference list.
-                node.References.Clear();
+                // clear unindexed reference list - not the ReferenceTable that
+                // was just populated above.
+                serializedNode.References = [];
             }
 
             // add the node to the table.
@@ -616,8 +619,11 @@ namespace Opc.Ua
 
                 if (target is ILocalNode targetNode)
                 {
+                    // The reference on the target points the other way round,
+                    // so its direction has to be inverted here - otherwise the
+                    // reverse reference stays behind and dangles.
                     targetNode.References
-                        .Remove(reference.ReferenceTypeId, reference.IsInverse, sourceNode.NodeId);
+                        .Remove(reference.ReferenceTypeId, !reference.IsInverse, sourceNode.NodeId);
                 }
             }
 

--- a/src/Opc.Ua.Types/Nodes/ReferenceNode.cs
+++ b/src/Opc.Ua.Types/Nodes/ReferenceNode.cs
@@ -226,8 +226,10 @@ namespace Opc.Ua
         /// <inheritdoc/>
         public override int GetHashCode()
         {
+            // Equality compares only these three members, so the hash must not
+            // mix in base.GetHashCode() - that is object identity and makes two
+            // equal references hash differently.
             var hash = new HashCode();
-            hash.Add(base.GetHashCode());
             hash.Add(ReferenceTypeId);
             hash.Add(IsInverse);
             hash.Add(TargetId);

--- a/src/Opc.Ua.Types/Nodes/VariableNode.cs
+++ b/src/Opc.Ua.Types/Nodes/VariableNode.cs
@@ -377,7 +377,8 @@ namespace Opc.Ua
                     AccessLevelEx = (uint)value;
                     return ServiceResult.Good;
                 case Attributes.MinimumSamplingInterval:
-                    MinimumSamplingInterval = (int)value;
+                    // The attribute is a Duration (Double), not an Int32.
+                    MinimumSamplingInterval = (double)value;
                     return ServiceResult.Good;
                 case Attributes.Historizing:
                     Historizing = (bool)value;

--- a/src/Opc.Ua.Types/Polyfills/System.cs
+++ b/src/Opc.Ua.Types/Polyfills/System.cs
@@ -142,9 +142,19 @@ namespace System
                 return target.Replace(oldValue, newValue);
             }
 
-            if (string.IsNullOrEmpty(oldValue))
+            // The framework overload throws for these, and so does the ordinal
+            // branch above through string.Replace. Returning the target instead
+            // would make the contract depend on the target framework and on the
+            // comparison the caller asked for.
+            if (oldValue == null)
             {
-                return target;
+                throw new ArgumentNullException(nameof(oldValue));
+            }
+            if (oldValue.Length == 0)
+            {
+                throw new ArgumentException(
+                    "String cannot be of zero length.",
+                    nameof(oldValue));
             }
 
             // Honour the comparison instead of always replacing ordinally.

--- a/src/Opc.Ua.Types/Polyfills/System.cs
+++ b/src/Opc.Ua.Types/Polyfills/System.cs
@@ -121,7 +121,11 @@ namespace System
         /// </summary>
         public static int IndexOf(this string target, char value, StringComparison comparisonType)
         {
-            return target.IndexOf(value);
+            // Honour the comparison instead of always using the ordinal
+            // overload, which ignored a requested culture or case insensitivity.
+            return comparisonType == StringComparison.Ordinal
+                ? target.IndexOf(value)
+                : target.IndexOf(value.ToString(), comparisonType);
         }
 
         /// <summary>
@@ -133,7 +137,82 @@ namespace System
             string newValue,
             StringComparison comparisonType)
         {
-            return target.Replace(oldValue, newValue);
+            if (comparisonType == StringComparison.Ordinal)
+            {
+                return target.Replace(oldValue, newValue);
+            }
+
+            if (string.IsNullOrEmpty(oldValue))
+            {
+                return target;
+            }
+
+            // Honour the comparison instead of always replacing ordinally.
+            var builder = new System.Text.StringBuilder(target.Length);
+            bool ordinalIgnoreCase = comparisonType == StringComparison.OrdinalIgnoreCase;
+            int index = 0;
+
+            while (index < target.Length)
+            {
+                int match = target.IndexOf(oldValue, index, comparisonType);
+
+                if (match < 0)
+                {
+                    builder.Append(target, index, target.Length - index);
+                    break;
+                }
+
+                // A culture sensitive match can span a different number of
+                // characters than oldValue - under de-DE "ss" matches the single
+                // sharp s character, and an ignorable oldValue matches none at
+                // all - so advance by the length that actually matched. Only the
+                // ordinal comparisons are guaranteed to match oldValue.Length
+                // characters.
+                int matched = ordinalIgnoreCase
+                    ? oldValue.Length
+                    : MatchLength(target, match, oldValue, comparisonType);
+
+                if (matched == 0)
+                {
+                    // Nothing to consume here, so keep the character and move
+                    // on rather than replacing the whole string one empty match
+                    // at a time.
+                    builder.Append(target, index, match - index + 1);
+                    index = match + 1;
+                    continue;
+                }
+
+                builder.Append(target, index, match - index).Append(newValue);
+                index = match + matched;
+            }
+
+            return builder.ToString();
+        }
+
+        /// <summary>
+        /// Returns the number of characters at <paramref name="start"/> that
+        /// compare equal to <paramref name="oldValue"/> under the given
+        /// comparison, which is not necessarily the length of
+        /// <paramref name="oldValue"/> for a culture sensitive comparison.
+        /// </summary>
+        private static int MatchLength(
+            string target,
+            int start,
+            string oldValue,
+            StringComparison comparisonType)
+        {
+            int available = target.Length - start;
+            for (int length = 0; length <= available; length++)
+            {
+                if (string.Equals(
+                    target.Substring(start, length),
+                    oldValue,
+                    comparisonType))
+                {
+                    return length;
+                }
+            }
+            return oldValue.Length;
         }
 
         /// <summary>

--- a/src/Opc.Ua.Types/Schema/BinarySchemaValidator.cs
+++ b/src/Opc.Ua.Types/Schema/BinarySchemaValidator.cs
@@ -162,10 +162,15 @@ namespace Opc.Ua.Schema.Binary
                     Import(directive.Location, directive.Namespace);
                 }
             }
-            else if (Dictionary.TargetNamespace != Ua.Types.Namespaces.OpcUa)
+            else if (Dictionary.TargetNamespace != Ua.Types.Namespaces.OpcUa &&
+                Dictionary.TargetNamespace != Ua.Types.Namespaces.OpcUaBuiltInTypes)
             {
                 // Import built-in types if no imports are specified and not built in.
-                Import(null, Ua.Types.Namespaces.OpcUa);
+                // The built-in type dictionary lives under the BuiltInTypes
+                // namespace: no resource is registered for Namespaces.OpcUa, so
+                // importing that one threw "Cannot import namespace" for every
+                // dictionary that declares no imports of its own.
+                Import(null, Ua.Types.Namespaces.OpcUaBuiltInTypes);
             }
 
             // import types from imported dictionaries.
@@ -534,7 +539,7 @@ namespace Opc.Ua.Schema.Binary
                         "Field '{0}' in structured type '{1}' references a length field '{2}' which is not an integer value.",
                         field.Name,
                         description.Name,
-                        field.SwitchField);
+                        field.LengthField);
                 }
             }
 

--- a/src/Opc.Ua.Types/Schema/NodeSetComparer.cs
+++ b/src/Opc.Ua.Types/Schema/NodeSetComparer.cs
@@ -337,8 +337,17 @@ namespace Opc.Ua.Export
         /// </summary>
         private static bool IsAliasedAttribute(string localName)
         {
-            return string.Equals(localName, "DataType", StringComparison.Ordinal) ||
-                string.Equals(localName, "ReferenceType", StringComparison.Ordinal);
+            // An alias may stand in for any NodeId valued attribute of the
+            // NodeSet schema, not just DataType and ReferenceType.
+            return localName switch
+            {
+                "DataType" or
+                "ReferenceType" or
+                "NodeId" or
+                "ParentNodeId" or
+                "MethodDeclarationId" => true,
+                _ => false
+            };
         }
 
         /// <summary>

--- a/src/Opc.Ua.Types/Schema/SchemaValidator.cs
+++ b/src/Opc.Ua.Types/Schema/SchemaValidator.cs
@@ -301,10 +301,17 @@ namespace Opc.Ua.Schema
             string file = Path.GetFileName(path);
             if (!string.IsNullOrEmpty(FilePath))
             {
-                path = Path.Combine(Path.GetFullPath(FilePath), file);
-                if (FileSystem.Exists(path))
+                // FilePath is the file under validation, so its directory is
+                // what "side by side" means - combining with the file path
+                // itself produced a path that can never exist.
+                string? directory = Path.GetDirectoryName(Path.GetFullPath(FilePath!));
+                if (!string.IsNullOrEmpty(directory))
                 {
-                    return FileSystem.OpenRead(path);
+                    path = Path.Combine(directory!, file);
+                    if (FileSystem.Exists(path))
+                    {
+                        return FileSystem.OpenRead(path);
+                    }
                 }
             }
 

--- a/src/Opc.Ua.Types/Schema/TypeDictionaryValidator.cs
+++ b/src/Opc.Ua.Types/Schema/TypeDictionaryValidator.cs
@@ -415,7 +415,13 @@ namespace Opc.Ua.Schema.Types
 
             ValidateBaseType(complexType, parentType.BaseType, fields);
 
-            for (int ii = 0; ii < parentType.Field!.Length; ii++)
+            // A base type without any field is legal, so Field can be null.
+            if (parentType.Field == null)
+            {
+                return;
+            }
+
+            for (int ii = 0; ii < parentType.Field.Length; ii++)
             {
                 fields.Add(parentType.Field[ii].Name!, parentType.Field[ii]);
             }

--- a/src/Opc.Ua.Types/Schema/UANodeSetHelpers.cs
+++ b/src/Opc.Ua.Types/Schema/UANodeSetHelpers.cs
@@ -2180,6 +2180,14 @@ namespace Opc.Ua.Export
                 return nodeId.WithNamespaceUri(namespaceUri).WithServerIndex(serverIndex);
             }
 
+            if (!resolveNamespaceUri && !string.IsNullOrEmpty(nodeId.NamespaceUri))
+            {
+                // The URI was not resolved against the namespace table, so keep
+                // the absolute form instead of silently dropping it - the
+                // alternative landed the target in namespace zero.
+                return nodeId.WithServerIndex(0);
+            }
+
             return nodeId.WithNamespaceIndex(namespaceIndex).WithServerIndex(0);
         }
 
@@ -2740,8 +2748,10 @@ namespace Opc.Ua.Export
                 return serverIndex;
             }
 
-            // return a bad value if parameters are bad.
-            if (serverUris == null || serverUris.Count < serverIndex)
+            // return a bad value if parameters are bad. Valid indexes run to
+            // Count - 1; "< serverIndex" let Count through and then appended
+            // the null that GetString returned for it.
+            if (serverUris == null || serverUris.Count <= serverIndex)
             {
                 return ushort.MaxValue;
             }

--- a/src/Opc.Ua.Types/Schema/XmlSchemaValidator2.cs
+++ b/src/Opc.Ua.Types/Schema/XmlSchemaValidator2.cs
@@ -92,7 +92,9 @@ namespace Opc.Ua.Schema.Xml
             var handler = new ValidationEventHandler(OnValidate);
             TargetSchema = Load(stream, handler);
 
-            foreach (XmlSchemaImport import in TargetSchema.Includes.Cast<XmlSchemaImport>())
+            // Includes carries xs:include and xs:redefine as well, which are not
+            // XmlSchemaImport - casting every entry threw InvalidCastException.
+            foreach (XmlSchemaImport import in TargetSchema.Includes.OfType<XmlSchemaImport>())
             {
                 import.Schema = Load(import.SchemaLocation, import.Namespace, handler);
             }

--- a/src/Opc.Ua.Types/State/BaseDataVariableState.cs
+++ b/src/Opc.Ua.Types/State/BaseDataVariableState.cs
@@ -122,7 +122,10 @@ namespace Opc.Ua
         {
             if (target is BaseDataVariableState state)
             {
-                state.EnumStrings = EnumStrings;
+                // EnumStrings is a child that base.CopyTo does not clone (it
+                // lives in a typed field, not in m_children), so clone it here.
+                state.EnumStrings =
+                    (PropertyState<ArrayOf<LocalizedText>>?)EnumStrings?.Clone();
             }
             base.CopyTo(target);
         }

--- a/src/Opc.Ua.Types/State/BaseVariableState.cs
+++ b/src/Opc.Ua.Types/State/BaseVariableState.cs
@@ -86,6 +86,10 @@ namespace Opc.Ua
             {
                 m_value = instance.m_value;
                 m_timestamp = instance.m_timestamp;
+                // The status code has to travel with the value: copying
+                // m_valueTouched without it left the copy reporting
+                // BadWaitingForInitialData forever.
+                m_statusCode = instance.m_statusCode;
                 m_dataType = instance.m_dataType;
                 m_valueRank = instance.m_valueRank;
                 m_arrayDimensions = instance.m_arrayDimensions;

--- a/src/Opc.Ua.Types/State/BaseVariableTypeState.cs
+++ b/src/Opc.Ua.Types/State/BaseVariableTypeState.cs
@@ -53,7 +53,7 @@ namespace Opc.Ua
         {
             if (source is BaseVariableTypeState type)
             {
-                m_value = m_value.Copy();
+                m_value = type.m_value.Copy();
                 m_dataType = type.m_dataType;
                 m_valueRank = type.m_valueRank;
                 m_arrayDimensions = type.m_arrayDimensions;

--- a/src/Opc.Ua.Types/State/DataTypeState.cs
+++ b/src/Opc.Ua.Types/State/DataTypeState.cs
@@ -298,7 +298,9 @@ namespace Opc.Ua
 
                     if (ServiceResult.IsGood(result))
                     {
-                        m_dataTypeDefinition = dataTypeDefinition;
+                        // Through the property so the change mask is raised and
+                        // monitored items on the attribute are notified.
+                        DataTypeDefinition = dataTypeDefinition;
                     }
 
                     return result!;

--- a/src/Opc.Ua.Types/State/MethodState.cs
+++ b/src/Opc.Ua.Types/State/MethodState.cs
@@ -120,8 +120,14 @@ namespace Opc.Ua
         {
             if (target is MethodState state)
             {
-                state.OutputArguments = OutputArguments;
-                state.InputArguments = InputArguments;
+                // The argument properties are children that base.CopyTo does
+                // not clone (they live in typed fields, not m_children), so they
+                // have to be cloned here - otherwise the clone and the original
+                // share them.
+                state.OutputArguments =
+                    (PropertyState<ArrayOf<Argument>>?)OutputArguments?.Clone();
+                state.InputArguments =
+                    (PropertyState<ArrayOf<Argument>>?)InputArguments?.Clone();
                 state.MethodDeclarationId = MethodDeclarationId;
                 state.Executable = Executable;
                 state.UserExecutable = UserExecutable;
@@ -249,7 +255,7 @@ namespace Opc.Ua
 
             if (m_userExecutable)
             {
-                encoder.WriteBoolean("UserExecutable", m_executable);
+                encoder.WriteBoolean("UserExecutable", m_userExecutable);
             }
 
             encoder.PopNamespace();

--- a/src/Opc.Ua.Types/State/NodeState.cs
+++ b/src/Opc.Ua.Types/State/NodeState.cs
@@ -167,10 +167,11 @@ namespace Opc.Ua
             target.m_displayName = m_displayName;
             target.m_description = m_description;
             target.m_writeMask = m_writeMask;
-            target.m_changeMasks = m_changeMasks;
+            target.m_userWriteMask = m_userWriteMask;
 
             target.RolePermissions = RolePermissions;
             target.UserRolePermissions = UserRolePermissions;
+            target.AccessRestrictions = AccessRestrictions;
 
             lock (m_referencesLock)
             {
@@ -202,6 +203,11 @@ namespace Opc.Ua
             target.ReleaseStatus = ReleaseStatus;
             target.NodeSetDocumentation = NodeSetDocumentation;
             target.Extensions = Extensions;
+
+            // Assigned last so that the copy reports the same change mask as
+            // the source instead of the bits the property setters and
+            // AddReferences above raise.
+            target.m_changeMasks = m_changeMasks;
         }
 
         /// <summary>
@@ -332,6 +338,16 @@ namespace Opc.Ua
             m_children = null;
             m_references = null;
             m_changeMasks = NodeStateChangeMasks.None;
+
+            // Note: unlike CopyTo, this deliberately does not carry over
+            // m_userWriteMask, RolePermissions, UserRolePermissions or
+            // AccessRestrictions. Initialize instantiates a node from a
+            // prototype rather than cloning it, and propagating the prototype's
+            // access control makes the instance inherit restrictions it never
+            // had - the GDS certificate group nodes become unreadable for the
+            // users that could read them before. Whether an instance should
+            // inherit its prototype's permissions is a security decision for
+            // the address space to make, not a copy detail.
 
             var children = new List<BaseInstanceState>();
             source.GetChildren(context, children);
@@ -1342,7 +1358,9 @@ namespace Opc.Ua
 
             if (string.IsNullOrEmpty(symbolicName) && !browseName.IsNull)
             {
-                SymbolicName = browseName.Name!;
+                // This defaults the CHILD's symbolic name. Assigning the
+                // property would rename this node after its last child.
+                symbolicName = browseName.Name!;
             }
 
             // check for children defined by the type.
@@ -4835,7 +4853,9 @@ namespace Opc.Ua
 
                     if (ServiceResult.IsGood(result))
                     {
-                        m_nodeId = nodeId;
+                        // Through the property so the change mask is raised and
+                        // monitored items on the attribute are notified.
+                        NodeId = nodeId;
                     }
 
                     return result;
@@ -4883,7 +4903,7 @@ namespace Opc.Ua
 
                     if (ServiceResult.IsGood(result))
                     {
-                        m_browseName = browseName;
+                        BrowseName = browseName;
                     }
 
                     return result;
@@ -4908,7 +4928,7 @@ namespace Opc.Ua
 
                     if (ServiceResult.IsGood(result))
                     {
-                        m_displayName = displayName;
+                        DisplayName = displayName;
                     }
 
                     return result;
@@ -4937,7 +4957,7 @@ namespace Opc.Ua
 
                     if (ServiceResult.IsGood(result))
                     {
-                        m_description = description;
+                        Description = description;
                     }
 
                     return result;
@@ -4990,7 +5010,7 @@ namespace Opc.Ua
 
                     if (ServiceResult.IsGood(result))
                     {
-                        m_userWriteMask = userWriteMask;
+                        UserWriteMask = userWriteMask;
                     }
 
                     return result;
@@ -5062,6 +5082,7 @@ namespace Opc.Ua
                     if (ServiceResult.IsGood(result))
                     {
                         SetAccessRestrictions(accessRestrictions);
+                        m_changeMasks |= NodeStateChangeMasks.NonValue;
                     }
 
                     return result;
@@ -5743,7 +5764,9 @@ namespace Opc.Ua
             uint attributeId,
             DataValue value)
         {
-            if (componentPath.Count >= index)
+            // check if writing attributes of the current node. The condition was
+            // inverted, so the path was never followed into the children.
+            if (index >= componentPath.Count)
             {
                 return WriteAttribute(context, attributeId, default, value);
             }
@@ -6124,6 +6147,9 @@ namespace Opc.Ua
             // that are not assigned to a sub type's properties. Unlike the sub
             // type implementations we do not create a new instance here if
             // replacement is null. TODO: should this be reconsidered?
+            BaseInstanceState? found = null;
+            bool adopted = false;
+
             lock (m_childrenLock)
             {
                 if (m_children != null)
@@ -6137,12 +6163,32 @@ namespace Opc.Ua
                             if (createOrReplace && replacement != null)
                             {
                                 m_children[ii] = child = replacement;
+                                m_changeMasks |= NodeStateChangeMasks.Children;
+                                adopted = true;
                             }
 
-                            return child;
+                            found = child;
+                            break;
                         }
                     }
                 }
+            }
+
+            if (found != null)
+            {
+                // A replacement has to be adopted the same way AddChild adopts
+                // a new child, otherwise it keeps pointing at its old parent.
+                if (adopted && !ReferenceEquals(found.Parent, this))
+                {
+                    found.Parent = this;
+
+                    if (found.ReferenceTypeId.IsNull)
+                    {
+                        found.ReferenceTypeId = ReferenceTypeIds.HasComponent;
+                    }
+                }
+
+                return found;
             }
 
             if (createOrReplace && replacement != null)

--- a/src/Opc.Ua.Types/State/NodeStateCollection.cs
+++ b/src/Opc.Ua.Types/State/NodeStateCollection.cs
@@ -445,7 +445,11 @@ namespace Opc.Ua
 
             var serverUris = new StringTable();
 
-            if (!decoder.LoadStringTable("ServerUris", "ServerUri", context.ServerUris))
+            // Load into the local table, like the namespace table above. Loading
+            // into context.ServerUris left serverUris empty, so the mapping
+            // below was built from nothing and the document's server indexes
+            // were never translated.
+            if (!decoder.LoadStringTable("ServerUris", "ServerUri", serverUris))
             {
                 serverUris = null;
             }

--- a/src/Opc.Ua.Types/Utils/CoreUtils.cs
+++ b/src/Opc.Ua.Types/Utils/CoreUtils.cs
@@ -786,6 +786,16 @@ namespace Opc.Ua
                             return false; // syntax
                         }
 
+                        // A character set has to be closed. Without this the
+                        // scanner below runs off the end of the pattern and then
+                        // leaves the switch as though the set had matched, so
+                        // "[a" matched "a" while the empty "[" was already
+                        // rejected as a syntax error.
+                        if (pattern.IndexOf(']', pIndex) < 0)
+                        {
+                            return false; // syntax
+                        }
+
                         c = ConvertCase(target[tIndex++], caseSensitive);
 
                         l = '\0';
@@ -846,6 +856,8 @@ namespace Opc.Ua
                         // match if char is in set []
                         else
                         {
+                            bool matchedInSet = false;
+
                             p = ConvertCase(pattern[pIndex++], caseSensitive);
 
                             while (pIndex < pattern.Length)
@@ -873,6 +885,7 @@ namespace Opc.Ua
 
                                     if (c >= l && c <= p)
                                     {
+                                        matchedInSet = true;
                                         break; // if in range, move on
                                     }
                                 }
@@ -881,10 +894,21 @@ namespace Opc.Ua
 
                                 if (c == p) // if char matches this element move on
                                 {
+                                    matchedInSet = true;
                                     break;
                                 }
 
                                 p = ConvertCase(pattern[pIndex++], caseSensitive);
+                            }
+
+                            // The loop above also ends when the pattern runs out,
+                            // which is what happens for the last element of a set
+                            // that closes the pattern. Leaving the switch then
+                            // treated the set as matched, so "[a]" matched every
+                            // character instead of only 'a'.
+                            if (!matchedInSet)
+                            {
+                                return false;
                             }
 
                             while (pIndex < pattern.Length && p != ']') // got a match in char set skip to end of set

--- a/src/Opc.Ua.Types/Utils/CoreUtils.cs
+++ b/src/Opc.Ua.Types/Utils/CoreUtils.cs
@@ -764,22 +764,29 @@ namespace Opc.Ua
                             return false;
                         }
 
-                        // check if end of pattern and still string data left.
-                        if (pIndex >= pattern.Length && tIndex < target.Length - 1)
+                        tIndex++;
+
+                        // check if end of pattern and still string data left. The
+                        // bound used to be target.Length - 1, which let one
+                        // unmatched trailing character through. The check has to
+                        // come after the character is consumed, as it does in
+                        // the exact char case below, or a pattern ending in '?'
+                        // never matches.
+                        if (pIndex >= pattern.Length && tIndex < target.Length)
                         {
                             return false;
                         }
 
-                        tIndex++;
                         break;
                     // match char set
                     case '[':
-                        c = ConvertCase(target[tIndex++], caseSensitive);
-
-                        if (tIndex > target.Length)
+                        // An unterminated '[' must not read past the pattern.
+                        if (pIndex >= pattern.Length)
                         {
                             return false; // syntax
                         }
+
+                        c = ConvertCase(target[tIndex++], caseSensitive);
 
                         l = '\0';
 
@@ -787,6 +794,13 @@ namespace Opc.Ua
                         if (pattern[pIndex] == '!')
                         {
                             ++pIndex;
+
+                            // A negated set with nothing after the '!' is a
+                            // syntax error, not a read past the pattern.
+                            if (pIndex >= pattern.Length)
+                            {
+                                return false; // syntax
+                            }
 
                             p = ConvertCase(pattern[pIndex++], caseSensitive);
 
@@ -799,11 +813,16 @@ namespace Opc.Ua
 
                                 if (p == '-')
                                 {
+                                    // get high limit of range
+                                    if (pIndex >= pattern.Length)
+                                    {
+                                        return false; // syntax
+                                    }
+
                                     // check a range of chars?
                                     p = ConvertCase(pattern[pIndex], caseSensitive);
 
-                                    // get high limit of range
-                                    if (pIndex > pattern.Length || p == ']')
+                                    if (p == ']')
                                     {
                                         return false; // syntax
                                     }
@@ -838,11 +857,16 @@ namespace Opc.Ua
 
                                 if (p == '-')
                                 {
+                                    // get high limit of range
+                                    if (pIndex >= pattern.Length)
+                                    {
+                                        return false; // syntax
+                                    }
+
                                     // check a range of chars?
                                     p = ConvertCase(pattern[pIndex], caseSensitive);
 
-                                    // get high limit of range
-                                    if (pIndex > pattern.Length || p == ']')
+                                    if (p == ']')
                                     {
                                         return false; // syntax
                                     }
@@ -890,7 +914,7 @@ namespace Opc.Ua
                         }
 
                         // check if end of pattern and still string data left.
-                        if (pIndex >= pattern.Length && tIndex < target.Length - 1)
+                        if (pIndex >= pattern.Length && tIndex < target.Length)
                         {
                             return false;
                         }
@@ -901,10 +925,18 @@ namespace Opc.Ua
 
             if (tIndex >= target.Length)
             {
+                // A trailing run of '*' matches the empty remainder, so "a"
+                // has to match "a*".
+                while (pIndex < pattern.Length && pattern[pIndex] == '*')
+                {
+                    pIndex++;
+                }
+
                 return pIndex >= pattern.Length; // if end of pattern true
             }
 
-            return true;
+            // The pattern is exhausted but the target still has characters.
+            return false;
         }
 
         /// <summary>

--- a/src/Opc.Ua.Types/Utils/FileSystem/LocalFileSystem.cs
+++ b/src/Opc.Ua.Types/Utils/FileSystem/LocalFileSystem.cs
@@ -78,7 +78,9 @@ namespace Opc.Ua
         /// <inheritdoc/>
         public Stream OpenRead(string path)
         {
-            return File.Open(path, FileMode.Open);
+            // FileMode.Open alone requests ReadWrite access with FileShare.None,
+            // which fails on a read-only file and locks out concurrent readers.
+            return File.Open(path, FileMode.Open, FileAccess.Read, FileShare.Read);
         }
 
         /// <inheritdoc/>

--- a/src/Opc.Ua.Types/Utils/FileSystem/VirtualFileSystem.cs
+++ b/src/Opc.Ua.Types/Utils/FileSystem/VirtualFileSystem.cs
@@ -118,8 +118,8 @@ namespace Opc.Ua
         public Stream OpenWrite(string path)
         {
             // Open an in-memory stream for writing. Existing content remains
-            // available until it is overwritten, and the file is truncated
-            // to the stream's final position when the stream is disposed.
+            // available until it is overwritten, and the file is truncated to
+            // the furthest byte the stream wrote when it is disposed.
             return Open(path, false).GetStream(true);
         }
 
@@ -506,7 +506,10 @@ namespace Opc.Ua
                         {
                             if (CanWrite)
                             {
-                                m_file.SetLength(m_position);
+                                // Truncate to the furthest byte written, not to
+                                // the final position - a writer that seeks back
+                                // and writes a shorter tail must not lose data.
+                                m_file.SetLength(m_highWaterMark);
                             }
                         }
                         finally
@@ -625,6 +628,10 @@ namespace Opc.Ua
 
                     if (CanWrite && position > length)
                     {
+                        // Seeking past the end zero extends the file, so the
+                        // extension counts as written - otherwise the truncation
+                        // on dispose would throw it away again.
+                        m_highWaterMark = position;
                         m_file.SetLength(position);
                     }
 
@@ -658,6 +665,7 @@ namespace Opc.Ua
                         m_position = value;
                     }
 
+                    m_highWaterMark = value;
                     m_file.SetLength(value);
                 }
 
@@ -685,6 +693,7 @@ namespace Opc.Ua
                     EnsureCanWrite();
                     m_file.WriteByte(m_position, value);
                     m_position = checked(m_position + 1);
+                    m_highWaterMark = Math.Max(m_highWaterMark, m_position);
                 }
 
                 /// <inheritdoc/>
@@ -735,6 +744,7 @@ namespace Opc.Ua
                     EnsureCanWrite();
                     m_file.Write(m_position, buffer);
                     m_position = checked(m_position + buffer.Length);
+                    m_highWaterMark = Math.Max(m_highWaterMark, m_position);
                 }
 
                 private void EnsureCanRead()
@@ -788,6 +798,7 @@ namespace Opc.Ua
 
                 private readonly VirtualFile m_file;
                 private long m_position;
+                private long m_highWaterMark;
                 private bool m_disposed;
             }
 

--- a/src/Opc.Ua.Types/Utils/FileSystem/VirtualFileSystem.cs
+++ b/src/Opc.Ua.Types/Utils/FileSystem/VirtualFileSystem.cs
@@ -643,6 +643,15 @@ namespace Opc.Ua
                 public override void SetLength(long value)
                 {
                     ThrowIfDisposed();
+
+                    // An explicit length request counts as written even when it
+                    // asks for the length the file already has, otherwise the
+                    // truncation on dispose throws those bytes away again.
+                    if (CanWrite && value >= 0)
+                    {
+                        m_highWaterMark = Math.Max(m_highWaterMark, value);
+                    }
+
                     if (m_file.Length == value)
                     {
                         return;

--- a/src/Opc.Ua.Types/Utils/ServiceResultException.cs
+++ b/src/Opc.Ua.Types/Utils/ServiceResultException.cs
@@ -130,7 +130,9 @@ namespace Opc.Ua
         /// Initializes the exception with a Result object.
         /// </summary>
         public ServiceResultException(ServiceResult status)
-            : base(GetMessage(status), status.InnerResult?.GetServiceResultException())
+            // status may be null: GetMessage and the Result assignment below
+            // both tolerate it, so this must too.
+            : base(GetMessage(status), status?.InnerResult?.GetServiceResultException())
         {
             Result = status ?? ServiceResult.Bad;
         }

--- a/src/Opc.Ua.Types/Wot/WotDocumentNodeResolver.cs
+++ b/src/Opc.Ua.Types/Wot/WotDocumentNodeResolver.cs
@@ -181,16 +181,7 @@ namespace Opc.Ua.Wot
             {
                 return;
             }
-            int colon = browseName.IndexOf(':', StringComparison.Ordinal);
-            if (colon <= 0)
-            {
-                return;
-            }
-            string local = browseName[(colon + 1)..];
-            string namespaceUri = browseName.StartsWith("nsu=", StringComparison.Ordinal)
-                ? browseName[4..colon]
-                : ResolvePrefix(document, browseName[..colon]);
-            if (namespaceUri.Length == 0)
+            if (!TrySplitBrowseName(document, browseName, out string namespaceUri, out string local))
             {
                 return;
             }
@@ -212,6 +203,46 @@ namespace Opc.Ua.Wot
             {
                 AddReferenceTypeName(namespaceUri, inverseName, nodeId, inverseName, false);
             }
+        }
+
+        /// <summary>
+        /// Splits a BrowseName into its namespace and local name. The portable
+        /// form is "nsu=&lt;uri&gt;;&lt;name&gt;": the URI itself contains colons, so it
+        /// must be split on the first ';' after the prefix and not on the first
+        /// ':' - doing the latter turned the namespace into "http".
+        /// </summary>
+        private bool TrySplitBrowseName(
+            WotDocument document,
+            string browseName,
+            out string namespaceUri,
+            out string local)
+        {
+            namespaceUri = string.Empty;
+            local = string.Empty;
+
+            if (browseName.StartsWith("nsu=", StringComparison.Ordinal))
+            {
+                int separator = browseName.IndexOf(';', 4);
+                if (separator <= 4 || separator == browseName.Length - 1)
+                {
+                    return false;
+                }
+                // The portable form escapes ';' and '%' in the namespace URI, so
+                // the raw substring would index under a different key than the
+                // unescaped URI every other reader resolves against.
+                namespaceUri = CoreUtils.UnescapeUri(browseName.AsSpan(4, separator - 4));
+                local = browseName[(separator + 1)..];
+                return namespaceUri.Length != 0;
+            }
+
+            int colon = browseName.IndexOf(':', StringComparison.Ordinal);
+            if (colon <= 0)
+            {
+                return false;
+            }
+            namespaceUri = ResolvePrefix(document, browseName[..colon]);
+            local = browseName[(colon + 1)..];
+            return namespaceUri.Length != 0;
         }
 
         private void AddReferenceTypeName(
@@ -386,7 +417,7 @@ namespace Opc.Ua.Wot
                 int separator = nodeId.IndexOf(';', StringComparison.Ordinal);
                 if (nodeId.StartsWith("nsu=", StringComparison.Ordinal) && separator > 4)
                 {
-                    m_namespaces.Add(nodeId[4..separator]);
+                    m_namespaces.Add(CoreUtils.UnescapeUri(nodeId.AsSpan(4, separator - 4)));
                 }
             }
             string? browseName = ReadString(element, "uav:browseName");
@@ -394,17 +425,7 @@ namespace Opc.Ua.Wot
             {
                 return;
             }
-            int colon = browseName.IndexOf(':', StringComparison.Ordinal);
-            if (colon <= 0)
-            {
-                return;
-            }
-            string prefix = browseName[..colon];
-            string local = browseName[(colon + 1)..];
-            string namespaceUri = browseName.StartsWith("nsu=", StringComparison.Ordinal)
-                ? browseName[4..colon]
-                : ResolvePrefix(document, prefix);
-            if (namespaceUri.Length == 0)
+            if (!TrySplitBrowseName(document, browseName, out string namespaceUri, out string local))
             {
                 return;
             }

--- a/src/Opc.Ua.Types/Wot/WotEventSelectionResolver.Definitions.cs
+++ b/src/Opc.Ua.Types/Wot/WotEventSelectionResolver.Definitions.cs
@@ -86,15 +86,42 @@ namespace Opc.Ua.Wot
         private const string ThingIdMember = "id";
 
         /// <summary>
+        /// A resolved definition together with the document that declares it.
+        /// </summary>
+        private readonly struct ResolvedDefinition
+        {
+            public ResolvedDefinition(JsonElement definition, WotDocument owner)
+            {
+                Definition = definition;
+                Owner = owner;
+                Found = true;
+            }
+
+            /// <summary> The definition object. </summary>
+            public JsonElement Definition { get; }
+
+            /// <summary> The document that declares it. </summary>
+            public WotDocument? Owner { get; }
+
+            /// <summary> Whether anything was resolved at all. </summary>
+            public bool Found { get; }
+        }
+
+        /// <summary>
         /// One definition a document declares, and where it was found.
         /// </summary>
         private readonly struct DefinitionCandidate
         {
-            public DefinitionCandidate(string origin, string pointer, JsonElement element)
+            public DefinitionCandidate(
+                string origin,
+                string pointer,
+                JsonElement element,
+                WotDocument owner)
             {
                 Origin = origin;
                 Pointer = pointer;
                 Element = element;
+                Owner = owner;
             }
 
             /// <summary>
@@ -113,6 +140,13 @@ namespace Opc.Ua.Wot
             /// The definition object.
             /// </summary>
             public JsonElement Element { get; }
+
+            /// <summary>
+            /// The document that declares the definition. A chained reference
+            /// the definition carries is written in this document's context,
+            /// not in the context of the document that started the chain.
+            /// </summary>
+            public WotDocument Owner { get; }
 
             /// <summary>
             /// The reference a diagnostic names this candidate by: the
@@ -154,7 +188,7 @@ namespace Opc.Ua.Wot
                 AddCandidate(
                     document,
                     ReadLogicalId(root),
-                    new DefinitionCandidate(origin, string.Empty, root),
+                    new DefinitionCandidate(origin, string.Empty, root, document),
                     index);
             }
             foreach (KeyValuePair<string, JsonElement> affordance in document.Events)
@@ -174,7 +208,8 @@ namespace Opc.Ua.Wot
                     new DefinitionCandidate(
                         origin,
                         "/events/" + EscapePointerToken(affordance.Key),
-                        affordance.Value),
+                        affordance.Value,
+                        document),
                     index);
             }
         }
@@ -442,7 +477,7 @@ namespace Opc.Ua.Wot
         /// held documents, then the configured resolvers, then the well-known
         /// catalog.
         /// </summary>
-        private async ValueTask<JsonElement?> ResolveReferenceTargetAsync(
+        private async ValueTask<ResolvedDefinition> ResolveReferenceTargetAsync(
             WotDocument document,
             string reference,
             string where,
@@ -454,13 +489,19 @@ namespace Opc.Ua.Wot
             // Held documents, by logical identifier, expanded in the active
             // context of the node that wrote the reference.
             if (TryLookupHeld(
-                    document, reference, where, scope, out JsonElement held, out bool ambiguous))
+                    document,
+                    reference,
+                    where,
+                    scope,
+                    out JsonElement held,
+                    out WotDocument? heldOwner,
+                    out bool ambiguous))
             {
-                return held;
+                return new ResolvedDefinition(held, heldOwner ?? document);
             }
             if (ambiguous)
             {
-                return null;
+                return default;
             }
 
             // Held documents and configured resolvers, by location. The attempt
@@ -470,6 +511,7 @@ namespace Opc.Ua.Wot
             // so a well-known identifier is not reported as a missing file.
             bool located = false;
             JsonElement target = default;
+            WotDocument? locatedIn = null;
             string? unresolvedDocument = null;
             bool pointerMissed = false;
             if (WotEventSelectClauses.TrySplitEventTypeReference(
@@ -499,19 +541,22 @@ namespace Opc.Ua.Wot
                             where,
                             scope,
                             out JsonElement identified,
+                            out WotDocument? identifiedOwner,
                             out bool nowAmbiguous))
                     {
-                        return identified;
+                        return new ResolvedDefinition(
+                            identified, identifiedOwner ?? resolved);
                     }
                     if (nowAmbiguous)
                     {
-                        return null;
+                        return default;
                     }
                     if (WotDocument.TryEvaluatePointer(
                             resolved.RootElement, pointer, out target) &&
                         target.ValueKind == JsonValueKind.Object)
                     {
                         located = true;
+                        locatedIn = resolved;
                     }
                     else
                     {
@@ -526,18 +571,20 @@ namespace Opc.Ua.Wot
                     $"The EventType reference '{reference}' is not a document URI with an " +
                     "optional RFC 6901 JSON Pointer (WoT Binding Section 6.1).",
                     where);
-                return null;
+                return default;
             }
             if (located)
             {
-                return target;
+                return new ResolvedDefinition(target, locatedIn ?? document);
             }
 
             // The well-known catalog, last: a definition this library carries
             // shall never shadow one an author shipped.
             if (TryLookupWellKnown(document, reference, out JsonElement builtIn))
             {
-                return builtIn;
+                // A well-known definition carries no chained reference, so the
+                // context it would be expanded in does not matter.
+                return new ResolvedDefinition(builtIn, document);
             }
 
             if (pointerMissed)
@@ -547,7 +594,7 @@ namespace Opc.Ua.Wot
                     $"The EventType reference '{reference}' does not resolve to a " +
                     "definition of the document it names (WoT Binding Section 6.1).",
                     where);
-                return null;
+                return default;
             }
             if (unresolvedDocument is not null && NamesDocumentLocation(reference))
             {
@@ -566,7 +613,7 @@ namespace Opc.Ua.Wot
                         "(WoT Binding Sections 5.1.5 and 6.1).",
                         where);
                 }
-                return null;
+                return default;
             }
 
             AddError(
@@ -576,7 +623,7 @@ namespace Opc.Ua.Wot
                 "one declare, or one of the well-known base types; it is never dereferenced " +
                 "over the network (WoT Binding Sections 5.1.5 and 6.1).",
                 where);
-            return null;
+            return default;
         }
 
         /// <summary>
@@ -589,9 +636,11 @@ namespace Opc.Ua.Wot
             string where,
             ResolutionScope scope,
             out JsonElement definition,
+            out WotDocument? owner,
             out bool ambiguous)
         {
             definition = default;
+            owner = null;
             ambiguous = false;
 
             var matches = new List<DefinitionCandidate>();
@@ -617,6 +666,7 @@ namespace Opc.Ua.Wot
                 return false;
             }
             definition = matches[0].Element;
+            owner = matches[0].Owner;
             return true;
         }
 

--- a/src/Opc.Ua.Types/Wot/WotEventSelectionResolver.cs
+++ b/src/Opc.Ua.Types/Wot/WotEventSelectionResolver.cs
@@ -731,7 +731,13 @@ namespace Opc.Ua.Wot
             System.Threading.CancellationToken cancellationToken)
         {
             List<WotDiagnostic> diagnostics = scope.Diagnostics;
-            var seen = new HashSet<string>(StringComparer.Ordinal);
+
+            // The same raw reference text resolves to different definitions
+            // under different @context mappings, so the chain is only revisiting
+            // a definition when both the text and the document it is read in
+            // repeat. Keying on the text alone rejected "x:Type" in document A
+            // followed by "x:Type" in document B as cyclic.
+            var seen = new HashSet<(WotDocument, string)>();
             string current = reference;
             bool carriesAnnotation = false;
             bool sawAnnotation = false;
@@ -747,8 +753,9 @@ namespace Opc.Ua.Wot
 
             for (int depth = 0; depth < maxDepth; depth++)
             {
+                WotDocument resolvedIn = context;
                 ResolvedDefinition located = await ResolveReferenceTargetAsync(
-                        context, current, where, scope, cancellationToken)
+                        resolvedIn, current, where, scope, cancellationToken)
                     .ConfigureAwait(false);
                 if (!located.Found)
                 {
@@ -756,7 +763,7 @@ namespace Opc.Ua.Wot
                 }
                 JsonElement definition = located.Definition;
                 context = located.Owner ?? context;
-                if (!seen.Add(current))
+                if (!seen.Add((resolvedIn, current)))
                 {
                     AddError(
                         diagnostics,

--- a/src/Opc.Ua.Types/Wot/WotEventSelectionResolver.cs
+++ b/src/Opc.Ua.Types/Wot/WotEventSelectionResolver.cs
@@ -740,16 +740,22 @@ namespace Opc.Ua.Wot
             bool hasData = false;
             int maxDepth = Math.Max(1, scope.Context.Options.MaxDepth);
 
+            // A chained reference is written in the context of the document
+            // that declares the definition carrying it, not in the context of
+            // the document that started the chain.
+            WotDocument context = document;
+
             for (int depth = 0; depth < maxDepth; depth++)
             {
-                JsonElement? located = await ResolveReferenceTargetAsync(
-                        document, current, where, scope, cancellationToken)
+                ResolvedDefinition located = await ResolveReferenceTargetAsync(
+                        context, current, where, scope, cancellationToken)
                     .ConfigureAwait(false);
-                if (located is null)
+                if (!located.Found)
                 {
                     return null;
                 }
-                JsonElement definition = located.Value;
+                JsonElement definition = located.Definition;
+                context = located.Owner ?? context;
                 if (!seen.Add(current))
                 {
                     AddError(

--- a/src/Opc.Ua.Types/Wot/WotJsonResidue.cs
+++ b/src/Opc.Ua.Types/Wot/WotJsonResidue.cs
@@ -107,6 +107,31 @@ namespace Opc.Ua.Wot
             nodeSet.Extensions = extensions.Count == 0 ? null : [.. extensions];
         }
 
+        /// <summary>
+        /// Parses one residue member, reporting a malformed one instead of
+        /// letting the JsonException escape the public entry point.
+        /// </summary>
+        private static JsonDocument? TryParseResidue(
+            Entry entry,
+            WotNodeSetConverterOptions options,
+            List<WotDiagnostic> diagnostics)
+        {
+            try
+            {
+                return JsonDocument.Parse(
+                    entry.Json,
+                    new JsonDocumentOptions { MaxDepth = options.MaxJsonDepth });
+            }
+            catch (JsonException ex)
+            {
+                diagnostics.Add(new WotDiagnostic(
+                    WotDiagnosticSeverity.Error,
+                    WotDiagnosticCode.ResidueInvalid,
+                    "Residue at '" + entry.Pointer + "' is not valid JSON: " + ex.Message,
+                    WotLocation.FromPointer(entry.Pointer)));
+                return null;
+            }
+        }
         internal static void RemoveDocumentSetLinks(
             UANodeSet nodeSet,
             WotDocument document,
@@ -118,30 +143,42 @@ namespace Opc.Ua.Wot
             var retained = new List<Entry>();
             foreach (Entry entry in entries)
             {
-                using JsonDocument value = JsonDocument.Parse(
-                    entry.Json, new JsonDocumentOptions { MaxDepth = options.MaxJsonDepth });
-                if (entry.Pointer == "/data" &&
-                    WotNodeSetConverter.IsGeneratedEventDefinitionData(
-                        document, nodeSet, value.RootElement, options.MaxJsonDepth))
+                // Residue is document content, so a malformed member must be
+                // reported rather than thrown out of the public
+                // MergeNodeSetPartitions entry point.
+                JsonDocument? value = TryParseResidue(entry, options, diagnostics);
+                if (value is null)
                 {
+                    retained.Add(entry);
                     continue;
                 }
-                if (entry.Pointer.StartsWith("/events/", StringComparison.Ordinal) &&
-                    entry.Pointer.EndsWith("/tm:ref", StringComparison.Ordinal) &&
-                    value.RootElement.ValueKind == JsonValueKind.String &&
-                    documents.TryGetDocument(value.RootElement.GetString()!, out _))
+
+                using (value)
                 {
-                    continue;
+                    if (entry.Pointer == "/data" &&
+                        WotNodeSetConverter.IsGeneratedEventDefinitionData(
+                            document, nodeSet, value.RootElement, options.MaxJsonDepth))
+                    {
+                        continue;
+                    }
+                    if (entry.Pointer.StartsWith("/events/", StringComparison.Ordinal) &&
+                        entry.Pointer.EndsWith("/tm:ref", StringComparison.Ordinal) &&
+                        value.RootElement.ValueKind == JsonValueKind.String &&
+                        documents.TryGetDocument(value.RootElement.GetString()!, out _))
+                    {
+                        continue;
+                    }
+                    string? rel = entry.LinkRel ?? GetString(value.RootElement, "rel");
+                    string? href = entry.LinkHref ?? GetString(value.RootElement, "href");
+                    if (rel is WotNodeSetConverter.ComponentOfRel or
+                            WotNodeSetConverter.ComponentOfAliasRel &&
+                        href is not null && documents.TryGetDocument(href, out _) &&
+                        IsDocumentSetParentLink(value.RootElement))
+                    {
+                        continue;
+                    }
+                    retained.Add(entry);
                 }
-                string? rel = entry.LinkRel ?? GetString(value.RootElement, "rel");
-                string? href = entry.LinkHref ?? GetString(value.RootElement, "href");
-                if (rel is WotNodeSetConverter.ComponentOfRel or WotNodeSetConverter.ComponentOfAliasRel &&
-                    href is not null && documents.TryGetDocument(href, out _) &&
-                    IsDocumentSetParentLink(value.RootElement))
-                {
-                    continue;
-                }
-                retained.Add(entry);
             }
             if (retained.Count == entries.Count)
             {
@@ -1408,7 +1445,7 @@ namespace Opc.Ua.Wot
             JsonNode? value,
             List<WotDiagnostic> diagnostics)
         {
-            if (root is not JsonObject rootObject || value is not JsonObject extras)
+            if (root is not JsonObject || value is not JsonObject extras)
             {
                 diagnostics.Add(new WotDiagnostic(
                     WotDiagnosticSeverity.Error,
@@ -1418,15 +1455,23 @@ namespace Opc.Ua.Wot
                 return;
             }
 
+            // The pointer names the links array the entry was captured from,
+            // e.g. "/properties/Speed/links/-". Ignoring it appended every
+            // affordance's link residue to the Thing's own links array.
+            if (ResolveLinkOwner(root, entry.Pointer, diagnostics) is not JsonObject owner)
+            {
+                return;
+            }
+
             JsonArray links;
-            if (rootObject["links"] is JsonArray existingLinks)
+            if (owner["links"] is JsonArray existingLinks)
             {
                 links = existingLinks;
             }
-            else if (rootObject["links"] is null)
+            else if (owner["links"] is null)
             {
                 links = new JsonArray();
-                rootObject["links"] = links;
+                owner["links"] = links;
             }
             else
             {
@@ -1434,7 +1479,7 @@ namespace Opc.Ua.Wot
                     WotDiagnosticSeverity.Error,
                     WotDiagnosticCode.ResidueConflict,
                     "Link residue conflicts with a non-array links member.",
-                    WotLocation.FromPointer("/links")));
+                    WotLocation.FromPointer(entry.Pointer)));
                 return;
             }
 
@@ -1488,6 +1533,60 @@ namespace Opc.Ua.Wot
             }
         }
 
+        /// <summary>
+        /// Resolves the object whose <c>links</c> array a link residue entry
+        /// belongs to. Its pointer is "&lt;owner&gt;/links/-", so the owner is
+        /// everything before the trailing "/links/-".
+        /// </summary>
+        private static JsonNode? ResolveLinkOwner(
+            JsonNode root,
+            string pointer,
+            List<WotDiagnostic> diagnostics)
+        {
+            const string suffix = "/links/-";
+            if (!pointer.EndsWith(suffix, StringComparison.Ordinal))
+            {
+                // Not an affordance scoped capture: the Thing root owns it.
+                return root;
+            }
+
+            string ownerPointer = pointer[..^suffix.Length];
+            if (ownerPointer.Length == 0)
+            {
+                return root;
+            }
+
+            JsonNode current = root;
+            foreach (string token in ParsePointer(ownerPointer))
+            {
+                if (current is JsonObject obj && obj[token] is JsonNode child)
+                {
+                    current = child;
+                    continue;
+                }
+                if (current is JsonArray array &&
+                    int.TryParse(
+                        token,
+                        NumberStyles.None,
+                        CultureInfo.InvariantCulture,
+                        out int index) &&
+                    index >= 0 &&
+                    index < array.Count &&
+                    array[index] is JsonNode item)
+                {
+                    current = item;
+                    continue;
+                }
+                diagnostics.Add(new WotDiagnostic(
+                    WotDiagnosticSeverity.Error,
+                    WotDiagnosticCode.ResidueInvalid,
+                    $"Residue parent '{ownerPointer}' does not resolve.",
+                    WotLocation.FromPointer(pointer)));
+                return null;
+            }
+
+            return current;
+        }
         private static JsonObject? FindLink(
             JsonArray links,
             Entry entry,

--- a/src/Opc.Ua.Types/Wot/WotNativeProjection.cs
+++ b/src/Opc.Ua.Types/Wot/WotNativeProjection.cs
@@ -1003,17 +1003,31 @@ namespace Opc.Ua.Wot
             {
                 return;
             }
+            // Each of these members is written at most once: a node that
+            // carries two HasTypeDefinition (or HasSubtype, or HasModellingRule)
+            // references would otherwise produce a duplicate JSON member.
+            bool typeDefinitionWritten = false;
+            bool superTypeWritten = false;
+            bool modellingRuleWritten = false;
+
             foreach (Reference reference in node.References)
             {
                 if (reference.IsForward &&
                     IsReference(reference.ReferenceType, "HasTypeDefinition", "i=40"))
                 {
-                    WriteString(writer, "typeDefinition", reference.Value);
+                    if (!typeDefinitionWritten)
+                    {
+                        typeDefinitionWritten =
+                            WriteString(writer, "typeDefinition", reference.Value);
+                    }
                 }
                 else if (!reference.IsForward &&
                     IsReference(reference.ReferenceType, "HasSubtype", "i=45"))
                 {
-                    WriteString(writer, "superType", reference.Value);
+                    if (!superTypeWritten)
+                    {
+                        superTypeWritten = WriteString(writer, "superType", reference.Value);
+                    }
                 }
                 else if (reference.IsForward &&
                     IsReference(reference.ReferenceType, "HasModellingRule", "i=37") &&
@@ -1022,7 +1036,11 @@ namespace Opc.Ua.Wot
                         reference.Value,
                         out string modellingRule))
                 {
-                    writer.WriteString("modellingRule", modellingRule);
+                    if (!modellingRuleWritten)
+                    {
+                        writer.WriteString("modellingRule", modellingRule);
+                        modellingRuleWritten = true;
+                    }
                 }
             }
         }
@@ -1316,15 +1334,21 @@ namespace Opc.Ua.Wot
             return [.. result];
         }
 
-        private static void WriteString(
+        /// <summary>
+        /// Writes a string member unless the value is absent. Returns whether
+        /// the member was written so a caller can avoid writing it twice.
+        /// </summary>
+        private static bool WriteString(
             Utf8JsonWriter writer,
             string name,
             string? value)
         {
-            if (!string.IsNullOrEmpty(value))
+            if (string.IsNullOrEmpty(value))
             {
-                writer.WriteString(name, value);
+                return false;
             }
+            writer.WriteString(name, value);
+            return true;
         }
 
         private static string? GetString(JsonElement element, string name)

--- a/src/Opc.Ua.Types/Wot/WotNodeSetConverter.Analog.cs
+++ b/src/Opc.Ua.Types/Wot/WotNodeSetConverter.Analog.cs
@@ -480,8 +480,12 @@ namespace Opc.Ua.Wot
                     field.InnerText.Trim(),
                     NumberStyles.Float,
                     CultureInfo.InvariantCulture,
-                    out double parsed))
+                    out double parsed) ||
+                    double.IsNaN(parsed) ||
+                    double.IsInfinity(parsed))
                 {
+                    // NaN / Infinity parse but cannot be written as JSON, and
+                    // NaN is what XmlConvert writes for an uninitialised range.
                     return false;
                 }
                 switch (field.LocalName)

--- a/src/Opc.Ua.Types/Wot/WotNodeSetConverter.DataTypes.cs
+++ b/src/Opc.Ua.Types/Wot/WotNodeSetConverter.DataTypes.cs
@@ -115,7 +115,7 @@ namespace Opc.Ua.Wot
                         nestedOnly, diagnostics);
                 }
             }
-            ValidateEncodingIdentities(complete, identities, diagnostics);
+            ValidateEncodingIdentities(complete, identities, nodeSet, diagnostics);
             ValidateInheritedFieldPrefixes(complete, diagnostics);
             ValidateSubtypeGraph(complete, diagnostics);
             return identities;
@@ -340,8 +340,13 @@ namespace Opc.Ua.Wot
                 bool belongsHere = false;
                 foreach (Reference reference in encoding.References)
                 {
-                    if (string.Equals(
-                            reference.ReferenceType, "HasEncoding", StringComparison.Ordinal) &&
+                    // The reference type may be written as the alias or as the
+                    // numeric identifier; matching only the alias missed every
+                    // document that writes "i=38".
+                    if (IsReferenceTypeNamed(
+                            reference.ReferenceType,
+                            "HasEncoding",
+                            WotVocabulary.HasEncoding) &&
                         string.Equals(reference.Value, dataType.NodeId, StringComparison.Ordinal))
                     {
                         belongsHere = true;
@@ -383,8 +388,13 @@ namespace Opc.Ua.Wot
             {
                 foreach (Reference reference in dataType.References)
                 {
-                    if (string.Equals(
-                            reference.ReferenceType, "HasEncoding", StringComparison.Ordinal) &&
+                    // The reference type may be written as the alias or as the
+                    // numeric identifier; matching only the alias missed every
+                    // document that writes "i=38".
+                    if (IsReferenceTypeNamed(
+                            reference.ReferenceType,
+                            "HasEncoding",
+                            WotVocabulary.HasEncoding) &&
                         reference.IsForward)
                     {
                         return true;
@@ -403,8 +413,13 @@ namespace Opc.Ua.Wot
                 }
                 foreach (Reference reference in encoding.References)
                 {
-                    if (string.Equals(
-                            reference.ReferenceType, "HasEncoding", StringComparison.Ordinal) &&
+                    // The reference type may be written as the alias or as the
+                    // numeric identifier; matching only the alias missed every
+                    // document that writes "i=38".
+                    if (IsReferenceTypeNamed(
+                            reference.ReferenceType,
+                            "HasEncoding",
+                            WotVocabulary.HasEncoding) &&
                         string.Equals(reference.Value, dataType.NodeId, StringComparison.Ordinal))
                     {
                         return true;
@@ -449,6 +464,7 @@ namespace Opc.Ua.Wot
         private static void ValidateEncodingIdentities(
             Dictionary<string, JsonElement> complete,
             Dictionary<string, string> identities,
+            UANodeSet nodeSet,
             List<WotDiagnostic> diagnostics)
         {
             var claimed = new Dictionary<string, string>(StringComparer.Ordinal);
@@ -461,11 +477,17 @@ namespace Opc.Ua.Wot
                     continue;
                 }
                 string name = GetElementString(entry.Value, "uav:dataTypeName") ?? entry.Key;
-                string binary = GetElementString(entry.Value, "uav:binaryEncodingId") ??
+                // An authored identity is portable while the derived one is
+                // NodeSet local, so the authored form has to be resolved before
+                // the two can be compared at all.
+                string binary = ResolveAuthoredEncodingId(
+                    entry.Value, "uav:binaryEncodingId", nodeSet) ??
                     identity + BinaryEncodingSuffix;
-                string xml = GetElementString(entry.Value, "uav:xmlEncodingId") ??
+                string xml = ResolveAuthoredEncodingId(
+                    entry.Value, "uav:xmlEncodingId", nodeSet) ??
                     identity + XmlEncodingSuffix;
-                string json = GetElementString(entry.Value, "uav:jsonEncodingId") ??
+                string json = ResolveAuthoredEncodingId(
+                    entry.Value, "uav:jsonEncodingId", nodeSet) ??
                     identity + JsonEncodingSuffix;
 
                 foreach (string encoding in new[] { binary, xml, json })
@@ -484,7 +506,8 @@ namespace Opc.Ua.Wot
                     claimed[encoding] = name;
                 }
 
-                string? declaredDefault = GetElementString(entry.Value, "uav:defaultEncodingId");
+                string? declaredDefault = ResolveAuthoredEncodingId(
+                    entry.Value, "uav:defaultEncodingId", nodeSet);
                 if (declaredDefault is not null &&
                     !string.Equals(declaredDefault, binary, StringComparison.Ordinal) &&
                     !string.Equals(declaredDefault, xml, StringComparison.Ordinal) &&
@@ -1424,6 +1447,25 @@ namespace Opc.Ua.Wot
             });
         }
 
+        /// <summary>
+        /// Reads an authored, portable encoding identity and resolves it into
+        /// the NodeSet local form the derived identities use.
+        /// </summary>
+        private static string? ResolveAuthoredEncodingId(
+            JsonElement definition,
+            string term,
+            UANodeSet nodeSet)
+        {
+            string? authored = GetElementString(definition, term);
+            if (authored is null)
+            {
+                return null;
+            }
+            // Any diagnostic about the identity itself is raised where the
+            // encoding Object is materialized, so it is not repeated here.
+            return ToNodeSetNodeId(authored, nodeSet, []);
+        }
+
         private static void RejectEncodingIdsOnAbstractType(
             JsonElement definition,
             List<WotDiagnostic> diagnostics,
@@ -1641,10 +1683,36 @@ namespace Opc.Ua.Wot
             {
                 return false;
             }
+            if (definition.IsUnion)
+            {
+                // Only a Structure can be a union.
+                return false;
+            }
+
+            var values = new HashSet<int>();
             foreach (Opc.Ua.Export.DataTypeField field in definition.Field)
             {
                 if (!string.IsNullOrEmpty(field.DataType) &&
                     !string.Equals(field.DataType, WotVocabulary.BaseDataType, StringComparison.Ordinal))
+                {
+                    return false;
+                }
+
+                // Facets only a structure field carries.
+                if (field.IsOptional ||
+                    field.AllowSubTypes ||
+                    field.ValueRank != -1 ||
+                    !string.IsNullOrEmpty(field.ArrayDimensions) ||
+                    field.MaxStringLength != 0)
+                {
+                    return false;
+                }
+
+                // An enumeration's field values are distinct, so two fields
+                // sharing one cannot be an enumeration. That is what a
+                // Structure whose fields are all typed BaseDataType looks like:
+                // every field leaves Value at the schema default of -1.
+                if (!values.Add(field.Value))
                 {
                     return false;
                 }
@@ -1870,6 +1938,14 @@ namespace Opc.Ua.Wot
             }
             string? identity = DeriveDataTypeNodeId(document, name, nodeSet, diagnostics);
             if (identity is null || !seen.Add(identity))
+            {
+                return;
+            }
+
+            // A name that a complete definition already claims is materialized
+            // by that definition; inferring it again would add a second Node
+            // with the same identity.
+            if (identities.ContainsValue(identity))
             {
                 return;
             }

--- a/src/Opc.Ua.Types/Wot/WotNodeSetConverter.NodeSet.cs
+++ b/src/Opc.Ua.Types/Wot/WotNodeSetConverter.NodeSet.cs
@@ -1691,6 +1691,34 @@ namespace Opc.Ua.Wot
                 string.Equals(referenceType, WotVocabulary.HasProperty, StringComparison.Ordinal);
         }
 
+        /// <summary>
+        /// Compares two component reference types, either of which may be
+        /// written as the alias or as the numeric identifier, so that
+        /// HasComponent and HasProperty are told apart however they are spelled.
+        /// </summary>
+        private static bool IsSameComponentReferenceType(string? left, string? right)
+        {
+            return NormalizeComponentReferenceType(left) ==
+                NormalizeComponentReferenceType(right);
+
+            static string? NormalizeComponentReferenceType(string? referenceType)
+            {
+                if (string.Equals(referenceType, "HasComponent", StringComparison.Ordinal) ||
+                    string.Equals(
+                        referenceType, WotVocabulary.HasComponent, StringComparison.Ordinal))
+                {
+                    return "HasComponent";
+                }
+                if (string.Equals(referenceType, "HasProperty", StringComparison.Ordinal) ||
+                    string.Equals(
+                        referenceType, WotVocabulary.HasProperty, StringComparison.Ordinal))
+                {
+                    return "HasProperty";
+                }
+                return referenceType;
+            }
+        }
+
         private static bool IsGeneratesEventReference(string? referenceType)
         {
             return string.Equals(referenceType, "GeneratesEvent", StringComparison.Ordinal) ||

--- a/src/Opc.Ua.Types/Wot/WotNodeSetConverter.WoT.cs
+++ b/src/Opc.Ua.Types/Wot/WotNodeSetConverter.WoT.cs
@@ -1458,7 +1458,12 @@ namespace Opc.Ua.Wot
                         nodeSet,
                         diagnostics),
                 ParentNodeId = rootNodeId,
-                DataType = MapJsonSchemaToDataType(document, schema, nodeSet, diagnostics),
+                DataType = MapJsonSchemaToDataType(
+                    document,
+                    schema,
+                    nodeSet,
+                    diagnostics,
+                    inferMissingDataType: true),
                 AccessLevel = MapAccessLevel(schema)
             };
 
@@ -1583,10 +1588,6 @@ namespace Opc.Ua.Wot
         }
 
         /// <summary>
-        /// Adds the forward component reference from the owning Variable, so the
-        /// child hangs where the document says rather than being orphaned.
-        /// </summary>
-        /// <summary>
         /// Adds the forward component Reference for every inverse component
         /// Reference whose owner could not be found when the child was
         /// materialized, because the document declares the owner later.
@@ -1619,13 +1620,19 @@ namespace Opc.Ua.Wot
                         continue;
                     }
 
+                    // The forward reference has to match the inverse one's type,
+                    // not merely be some component reference to the same child.
+                    // A forward HasComponent does not satisfy an inverse
+                    // HasProperty, and treating it as satisfied left that
+                    // relation stated in one direction only.
                     bool present = false;
                     foreach (Reference existing in owner.References ?? [])
                     {
                         if (existing.IsForward &&
                             string.Equals(
                                 existing.Value, node.NodeId, StringComparison.Ordinal) &&
-                            IsComponentReference(existing.ReferenceType))
+                            IsSameComponentReferenceType(
+                                existing.ReferenceType, reference.ReferenceType))
                         {
                             present = true;
                             break;
@@ -4281,11 +4288,23 @@ namespace Opc.Ua.Wot
         /// portable <c>nsu=</c> form into the <c>ns=&lt;index&gt;</c> form a
         /// NodeSet2 <c>DataType</c> attribute is allowed to carry.
         /// </remarks>
+        /// <param name="document">The document the schema is read in.</param>
+        /// <param name="schema">The DataSchema to map.</param>
+        /// <param name="nodeSet">The NodeSet being built.</param>
+        /// <param name="diagnostics">Where to report a disagreement.</param>
+        /// <param name="inferMissingDataType">Whether a <c>uav:dataTypeName</c>
+        /// that no definition claims may be returned as an inferred identity.
+        /// Only a property schema may: SynthesizeInferredDataTypes walks
+        /// <see cref="WotDocument.Properties"/> and materializes the UADataType
+        /// for those alone, so returning an inferred identity for an action
+        /// argument or an event field would type it against a Node that is
+        /// never written.</param>
         private static string MapJsonSchemaToDataType(
             WotDocument document,
             JsonElement schema,
             UANodeSet nodeSet,
-            List<WotDiagnostic> diagnostics)
+            List<WotDiagnostic> diagnostics,
+            bool inferMissingDataType = false)
         {
             string? mapped = GetElementString(schema, "uav:mapToType") is { } definitive
                 ? ToNodeSetNodeId(definitive, nodeSet, diagnostics)
@@ -4306,7 +4325,9 @@ namespace Opc.Ua.Wot
             return mapped ??
                 defined ??
                 annotated ??
-                InferredDataTypeIdentity(document, schema, nodeSet) ??
+                (inferMissingDataType
+                    ? InferredDataTypeIdentity(document, schema, nodeSet)
+                    : null) ??
                 WotVocabulary.MapJsonTypeToDataType(
                     GetElementString(schema, "type"),
                     GetElementString(schema, "contentEncoding"),

--- a/src/Opc.Ua.Types/Wot/WotNodeSetConverter.WoT.cs
+++ b/src/Opc.Ua.Types/Wot/WotNodeSetConverter.WoT.cs
@@ -1366,6 +1366,12 @@ namespace Opc.Ua.Wot
                     eventSelections);
             }
 
+            // An affordance may name an owner that the document only declares
+            // later, so at that point the owner's Node did not exist yet and
+            // the forward component Reference could not be added. Every Node is
+            // materialized now, so the missing direction can be restored.
+            ReconcileOwnedComponents(items);
+
             // Section 5.2.1: every affordance is now a Node, so a member that
             // names an instance declaration of the bound type can be matched
             // against it and populate it rather than stand beside it. The pass
@@ -1580,6 +1586,69 @@ namespace Opc.Ua.Wot
         /// Adds the forward component reference from the owning Variable, so the
         /// child hangs where the document says rather than being orphaned.
         /// </summary>
+        /// <summary>
+        /// Adds the forward component Reference for every inverse component
+        /// Reference whose owner could not be found when the child was
+        /// materialized, because the document declares the owner later.
+        /// </summary>
+        private static void ReconcileOwnedComponents(List<UANode> items)
+        {
+            var byId = new Dictionary<string, UANode>(StringComparer.Ordinal);
+            foreach (UANode node in items)
+            {
+                if (!string.IsNullOrEmpty(node.NodeId))
+                {
+                    byId[node.NodeId!] = node;
+                }
+            }
+
+            foreach (UANode node in items)
+            {
+                if (node.References is null || string.IsNullOrEmpty(node.NodeId))
+                {
+                    continue;
+                }
+
+                foreach (Reference reference in node.References)
+                {
+                    if (reference.IsForward ||
+                        string.IsNullOrEmpty(reference.Value) ||
+                        !IsComponentReference(reference.ReferenceType) ||
+                        !byId.TryGetValue(reference.Value!, out UANode? owner))
+                    {
+                        continue;
+                    }
+
+                    bool present = false;
+                    foreach (Reference existing in owner.References ?? [])
+                    {
+                        if (existing.IsForward &&
+                            string.Equals(
+                                existing.Value, node.NodeId, StringComparison.Ordinal) &&
+                            IsComponentReference(existing.ReferenceType))
+                        {
+                            present = true;
+                            break;
+                        }
+                    }
+                    if (present)
+                    {
+                        continue;
+                    }
+
+                    var references = new List<Reference>(owner.References ?? [])
+                    {
+                        new Reference
+                        {
+                            ReferenceType = reference.ReferenceType,
+                            IsForward = true,
+                            Value = node.NodeId
+                        }
+                    };
+                    owner.References = [.. references];
+                }
+            }
+        }
         private static void AddOwnedComponent(
             List<UANode> items,
             string owner,
@@ -1946,6 +2015,21 @@ namespace Opc.Ua.Wot
                 {
                     attached = [];
                     conditionMethods[actsOn] = attached;
+                }
+                if (attached.Contains(nodeId))
+                {
+                    // The Condition Method's identifier is derived from the
+                    // standard BrowseName, so two actions naming the same
+                    // uav:conditionAction on the same event would synthesize
+                    // two Methods with the same NodeId and BrowseName.
+                    diagnostics.Add(new WotDiagnostic(
+                        WotDiagnosticSeverity.Error,
+                        WotDiagnosticCode.ValidationError,
+                        "Two actions name the Condition Method '" + conditionAction +
+                        "' on event '" + actsOn + "'.",
+                        WotLocation.FromPointer(
+                            "/actions/" + EscapeJsonPointerToken(key))));
+                    return;
                 }
                 attached.Add(nodeId);
             }
@@ -2607,8 +2691,20 @@ namespace Opc.Ua.Wot
             {
                 return [modelUri];
             }
-            if (!uris.Contains(modelUri))
+
+            // The model's own namespace has to be the first entry: the
+            // generated BrowseNames are written in namespace index 1 and
+            // GeneratedNamespaceUri reads entry zero, so a model URI that the
+            // @context happens to bind to a later prefix would otherwise name
+            // a different namespace than the Nodes are generated into.
+            int existing = uris.IndexOf(modelUri);
+            if (existing < 0)
             {
+                uris.Insert(0, modelUri);
+            }
+            else if (existing > 0)
+            {
+                uris.RemoveAt(existing);
                 uris.Insert(0, modelUri);
             }
             return [.. uris];
@@ -4151,9 +4247,12 @@ namespace Opc.Ua.Wot
                 if (uavId.StartsWith(marker, StringComparison.Ordinal))
                 {
                     int semicolon = uavId.IndexOf(';', marker.Length);
+                    // The nsu= form is percent escaped, like every other place
+                    // the converter reads one.
                     string ns = semicolon < 0
-                        ? uavId.Substring(marker.Length)
-                        : uavId.Substring(marker.Length, semicolon - marker.Length);
+                        ? CoreUtils.UnescapeUri(uavId.AsSpan(marker.Length))
+                        : CoreUtils.UnescapeUri(
+                            uavId.AsSpan(marker.Length, semicolon - marker.Length));
                     if (ns.Length > 0)
                     {
                         return ns;
@@ -4207,10 +4306,35 @@ namespace Opc.Ua.Wot
             return mapped ??
                 defined ??
                 annotated ??
+                InferredDataTypeIdentity(document, schema, nodeSet) ??
                 WotVocabulary.MapJsonTypeToDataType(
                     GetElementString(schema, "type"),
                     GetElementString(schema, "contentEncoding"),
                     GetElementString(schema, "format"));
+        }
+
+        /// <summary>
+        /// Gets the identity of the DataType a schema's <c>uav:dataTypeName</c>
+        /// names, which is the one inference materializes for it.
+        /// </summary>
+        /// <remarks>
+        /// Without this the inferred DataType is created but nothing is typed
+        /// with it: the Variable keeps the built-in the json type implies and
+        /// the new DataType is orphaned in the address space.
+        /// </remarks>
+        private static string? InferredDataTypeIdentity(
+            WotDocument document,
+            JsonElement schema,
+            UANodeSet nodeSet)
+        {
+            string? name = GetElementString(schema, "uav:dataTypeName");
+            if (name is null || name.StartsWith("ua:", StringComparison.Ordinal))
+            {
+                return null;
+            }
+            // Inference is the lowest ranked channel, so a name that does not
+            // resolve is simply not used and reported where it is materialized.
+            return DeriveDataTypeNodeId(document, name, nodeSet, []);
         }
 
         /// <summary>

--- a/src/Opc.Ua.Types/Wot/WotProjectionResolver.cs
+++ b/src/Opc.Ua.Types/Wot/WotProjectionResolver.cs
@@ -1534,7 +1534,11 @@ namespace Opc.Ua.Wot
                 return href;
             }
             if (!TrySplitBase(
-                    baseHref, out string scheme, out string? authority, out string basePath))
+                    baseHref,
+                    out string scheme,
+                    out string? authority,
+                    out string basePath,
+                    out string baseQuery))
             {
                 return href;
             }
@@ -1549,9 +1553,15 @@ namespace Opc.Ua.Wot
             {
                 return prefix + href;
             }
-            if (href.StartsWith('?') || href.StartsWith('#'))
+            if (href.StartsWith('?'))
             {
+                // RFC 3986 5.3: a query only reference replaces the base query.
                 return prefix + basePath + href;
+            }
+            if (href.StartsWith('#'))
+            {
+                // A fragment only reference keeps the base query.
+                return prefix + basePath + baseQuery + href;
             }
             string merged = MergePath(basePath, href, authority is not null);
             return prefix + RemoveDotSegments(merged);
@@ -1582,11 +1592,28 @@ namespace Opc.Ua.Wot
             string baseHref,
             out string scheme,
             out string? authority,
-            out string path)
+            out string path,
+            out string query)
         {
             scheme = string.Empty;
             authority = null;
             path = string.Empty;
+            query = string.Empty;
+
+            // RFC 3986 5.2.1 discards the base's fragment and 5.2.2 merges
+            // against its path only, so neither may stay inside the path.
+            int fragment = baseHref.IndexOf('#', StringComparison.Ordinal);
+            if (fragment >= 0)
+            {
+                baseHref = baseHref[..fragment];
+            }
+            int queryStart = baseHref.IndexOf('?', StringComparison.Ordinal);
+            if (queryStart >= 0)
+            {
+                query = baseHref[queryStart..];
+                baseHref = baseHref[..queryStart];
+            }
+
             int colon = baseHref.IndexOf(':', StringComparison.Ordinal);
             if (colon <= 0)
             {

--- a/tests/Opc.Ua.Aot.Tests/SecurityAotTests.cs
+++ b/tests/Opc.Ua.Aot.Tests/SecurityAotTests.cs
@@ -139,8 +139,12 @@ namespace Opc.Ua.Aot.Tests
             var copy = (NodeState)node.Clone();
             await Assert.That(copy.RolePermissions == permissions).IsTrue();
             await Assert.That(copy.UserRolePermissions == userPermissions).IsTrue();
-            // CopyTo intentionally does not copy AccessRestrictions.
-            await Assert.That(copy.AccessRestrictions).IsNull();
+            // Clone is a full copy, so it carries the node's access control too.
+            // Dropping AccessRestrictions silently handed out a copy that was
+            // less restricted than the node it was made from.
+            await Assert.That(copy.AccessRestrictions.HasValue).IsTrue();
+            await Assert.That(copy.AccessRestrictions.GetValueOrDefault())
+                .IsEqualTo(AccessRestrictionType.SigningRequired);
 
             await node.ClearChangeMasksAsync(context, false).ConfigureAwait(false);
             node.AccessRestrictions = null;

--- a/tests/Opc.Ua.Aot.Tests/VariantStorageAotTests.cs
+++ b/tests/Opc.Ua.Aot.Tests/VariantStorageAotTests.cs
@@ -170,10 +170,15 @@ namespace Opc.Ua.Aot.Tests
             {
                 Variant andResult = Variant.From(-1L) & input;
                 Variant orResult = Variant.From(0L) | input;
-                await Assert.That(andResult.TryGetValue(out long andValue)).IsTrue();
-                await Assert.That(orResult.TryGetValue(out long orValue)).IsTrue();
-                await Assert.That(andValue).IsEqualTo(0L);
-                await Assert.That(orValue).IsEqualTo(0L);
+
+                // An operand that does not resolve to an integer makes the
+                // result null (OPC 10000-4 7.7.3), rather than a zero that is
+                // indistinguishable from a real result. Either way the packed
+                // payload's raw bits never reach the operator.
+                await Assert.That(andResult.IsNull).IsTrue();
+                await Assert.That(orResult.IsNull).IsTrue();
+                await Assert.That(andResult.TryGetValue(out long _)).IsFalse();
+                await Assert.That(orResult.TryGetValue(out long _)).IsFalse();
                 await Assert.That((Variant.From(true) & input).GetBoolean()).IsFalse();
                 await Assert.That((Variant.From(false) | input).GetBoolean()).IsFalse();
             }

--- a/tests/Opc.Ua.Core.Encoders.Tests/EncodeableFactoryTests.cs
+++ b/tests/Opc.Ua.Core.Encoders.Tests/EncodeableFactoryTests.cs
@@ -579,10 +579,12 @@ namespace Opc.Ua.Core.Encoders.Tests
             bool foundWithNs = factory.TryGetEncodeableType(typeIdWithDefaultNs, out IEncodeableType typeWithNs);
             bool foundWithoutNs = factory.TryGetEncodeableType(typeIdWithoutNs, out IEncodeableType typeWithoutNs);
 
+            // Registrations and lookups both normalize an id that names
+            // namespace zero by its URI, so either spelling resolves.
             Assert.That(foundWithNs, Is.True);
-            Assert.That(foundWithoutNs, Is.False);
+            Assert.That(foundWithoutNs, Is.True);
             Assert.That(typeWithNs.Type, Is.EqualTo(typeof(TestEncodeable)));
-            Assert.That(typeWithoutNs, Is.Null);
+            Assert.That(typeWithoutNs.Type, Is.EqualTo(typeof(TestEncodeable)));
         }
 
         [Test]
@@ -976,8 +978,10 @@ namespace Opc.Ua.Core.Encoders.Tests
             bool foundWithoutNs = factory.TryGetEncodeableType(new ExpandedNodeId(140000), out IEncodeableType typeWithoutNs);
             bool foundWithNs = factory.TryGetEncodeableType(new ExpandedNodeId(140000, Namespaces.OpcUa), out _);
 
+            // The lookup normalizes the namespace zero URI form as well, so
+            // both spellings resolve to the same registration.
             Assert.That(foundWithoutNs, Is.True);
-            Assert.That(foundWithNs, Is.False);
+            Assert.That(foundWithNs, Is.True);
             Assert.That(typeWithoutNs.Type, Is.EqualTo(typeof(TestEncodeableWithDefaultNamespace)));
         }
 

--- a/tests/Opc.Ua.Core.Tests/Types/ContentFilter/FilterEvaluatorTests.cs
+++ b/tests/Opc.Ua.Core.Tests/Types/ContentFilter/FilterEvaluatorTests.cs
@@ -399,9 +399,24 @@ namespace Opc.Ua.Core.Tests.Types.ContentFilter
         }
 
         [Test]
-        public void EqualsWithDifferentNumericTypesReturnsFalse()
+        public void EqualsConvertsBetweenNumericTypes()
         {
-            Ua.ContentFilter filter = BuildBinaryFilter(FilterOperator.Equals, Variant.From(42), Variant.From((double)42.0));
+            // Part 4 7.4.1 converts the operands to a common type before the
+            // comparison, so an Int32 and a Double naming the same number are
+            // equal. The raw union comparison this used to do reported false
+            // for every Float or Double operand, and true for a negative Int32
+            // only when the other operand happened to share its low bytes.
+            Ua.ContentFilter filter = BuildBinaryFilter(
+                FilterOperator.Equals, Variant.From(42), Variant.From((double)42.0));
+            bool result = filter.Evaluate(m_filterContext, m_target);
+            Assert.That(result, Is.True);
+        }
+
+        [Test]
+        public void EqualsWithDifferentNumericValuesReturnsFalse()
+        {
+            Ua.ContentFilter filter = BuildBinaryFilter(
+                FilterOperator.Equals, Variant.From(42), Variant.From((double)42.5));
             bool result = filter.Evaluate(m_filterContext, m_target);
             Assert.That(result, Is.False);
         }

--- a/tests/Opc.Ua.Types.Tests/BuiltIn/DateTimeUtcTests.cs
+++ b/tests/Opc.Ua.Types.Tests/BuiltIn/DateTimeUtcTests.cs
@@ -156,36 +156,61 @@ namespace Opc.Ua.Types.Tests.BuiltIn
             Assert.That(hash, Is.EqualTo(value.GetHashCode()));
         }
 
-        [TestCase("2023-01-01")]
-        [TestCase("2023-01-01T12:30:45Z")]
-        public void ParseStringShouldReturnCorrectDateTimeUtc(string dateString)
+        // Text without a time zone designator denotes UTC, so the result must not
+        // depend on the machine's local offset.
+        [TestCase("2023-01-01", 2023, 1, 1, 0, 0, 0)]
+        [TestCase("2023-01-01T12:30:45Z", 2023, 1, 1, 12, 30, 45)]
+        public void ParseStringShouldReturnCorrectDateTimeUtc(
+            string dateString,
+            int year,
+            int month,
+            int day,
+            int hour,
+            int minute,
+            int second)
         {
             // Act
             var result = DateTimeUtc.Parse(dateString, null);
 
             // Assert
-            DateTime expectedDateTime = DateTime.Parse(dateString, null).ToUniversalTime();
+            var expectedDateTime = new DateTime(
+                year, month, day, hour, minute, second, DateTimeKind.Utc);
             var actualDateTime = (DateTime)result;
             Assert.That(actualDateTime, Is.EqualTo(expectedDateTime));
         }
 
-        [TestCase("2023-01-01")]
-        [TestCase("2023-01-01T12:30:45Z")]
-        [TestCase("01/15/2023")]
-        public void ParseStringShouldReturnCorrectDateTimeUtcWithFormatProvider(string dateString)
+        [TestCase("2023-01-01", 2023, 1, 1, 0, 0, 0)]
+        [TestCase("2023-01-01T12:30:45Z", 2023, 1, 1, 12, 30, 45)]
+        [TestCase("01/15/2023", 2023, 1, 15, 0, 0, 0)]
+        public void ParseStringShouldReturnCorrectDateTimeUtcWithFormatProvider(
+            string dateString,
+            int year,
+            int month,
+            int day,
+            int hour,
+            int minute,
+            int second)
         {
             // Act
             var result = DateTimeUtc.Parse(dateString, CultureInfo.InvariantCulture);
 
             // Assert
-            DateTime expectedDateTime = DateTime.Parse(dateString, CultureInfo.InvariantCulture).ToUniversalTime();
+            var expectedDateTime = new DateTime(
+                year, month, day, hour, minute, second, DateTimeKind.Utc);
             var actualDateTime = (DateTime)result;
             Assert.That(actualDateTime, Is.EqualTo(expectedDateTime));
         }
 
-        [TestCase("2023-01-01")]
-        [TestCase("2023-01-01T12:30:45Z")]
-        public void ParseReadOnlySpanShouldReturnCorrectDateTimeUtc(string dateString)
+        [TestCase("2023-01-01", 2023, 1, 1, 0, 0, 0)]
+        [TestCase("2023-01-01T12:30:45Z", 2023, 1, 1, 12, 30, 45)]
+        public void ParseReadOnlySpanShouldReturnCorrectDateTimeUtc(
+            string dateString,
+            int year,
+            int month,
+            int day,
+            int hour,
+            int minute,
+            int second)
         {
             // Arrange
             ReadOnlySpan<char> span = dateString.AsSpan();
@@ -194,9 +219,8 @@ namespace Opc.Ua.Types.Tests.BuiltIn
             var result = DateTimeUtc.Parse(span, null);
 
             // Assert
-#pragma warning disable CA1305 // Specify IFormatProvider
-            DateTime expectedDateTime = DateTime.Parse(dateString).ToUniversalTime();
-#pragma warning restore CA1305 // Specify IFormatProvider
+            var expectedDateTime = new DateTime(
+                year, month, day, hour, minute, second, DateTimeKind.Utc);
             var actualDateTime = (DateTime)result;
             Assert.That(actualDateTime, Is.EqualTo(expectedDateTime));
         }

--- a/tests/Opc.Ua.Types.Tests/BuiltIn/ExpandedNodeIdTests.cs
+++ b/tests/Opc.Ua.Types.Tests/BuiltIn/ExpandedNodeIdTests.cs
@@ -570,7 +570,9 @@ namespace Opc.Ua.Types.Tests.BuiltIn
         public void CompareToNullWhenNotNull()
         {
             var id = new ExpandedNodeId(42u);
-            Assert.That(id.CompareTo(null), Is.LessThan(0));
+
+            // A null operand sorts before any value, matching NodeId.CompareTo.
+            Assert.That(id.CompareTo(null), Is.GreaterThan(0));
         }
 
         [Test]

--- a/tests/Opc.Ua.Types.Tests/BuiltIn/IdentifierAuditRegressionTests.cs
+++ b/tests/Opc.Ua.Types.Tests/BuiltIn/IdentifierAuditRegressionTests.cs
@@ -1,0 +1,419 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NUnit.Framework;
+using Opc.Ua.Tests;
+
+namespace Opc.Ua.Types.Tests.BuiltIn
+{
+    /// <summary>
+    /// Regression tests for the NodeId / ExpandedNodeId / NumericRange /
+    /// DateTimeUtc / DiagnosticInfo / QualifiedName / XmlElement defects
+    /// reported by the read-only bug audit of Opc.Ua.Types.
+    /// </summary>
+    [TestFixture]
+    [Category("BuiltInType")]
+    [SetCulture("en-us")]
+    [SetUICulture("en-us")]
+    [Parallelizable]
+    public class IdentifierAuditRegressionTests
+    {
+        private static readonly ILogger s_logger = new Mock<ILogger>().Object;
+        private static readonly string[] s_twoStrings = ["a", "b"];
+        private static readonly int[] s_oneTwoThree = [1, 2, 3];
+        private static readonly int[] s_fourFive = [4, 5];
+
+        private static ServiceMessageContext CreateContext()
+        {
+            return ServiceMessageContext.CreateEmpty(NUnitTelemetryContext.Create());
+        }
+
+        [Test]
+        public void ServerIndexIsMappedThroughTheServerMappingTable()
+        {
+            // The parser mapped svr= through NamespaceMappings with an inverted
+            // bounds check, so this payload threw IndexOutOfRangeException.
+            ServiceMessageContext context = CreateContext();
+            var options = new NodeIdParsingOptions
+            {
+                NamespaceMappings = [0, 1],
+                ServerMappings = [0, 0, 0, 0, 0, 7]
+            };
+
+            Assert.That(
+                ExpandedNodeId.TryParse(context, "svr=5;i=42", options, out ExpandedNodeId value),
+                Is.True);
+            Assert.Multiple(() =>
+            {
+                Assert.That(value.ServerIndex, Is.EqualTo(7u));
+                Assert.That(value.InnerNodeId.NumericIdentifier, Is.EqualTo(42u));
+            });
+        }
+
+        [Test]
+        public void ServerIndexAboveUInt16RangeIsNotDropped()
+        {
+            // The index was parsed as a ushort, so anything above 65535 was
+            // silently discarded and the node id became server local.
+            ServiceMessageContext context = CreateContext();
+
+            Assert.That(
+                ExpandedNodeId.TryParse(context, "svr=70000;i=42", null, out ExpandedNodeId value),
+                Is.True);
+            Assert.That(value.ServerIndex, Is.EqualTo(70000u));
+        }
+
+        [Test]
+        public void AnUnparsableServerIndexIsReportedInsteadOfDropped()
+        {
+            // The context taking parse path ignored a failed uint.TryParse, so
+            // TryParse reported success with ServerIndex zero and turned a
+            // remote node id into a local one undetectably. The sibling ns=
+            // case in NodeId already rejects the same shape.
+            ServiceMessageContext context = CreateContext();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(
+                    ExpandedNodeId.TryParse(
+                        context,
+                        "svr=abc;i=42",
+                        null,
+                        out ExpandedNodeId _,
+                        out NodeIdParseError text),
+                    Is.False);
+                Assert.That(text, Is.EqualTo(NodeIdParseError.InvalidServerIndex));
+
+                Assert.That(
+                    ExpandedNodeId.TryParse(
+                        context,
+                        "svr=99999999999;i=42",
+                        null,
+                        out ExpandedNodeId _,
+                        out NodeIdParseError overflow),
+                    Is.False);
+                Assert.That(overflow, Is.EqualTo(NodeIdParseError.InvalidServerIndex));
+
+                // a well formed index still parses.
+                Assert.That(
+                    ExpandedNodeId.TryParse(context, "svr=7;i=42", null, out ExpandedNodeId good),
+                    Is.True);
+                Assert.That(good.ServerIndex, Is.EqualTo(7u));
+            });
+        }
+
+        [Test]
+        public void ValidateRejectsAnEmptyDimensionInsteadOfThrowing()
+        {
+            // ",1:2" produced a null leading sub range whose Begin is -1, and
+            // the NumericRange constructor then threw out of Validate.
+            Assert.Multiple(() =>
+            {
+                ServiceResult result = NumericRange.Validate(",1:2", out NumericRange range);
+                Assert.That(result.StatusCode, Is.EqualTo((StatusCode)StatusCodes.BadIndexRangeInvalid));
+                Assert.That(range.IsNull, Is.True);
+
+                ServiceResult middle = NumericRange.Validate("1:2,,3:4", out NumericRange other);
+                Assert.That(middle.StatusCode, Is.EqualTo((StatusCode)StatusCodes.BadIndexRangeInvalid));
+                Assert.That(other.IsNull, Is.True);
+            });
+        }
+
+        [Test]
+        public void NodeIdCompareToIsAntisymmetricForNull()
+        {
+            NodeId nullId = NodeId.Null;
+            var numericId = new NodeId(42u);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(nullId.CompareTo(numericId), Is.LessThan(0));
+                Assert.That(numericId.CompareTo(nullId), Is.GreaterThan(0));
+            });
+        }
+
+        [Test]
+        public void EmptyOpaqueIdentifierHashesLikeNull()
+        {
+            // The two argument constructor cached ByteString.Empty.GetHashCode()
+            // while the one argument constructor and NodeId.Null cached zero.
+            var withNamespace = new NodeId(ByteString.Empty, 0);
+            var withoutNamespace = new NodeId(ByteString.Empty);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(withNamespace.IsNull, Is.True);
+                Assert.That(withNamespace.GetHashCode(), Is.EqualTo(withoutNamespace.GetHashCode()));
+                Assert.That(withNamespace.GetHashCode(), Is.EqualTo(NodeId.Null.GetHashCode()));
+            });
+        }
+
+        [Test]
+        public void MultiDimensionalNumericRangeRoundTripsThroughItsText()
+        {
+            // ToString() only wrote the first dimension, so a persisted index
+            // range restored the wrong slice.
+            ServiceResult result = NumericRange.Validate("1:2,3:4", out NumericRange range);
+            Assert.That(ServiceResult.IsGood(result), Is.True);
+
+            string text = range.ToString();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(text, Is.EqualTo("1:2,3:4"));
+                ServiceResult roundTrip = NumericRange.Validate(text, out NumericRange parsed);
+                Assert.That(ServiceResult.IsGood(roundTrip), Is.True);
+                Assert.That(parsed.SubRanges, Is.Not.Null);
+                Assert.That(parsed.SubRanges, Has.Length.EqualTo(2));
+            });
+        }
+
+        [Test]
+        public void ResolvedNamespaceUriBecomesRelativeEvenForNamespaceZero()
+        {
+            // A nsu= that resolved to namespace 0 stayed absolute, unlike the
+            // equivalent ns=0 form parsed by NodeId.Parse.
+            ServiceMessageContext context = CreateContext();
+            string namespaceZeroUri = context.NamespaceUris.GetString(0);
+
+            Assert.That(
+                ExpandedNodeId.TryParse(
+                    context,
+                    "nsu=" + namespaceZeroUri + ";i=42",
+                    null,
+                    out ExpandedNodeId value),
+                Is.True);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(value.IsAbsolute, Is.False);
+                Assert.That(value.NamespaceUri, Is.Null);
+                Assert.That(value.InnerNodeId, Is.EqualTo(new NodeId(42u)));
+            });
+        }
+
+        [Test]
+        public void DateTimeUtcFromStringTreatsTextAsUtc()
+        {
+            // From() used ParseExact without AssumeUniversal, so the value was
+            // shifted by the machine's local offset.
+            DateTimeUtc value = DateTimeUtc.From("2023-06-15 12:00:00");
+
+            Assert.That(
+                value.ToDateTime(),
+                Is.EqualTo(new DateTime(2023, 6, 15, 12, 0, 0, DateTimeKind.Utc)));
+        }
+
+        [Test]
+        public void MaxValueArithmeticSaturatesInsteadOfWrapping()
+        {
+            // Value reports long.MaxValue for the sentinel, so plain addition
+            // overflowed into a negative file time that was clamped to MinValue.
+            Assert.Multiple(() =>
+            {
+                Assert.That(
+                    DateTimeUtc.MaxValue.Add(TimeSpan.FromSeconds(1)),
+                    Is.EqualTo(DateTimeUtc.MaxValue));
+                Assert.That(
+                    DateTimeUtc.MaxValue.AddMilliseconds(1000),
+                    Is.EqualTo(DateTimeUtc.MaxValue));
+                Assert.That(
+                    DateTimeUtc.MinValue.Subtract(TimeSpan.FromSeconds(1)),
+                    Is.EqualTo(DateTimeUtc.MinValue));
+
+                // Negating long.MinValue is not representable and yields itself
+                // unchecked, so subtracting the most negative offset - which is
+                // mathematically a very large addition - saturated to MinValue.
+                Assert.That(
+                    DateTimeUtc.MinValue.Subtract(TimeSpan.MinValue),
+                    Is.EqualTo(DateTimeUtc.MaxValue));
+                Assert.That(
+                    DateTimeUtc.MinValue.SubtractMilliseconds(-1e30),
+                    Is.EqualTo(DateTimeUtc.MaxValue));
+
+                // A double to long cast saturates on .NET 5 and later but gives
+                // long.MinValue for NaN and out of range values on .NET
+                // Framework, so the conversion is clamped explicitly.
+                Assert.That(
+                    DateTimeUtc.MinValue.AddMilliseconds(double.NaN),
+                    Is.EqualTo(DateTimeUtc.MinValue));
+                Assert.That(
+                    DateTimeUtc.MinValue.AddMilliseconds(1e30),
+                    Is.EqualTo(DateTimeUtc.MaxValue));
+            });
+        }
+
+        [Test]
+        public void OperationLevelDiagnosticsCanCarryAdditionalInfo()
+        {
+            // UserPermissionAdditionalInfo (bit 31) was shifted down with the
+            // operation bits, so the test for it at bit 31 never matched.
+            var result = new ServiceResult(
+                "http://test.org/ns",
+                StatusCodes.Bad,
+                new LocalizedText("en", "Error"),
+                "debug info",
+                (ServiceResult)null);
+
+            var stringTable = new StringTable();
+            const DiagnosticsMasks mask =
+                DiagnosticsMasks.OperationAdditionalInfo |
+                DiagnosticsMasks.UserPermissionAdditionalInfo;
+
+            var di = new DiagnosticInfo(result, mask, false, stringTable, s_logger);
+
+            Assert.That(di.AdditionalInfo, Is.EqualTo("debug info"));
+        }
+
+        [Test]
+        public void QualifiedNameFormatGuardsNamesContainingAColon()
+        {
+            // Format() omitted the "0:" guard that ToString() writes, so the
+            // text parsed back into namespace 1.
+            ServiceMessageContext context = CreateContext();
+            var name = new QualifiedName("1:Tag", 0);
+
+            string text = name.Format(context);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(text, Is.EqualTo("0:1:Tag"));
+                Assert.That(QualifiedName.Parse(text), Is.EqualTo(name));
+            });
+        }
+
+        [Test]
+        public void AbsoluteExpandedNodeIdWithNullInnerIdRoundTrips()
+        {
+            // The formatter wrote "nsu=<uri>;i=" with no identifier at all.
+            var value = new ExpandedNodeId(NodeId.Null, "http://test.org/ns", 0);
+
+            string text = value.Format(null);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(text, Is.EqualTo("nsu=http://test.org/ns;i=0"));
+                Assert.That(ExpandedNodeId.TryParse(text, out ExpandedNodeId parsed), Is.True);
+                Assert.That(parsed.NamespaceUri, Is.EqualTo("http://test.org/ns"));
+                Assert.That(parsed.InnerNodeId.IsNull, Is.True);
+            });
+        }
+
+        [Test]
+        public void ExpandedNodeIdEqualsAcceptsABoxedNodeId()
+        {
+            var nodeId = new NodeId(42u);
+            var expanded = new ExpandedNodeId(nodeId);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(expanded, Is.EqualTo((object)nodeId));
+                Assert.That(expanded.GetHashCode(), Is.EqualTo(nodeId.GetHashCode()));
+            });
+        }
+
+        [Test]
+        public void ExpandedNodeIdCompareToForeignTypeIsNotEqual()
+        {
+            // A null ExpandedNodeId reported 0 ("equal") for any foreign type.
+            ExpandedNodeId nullId = ExpandedNodeId.Null;
+
+            Assert.That(nullId.CompareTo("not an id"), Is.Not.Zero);
+        }
+
+        [Test]
+        public void NullRangeLeavesTypedArraysUntouched()
+        {
+            // SliceArrayOf returned Good for a null range, but the caller then
+            // fell into the "not two dimensional" branch and nulled the value.
+            NumericRange range = NumericRange.Null;
+
+            ArrayOf<string> strings = s_twoStrings.ToArrayOf();
+            ArrayOf<ByteString> byteStrings = new[]
+            {
+                new ByteString(new byte[] { 1 }),
+                new ByteString(new byte[] { 2 })
+            }.ToArrayOf();
+
+            ArrayOf<int> ints = s_oneTwoThree.ToArrayOf();
+
+            StatusCode stringStatus = range.ApplyRange(ref strings);
+            StatusCode byteStringStatus = range.ApplyRange(ref byteStrings);
+
+            // The generic overloads tested the dimension count first, so a null
+            // range (Dimensions == 0) was rejected before SliceArrayOf could
+            // report Good like every sibling overload does.
+            StatusCode intStatus = range.ApplyRange(ref ints);
+            StatusCode intUpdateStatus = range.UpdateRange(ref ints, s_fourFive.ToArrayOf());
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(stringStatus, Is.EqualTo((StatusCode)StatusCodes.Good));
+                Assert.That(strings.ToArray(), Is.EqualTo(s_twoStrings));
+                Assert.That(byteStringStatus, Is.EqualTo((StatusCode)StatusCodes.Good));
+                Assert.That(byteStrings.Count, Is.EqualTo(2));
+                Assert.That(intStatus, Is.EqualTo((StatusCode)StatusCodes.Good));
+                Assert.That(intUpdateStatus, Is.EqualTo((StatusCode)StatusCodes.Good));
+                Assert.That(ints.ToArray(), Is.EqualTo(s_oneTwoThree));
+            });
+        }
+
+        [Test]
+        public void UnparsableNamespaceIndexIsRejected()
+        {
+            // An out of range or non numeric ns= was silently ignored, landing
+            // the node id in namespace zero.
+            ServiceMessageContext context = CreateContext();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(NodeId.TryParse(context, "ns=70000;i=42", out _), Is.False);
+                Assert.That(NodeId.TryParse(context, "ns=abc;i=42", out _), Is.False);
+            });
+        }
+
+        [Test]
+        public void MalformedXmlElementsAreNotAllEqual()
+        {
+            // Both sides failed to parse, so DeepEquals(null, null) reported
+            // equality while the hashes differed.
+            var first = XmlElement.From("<not well formed");
+            var second = XmlElement.From("<also not well formed");
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(first, Is.Not.EqualTo(second));
+                Assert.That(first, Is.EqualTo(XmlElement.From("<not well formed")));
+            });
+        }
+    }
+}

--- a/tests/Opc.Ua.Types.Tests/BuiltIn/NodeIdTests.cs
+++ b/tests/Opc.Ua.Types.Tests/BuiltIn/NodeIdTests.cs
@@ -1033,7 +1033,48 @@ namespace Opc.Ua.Types.Tests.BuiltIn
         {
             NodeId a = NodeId.Null;
             var b = new NodeId(42u);
-            Assert.That(a.CompareTo(b), Is.EqualTo(1));
+
+            // A null NodeId sorts before any value, and the comparison must be
+            // antisymmetric: both directions used to return +1.
+            Assert.That(a.CompareTo(b), Is.EqualTo(-1));
+            Assert.That(b.CompareTo(a), Is.GreaterThan(0));
+        }
+
+        [Test]
+        public void CompareToNullIsAntisymmetricForEveryIdentifierType()
+        {
+            // Only the reverse direction of a namespace zero numeric id was
+            // covered. For every other shape the un-null-checked comparisons
+            // below returned -1 as well, so both directions said "less than"
+            // and the comparer was not even transitive - a SortedSet<NodeId>
+            // could no longer find the NodeId.Null it had just inserted.
+            NodeId[] values =
+            [
+                new NodeId(42u),
+                new NodeId(42u, 2),
+                new NodeId("abc", 0),
+                new NodeId(Guid.NewGuid(), 0),
+                new NodeId(new ByteString(new byte[] { 1, 2 }), 0)
+            ];
+
+            Assert.Multiple(() =>
+            {
+                foreach (NodeId value in values)
+                {
+                    Assert.That(
+                        NodeId.Null.CompareTo(value),
+                        Is.LessThan(0),
+                        $"{value} must sort after the null node id");
+                    Assert.That(
+                        value.CompareTo(NodeId.Null),
+                        Is.GreaterThan(0),
+                        $"{value} must sort after the null node id");
+                }
+
+                var set = new SortedSet<NodeId>(values) { NodeId.Null };
+                Assert.That(set.Contains(NodeId.Null), Is.True);
+                Assert.That(set, Has.Count.EqualTo(values.Length + 1));
+            });
         }
 
         [Test]
@@ -1110,7 +1151,7 @@ namespace Opc.Ua.Types.Tests.BuiltIn
         public void CompareToStringNullWithValue()
         {
             NodeId nullId = NodeId.Null;
-            Assert.That(nullId.CompareTo("something"), Is.EqualTo(1));
+            Assert.That(nullId.CompareTo("something"), Is.EqualTo(-1));
         }
 
         [Test]
@@ -1136,7 +1177,7 @@ namespace Opc.Ua.Types.Tests.BuiltIn
         {
             NodeId nullId = NodeId.Null;
             Assert.That(nullId.CompareTo(0u), Is.Zero);
-            Assert.That(nullId.CompareTo(5u), Is.EqualTo(1));
+            Assert.That(nullId.CompareTo(5u), Is.EqualTo(-1));
         }
 
         [Test]
@@ -1162,7 +1203,7 @@ namespace Opc.Ua.Types.Tests.BuiltIn
         {
             NodeId nullId = NodeId.Null;
             Assert.That(nullId.CompareTo(Guid.Empty), Is.Zero);
-            Assert.That(nullId.CompareTo(Guid.NewGuid()), Is.EqualTo(1));
+            Assert.That(nullId.CompareTo(Guid.NewGuid()), Is.EqualTo(-1));
         }
 
         [Test]
@@ -1188,7 +1229,7 @@ namespace Opc.Ua.Types.Tests.BuiltIn
         {
             NodeId nullId = NodeId.Null;
             Assert.That(nullId.CompareTo(ByteString.Empty), Is.Zero);
-            Assert.That(nullId.CompareTo(new ByteString(new byte[] { 1 })), Is.EqualTo(1));
+            Assert.That(nullId.CompareTo(new ByteString(new byte[] { 1 })), Is.EqualTo(-1));
         }
 
         [Test]
@@ -1217,7 +1258,7 @@ namespace Opc.Ua.Types.Tests.BuiltIn
 
             // non-null nodeId vs null
             var nodeId = new NodeId(42u);
-            Assert.That(nodeId.CompareTo((object)null), Is.EqualTo(-1));
+            Assert.That(nodeId.CompareTo((object)null), Is.EqualTo(1));
         }
 
         [Test]

--- a/tests/Opc.Ua.Types.Tests/BuiltIn/VariantAuditRegressionTests.cs
+++ b/tests/Opc.Ua.Types.Tests/BuiltIn/VariantAuditRegressionTests.cs
@@ -373,11 +373,23 @@ namespace Opc.Ua.Types.Tests.BuiltIn
                     positiveZeroFloat.GetHashCode(),
                     Is.EqualTo(negativeZeroFloat.GetHashCode()));
 
+                // .NET Framework's Double.GetHashCode folds the two zeroes
+                // together but hashes the raw bits of a NaN, so a variant has
+                // to canonicalize NaN itself to keep the hash in agreement with
+                // Equals on every target framework.
                 var nan = new Variant(double.NaN);
                 var otherNan = new Variant(BitConverter.Int64BitsToDouble(
                     BitConverter.DoubleToInt64Bits(double.NaN) | 0x1));
                 Assert.That(nan, Is.EqualTo(otherNan));
                 Assert.That(nan.GetHashCode(), Is.EqualTo(otherNan.GetHashCode()));
+
+                var nanFloat = new Variant(float.NaN);
+                var otherNanFloat = new Variant(BitConverter.ToSingle(
+                    BitConverter.GetBytes(
+                        BitConverter.ToInt32(BitConverter.GetBytes(float.NaN), 0) | 0x1),
+                    0));
+                Assert.That(nanFloat, Is.EqualTo(otherNanFloat));
+                Assert.That(nanFloat.GetHashCode(), Is.EqualTo(otherNanFloat.GetHashCode()));
             });
         }
 

--- a/tests/Opc.Ua.Types.Tests/BuiltIn/VariantAuditRegressionTests.cs
+++ b/tests/Opc.Ua.Types.Tests/BuiltIn/VariantAuditRegressionTests.cs
@@ -1,0 +1,443 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using System.Collections.Generic;
+using Moq;
+using NUnit.Framework;
+
+namespace Opc.Ua.Types.Tests.BuiltIn
+{
+    /// <summary>
+    /// Regression tests for the Variant / TypeInfo / ArrayOf / MatrixOf defects
+    /// reported by the read-only bug audit of Opc.Ua.Types.
+    /// </summary>
+    [TestFixture]
+    [Category("BuiltInType")]
+    [SetCulture("en-us")]
+    [SetUICulture("en-us")]
+    [Parallelizable]
+    public class VariantAuditRegressionTests
+    {
+        private static readonly int[] s_oneTwoThree = [1, 2, 3];
+        private static readonly int[] s_sevenEight = [7, 8];
+        private static readonly int[] s_oneTwoNine = [1, 2, 9];
+
+        [Test]
+        public void TryGetDecimalSignExtendsNarrowSignedScalars()
+        {
+            // The narrow signed scalars were read through m_union.Int32, which
+            // zero extends: SByte -1 became 255 and Int16 -1 became 65535.
+            Assert.Multiple(() =>
+            {
+                Assert.That(new Variant((sbyte)-1).TryGetDecimal(out decimal sbyteValue), Is.True);
+                Assert.That(sbyteValue, Is.EqualTo(-1m));
+
+                Assert.That(new Variant((short)-1).TryGetDecimal(out decimal int16Value), Is.True);
+                Assert.That(int16Value, Is.EqualTo(-1m));
+
+                Assert.That(new Variant(short.MinValue).TryGetDecimal(out decimal minValue), Is.True);
+                Assert.That(minValue, Is.EqualTo((decimal)short.MinValue));
+
+                // Unsigned narrow types stay unsigned.
+                Assert.That(new Variant(byte.MaxValue).TryGetDecimal(out decimal byteValue), Is.True);
+                Assert.That(byteValue, Is.EqualTo(255m));
+
+                Assert.That(new Variant(ushort.MaxValue).TryGetDecimal(out decimal uint16Value), Is.True);
+                Assert.That(uint16Value, Is.EqualTo(65535m));
+            });
+        }
+
+        [Test]
+        public void CompareToDoesNotCompareRawUnionBitsOfDifferentTypes()
+        {
+            // UInt16 100 vs Double 500 used to read the low 16 bits of the
+            // double and report "greater".
+            Assert.Multiple(() =>
+            {
+                Assert.That(new Variant((ushort)100).CompareTo(new Variant(500.0)), Is.LessThan(0));
+                Assert.That(new Variant(500.0).CompareTo(new Variant((ushort)100)), Is.GreaterThan(0));
+                Assert.That(new Variant((ushort)100).CompareTo(new Variant(100.0)), Is.Zero);
+            });
+        }
+
+        [Test]
+        public void CompareToConvertsAcrossNumericWidthsAndSigns()
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(new Variant(-1).CompareTo(new Variant(1UL)), Is.LessThan(0));
+                Assert.That(new Variant(1UL).CompareTo(new Variant(-1)), Is.GreaterThan(0));
+                Assert.That(new Variant((sbyte)-5).CompareTo(new Variant(-5L)), Is.Zero);
+                Assert.That(new Variant(1.5f).CompareTo(new Variant(1.5)), Is.Zero);
+            });
+        }
+
+        [Test]
+        public void CompareToIsNotComparableForUnrelatedTypes()
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(
+                    new Variant(1).CompareTo(new Variant(new NodeId(1u))),
+                    Is.EqualTo(int.MinValue));
+                Assert.That(
+                    new Variant(double.NaN).CompareTo(new Variant(1)),
+                    Is.EqualTo(int.MinValue));
+            });
+        }
+
+        [Test]
+        public void CompareToOrdersNegativeEnumerationValues()
+        {
+            // Enumeration was compared through m_union.UInt64, so -1 read back
+            // as 4294967295 and sorted above every positive value.
+            Assert.That(
+                new Variant(new EnumValue(-1)).CompareTo(new Variant(new EnumValue(1))),
+                Is.LessThan(0));
+        }
+
+        [Test]
+        public void ValueEqualsComparesStatusCodeValue()
+        {
+            // StatusCode was not a "value type" for ValueEquals, so the fallback
+            // compared the boxed SymbolicId - null on both sides - and reported
+            // every pair of StatusCode variants as equal.
+            var good = new Variant(new StatusCode(0u));
+            var bad = new Variant(new StatusCode(0x80010000u));
+            var alsoBad = new Variant(new StatusCode(0x80010000u));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(good.ValueEquals(bad), Is.False);
+                Assert.That(bad.ValueEquals(alsoBad), Is.True);
+            });
+        }
+
+        [Test]
+        public void ValueEqualsStillComparesNumericValuesAcrossWidths()
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(new Variant((byte)1).ValueEquals(new Variant(1)), Is.True);
+                Assert.That(new Variant(-1).ValueEquals(new Variant(-1L)), Is.True);
+                Assert.That(new Variant(1.5f).ValueEquals(new Variant(1.5)), Is.True);
+                Assert.That(new Variant(1).ValueEquals(new Variant(2L)), Is.False);
+            });
+        }
+
+        [Test]
+        public void ArrayVariantIsNotReadBackAsScalarZero()
+        {
+            // TryGetValue(out EnumValue) ignored the value rank, so an Int32
+            // array fell through to it and produced the array slice metadata.
+            var value = Variant.From(s_oneTwoThree.ToArrayOf());
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(value.TryGetValue(out int scalar), Is.False);
+                Assert.That(scalar, Is.Zero);
+                Assert.That(value.TryGetValue(out EnumValue enumValue), Is.False);
+                Assert.That(enumValue.Value, Is.Zero);
+            });
+        }
+
+        [Test]
+        public void EqualsIsSymmetricAgainstNullVariant()
+        {
+            var zero = new Variant(0);
+            Variant nullVariant = Variant.Null;
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(Variant.Equals(zero, nullVariant), Is.EqualTo(Variant.Equals(nullVariant, zero)));
+                Assert.That(
+                    Variant.Equals(new Variant(5), nullVariant),
+                    Is.EqualTo(Variant.Equals(nullVariant, new Variant(5))));
+            });
+        }
+
+        [Test]
+        public void AZeroValuedScalarDoesNotEqualTheNullVariant()
+        {
+            // Making the null comparison symmetric first made it symmetrically
+            // TRUE, because the accessors hand out default(T) for a null
+            // variant. Every zero then equalled Variant.Null while staying
+            // unequal to each other, and all of them hash to zero, so a
+            // HashSet<Variant> collapsed them into whichever arrived first and
+            // Dictionary.Add threw for two semantically distinct keys.
+            Variant nullVariant = Variant.Null;
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(new Variant(0), Is.Not.EqualTo(nullVariant));
+                Assert.That(nullVariant, Is.Not.EqualTo(new Variant(0)));
+                Assert.That(new Variant(false), Is.Not.EqualTo(nullVariant));
+                Assert.That(nullVariant, Is.Not.EqualTo(new Variant(false)));
+                Assert.That(new Variant(0.0), Is.Not.EqualTo(nullVariant));
+                Assert.That(nullVariant, Is.Not.EqualTo(new Variant(0.0)));
+                Assert.That(new Variant(0L), Is.Not.EqualTo(nullVariant));
+                Assert.That(new Variant(0u), Is.Not.EqualTo(nullVariant));
+
+                Assert.That(
+                    new HashSet<Variant> { nullVariant, new Variant(0), new Variant(false) },
+                    Has.Count.EqualTo(3));
+
+                // A typed variant whose reference payload is absent still equals
+                // the null variant - that is what a null bodied ExtensionObject
+                // round trips to.
+                Assert.That(nullVariant, Is.EqualTo(new Variant((string)null)));
+                Assert.That(new Variant((string)null), Is.EqualTo(nullVariant));
+            });
+        }
+
+        [Test]
+        public void ComparisonOperatorsAreFalseForIncomparableVariants()
+        {
+            // CompareTo signals "not comparable" with int.MinValue, which is its
+            // own negation, so reading it as an ordinary negative number made
+            // both a < b and b < a true at the same time.
+            var nan = new Variant(float.NaN);
+            var one = new Variant(1.0);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(nan < one, Is.False);
+                Assert.That(nan <= one, Is.False);
+                Assert.That(nan > one, Is.False);
+                Assert.That(nan >= one, Is.False);
+                Assert.That(one < nan, Is.False);
+                Assert.That(one > nan, Is.False);
+
+                // ordinary comparisons are unaffected.
+                Assert.That(new Variant(1) < new Variant(2), Is.True);
+                Assert.That(new Variant(2) > new Variant(1), Is.True);
+                Assert.That(new Variant(1) <= new Variant(1), Is.True);
+            });
+        }
+
+        [Test]
+        public void ExpandEnumerationArrayYieldsItsElements()
+        {
+            // Expand() routed Enumeration arrays through GetVariantArray, which
+            // cannot read them, and returned a null array.
+            var values = new[] { new EnumValue(1), new EnumValue(2) }.ToArrayOf();
+            var variant = new Variant(values);
+
+            ArrayOf<Variant> expanded = variant.Expand();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(expanded.IsNull, Is.False);
+                Assert.That(expanded.Count, Is.EqualTo(2));
+                Assert.That(expanded[0].GetEnumeration().Value, Is.EqualTo(1));
+                Assert.That(expanded[1].GetEnumeration().Value, Is.EqualTo(2));
+            });
+        }
+
+        [Test]
+        public void ConvertToEnumerationArrayProducesValues()
+        {
+            var values = new[] { new EnumValue(7), new EnumValue(8) }.ToArrayOf();
+            var variant = new Variant(values);
+
+            Variant converted = variant.ConvertTo(BuiltInType.Int32);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(converted.IsNull, Is.False);
+                Assert.That(converted.GetInt32Array().ToArray(), Is.EqualTo(s_sevenEight));
+            });
+        }
+
+        [Test]
+        public void MatrixOfReferenceTypeAcceptsNullElements()
+        {
+            // MatrixOf<T>(Array) threw ArgumentException for any null element,
+            // so a string matrix with unset entries could not be created.
+            var source = new string[2, 2];
+            source[0, 0] = "a";
+
+            MatrixOf<string> matrix = source.ToMatrixOf();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(matrix.Count, Is.EqualTo(4));
+                Assert.That(matrix.Span[0], Is.EqualTo("a"));
+                Assert.That(matrix.Span[1], Is.Null);
+            });
+        }
+
+        [Test]
+        public void MatrixOfValueTypeStillRejectsNullElements()
+        {
+            var source = new object[1, 1];
+
+            Assert.Throws<ArgumentException>(() => _ = ToIntMatrix(source));
+
+            static MatrixOf<int> ToIntMatrix(Array array)
+            {
+                return MatrixOf<int>.CreateFromArray(array);
+            }
+        }
+
+        [Test]
+        public void IsInstanceOfDataTypeAcceptsEnumerationVariantForEnumerationDataType()
+        {
+            var value = new Variant(new EnumValue(3));
+
+            TypeInfo result = TypeInfo.IsInstanceOfDataType(
+                value,
+                new NodeId(DataTypes.Enumeration),
+                ValueRanks.Scalar,
+                new NamespaceTable(),
+                new Mock<ITypeTable>().Object);
+
+            Assert.That(result.IsUnknown, Is.False);
+        }
+
+        [Test]
+        public void NullMatrixVariantEqualsItself()
+        {
+            // A default MatrixOf<T> has no dimensions, so its type info has a
+            // value rank that is neither scalar, array nor matrix. Equals fell
+            // through every branch and reported the variant as not equal even
+            // to an identical one.
+            var variant = new Variant(default(MatrixOf<bool>));
+            var same = new Variant(default(MatrixOf<bool>));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(variant.TypeInfo.BuiltInType, Is.EqualTo(BuiltInType.Boolean));
+                Assert.That(variant, Is.EqualTo(same));
+                Assert.That(
+                    variant,
+                    Is.Not.EqualTo(new Variant(default(MatrixOf<int>))));
+            });
+        }
+
+        [Test]
+        public void ByteArrayAndByteStringHashAlike()
+        {
+            byte[] bytes = [1, 2, 3];
+            var asArray = Variant.From(bytes.ToArrayOf());
+            var asByteString = Variant.From(new ByteString(bytes));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(asArray, Is.EqualTo(asByteString));
+                Assert.That(asArray.GetHashCode(), Is.EqualTo(asByteString.GetHashCode()));
+            });
+        }
+
+        [Test]
+        public void SignedZeroAndNaNHashConsistentlyWithEquals()
+        {
+            Assert.Multiple(() =>
+            {
+                var positiveZero = new Variant(0.0);
+                var negativeZero = new Variant(-0.0);
+                Assert.That(positiveZero, Is.EqualTo(negativeZero));
+                Assert.That(positiveZero.GetHashCode(), Is.EqualTo(negativeZero.GetHashCode()));
+
+                var positiveZeroFloat = new Variant(0.0f);
+                var negativeZeroFloat = new Variant(-0.0f);
+                Assert.That(positiveZeroFloat, Is.EqualTo(negativeZeroFloat));
+                Assert.That(
+                    positiveZeroFloat.GetHashCode(),
+                    Is.EqualTo(negativeZeroFloat.GetHashCode()));
+
+                var nan = new Variant(double.NaN);
+                var otherNan = new Variant(BitConverter.Int64BitsToDouble(
+                    BitConverter.DoubleToInt64Bits(double.NaN) | 0x1));
+                Assert.That(nan, Is.EqualTo(otherNan));
+                Assert.That(nan.GetHashCode(), Is.EqualTo(otherNan.GetHashCode()));
+            });
+        }
+
+        [Test]
+        public void BitwiseOperatorsReadTheRightHandOperandThroughItsOwnType()
+        {
+            // The right hand operand's payload was read through the left
+            // operand's union field, so 0x100 masked as a byte became 0.
+            var lhs = new Variant((byte)0xFF);
+            var rhs = new Variant(0x0100);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That((lhs & rhs).GetByte(), Is.Zero);
+                Assert.That((lhs | rhs).GetByte(), Is.EqualTo((byte)0xFF));
+
+                // A non integer right hand operand is not usable at all.
+                Assert.That((lhs & new Variant("text")).IsNull, Is.True);
+            });
+        }
+
+        [Test]
+        public void BitwiseOperatorsKeepTheLeftHandOperandType()
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(
+                    (new Variant((sbyte)-1) & new Variant((sbyte)0x0F)).TypeInfo.BuiltInType,
+                    Is.EqualTo(BuiltInType.SByte));
+                Assert.That(
+                    (new Variant((sbyte)-1) & new Variant((sbyte)0x0F)).GetSByte(),
+                    Is.EqualTo((sbyte)0x0F));
+                Assert.That(
+                    (new Variant((ushort)0xFF00) | new Variant((ushort)0x00FF)).GetUInt16(),
+                    Is.EqualTo((ushort)0xFFFF));
+            });
+        }
+
+        [Test]
+        public void NullExtensionObjectArrayStaysNullWhenReadAsStructures()
+        {
+            // GetStructureArray turned a null ExtensionObject array into an
+            // empty array, losing the distinction.
+            var variant = new Variant(default(ArrayOf<ExtensionObject>));
+
+            ArrayOf<ReadValueId> structures = variant.GetStructureArray<ReadValueId>();
+
+            Assert.That(structures.IsNull, Is.True);
+        }
+
+        [Test]
+        public void ReplaceItemRejectsIndexEqualToCount()
+        {
+            ArrayOf<int> array = s_oneTwoThree.ToArrayOf();
+
+            Assert.Multiple(() =>
+            {
+                Assert.Throws<ArgumentOutOfRangeException>(() => array.ReplaceItem(9, 3));
+                Assert.That(array.ReplaceItem(9, 2).ToArray(), Is.EqualTo(s_oneTwoNine));
+            });
+        }
+    }
+}

--- a/tests/Opc.Ua.Types.Tests/BuiltIn/VariantAuditRegressionTests.cs
+++ b/tests/Opc.Ua.Types.Tests/BuiltIn/VariantAuditRegressionTests.cs
@@ -218,6 +218,46 @@ namespace Opc.Ua.Types.Tests.BuiltIn
         }
 
         [Test]
+        public void CompareToOrdersTheNullVariantConsistentlyWithEquals()
+        {
+            // CompareTo substituted the typed side's type info and then read
+            // the null variant's zeroed union storage, so it reported equality
+            // for every zero valued scalar while Equals reported them distinct.
+            // A SortedSet keyed on CompareTo therefore still collapsed them.
+            Variant nullVariant = Variant.Null;
+
+            Assert.Multiple(() =>
+            {
+                foreach (Variant zero in new[]
+                {
+                    new Variant(0),
+                    new Variant(false),
+                    new Variant(0.0),
+                    new Variant(0L)
+                })
+                {
+                    Assert.That(
+                        nullVariant.CompareTo(zero),
+                        Is.LessThan(0),
+                        $"{zero.TypeInfo.BuiltInType} must sort after the null variant");
+                    Assert.That(
+                        zero.CompareTo(nullVariant),
+                        Is.GreaterThan(0),
+                        $"{zero.TypeInfo.BuiltInType} must sort after the null variant");
+                }
+
+                Assert.That(
+                    new SortedSet<Variant> { nullVariant, new Variant(0), new Variant(false) },
+                    Has.Count.EqualTo(3));
+
+                // and the order agrees with Equals where Equals says equal.
+                Assert.That(nullVariant.CompareTo(new Variant((string)null)), Is.Zero);
+                Assert.That(new Variant((string)null).CompareTo(nullVariant), Is.Zero);
+                Assert.That(nullVariant.CompareTo(nullVariant), Is.Zero);
+            });
+        }
+
+        [Test]
         public void ComparisonOperatorsAreFalseForIncomparableVariants()
         {
             // CompareTo signals "not comparable" with int.MinValue, which is its

--- a/tests/Opc.Ua.Types.Tests/BuiltIn/VariantCoverageTests.cs
+++ b/tests/Opc.Ua.Types.Tests/BuiltIn/VariantCoverageTests.cs
@@ -539,10 +539,12 @@ namespace Opc.Ua.Types.Tests.BuiltIn
         {
             Assert.Multiple(() =>
             {
-                Assert.That((new Variant((byte)0b1100) & new Variant((byte)0b1010)).GetInt32(), Is.EqualTo(0b1000));
-                Assert.That((new Variant((sbyte)0b0110) & new Variant((sbyte)0b0011)).GetInt32(), Is.EqualTo(0b0010));
-                Assert.That((new Variant((short)0b1100) & new Variant((short)0b1010)).GetInt32(), Is.EqualTo(0b1000));
-                Assert.That((new Variant((ushort)0b1100) & new Variant((ushort)0b1010)).GetInt32(), Is.EqualTo(0b1000));
+                // The result keeps the type of the left hand operand instead of
+                // widening 8/16 bit operands to Int32.
+                Assert.That((new Variant((byte)0b1100) & new Variant((byte)0b1010)).GetByte(), Is.EqualTo((byte)0b1000));
+                Assert.That((new Variant((sbyte)0b0110) & new Variant((sbyte)0b0011)).GetSByte(), Is.EqualTo((sbyte)0b0010));
+                Assert.That((new Variant((short)0b1100) & new Variant((short)0b1010)).GetInt16(), Is.EqualTo((short)0b1000));
+                Assert.That((new Variant((ushort)0b1100) & new Variant((ushort)0b1010)).GetUInt16(), Is.EqualTo((ushort)0b1000));
                 Assert.That((new Variant(0b1100u) & new Variant(0b1010u)).GetUInt32(), Is.EqualTo(0b1000u));
                 Assert.That((new Variant(0b1100L) & new Variant(0b1010L)).GetInt64(), Is.EqualTo(0b1000L));
                 Assert.That((new Variant(0b1100UL) & new Variant(0b1010UL)).GetUInt64(), Is.EqualTo(0b1000UL));
@@ -557,10 +559,12 @@ namespace Opc.Ua.Types.Tests.BuiltIn
         {
             Assert.Multiple(() =>
             {
-                Assert.That((new Variant((byte)0b1100) | new Variant((byte)0b1010)).GetInt32(), Is.EqualTo(0b1110));
-                Assert.That((new Variant((sbyte)0b0110) | new Variant((sbyte)0b0011)).GetInt32(), Is.EqualTo(0b0111));
-                Assert.That((new Variant((short)0b1100) | new Variant((short)0b1010)).GetInt32(), Is.EqualTo(0b1110));
-                Assert.That((new Variant((ushort)0b1100) | new Variant((ushort)0b1010)).GetInt32(), Is.EqualTo(0b1110));
+                // The result keeps the type of the left hand operand instead of
+                // widening 8/16 bit operands to Int32.
+                Assert.That((new Variant((byte)0b1100) | new Variant((byte)0b1010)).GetByte(), Is.EqualTo((byte)0b1110));
+                Assert.That((new Variant((sbyte)0b0110) | new Variant((sbyte)0b0011)).GetSByte(), Is.EqualTo((sbyte)0b0111));
+                Assert.That((new Variant((short)0b1100) | new Variant((short)0b1010)).GetInt16(), Is.EqualTo((short)0b1110));
+                Assert.That((new Variant((ushort)0b1100) | new Variant((ushort)0b1010)).GetUInt16(), Is.EqualTo((ushort)0b1110));
                 Assert.That((new Variant(0b1100u) | new Variant(0b1010u)).GetUInt32(), Is.EqualTo(0b1110u));
                 Assert.That((new Variant(0b1100L) | new Variant(0b1010L)).GetInt64(), Is.EqualTo(0b1110L));
                 Assert.That((new Variant(0b1100UL) | new Variant(0b1010UL)).GetUInt64(), Is.EqualTo(0b1110UL));

--- a/tests/Opc.Ua.Types.Tests/BuiltIn/VariantStorageTests.cs
+++ b/tests/Opc.Ua.Types.Tests/BuiltIn/VariantStorageTests.cs
@@ -257,7 +257,9 @@ namespace Opc.Ua.Types.Tests.BuiltIn
                 Assert.That(actual.GetQualifiedName().Name, Is.Null);
                 Assert.That(actual.GetHashCode(), Is.Zero);
                 Assert.That(actual.ToString(), Is.EqualTo("<null>"));
-                Assert.That(new Variant(1UL).CompareTo(actual), Is.EqualTo(1UL.CompareTo(bits)));
+                // A UInt64 is not comparable to a QualifiedName/NodeId/ByteString/
+                // LocalizedText variant - the raw union payload must never be used.
+                Assert.That(new Variant(1UL).CompareTo(actual), Is.EqualTo(int.MinValue));
                 Assert.That(actual.GetNodeId(), Is.EqualTo(expected.GetNodeId()));
                 Assert.That(actual.GetQualifiedName(), Is.EqualTo(expected.GetQualifiedName()));
                 Assert.That(actual.GetByteString(), Is.EqualTo(expected.GetByteString()));
@@ -266,8 +268,10 @@ namespace Opc.Ua.Types.Tests.BuiltIn
                 Assert.That(actual.ToString(), Is.EqualTo(expected.ToString()));
                 Assert.That(actual.ValueEquals(default), Is.EqualTo(expected.ValueEquals(default)));
                 Assert.That(new Variant(1UL).CompareTo(actual), Is.EqualTo(new Variant(1UL).CompareTo(expected)));
-                Assert.That((new Variant(ulong.MaxValue) & actual).GetUInt64(), Is.EqualTo(bits));
-                Assert.That((new Variant(0UL) | actual).GetUInt64(), Is.EqualTo(bits));
+                // The bitwise operators read the right hand operand through its
+                // own type, so a non integer operand yields a null variant.
+                Assert.That((new Variant(ulong.MaxValue) & actual).IsNull, Is.True);
+                Assert.That((new Variant(0UL) | actual).IsNull, Is.True);
             }
         }
 

--- a/tests/Opc.Ua.Types.Tests/BuiltIn/XmlElementTests.cs
+++ b/tests/Opc.Ua.Types.Tests/BuiltIn/XmlElementTests.cs
@@ -274,14 +274,27 @@ namespace Opc.Ua.Types.Tests.BuiltIn
         }
 
         [Test]
-        public void XmlElementGetHashCodeShouldReturnCorrectHashCode()
+        public void XmlElementGetHashCodeShouldAgreeWithEquals()
         {
+            // The hash used to be the hash of the raw text, which broke the
+            // Equals/GetHashCode contract: Equals compares structurally, so two
+            // elements that differ only in quote character or an entity are
+            // equal and must hash the same.
             const string xmlString = "<root></root>";
             var xmlElement = new XmlElement(xmlString);
 
-            Assert.That(
-                xmlElement.GetHashCode(),
-                Is.EqualTo(xmlString.GetHashCode(StringComparison.Ordinal)));
+            Assert.Multiple(() =>
+            {
+                Assert.That(
+                    xmlElement.GetHashCode(),
+                    Is.EqualTo(new XmlElement(xmlString).GetHashCode()));
+                Assert.That(
+                    XmlElement.From("<a x='1'/>").GetHashCode(),
+                    Is.EqualTo(XmlElement.From("<a x=\"1\"/>").GetHashCode()));
+                Assert.That(
+                    XmlElement.From("<root></root>").GetHashCode(),
+                    Is.Not.EqualTo(XmlElement.From("<other></other>").GetHashCode()));
+            });
         }
 
         [Test]

--- a/tests/Opc.Ua.Types.Tests/Encoders/BinaryDecoderTests.cs
+++ b/tests/Opc.Ua.Types.Tests/Encoders/BinaryDecoderTests.cs
@@ -4114,7 +4114,33 @@ namespace Opc.Ua.Types.Tests.Encoders
         [Test]
         public void ReadDiagnosticInfoThrowsWhenInnerDepthExceedsMaxInnerDepth()
         {
-            // Arrange
+            // Arrange - a hand crafted chain that is one level deeper than the
+            // encoder would ever write.
+            ITelemetryContext telemetryContext = NUnitTelemetryContext.Create();
+            var messageContext = ServiceMessageContext.CreateEmpty(telemetryContext);
+
+            var buffer = new List<byte>();
+            for (int ii = 0; ii <= DiagnosticInfo.MaxInnerDepth + 1; ii++)
+            {
+                buffer.Add(0x40); // InnerDiagnosticInfo present
+            }
+            buffer.Add(0x00); // innermost has no fields
+
+            using var decoder = new BinaryDecoder(buffer.ToArray(), messageContext);
+
+            // Act
+            ServiceResultException ex = Assert.Throws<ServiceResultException>(() => decoder.ReadDiagnosticInfo(null));
+
+            // Assert
+            Assert.That(ex.StatusCode, Is.EqualTo(StatusCodes.BadEncodingLimitsExceeded));
+        }
+
+        [Test]
+        public void ReadDiagnosticInfoAcceptsEveryLevelTheEncoderWrites()
+        {
+            // Regression: the encoder emits an InnerDiagnosticInfo while
+            // depth < MaxInnerDepth, so the deepest child it writes sits at
+            // depth == MaxInnerDepth. The decoder used to reject that level.
             ITelemetryContext telemetryContext = NUnitTelemetryContext.Create();
             var messageContext = ServiceMessageContext.CreateEmpty(telemetryContext);
             DiagnosticInfo diagnosticInfo = CreateDiagnosticInfoChain(DiagnosticInfo.MaxInnerDepth);
@@ -4125,11 +4151,10 @@ namespace Opc.Ua.Types.Tests.Encoders
 
             using var decoder = new BinaryDecoder(buffer, messageContext);
 
-            // Act
-            ServiceResultException ex = Assert.Throws<ServiceResultException>(() => decoder.ReadDiagnosticInfo(null));
+            DiagnosticInfo decoded = decoder.ReadDiagnosticInfo(null);
 
-            // Assert
-            Assert.That(ex.StatusCode, Is.EqualTo(StatusCodes.BadEncodingLimitsExceeded));
+            Assert.That(decoded, Is.Not.Null);
+            Assert.That(CountDiagnosticInfoDepth(decoded), Is.EqualTo(DiagnosticInfo.MaxInnerDepth + 1));
         }
 
         [Test]

--- a/tests/Opc.Ua.Types.Tests/Encoders/CodecAuditRegressionTests.cs
+++ b/tests/Opc.Ua.Types.Tests/Encoders/CodecAuditRegressionTests.cs
@@ -1,0 +1,569 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Xml;
+using NUnit.Framework;
+using Opc.Ua.Tests;
+
+namespace Opc.Ua.Types.Tests.Encoders
+{
+    /// <summary>
+    /// Regression tests for the binary and XML codec defects reported by the
+    /// read-only bug audit of Opc.Ua.Types.
+    /// </summary>
+    [TestFixture]
+    [Category("Encoders")]
+    [SetCulture("en-us")]
+    [SetUICulture("en-us")]
+    [Parallelizable]
+    public class CodecAuditRegressionTests
+    {
+        private const string kNs = Namespaces.OpcUaXsd;
+
+        private static ServiceMessageContext CreateContext()
+        {
+            ITelemetryContext telemetry = NUnitTelemetryContext.Create();
+            var context = ServiceMessageContext.CreateEmpty(telemetry);
+            context.Factory.AddEncodeableType(typeof(Sample));
+            return context;
+        }
+
+        [Test]
+        [CancelAfter(30000)]
+        public void ReadVariantValueThrowsForTextOnlyContentInsteadOfSpinning()
+        {
+            // The whitespace skip loop called Read() until an Element appeared,
+            // but Read() returns false at EOF with NodeType None - so a Value
+            // element that carries text instead of a typed child element made
+            // the decoder spin forever.
+            ServiceMessageContext context = CreateContext();
+            const string xml = "<Value xmlns=\"" + kNs + "\">not an element</Value>";
+
+            using var decoder = new XmlDecoder(
+                XmlReader.Create(
+                    new StringReader(xml),
+                    CoreUtils.DefaultXmlReaderSettings()),
+                context);
+            decoder.PushNamespace(kNs);
+
+            ServiceResultException ex = Assert.Throws<ServiceResultException>(
+                () => decoder.ReadVariant("Value"));
+            Assert.That(ex.StatusCode, Is.EqualTo((StatusCode)StatusCodes.BadDecodingError));
+        }
+
+        [Test]
+        public void EncodeableMatrixUsesTheFieldNameNotTheLiteralMatrix()
+        {
+            // WriteEncodeableMatrix hard-coded the element name "Matrix", so a
+            // structure field with any other name could not be decoded.
+            ServiceMessageContext context = CreateContext();
+            Sample[] elements = [new Sample { Value = 1 }, new Sample { Value = 2 }];
+            var input = new MatrixOf<Sample>(elements, [1, 2]);
+
+            string xml;
+            using (var encoder = new XmlEncoder(context))
+            {
+                encoder.PushNamespace(kNs);
+                encoder.WriteEncodeableMatrix("Samples", input);
+                encoder.PopNamespace();
+                xml = encoder.CloseAndReturnText();
+            }
+
+            Assert.That(xml, Does.Contain("Samples"));
+
+            using var decoder = new XmlParser(xml, context);
+            decoder.PushNamespace(kNs);
+            MatrixOf<Sample> output = decoder.ReadEncodeableMatrix<Sample>("Samples");
+            decoder.PopNamespace();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(output.Count, Is.EqualTo(2));
+                Assert.That(output.Span[0].Value, Is.EqualTo(1));
+                Assert.That(output.Span[1].Value, Is.EqualTo(2));
+            });
+        }
+
+        [Test]
+        public void BinaryEncoderAppliesMaxStringLengthToTheEncodedLength()
+        {
+            // The encoder counted UTF-16 chars while the decoder counts UTF-8
+            // bytes, so a non ASCII string could encode and fail to decode.
+            ServiceMessageContext context = CreateContext();
+            context.MaxStringLength = 10;
+            string value = new('ä', 10); // 10 chars, 20 UTF-8 bytes
+
+            using var encoder = new BinaryEncoder(context);
+
+            ServiceResultException ex = Assert.Throws<ServiceResultException>(
+                () => encoder.WriteString("Value", value));
+            Assert.That(
+                ex.StatusCode,
+                Is.EqualTo((StatusCode)StatusCodes.BadEncodingLimitsExceeded));
+        }
+
+        [Test]
+        public void BinaryEncoderStillAcceptsAStringWithinTheEncodedLimit()
+        {
+            ServiceMessageContext context = CreateContext();
+            context.MaxStringLength = 10;
+
+            using var encoder = new BinaryEncoder(context);
+            Assert.DoesNotThrow(() => encoder.WriteString("Value", new string('a', 10)));
+        }
+
+        [Test]
+        public void EncodeableMatrixWithInconsistentDimensionsIsADecodingError()
+        {
+            // MatrixOf throws ArgumentException for wire dimensions that do not
+            // match the payload; that must surface as BadDecodingError.
+            ServiceMessageContext context = CreateContext();
+            Sample[] elements = [new Sample { Value = 1 }, new Sample { Value = 2 }];
+            var input = new MatrixOf<Sample>(elements, [1, 2]);
+
+            string xml;
+            using (var encoder = new XmlEncoder(context))
+            {
+                encoder.PushNamespace(kNs);
+                encoder.WriteEncodeableMatrix("Samples", input);
+                encoder.PopNamespace();
+                xml = encoder.CloseAndReturnText();
+            }
+
+            // Claim three columns for a payload that only carries two elements.
+            string tampered = xml.Replace(
+                "<Int32>2</Int32>",
+                "<Int32>3</Int32>",
+                StringComparison.Ordinal);
+            Assert.That(tampered, Is.Not.EqualTo(xml));
+
+            using var parser = new XmlParser(tampered, context);
+            parser.PushNamespace(kNs);
+            ServiceResultException ex = Assert.Throws<ServiceResultException>(
+                () => parser.ReadEncodeableMatrix<Sample>("Samples"));
+            Assert.That(ex.StatusCode, Is.EqualTo((StatusCode)StatusCodes.BadDecodingError));
+        }
+
+        [Test]
+        public void ByteStringArrayLengthIsCheckedAgainstMaxArrayLength()
+        {
+            // The element count was compared against MaxByteStringLength.
+            ServiceMessageContext context = CreateContext();
+            context.MaxArrayLength = 1;
+            context.MaxByteStringLength = 1024;
+
+            const string xml =
+                "<ListOfByteString xmlns=\"" + kNs + "\">" +
+                "<ByteString>AQ==</ByteString>" +
+                "<ByteString>Ag==</ByteString>" +
+                "</ListOfByteString>";
+
+            using var parser = new XmlParser(xml, context);
+            parser.PushNamespace(kNs);
+
+            ServiceResultException ex = Assert.Throws<ServiceResultException>(
+                () => parser.ReadByteStringArray("ListOfByteString"));
+            Assert.That(
+                ex.StatusCode,
+                Is.EqualTo((StatusCode)StatusCodes.BadEncodingLimitsExceeded));
+        }
+
+        [Test]
+        public void PreEncodedExtensionObjectBodyIsNotLimitedByMaxByteStringLength()
+        {
+            // The buffer-writer encoder wrote the pre-encoded body through
+            // WriteByteString, applying a limit that neither the seekable
+            // stream path nor the decoder applies.
+            ServiceMessageContext context = CreateContext();
+            context.MaxByteStringLength = 2; // the body is a 4 byte Int32
+
+            using var encoder = new BinaryEncoder(context);
+            Assert.DoesNotThrow(
+                () => encoder.WriteExtensionObject(
+                    "Body",
+                    new ExtensionObject(new Sample { Value = 7 })));
+        }
+
+        [Test]
+        public void PreEncodedExtensionObjectBodyRoundTrips()
+        {
+            ServiceMessageContext context = CreateContext();
+
+            byte[] buffer;
+            using (var encoder = new BinaryEncoder(context))
+            {
+                encoder.WriteExtensionObject(
+                    "Body",
+                    new ExtensionObject(new Sample { Value = 7 }));
+                buffer = encoder.CloseAndReturnBuffer();
+            }
+
+            using var decoder = new BinaryDecoder(buffer, context);
+            ExtensionObject decoded = decoder.ReadExtensionObject("Body");
+
+            Assert.That(decoded.TryGetValue(out Sample sample), Is.True);
+            Assert.That(sample.Value, Is.EqualTo(7));
+        }
+
+        [Test]
+        public void NestedXmlDecoderInheritsTheNamespaceMappings()
+        {
+            // An ExtensionObject with an XML body was decoded by a fresh
+            // XmlDecoder that had no mapping tables, so node ids in the body
+            // were not remapped.
+            ServiceMessageContext context = CreateContext();
+            const string xml = "<NodeId xmlns=\"" + kNs + "\"><Identifier>ns=1;i=5</Identifier></NodeId>";
+
+            using var decoder = new XmlDecoder(
+                XmlReader.Create(
+                    new StringReader(xml),
+                    CoreUtils.DefaultXmlReaderSettings()),
+                context);
+            decoder.InheritDecodingState([0, 3], null, 0);
+            decoder.PushNamespace(kNs);
+
+            NodeId value = decoder.ReadNodeId("NodeId");
+
+            Assert.That(value.NamespaceIndex, Is.EqualTo((ushort)3));
+        }
+
+        [Test]
+        public void ReadEncodeableRejectsAWireTypeThatIsNotTheRequestedType()
+        {
+            // The activator result was cast unchecked, producing an
+            // InvalidCastException instead of a decoding error.
+            ServiceMessageContext context = CreateContext();
+
+            byte[] buffer;
+            using (var encoder = new BinaryEncoder(context))
+            {
+                encoder.WriteEncodeable("Value", new Sample { Value = 1 }, Sample.TypeIdStatic);
+                buffer = encoder.CloseAndReturnBuffer();
+            }
+
+            using var decoder = new BinaryDecoder(buffer, context);
+
+            ServiceResultException ex = Assert.Throws<ServiceResultException>(
+                () => decoder.ReadEncodeable<ReadValueId>(null, Sample.TypeIdStatic));
+            Assert.That(ex.StatusCode, Is.EqualTo((StatusCode)StatusCodes.BadDecodingError));
+        }
+
+        [Test]
+        public void Base64ByteStringIsNotGatedByMaxStringLength()
+        {
+            // XmlParser read the base64 text through the String limit, so blobs
+            // well within MaxByteStringLength failed to load.
+            ServiceMessageContext context = CreateContext();
+            context.MaxStringLength = 8;
+            context.MaxByteStringLength = 1024;
+
+            byte[] payload = new byte[64];
+            for (int ii = 0; ii < payload.Length; ii++)
+            {
+                payload[ii] = (byte)ii;
+            }
+
+            string xml =
+                "<ByteString xmlns=\"" + kNs + "\">" +
+                Convert.ToBase64String(payload) +
+                "</ByteString>";
+
+            using var parser = new XmlParser(xml, context);
+            parser.PushNamespace(kNs);
+
+            ByteString value = parser.ReadByteString("ByteString");
+
+            Assert.That(value.ToArray(), Is.EqualTo(payload));
+        }
+
+        [Test]
+        public void WhitespaceOnlyStringIsWrittenOut()
+        {
+            // The encoder dropped the content of a whitespace only string,
+            // turning it into an empty string on the wire.
+            ServiceMessageContext context = CreateContext();
+
+            string xml;
+            using (var encoder = new XmlEncoder(context))
+            {
+                encoder.PushNamespace(kNs);
+                encoder.WriteString("Value", "   ");
+                encoder.PopNamespace();
+                xml = encoder.CloseAndReturnText();
+            }
+
+            Assert.That(xml, Does.Contain("   "));
+        }
+
+        [Test]
+        public void XmlStringLengthIsMeasuredInBytesNotCharacters()
+        {
+            // The XML codec counted UTF-16 code units while the binary and JSON
+            // codecs count UTF-8 bytes, so one context gave two answers and a
+            // string a binary peer rejects survived an XML round trip.
+            // MaxStringLength is a byte count per Part 3 5.6.4 and Part 5 6.3.2.
+            ServiceMessageContext context = CreateContext();
+            context.MaxStringLength = 4;
+
+            // Three characters, six UTF-8 bytes.
+            const string text = "äöü";
+
+            using var encoder = new XmlEncoder(context);
+            encoder.PushNamespace(kNs);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(
+                    Assert.Throws<ServiceResultException>(
+                        () => encoder.WriteString("Value", text)).StatusCode,
+                    Is.EqualTo((StatusCode)StatusCodes.BadEncodingLimitsExceeded));
+
+                Assert.That(
+                    Assert.Throws<ServiceResultException>(
+                        () => ReadStringFromXml(text, context, useParser: false)).StatusCode,
+                    Is.EqualTo((StatusCode)StatusCodes.BadEncodingLimitsExceeded));
+                Assert.That(
+                    Assert.Throws<ServiceResultException>(
+                        () => ReadStringFromXml(text, context, useParser: true)).StatusCode,
+                    Is.EqualTo((StatusCode)StatusCodes.BadEncodingLimitsExceeded));
+            });
+        }
+
+        [Test]
+        public void XmlStringAtExactlyTheByteLimitIsAccepted()
+        {
+            ServiceMessageContext context = CreateContext();
+            context.MaxStringLength = 6;
+            const string text = "äöü";
+
+            using var encoder = new XmlEncoder(context);
+            encoder.PushNamespace(kNs);
+
+            Assert.Multiple(() =>
+            {
+                Assert.DoesNotThrow(() => encoder.WriteString("Value", text));
+                Assert.That(ReadStringFromXml(text, context, useParser: false), Is.EqualTo(text));
+                Assert.That(ReadStringFromXml(text, context, useParser: true), Is.EqualTo(text));
+            });
+        }
+
+        private static string ReadStringFromXml(
+            string text,
+            IServiceMessageContext context,
+            bool useParser)
+        {
+            string document =
+                $"<Value xmlns=\"{kNs}\">{text}</Value>";
+
+            if (useParser)
+            {
+                using var parser = new XmlParser(document, context);
+                parser.PushNamespace(kNs);
+                return parser.ReadString("Value");
+            }
+
+            using var decoder = new XmlDecoder(
+                XmlReader.Create(
+                    new StringReader(document),
+                    CoreUtils.DefaultXmlReaderSettings()),
+                context);
+            decoder.PushNamespace(kNs);
+            return decoder.ReadString("Value");
+        }
+
+        [Test]
+        public void EqualXmlElementsHashTheSame()
+        {
+            // Equals compares structurally through XNode.DeepEquals, which
+            // ignores the quote character, character entities, insignificant
+            // whitespace inside the tag and an XML declaration, while
+            // GetHashCode hashed the raw text - so two equal elements landed in
+            // different buckets of every hash container.
+            var pairs = new[]
+            {
+                (XmlElement.From("<a x='1'/>"), XmlElement.From("<a x=\"1\"/>")),
+                (XmlElement.From("<a>&#65;</a>"), XmlElement.From("<a>A</a>")),
+                (XmlElement.From("<a   x=\"1\"  />"), XmlElement.From("<a x=\"1\"/>")),
+                (
+                    XmlElement.From("<?xml version=\"1.0\"?><a x=\"1\"/>"),
+                    XmlElement.From("<a x=\"1\"/>")
+                )
+            };
+
+            Assert.Multiple(() =>
+            {
+                foreach ((XmlElement first, XmlElement second) in pairs)
+                {
+                    Assert.That(first, Is.EqualTo(second), $"{first} vs {second}");
+                    Assert.That(
+                        first.GetHashCode(),
+                        Is.EqualTo(second.GetHashCode()),
+                        $"{first} vs {second}");
+                }
+
+                // Unequal elements still hash apart, and a malformed document
+                // is hashed by its text, matching how Equals compares it.
+                Assert.That(
+                    XmlElement.From("<a>1</a>").GetHashCode(),
+                    Is.Not.EqualTo(XmlElement.From("<a>2</a>").GetHashCode()));
+                Assert.That(
+                    XmlElement.From("<not well formed").GetHashCode(),
+                    Is.EqualTo(XmlElement.From("<not well formed").GetHashCode()));
+            });
+        }
+
+        [Test]
+        public void MalformedXmlElementIsRejectedInsteadOfWrittenRaw()
+        {
+            // WriteRaw bypasses the writer's checks, so an unparsable body was
+            // written verbatim and produced a document no decoder can read.
+            ServiceMessageContext context = CreateContext();
+
+            using var encoder = new XmlEncoder(context);
+            encoder.PushNamespace(kNs);
+
+            ServiceResultException ex = Assert.Throws<ServiceResultException>(
+                () => encoder.WriteXmlElement("Body", XmlElement.From("<not well formed")));
+            Assert.That(ex.StatusCode, Is.EqualTo((StatusCode)StatusCodes.BadEncodingError));
+        }
+
+        [Test]
+        public void CloseThenDisposeDoesNotFlushADisposedWriter()
+        {
+            // Close() disposed the writer but kept the reference, so Dispose()
+            // flushed it again - which throws for every owned stream that is
+            // not a MemoryStream.
+            ServiceMessageContext context = CreateContext();
+            var stream = new ThrowAfterDisposeStream();
+
+            var encoder = new BinaryEncoder(stream, context, leaveOpen: false);
+            encoder.WriteInt32("Value", 1);
+            encoder.Close();
+
+            Assert.DoesNotThrow(encoder.Dispose);
+        }
+
+        /// <summary>
+        /// A stream that behaves like a FileStream: flushing it after it has
+        /// been disposed throws.
+        /// </summary>
+        private sealed class ThrowAfterDisposeStream : Stream
+        {
+            public override bool CanRead => !m_disposed;
+            public override bool CanSeek => false;
+            public override bool CanWrite => !m_disposed;
+            public override long Length => m_length;
+
+            public override long Position
+            {
+                get => m_length;
+                set => throw new NotSupportedException();
+            }
+
+            public override void Flush()
+            {
+                if (m_disposed)
+                {
+                    throw new ObjectDisposedException(nameof(ThrowAfterDisposeStream));
+                }
+            }
+
+            public override int Read(byte[] buffer, int offset, int count)
+            {
+                throw new NotSupportedException();
+            }
+
+            public override long Seek(long offset, SeekOrigin origin)
+            {
+                throw new NotSupportedException();
+            }
+
+            public override void SetLength(long value)
+            {
+                throw new NotSupportedException();
+            }
+
+            public override void Write(byte[] buffer, int offset, int count)
+            {
+                if (m_disposed)
+                {
+                    throw new ObjectDisposedException(nameof(ThrowAfterDisposeStream));
+                }
+                m_length += count;
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                m_disposed = true;
+                base.Dispose(disposing);
+            }
+
+            private long m_length;
+            private bool m_disposed;
+        }
+
+        /// <summary>
+        /// A minimal encodeable used as an ExtensionObject body.
+        /// </summary>
+        public sealed class Sample : IEncodeable
+        {
+            public static readonly ExpandedNodeId TypeIdStatic = new(88801, 0);
+
+            public int Value { get; set; }
+
+            public ExpandedNodeId TypeId => TypeIdStatic;
+            public ExpandedNodeId BinaryEncodingId => new(88802, 0);
+            public ExpandedNodeId XmlEncodingId => new(88803, 0);
+
+            public void Encode(IEncoder encoder)
+            {
+                encoder.WriteInt32("Value", Value);
+            }
+
+            public void Decode(IDecoder decoder)
+            {
+                Value = decoder.ReadInt32("Value");
+            }
+
+            public bool IsEqual(IEncodeable encodeable)
+            {
+                return encodeable is Sample other && other.Value == Value;
+            }
+
+            public object Clone()
+            {
+                return new Sample { Value = Value };
+            }
+        }
+    }
+}

--- a/tests/Opc.Ua.Types.Tests/Encoders/CodecAuditRegressionTests.cs
+++ b/tests/Opc.Ua.Types.Tests/Encoders/CodecAuditRegressionTests.cs
@@ -32,6 +32,7 @@ using System.IO;
 using System.Text;
 using System.Threading;
 using System.Xml;
+using System.Xml.Linq;
 using NUnit.Framework;
 using Opc.Ua.Tests;
 
@@ -439,6 +440,32 @@ namespace Opc.Ua.Types.Tests.Encoders
                 Assert.That(
                     XmlElement.From("<not well formed").GetHashCode(),
                     Is.EqualTo(XmlElement.From("<not well formed").GetHashCode()));
+            });
+        }
+
+        [Test]
+        public void XmlDeclarationIsNotInjectedIntoTheFieldElement()
+        {
+            // An XmlElement whose body starts with an XML declaration parses
+            // fine, so the validation accepted it, but WriteRaw then put the
+            // declaration in the middle of the document - where it is illegal -
+            // and produced XML no decoder can read.
+            ServiceMessageContext context = CreateContext();
+
+            using var encoder = new XmlEncoder(context);
+            encoder.PushNamespace(kNs);
+            encoder.WriteXmlElement(
+                "Body",
+                XmlElement.From("<?xml version=\"1.0\" encoding=\"utf-8\"?><a x=\"1\" />"));
+            string xml = encoder.CloseAndReturnText();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(xml, Does.Not.Contain("<?xml version=\"1.0\" encoding=\"utf-8\"?><a"));
+                Assert.That(xml, Does.Contain("<a x=\"1\""));
+
+                // and the result is parseable, which is the point of the check.
+                Assert.DoesNotThrow(() => XDocument.Parse(xml));
             });
         }
 

--- a/tests/Opc.Ua.Types.Tests/Encoders/EncodeableFactoryTests.cs
+++ b/tests/Opc.Ua.Types.Tests/Encoders/EncodeableFactoryTests.cs
@@ -593,10 +593,12 @@ namespace Opc.Ua.Types.Tests.Encoders
             bool foundWithNs = factory.TryGetEncodeableType(typeIdWithDefaultNs, out IEncodeableType typeWithNs);
             bool foundWithoutNs = factory.TryGetEncodeableType(typeIdWithoutNs, out IEncodeableType typeWithoutNs);
 
+            // Registrations and lookups both normalize an id that names
+            // namespace zero by its URI, so either spelling resolves.
             Assert.That(foundWithNs, Is.True);
-            Assert.That(foundWithoutNs, Is.False);
+            Assert.That(foundWithoutNs, Is.True);
             Assert.That(typeWithNs.Type, Is.EqualTo(typeof(TestEncodeable)));
-            Assert.That(typeWithoutNs, Is.Null);
+            Assert.That(typeWithoutNs.Type, Is.EqualTo(typeof(TestEncodeable)));
         }
 
         [Test]
@@ -991,8 +993,10 @@ namespace Opc.Ua.Types.Tests.Encoders
             bool foundWithoutNs = factory.TryGetEncodeableType(new ExpandedNodeId(140000), out IEncodeableType typeWithoutNs);
             bool foundWithNs = factory.TryGetEncodeableType(new ExpandedNodeId(140000, Namespaces.OpcUa), out _);
 
+            // The lookup normalizes the namespace zero URI form as well, so
+            // both spellings resolve to the same registration.
             Assert.That(foundWithoutNs, Is.True);
-            Assert.That(foundWithNs, Is.False);
+            Assert.That(foundWithNs, Is.True);
             Assert.That(typeWithoutNs.Type, Is.EqualTo(typeof(TestEncodeableWithDefaultNamespace)));
         }
 

--- a/tests/Opc.Ua.Types.Tests/Encoders/JsonAuditRegressionTests.cs
+++ b/tests/Opc.Ua.Types.Tests/Encoders/JsonAuditRegressionTests.cs
@@ -1,0 +1,461 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Opc.Ua.Tests;
+
+namespace Opc.Ua.Types.Tests.Encoders
+{
+    /// <summary>
+    /// Regression tests for the JSON codec and EncodeableFactory defects
+    /// reported by the read-only bug audit of Opc.Ua.Types.
+    /// </summary>
+    [TestFixture]
+    [Category("Encoders")]
+    [SetCulture("en-us")]
+    [SetUICulture("en-us")]
+    [Parallelizable]
+    public class JsonAuditRegressionTests
+    {
+        private static ServiceMessageContext CreateContext()
+        {
+            return ServiceMessageContext.CreateEmpty(NUnitTelemetryContext.Create());
+        }
+
+        private static readonly string[] s_switches = ["First", "Second"];
+        private static readonly int[] s_oneTwoThree = [1, 2, 3];
+
+        [Test]
+        public void AbsentSwitchFieldIsResolvedFromTheMemberName()
+        {
+            // An absent SwitchField was read as selector 0 and then indexed
+            // switches[-1], which threw IndexOutOfRangeException. The name based
+            // Verbose fallback was unreachable.
+            ServiceMessageContext context = CreateContext();
+            using var decoder = new JsonDecoder("{\"Second\":42}", context);
+
+            uint selector = decoder.ReadSwitchField(s_switches, out string fieldName);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(selector, Is.EqualTo(2u));
+                Assert.That(fieldName, Is.EqualTo("Second"));
+            });
+        }
+
+        [Test]
+        public void SwitchFieldZeroSelectsNoField()
+        {
+            // A Compact union with selector 0 also indexed switches[-1].
+            ServiceMessageContext context = CreateContext();
+            using var decoder = new JsonDecoder("{\"SwitchField\":0}", context);
+
+            uint selector = decoder.ReadSwitchField(s_switches, out string fieldName);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(selector, Is.Zero);
+                Assert.That(fieldName, Is.Null);
+            });
+        }
+
+        [Test]
+        public void LastSwitchFieldSelectorIsResolved()
+        {
+            // The bounds check used >= instead of >, so the selector of the last
+            // union field was reported as unknown.
+            ServiceMessageContext context = CreateContext();
+            using var decoder = new JsonDecoder("{\"SwitchField\":2,\"Second\":42}", context);
+
+            uint selector = decoder.ReadSwitchField(s_switches, out string fieldName);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(selector, Is.EqualTo(2u));
+                Assert.That(fieldName, Is.EqualTo("Second"));
+            });
+        }
+
+        [Test]
+        public void SwitchFieldWithoutFieldNamesStillReportsTheSelector()
+        {
+            // ReadSwitchField(null) always returned 0, so a dynamically decoded
+            // union lost its selector.
+            ServiceMessageContext context = CreateContext();
+            using var decoder = new JsonDecoder("{\"SwitchField\":2,\"Second\":42}", context);
+
+            uint selector = decoder.ReadSwitchField(null, out _);
+
+            Assert.That(selector, Is.EqualTo(2u));
+        }
+
+        [Test]
+        public void ArrayLengthIsCheckedAgainstMaxArrayLength()
+        {
+            // The JSON decoder enforced no array limit at all.
+            ServiceMessageContext context = CreateContext();
+            context.MaxArrayLength = 2;
+            using var decoder = new JsonDecoder("{\"Value\":[1,2,3]}", context);
+
+            ServiceResultException ex = Assert.Throws<ServiceResultException>(
+                () => decoder.ReadInt32Array("Value"));
+            Assert.That(
+                ex.StatusCode,
+                Is.EqualTo((StatusCode)StatusCodes.BadEncodingLimitsExceeded));
+        }
+
+        [Test]
+        public void StringLengthIsCheckedAgainstMaxStringLength()
+        {
+            ServiceMessageContext context = CreateContext();
+            context.MaxStringLength = 3;
+            using var decoder = new JsonDecoder("{\"Value\":\"abcdef\"}", context);
+
+            ServiceResultException ex = Assert.Throws<ServiceResultException>(
+                () => decoder.ReadString("Value"));
+            Assert.That(
+                ex.StatusCode,
+                Is.EqualTo((StatusCode)StatusCodes.BadEncodingLimitsExceeded));
+        }
+
+        [Test]
+        public void StringLengthIsMeasuredInBytesNotCharactersWhenDecoding()
+        {
+            // Part 3 5.6.4 and Part 5 6.3.2 define MaxStringLength as a number
+            // of bytes, which is also what the binary codec enforces. Counting
+            // UTF-16 code units here would accept a string the binary decoder
+            // rejects.
+            ServiceMessageContext context = CreateContext();
+            context.MaxStringLength = 4;
+
+            // Three characters, six UTF-8 bytes.
+            using var decoder = new JsonDecoder("{\"Value\":\"äöü\"}", context);
+
+            ServiceResultException ex = Assert.Throws<ServiceResultException>(
+                () => decoder.ReadString("Value"));
+            Assert.That(
+                ex.StatusCode,
+                Is.EqualTo((StatusCode)StatusCodes.BadEncodingLimitsExceeded));
+        }
+
+        [Test]
+        public void StringLengthIsMeasuredInBytesNotCharactersWhenEncoding()
+        {
+            ServiceMessageContext context = CreateContext();
+            context.MaxStringLength = 4;
+
+            using var encoder = new JsonEncoder(context, JsonEncoderOptions.Compact);
+
+            ServiceResultException ex = Assert.Throws<ServiceResultException>(
+                () => encoder.WriteString("Value", "äöü"));
+            Assert.That(
+                ex.StatusCode,
+                Is.EqualTo((StatusCode)StatusCodes.BadEncodingLimitsExceeded));
+        }
+
+        [Test]
+        public void StringAtExactlyTheByteLimitIsAccepted()
+        {
+            ServiceMessageContext context = CreateContext();
+            context.MaxStringLength = 6;
+
+            using var encoder = new JsonEncoder(context, JsonEncoderOptions.Compact);
+            Assert.DoesNotThrow(() => encoder.WriteString("Value", "äöü"));
+
+            using var decoder = new JsonDecoder("{\"Value\":\"äöü\"}", context);
+            Assert.That(decoder.ReadString("Value"), Is.EqualTo("äöü"));
+        }
+
+        [Test]
+        public void ByteStringLengthIsCheckedAgainstMaxByteStringLength()
+        {
+            ServiceMessageContext context = CreateContext();
+            context.MaxByteStringLength = 2;
+            using var decoder = new JsonDecoder("{\"Value\":\"AQIDBA==\"}", context);
+
+            ServiceResultException ex = Assert.Throws<ServiceResultException>(
+                () => decoder.ReadByteString("Value"));
+            Assert.That(
+                ex.StatusCode,
+                Is.EqualTo((StatusCode)StatusCodes.BadEncodingLimitsExceeded));
+        }
+
+        [Test]
+        public void EveryByteArraySpellingIsCheckedAgainstMaxArrayLength()
+        {
+            // TryGetArrayElements is the choke point for MaxArrayLength, and the
+            // base64 fast paths never went through it, so the same value was
+            // bounded as a JSON array and unbounded as a base64 string.
+            ServiceMessageContext context = CreateContext();
+            context.MaxArrayLength = 2;
+            string base64 = Convert.ToBase64String(new byte[8]);
+
+            using var bytes = new JsonDecoder($"{{\"Value\":\"{base64}\"}}", context);
+            using var sbytes = new JsonDecoder($"{{\"Value\":\"{base64}\"}}", context);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(
+                    Assert.Throws<ServiceResultException>(() => bytes.ReadByteArray("Value"))
+                        .StatusCode,
+                    Is.EqualTo((StatusCode)StatusCodes.BadEncodingLimitsExceeded));
+                Assert.That(
+                    Assert.Throws<ServiceResultException>(() => sbytes.ReadSByteArray("Value"))
+                        .StatusCode,
+                    Is.EqualTo((StatusCode)StatusCodes.BadEncodingLimitsExceeded));
+            });
+        }
+
+        [Test]
+        public void EveryByteStringSpellingIsCheckedAgainstMaxByteStringLength()
+        {
+            // The check was added only to the base64 branch, so the array
+            // spelling of the same byte string stayed unbounded.
+            ServiceMessageContext context = CreateContext();
+            context.MaxByteStringLength = 2;
+            context.MaxArrayLength = 0;
+            using var decoder = new JsonDecoder("{\"Value\":[1,2,3,4,5]}", context);
+
+            ServiceResultException ex = Assert.Throws<ServiceResultException>(
+                () => decoder.ReadByteString("Value"));
+            Assert.That(
+                ex.StatusCode,
+                Is.EqualTo((StatusCode)StatusCodes.BadEncodingLimitsExceeded));
+        }
+
+        [Test]
+        public void LocalizedTextShorthandIsCheckedAgainstMaxStringLength()
+        {
+            // The object form was checked through TryGetStringFromElement while
+            // the shorthand string form was not, so whether MaxStringLength
+            // applied depended on which legal spelling the peer chose.
+            ServiceMessageContext context = CreateContext();
+            context.MaxStringLength = 4;
+            using var shorthand = new JsonDecoder("{\"Value\":\"abcdefgh\"}", context);
+            using var verbose = new JsonDecoder("{\"Value\":{\"Text\":\"abcdefgh\"}}", context);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(
+                    Assert.Throws<ServiceResultException>(() => shorthand.ReadLocalizedText("Value"))
+                        .StatusCode,
+                    Is.EqualTo((StatusCode)StatusCodes.BadEncodingLimitsExceeded));
+                Assert.That(
+                    Assert.Throws<ServiceResultException>(() => verbose.ReadLocalizedText("Value"))
+                        .StatusCode,
+                    Is.EqualTo((StatusCode)StatusCodes.BadEncodingLimitsExceeded));
+            });
+        }
+
+        [Test]
+        public void EnumerationSymbolIsCheckedAgainstMaxStringLength()
+        {
+            // The symbolic name is kept verbatim from the wire, so an unbounded
+            // one let a peer park an arbitrarily long string in an EnumValue.
+            ServiceMessageContext context = CreateContext();
+            context.MaxStringLength = 4;
+            using var decoder = new JsonDecoder("{\"Value\":\"AAAAAAAAAAAA_5\"}", context);
+
+            ServiceResultException ex = Assert.Throws<ServiceResultException>(
+                () => decoder.ReadEnumerated("Value"));
+            Assert.That(
+                ex.StatusCode,
+                Is.EqualTo((StatusCode)StatusCodes.BadEncodingLimitsExceeded));
+        }
+
+        [Test]
+        public void ZeroLimitsStillMeanUnlimited()
+        {
+            ServiceMessageContext context = CreateContext();
+            context.MaxArrayLength = 0;
+            context.MaxStringLength = 0;
+            context.MaxByteStringLength = 0;
+            using var decoder = new JsonDecoder(
+                "{\"Array\":[1,2,3],\"Text\":\"abcdef\",\"Bytes\":\"AQIDBA==\"}",
+                context);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(decoder.ReadInt32Array("Array").Count, Is.EqualTo(3));
+                Assert.That(decoder.ReadString("Text"), Is.EqualTo("abcdef"));
+                Assert.That(decoder.ReadByteString("Bytes").Length, Is.EqualTo(4));
+            });
+        }
+
+        [Test]
+        public void JsonEncoderTreatsZeroLimitsAsUnlimited()
+        {
+            // The encoder's limit checks lacked the "0 = unlimited" convention
+            // that every other codec uses, so an empty context rejected
+            // everything.
+            ServiceMessageContext context = CreateContext();
+            context.MaxArrayLength = 0;
+            context.MaxStringLength = 0;
+            context.MaxByteStringLength = 0;
+
+            using var encoder = new JsonEncoder(context, JsonEncoderOptions.Compact);
+
+            Assert.Multiple(() =>
+            {
+                Assert.DoesNotThrow(() => encoder.WriteString("Text", "abcdef"));
+                Assert.DoesNotThrow(
+                    () => encoder.WriteByteString("Bytes", new ByteString(new byte[] { 1, 2 })));
+                Assert.DoesNotThrow(
+                    () => encoder.WriteInt32Array("Array", s_oneTwoThree.ToArrayOf()));
+            });
+        }
+
+        [Test]
+        public void OmittedMatrixFieldDecodesAsNullVariant()
+        {
+            // A null or omitted matrix field was rejected by the dimension
+            // check instead of decoding as a null variant.
+            ServiceMessageContext context = CreateContext();
+            using var decoder = new JsonDecoder("{\"Value\":null}", context);
+
+            Variant value = decoder.ReadVariantValue(
+                "Value",
+                TypeInfo.Create(BuiltInType.Int32, 2));
+
+            Assert.That(value.IsNull, Is.True);
+        }
+
+        [Test]
+        public void MatrixFieldWithBadDimensionsDoesNotDesynchronizeLaterFields()
+        {
+            // The matrix branch pushed a stack entry and returned early on the
+            // dimension check, leaking it, so every following field decoded
+            // from the wrong element.
+            ServiceMessageContext context = CreateContext();
+            using var decoder = new JsonDecoder(
+                "{\"Matrix\":{\"Array\":[1,2],\"Dimensions\":[2]},\"After\":7}",
+                context);
+
+            // The bad matrix is rejected ...
+            Assert.Throws<ServiceResultException>(
+                () => decoder.ReadVariantValue("Matrix", TypeInfo.Create(BuiltInType.Int32, 2)));
+
+            // ... and the element stack is balanced again, so the next field
+            // still decodes from the right element.
+            Assert.That(decoder.ReadInt32("After"), Is.EqualTo(7));
+        }
+
+        [Test]
+        public void BareNumericEnumTextRoundTrips()
+        {
+            // A bare "5" was decoded with the symbol "5", so re-encoding it
+            // produced "5_5".
+            ServiceMessageContext context = CreateContext();
+            using var decoder = new JsonDecoder("{\"Value\":\"5\"}", context);
+
+            EnumValue value = decoder.ReadEnumerated("Value");
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(value.Value, Is.EqualTo(5));
+                Assert.That(value.ToString(), Is.EqualTo("5"));
+            });
+        }
+
+        [Test]
+        public void NonObjectRawJsonBodyIsRejectedInsteadOfDropped()
+        {
+            // The body was silently dropped, producing an ExtensionObject whose
+            // body was gone without any error.
+            ServiceMessageContext context = CreateContext();
+            var extension = new ExtensionObject(new NodeId(1234u), "[1,2,3]");
+
+            using var encoder = new JsonEncoder(context, JsonEncoderOptions.Compact);
+
+            ServiceResultException ex = Assert.Throws<ServiceResultException>(
+                () => encoder.WriteExtensionObject("Body", extension));
+            Assert.That(ex.StatusCode, Is.EqualTo((StatusCode)StatusCodes.BadEncodingError));
+        }
+
+        [Test]
+        public void ExplicitIdRegistrationNormalizesTheNamespaceZeroUri()
+        {
+            // Registering with an explicit id skipped the namespace zero
+            // normalization that the reflection based path applies, so the type
+            // could not be found by its relative id.
+            IEncodeableFactory factory = EncodeableFactory.Create();
+            var absoluteId = new ExpandedNodeId(99001, Namespaces.OpcUa);
+
+            factory.Builder.AddType(absoluteId, typeof(Sample)).Commit();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(
+                    factory.TryGetEncodeableType(absoluteId, out IEncodeableType byAbsolute),
+                    Is.True);
+                Assert.That(byAbsolute.Type, Is.EqualTo(typeof(Sample)));
+                Assert.That(
+                    factory.TryGetEncodeableType(
+                        new ExpandedNodeId(99001),
+                        out IEncodeableType byRelative),
+                    Is.True);
+                Assert.That(byRelative.Type, Is.EqualTo(typeof(Sample)));
+            });
+        }
+
+        /// <summary>
+        /// A minimal encodeable used for factory registration.
+        /// </summary>
+        public sealed class Sample : IEncodeable
+        {
+            public int Value { get; set; }
+
+            public ExpandedNodeId TypeId => new(99001, 0);
+            public ExpandedNodeId BinaryEncodingId => new(99002, 0);
+            public ExpandedNodeId XmlEncodingId => new(99003, 0);
+
+            public void Encode(IEncoder encoder)
+            {
+                encoder.WriteInt32("Value", Value);
+            }
+
+            public void Decode(IDecoder decoder)
+            {
+                Value = decoder.ReadInt32("Value");
+            }
+
+            public bool IsEqual(IEncodeable encodeable)
+            {
+                return encodeable is Sample other && other.Value == Value;
+            }
+
+            public object Clone()
+            {
+                return new Sample { Value = Value };
+            }
+        }
+    }
+}

--- a/tests/Opc.Ua.Types.Tests/Schema/SchemaAuditRegressionTests.cs
+++ b/tests/Opc.Ua.Types.Tests/Schema/SchemaAuditRegressionTests.cs
@@ -1,0 +1,188 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+#nullable enable
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using NUnit.Framework;
+using Opc.Ua.Export;
+using Opc.Ua.Schema.Binary;
+using Opc.Ua.Tests;
+
+namespace Opc.Ua.Types.Tests.Schema
+{
+    /// <summary>
+    /// Regression tests for the Schema loader defects reported by the read-only
+    /// bug audit of Opc.Ua.Types.
+    /// </summary>
+    [TestFixture]
+    [Category("Schema")]
+    [SetCulture("en-us")]
+    [SetUICulture("en-us")]
+    [Parallelizable]
+    public class SchemaAuditRegressionTests
+    {
+        [Test]
+        public void DefaultImportKeepsAnUnresolvedNamespaceUriOnAReferenceTarget()
+        {
+            // The default import dropped nsu= on a reference target and landed
+            // it in namespace zero.
+            const string xml =
+                "<UANodeSet xmlns=\"http://opcfoundation.org/UA/2011/03/UANodeSet.xsd\">" +
+                "<NamespaceUris><Uri>urn:test:audit</Uri></NamespaceUris>" +
+                "<Models><Model ModelUri=\"urn:test:audit\" /></Models>" +
+                "<UAObject NodeId=\"ns=1;s=Node\" BrowseName=\"1:Node\">" +
+                "<DisplayName>Node</DisplayName>" +
+                "<References>" +
+                "<Reference ReferenceType=\"i=35\">nsu=urn:other:model;s=Target</Reference>" +
+                "</References>" +
+                "</UAObject>" +
+                "</UANodeSet>";
+
+            using var stream = new MemoryStream(Encoding.UTF8.GetBytes(xml));
+            UANodeSet nodeSet = UANodeSet.Read(stream)!;
+
+            var context = new SystemContext(NUnitTelemetryContext.Create())
+            {
+                NamespaceUris = new NamespaceTable(),
+                ServerUris = new StringTable()
+            };
+            context.NamespaceUris.GetIndexOrAppend("urn:test:audit");
+
+            var nodes = new NodeStateCollection();
+            nodeSet.Import(context, nodes);
+
+            Assert.That(nodes, Is.Not.Empty);
+
+            var references = new List<IReference>();
+            nodes[0].GetReferences(context, references);
+
+            IReference? organizes = references.Find(
+                r => r.ReferenceTypeId == ReferenceTypeIds.Organizes);
+
+            Assert.That(organizes, Is.Not.Null);
+            Assert.That(
+                organizes!.TargetId.NamespaceUri,
+                Is.EqualTo("urn:other:model"),
+                "an unresolved nsu= must not be dropped into namespace zero");
+        }
+
+        [Test]
+        public void ExportServerIndexDoesNotAppendANullServerUri()
+        {
+            // The bound check let an index equal to Count through, and the null
+            // GetString returned for it was appended to the export table.
+            var namespaceUris = new NamespaceTable();
+            namespaceUris.GetIndexOrAppend("urn:test:audit");
+            var serverUris = new StringTable();
+            serverUris.Append("urn:known:server");
+
+            var source = new NodeStateCollection
+            {
+                new BaseObjectState(null)
+                {
+                    NodeId = new NodeId("Node", 1),
+                    BrowseName = new QualifiedName("Node", 1),
+                    SymbolicName = "Node"
+                }
+            };
+            // A reference to a server index that the table does not hold.
+            source[0].AddReference(
+                ReferenceTypeIds.Organizes,
+                false,
+                new ExpandedNodeId(new NodeId("Target", 1), null, 5));
+
+            var nodeSet = new UANodeSet();
+            nodeSet.Import(
+                new SystemContext(NUnitTelemetryContext.Create())
+                {
+                    NamespaceUris = namespaceUris,
+                    ServerUris = serverUris
+                },
+                source);
+
+            Assert.That(
+                nodeSet.ServerUris is null ||
+                    nodeSet.ServerUris.All(uri => uri is not null),
+                Is.True,
+                "no null entry may be appended to the export table");
+        }
+
+        [Test]
+        public void BinarySchemaValidatorReportsALengthFieldByItsOwnName()
+        {
+            // The diagnostic printed the SwitchField instead of the LengthField.
+            const string bsd =
+                "<opc:TypeDictionary xmlns:opc=\"http://opcfoundation.org/BinarySchema/\" " +
+                "xmlns:ua=\"http://opcfoundation.org/UA/\" " +
+                "DefaultByteOrder=\"LittleEndian\" " +
+                "TargetNamespace=\"http://test.org/Types/\">" +
+                "<opc:StructuredType Name=\"Sample\">" +
+                "<opc:Field Name=\"Count\" TypeName=\"opc:String\" />" +
+                "<opc:Field Name=\"Values\" TypeName=\"opc:Int32\" LengthField=\"Count\" />" +
+                "</opc:StructuredType>" +
+                "</opc:TypeDictionary>";
+
+            var validator = new BinarySchemaValidator();
+
+            using var stream = new MemoryStream(Encoding.UTF8.GetBytes(bsd));
+            System.Exception? thrown = Assert.Catch(() => validator.Validate(stream));
+
+            Assert.That(thrown, Is.Not.Null);
+            Assert.That(
+                thrown!.Message,
+                Does.Contain("'Count'"),
+                "the diagnostic must name the length field, not the switch field");
+        }
+
+        [Test]
+        public void TypeDictionaryValidatorToleratesAFieldlessBaseType()
+        {
+            // A base type declaring no field at all produced an NRE.
+            const string bsd =
+                "<opc:TypeDictionary xmlns:opc=\"http://opcfoundation.org/BinarySchema/\" " +
+                "xmlns:ua=\"http://opcfoundation.org/UA/\" " +
+                "xmlns:tns=\"http://test.org/Types/\" " +
+                "DefaultByteOrder=\"LittleEndian\" " +
+                "TargetNamespace=\"http://test.org/Types/\">" +
+                "<opc:StructuredType Name=\"Base\" />" +
+                "<opc:StructuredType Name=\"Derived\" BaseType=\"tns:Base\">" +
+                "<opc:Field Name=\"Value\" TypeName=\"opc:Int32\" />" +
+                "</opc:StructuredType>" +
+                "</opc:TypeDictionary>";
+
+            var validator = new BinarySchemaValidator();
+
+            using var stream = new MemoryStream(Encoding.UTF8.GetBytes(bsd));
+            Assert.DoesNotThrow(() => validator.Validate(stream));
+        }
+    }
+}

--- a/tests/Opc.Ua.Types.Tests/State/NodeStateAuditRegressionTests.cs
+++ b/tests/Opc.Ua.Types.Tests/State/NodeStateAuditRegressionTests.cs
@@ -1,0 +1,599 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System.Collections.Generic;
+using System.IO;
+using NUnit.Framework;
+using Opc.Ua.Tests;
+
+namespace Opc.Ua.Types.Tests.State
+{
+    /// <summary>
+    /// Regression tests for the NodeState / Nodes defects reported by the
+    /// read-only bug audit of Opc.Ua.Types.
+    /// </summary>
+    [TestFixture]
+    [Category("NodeState")]
+    [SetCulture("en-us")]
+    [SetUICulture("en-us")]
+    [Parallelizable]
+    public class NodeStateAuditRegressionTests
+    {
+        private static readonly bool[] s_booleans = [true, false];
+        private static readonly uint[] s_masks = [1u, 2u];
+
+        private static SystemContext CreateContext()
+        {
+            var namespaceUris = new NamespaceTable();
+            return new SystemContext(NUnitTelemetryContext.Create())
+            {
+                NamespaceUris = namespaceUris,
+                ServerUris = new StringTable(),
+                TypeTable = new TypeTable(namespaceUris)
+            };
+        }
+
+        [Test]
+        public void VariableTypeCreatedFromSourceKeepsItsValue()
+        {
+            // Initialize copied its own (still empty) value instead of the
+            // source's, so the value was lost.
+            SystemContext context = CreateContext();
+            var source = new BaseDataVariableTypeState
+            {
+                Value = new Variant(42),
+                DataType = DataTypeIds.Int32,
+                ValueRank = ValueRanks.Scalar
+            };
+            var target = new BaseDataVariableTypeState();
+
+            target.Create(context, source);
+
+            Assert.That(target.Value.GetInt32(), Is.EqualTo(42));
+        }
+
+        [Test]
+        public void VariableCreatedFromSourceKeepsItsStatusCode()
+        {
+            // m_valueTouched was copied but m_statusCode was not, so the copy
+            // stayed BadWaitingForInitialData forever.
+            SystemContext context = CreateContext();
+            var source = new BaseDataVariableState(null)
+            {
+                Value = new Variant(1),
+                StatusCode = StatusCodes.Good
+            };
+            var target = new BaseDataVariableState(null);
+
+            target.Create(context, source);
+
+            Assert.That(target.StatusCode, Is.EqualTo((StatusCode)StatusCodes.Good));
+        }
+
+        [Test]
+        public void BinaryRoundTripDoesNotRenameTheParentAfterItsLastChild()
+        {
+            // UpdateChild assigned the property instead of the local, so the
+            // parent ended up named after its last child.
+            SystemContext context = CreateContext();
+            IServiceMessageContext messageContext = context.AsMessageContext();
+
+            var parent = new BaseObjectState(null)
+            {
+                NodeId = new NodeId(1000u),
+                BrowseName = QualifiedName.From("Parent"),
+                SymbolicName = "Parent"
+            };
+            var child = new PropertyState(parent)
+            {
+                NodeId = new NodeId(1001u),
+                BrowseName = QualifiedName.From("Child"),
+                SymbolicName = "Child",
+                ReferenceTypeId = ReferenceTypeIds.HasProperty,
+                TypeDefinitionId = VariableTypeIds.PropertyType,
+                DataType = DataTypeIds.Int32,
+                ValueRank = ValueRanks.Scalar
+            };
+            parent.AddChild(child);
+
+            using var stream = new MemoryStream();
+            parent.SaveAsBinary(context, stream);
+            stream.Position = 0;
+
+            var reloaded = new BaseObjectState(null);
+            reloaded.LoadAsBinary(context, stream);
+
+            Assert.That(reloaded.SymbolicName, Is.EqualTo("Parent"));
+        }
+
+        [Test]
+        public void MethodCloneDoesNotShareItsArgumentChildren()
+        {
+            // CopyTo assigned the same child instance to the clone.
+            SystemContext context = CreateContext();
+            var method = new MethodState(null)
+            {
+                NodeId = new NodeId(2000u),
+                BrowseName = QualifiedName.From("DoIt")
+            };
+            method.CreateOrReplaceInputArguments(context, null);
+
+            var clone = (MethodState)method.Clone();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(clone.InputArguments, Is.Not.Null);
+                Assert.That(clone.InputArguments, Is.Not.SameAs(method.InputArguments));
+            });
+        }
+
+        [Test]
+        public void CloneCopiesUserWriteMask()
+        {
+            var source = new BaseObjectState(null)
+            {
+                WriteMask = AttributeWriteMask.DisplayName,
+                UserWriteMask = AttributeWriteMask.Description
+            };
+
+            var copy = (BaseObjectState)source.Clone();
+
+            Assert.That(copy.UserWriteMask, Is.EqualTo(AttributeWriteMask.Description));
+        }
+
+        [Test]
+        public void MethodStateXmlSaveWritesUserExecutable()
+        {
+            // The UserExecutable element was written from m_executable. The
+            // element is only written when UserExecutable is true, so the two
+            // fields have to disagree for the defect to be observable: with
+            // Executable false the old code wrote "false" into an element it
+            // had just decided to write because the value is true.
+            SystemContext context = CreateContext();
+
+            string userExecutableOnly = SaveMethodStateToXml(
+                context,
+                executable: false,
+                userExecutable: true);
+            string executableOnly = SaveMethodStateToXml(
+                context,
+                executable: true,
+                userExecutable: false);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(userExecutableOnly, Does.Contain("UserExecutable"));
+                Assert.That(userExecutableOnly, Does.Contain(">true<"));
+                Assert.That(userExecutableOnly, Does.Not.Contain(">false<"));
+
+                // UserExecutable is false here, so nothing is written for it.
+                Assert.That(executableOnly, Does.Not.Contain("UserExecutable"));
+            });
+        }
+
+        private static string SaveMethodStateToXml(
+            SystemContext context,
+            bool executable,
+            bool userExecutable)
+        {
+            var method = new MethodState(null)
+            {
+                NodeId = new NodeId(2100u),
+                BrowseName = QualifiedName.From("DoIt"),
+                Executable = executable,
+                UserExecutable = userExecutable
+            };
+
+            using var encoder = new XmlEncoder(context.AsMessageContext());
+            encoder.PushNamespace(Namespaces.OpcUaXsd);
+            method.Save(context, encoder);
+            encoder.PopNamespace();
+            return encoder.CloseAndReturnText();
+        }
+
+        [Test]
+        public void WriteToBrowseNameRaisesTheChangeMask()
+        {
+            // The write handlers assigned the backing fields directly, so
+            // monitored items on those attributes were never notified.
+            SystemContext context = CreateContext();
+            var node = new BaseObjectState(null)
+            {
+                NodeId = new NodeId(2200u),
+                BrowseName = QualifiedName.From("Name"),
+                WriteMask = AttributeWriteMask.BrowseName |
+                    AttributeWriteMask.DisplayName |
+                    AttributeWriteMask.Description |
+                    AttributeWriteMask.UserWriteMask
+            };
+            node.ClearChangeMasks(context, false);
+
+            ServiceResult result = node.WriteAttribute(
+                context,
+                Attributes.BrowseName,
+                default,
+                new DataValue(new Variant(QualifiedName.From("Renamed"))));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(ServiceResult.IsGood(result), Is.True);
+                Assert.That(node.BrowseName.Name, Is.EqualTo("Renamed"));
+                Assert.That(
+                    node.ChangeMasks & NodeStateChangeMasks.NonValue,
+                    Is.EqualTo(NodeStateChangeMasks.NonValue));
+            });
+        }
+
+        [Test]
+        public void WriteToDisplayNameRaisesTheChangeMask()
+        {
+            SystemContext context = CreateContext();
+            var node = new BaseObjectState(null)
+            {
+                NodeId = new NodeId(2300u),
+                WriteMask = AttributeWriteMask.DisplayName
+            };
+            node.ClearChangeMasks(context, false);
+
+            ServiceResult result = node.WriteAttribute(
+                context,
+                Attributes.DisplayName,
+                default,
+                new DataValue(new Variant(LocalizedText.From("Shown"))));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(ServiceResult.IsGood(result), Is.True);
+                Assert.That(
+                    node.ChangeMasks & NodeStateChangeMasks.NonValue,
+                    Is.EqualTo(NodeStateChangeMasks.NonValue));
+            });
+        }
+
+        [Test]
+        public void WriteChildAttributeDescendsIntoChildren()
+        {
+            // The path check was inverted, so the write always landed on the
+            // node itself and never followed the component path.
+            SystemContext context = CreateContext();
+            var parent = new BaseObjectState(null)
+            {
+                NodeId = new NodeId(2400u),
+                BrowseName = QualifiedName.From("Parent")
+            };
+            var child = new BaseDataVariableState(parent)
+            {
+                NodeId = new NodeId(2401u),
+                BrowseName = QualifiedName.From("Child"),
+                DataType = DataTypeIds.Int32,
+                ValueRank = ValueRanks.Scalar,
+                AccessLevel = AccessLevels.CurrentReadOrWrite,
+                UserAccessLevel = AccessLevels.CurrentReadOrWrite
+            };
+            parent.AddChild(child);
+
+            ServiceResult result = parent.WriteChildAttribute(
+                context,
+                new[] { QualifiedName.From("Child") }.ToArrayOf(),
+                0,
+                Attributes.Value,
+                new DataValue(new Variant(11)));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(ServiceResult.IsGood(result), Is.True);
+                Assert.That(child.Value.GetInt32(), Is.EqualTo(11));
+            });
+        }
+
+        [Test]
+        public void ReplacedChildIsAdopted()
+        {
+            // The in-place replacement left Parent pointing at the previous
+            // owner and did not raise the Children change mask.
+            SystemContext context = CreateContext();
+            var firstParent = new BaseObjectState(null)
+            {
+                NodeId = new NodeId(2500u),
+                BrowseName = QualifiedName.From("First")
+            };
+            var secondParent = new BaseObjectState(null)
+            {
+                NodeId = new NodeId(2501u),
+                BrowseName = QualifiedName.From("Second")
+            };
+
+            var existing = new BaseObjectState(secondParent)
+            {
+                NodeId = new NodeId(2502u),
+                BrowseName = QualifiedName.From("Child")
+            };
+            secondParent.AddChild(existing);
+
+            var replacement = new BaseObjectState(firstParent)
+            {
+                NodeId = new NodeId(2503u),
+                BrowseName = QualifiedName.From("Child")
+            };
+
+            secondParent.ClearChangeMasks(context, false);
+            secondParent.ReplaceChild(context, replacement);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(replacement.Parent, Is.SameAs(secondParent));
+                Assert.That(
+                    secondParent.ChangeMasks & NodeStateChangeMasks.Children,
+                    Is.EqualTo(NodeStateChangeMasks.Children));
+            });
+        }
+
+        [Test]
+        public void EqualReferenceNodesHashAlike()
+        {
+            // The hash mixed in object identity, so two value-equal references
+            // hashed differently.
+            var first = new ReferenceNode
+            {
+                ReferenceTypeId = ReferenceTypeIds.HasComponent,
+                IsInverse = false,
+                TargetId = new ExpandedNodeId(5u)
+            };
+            var second = new ReferenceNode
+            {
+                ReferenceTypeId = ReferenceTypeIds.HasComponent,
+                IsInverse = false,
+                TargetId = new ExpandedNodeId(5u)
+            };
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(first, Is.EqualTo(second));
+                Assert.That(first.GetHashCode(), Is.EqualTo(second.GetHashCode()));
+            });
+        }
+
+        [Test]
+        public void MinimumSamplingIntervalIsWrittenAsADuration()
+        {
+            // The gate rejected the Double value as BadTypeMismatch, and the
+            // handler behind it cast the Double variant to int.
+            var node = new VariableNode
+            {
+                NodeId = new NodeId(2600u),
+                BrowseName = QualifiedName.From("Value"),
+                WriteMask = (uint)AttributeWriteMask.MinimumSamplingInterval
+            };
+
+            ServiceResult result = node.Write(
+                Attributes.MinimumSamplingInterval,
+                new DataValue(new Variant(250.0)));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(ServiceResult.IsGood(result), Is.True);
+                Assert.That(node.MinimumSamplingInterval, Is.EqualTo(250.0));
+            });
+        }
+
+        [Test]
+        public void AnArrayValueIsRejectedInsteadOfThrowingFromTheAttributeCast()
+        {
+            // The gate compared built-in types only, which does not separate a
+            // Boolean from an array of Boolean, so an array reached the handler
+            // behind it and its unconditional cast threw InvalidCastException
+            // out of a method that reports failure as a status code.
+            var node = new VariableNode
+            {
+                NodeId = new NodeId(2601u),
+                BrowseName = QualifiedName.From("Value")
+            };
+
+            ServiceResult booleans = node.Write(
+                Attributes.Historizing,
+                new DataValue(new Variant(s_booleans.ToArrayOf())));
+            ServiceResult masks = node.Write(
+                Attributes.WriteMask,
+                new DataValue(new Variant(s_masks.ToArrayOf())));
+            ServiceResult scalar = node.Write(
+                Attributes.Historizing,
+                new DataValue(new Variant(true)));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(booleans.StatusCode, Is.EqualTo((StatusCode)StatusCodes.BadTypeMismatch));
+                Assert.That(masks.StatusCode, Is.EqualTo((StatusCode)StatusCodes.BadTypeMismatch));
+
+                // the matching scalar still writes.
+                Assert.That(ServiceResult.IsGood(scalar), Is.True);
+                Assert.That(node.Historizing, Is.True);
+            });
+        }
+
+        [Test]
+        public void RolePermissionAttributesSurviveAReadWriteRoundTrip()
+        {
+            // RolePermissionType is not a built-in type, so the gate derived
+            // BuiltInType.Null for the attribute and rejected every value,
+            // leaving the handler behind it permanently unreachable.
+            var node = new VariableNode
+            {
+                NodeId = new NodeId(2602u),
+                BrowseName = QualifiedName.From("Value"),
+                RolePermissions =
+                [
+                    new RolePermissionType { RoleId = new NodeId(15644u), Permissions = 1 }
+                ]
+            };
+
+            var read = new DataValue();
+            ServiceResult readResult = node.Read(null, Attributes.RolePermissions, ref read);
+            ServiceResult result = node.Write(Attributes.RolePermissions, read);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(ServiceResult.IsGood(readResult), Is.True);
+                Assert.That(ServiceResult.IsGood(result), Is.True);
+                Assert.That(node.RolePermissions, Has.Count.EqualTo(1));
+            });
+        }
+
+        [Test]
+        public void NodeTableRemoveDropsTheReverseReference()
+        {
+            // The reverse reference was removed with the wrong direction, so it
+            // stayed behind and dangled.
+            var namespaceUris = new NamespaceTable();
+            var serverUris = new StringTable();
+            var table = new NodeTable(namespaceUris, serverUris, new TypeTable(namespaceUris));
+
+            var source = new ObjectNode
+            {
+                NodeId = new NodeId(3000u),
+                BrowseName = QualifiedName.From("Source")
+            };
+            var target = new ObjectNode
+            {
+                NodeId = new NodeId(3001u),
+                BrowseName = QualifiedName.From("Target")
+            };
+
+            table.Attach(target);
+            source.ReferenceTable.Add(
+                ReferenceTypeIds.Organizes,
+                false,
+                new ExpandedNodeId(3001u));
+            table.Attach(source);
+
+            Assert.That(
+                target.ReferenceTable.Exists(
+                    ReferenceTypeIds.Organizes,
+                    true,
+                    new ExpandedNodeId(3000u),
+                    false,
+                    null),
+                Is.True,
+                "the reverse reference should have been added");
+
+            table.Remove(new ExpandedNodeId(3000u));
+
+            Assert.That(
+                target.ReferenceTable.Exists(
+                    ReferenceTypeIds.Organizes,
+                    true,
+                    new ExpandedNodeId(3000u),
+                    false,
+                    null),
+                Is.False,
+                "the reverse reference should have been removed");
+        }
+
+        [Test]
+        public void NodeTableAttachIndexesTheUnindexedReferenceList()
+        {
+            // Attach enumerated the (still empty) ReferenceTable instead of the
+            // Node's References array, so nothing was indexed.
+            var namespaceUris = new NamespaceTable();
+            var serverUris = new StringTable();
+            var table = new NodeTable(namespaceUris, serverUris, new TypeTable(namespaceUris));
+
+            var node = new ObjectNode
+            {
+                NodeId = new NodeId(3100u),
+                BrowseName = QualifiedName.From("Imported"),
+                References = new[]
+                {
+                    new ReferenceNode
+                    {
+                        ReferenceTypeId = ReferenceTypeIds.Organizes,
+                        IsInverse = false,
+                        TargetId = new ExpandedNodeId(3101u)
+                    }
+                }.ToArrayOf()
+            };
+
+            table.Attach(node);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(node.ReferenceTable, Has.Count.EqualTo(1));
+                Assert.That(node.References.Count, Is.Zero);
+            });
+        }
+
+        [Test]
+        public void ServerUriTableIsLoadedFromTheDocument()
+        {
+            // LoadFromXml loaded the ServerUris into the shared context table
+            // and then built the decoding mapping from an empty local one, so
+            // the document's server indexes were never translated.
+            SystemContext source = CreateContext();
+            source.ServerUris.Append("urn:source:server");
+
+            var node = new BaseObjectState(null)
+            {
+                NodeId = new NodeId(3200u),
+                BrowseName = QualifiedName.From("Node"),
+                SymbolicName = "Node"
+            };
+            node.AddReference(
+                ReferenceTypeIds.Organizes,
+                false,
+                new ExpandedNodeId(new NodeId(3201u), null, 1));
+
+            var collection = new NodeStateCollection { node };
+
+            using var stream = new MemoryStream();
+            collection.SaveAsXml(source, stream, true);
+            stream.Position = 0;
+
+            // The loading context knows the same server URI at a different index.
+            SystemContext target = CreateContext();
+            target.ServerUris.Append("urn:other:server");
+            target.ServerUris.Append("urn:source:server");
+
+            var reloaded = new NodeStateCollection();
+            reloaded.LoadFromXml(target, stream, true);
+
+            Assert.That(reloaded, Is.Not.Empty);
+
+            var references = new List<IReference>();
+            reloaded[0].GetReferences(target, references);
+
+            IReference organizes = references.Find(
+                r => r.ReferenceTypeId == ReferenceTypeIds.Organizes && !r.IsInverse);
+
+            Assert.That(organizes, Is.Not.Null);
+            Assert.That(
+                organizes.TargetId.ServerIndex,
+                Is.EqualTo(target.ServerUris.GetIndex("urn:source:server")),
+                "the document's server index must be mapped into the target table");
+        }
+    }
+}

--- a/tests/Opc.Ua.Types.Tests/State/NodeStateAuditRegressionTests.cs
+++ b/tests/Opc.Ua.Types.Tests/State/NodeStateAuditRegressionTests.cs
@@ -437,6 +437,32 @@ namespace Opc.Ua.Types.Tests.State
         }
 
         [Test]
+        public void DataTypeDefinitionSurvivesAReadWriteRoundTrip()
+        {
+            // The attribute's data type is Structure, whose identifier is the
+            // same number as BuiltInType.ExtensionObject, so the gate resolves
+            // it without needing the structured-type override the permission
+            // attributes need. This pins that, because the two look alike.
+            var node = new DataTypeNode
+            {
+                NodeId = new NodeId(2603u),
+                BrowseName = QualifiedName.From("Custom"),
+                DataTypeDefinition = new ExtensionObject(new StructureDefinition())
+            };
+
+            var read = new DataValue();
+            ServiceResult readResult = node.Read(null, Attributes.DataTypeDefinition, ref read);
+            ServiceResult result = node.Write(Attributes.DataTypeDefinition, read);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(readResult.StatusCode, Is.EqualTo((StatusCode)StatusCodes.Good));
+                Assert.That(result.StatusCode, Is.EqualTo((StatusCode)StatusCodes.Good));
+                Assert.That(node.DataTypeDefinition.IsNull, Is.False);
+            });
+        }
+
+        [Test]
         public void RolePermissionAttributesSurviveAReadWriteRoundTrip()
         {
             // RolePermissionType is not a built-in type, so the gate derived

--- a/tests/Opc.Ua.Types.Tests/State/NodeStateOptionalStorageTests.cs
+++ b/tests/Opc.Ua.Types.Tests/State/NodeStateOptionalStorageTests.cs
@@ -249,14 +249,15 @@ namespace Opc.Ua.Types.Tests.State
         }
 
         [Test]
-        public void CloneRetainsExistingAccessRestrictionOmission()
+        public void CloneCopiesAccessRestrictions()
         {
             var source = new BaseObjectState(null) { AccessRestrictions = AccessRestrictionType.SigningRequired };
             var copy = (BaseObjectState)source.Clone();
-            // CopyTo does not copy AccessRestrictions; changing that is not a storage optimization.
-            Assert.That(copy.AccessRestrictions, Is.Null);
-            Assert.That(s_securityField.GetValue(copy), Is.Null);
-            Assert.That(copy.DeepEquals(source), Is.False);
+            // CopyTo used to drop AccessRestrictions (and UserWriteMask) entirely.
+            Assert.That(copy.AccessRestrictions, Is.EqualTo(AccessRestrictionType.SigningRequired));
+            Assert.That(s_securityField.GetValue(copy), Is.Not.Null);
+            Assert.That(copy.DeepEquals(source), Is.True);
+            // The copy has its own storage.
             copy.AccessRestrictions = AccessRestrictionType.EncryptionRequired;
             Assert.That(source.AccessRestrictions, Is.EqualTo(AccessRestrictionType.SigningRequired));
         }
@@ -413,7 +414,9 @@ namespace Opc.Ua.Types.Tests.State
             Assert.That(calls, Is.EqualTo(1));
             Assert.That(node.AccessRestrictions, Is.EqualTo(reset
                 ? (AccessRestrictionType?)null : AccessRestrictionType.EncryptionRequired));
-            Assert.That(node.ChangeMasks, Is.EqualTo(NodeStateChangeMasks.None));
+            // A successful write raises the change mask so that monitored
+            // items on the attribute are notified.
+            Assert.That(node.ChangeMasks, Is.EqualTo(NodeStateChangeMasks.NonValue));
             Assert.That(s_securityField.GetValue(node), reset ? Is.Null : Is.Not.Null);
         }
 

--- a/tests/Opc.Ua.Types.Tests/Utils/UtilsAuditRegressionTests.cs
+++ b/tests/Opc.Ua.Types.Tests/Utils/UtilsAuditRegressionTests.cs
@@ -1,0 +1,223 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using System.IO;
+using System.Text;
+using NUnit.Framework;
+
+namespace Opc.Ua.Types.Tests.Utils
+{
+    /// <summary>
+    /// Regression tests for the Utils / Schema / Polyfill defects reported by
+    /// the read-only bug audit of Opc.Ua.Types.
+    /// </summary>
+    [TestFixture]
+    [Category("Utils")]
+    [SetCulture("en-us")]
+    [SetUICulture("en-us")]
+    [Parallelizable]
+    public class UtilsAuditRegressionTests
+    {
+        [Test]
+        public void OpenReadAllowsConcurrentReadersAndReadOnlyFiles()
+        {
+            // File.Open(path, FileMode.Open) requests ReadWrite access with
+            // FileShare.None, which fails on a read-only file and locks out
+            // concurrent readers.
+            string path = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            File.WriteAllText(path, "content");
+
+            try
+            {
+                File.SetAttributes(path, FileAttributes.ReadOnly);
+
+                var fileSystem = new LocalFileSystem();
+
+                using Stream first = fileSystem.OpenRead(path);
+                using Stream second = fileSystem.OpenRead(path);
+
+                Assert.Multiple(() =>
+                {
+                    Assert.That(first.CanRead, Is.True);
+                    Assert.That(second.CanRead, Is.True);
+                });
+            }
+            finally
+            {
+                File.SetAttributes(path, FileAttributes.Normal);
+                File.Delete(path);
+            }
+        }
+
+        [Test]
+        public void MatchDoesNotThrowForAnUnterminatedCharacterSet()
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.DoesNotThrow(() => CoreUtils.Match("ab", "a[", true));
+                Assert.DoesNotThrow(() => CoreUtils.Match("abc", "a[b-", true));
+                Assert.DoesNotThrow(() => CoreUtils.Match("abc", "a[!", true));
+            });
+        }
+
+        [Test]
+        public void MatchRejectsAnUnmatchedTrailingCharacter()
+        {
+            // The trailing bound was target.Length - 1, which let exactly one
+            // unmatched character through.
+            Assert.Multiple(() =>
+            {
+                Assert.That(CoreUtils.Match("abc", "ab", true), Is.False);
+                Assert.That(CoreUtils.Match("ab", "ab", true), Is.True);
+                Assert.That(CoreUtils.Match("12", "#", true), Is.False);
+            });
+        }
+
+        [Test]
+        public void MatchAcceptsAPatternEndingInASingleCharacterWildcard()
+        {
+            // The unmatched-trailing-character guard was placed before the '?'
+            // consumed its character, so it fired for every pattern whose last
+            // character is '?' and nothing matched.
+            Assert.Multiple(() =>
+            {
+                Assert.That(CoreUtils.Match("a", "?", true), Is.True);
+                Assert.That(CoreUtils.Match("ab", "a?", true), Is.True);
+                Assert.That(CoreUtils.Match("abc", "a??", true), Is.True);
+                Assert.That(CoreUtils.Match("abcd", "ab??", true), Is.True);
+
+                // and the guard still rejects a genuinely unmatched tail.
+                Assert.That(CoreUtils.Match("abc", "a?", true), Is.False);
+                Assert.That(CoreUtils.Match(string.Empty, "?", true), Is.False);
+            });
+        }
+
+        [Test]
+        public void MatchAcceptsATrailingWildcardOverAnEmptyRemainder()
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(CoreUtils.Match("a", "a*", true), Is.True);
+                Assert.That(CoreUtils.Match("a", "a**", true), Is.True);
+                Assert.That(CoreUtils.Match("abc", "a*", true), Is.True);
+            });
+        }
+
+        [Test]
+        public void ServiceResultExceptionToleratesANullResult()
+        {
+            // The constructor dereferenced the null it explicitly tolerates.
+            var ex = new ServiceResultException((ServiceResult)null);
+
+            Assert.That(ex.StatusCode, Is.EqualTo(ServiceResult.Bad.StatusCode));
+        }
+
+        [Test]
+        public void VirtualFileSystemKeepsBytesPastTheFinalPosition()
+        {
+            // The write stream truncated the file to its final position, so a
+            // writer that seeked back and wrote a shorter tail lost data.
+            var fileSystem = new VirtualFileSystem();
+            const string path = "audit/regression.bin";
+
+            using (Stream stream = fileSystem.OpenWrite(path))
+            {
+                stream.Write([1, 2, 3, 4, 5, 6], 0, 6);
+                stream.Seek(2, SeekOrigin.Begin);
+                stream.Write([9], 0, 1);
+            }
+
+            using (Stream stream = fileSystem.OpenRead(path))
+            {
+                byte[] buffer = new byte[8];
+                int read = stream.Read(buffer, 0, buffer.Length);
+
+                Assert.That(read, Is.EqualTo(6));
+                Assert.That(buffer[..6], Is.EqualTo(new byte[] { 1, 2, 9, 4, 5, 6 }));
+            }
+        }
+
+        [Test]
+        public void VirtualFileSystemStillHonoursAnExplicitSetLength()
+        {
+            var fileSystem = new VirtualFileSystem();
+            const string path = "audit/truncated.bin";
+
+            using (Stream stream = fileSystem.OpenWrite(path))
+            {
+                stream.Write([1, 2, 3, 4], 0, 4);
+                stream.SetLength(2);
+            }
+
+            Assert.That(fileSystem.GetLength(path), Is.EqualTo(2));
+        }
+
+        [Test]
+        public void BinarySchemaValidatorImportsTheBuiltInTypeDictionary()
+        {
+            // The fallback imported Namespaces.OpcUa, for which no embedded
+            // resource exists, so validating a dictionary without explicit
+            // imports always failed.
+            const string bsd =
+                "<opc:TypeDictionary xmlns:opc=\"http://opcfoundation.org/BinarySchema/\" " +
+                "xmlns:ua=\"http://opcfoundation.org/UA/\" " +
+                "DefaultByteOrder=\"LittleEndian\" " +
+                "TargetNamespace=\"http://test.org/Types/\">" +
+                "<opc:StructuredType Name=\"Sample\">" +
+                "<opc:Field Name=\"Value\" TypeName=\"opc:Int32\" />" +
+                "</opc:StructuredType>" +
+                "</opc:TypeDictionary>";
+
+            var validator = new Opc.Ua.Schema.Binary.BinarySchemaValidator();
+
+            using var stream = new MemoryStream(Encoding.UTF8.GetBytes(bsd));
+            Assert.DoesNotThrow(() => validator.Validate(stream));
+        }
+
+        [Test]
+        public void PolyfillIndexOfHonoursTheComparison()
+        {
+            // The polyfills ignored the comparison argument entirely. On modern
+            // target frameworks the framework method is used, so this asserts
+            // the behaviour both implementations must agree on.
+            const string target = "ABC";
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(
+                    target.IndexOf('b', StringComparison.OrdinalIgnoreCase),
+                    Is.EqualTo(1));
+                Assert.That(
+                    target.Replace("b", "x", StringComparison.OrdinalIgnoreCase),
+                    Is.EqualTo("AxC"));
+            });
+        }
+    }
+}

--- a/tests/Opc.Ua.Types.Tests/Utils/UtilsAuditRegressionTests.cs
+++ b/tests/Opc.Ua.Types.Tests/Utils/UtilsAuditRegressionTests.cs
@@ -101,6 +101,25 @@ namespace Opc.Ua.Types.Tests.Utils
         }
 
         [Test]
+        public void ReplaceThrowsForAnInvalidOldValueUnderEveryComparison()
+        {
+            // The non-ordinal path returned the target instead of throwing, so
+            // the polyfill's contract differed from the framework overload and
+            // from its own ordinal branch.
+            Assert.Multiple(() =>
+            {
+                Assert.Throws<ArgumentNullException>(
+                    () => "abc".Replace(null!, "x", StringComparison.CurrentCulture));
+                Assert.Throws<ArgumentException>(
+                    () => "abc".Replace(string.Empty, "x", StringComparison.CurrentCulture));
+                Assert.Throws<ArgumentNullException>(
+                    () => "abc".Replace(null!, "x", StringComparison.OrdinalIgnoreCase));
+                Assert.Throws<ArgumentException>(
+                    () => "abc".Replace(string.Empty, "x", StringComparison.OrdinalIgnoreCase));
+            });
+        }
+
+        [Test]
         public void MatchAcceptsAPatternEndingInASingleCharacterWildcard()
         {
             // The unmatched-trailing-character guard was placed before the '?'
@@ -159,8 +178,13 @@ namespace Opc.Ua.Types.Tests.Utils
                 byte[] buffer = new byte[8];
                 int read = stream.Read(buffer, 0, buffer.Length);
 
+                // A range indexer over an array needs RuntimeHelpers.GetSubArray,
+                // which .NET Framework does not have.
+                byte[] head = new byte[6];
+                Array.Copy(buffer, head, head.Length);
+
                 Assert.That(read, Is.EqualTo(6));
-                Assert.That(buffer[..6], Is.EqualTo(new byte[] { 1, 2, 9, 4, 5, 6 }));
+                Assert.That(head, Is.EqualTo(new byte[] { 1, 2, 9, 4, 5, 6 }));
             }
         }
 
@@ -177,6 +201,29 @@ namespace Opc.Ua.Types.Tests.Utils
             }
 
             Assert.That(fileSystem.GetLength(path), Is.EqualTo(2));
+        }
+
+        [Test]
+        public void VirtualFileSystemHonoursSetLengthToTheCurrentLength()
+        {
+            // SetLength returned early when asked for the length the file
+            // already had, so the high water mark stayed at zero and the
+            // truncation on dispose emptied the file despite the explicit
+            // length request.
+            var fileSystem = new VirtualFileSystem();
+            const string path = "audit/unchanged.bin";
+
+            using (Stream stream = fileSystem.OpenWrite(path))
+            {
+                stream.Write([1, 2, 3, 4, 5, 6], 0, 6);
+            }
+
+            using (Stream stream = fileSystem.OpenWrite(path))
+            {
+                stream.SetLength(6);
+            }
+
+            Assert.That(fileSystem.GetLength(path), Is.EqualTo(6));
         }
 
         [Test]

--- a/tests/Opc.Ua.Types.Tests/Utils/UtilsAuditRegressionTests.cs
+++ b/tests/Opc.Ua.Types.Tests/Utils/UtilsAuditRegressionTests.cs
@@ -88,6 +88,27 @@ namespace Opc.Ua.Types.Tests.Utils
         }
 
         [Test]
+        public void MatchRejectsAnUnterminatedCharacterSet()
+        {
+            // Only an empty "[" was rejected. A non-empty set with no closing
+            // ']' ran the scanner off the end of the pattern, which then left
+            // the switch as though the set had matched.
+            Assert.Multiple(() =>
+            {
+                Assert.That(CoreUtils.Match("a", "[a", true), Is.False);
+                Assert.That(CoreUtils.Match("b", "[!a", true), Is.False);
+                Assert.That(CoreUtils.Match("a", "[a-c", true), Is.False);
+                Assert.That(CoreUtils.Match("a", "[", true), Is.False);
+
+                // a closed set still works, in both directions.
+                Assert.That(CoreUtils.Match("a", "[a]", true), Is.True);
+                Assert.That(CoreUtils.Match("b", "[a]", true), Is.False);
+                Assert.That(CoreUtils.Match("b", "[!a]", true), Is.True);
+                Assert.That(CoreUtils.Match("b", "[a-c]", true), Is.True);
+            });
+        }
+
+        [Test]
         public void MatchRejectsAnUnmatchedTrailingCharacter()
         {
             // The trailing bound was target.Length - 1, which let exactly one

--- a/tests/Opc.Ua.Types.Tests/Wot/WotAuditRegressionTests.cs
+++ b/tests/Opc.Ua.Types.Tests/Wot/WotAuditRegressionTests.cs
@@ -308,10 +308,15 @@ namespace Opc.Ua.Types.Tests.Wot
                 "uav", "Member", WotVocabulary.VocabularyNamespace);
             member.SetAttribute("Pointer", pointer);
             member.SetAttribute("Encoding", WotVocabulary.Base64Encoding);
+            // SHA256.HashData is .NET 5 and later only.
+            byte[] hash;
+            using (var sha256 = System.Security.Cryptography.SHA256.Create())
+            {
+                hash = sha256.ComputeHash(bytes);
+            }
             member.SetAttribute(
                 "Sha256",
-                CoreUtils.ToHexString(
-                    System.Security.Cryptography.SHA256.HashData(bytes)).ToLowerInvariant());
+                CoreUtils.ToHexString(hash).ToLowerInvariant());
             member.InnerText = Convert.ToBase64String(bytes);
             root.AppendChild(member);
             return root;

--- a/tests/Opc.Ua.Types.Tests/Wot/WotAuditRegressionTests.cs
+++ b/tests/Opc.Ua.Types.Tests/Wot/WotAuditRegressionTests.cs
@@ -1,0 +1,400 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Opc.Ua.Export;
+using Opc.Ua.Wot;
+
+namespace Opc.Ua.Types.Tests.Wot
+{
+    /// <summary>
+    /// Regression tests for the WoT converter / resolver / residue defects
+    /// reported by the read-only bug audit of Opc.Ua.Types.
+    /// </summary>
+    [TestFixture]
+    [Category("WoT")]
+    [Parallelizable]
+    public class WotAuditRegressionTests
+    {
+        [Test]
+        public void NonFiniteRangeBoundsAreNotProjected()
+        {
+            // double.TryParse accepts NaN - which XmlConvert writes for an
+            // uninitialised Range - and WriteNumber then threw
+            // ArgumentOutOfRangeException out of FromNodeSet.
+            UANodeSet source = WotAnalogTestData.CreateAnalogNodeSet(withInstrumentRange: false);
+            UAVariable range = source.Items!.OfType<UAVariable>()
+                .First(v => v.BrowseName == "EURange");
+            range.Value = WotAnalogTestData.RangeValue(double.NaN, double.NaN);
+
+            using WotDocument document = WotNodeSetConverter.FromNodeSet(source);
+
+            JsonElement measurement = document.Properties["Measurement"];
+            Assert.Multiple(() =>
+            {
+                Assert.That(measurement.TryGetProperty("minimum", out _), Is.False);
+                Assert.That(measurement.TryGetProperty("maximum", out _), Is.False);
+            });
+        }
+
+        [Test]
+        public void FiniteRangeBoundsAreStillProjected()
+        {
+            UANodeSet source = WotAnalogTestData.CreateAnalogNodeSet(withInstrumentRange: false);
+
+            using WotDocument document = WotNodeSetConverter.FromNodeSet(source);
+
+            JsonElement measurement = document.Properties["Measurement"];
+            Assert.Multiple(() =>
+            {
+                Assert.That(measurement.GetProperty("minimum").GetDouble(), Is.EqualTo(-5));
+                Assert.That(measurement.GetProperty("maximum").GetDouble(), Is.EqualTo(95));
+            });
+        }
+
+        [Test]
+        public void StructureOfBaseDataTypeFieldsStaysAStructure()
+        {
+            // Every field of this Structure reads back as BaseDataType with no
+            // Value, which the enumeration heuristic mistook for an
+            // EnumDefinition.
+            UANodeSet source = CreateDataTypeNodeSet(
+                "Bag",
+                "i=22",
+                new Export.DataTypeDefinition
+                {
+                    Name = "1:Bag",
+                    Field =
+                    [
+                        new Export.DataTypeField { Name = "First", DataType = "i=24" },
+                        new Export.DataTypeField { Name = "Second", DataType = "i=24" }
+                    ]
+                });
+
+            using WotDocument document = WotNodeSetConverter.FromNodeSet(source);
+
+            Assert.That(
+                DefinitionKindOf(document, "Bag"),
+                Is.EqualTo("uav:StructureDefinition"));
+        }
+
+        [Test]
+        public void EnumerationWithANegativeValueStaysAnEnumeration()
+        {
+            UANodeSet source = CreateDataTypeNodeSet(
+                "State",
+                "i=29",
+                new Export.DataTypeDefinition
+                {
+                    Name = "1:State",
+                    Field =
+                    [
+                        new Export.DataTypeField { Name = "Faulted", Value = -1 },
+                        new Export.DataTypeField { Name = "Stopped", Value = 0 }
+                    ]
+                });
+
+            using WotDocument document = WotNodeSetConverter.FromNodeSet(source);
+
+            Assert.That(
+                DefinitionKindOf(document, "State"),
+                Is.EqualTo("uav:EnumDefinition"));
+        }
+
+        [Test]
+        public async Task PortableBrowseNamesResolveInTheDocumentNodeResolverAsync()
+        {
+            // The nsu= form was split on the first ':', so the namespace of
+            // "nsu=http://example.com/x;PumpType" became "http".
+            const string json =
+                "{" +
+                "\"@context\":[\"https://www.w3.org/2022/wot/td/v1.1\"]," +
+                "\"@type\":[\"tm:ThingModel\",\"uav:objectType\"]," +
+                "\"title\":\"Pump\"," +
+                "\"uav:id\":\"nsu=http://example.com/x;s=PumpType\"," +
+                "\"uav:browseName\":\"nsu=http://example.com/x;PumpType\"" +
+                "}";
+
+            using WotDocument document = WotDocument.Parse(Encoding.UTF8.GetBytes(json));
+            var resolver = new WotDocumentNodeResolver([document]);
+
+            Assert.That(
+                await resolver.HoldsNamespaceAsync("http://example.com/x").ConfigureAwait(false),
+                Is.True,
+                "the portable namespace should have been indexed");
+
+            ArrayOf<WotResolvedNode> resolved = await resolver
+                .ResolveByBrowseNameAsync(
+                    "http://example.com/x",
+                    "PumpType",
+                    WotExpectedNodeClass.ObjectType)
+                .ConfigureAwait(false);
+
+            Assert.That(resolved.Count, Is.EqualTo(1));
+        }
+
+        [Test]
+        public async Task AnEscapedPortableNamespaceIsUnescapedWhenIndexedAsync()
+        {
+            // The nsu= namespace was indexed raw while every other reader of the
+            // same member unescapes it, so a namespace URI containing ';' or '%'
+            // was keyed one way and looked up the other.
+            const string json =
+                "{" +
+                "\"@context\":[\"https://www.w3.org/2022/wot/td/v1.1\"]," +
+                "\"@type\":[\"tm:ThingModel\",\"uav:objectType\"]," +
+                "\"title\":\"Pump\"," +
+                "\"uav:id\":\"nsu=http://example.com/a%3Bb;s=PumpType\"," +
+                "\"uav:browseName\":\"nsu=http://example.com/a%3Bb;PumpType\"" +
+                "}";
+
+            using WotDocument document = WotDocument.Parse(Encoding.UTF8.GetBytes(json));
+            var resolver = new WotDocumentNodeResolver([document]);
+
+            Assert.That(
+                await resolver.HoldsNamespaceAsync("http://example.com/a;b").ConfigureAwait(false),
+                Is.True,
+                "the unescaped namespace should have been indexed");
+
+            ArrayOf<WotResolvedNode> resolved = await resolver
+                .ResolveByBrowseNameAsync(
+                    "http://example.com/a;b",
+                    "PumpType",
+                    WotExpectedNodeClass.ObjectType)
+                .ConfigureAwait(false);
+
+            Assert.That(resolved.Count, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void AffordanceLinkResidueStaysOnItsAffordance()
+        {
+            // Residue captured for /properties/<name>/links/- was appended to
+            // the Thing's own links array, so the affordance lost its extras
+            // and the Thing gained a second type definition link.
+            string authored = CreateThingWithAffordanceLink(withExtra: true);
+            string generated = CreateThingWithAffordanceLink(withExtra: false);
+
+            var options = new WotNodeSetConverterOptions();
+            var nodeSet = new UANodeSet
+            {
+                NamespaceUris = ["urn:test:audit"],
+                Models = [new ModelTableEntry { ModelUri = "urn:test:audit" }]
+            };
+            var diagnostics = new List<WotDiagnostic>();
+
+            using (WotDocument authoredDocument = WotDocument.Parse(
+                Encoding.UTF8.GetBytes(authored), options))
+            {
+                WotJsonResidue.Replace(nodeSet, authoredDocument, options, diagnostics);
+            }
+
+            byte[] merged = WotJsonResidue.Apply(
+                Encoding.UTF8.GetBytes(generated), nodeSet, options, diagnostics);
+
+            using JsonDocument parsed = JsonDocument.Parse(merged);
+            JsonElement rootElement = parsed.RootElement;
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(
+                    diagnostics.Count(d => d.Severity == WotDiagnosticSeverity.Error),
+                    Is.Zero);
+                Assert.That(
+                    rootElement.TryGetProperty("links", out _),
+                    Is.False,
+                    "the Thing's own links must not gain the affordance's residue");
+
+                JsonElement links = rootElement
+                    .GetProperty("properties")
+                    .GetProperty("Speed")
+                    .GetProperty("links");
+                Assert.That(links.GetArrayLength(), Is.EqualTo(1));
+                Assert.That(
+                    links[0].GetProperty("x:extra").GetString(),
+                    Is.EqualTo("keep"));
+            });
+        }
+
+        [Test]
+        public void MalformedResidueIsReportedInsteadOfThrown()
+        {
+            // RemoveDocumentSetLinks parsed every residue member unguarded, so
+            // a malformed one threw a JsonException out of the public
+            // MergeNodeSetPartitions entry point.
+            const string json =
+                "{" +
+                "\"@context\":[\"https://www.w3.org/2022/wot/td/v1.1\"]," +
+                "\"@type\":[\"tm:ThingModel\",\"uav:objectType\"]," +
+                "\"title\":\"Thing\"," +
+                "\"uav:browseName\":\"ns1:ThingType\"" +
+                "}";
+
+            using WotDocument document = WotDocument.Parse(Encoding.UTF8.GetBytes(json));
+            using var documents = new WotDocumentSet(
+                "root",
+                new[] { new WotDocumentSetEntry("root", document) }.ToArrayOf());
+
+            var partition = new UANodeSet
+            {
+                NamespaceUris = ["urn:test:audit"],
+                Models = [new ModelTableEntry { ModelUri = "urn:test:audit" }],
+                Items = [],
+                Extensions = [CreateResidueExtension("/title", "{ not json")]
+            };
+
+            var diagnostics = new List<WotDiagnostic>();
+
+            Assert.DoesNotThrow(() => WotJsonResidue.RemoveDocumentSetLinks(
+                partition,
+                document,
+                documents,
+                new WotNodeSetConverterOptions(),
+                diagnostics));
+
+            Assert.That(
+                diagnostics.Any(d =>
+                    d.Severity == WotDiagnosticSeverity.Error &&
+                    d.Code == WotDiagnosticCode.ResidueInvalid),
+                Is.True,
+                "the malformed member should have been reported");
+        }
+
+        private static System.Xml.XmlElement CreateResidueExtension(
+            string pointer,
+            string payload)
+        {
+            var document = new System.Xml.XmlDocument { XmlResolver = null };
+            System.Xml.XmlElement root = document.CreateElement(
+                "uav", "WoTJsonResidue", WotVocabulary.VocabularyNamespace);
+            root.SetAttribute("Version", "1.0");
+            document.AppendChild(root);
+
+            byte[] bytes = Encoding.UTF8.GetBytes(payload);
+            System.Xml.XmlElement member = document.CreateElement(
+                "uav", "Member", WotVocabulary.VocabularyNamespace);
+            member.SetAttribute("Pointer", pointer);
+            member.SetAttribute("Encoding", WotVocabulary.Base64Encoding);
+            member.SetAttribute(
+                "Sha256",
+                CoreUtils.ToHexString(
+                    System.Security.Cryptography.SHA256.HashData(bytes)).ToLowerInvariant());
+            member.InnerText = Convert.ToBase64String(bytes);
+            root.AppendChild(member);
+            return root;
+        }
+
+        private static string CreateThingWithAffordanceLink(bool withExtra)
+        {
+            return
+                "{" +
+                "\"@context\":[\"https://www.w3.org/2022/wot/td/v1.1\"]," +
+                "\"@type\":[\"tm:ThingModel\",\"uav:objectType\"]," +
+                "\"title\":\"Thing\"," +
+                "\"uav:browseName\":\"ns1:ThingType\"," +
+                "\"properties\":{\"Speed\":{\"type\":\"number\",\"links\":[{" +
+                "\"rel\":\"ua:HasTypeDefinition\",\"href\":\"i=68\"" +
+                (withExtra ? ",\"x:extra\":\"keep\"" : string.Empty) +
+                "}]}}" +
+                "}";
+        }
+
+        private static UANodeSet CreateDataTypeNodeSet(
+            string name,
+            string baseTypeId,
+            Export.DataTypeDefinition definition)
+        {
+            return new UANodeSet
+            {
+                NamespaceUris = ["urn:test:audit"],
+                Models = [new ModelTableEntry { ModelUri = "urn:test:audit" }],
+                Items =
+                [
+                    new UAObjectType
+                    {
+                        NodeId = "ns=1;s=Root",
+                        BrowseName = "1:RootType",
+                        DisplayName = WotAnalogTestData.Text("RootType"),
+                        References =
+                        [
+                            new Reference
+                            {
+                                ReferenceType = "i=45",
+                                IsForward = false,
+                                Value = "i=58"
+                            }
+                        ]
+                    },
+                    new UADataType
+                    {
+                        NodeId = "ns=1;s=" + name,
+                        BrowseName = "1:" + name,
+                        DisplayName = WotAnalogTestData.Text(name),
+                        References =
+                        [
+                            new Reference
+                            {
+                                ReferenceType = "i=45",
+                                IsForward = false,
+                                Value = baseTypeId
+                            }
+                        ],
+                        Definition = definition
+                    }
+                ]
+            };
+        }
+
+        private static string? DefinitionKindOf(WotDocument document, string name)
+        {
+            JsonElement definitions = document.RootElement
+                .GetProperty("uav:dataTypeDefinitions");
+            foreach (JsonElement definition in definitions.EnumerateArray())
+            {
+                string? declared = definition.TryGetProperty(
+                    "uav:dataTypeName", out JsonElement declaredName)
+                    ? declaredName.GetString()
+                    : null;
+                if (declared is not null &&
+                    declared.EndsWith(name, StringComparison.Ordinal))
+                {
+                    return definition.GetProperty("@type").GetString();
+                }
+            }
+            return null;
+        }
+    }
+}

--- a/tests/Opc.Ua.Types.Tests/Wot/WotAuditRegressionTests.cs
+++ b/tests/Opc.Ua.Types.Tests/Wot/WotAuditRegressionTests.cs
@@ -308,12 +308,15 @@ namespace Opc.Ua.Types.Tests.Wot
                 "uav", "Member", WotVocabulary.VocabularyNamespace);
             member.SetAttribute("Pointer", pointer);
             member.SetAttribute("Encoding", WotVocabulary.Base64Encoding);
-            // SHA256.HashData is .NET 5 and later only.
+            // SHA256.HashData is .NET 5 and later only, and this fixture also
+            // builds for the .NET Framework targets.
+#pragma warning disable CA1850 // Prefer static HashData over ComputeHash
             byte[] hash;
             using (var sha256 = System.Security.Cryptography.SHA256.Create())
             {
                 hash = sha256.ComputeHash(bytes);
             }
+#pragma warning restore CA1850
             member.SetAttribute(
                 "Sha256",
                 CoreUtils.ToHexString(hash).ToLowerInvariant());

--- a/tests/Opc.Ua.WotCon.Tests/WotConnectivityNodeManagerTests.cs
+++ b/tests/Opc.Ua.WotCon.Tests/WotConnectivityNodeManagerTests.cs
@@ -107,7 +107,10 @@ namespace Opc.Ua.WotCon.Tests
             Variant expected = TypeInfo.GetDefaultVariantValue(Ua.DataTypeIds.String, ValueRanks.Scalar);
 
             Assert.That(actual, Is.EqualTo(expected));
-            Assert.That(actual, Is.Not.EqualTo(Variant.Null));
+            // The value is typed, not the UA Null variant. Asked through
+            // Equals this is ambiguous, because a String variant whose payload
+            // is null and Variant.Null compare equal; IsNull states it exactly.
+            Assert.That(actual.IsNull, Is.False);
             Assert.That(actual.TypeInfo.BuiltInType, Is.EqualTo(BuiltInType.String));
         }
 


### PR DESCRIPTION
# Description

Fixes the defects a read-only audit reported against `Opc.Ua.Types` at a05a36055: 98 of its 99 findings for `Variant`/`TypeInfo`, the identifier types, the four codecs, `NodeState`/`Nodes`, `Schema`/`Utils`/`Polyfills` and the WoT binding, plus **21 further defects found while reviewing those fixes** — several of which were regressions the first pass introduced. Every fix carries a regression test that fails without it.

`Opc.Ua.Types` is the lowest-level assembly in the stack, so most of these are silent wrong answers in code every other project sits on rather than crashes.

## The higher-impact ones

**`Variant` equality, hashing and ordering.** `ValueEquals` and `CompareTo` — the ContentFilter comparison surface, whose only consumer is `FilterEvaluator` — now convert between numeric built-in types as Part 4 §7.7.3's implicit-conversion and data-precedence rules require. `Variant.Equals` deliberately does **not**: it stays strict on `BuiltInType`, so it remains consistent with `GetHashCode` and safe as a `Dictionary`/`HashSet` key. `GetHashCode` read `Float`/`Double`/`Enumeration`/`DateTime` through the wrong union field and hashed byte arrays by reference, so equal values hashed apart. Comparing a null variant against a typed one gave a different answer depending on which side it was written on; that is now decided once and symmetrically, and a numeric or boolean zero stays *unequal* to a null variant — letting it compare equal collapsed both into one bucket of every `Dictionary`/`HashSet` keyed on `Variant`, made `Equals` intransitive, and made a `HashSet`'s count depend on insertion order. `CompareTo` reports an unrelated pair as not comparable instead of ordering it by raw union bits, and the comparison operators now reject that sentinel — reading `int.MinValue` as an ordinary negative result made both `a < b` and `b < a` true, which `OrderBy` detects and throws on.

**`NodeId.CompareTo` was not transitive.** The null case reported "less than" in both directions for every identifier shape except a namespace-zero numeric id, so a `SortedSet<NodeId>` could not find a `NodeId.Null` it had just inserted.

**Encoding limits.** `MaxStringLength` counts the **bytes** of the encoded string (Part 3 §5.6.4, Part 5 §6.3.2). The XML codecs counted UTF-16 code units, so one message context gave two answers and a string a binary peer rejects survived an XML round trip. The measurement now lives in a single `EncodingLimits` helper, replacing three separate copies across the codecs. The JSON decoder additionally enforces the array, byte-string and string limits it never had — including on the base64 and shorthand spellings that bypassed the checks entirely, so a peer could opt out of a limit just by choosing the other legal encoding. An encoding-limit breach is also no longer downgraded into a successful decode that keeps the raw over-limit body.

**`Node.Write` threw out of a status-code API.** The attribute type gate compared built-in types only, which does not separate a scalar from an array, so an array value passed and the unconditional cast behind it threw `InvalidCastException` out of a method contracted to return a `ServiceResult`. It now compares the value rank too, and the structured permission attributes became writable at all (their data type has no built-in type, so the gate had rejected every value).

**`CoreUtils.Match`.** Rejects an unmatched trailing character without breaking the single-character wildcard — an earlier version of this fix made every pattern ending in `?` return false, which no existing test covered.

Spec conformance was checked against Part 3, 4, 5 and 6 for each behavioural change: implicit conversion and data precedence (4 §7.7.3), `NumericRange` BNF (4 §7.27/A.3), `returnDiagnostics` bits (4 §7.32), `MinimumSamplingInterval` as a `Duration` (3 §5.6.2), `ServerIndex` as UInt32 (6 §5.2.2.10), DateTime UTC (6 §5.3.1.6), Union `SwitchField` (6 §5.2.8, §5.3.7, H.10), and the verbose JSON Enumeration form (6 §5.4.4.2).

## Reviewer notes

- **One deliberate behaviour tightening.** XML with more than `MaxStringLength` non-ASCII *bytes* is now rejected where it previously passed on *character* count. Nothing in the repo's fixtures trips it, but it is a real narrowing for a deployment with a low `MaxStringLength` and non-ASCII display names.
- **One finding deliberately left open.** `NodeState.Initialize` still does not carry over the optional storage that `CopyTo` copies. It instantiates a node from a prototype rather than cloning it, and propagating the prototype's `RolePermissions` makes the GDS certificate-group nodes unreadable for users that could read them before (`CustomCertificateGroupNodeExistsInAddressSpaceAsync` fails with `BadUserAccessDenied`). Whether an instance inherits its prototype's permissions is a security decision for the address space, so the omission is now documented in place rather than quietly closed. Happy to split it into its own issue.
- **Nine existing tests were updated** because they pinned the buggy behaviour. Each is worth a look: `EqualsWithDifferentNumericTypesReturnsFalse` asserted the opposite of Part 4 §7.7.3 and was renamed with a replacement negative case; `XmlElementGetHashCodeShouldReturnCorrectHashCode` pinned the textual hash that broke the `Equals` contract; the `CompareTo`-versus-null cases in `NodeIdTests`/`ExpandedNodeIdTests` asserted the non-antisymmetric answers; three `DateTimeUtcTests` parse cases depended on the local time zone.
- 21 of the fixes (5,558 insertions across 74 files) came out of an adversarial review of the first pass, with each candidate independently verified against the built assembly rather than by inspection — the `Variant` null-equality, `NodeId.CompareTo`, `Node.Write`, `CoreUtils.Match` and JSON-limit items above are all in that group.

## Related Issues

No tracking issue exists — this came from an internal read-only audit rather than a reported defect. Happy to open one, or to split the WoT, encoder and `Variant` groups into separate issues if the maintainers prefer that shape for a change this size.

- Fixes #

## Checklist

_Put an `x` in the boxes that apply. You can complete these step by step after opening the PR._

- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf) and read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added all necessary documentation.
- [x] I have verified that my changes do not introduce (new) build or analyzer warnings.
- [ ] I ran **all** tests locally using the **UA.slnx** solution against at least .net **framework** and .net **10**, and all passed.
- [ ] I fixed **all** failing and flaky tests in the CI pipelines and **all** CodeQL warnings.
- [ ] I have addressed **all** PR feedback received.

### Notes on the checklist

- **Tests:** every fix has a regression test; 9 new test files, ~130 new test cases. Several were verified discriminating by temporarily reverting the production line and confirming the test fails.
- **Warnings:** full `UA.slnx` build is clean, and `dotnet format whitespace --verify-no-changes` reports the same 101 pre-existing findings in the same file set as an unmodified worktree at the same commit — none in changed files.
- **Test runs:** all suites were run on **net10.0 only**, so that box is left unchecked pending a .NET Framework run: Types 10374, Core 4490, Core.Encoders 2929, Core.Schema 157, Configuration 227, Server 5540, Client 2217, Gds 1117, PubSub 1369, WotCon 1496, ComplexTypes 2773, InformationModel 1080, Di 425 — all passing, 0 failures. Two failures in `Core.Diagnostics.Tests` and `OpenUsd.Tests` are pre-existing on master and caused by a German locale decimal separator, confirmed against a clean baseline worktree at the same commit.
- **Documentation:** no separate docs; the new and changed members carry XML doc comments explaining the spec clause behind each behavioural decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

