### PR TITLE
Fix the Opc.Ua.Core defects from the server/core audit

### DIFF
--- a/docs/DependencyInjection.md
+++ b/docs/DependencyInjection.md
@@ -236,7 +236,7 @@ Prefer the first-class properties for their common settings and use
 | Method | Purpose and secure default |
 |--------|----------------------------|
 | `SetApplicationCertificates(...)` | Replaces the generated application-certificate identifiers. Prefer `SubjectName` and `PkiRoot` for the normal generated layout. |
-| `SetMaxRejectedCertificates(...)` | Sets rejected-certificate retention; default `5`, `0` keeps all, and a negative value keeps no history. |
+| `SetMaxRejectedCertificates(...)` | Sets rejected-certificate retention; default `5`. Zero or a negative value keeps no history and clears what the store already holds. |
 | `SetAutoAcceptUntrustedCertificates(...)` | Accepts otherwise-valid unknown peer certificates; default `false`. Prefer `AutoAcceptUntrustedCertificates`. Use `true` only in an isolated lab. |
 | `SetAddAppCertToTrustedStore(...)` | Adds a newly created application certificate to a shared trusted store; default `false`. |
 | `SetRejectSHA1SignedCertificates(...)` | Rejects SHA-1-signed certificates; default `true`. Prefer `RejectSHA1SignedCertificates`. |

--- a/src/Opc.Ua.Core/Redundancy/SharedStoreLeaseElection.cs
+++ b/src/Opc.Ua.Core/Redundancy/SharedStoreLeaseElection.cs
@@ -139,6 +139,16 @@ namespace Opc.Ua.Redundancy
                 .CompareAndSwapAsync(m_leaseKey, expected, newLease, ct)
                 .ConfigureAwait(false);
 
+            // The expiry was computed before the store call. A call that took
+            // longer than the lease duration wrote a lease that has already run
+            // out, and another replica may have taken over in the meantime - so
+            // this is not leadership, however the swap went.
+            if (acquired && m_timeProvider.GetUtcNow().UtcTicks >= expiry)
+            {
+                SetLeader(false);
+                return false;
+            }
+
             if (acquired)
             {
                 Interlocked.Exchange(ref m_localLeaseExpiryTicks, expiry);
@@ -159,6 +169,18 @@ namespace Opc.Ua.Redundancy
                 }
                 m_started = true;
                 m_loop = Task.Run(() => RenewLoopAsync(m_cts.Token));
+
+                // Runs independently of the renew loop. A store that hangs
+                // rather than throws never lets that loop come round to its
+                // failure path, so the step-down has to be driven from
+                // somewhere the store cannot block - otherwise a replica keeps
+                // announcing itself as leader on a lease every other replica
+                // has already watched expire.
+                m_watchdog = m_timeProvider.CreateTimer(
+                    _ => StepDownIfLeaseExpired(),
+                    null,
+                    m_renewInterval,
+                    m_renewInterval);
             }
         }
 
@@ -172,6 +194,18 @@ namespace Opc.Ua.Redundancy
                     return;
                 }
                 m_disposed = true;
+            }
+
+            ITimer? watchdog;
+            lock (m_lock)
+            {
+                watchdog = m_watchdog;
+                m_watchdog = null;
+            }
+
+            if (watchdog != null)
+            {
+                await watchdog.DisposeAsync().ConfigureAwait(false);
             }
 
             m_cts.Cancel();
@@ -327,6 +361,13 @@ namespace Opc.Ua.Redundancy
         private bool m_isLeader;
         private bool m_started;
         private bool m_disposed;
+
+        /// <summary>
+        /// Drives <see cref="StepDownIfLeaseExpired"/> on its own cadence, so a
+        /// store call that never returns cannot keep this replica claiming
+        /// leadership.
+        /// </summary>
+        private ITimer? m_watchdog;
 
         /// <summary>
         /// When the lease this replica last wrote to the store runs out. Used to

--- a/src/Opc.Ua.Core/Redundancy/SharedStoreLeaseElection.cs
+++ b/src/Opc.Ua.Core/Redundancy/SharedStoreLeaseElection.cs
@@ -93,8 +93,19 @@ namespace Opc.Ua.Redundancy
             {
                 lock (m_lock)
                 {
-                    return m_isLeader;
+                    if (!m_isLeader)
+                    {
+                        return false;
+                    }
                 }
+
+                // The lease this replica last wrote has to still be running for
+                // it to count as the leader. Checked on read, not only where a
+                // renew fails: a store that hangs rather than throws never
+                // reaches the failure path at all, and every other replica
+                // watches the lease expire while this one keeps claiming it.
+                return m_timeProvider.GetUtcNow().UtcTicks <
+                    Interlocked.Read(ref m_localLeaseExpiryTicks);
             }
         }
 
@@ -121,11 +132,18 @@ namespace Opc.Ua.Redundancy
                 return false;
             }
 
-            ByteString newLease = EncodeLease(m_nodeId, nowTicks + m_leaseDuration.Ticks);
+            long expiry = nowTicks + m_leaseDuration.Ticks;
+            ByteString newLease = EncodeLease(m_nodeId, expiry);
             ByteString expected = found ? current : default;
             bool acquired = await m_store
                 .CompareAndSwapAsync(m_leaseKey, expected, newLease, ct)
                 .ConfigureAwait(false);
+
+            if (acquired)
+            {
+                Interlocked.Exchange(ref m_localLeaseExpiryTicks, expiry);
+            }
+
             SetLeader(acquired);
             return acquired;
         }
@@ -190,6 +208,13 @@ namespace Opc.Ua.Redundancy
                     catch (Exception ex)
                     {
                         m_logger?.SharedStoreLeaseElectionLogMessage0(ex, m_nodeId);
+
+                        // A renew that never reached the store leaves the shared
+                        // lease to expire on its own, and a standby takes over
+                        // once it does. Step down at the same moment rather than
+                        // keep leading on a lease that is no longer held, which
+                        // would put two leaders on the line.
+                        StepDownIfLeaseExpired();
                     }
 
                     await Task.Delay(m_renewInterval, ct).ConfigureAwait(false);
@@ -221,6 +246,27 @@ namespace Opc.Ua.Redundancy
             }
         }
 
+        /// <summary>
+        /// Gives up leadership once the lease last written to the store has
+        /// run out locally.
+        /// </summary>
+        private void StepDownIfLeaseExpired()
+        {
+            bool wasLeader;
+            lock (m_lock)
+            {
+                wasLeader = m_isLeader;
+            }
+
+            // IsLeader already reports false once the lease has run out; this
+            // makes the step-down explicit so LeadershipChanged fires and the
+            // replica releases whatever it holds as leader.
+            if (wasLeader && !IsLeader)
+            {
+                SetLeader(false);
+            }
+        }
+
         private void SetLeader(bool value)
         {
             bool changed;
@@ -228,6 +274,10 @@ namespace Opc.Ua.Redundancy
             {
                 changed = m_isLeader != value;
                 m_isLeader = value;
+            }
+            if (!value)
+            {
+                Interlocked.Exchange(ref m_localLeaseExpiryTicks, 0);
             }
             if (changed)
             {
@@ -277,6 +327,13 @@ namespace Opc.Ua.Redundancy
         private bool m_isLeader;
         private bool m_started;
         private bool m_disposed;
+
+        /// <summary>
+        /// When the lease this replica last wrote to the store runs out. Used to
+        /// step down while the store is unreachable, because a lease that cannot
+        /// be renewed expires for everyone else too.
+        /// </summary>
+        private long m_localLeaseExpiryTicks;
     }
 
     /// <summary>

--- a/src/Opc.Ua.Core/Security/Certificates/CertificateManager/CertificateLifecycleMonitor.cs
+++ b/src/Opc.Ua.Core/Security/Certificates/CertificateManager/CertificateLifecycleMonitor.cs
@@ -49,7 +49,11 @@ namespace Opc.Ua
         /// The change subject used to emit certificate change events.
         /// </param>
         /// <param name="getCertificates">
-        /// A delegate that returns the current application certificates.
+        /// A delegate that returns a snapshot of the current application
+        /// certificates. It must hand back a collection this monitor owns and
+        /// disposes: the timer callback runs while other threads add, replace
+        /// and dispose entries, so enumerating the live list would throw and
+        /// could read an entry that has just been released.
         /// </param>
         /// <param name="expiryThreshold">
         /// The time span before expiry at which a warning is emitted.
@@ -66,7 +70,7 @@ namespace Opc.Ua
         /// </param>
         public CertificateLifecycleMonitor(
             CertificateChangeSubject subject,
-            Func<IReadOnlyList<CertificateEntry>> getCertificates,
+            Func<CertificateEntryCollection> getCertificates,
             TimeSpan expiryThreshold,
             TimeSpan checkInterval,
             ITelemetryContext telemetry,
@@ -86,7 +90,8 @@ namespace Opc.Ua
             try
             {
                 DateTime now = m_timeProvider.GetUtcNow().UtcDateTime;
-                foreach (CertificateEntry entry in m_getCertificates())
+                using CertificateEntryCollection certificates = m_getCertificates();
+                foreach (CertificateEntry entry in certificates)
                 {
                     if (now.Add(m_expiryThreshold) >= entry.NotAfter &&
                         m_alreadyNotified.Add(entry.Certificate.Thumbprint))
@@ -130,7 +135,7 @@ namespace Opc.Ua
         }
 
         private readonly CertificateChangeSubject m_subject;
-        private readonly Func<IReadOnlyList<CertificateEntry>> m_getCertificates;
+        private readonly Func<CertificateEntryCollection> m_getCertificates;
         private readonly TimeSpan m_expiryThreshold;
         private readonly TimeProvider m_timeProvider;
         private readonly ITimer m_timer;

--- a/src/Opc.Ua.Core/Security/Certificates/CertificateManager/CertificateManager.cs
+++ b/src/Opc.Ua.Core/Security/Certificates/CertificateManager/CertificateManager.cs
@@ -28,6 +28,7 @@
  * ======================================================================*/
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -85,7 +86,12 @@ namespace Opc.Ua
         {
             m_telemetry = telemetry ?? throw new ArgumentNullException(nameof(telemetry));
             m_logger = telemetry.CreateLogger<CertificateManager>();
-            m_maxRejectedCertificates = maxRejectedCertificates;
+            // Normalised the same way the property setter does, so the two ways
+            // of configuring the limit cannot disagree about what a negative
+            // value means.
+            m_maxRejectedCertificates = maxRejectedCertificates < 0
+                ? 0
+                : maxRejectedCertificates;
             m_storeProviders = storeProviders?.ToList() ??
                 [
                     new DirectoryStoreProvider(),
@@ -96,7 +102,7 @@ namespace Opc.Ua
             TimeSpan threshold = expiryWarningThreshold ?? TimeSpan.FromDays(14);
             m_lifecycleMonitor = new CertificateLifecycleMonitor(
                 m_changeSubject,
-                () => m_applicationCertificates,
+                SnapshotApplicationCertificates,
                 threshold,
                 TimeSpan.FromHours(1),
                 m_telemetry,
@@ -117,7 +123,7 @@ namespace Opc.Ua
         public ICertificateProvider CertificateProvider => m_certificateProvider;
 
         /// <inheritdoc/>
-        public IReadOnlyCollection<TrustListIdentifier> TrustLists => m_trustLists.Keys;
+        public IReadOnlyCollection<TrustListIdentifier> TrustLists => [.. m_trustLists.Keys];
 
         /// <inheritdoc/>
         public IObservable<CertificateChangeEvent> CertificateChanges => m_changeSubject;
@@ -141,11 +147,20 @@ namespace Opc.Ua
             }
 
             if (!m_trustLists.TryAdd(trustList, new TrustListEntry(
-                                    trustedStorePath, issuerStorePath, StoreType: null)) &&
-                m_logger.IsEnabled(LogLevel.Debug))
+                                    trustedStorePath, issuerStorePath, StoreType: null)))
             {
-                m_logger.CertificateManagerLogMessage0(trustList.ToString());
+                if (m_logger.IsEnabled(LogLevel.Debug))
+                {
+                    m_logger.CertificateManagerLogMessage0(trustList.ToString());
+                }
+
+                return;
             }
+
+            // A validation against this list before it was registered cached a
+            // core with no trust material at all, which would then reject every
+            // certificate for as long as it stayed cached.
+            InvalidateCores();
         }
 
         /// <inheritdoc/>
@@ -259,32 +274,48 @@ namespace Opc.Ua
 
             RegisterOrReplaceTrustList(
                 TrustListIdentifier.Peers,
-                config.TrustedPeerCertificates?.StorePath,
+                config.TrustedPeerCertificates,
                 config.TrustedIssuerCertificates?.StorePath,
                 replaceExisting);
 
             RegisterOrReplaceTrustList(
                 TrustListIdentifier.Users,
-                config.TrustedUserCertificates?.StorePath,
+                config.TrustedUserCertificates,
                 config.UserIssuerCertificates?.StorePath,
                 replaceExisting);
 
             RegisterOrReplaceTrustList(
                 TrustListIdentifier.Https,
-                config.TrustedHttpsCertificates?.StorePath,
+                config.TrustedHttpsCertificates,
                 config.HttpsIssuerCertificates?.StorePath,
                 replaceExisting);
 
             RegisterOrReplaceTrustList(
                 TrustListIdentifier.Rejected,
                 config.RejectedCertificateStore?.StorePath,
+                explicitTrustedCertificates: default,
                 issuerStorePath: null,
                 replaceExisting);
         }
 
         private void RegisterOrReplaceTrustList(
             TrustListIdentifier trustList,
+            CertificateTrustList? trustedList,
+            string? issuerStorePath,
+            bool replaceExisting)
+        {
+            RegisterOrReplaceTrustList(
+                trustList,
+                trustedList?.StorePath,
+                trustedList?.TrustedCertificates ?? default,
+                issuerStorePath,
+                replaceExisting);
+        }
+
+        private void RegisterOrReplaceTrustList(
+            TrustListIdentifier trustList,
             string? trustedStorePath,
+            ArrayOf<CertificateIdentifier> explicitTrustedCertificates,
             string? issuerStorePath,
             bool replaceExisting)
         {
@@ -293,15 +324,39 @@ namespace Opc.Ua
                 return;
             }
 
-            if (replaceExisting)
+            var entry = new TrustListEntry(
+                trustedStorePath!,
+                issuerStorePath,
+                StoreType: null,
+                explicitTrustedCertificates);
+
+            if (!replaceExisting)
             {
-                m_trustLists[trustList] = new TrustListEntry(
-                    trustedStorePath!, issuerStorePath, StoreType: null);
+                // TryAdd, not ContainsKey-then-assign: the dictionary is written
+                // at run time and read lock-free, so the compound form would let
+                // two registrations both decide the list was absent and the
+                // second silently replace the first.
+                if (!m_trustLists.TryAdd(trustList, entry) &&
+                    m_logger.IsEnabled(LogLevel.Debug))
+                {
+                    m_logger.CertificateManagerLogMessage0(trustList.ToString());
+                }
+
+                return;
             }
-            else
+
+            if (m_trustLists.TryGetValue(trustList, out TrustListEntry? existing) &&
+                existing == entry)
             {
-                RegisterTrustList(trustList, trustedStorePath!, issuerStorePath);
+                return;
             }
+
+            m_trustLists[trustList] = entry;
+
+            // A cached core snapshots its trust list when it is built, so one
+            // that already exists would keep validating against the store path
+            // and the explicitly trusted certificates this call just replaced.
+            InvalidateCores();
         }
 
         /// <inheritdoc/>
@@ -368,24 +423,20 @@ namespace Opc.Ua
 
         /// <summary>
         /// Gets or sets the maximum number of rejected certificates kept in
-        /// the rejected-certificate store. Setting a negative value clears
-        /// the rejected store.
+        /// the rejected-certificate store. Setting zero or a negative value
+        /// keeps none and clears the rejected store; a negative value reads
+        /// back as zero.
         /// </summary>
         public int MaxRejectedCertificates
         {
             get => m_maxRejectedCertificates;
             set
             {
-                if (value < 0)
-                {
-                    // Negative limit disables the rejected store entirely
-                    // and asks the processor to clear what's there.
-                    m_maxRejectedCertificates = 0;
-                }
-                else
-                {
-                    m_maxRejectedCertificates = value;
-                }
+                // A negative limit means the same as zero - keep no rejected
+                // history - so it is normalised here and the stores only ever
+                // see zero or a positive cap.
+                m_maxRejectedCertificates = value < 0 ? 0 : value;
+
                 if (m_rejectedProcessor != null)
                 {
                     m_rejectedProcessor.SetMaxRejectedCertificates(m_maxRejectedCertificates);
@@ -451,7 +502,7 @@ namespace Opc.Ua
         }
 
         /// <inheritdoc/>
-        public Task<bool> GetIssuersAsync(
+        public async Task<bool> GetIssuersAsync(
             Certificate certificate,
             IList<CertificateIssuerReference> issuers,
             CancellationToken ct = default)
@@ -466,12 +517,11 @@ namespace Opc.Ua
                 throw new ArgumentNullException(nameof(issuers));
             }
 
-            // CA2000: GetOrCreateCore returns a shared validation core owned by this
-            // manager (cached per well-known trust list, disposed in Dispose); borrowed here.
-#pragma warning disable CA2000
-            CertificateValidationCore core = GetOrCreateCore(TrustListIdentifier.Peers);
-#pragma warning restore CA2000
-            return core.GetIssuersAsync(certificate, issuers, ct);
+            // GetOrCreateCore hands back a reference on the shared core; holding
+            // it keeps a concurrent trust-list change from tearing the core down
+            // while this validation is still running.
+            using CertificateValidationCore core = GetOrCreateCore(TrustListIdentifier.Peers);
+            return await core.GetIssuersAsync(certificate, issuers, ct).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -628,11 +678,11 @@ namespace Opc.Ua
             CancellationToken ct = default)
         {
             trustList ??= TrustListIdentifier.Peers;
-            // CA2000: GetOrCreateCore returns a shared validation core owned by this
-            // manager (cached per well-known trust list, disposed in Dispose); borrowed here.
-#pragma warning disable CA2000
-            CertificateValidationCore core = GetOrCreateCore(trustList);
-#pragma warning restore CA2000
+
+            // GetOrCreateCore hands back a reference on the shared core; holding
+            // it keeps a concurrent trust-list change from tearing the core down
+            // while this validation is still running.
+            using CertificateValidationCore core = GetOrCreateCore(trustList);
 
             // Per-call AcceptError takes precedence over the global hook.
             Func<Certificate, ServiceResult, bool>? acceptError =
@@ -705,11 +755,10 @@ namespace Opc.Ua
                 throw new ArgumentNullException(nameof(endpoint));
             }
 
-            // CA2000: GetOrCreateCore returns a shared validation core owned by this
-            // manager (cached per well-known trust list, disposed in Dispose); borrowed here.
-#pragma warning disable CA2000
-            CertificateValidationCore core = GetOrCreateCore(TrustListIdentifier.Peers);
-#pragma warning restore CA2000
+            // GetOrCreateCore hands back a reference on the shared core; holding
+            // it keeps a concurrent trust-list change from tearing the core down
+            // while this validation is still running.
+            using CertificateValidationCore core = GetOrCreateCore(TrustListIdentifier.Peers);
             try
             {
                 core.ValidateApplicationUri(serverCertificate, endpoint, m_acceptError);
@@ -756,11 +805,10 @@ namespace Opc.Ua
                 throw new ArgumentNullException(nameof(endpoint));
             }
 
-            // CA2000: GetOrCreateCore returns a shared validation core owned by this
-            // manager (cached per well-known trust list, disposed in Dispose); borrowed here.
-#pragma warning disable CA2000
-            CertificateValidationCore core = GetOrCreateCore(TrustListIdentifier.Peers);
-#pragma warning restore CA2000
+            // GetOrCreateCore hands back a reference on the shared core; holding
+            // it keeps a concurrent trust-list change from tearing the core down
+            // while this validation is still running.
+            using CertificateValidationCore core = GetOrCreateCore(TrustListIdentifier.Peers);
             try
             {
                 core.ValidateDomains(
@@ -1160,29 +1208,7 @@ namespace Opc.Ua
             // HTTPS validators alike, and a change announced for a custom
             // trust list must not leave its cached core validating against
             // stale trust material.
-            CertificateValidationCore? oldPeer;
-            CertificateValidationCore? oldUser;
-            CertificateValidationCore? oldHttps;
-            CertificateValidationCore[] oldCustom;
-            lock (m_certificatesLock)
-            {
-                oldPeer = m_peerCore;
-                m_peerCore = null;
-                oldUser = m_userCore;
-                m_userCore = null;
-                oldHttps = m_httpsCore;
-                m_httpsCore = null;
-                oldCustom = [.. m_customCores.Values];
-                m_customCores.Clear();
-            }
-
-            oldPeer?.Dispose();
-            oldUser?.Dispose();
-            oldHttps?.Dispose();
-            foreach (CertificateValidationCore core in oldCustom)
-            {
-                core.Dispose();
-            }
+            InvalidateCores();
 
             if (trustChanged)
             {
@@ -1259,21 +1285,11 @@ namespace Opc.Ua
                     await m_rejectedProcessor.DisposeAsync().ConfigureAwait(false);
                 }
 
-                m_peerCore?.Dispose();
-                m_peerCore = null;
-                m_userCore?.Dispose();
-                m_userCore = null;
-                m_httpsCore?.Dispose();
-                m_httpsCore = null;
-
-                lock (m_certificatesLock)
-                {
-                    foreach (CertificateValidationCore core in m_customCores.Values)
-                    {
-                        core.Dispose();
-                    }
-                    m_customCores.Clear();
-                }
+                // Clears the fields under the lock before releasing, so a
+                // validation starting concurrently cannot pick up a core that has
+                // already been torn down - GetOrCreateCore only trusts what it
+                // finds cached because the field is cleared first.
+                InvalidateCores();
 
                 m_certificateProvider.Dispose();
 
@@ -1290,14 +1306,75 @@ namespace Opc.Ua
         }
 
         /// <summary>
+        /// Drops every cached validation core so the next validation rebuilds it
+        /// from the current trust-list configuration.
+        /// </summary>
+        /// <remarks>
+        /// A core snapshots its trust list when it is built, so anything that
+        /// changes that material - a trust list re-registered, a store updated,
+        /// an application certificate replaced - has to evict the cores as well.
+        /// The fields are cleared under the lock and the cores released outside
+        /// it; a validation already running keeps its own reference and finishes
+        /// against the trust material it started with.
+        /// </remarks>
+        private void InvalidateCores()
+        {
+            CertificateValidationCore? oldPeer;
+            CertificateValidationCore? oldUser;
+            CertificateValidationCore? oldHttps;
+            CertificateValidationCore[] oldCustom;
+
+            lock (m_certificatesLock)
+            {
+                oldPeer = m_peerCore;
+                m_peerCore = null;
+                oldUser = m_userCore;
+                m_userCore = null;
+                oldHttps = m_httpsCore;
+                m_httpsCore = null;
+                oldCustom = [.. m_customCores.Values];
+                m_customCores.Clear();
+            }
+
+            oldPeer?.Dispose();
+            oldUser?.Dispose();
+            oldHttps?.Dispose();
+            foreach (CertificateValidationCore core in oldCustom)
+            {
+                core.Dispose();
+            }
+        }
+
+        /// <summary>
         /// Gets or creates a <see cref="CertificateValidationCore"/> configured
         /// for the specified trust list.
         /// </summary>
         private CertificateValidationCore GetOrCreateCore(TrustListIdentifier trustList)
         {
+            while (true)
+            {
+                CertificateValidationCore? core = TryGetOrCreateCore(trustList);
+
+                if (core != null)
+                {
+                    return core;
+                }
+
+                // The trust list was replaced while the core was being built, so
+                // the one just built is already stale. Try again with what the
+                // replacement put there.
+            }
+        }
+
+        /// <summary>
+        /// One attempt at <see cref="GetOrCreateCore"/>, returning <c>null</c>
+        /// when the trust list changed underneath it and the caller should retry.
+        /// </summary>
+        private CertificateValidationCore? TryGetOrCreateCore(TrustListIdentifier trustList)
+        {
             // Fast path: return a cached core without taking the lock.
             CertificateValidationCore? cached = GetCachedCore(trustList);
-            if (cached != null)
+            if (cached != null && cached.TryAddRef())
             {
                 return cached;
             }
@@ -1307,11 +1384,14 @@ namespace Opc.Ua
             // dispose the loser.
             var candidate = new CertificateValidationCore(m_telemetry);
 
-            if (m_trustLists.TryGetValue(trustList, out TrustListEntry? entry))
+            m_trustLists.TryGetValue(trustList, out TrustListEntry? entry);
+
+            if (entry != null)
             {
                 var trustedStore = new CertificateTrustList
                 {
-                    StorePath = entry.TrustedStorePath
+                    StorePath = entry.TrustedStorePath,
+                    TrustedCertificates = entry.ExplicitTrustedCertificates
                 };
 
                 CertificateTrustList? issuerStore = entry.IssuerStorePath != null
@@ -1326,6 +1406,18 @@ namespace Opc.Ua
             CertificateValidationCore winner;
             lock (m_certificatesLock)
             {
+                // The entry was read outside the lock, so a replacement that
+                // invalidated the cores in the meantime would be undone by
+                // installing this candidate - the new trust material would then
+                // never be picked up. Report the miss and let the caller retry.
+                m_trustLists.TryGetValue(trustList, out TrustListEntry? current);
+
+                if (current != entry)
+                {
+                    candidate.Dispose();
+                    return null;
+                }
+
                 if (trustList == TrustListIdentifier.Peers)
                 {
                     winner = m_peerCore ??= candidate;
@@ -1353,6 +1445,16 @@ namespace Opc.Ua
                     m_customCores.Add(trustList, candidate);
                     winner = candidate;
                 }
+
+                // A cached core whose last reference has already gone (a teardown
+                // that released it before clearing the field) must not be handed
+                // out: replace it with the freshly built candidate instead.
+                if (!winner.TryAddRef())
+                {
+                    winner = candidate;
+                    ReplaceCachedCore(trustList, candidate);
+                    winner.TryAddRef();
+                }
             }
 
             if (!ReferenceEquals(winner, candidate))
@@ -1361,6 +1463,32 @@ namespace Opc.Ua
                 candidate.Dispose();
             }
             return winner;
+        }
+
+        /// <summary>
+        /// Installs a freshly built core for a trust list, replacing whatever was
+        /// cached. The caller must hold <see cref="m_certificatesLock"/>.
+        /// </summary>
+        private void ReplaceCachedCore(
+            TrustListIdentifier trustList,
+            CertificateValidationCore core)
+        {
+            if (trustList == TrustListIdentifier.Peers)
+            {
+                m_peerCore = core;
+            }
+            else if (trustList == TrustListIdentifier.Users)
+            {
+                m_userCore = core;
+            }
+            else if (trustList == TrustListIdentifier.Https)
+            {
+                m_httpsCore = core;
+            }
+            else
+            {
+                m_customCores[trustList] = core;
+            }
         }
 
         /// <summary>
@@ -1450,9 +1578,16 @@ namespace Opc.Ua
         private sealed record TrustListEntry(
             string TrustedStorePath,
             string? IssuerStorePath,
-            string? StoreType);
+            string? StoreType,
+            ArrayOf<CertificateIdentifier> ExplicitTrustedCertificates = default);
 
-        private readonly Dictionary<TrustListIdentifier, TrustListEntry> m_trustLists = [];
+        /// <summary>
+        /// Registered trust lists. Concurrent because the validation hot path
+        /// reads it without a lock while <c>MapFromSecurityConfiguration</c>
+        /// and <see cref="RegisterTrustList"/> can write to it at run time.
+        /// </summary>
+        private readonly ConcurrentDictionary<TrustListIdentifier, TrustListEntry> m_trustLists
+            = new();
         private readonly Dictionary<TrustListIdentifier, CertificateValidationCore> m_customCores = [];
         private readonly List<CertificateEntry> m_applicationCertificates = [];
         private readonly List<ICertificateStoreProvider> m_storeProviders;

--- a/src/Opc.Ua.Core/Security/Certificates/CertificateManager/CertificateManager.cs
+++ b/src/Opc.Ua.Core/Security/Certificates/CertificateManager/CertificateManager.cs
@@ -172,7 +172,14 @@ namespace Opc.Ua
                     $"Trust list '{trustList}' is not registered.");
             }
 
-            return OpenStore(entry.TrustedStorePath, entry.StoreType);
+            if (string.IsNullOrEmpty(entry.TrustedStorePath))
+            {
+                throw new InvalidOperationException(
+                    $"Trust list '{trustList}' names its trusted certificates " +
+                    "inline and has no store to open.");
+            }
+
+            return OpenStore(entry.TrustedStorePath!, entry.StoreType);
         }
 
         /// <inheritdoc/>
@@ -319,13 +326,18 @@ namespace Opc.Ua
             string? issuerStorePath,
             bool replaceExisting)
         {
-            if (string.IsNullOrEmpty(trustedStorePath))
+            // A trust list is worth registering as soon as it names trust
+            // material, and <TrustedCertificates> alone is enough: a
+            // configuration that lists peers inline and sets no store path had
+            // nothing registered at all, so the validator went on rejecting
+            // exactly the peers it was told to trust.
+            if (string.IsNullOrEmpty(trustedStorePath) && explicitTrustedCertificates.IsEmpty)
             {
                 return;
             }
 
             var entry = new TrustListEntry(
-                trustedStorePath!,
+                trustedStorePath,
                 issuerStorePath,
                 StoreType: null,
                 explicitTrustedCertificates);
@@ -1575,8 +1587,19 @@ namespace Opc.Ua
         /// <summary>
         /// Internal record for a registered trust list.
         /// </summary>
+        /// <param name="TrustedStorePath">
+        /// The trusted store, or <c>null</c> when the list names its trusted
+        /// certificates inline and has no store behind it.
+        /// </param>
+        /// <param name="IssuerStorePath">The issuer store, if any.</param>
+        /// <param name="StoreType">
+        /// The store type, or <c>null</c> to derive it from the path.
+        /// </param>
+        /// <param name="ExplicitTrustedCertificates">
+        /// The certificates named on the trust list itself.
+        /// </param>
         private sealed record TrustListEntry(
-            string TrustedStorePath,
+            string? TrustedStorePath,
             string? IssuerStorePath,
             string? StoreType,
             ArrayOf<CertificateIdentifier> ExplicitTrustedCertificates = default);

--- a/src/Opc.Ua.Core/Security/Certificates/CertificateManager/CertificateValidationCore.cs
+++ b/src/Opc.Ua.Core/Security/Certificates/CertificateManager/CertificateValidationCore.cs
@@ -78,6 +78,13 @@ namespace Opc.Ua
         private volatile TrustListState m_state;
 
         /// <summary>
+        /// Outstanding references. One is held by whoever created the core (the
+        /// cache); each in-flight use takes another through
+        /// <see cref="TryAddRef"/>.
+        /// </summary>
+        private int m_refCount = 1;
+
+        /// <summary>
         /// Initializes a new instance of the
         /// <see cref="CertificateValidationCore"/> class.
         /// </summary>
@@ -95,9 +102,50 @@ namespace Opc.Ua
             UseValidatedCertificates = false;
         }
 
+        /// <summary>
+        /// Takes a reference for a caller that is about to use the core, or
+        /// returns <see langword="false"/> when the last reference has already
+        /// been released.
+        /// </summary>
+        /// <remarks>
+        /// A core is cached by <see cref="CertificateManager"/> and evicted when
+        /// the trust list changes. Validations already running on it must keep it
+        /// alive until they finish, otherwise the eviction tears down the
+        /// semaphore and the trust-list stores underneath them.
+        /// </remarks>
+        public bool TryAddRef()
+        {
+            int current = Volatile.Read(ref m_refCount);
+
+            while (current > 0)
+            {
+                int observed = Interlocked.CompareExchange(
+                    ref m_refCount, current + 1, current);
+
+                if (observed == current)
+                {
+                    return true;
+                }
+
+                current = observed;
+            }
+
+            return false;
+        }
+
         /// <inheritdoc/>
+        /// <remarks>
+        /// Releases one reference. The core is torn down when the last one goes,
+        /// so an eviction while validations are in flight only takes the cache's
+        /// reference and the teardown happens when they complete.
+        /// </remarks>
         public void Dispose()
         {
+            if (Interlocked.Decrement(ref m_refCount) != 0)
+            {
+                return;
+            }
+
             InternalResetValidatedCertificates();
 
             TrustListState state = m_state;
@@ -336,10 +384,16 @@ namespace Opc.Ua
             // Publish the new immutable trust-list state. Application
             // certificates are carried forward; they are changed only by
             // UpdateAsync.
+            //
+            // The certificates listed on the trust list itself (the
+            // <TrustedCertificates> configuration element, or
+            // SecurityConfiguration.AddTrustedPeer) are trusted in addition to
+            // whatever the store holds, so they travel with the state.
             m_state = new TrustListState(
                 trustedCertificateStore,
                 issuerCertificateStore,
-                m_state.ApplicationCertificates);
+                m_state.ApplicationCertificates,
+                trustedStore?.TrustedCertificates ?? default);
         }
 
         /// <summary>
@@ -1330,6 +1384,43 @@ namespace Opc.Ua
                 }
             }
 
+            // check the certificates listed on the trust list itself. These are
+            // configured alongside the store, not inside it, so a peer trusted
+            // only this way is not found above.
+            for (int ii = 0; ii < state.ExplicitTrustedCertificates.Count; ii++)
+            {
+                CertificateIdentifier trusted = state.ExplicitTrustedCertificates[ii];
+
+                // avoid the store I/O a resolve can cost when the identifier
+                // already says which certificate it means.
+                if (!string.IsNullOrEmpty(trusted.Thumbprint) &&
+                    !string.Equals(
+                        trusted.Thumbprint,
+                        certificate.Thumbprint,
+                        StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                using Certificate? resolved = await CertificateIdentifierResolver
+                    .ResolveAsync(
+                        trusted,
+                        registry: null,
+                        needPrivateKey: false,
+                        applicationUri: null,
+                        m_telemetry,
+                        ct)
+                    .ConfigureAwait(false);
+
+                if (resolved != null &&
+                    Utils.IsEqual(resolved.RawData, certificate.RawData))
+                {
+                    return new CertificateIssuerReference(
+                        resolved.AddRef(),
+                        trusted.ValidationOptions);
+                }
+            }
+
             // not a trusted.
             return null;
         }
@@ -1870,7 +1961,8 @@ namespace Opc.Ua
         private sealed record TrustListState(
             CertificateStoreIdentifier? TrustedStore,
             CertificateStoreIdentifier? IssuerStore,
-            ArrayOf<Certificate> ApplicationCertificates);
+            ArrayOf<Certificate> ApplicationCertificates,
+            ArrayOf<CertificateIdentifier> ExplicitTrustedCertificates = default);
     }
 
     /// <summary>

--- a/src/Opc.Ua.Core/Security/Certificates/CertificateManager/CertificateValidationCore.cs
+++ b/src/Opc.Ua.Core/Security/Certificates/CertificateManager/CertificateValidationCore.cs
@@ -521,11 +521,15 @@ namespace Opc.Ua
                     break;
                 }
 
+                // The certificates listed on the trust list itself count as
+                // trusted issuers alongside the ones its store holds, so a CA
+                // configured only through <TrustedCertificates> can complete the
+                // chain of a peer presenting a leaf under it.
                 if (validationErrors != null)
                 {
                     (issuer, revocationStatus) = await GetIssuerNoExceptionAsync(
                             certificate,
-                            default,
+                            state.ExplicitTrustedCertificates,
                             state.TrustedStore,
                             true,
                             ct)
@@ -535,7 +539,7 @@ namespace Opc.Ua
                 {
                     issuer = await GetIssuerAsync(
                             certificate,
-                            default,
+                            state.ExplicitTrustedCertificates,
                             state.TrustedStore,
                             true,
                             ct)
@@ -1507,59 +1511,25 @@ namespace Opc.Ua
                 serialNumber = authority.SerialNumber;
             }
 
-            // check in explicit list.
-            if (!explicitList.IsEmpty)
+            // Check in the certificate store first. An issuer the store holds
+            // can have its revocation status checked against that store's CRLs,
+            // and one named inline on the trust list cannot - so preferring the
+            // store keeps the revocation check for a CA that is configured both
+            // ways.
+            ICertificateStore? store = null;
+
+            if (certificateStore != null)
             {
-                for (int ii = 0; ii < explicitList.Count; ii++)
+                store = OpenCachedStore(certificateStore);
+
+                if (store == null && m_logger.IsEnabled(LogLevel.Warning))
                 {
-                    Certificate? issuer = await CertificateIdentifierResolver
-                        .ResolveAsync(
-                            explicitList[ii],
-                            registry: null,
-                            needPrivateKey: false,
-                            applicationUri: null,
-                            m_telemetry,
-                            ct)
-                        .ConfigureAwait(false);
-
-                    if (issuer != null)
-                    {
-                        if (!X509Utils.IsIssuerAllowed(issuer))
-                        {
-                            issuer.Dispose();
-                            continue;
-                        }
-
-                        if (Match(issuer, subjectName, serialNumber, keyId))
-                        {
-                            // can't check revocation.
-                            return (
-                                new CertificateIssuerReference(
-                                    issuer,
-                                    CertificateValidationOptions.SuppressRevocationStatusUnknown),
-                                null);
-                        }
-
-                        issuer.Dispose();
-                    }
+                    m_logger.CertificateValidationLog12(Redact.Create(certificateStore));
                 }
             }
 
-            // check in certificate store.
-            if (certificateStore != null)
+            if (certificateStore != null && store != null)
             {
-                ICertificateStore? store = OpenCachedStore(certificateStore);
-
-                if (store == null)
-                {
-                    if (m_logger.IsEnabled(LogLevel.Warning))
-                    {
-                        m_logger.CertificateValidationLog12(Redact.Create(certificateStore));
-                    }
-                    // not a trusted issuer.
-                    return (null, null);
-                }
-
                 using CertificateCollection certificates = await store.EnumerateAsync(ct)
                     .ConfigureAwait(false);
 
@@ -1621,6 +1591,45 @@ namespace Opc.Ua
 
                             return (new CertificateIssuerReference(issuer.AddRef(), options), serviceResult);
                         }
+                    }
+                }
+            }
+
+            // Then the certificates named on the list itself, which the store
+            // above does not hold.
+            if (!explicitList.IsEmpty)
+            {
+                for (int ii = 0; ii < explicitList.Count; ii++)
+                {
+                    Certificate? issuer = await CertificateIdentifierResolver
+                        .ResolveAsync(
+                            explicitList[ii],
+                            registry: null,
+                            needPrivateKey: false,
+                            applicationUri: null,
+                            m_telemetry,
+                            ct)
+                        .ConfigureAwait(false);
+
+                    if (issuer != null)
+                    {
+                        if (!X509Utils.IsIssuerAllowed(issuer))
+                        {
+                            issuer.Dispose();
+                            continue;
+                        }
+
+                        if (Match(issuer, subjectName, serialNumber, keyId))
+                        {
+                            // can't check revocation.
+                            return (
+                                new CertificateIssuerReference(
+                                    issuer,
+                                    CertificateValidationOptions.SuppressRevocationStatusUnknown),
+                                null);
+                        }
+
+                        issuer.Dispose();
                     }
                 }
             }

--- a/src/Opc.Ua.Core/Security/Certificates/CertificateManager/CertificateValidationCore.cs
+++ b/src/Opc.Ua.Core/Security/Certificates/CertificateManager/CertificateValidationCore.cs
@@ -358,7 +358,11 @@ namespace Opc.Ua
             InternalResetValidatedCertificates();
 
             CertificateStoreIdentifier? trustedCertificateStore = null;
-            if (trustedStore != null)
+
+            // A trust list can name its certificates inline and have no store
+            // behind it; building an identifier for an empty path would make
+            // every validation try to open a store that does not exist.
+            if (trustedStore != null && !string.IsNullOrEmpty(trustedStore.StorePath))
             {
                 trustedCertificateStore = new CertificateStoreIdentifier(trustedStore.StorePath!)
                 {

--- a/src/Opc.Ua.Core/Security/Certificates/CertificateManager/SharedKeyValue/SharedKeyValueCertificateStore.cs
+++ b/src/Opc.Ua.Core/Security/Certificates/CertificateManager/SharedKeyValue/SharedKeyValueCertificateStore.cs
@@ -186,9 +186,13 @@ namespace Opc.Ua
                 throw new ArgumentNullException(nameof(certificates));
             }
 
-            // A negative maximum keeps no rejected history.
-            if (maxCertificates < 0)
+            // A maximum of zero or less keeps no rejected history: nothing new
+            // is written, and whatever is already stored is discarded. Same rule
+            // as the directory store, which is what the CertificateManager's
+            // MaxRejectedCertificates contract is written against.
+            if (maxCertificates <= 0)
             {
+                await TrimRejectedAsync(0, ct).ConfigureAwait(false);
                 return;
             }
 
@@ -199,13 +203,9 @@ namespace Opc.Ua
                     .ConfigureAwait(false);
             }
 
-            // A zero maximum is unlimited; otherwise trim the oldest by the
-            // stored insertion timestamp (best-effort; the rejected list is
-            // advisory and not security-critical).
-            if (maxCertificates > 0)
-            {
-                await TrimRejectedAsync(maxCertificates, ct).ConfigureAwait(false);
-            }
+            // Trim the oldest by the stored insertion timestamp (best-effort;
+            // the rejected list is advisory and not security-critical).
+            await TrimRejectedAsync(maxCertificates, ct).ConfigureAwait(false);
         }
 
         /// <inheritdoc/>

--- a/src/Opc.Ua.Core/Security/Certificates/CertificateTrustList.cs
+++ b/src/Opc.Ua.Core/Security/Certificates/CertificateTrustList.cs
@@ -107,23 +107,37 @@ namespace Opc.Ua
 
             collection ??= [];
 
-            for (int i = 0; i < TrustedCertificates.Count; i++)
+            try
             {
-                CertificateIdentifier trustedCertificate = TrustedCertificates[i];
-                Certificate? certificate = await CertificateIdentifierResolver
-                    .ResolveAsync(
-                        trustedCertificate,
-                        registry: null,
-                        needPrivateKey: false,
-                        applicationUri: null,
-                        telemetry,
-                        ct)
-                    .ConfigureAwait(false);
-
-                if (certificate != null)
+                for (int i = 0; i < TrustedCertificates.Count; i++)
                 {
-                    collection.Add(certificate);
+                    CertificateIdentifier trustedCertificate = TrustedCertificates[i];
+
+                    // ResolveAsync hands back an owning handle and Add takes one
+                    // of its own, so the resolved handle has to be released here.
+                    using Certificate? certificate = await CertificateIdentifierResolver
+                        .ResolveAsync(
+                            trustedCertificate,
+                            registry: null,
+                            needPrivateKey: false,
+                            applicationUri: null,
+                            telemetry,
+                            ct)
+                        .ConfigureAwait(false);
+
+                    if (certificate != null)
+                    {
+                        collection.Add(certificate);
+                    }
                 }
+            }
+            catch
+            {
+                // The collection already owns a handle per certificate read from
+                // the store; nothing else would release them if an unreadable
+                // entry or a cancellation stops the loop before it is returned.
+                collection.Dispose();
+                throw;
             }
 
             return collection;

--- a/src/Opc.Ua.Core/Security/Certificates/CryptoUtils.cs
+++ b/src/Opc.Ua.Core/Security/Certificates/CryptoUtils.cs
@@ -778,28 +778,42 @@ namespace Opc.Ua
             byte[] dataArray = data.Array ??
                 throw new ArgumentNullException(nameof(data), "Data array must not be null.");
 
-            int paddingSize = dataArray[data.Offset + data.Count - 1];
-            int paddingByteSize = 1;
+            int paddingByteSize = blockSize > byte.MaxValue ? 2 : 1;
 
-            if (blockSize > byte.MaxValue)
+            if (data.Count < paddingByteSize)
             {
-                paddingSize <<= 8;
-                paddingSize += dataArray[data.Offset + data.Count - 2];
-                paddingByteSize = 2;
+                throw new CryptographicException("Invalid padding.");
             }
 
-            int notvalid = paddingSize < data.Count ? 0 : 1;
-            int start = data.Offset + data.Count - paddingSize - paddingByteSize;
+            // the plain text ends at this index; the padding count byte(s) are
+            // the last bytes before it.
+            int end = data.Offset + data.Count;
 
-            for (int ii = data.Offset; ii < data.Count - paddingByteSize && ii < paddingSize; ii++)
+            int paddingSize = dataArray[end - 1];
+
+            if (paddingByteSize == 2)
             {
-                if (start < 0 || start + ii >= data.Count)
+                paddingSize <<= 8;
+                paddingSize += dataArray[end - 2];
+            }
+
+            // the filler bytes precede the count byte(s) and must all repeat the
+            // low byte of the count (see AddPadding).
+            int start = end - paddingSize - paddingByteSize;
+
+            int notvalid = paddingSize + paddingByteSize > data.Count ? 1 : 0;
+
+            for (int ii = 0; ii < paddingSize; ii++)
+            {
+                int index = start + ii;
+
+                if (index < data.Offset || index >= end)
                 {
                     notvalid |= 1;
                     continue;
                 }
 
-                notvalid |= dataArray[start + ii] ^ (paddingSize & 0xFF);
+                notvalid |= dataArray[index] ^ (paddingSize & 0xFF);
             }
 
             if (notvalid != 0)
@@ -807,7 +821,7 @@ namespace Opc.Ua
                 throw new CryptographicException("Invalid padding.");
             }
 
-            return new ArraySegment<byte>(dataArray, 0, data.Offset + data.Count - paddingSize - paddingByteSize);
+            return new ArraySegment<byte>(dataArray, 0, start);
         }
 
         /// <summary>
@@ -1728,14 +1742,17 @@ namespace Opc.Ua
                 }
             }
 
-            if (!signOnly)
-            {
-                data = RemovePadding(data, iv.Length);
-            }
-
+            // Checked before the padding is inspected: padding on a message that
+            // failed its signature is attacker-chosen, and reporting the two
+            // failures apart would make the padding check an oracle.
             if (isNotValid != 0)
             {
                 throw new CryptographicException("Invalid signature.");
+            }
+
+            if (!signOnly)
+            {
+                data = RemovePadding(data, iv.Length);
             }
 
             return new ArraySegment<byte>(dataArray, 0, data.Offset + data.Count);

--- a/src/Opc.Ua.Core/Security/Certificates/DirectoryCertificateStore.cs
+++ b/src/Opc.Ua.Core/Security/Certificates/DirectoryCertificateStore.cs
@@ -337,10 +337,14 @@ namespace Opc.Ua
 
                 DateTime now = m_timeProvider.GetUtcNow().UtcDateTime;
                 int entries = 0;
+
                 foreach (Certificate certificate in certificates)
                 {
-                    // limit the number of certificates added per call.
-                    if (maxCertificates != 0 && entries >= maxCertificates)
+                    // Limit the number of certificates added per call. A maximum
+                    // of zero or less keeps no history at all, so this stops
+                    // before the first one - and the trim below then discards
+                    // whatever the store already held.
+                    if (entries >= maxCertificates)
                     {
                         break;
                     }
@@ -377,6 +381,8 @@ namespace Opc.Ua
                     entries++;
                 }
 
+                // Keep the newest maxCertificates entries and discard the rest;
+                // with a maximum of zero or less that discards everything.
                 entries = 0;
                 foreach (Entry entry in m_certificates.Values
                     .OrderByDescending(e => e.LastWriteTimeUtc))
@@ -463,9 +469,14 @@ namespace Opc.Ua
                                             out byte[]? newContent) &&
                                         newContent != null)
                                     {
+                                        // FileMode.Create, not OpenOrCreate: the
+                                        // rewritten PEM is shorter than the one
+                                        // it replaces, and without truncating,
+                                        // the tail of the removed certificate
+                                        // stays in the file and parses again.
                                         var writer = new BinaryWriter(
                                             entry.CertificateFile
-                                                .Open(FileMode.OpenOrCreate, FileAccess.Write));
+                                                .Open(FileMode.Create, FileAccess.Write));
                                         try
                                         {
                                             writer.Write(newContent);

--- a/src/Opc.Ua.Core/Security/Certificates/EncryptedSecret.cs
+++ b/src/Opc.Ua.Core/Security/Certificates/EncryptedSecret.cs
@@ -178,32 +178,41 @@ namespace Opc.Ua
             encryptingKey = new byte[encryptingKeySize];
             iv = new byte[blockSize];
 
-            byte[] secret = localNonce.GenerateSecret(remoteNonce, null) ?? throw new InvalidOperationException("Failed to generate secret.");
-            byte[] keyLength = BitConverter.GetBytes((ushort)(encryptingKeySize + blockSize));
+            byte[] secret = localNonce.GenerateSecret(remoteNonce, null) ??
+                throw new InvalidOperationException("Failed to generate secret.");
+            byte[]? keyData = null;
 
-            byte[] salt = Utils.Append(
-                keyLength,
-                s_secretLabel,
-                forDecryption ? remoteNonce.Data : localNonce.Data,
-                forDecryption ? localNonce.Data : remoteNonce.Data);
-
-            byte[] keyData = localNonce.DeriveKeyData(
-                secret!,
-                salt,
-                securityPolicy.KeyDerivationAlgorithm,
-                encryptingKeySize + blockSize);
-
+            // The scope starts at the shared secret, not at the copy below: the
+            // derivation in between can throw, and neither of these leaves this
+            // method. The secret is the worse of the two to leave behind - it
+            // derives the keys for every message of the exchange, not just this
+            // one.
             try
             {
+                byte[] keyLength = BitConverter.GetBytes((ushort)(encryptingKeySize + blockSize));
+
+                byte[] salt = Utils.Append(
+                    keyLength,
+                    s_secretLabel,
+                    forDecryption ? remoteNonce.Data : localNonce.Data,
+                    forDecryption ? localNonce.Data : remoteNonce.Data);
+
+                keyData = localNonce.DeriveKeyData(
+                    secret,
+                    salt,
+                    securityPolicy.KeyDerivationAlgorithm,
+                    encryptingKeySize + blockSize);
+
                 Buffer.BlockCopy(keyData, 0, encryptingKey, 0, encryptingKey.Length);
                 Buffer.BlockCopy(keyData, encryptingKeySize, iv, 0, iv.Length);
             }
             finally
             {
-                // Neither of these leaves this method, and the shared secret is
-                // the worse of the two to leave behind: it derives the keys for
-                // every message of the exchange, not just this one.
-                CryptoUtils.ZeroMemory(keyData);
+                if (keyData != null)
+                {
+                    CryptoUtils.ZeroMemory(keyData);
+                }
+
                 CryptoUtils.ZeroMemory(secret);
             }
         }

--- a/src/Opc.Ua.Core/Security/Certificates/EncryptedSecret.cs
+++ b/src/Opc.Ua.Core/Security/Certificates/EncryptedSecret.cs
@@ -193,8 +193,19 @@ namespace Opc.Ua
                 securityPolicy.KeyDerivationAlgorithm,
                 encryptingKeySize + blockSize);
 
-            Buffer.BlockCopy(keyData, 0, encryptingKey, 0, encryptingKey.Length);
-            Buffer.BlockCopy(keyData, encryptingKeySize, iv, 0, iv.Length);
+            try
+            {
+                Buffer.BlockCopy(keyData, 0, encryptingKey, 0, encryptingKey.Length);
+                Buffer.BlockCopy(keyData, encryptingKeySize, iv, 0, iv.Length);
+            }
+            finally
+            {
+                // Neither of these leaves this method, and the shared secret is
+                // the worse of the two to leave behind: it derives the keys for
+                // every message of the exchange, not just this one.
+                CryptoUtils.ZeroMemory(keyData);
+                CryptoUtils.ZeroMemory(secret);
+            }
         }
 
         /// <summary>
@@ -367,11 +378,21 @@ namespace Opc.Ua
             message[lengthPosition++] = (byte)((length & 0xFF0000) >> 16);
             message[lengthPosition++] = (byte)((length & 0xFF000000) >> 24);
 
-            _ = CryptoUtils.SymmetricEncryptAndSign(
-                new ArraySegment<byte>(message, startOfSecret, endOfSecret - startOfSecret),
-                SecurityPolicy,
-                encryptingKey,
-                iv);
+            try
+            {
+                _ = CryptoUtils.SymmetricEncryptAndSign(
+                    new ArraySegment<byte>(message, startOfSecret, endOfSecret - startOfSecret),
+                    SecurityPolicy,
+                    encryptingKey,
+                    iv);
+            }
+            finally
+            {
+                // Matches the decrypt side: the derived key and IV are finished
+                // with once the body is encrypted.
+                CryptoUtils.ZeroMemory(encryptingKey);
+                CryptoUtils.ZeroMemory(iv);
+            }
 
             var dataToSign = new ArraySegment<byte>(message, 0, message.Length - signatureLength);
 
@@ -1218,54 +1239,80 @@ namespace Opc.Ua
                 out byte[] encryptingKey,
                 out byte[] iv);
 
-            ArraySegment<byte> plainText = CryptoUtils.SymmetricDecryptAndVerify(
-                dataToDecrypt,
-                SecurityPolicy,
-                encryptingKey,
-                iv);
-
-            using var decoder = new BinaryDecoder(
-                plainText.GetArray(),
-                plainText.Offset + dataToDecrypt.Offset,
-                plainText.Count - dataToDecrypt.Offset,
-                Context);
-
-            ByteString actualNonce = decoder.ReadByteString(null);
-
-            if (expectedNonce != null && expectedNonce.Length > 0)
+            try
             {
-                int notvalid = expectedNonce.Length == actualNonce.Length ? 0 : 1;
+                ArraySegment<byte> plainText = CryptoUtils.SymmetricDecryptAndVerify(
+                    dataToDecrypt,
+                    SecurityPolicy,
+                    encryptingKey,
+                    iv);
 
-                for (int ii = 0; ii < expectedNonce.Length && ii < actualNonce.Length; ii++)
+
+                using var decoder = new BinaryDecoder(
+                    plainText.GetArray(),
+                    plainText.Offset + dataToDecrypt.Offset,
+                    plainText.Count - dataToDecrypt.Offset,
+                    Context);
+
+                ByteString actualNonce = decoder.ReadByteString(null);
+
+                if (expectedNonce != null && expectedNonce.Length > 0)
                 {
-                    notvalid |= expectedNonce[ii] ^ actualNonce.Span[ii];
+                    int notvalid = expectedNonce.Length == actualNonce.Length ? 0 : 1;
+
+                    for (int ii = 0; ii < expectedNonce.Length && ii < actualNonce.Length; ii++)
+                    {
+                        notvalid |= expectedNonce[ii] ^ actualNonce.Span[ii];
+                    }
+
+                    if (notvalid != 0)
+                    {
+                        throw new ServiceResultException(StatusCodes.BadNonceInvalid);
+                    }
                 }
 
-                if (notvalid != 0)
+                ByteString key = decoder.ReadByteString(null);
+                byte paddingCount = decoder.ReadByte(null);
+
+                int error = 0;
+
+                for (int ii = 0; ii < paddingCount; ii++)
                 {
-                    throw new ServiceResultException(StatusCodes.BadNonceInvalid);
+                    byte padding = decoder.ReadByte(null);
+                    error |= padding & ~paddingCount;
                 }
+
+                byte highByte = decoder.ReadByte(null);
+
+                if (error != 0 || highByte != 0)
+                {
+                    throw new ServiceResultException(StatusCodes.BadDecodingError);
+                }
+
+                return key.ToArray();
             }
-
-            ByteString key = decoder.ReadByteString(null);
-            byte paddingCount = decoder.ReadByte(null);
-
-            int error = 0;
-
-            for (int ii = 0; ii < paddingCount; ii++)
+            finally
             {
-                byte padding = decoder.ReadByte(null);
-                error |= padding & ~paddingCount;
+                // The decryption writes the secret in place, over the buffer the
+                // caller handed in, and only the extracted key is copied out - so
+                // without this the plain text lives on in that buffer.
+                //
+                // The region is taken from dataToDecrypt, not from the returned
+                // segment: SymmetricDecryptAndVerify decrypts first and verifies
+                // afterwards, so on a signature or padding failure it throws with
+                // the plain text already written and nothing returned. That is
+                // precisely the path this has to cover.
+                if (dataToDecrypt.Array != null)
+                {
+                    CryptoUtils.ZeroMemory(
+                        dataToDecrypt.Array.AsSpan(
+                            dataToDecrypt.Offset,
+                            dataToDecrypt.Count));
+                }
+
+                CryptoUtils.ZeroMemory(encryptingKey);
+                CryptoUtils.ZeroMemory(iv);
             }
-
-            byte highByte = decoder.ReadByte(null);
-
-            if (error != 0 || highByte != 0)
-            {
-                throw new ServiceResultException(StatusCodes.BadDecodingError);
-            }
-
-            return key.ToArray();
         }
 
         /// <summary>

--- a/src/Opc.Ua.Core/Security/Certificates/ICertificateStore.cs
+++ b/src/Opc.Ua.Core/Security/Certificates/ICertificateStore.cs
@@ -104,7 +104,8 @@ namespace Opc.Ua
         /// </summary>
         /// <param name="certificates">The certificate collection.</param>
         /// <param name="maxCertificates">The max number of rejected certificates to keep in the store.
-        /// A negative number keeps no history, 0 is unlimited.</param>
+        /// Zero or less keeps no history at all and discards whatever is already stored; a positive
+        /// value caps the history at that many, discarding the oldest first.</param>
         /// <param name="ct">Cancellation token to cancel operation with</param>
         Task AddRejectedAsync(
             CertificateCollection certificates,

--- a/src/Opc.Ua.Core/Security/Certificates/Nonce.cs
+++ b/src/Opc.Ua.Core/Security/Certificates/Nonce.cs
@@ -734,8 +734,24 @@ namespace Opc.Ua
         /// <summary>
         /// Creates a new RSADiffieHellman instance from the nonce.
         /// </summary>
+        /// <exception cref="ArgumentNullException"><paramref name="nonce"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">
+        /// The nonce does not belong to a supported finite field group, or the
+        /// public key it carries is outside the valid range for that group.
+        /// </exception>
         public static RSADiffieHellman Create(byte[] nonce)
         {
+            if (nonce == null)
+            {
+                throw new ArgumentNullException(nameof(nonce));
+            }
+
+            if (!TryGetGroupModulus(nonce.Length, out BigInteger p))
+            {
+                throw new ArgumentException(
+                    "Invalid nonce data provided", nameof(nonce));
+            }
+
             var dh = new RSADiffieHellman();
 
             byte[] bytes = new byte[nonce.Length + 1];
@@ -748,7 +764,48 @@ namespace Opc.Ua
             dh.m_publicKey = new BigInteger(bytes);
             dh.m_nonceLength = nonce.Length;
 
+            // Part 6 §6.7.6 / RFC 7919 §5.1: a peer value outside 2 <= y <= p-2
+            // is rejected. Without this the shared secret can be forced to a
+            // known constant by sending 0, 1 or p-1.
+            if (!IsValidPeerValue(dh.m_publicKey, p))
+            {
+                throw new ArgumentException(
+                    "Invalid nonce data provided", nameof(nonce));
+            }
+
             return dh;
+        }
+
+        /// <summary>
+        /// Returns the finite field prime for the group a nonce of the given
+        /// length belongs to.
+        /// </summary>
+        private static bool TryGetGroupModulus(int nonceLength, out BigInteger p)
+        {
+            switch (nonceLength)
+            {
+                case 256:
+                    p = s_P2048.Value;
+                    return true;
+                case 384:
+                    p = s_P3072.Value;
+                    return true;
+                case 512:
+                    p = s_P4096.Value;
+                    return true;
+                default:
+                    p = BigInteger.Zero;
+                    return false;
+            }
+        }
+
+        /// <summary>
+        /// Returns whether a peer's public value lies in the safe range
+        /// 2 &lt;= y &lt;= p-2 for the group with prime <paramref name="p"/>.
+        /// </summary>
+        private static bool IsValidPeerValue(BigInteger y, BigInteger p)
+        {
+            return y >= 2 && y <= p - 2;
         }
 
         /// <summary>
@@ -770,30 +827,35 @@ namespace Opc.Ua
         /// <summary>
         /// Derives the raw secret agreement from the remote key.
         /// </summary>
+        /// <exception cref="ArgumentNullException"></exception>
+        /// <exception cref="ArgumentException"></exception>
         /// <exception cref="InvalidOperationException"></exception>
         /// <exception cref="NotSupportedException"></exception>
         public byte[] DeriveRawSecretAgreement(RSADiffieHellman remoteKey)
         {
+            if (remoteKey == null)
+            {
+                throw new ArgumentNullException(nameof(remoteKey));
+            }
+
             if (m_privateKey.IsZero)
             {
                 throw new InvalidOperationException("Private key not available.");
             }
 
-            BigInteger p;
-
-            switch (m_nonceLength)
+            if (!TryGetGroupModulus(m_nonceLength, out BigInteger p))
             {
-                case 256:
-                    p = s_P2048.Value;
-                    break;
-                case 384:
-                    p = s_P3072.Value;
-                    break;
-                case 512:
-                    p = s_P4096.Value;
-                    break;
-                default:
-                    throw new NotSupportedException("Unsupported RSA DH finite group type.");
+                throw new NotSupportedException("Unsupported RSA DH finite group type.");
+            }
+
+            // The peer must be in the same group, and its public value must lie
+            // in 2 <= y <= p-2 (checked again here because a key can be
+            // assembled without going through Create).
+            if (remoteKey.m_nonceLength != m_nonceLength ||
+                !IsValidPeerValue(remoteKey.m_publicKey, p))
+            {
+                throw new ArgumentException(
+                    "Invalid remote key provided", nameof(remoteKey));
             }
 
             var shared = BigInteger.ModPow(remoteKey.m_publicKey, m_privateKey, p);

--- a/src/Opc.Ua.Core/Security/Certificates/X509CertificateStore/X509CertificateStore.cs
+++ b/src/Opc.Ua.Core/Security/Certificates/X509CertificateStore/X509CertificateStore.cs
@@ -162,7 +162,17 @@ namespace Opc.Ua
             {
                 store.Open(OpenFlags.ReadWrite);
                 using X509Certificate2 x509ForCheck = X509CertificateLoader.LoadCertificate(certificate.RawData);
-                if (!store.Certificates.Contains(x509ForCheck))
+
+                // store.Certificates materialises a fresh handle per entry and
+                // nothing else releases them.
+                X509Certificate2Collection existing = store.Certificates;
+                bool alreadyPresent = existing.Contains(x509ForCheck);
+                foreach (X509Certificate2 present in existing)
+                {
+                    present.Dispose();
+                }
+
+                if (!alreadyPresent)
                 {
                     if (certificate.HasPrivateKey && !NoPrivateKeys)
                     {
@@ -241,9 +251,14 @@ namespace Opc.Ua
 
                 foreach (X509Certificate2 certificate in store.Certificates)
                 {
-                    if (certificate.Thumbprint == thumbprint)
+                    // Each element is a fresh handle on the platform store's
+                    // certificate context; nothing else releases them.
+                    using (certificate)
                     {
-                        store.Remove(certificate);
+                        if (certificate.Thumbprint == thumbprint)
+                        {
+                            store.Remove(certificate);
+                        }
                     }
                 }
             }
@@ -265,9 +280,17 @@ namespace Opc.Ua
             {
                 if (certificate.Thumbprint == thumbprint)
                 {
+                    // Certificate.From takes ownership of the handle; Add takes
+                    // its own reference, so the local one is released here.
                     var cert = Certificate.From(certificate);
                     collection.Add(cert);
                     cert.Dispose();
+                }
+                else
+                {
+                    // Nothing took ownership of this handle on the platform
+                    // store's certificate context, so release it here.
+                    certificate.Dispose();
                 }
             }
 
@@ -303,7 +326,11 @@ namespace Opc.Ua
         {
             if (!SupportsCRLs)
             {
-                throw new ServiceResultException(StatusCodes.BadNotSupported);
+                // Reported, not thrown: the validator treats BadNotSupported as
+                // "this store cannot answer" and moves on, while a thrown
+                // ServiceResultException surfaces as an unsuppressible
+                // BadCertificateInvalid and fails every CA-issued certificate.
+                return StatusCodes.BadNotSupported;
             }
 
             if (issuer == null)

--- a/src/Opc.Ua.Core/Stack/Client/Channels/ClientChannelManager.cs
+++ b/src/Opc.Ua.Core/Stack/Client/Channels/ClientChannelManager.cs
@@ -191,25 +191,9 @@ namespace Opc.Ua
             ISecurityPolicyRegistry? securityPolicies = null,
             CancellationToken ct = default)
         {
-            // initialize the channel which will be created with the server.
-            string uriScheme = new Uri(description.EndpointUrl
-                ?? throw new ArgumentException("EndpointUrl cannot be null", nameof(description))).Scheme;
-            transportChannelBindings ??= GetDefaultBindingsLazy();
-            ITransportChannel channel =
-                transportChannelBindings.Create(uriScheme, messageContext.Telemetry)
-                ?? throw ServiceResultException.Create(
-                    StatusCodes.BadProtocolVersionUnsupported,
-                    "Unsupported transport profile for scheme {0}.",
-                    uriScheme);
-
-            if (channel is not ISecureChannel secureChannel)
-            {
-                throw ServiceResultException.Create(
-                    StatusCodes.BadNotSupported,
-                    "The transport channel does not support opening.");
-            }
-
-            // create a UA channel.
+            // Built before anything that can throw, so every failure below runs
+            // the cleanup that releases the caller's certificate handles - this
+            // method owns them from here on.
             var settings = new TransportChannelSettings
             {
                 Description = description,
@@ -219,8 +203,28 @@ namespace Opc.Ua
                 SecurityPolicyRegistry = securityPolicies
             };
 
+            ITransportChannel? channel = null;
+
             try
             {
+                // initialize the channel which will be created with the server.
+                string uriScheme = new Uri(description.EndpointUrl
+                    ?? throw new ArgumentException("EndpointUrl cannot be null", nameof(description))).Scheme;
+                transportChannelBindings ??= GetDefaultBindingsLazy();
+                channel =
+                    transportChannelBindings.Create(uriScheme, messageContext.Telemetry)
+                    ?? throw ServiceResultException.Create(
+                        StatusCodes.BadProtocolVersionUnsupported,
+                        "Unsupported transport profile for scheme {0}.",
+                        uriScheme);
+
+                if (channel is not ISecureChannel secureChannel)
+                {
+                    throw ServiceResultException.Create(
+                        StatusCodes.BadNotSupported,
+                        "The transport channel does not support opening.");
+                }
+
                 if (description.ServerCertificate.Length > 0)
                 {
                     settings.ServerCertificate = Utils.ParseCertificateBlob(
@@ -237,17 +241,16 @@ namespace Opc.Ua
                 settings.Factory = messageContext.Factory;
 
                 await secureChannel.OpenAsync(connection, settings, ct).ConfigureAwait(false);
+
+                ITransportChannel opened = channel;
+                channel = null;
+                return opened;
             }
             catch
             {
-                // settings.ServerCertificate is allocated above; dispose on
-                // failure since the channel never assumed ownership.
-                settings.ServerCertificate?.Dispose();
-                channel.Dispose();
+                ReleaseUnopenedChannel(channel, settings);
                 throw;
             }
-
-            return channel;
         }
 
         /// <summary>
@@ -277,37 +280,9 @@ namespace Opc.Ua
             ISecurityPolicyRegistry? securityPolicies = null,
             CancellationToken ct = default)
         {
-            var endpointUrl = new Uri(description.EndpointUrl
-                ?? throw new ArgumentException("EndpointUrl cannot be null", nameof(description)));
-            string uriScheme = description.TransportProfileUri switch
-            {
-                Profiles.UaTcpTransport => Utils.UriSchemeOpcTcp,
-                Profiles.HttpsBinaryTransport => Utils.UriSchemeOpcHttps,
-                Profiles.HttpsJsonTransport => Utils.UriSchemeOpcHttps,
-                Profiles.HttpsOpenApiTransport => Utils.UriSchemeOpcHttpsWebApi,
-                Profiles.UaWssTransport => Utils.UriSchemeOpcWss,
-                Profiles.UaWssJsonTransport => "opc.wss+json",
-                Profiles.WssOpenApiTransport => Utils.UriSchemeOpcWssOpenApi,
-                _ => endpointUrl.Scheme
-            };
-
-            // initialize the channel which will be created with the server.
-            transportChannelBindings ??= GetDefaultBindingsLazy();
-            ITransportChannel channel =
-                transportChannelBindings.Create(uriScheme, messageContext.Telemetry)
-                ?? throw ServiceResultException.Create(
-                    StatusCodes.BadProtocolVersionUnsupported,
-                    "Unsupported transport profile for scheme {0}.",
-                    uriScheme);
-
-            if (channel is not ISecureChannel secureChannel)
-            {
-                throw ServiceResultException.Create(
-                    StatusCodes.BadNotSupported,
-                    "The transport channel does not support opening.");
-            }
-
-            // create a UA-TCP channel.
+            // Built before anything that can throw, so every failure below runs
+            // the cleanup that releases the caller's certificate handles - this
+            // method owns them from here on.
             var settings = new TransportChannelSettings
             {
                 Description = description,
@@ -317,8 +292,40 @@ namespace Opc.Ua
                 SecurityPolicyRegistry = securityPolicies
             };
 
+            ITransportChannel? channel = null;
+
             try
             {
+                var endpointUrl = new Uri(description.EndpointUrl
+                    ?? throw new ArgumentException("EndpointUrl cannot be null", nameof(description)));
+                string uriScheme = description.TransportProfileUri switch
+                {
+                    Profiles.UaTcpTransport => Utils.UriSchemeOpcTcp,
+                    Profiles.HttpsBinaryTransport => Utils.UriSchemeOpcHttps,
+                    Profiles.HttpsJsonTransport => Utils.UriSchemeOpcHttps,
+                    Profiles.HttpsOpenApiTransport => Utils.UriSchemeOpcHttpsWebApi,
+                    Profiles.UaWssTransport => Utils.UriSchemeOpcWss,
+                    Profiles.UaWssJsonTransport => "opc.wss+json",
+                    Profiles.WssOpenApiTransport => Utils.UriSchemeOpcWssOpenApi,
+                    _ => endpointUrl.Scheme
+                };
+
+                // initialize the channel which will be created with the server.
+                transportChannelBindings ??= GetDefaultBindingsLazy();
+                channel =
+                    transportChannelBindings.Create(uriScheme, messageContext.Telemetry)
+                    ?? throw ServiceResultException.Create(
+                        StatusCodes.BadProtocolVersionUnsupported,
+                        "Unsupported transport profile for scheme {0}.",
+                        uriScheme);
+
+                if (channel is not ISecureChannel secureChannel)
+                {
+                    throw ServiceResultException.Create(
+                        StatusCodes.BadNotSupported,
+                        "The transport channel does not support opening.");
+                }
+
                 if (description.ServerCertificate.Length > 0)
                 {
                     settings.ServerCertificate = Utils.ParseCertificateBlob(
@@ -335,16 +342,42 @@ namespace Opc.Ua
                 settings.Factory = messageContext.Factory;
 
                 await secureChannel.OpenAsync(endpointUrl, settings, ct).ConfigureAwait(false);
+
+                ITransportChannel opened = channel;
+                channel = null;
+                return opened;
             }
             catch
             {
-                // settings.ServerCertificate is allocated above; dispose on
-                // failure since the channel never assumed ownership.
-                settings.ServerCertificate?.Dispose();
-                channel.Dispose();
+                ReleaseUnopenedChannel(channel, settings);
                 throw;
             }
-            return channel;
+        }
+
+        /// <summary>
+        /// Releases everything a channel that never opened was holding: the
+        /// channel itself and the certificate handles the settings took over.
+        /// </summary>
+        /// <remarks>
+        /// Disposing the channel releases the settings' certificates and clears
+        /// them when it got as far as storing the settings, so the disposals
+        /// after it cover only the handles it never saw. Each therefore runs
+        /// exactly once, which matters because these are reference-counted
+        /// handles the caller AddRef'd for this call.
+        /// </remarks>
+        private static void ReleaseUnopenedChannel(
+            ITransportChannel? channel,
+            TransportChannelSettings settings)
+        {
+            settings.ServerCertificate?.Dispose();
+            settings.ServerCertificate = null;
+
+            channel?.Dispose();
+
+            settings.ClientCertificate?.Dispose();
+            settings.ClientCertificate = null;
+            settings.ClientCertificateChain?.Dispose();
+            settings.ClientCertificateChain = null;
         }
 
         /// <summary>
@@ -1257,11 +1290,18 @@ namespace Opc.Ua
             CancellationToken ct)
         {
             IServiceMessageContext context = Configuration.CreateMessageContext();
+
+            // The entry passes on what SnapshotClientCertificate handed it,
+            // which are the manager's own handles. CreateChannelAsync stores its
+            // arguments in TransportChannelSettings, and those are disposed when
+            // the channel closes, so each channel needs a handle of its own -
+            // otherwise the first channel to close invalidates the manager's and
+            // every later channel (and DiscoveryClient) throws on a dead handle.
             return CreateChannelAsync(
                 endpoint,
                 context,
-                clientCertificate,
-                clientCertificateChain,
+                clientCertificate?.AddRef(),
+                clientCertificateChain?.AddRef(),
                 reverseConnection,
                 ct);
         }

--- a/src/Opc.Ua.Core/Stack/Client/Channels/ManagedChannelKey.cs
+++ b/src/Opc.Ua.Core/Stack/Client/Channels/ManagedChannelKey.cs
@@ -63,6 +63,9 @@ namespace Opc.Ua
         /// <param name="reverseConnectionIdentity">Opaque identity of
         /// the reverse-connect wait handle. Use <c>null</c> for
         /// forward connections.</param>
+        /// <param name="transportProfileUri">The transport profile URI.
+        /// Binary, JSON and OpenAPI endpoints share a URL, security mode
+        /// and policy but not a channel.</param>
         public ManagedChannelKey(
             string endpointUrl,
             string securityPolicyUri,
@@ -70,7 +73,8 @@ namespace Opc.Ua
             ByteString serverCertificateThumbprint,
             int endpointConfigurationHash,
             ByteString clientCertificateThumbprint,
-            object? reverseConnectionIdentity)
+            object? reverseConnectionIdentity,
+            string? transportProfileUri = null)
         {
             EndpointUrl = endpointUrl ?? throw new ArgumentNullException(nameof(endpointUrl));
             SecurityPolicyUri = securityPolicyUri
@@ -80,6 +84,7 @@ namespace Opc.Ua
             EndpointConfigurationHash = endpointConfigurationHash;
             ClientCertificateThumbprint = clientCertificateThumbprint;
             ReverseConnectionIdentity = reverseConnectionIdentity;
+            TransportProfileUri = transportProfileUri ?? string.Empty;
         }
 
         /// <summary>
@@ -122,6 +127,15 @@ namespace Opc.Ua
         public object? ReverseConnectionIdentity { get; }
 
         /// <summary>
+        /// The transport profile URI, or an empty string when the endpoint
+        /// does not name one. The HTTPS binary, JSON and OpenAPI endpoints
+        /// of a server share a URL, security mode and policy, so without
+        /// this they would all be served by a single channel of whichever
+        /// transport happened to be created first.
+        /// </summary>
+        public string TransportProfileUri { get; }
+
+        /// <summary>
         /// Computes a key for the supplied configured endpoint and
         /// (optional) client certificate / reverse connection identity.
         /// </summary>
@@ -160,7 +174,8 @@ namespace Opc.Ua
                 serverThumbprint,
                 ComputeEndpointConfigurationHash(configuration),
                 clientThumbprint,
-                reverseConnectionIdentity);
+                reverseConnectionIdentity,
+                description.TransportProfileUri);
         }
 
         private static ByteString ComputeServerCertificateThumbprint(ByteString rawCertificate)

--- a/src/Opc.Ua.Core/Stack/Client/Channels/ManagedChannelKey.cs
+++ b/src/Opc.Ua.Core/Stack/Client/Channels/ManagedChannelKey.cs
@@ -63,6 +63,49 @@ namespace Opc.Ua
         /// <param name="reverseConnectionIdentity">Opaque identity of
         /// the reverse-connect wait handle. Use <c>null</c> for
         /// forward connections.</param>
+        /// <remarks>
+        /// Kept as its own overload rather than folded into the one below with
+        /// an optional argument: an optional parameter is source compatible but
+        /// not binary compatible, and an application compiled against this
+        /// signature would fail with a <see cref="MissingMethodException"/>.
+        /// </remarks>
+        public ManagedChannelKey(
+            string endpointUrl,
+            string securityPolicyUri,
+            MessageSecurityMode securityMode,
+            ByteString serverCertificateThumbprint,
+            int endpointConfigurationHash,
+            ByteString clientCertificateThumbprint,
+            object? reverseConnectionIdentity)
+            : this(
+                endpointUrl,
+                securityPolicyUri,
+                securityMode,
+                serverCertificateThumbprint,
+                endpointConfigurationHash,
+                clientCertificateThumbprint,
+                reverseConnectionIdentity,
+                transportProfileUri: null)
+        {
+        }
+
+        /// <summary>
+        /// Creates a key for the supplied endpoint identity.
+        /// </summary>
+        /// <param name="endpointUrl">The endpoint URL.</param>
+        /// <param name="securityPolicyUri">The security policy URI.</param>
+        /// <param name="securityMode">The message security mode.</param>
+        /// <param name="serverCertificateThumbprint">Thumbprint of the
+        /// expected server certificate (may be empty for None
+        /// security).</param>
+        /// <param name="endpointConfigurationHash">Stable hash of the
+        /// endpoint configuration values.</param>
+        /// <param name="clientCertificateThumbprint">Thumbprint of the
+        /// client instance certificate (may be empty for None
+        /// security).</param>
+        /// <param name="reverseConnectionIdentity">Opaque identity of
+        /// the reverse-connect wait handle. Use <c>null</c> for
+        /// forward connections.</param>
         /// <param name="transportProfileUri">The transport profile URI.
         /// Binary, JSON and OpenAPI endpoints share a URL, security mode
         /// and policy but not a channel.</param>
@@ -74,7 +117,7 @@ namespace Opc.Ua
             int endpointConfigurationHash,
             ByteString clientCertificateThumbprint,
             object? reverseConnectionIdentity,
-            string? transportProfileUri = null)
+            string? transportProfileUri)
         {
             EndpointUrl = endpointUrl ?? throw new ArgumentNullException(nameof(endpointUrl));
             SecurityPolicyUri = securityPolicyUri

--- a/src/Opc.Ua.Core/Stack/Configuration/ConfiguredEndpoints.cs
+++ b/src/Opc.Ua.Core/Stack/Configuration/ConfiguredEndpoints.cs
@@ -1405,7 +1405,7 @@ namespace Opc.Ua
                         if (ReferenceEquals(policies[ii], value))
                         {
                             SelectedUserTokenPolicyIndex = ii;
-                            break;
+                            return;
                         }
                     }
                 }

--- a/src/Opc.Ua.Core/Stack/Https/HttpsTransportChannel.cs
+++ b/src/Opc.Ua.Core/Stack/Https/HttpsTransportChannel.cs
@@ -28,11 +28,14 @@
  * ======================================================================*/
 
 using System;
+using System.Buffers;
 using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Net.Security;
+using System.Net.Sockets;
+using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
@@ -117,6 +120,11 @@ namespace Opc.Ua.Bindings
         /// limit the number of concurrent service requests on the server
         /// </summary>
         private const int kMaxConnectionsPerServer = 64;
+
+        /// <summary>
+        /// Size of the scratch buffer the response body is copied through.
+        /// </summary>
+        private const int kResponseCopyBufferSize = 8192;
 
         /// <summary>
         /// Create a transport channel based on the uri scheme.
@@ -279,9 +287,17 @@ namespace Opc.Ua.Bindings
                         EndpointDescription.SecurityPolicyUri);
                 }
 
-                HttpResponseMessage response = await client.PostAsync(
-                    m_url,
-                    content,
+                using var httpRequest = new HttpRequestMessage(HttpMethod.Post, m_url)
+                {
+                    Content = content
+                };
+
+                // ResponseHeadersRead: the default buffers the whole body into
+                // memory before this returns, so MaxMessageSize would only be
+                // applied to an allocation that has already happened.
+                using HttpResponseMessage response = await client.SendAsync(
+                    httpRequest,
+                    HttpCompletionOption.ResponseHeadersRead,
                     linkedCts.Token).ConfigureAwait(false);
 
                 // Translate an HTTP 429/503 (e.g. from an AddHttpsRateLimiter
@@ -296,6 +312,18 @@ namespace Opc.Ua.Bindings
 
                 response.EnsureSuccessStatusCode();
 
+                int maxMessageSize = m_quotas.MaxMessageSize;
+
+                if (maxMessageSize > 0 &&
+                    response.Content.Headers.ContentLength > maxMessageSize)
+                {
+                    throw ServiceResultException.Create(
+                        StatusCodes.BadResponseTooLarge,
+                        "Response of {0} bytes exceeds the maximum message size of {1} bytes.",
+                        response.Content.Headers.ContentLength,
+                        maxMessageSize);
+                }
+
 #if NET6_0_OR_GREATER
                 Stream responseContent = await response.Content.ReadAsStreamAsync(ct)
                     .ConfigureAwait(false);
@@ -303,7 +331,15 @@ namespace Opc.Ua.Bindings
                 Stream responseContent = await response.Content.ReadAsStreamAsync()
                     .ConfigureAwait(false);
 #endif
-                IServiceResponse serviceResponse = DecodeResponse(responseContent, context);
+                // The decoder needs a seekable stream, so the body is buffered -
+                // but only up to MaxMessageSize. A chunked response carries no
+                // ContentLength, so the limit is applied as the body arrives.
+                using MemoryStream body = await ReadBoundedBodyAsync(
+                    responseContent,
+                    maxMessageSize,
+                    linkedCts.Token).ConfigureAwait(false);
+
+                IServiceResponse serviceResponse = DecodeResponse(body, context);
                 if (serviceResponse != null)
                 {
                     return serviceResponse;
@@ -333,8 +369,25 @@ namespace Opc.Ua.Bindings
                     m_logger.HttpsChannelLog1(webex);
                     throw ServiceResultException.Create((uint)statusCode, webex.Message);
                 }
+
                 m_logger.HttpsChannelLog2(hre);
-                throw;
+
+                // On .NET the inner exception is a SocketException, not a
+                // WebException, so the branch above never runs there and the
+                // HttpRequestException would escape as-is - callers that expect a
+                // ServiceResultException see a transport exception instead.
+                //
+                // Only a genuine connect/socket failure maps to BadNotConnected.
+                // EnsureSuccessStatusCode throws with no inner exception at all,
+                // and a TLS or certificate rejection carries an
+                // AuthenticationException - reporting either as "not connected"
+                // tells the reconnect policy to retry a request that will fail
+                // the same way every time.
+                throw ServiceResultException.Create(
+                    MapRequestFailure(hre),
+                    hre,
+                    "Error sending request: {0}",
+                    hre.Message);
             }
             catch (OperationCanceledException e)
             {
@@ -736,6 +789,12 @@ namespace Opc.Ua.Bindings
                 var client = new HttpClient(handler);
 #pragma warning restore CA5400 // HttpClient is created without enabling CheckCertificateRevocationList
                 handler = null; // ownership transferred to HttpClient
+
+                // No MaxResponseContentBufferSize here: it only bounds buffering
+                // HttpClient does itself, and every response is read with
+                // HttpCompletionOption.ResponseHeadersRead and bounded by
+                // ReadBoundedBodyAsync. Setting it would read as a limit that is
+                // in force on the factory-supplied client too, and it is not.
                 return client;
             }
             finally
@@ -805,6 +864,113 @@ namespace Opc.Ua.Bindings
                 return JsonDecoder.DecodeMessage<IServiceResponse>(memory.ToArray(), context);
             }
             return BinaryDecoder.DecodeMessage<IServiceResponse>(stream, context);
+        }
+
+        /// <summary>
+        /// Maps a failed HTTP request onto the status code the stack reports for
+        /// it, distinguishing a transport failure worth retrying from a delivered
+        /// HTTP error or a rejected TLS handshake.
+        /// </summary>
+        private static uint MapRequestFailure(HttpRequestException exception)
+        {
+            if (exception.InnerException is SocketException socketException)
+            {
+                return MapSocketError(socketException.SocketErrorCode);
+            }
+
+            // A TLS failure - including a server certificate the UA validator
+            // rejected in the handler callback - is permanent for this endpoint.
+            if (exception.InnerException is AuthenticationException)
+            {
+                return (uint)StatusCodes.BadSecurityChecksFailed;
+            }
+
+            // Anything else reached the server or failed for a reason the
+            // transport cannot fix by trying again: EnsureSuccessStatusCode
+            // throws with no inner exception at all.
+            return (uint)StatusCodes.BadUnknownResponse;
+        }
+
+        /// <summary>
+        /// Maps the socket error behind a failed HTTP request onto the status
+        /// code the stack reports for it.
+        /// </summary>
+        private static uint MapSocketError(SocketError error)
+        {
+            switch (error)
+            {
+                case SocketError.TimedOut:
+                    return (uint)StatusCodes.BadRequestTimeout;
+                case SocketError.ConnectionAborted:
+                case SocketError.ConnectionRefused:
+                case SocketError.ConnectionReset:
+                case SocketError.HostDown:
+                case SocketError.HostNotFound:
+                case SocketError.HostUnreachable:
+                case SocketError.NetworkDown:
+                case SocketError.NetworkUnreachable:
+                    return (uint)StatusCodes.BadNotConnected;
+                default:
+                    return (uint)StatusCodes.BadUnknownResponse;
+            }
+        }
+
+        /// <summary>
+        /// Buffers the HTTP response body into a seekable stream, refusing it as
+        /// soon as it passes <paramref name="maxBytes"/> rather than after the
+        /// whole body has been allocated.
+        /// </summary>
+        /// <param name="source">The response body.</param>
+        /// <param name="maxBytes">
+        /// The most that may be read, or a value of zero or less for no limit.
+        /// </param>
+        /// <param name="ct">Cancels the read.</param>
+        /// <exception cref="ServiceResultException">The body is too large.</exception>
+        private static async Task<MemoryStream> ReadBoundedBodyAsync(
+            Stream source,
+            int maxBytes,
+            CancellationToken ct)
+        {
+            var buffered = new MemoryStream();
+            byte[] rented = ArrayPool<byte>.Shared.Rent(kResponseCopyBufferSize);
+
+            try
+            {
+                int read;
+
+#if NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER
+                while ((read = await source
+                    .ReadAsync(rented.AsMemory(0, rented.Length), ct)
+                    .ConfigureAwait(false)) > 0)
+#else
+                while ((read = await source
+                    .ReadAsync(rented, 0, rented.Length, ct)
+                    .ConfigureAwait(false)) > 0)
+#endif
+                {
+                    if (maxBytes > 0 && buffered.Length + read > maxBytes)
+                    {
+                        throw ServiceResultException.Create(
+                            StatusCodes.BadResponseTooLarge,
+                            "Response exceeds the maximum message size of {0} bytes.",
+                            maxBytes);
+                    }
+
+                    buffered.Write(rented, 0, read);
+                }
+
+                buffered.Position = 0;
+                return buffered;
+            }
+            catch
+            {
+                buffered.Dispose();
+                throw;
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(rented);
+            }
         }
 
         /// <summary>

--- a/src/Opc.Ua.Core/Stack/Server/ServerBase.cs
+++ b/src/Opc.Ua.Core/Stack/Server/ServerBase.cs
@@ -1250,7 +1250,15 @@ namespace Opc.Ua
             {
                 foreach (string profileUri in profileUris)
                 {
-                    if (baseAddress.ProfileUri == Profiles.NormalizeUri(profileUri))
+                    string normalized = Profiles.NormalizeUri(profileUri);
+
+                    // A base address carries only the profile its URL scheme
+                    // implies, so a client asking for the JSON or OpenAPI profile
+                    // would match nothing and get an empty endpoint list back -
+                    // the same mismatch TranslateEndpointDescriptions works
+                    // around when it decides which endpoints belong here.
+                    if (baseAddress.ProfileUri == normalized ||
+                        ServesSameScheme(baseAddress.ProfileUri, normalized))
                     {
                         filteredAddresses.Add(baseAddress);
                         break;
@@ -1419,15 +1427,16 @@ namespace Opc.Ua
                     // find matching base address.
                     foreach (BaseAddress baseAddress in baseAddresses)
                     {
-                        bool translateHttpsEndpoint = false;
-                        if (endpoint.TransportProfileUri == Profiles.HttpsBinaryTransport &&
-                            baseAddress.ProfileUri == Profiles.HttpsBinaryTransport)
-                        {
-                            translateHttpsEndpoint = true;
-                        }
-
+                        // A base address carries the one profile its URL scheme
+                        // implies, but a listener publishes every profile it
+                        // serves on that scheme - HTTPS serves binary, JSON and
+                        // OpenAPI; WSS serves binary, JSON and OpenAPI too.
+                        // Without this those twins match no base address and
+                        // GetEndpoints drops them.
                         if (endpoint.TransportProfileUri != baseAddress.ProfileUri &&
-                            !translateHttpsEndpoint)
+                            !ServesSameScheme(
+                                baseAddress.ProfileUri,
+                                endpoint.TransportProfileUri))
                         {
                             continue;
                         }
@@ -1466,10 +1475,17 @@ namespace Opc.Ua
                         translation.UserIdentityTokens = endpoint.UserIdentityTokens;
                         translation.Server = application;
 
+                        // The transport profile is part of the identity: binary,
+                        // JSON and OpenAPI endpoints share a URL, security mode
+                        // and policy, so leaving it out collapses them into one.
                         if (!translations.Exists(match =>
                                 match.EndpointUrl!
                                     .Equals(translation.EndpointUrl, StringComparison.Ordinal) &&
                                 match.SecurityMode == translation.SecurityMode &&
+                                string.Equals(
+                                    match.TransportProfileUri,
+                                    translation.TransportProfileUri,
+                                    StringComparison.Ordinal) &&
                                 match.SecurityPolicyUri!.Equals(
                                     translation.SecurityPolicyUri,
                                     StringComparison.Ordinal)))
@@ -1480,10 +1496,76 @@ namespace Opc.Ua
                 }
             } while (matchPort && translations.Count == 0);
 
-            translations.Sort(
-                (ep1, ep2) => string.CompareOrdinal(ep1.EndpointUrl, ep2.EndpointUrl));
+            // Ordered by URL, then by transport profile. The HTTPS binary, JSON
+            // and OpenAPI descriptions of one listener share a URL, security mode
+            // and policy, and List.Sort is not stable - without the second key a
+            // client that picks "the first endpoint that fits" (which is what
+            // CoreClientUtils.SelectEndpoint does, having no transport filter of
+            // its own) would get an arbitrary one of the three and fail to open a
+            // channel for a profile it has no binding for. Binary sorts first, so
+            // that client keeps getting the endpoint it got before the JSON and
+            // OpenAPI twins were published at all.
+            translations.Sort((ep1, ep2) =>
+            {
+                int byUrl = string.CompareOrdinal(ep1.EndpointUrl, ep2.EndpointUrl);
+                return byUrl != 0
+                    ? byUrl
+                    : TransportProfileRank(ep1.TransportProfileUri)
+                        .CompareTo(TransportProfileRank(ep2.TransportProfileUri));
+            });
 
             return translations;
+        }
+
+        /// <summary>
+        /// Returns whether an endpoint's transport profile is served by the same
+        /// URL scheme as a base address's profile, so the endpoint belongs on
+        /// that address even though the two profile URIs differ.
+        /// </summary>
+        private static bool ServesSameScheme(
+            string? baseAddressProfileUri,
+            string? endpointProfileUri)
+        {
+            if (Profiles.IsHttpsBinary(baseAddressProfileUri))
+            {
+                return Profiles.IsHttpsJson(endpointProfileUri) ||
+                    Profiles.IsHttpsOpenApi(endpointProfileUri);
+            }
+
+            if (Profiles.IsWssBinary(baseAddressProfileUri))
+            {
+                return Profiles.IsWssOpenApi(endpointProfileUri) ||
+                    string.Equals(
+                        endpointProfileUri,
+                        Profiles.UaWssJsonTransport,
+                        StringComparison.Ordinal);
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Orders transport profiles so that the binary encodings a client is
+        /// always able to speak are offered ahead of the JSON and OpenAPI ones.
+        /// </summary>
+        private static int TransportProfileRank(string? transportProfileUri)
+        {
+            if (Profiles.IsHttpsJson(transportProfileUri) ||
+                string.Equals(
+                    transportProfileUri,
+                    Profiles.UaWssJsonTransport,
+                    StringComparison.Ordinal))
+            {
+                return 1;
+            }
+
+            if (Profiles.IsHttpsOpenApi(transportProfileUri) ||
+                Profiles.IsWssOpenApi(transportProfileUri))
+            {
+                return 2;
+            }
+
+            return 0;
         }
 
         /// <summary>

--- a/src/Opc.Ua.Core/Stack/Tcp/TcpServerChannel.cs
+++ b/src/Opc.Ua.Core/Stack/Tcp/TcpServerChannel.cs
@@ -340,7 +340,24 @@ namespace Opc.Ua.Bindings
                     {
                         transportLimits.SetReceiveBufferSize(ReceiveBufferSize);
                     }
+
+                    // Retire the old loop BEFORE closing the socket it reads
+                    // from. Closing first makes that loop fail out of
+                    // ReceiveChunkAsync with a socket error rather than a
+                    // cancellation, and its error path faults the channel - on
+                    // the new transport, after this method has already reported
+                    // the reconnect as successful.
+                    IUaSCByteTransport? dropped = DetachTransport();
+
                     Transport = transport;
+
+                    // The socket this channel used before the client dropped it
+                    // is nobody's any more.
+                    if (dropped != null && !ReferenceEquals(dropped, transport))
+                    {
+                        dropped.Close();
+                    }
+
                     StartReceiveLoop();
 
                     // need to assign a new token id.
@@ -700,6 +717,12 @@ namespace Opc.Ua.Bindings
                 // check for replay attacks.
                 if (!VerifySequenceNumber(sequenceNumber, "ProcessOpenSecureChannelRequest"))
                 {
+                    // The decrypted body sits in a buffer of its own that only
+                    // the chunk collection below ever returns, and that does not
+                    // exist yet - so it has to go back here.
+                    ReturnDecryptedBuffer(messageBody);
+                    messageBody = default;
+
                     throw new ServiceResultException(StatusCodes.BadSequenceNumberInvalid);
                 }
             }
@@ -860,22 +883,56 @@ namespace Opc.Ua.Bindings
                     // may be reconnecting to a dropped channel.
                     if (State == TcpChannelState.Opening)
                     {
-                        // tell the listener to find the channel that can process the request.
-                        Listener.ReconnectToExistingChannel(
-                            Transport!,
-                            requestId,
-                            sequenceNumber,
-                            channelId,
-                            ClientCertificate!,
-                            token,
-                            request);
+                        // The transport moves to the existing channel, which
+                        // reads from it and answers on it from here on. Detach it
+                        // first, which also stops this channel's receive loop:
+                        // ChannelClosed() below closes whatever Transport still
+                        // points at, and closing the socket the other channel
+                        // just adopted fails its OpenSecureChannel response with
+                        // BadConnectionClosed - reconnecting to a dropped channel
+                        // could never succeed.
+                        // Dispose and the listener's idle reclaim can take the
+                        // transport away without holding the gate, so it may
+                        // already be gone.
+                        IUaSCByteTransport? handedOver = DetachTransport()
+                            ?? throw ServiceResultException.Create(
+                                StatusCodes.BadConnectionClosed,
+                                "The transport was closed while reconnecting to an existing channel.");
+
+                        System.Net.EndPoint? remoteEndpoint = handedOver.RemoteEndpoint;
+
+                        try
+                        {
+                            // tell the listener to find the channel that can process the request.
+                            Listener.ReconnectToExistingChannel(
+                                handedOver,
+                                requestId,
+                                sequenceNumber,
+                                channelId,
+                                ClientCertificate!,
+                                token,
+                                request);
+                        }
+                        catch
+                        {
+                            // The hand-over did not happen - an unknown channel
+                            // id, or a listener that does not support it - so this
+                            // channel still owns the socket. Put it back and read
+                            // from it again: the enclosing catch only sends a
+                            // fault and returns, so without the loop the channel
+                            // would sit on an open socket nobody reads, until the
+                            // idle reclaim finally takes it.
+                            Transport = handedOver;
+                            StartReceiveLoop();
+                            throw;
+                        }
 
                         token = null;
 
                         m_logger
                             .TcpServerLog5(
                                 ChannelName,
-                                Transport?.RemoteEndpoint,
+                                remoteEndpoint,
                                 CurrentToken != null ? CurrentToken.ChannelId : 0,
                                 CurrentToken != null ? CurrentToken.TokenId : 0);
 
@@ -1248,8 +1305,13 @@ namespace Opc.Ua.Bindings
                 // check if it is necessary to wait for more chunks.
                 if (!TcpMessageType.IsFinal(messageType))
                 {
+                    // The symmetric message was decrypted in place, so messageBody
+                    // and messageChunk share one array. SaveIntermediateChunk has
+                    // taken it, so reporting "not owned" here would hand the same
+                    // buffer back to the pool as well - the double free the return
+                    // at the end of this method already warns about.
                     SaveIntermediateChunk(requestId, messageBody, true, gateHeld: true);
-                    return false;
+                    return true;
                 }
 
                 // get the chunks to process.
@@ -1416,7 +1478,14 @@ namespace Opc.Ua.Bindings
                 {
                     bool firstChunk = SaveIntermediateChunk(requestId, messageBody, true, gateHeld: true);
 
-                    // validate the type is allowed with a discovery channel
+                    // Validate the type is allowed with a discovery channel.
+                    //
+                    // Not gated on the saved size: a first chunk with an empty
+                    // body would then skip the check entirely and let a non
+                    // discovery request buffer until the size limit. The first
+                    // chunk is always stored - the limits are measured against a
+                    // collection that is still empty at that point - so the body
+                    // is there to read whenever firstChunk is set.
                     if (DiscoveryOnly)
                     {
                         if (firstChunk)
@@ -1425,6 +1494,7 @@ namespace Opc.Ua.Bindings
                                 token,
                                 requestId,
                                 messageBody,
+                                messageBodySaved: true,
                                 out chunksToProcess))
                             {
                                 ChannelClosed();
@@ -1433,7 +1503,9 @@ namespace Opc.Ua.Bindings
                         else if (GetSavedChunksTotalSize() > TcpMessageLimits
                             .DefaultDiscoveryMaxMessageSize)
                         {
-                            chunksToProcess = GetSavedChunks(0, messageBody, true, gateHeld: true);
+                            // messageBody was saved by the call above; take the
+                            // collection rather than offering the chunk again.
+                            chunksToProcess = TakeSavedChunks();
                             SendServiceFault(
                                 token,
                                 requestId,
@@ -1458,6 +1530,7 @@ namespace Opc.Ua.Bindings
                         token,
                         requestId,
                         messageBody,
+                        messageBodySaved: false,
                         out chunksToProcess))
                 {
                     return true;
@@ -1644,10 +1717,23 @@ namespace Opc.Ua.Bindings
         /// <summary>
         /// Validate the type of message before it is decoded.
         /// </summary>
+        /// <param name="token">The token the fault is sent under.</param>
+        /// <param name="requestId">The request the body belongs to.</param>
+        /// <param name="messageBody">The decrypted body of the chunk.</param>
+        /// <param name="messageBodySaved">
+        /// Whether <paramref name="messageBody"/> has already been handed to the
+        /// partial message. On the first chunk of a multi chunk message it has;
+        /// on a single chunk message it has not, and it has to be taken over
+        /// here or its buffer is never returned to the pool.
+        /// </param>
+        /// <param name="chunksToProcess">
+        /// The chunks the caller must release when the call is rejected.
+        /// </param>
         private bool ValidateDiscoveryServiceCall(
             ChannelToken token,
             uint requestId,
             ArraySegment<byte> messageBody,
+            bool messageBodySaved,
             out BufferCollection chunksToProcess)
         {
             chunksToProcess = null!;
@@ -1659,7 +1745,9 @@ namespace Opc.Ua.Bindings
                 typeId != ObjectIds.FindServersRequest_Encoding_DefaultBinary &&
                 typeId != ObjectIds.FindServersOnNetworkRequest_Encoding_DefaultBinary)
             {
-                chunksToProcess = GetSavedChunks(0, messageBody, true, gateHeld: true);
+                chunksToProcess = messageBodySaved
+                    ? TakeSavedChunks()
+                    : GetSavedChunks(requestId, messageBody, true, gateHeld: true);
                 SendServiceFault(
                     token,
                     requestId,

--- a/src/Opc.Ua.Core/Stack/Tcp/TcpTransportListener.cs
+++ b/src/Opc.Ua.Core/Stack/Tcp/TcpTransportListener.cs
@@ -1117,6 +1117,11 @@ namespace Opc.Ua.Bindings
                                 ((IPEndPoint)e!.AcceptSocket!.RemoteEndPoint!).Address);
                         }
                         isBlocked = true;
+
+                        // No channel ever takes this socket, and disposing the
+                        // SocketAsyncEventArgs below does not close it, so the
+                        // connection would stay open until the process exits.
+                        e!.AcceptSocket!.Dispose();
                     }
                 }
 
@@ -1168,7 +1173,13 @@ namespace Opc.Ua.Bindings
                     }
 
                     ConcurrentDictionary<uint, TcpListenerChannel>? channels = m_channels;
-                    if (channels != null && !isBlocked)
+                    if (channels == null && !isBlocked)
+                    {
+                        // the listener is shutting down; nothing will take
+                        // ownership of the accepted socket.
+                        e.AcceptSocket?.Dispose();
+                    }
+                    else if (channels != null && !isBlocked)
                     {
                         // TODO: .Count is flagged as hotpath, implement separate counter
                         int channelCount = channels.Count;

--- a/src/Opc.Ua.Core/Stack/Tcp/UaSCBinaryChannel.Asymmetric.cs
+++ b/src/Opc.Ua.Core/Stack/Tcp/UaSCBinaryChannel.Asymmetric.cs
@@ -267,27 +267,39 @@ namespace Opc.Ua.Bindings
                 return false;
             }
 
-            switch (securityPolicy.CertificateKeyFamily)
+            // A nonce the peer chose is data, not a programming error: the
+            // key-agreement checks inside CreateNonce reject an out-of-range
+            // Diffie-Hellman value or an off-curve point by throwing, and this
+            // method's contract is to answer false so the caller can report
+            // BadNonceInvalid rather than a generic internal error.
+            try
             {
-                case CertificateKeyFamily.RSA:
-                    if (securityPolicy.EphemeralKeyAlgorithm == CertificateKeyAlgorithm.RSADH)
-                    {
-                        m_remoteNonce = Nonce.CreateNonce(securityPolicy, nonce);
-                        return true;
-                    }
-
-                    // try to catch programming errors by rejecting nonces with all zeros.
-                    for (int ii = 0; ii < nonce.Length; ii++)
-                    {
-                        if (nonce[ii] != 0)
+                switch (securityPolicy.CertificateKeyFamily)
+                {
+                    case CertificateKeyFamily.RSA:
+                        if (securityPolicy.EphemeralKeyAlgorithm == CertificateKeyAlgorithm.RSADH)
                         {
+                            m_remoteNonce = Nonce.CreateNonce(securityPolicy, nonce);
                             return true;
                         }
-                    }
-                    break;
-                case CertificateKeyFamily.ECC:
-                    m_remoteNonce = Nonce.CreateNonce(securityPolicy, nonce);
-                    return true;
+
+                        // try to catch programming errors by rejecting nonces with all zeros.
+                        for (int ii = 0; ii < nonce.Length; ii++)
+                        {
+                            if (nonce[ii] != 0)
+                            {
+                                return true;
+                            }
+                        }
+                        break;
+                    case CertificateKeyFamily.ECC:
+                        m_remoteNonce = Nonce.CreateNonce(securityPolicy, nonce);
+                        return true;
+                }
+            }
+            catch (ArgumentException e)
+            {
+                m_logger.UaSCChannelNonceRejected(e);
             }
 
             return false;
@@ -1415,15 +1427,44 @@ namespace Opc.Ua.Bindings
                 new ArraySegment<byte>(buffer.GetArray(), buffer.Offset, headerSize),
                 receiverCertificate!);
 
-            return FinishReadAsymmetricMessage(
-                plainText,
-                headerSize,
-                receiverCertificate,
-                senderCertificate,
-                oscRequestSignature,
-                out requestId,
-                out sequenceNumber,
-                out signature);
+            try
+            {
+                return FinishReadAsymmetricMessage(
+                    plainText,
+                    headerSize,
+                    receiverCertificate,
+                    senderCertificate,
+                    oscRequestSignature,
+                    out requestId,
+                    out sequenceNumber,
+                    out signature);
+            }
+            catch
+            {
+                // Decrypt took a buffer of its own; only the returned body keeps
+                // it alive. A signature, padding or short body failure is
+                // reachable before authentication, so leaking it here lets a
+                // peer drain the pool with malformed OPN messages.
+                ReturnDecryptedBuffer(plainText);
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Returns the buffer <see cref="Decrypt"/> allocated for the plain text
+        /// when nothing downstream took ownership of it.
+        /// </summary>
+        /// <remarks>
+        /// The body an asymmetric read hands back is a segment of a buffer of its
+        /// own, distinct from the chunk it was decrypted from. Only the chunk
+        /// collection built further down returns it, so any path that fails
+        /// between the read and that collection has to return it here.
+        /// </remarks>
+        protected void ReturnDecryptedBuffer(ArraySegment<byte> plainText)
+        {
+            // Returned under the name Decrypt rented it with, so the buffer
+            // manager's own owner tracking lines the two up.
+            ReturnBuffer(plainText, "Decrypt");
         }
 
         /// <summary>
@@ -1517,15 +1558,30 @@ namespace Opc.Ua.Bindings
                 receiverCertificate!,
                 ct).ConfigureAwait(false);
 
-            ArraySegment<byte> body = FinishReadAsymmetricMessage(
-                plainText,
-                headerSize,
-                receiverCertificate,
-                senderCertificate,
-                oscRequestSignature,
-                out uint requestId,
-                out uint sequenceNumber,
-                out byte[] signature);
+            ArraySegment<byte> body;
+            uint requestId;
+            uint sequenceNumber;
+            byte[] signature;
+
+            try
+            {
+                body = FinishReadAsymmetricMessage(
+                    plainText,
+                    headerSize,
+                    receiverCertificate,
+                    senderCertificate,
+                    oscRequestSignature,
+                    out requestId,
+                    out sequenceNumber,
+                    out signature);
+            }
+            catch
+            {
+                // See ReadAsymmetricMessage: nothing else owns the decrypted
+                // buffer until the body is handed back.
+                ReturnDecryptedBuffer(plainText);
+                throw;
+            }
 
             return new AsymmetricMessage(
                 body, channelId, senderCertificate, requestId, sequenceNumber, signature);

--- a/src/Opc.Ua.Core/Stack/Tcp/UaSCBinaryChannel.Symmetric.cs
+++ b/src/Opc.Ua.Core/Stack/Tcp/UaSCBinaryChannel.Symmetric.cs
@@ -574,12 +574,16 @@ namespace Opc.Ua.Bindings
                     {
                         encoder.WriteUInt32(null, messageType | TcpMessageType.Abort);
 
-                        // replace the body in the chunk with an error message.
+                        // Replace the body in the chunk with an error message.
+                        // The encoder is bounded by the room the chunk has for a
+                        // body, not by what the chunk currently holds: an error
+                        // body is at least eight bytes and the offending chunk
+                        // can be shorter than that.
                         using (
                             var errorEncoder = new BinaryEncoder(
                                 chunkArray,
                                 chunkToProcess.Offset,
-                                chunkToProcess.Count,
+                                maxPayloadSize,
                                 Quotas.MessageContext))
                         {
                             WriteErrorMessageBody(

--- a/src/Opc.Ua.Core/Stack/Tcp/UaSCBinaryChannel.cs
+++ b/src/Opc.Ua.Core/Stack/Tcp/UaSCBinaryChannel.cs
@@ -835,6 +835,22 @@ namespace Opc.Ua.Bindings
             // it ends as soon as it observes the cancellation.
             previous?.Cancel();
 
+            // The transport was read before the epoch went in, so a detach could
+            // have run in between and this epoch would now be reading a socket
+            // the channel has given up - one the listener may have closed, or
+            // handed to the channel that adopted it.
+            //
+            // DetachTransport clears the transport before it retires the loop,
+            // so the two orderings are both covered: a detach that got as far as
+            // the transport is seen here, and a later one retires this epoch and
+            // cancels it before the body reads anything.
+            if (!ReferenceEquals(Volatile.Read(ref m_transport), transport))
+            {
+                Interlocked.CompareExchange(ref m_receiveLoop, null, epoch);
+                epoch.Cancel();
+                return;
+            }
+
             CancellationToken ct = epoch.Token;
             m_receiveLoopTask = Task.Run(
                 async () =>

--- a/src/Opc.Ua.Core/Stack/Tcp/UaSCBinaryChannel.cs
+++ b/src/Opc.Ua.Core/Stack/Tcp/UaSCBinaryChannel.cs
@@ -311,6 +311,14 @@ namespace Opc.Ua.Bindings
                 transport?.Close();
                 DiscardTokens();
 
+                // A message the peer never finished sending leaves its chunks
+                // queued here. Nothing else returns them, so a client that sends
+                // one intermediate chunk and disconnects would cost the pool a
+                // receive buffer per channel.
+                BufferCollection? partialChunks = m_partialMessageChunks;
+                m_partialMessageChunks = null;
+                partialChunks?.Release(BufferManager, "Dispose");
+
                 ServerCertificateChain?.Dispose();
                 ServerCertificateChain = null;
                 // The channel always owns an independent handle on

--- a/src/Opc.Ua.Core/Stack/Tcp/UaSCBinaryChannel.cs
+++ b/src/Opc.Ua.Core/Stack/Tcp/UaSCBinaryChannel.cs
@@ -306,12 +306,10 @@ namespace Opc.Ua.Bindings
                 // accepted immediately and any in flight are cancelled.
                 m_backgroundWork.Dispose();
 
-                m_receiveLoopCts?.Cancel();
+                Interlocked.Exchange(ref m_receiveLoop, null)?.Cancel();
                 IUaSCByteTransport? transport = Interlocked.Exchange(ref m_transport, null);
                 transport?.Close();
                 DiscardTokens();
-                m_receiveLoopCts?.Dispose();
-                m_receiveLoopCts = null;
 
                 ServerCertificateChain?.Dispose();
                 ServerCertificateChain = null;
@@ -521,6 +519,13 @@ namespace Opc.Ua.Bindings
         /// <see cref="DoMessageLimitsExceeded(bool)"/>, which tears the channel
         /// down and must know whether it may take the gate.
         /// </param>
+        /// <remarks>
+        /// Always takes ownership of <paramref name="chunk"/>: it is either added
+        /// to the partial message, or returned to the <see cref="BufferManager"/>
+        /// straight away. A caller must therefore never pass a chunk it has
+        /// already handed over — use <see cref="TakeSavedChunks"/> when the body
+        /// is saved and only the collection is wanted.
+        /// </remarks>
         protected bool SaveIntermediateChunk(
             uint requestId,
             ArraySegment<byte> chunk,
@@ -551,6 +556,7 @@ namespace Opc.Ua.Bindings
 
             if (chunkOrSizeLimitsExceeded)
             {
+                ReturnBuffer(chunk, "SaveIntermediateChunk");
                 DoMessageLimitsExceeded(gateHeld);
                 return firstChunk;
             }
@@ -560,8 +566,25 @@ namespace Opc.Ua.Bindings
                 m_partialRequestId = requestId;
                 m_partialMessageChunks.Add(chunk);
             }
+            else
+            {
+                ReturnBuffer(chunk, "SaveIntermediateChunk");
+            }
 
             return firstChunk;
+        }
+
+        /// <summary>
+        /// Returns a pooled buffer nothing downstream took ownership of.
+        /// </summary>
+        /// <param name="buffer">The segment whose array goes back to the pool.</param>
+        /// <param name="owner">The owner name the buffer manager tracks it under.</param>
+        protected void ReturnBuffer(ArraySegment<byte> buffer, string owner)
+        {
+            if (buffer.Array != null)
+            {
+                BufferManager.ReturnBuffer(buffer.Array, owner);
+            }
         }
 
         /// <summary>
@@ -575,7 +598,18 @@ namespace Opc.Ua.Bindings
             bool gateHeld)
         {
             SaveIntermediateChunk(requestId, chunk, isServerContext, gateHeld);
-            BufferCollection savedChunks = m_partialMessageChunks!;
+            return TakeSavedChunks();
+        }
+
+        /// <summary>
+        /// Detaches the chunks saved so far without offering another one. Used
+        /// where the final chunk has already been saved and only the collection
+        /// is needed; passing it to <see cref="GetSavedChunks"/> a second time
+        /// would either queue the same buffer twice or release it early.
+        /// </summary>
+        protected BufferCollection TakeSavedChunks()
+        {
+            BufferCollection savedChunks = m_partialMessageChunks ?? [];
             m_partialMessageChunks = null;
             return savedChunks;
         }
@@ -693,8 +727,14 @@ namespace Opc.Ua.Bindings
         /// <summary>
         /// Handles an error parsing or verifying a message.
         /// </summary>
+        /// <remarks>
+        /// The default reports the error to the log. A channel that has to act
+        /// on it — fault, reconnect, fail the pending operation — does so at the
+        /// point the error is detected rather than relying on this.
+        /// </remarks>
         protected virtual void HandleMessageProcessingError(ServiceResult result)
         {
+            m_logger.UaSCChannelMessageProcessingError(ChannelId, result);
         }
 
         /// <summary>
@@ -751,13 +791,43 @@ namespace Opc.Ua.Bindings
             {
                 return;
             }
-            if (Interlocked.CompareExchange(ref m_receiveLoopRunning, 1, 0) != 0)
+
+            // Idempotent per transport. A loop already running on this transport
+            // is left alone, but one still running on a transport the channel has
+            // since replaced (a reconnect binds a new socket to an existing
+            // channel) is superseded - otherwise the channel would never read
+            // from the socket it just adopted.
+            //
+            // The whole state is one object swapped atomically, so a second
+            // caller can never observe a half-installed loop (the new transport
+            // paired with the previous token) and start a competing reader on the
+            // same socket.
+            var epoch = new ReceiveLoopEpoch(transport);
+            ReceiveLoopEpoch? previous;
+
+            while (true)
             {
-                return;
+                previous = Volatile.Read(ref m_receiveLoop);
+
+                if (previous != null && ReferenceEquals(previous.Transport, transport))
+                {
+                    return;
+                }
+
+                if (ReferenceEquals(
+                    Interlocked.CompareExchange(ref m_receiveLoop, epoch, previous),
+                    previous))
+                {
+                    break;
+                }
             }
-            m_receiveLoopCts?.Dispose();
-            m_receiveLoopCts = new CancellationTokenSource();
-            CancellationToken ct = m_receiveLoopCts.Token;
+
+            // Cancel the loop this one replaces. Not awaited: the caller may be
+            // running on that very loop (a reconnect is dispatched from it), so
+            // it ends as soon as it observes the cancellation.
+            previous?.Cancel();
+
+            CancellationToken ct = epoch.Token;
             m_receiveLoopTask = Task.Run(
                 async () =>
                 {
@@ -767,10 +837,67 @@ namespace Opc.Ua.Bindings
                     }
                     finally
                     {
-                        Interlocked.Exchange(ref m_receiveLoopRunning, 0);
+                        // Retire only if still current; a superseded loop must not
+                        // clear the epoch the loop that replaced it installed.
+                        Interlocked.CompareExchange(ref m_receiveLoop, null, epoch);
                     }
                 },
                 ct);
+        }
+
+        /// <summary>
+        /// One run of the receive loop: the transport it reads from and the
+        /// source that stops it. Installed and retired as a unit so the two can
+        /// never be observed out of step.
+        /// </summary>
+        /// <remarks>
+        /// The token source is deliberately never disposed. It carries no timer
+        /// and no linked registration, so it holds nothing a garbage collection
+        /// will not reclaim - and disposing it would race every other path that
+        /// cancels a loop, turning a teardown into an
+        /// <see cref="ObjectDisposedException"/>.
+        /// </remarks>
+#pragma warning disable CA1001 // m_cts is intentionally not disposed; see the remarks above.
+        private sealed class ReceiveLoopEpoch
+#pragma warning restore CA1001
+        {
+            public ReceiveLoopEpoch(IUaSCByteTransport transport)
+            {
+                Transport = transport;
+            }
+
+            public IUaSCByteTransport Transport { get; }
+
+            public CancellationToken Token => m_cts.Token;
+
+            public void Cancel()
+            {
+                m_cts.Cancel();
+            }
+
+            private readonly CancellationTokenSource m_cts = new();
+        }
+
+        /// <summary>
+        /// Detaches the current <see cref="Transport"/> and signals the receive
+        /// loop reading from it to stop, without waiting for it to finish. The
+        /// returned transport is the caller's responsibility — the channel's own
+        /// <see cref="Dispose(bool)"/> will no longer close it.
+        /// </summary>
+        /// <remarks>
+        /// The synchronous counterpart to <see cref="DetachTransportAsync"/>,
+        /// for the handover in <c>TcpServerChannel</c> that runs on the very
+        /// receive loop being stopped and so cannot await it.
+        /// </remarks>
+        protected internal IUaSCByteTransport? DetachTransport()
+        {
+            IUaSCByteTransport? transport = Interlocked.Exchange(ref m_transport, null);
+
+            // Retire the loop as well as cancelling it, so a later
+            // StartReceiveLoop on a reattached transport is not mistaken for a
+            // loop that is already serving it.
+            Interlocked.Exchange(ref m_receiveLoop, null)?.Cancel();
+            return transport;
         }
 
         /// <summary>
@@ -789,8 +916,7 @@ namespace Opc.Ua.Bindings
         {
             IUaSCByteTransport? transport = Interlocked.Exchange(ref m_transport, null);
 
-            CancellationTokenSource? cts = m_receiveLoopCts;
-            cts?.Cancel();
+            Interlocked.Exchange(ref m_receiveLoop, null)?.Cancel();
 
             Task? loop = m_receiveLoopTask;
             if (loop != null)
@@ -1489,9 +1615,14 @@ namespace Opc.Ua.Bindings
 
         private IUaSCByteTransport? m_transport;
         private readonly BackgroundTaskScope m_backgroundWork;
-        private CancellationTokenSource? m_receiveLoopCts;
         private Task? m_receiveLoopTask;
-        private int m_receiveLoopRunning;
+
+        /// <summary>
+        /// The receive loop currently installed, or <c>null</c> when none is.
+        /// Swapped atomically so the transport a loop reads from and the source
+        /// that stops it are always seen together.
+        /// </summary>
+        private ReceiveLoopEpoch? m_receiveLoop;
 
         private volatile TcpChannelStateEventHandler? m_stateChanged;
         private const uint kMaxValueLegacyTrue = TcpMessageLimits.MinSequenceNumber;
@@ -1656,6 +1787,19 @@ namespace Opc.Ua.Bindings
             this ILogger logger,
             Exception exception,
             uint channelId);
+
+        [LoggerMessage(EventId = CoreEventIds.UaSCBinaryChannel + 15, Level = LogLevel.Error,
+            Message = "ChannelId {ChannelId}: Could not process an incoming message. {ServiceResult}")]
+        public static partial void UaSCChannelMessageProcessingError(
+            this ILogger logger,
+            uint channelId,
+            ServiceResult serviceResult);
+
+        [LoggerMessage(EventId = CoreEventIds.UaSCBinaryChannel + 16, Level = LogLevel.Debug,
+            Message = "The nonce supplied by the peer was rejected.")]
+        public static partial void UaSCChannelNonceRejected(
+            this ILogger logger,
+            Exception exception);
     }
 
 }

--- a/src/Opc.Ua.Core/Stack/Tcp/UaSCBinaryClientChannel.cs
+++ b/src/Opc.Ua.Core/Stack/Tcp/UaSCBinaryClientChannel.cs
@@ -738,6 +738,13 @@ namespace Opc.Ua.Bindings
 
             BufferCollection? chunksToProcess = null;
 
+            // The decrypted body lives in a buffer of its own, separate from the
+            // chunk it came from, and only the chunk collection returns it. Until
+            // it joins that collection it is this method's to return - the
+            // certificate and sequence-number checks below both reject messages a
+            // peer can send at will.
+            bool bodyOwned = true;
+
             try
             {
                 // verify server certificate.
@@ -753,11 +760,13 @@ namespace Opc.Ua.Bindings
                 if (!TcpMessageType.IsFinal(messageType))
                 {
                     SaveIntermediateChunk(requestId, messageBody, false, gateHeld: true);
+                    bodyOwned = false;
                     return false;
                 }
 
                 // get the chunks to process.
                 chunksToProcess = GetSavedChunks(requestId, messageBody, false, gateHeld: true);
+                bodyOwned = false;
 
                 // read message body.
 
@@ -844,6 +853,12 @@ namespace Opc.Ua.Bindings
 #pragma warning disable CA1508
                 serverCertificate?.Dispose();
 #pragma warning restore CA1508
+
+                if (bodyOwned)
+                {
+                    ReturnDecryptedBuffer(messageBody);
+                }
+
                 chunksToProcess?.Release(BufferManager, "ProcessOpenSecureChannelResponse");
             }
 
@@ -1808,10 +1823,18 @@ namespace Opc.Ua.Bindings
 
             BufferCollection? chunksToProcess = null;
 
-            // check for replay attacks.
+            // Check for replay attacks. Handled the same way as a failed security
+            // check above: throwing here would only reach the receive loop's
+            // catch-all, which logs the error and moves on, leaving the pending
+            // operation to hang until it times out on a channel that is still
+            // open and still trusting the peer's sequence numbers.
             if (!VerifySequenceNumber(sequenceNumber, "ProcessResponseMessage"))
             {
-                throw new ServiceResultException(StatusCodes.BadSequenceNumberInvalid);
+                ForceReconnect(
+                    ServiceResult.Create(
+                        StatusCodes.BadSequenceNumberInvalid,
+                        "Invalid sequence number in response."));
+                return false;
             }
 
             try

--- a/src/Opc.Ua.Core/Stack/Types/FilterEvaluator.cs
+++ b/src/Opc.Ua.Core/Stack/Types/FilterEvaluator.cs
@@ -473,7 +473,16 @@ namespace Opc.Ua
 
                 if (value.TryGetValue(out string lhsString) && rhs.TryGetValue(out string rhsString))
                 {
-                    return lhsString.Equals(rhsString, ContentFilter.EqualsOperatorDefaultStringComparison);
+                    // a non-matching string operand only rules out this operand,
+                    // not the rest of the list.
+                    if (lhsString.Equals(
+                        rhsString,
+                        ContentFilter.EqualsOperatorDefaultStringComparison))
+                    {
+                        return true;
+                    }
+
+                    continue;
                 }
 
                 if (value.ValueEquals(rhs))

--- a/src/Opc.Ua.Core/Types/BuiltIn/SessionLessServiceMessage.cs
+++ b/src/Opc.Ua.Core/Types/BuiltIn/SessionLessServiceMessage.cs
@@ -97,7 +97,7 @@ namespace Opc.Ua
                 encoder.WriteStringArray("ServerUris", Array.Empty<string>());
             }
 
-            if (LocaleIds != null && LocaleIds.Count > 1)
+            if (LocaleIds != null && LocaleIds.Count > 0)
             {
                 encoder.WriteStringArray("LocaleIds", LocaleIds.ToArray());
             }

--- a/src/Opc.Ua.Core/Types/Utils/DataGenerator.cs
+++ b/src/Opc.Ua.Core/Types/Utils/DataGenerator.cs
@@ -681,7 +681,7 @@ namespace Opc.Ua.Test
             m_random.NextBytes(bytes, 0, bytes.Length);
             return GetBoundaryValue(
                 useBoundaryValues,
-                BitConverter.ToSingle(bytes, 0),
+                BitConverter.ToDouble(bytes, 0),
                 [
                     double.Epsilon,
                     double.MaxValue,
@@ -1644,11 +1644,9 @@ namespace Opc.Ua.Test
 
             var variants = new Variant[length];
 
-            _ = TypeInfo.CreateScalar(builtInType);
-
             for (int ii = 0; ii < variants.Length; ii++)
             {
-                variants[ii] = GetRandomVariant(false);
+                variants[ii] = GetRandomScalar(builtInType, useBoundaryValues);
             }
 
             return variants;

--- a/src/Opc.Ua.Core/Types/Utils/TraceLoggerProvider.cs
+++ b/src/Opc.Ua.Core/Types/Utils/TraceLoggerProvider.cs
@@ -170,7 +170,17 @@ namespace Opc.Ua
 
             public bool IsEnabled(LogLevel logLevel)
             {
-                return Tracing.IsEnabled();
+                // Log() writes when either the trace mask or a Tracing handler
+                // lets the message through, so both have to be considered here.
+                // Reporting only the handler makes every source-generated log
+                // call short-circuit, and nothing reaches the trace file when no
+                // handler is subscribed - the usual case.
+                //
+                // The event id is not available at this point, so the mask is the
+                // one GetTraceMask derives from the level alone; a call whose
+                // event id carries its own mask is filtered exactly in Log().
+                return Tracing.IsEnabled() ||
+                    (m_provider.TraceMask & GetTraceMask(default, logLevel)) != 0;
             }
 
             public void Log<TState>(
@@ -416,8 +426,12 @@ namespace Opc.Ua
                     }
                     catch (Exception e)
                     {
-                        Debug.WriteLine("Could not write to trace file. Error={0}", e.Message);
-                        Debug.WriteLine("FilePath={1}", traceFileName);
+                        // Interpolated, not a format string: WriteLine(string,
+                        // string) is the better overload for two string
+                        // arguments, so the second would be taken as a category
+                        // and the placeholder printed verbatim.
+                        Debug.WriteLine($"Could not write to trace file. Error={e.Message}");
+                        Debug.WriteLine($"FilePath={traceFileName}");
                     }
                 }
             }

--- a/src/Opc.Ua.Core/Types/Utils/TraceLoggerProvider.cs
+++ b/src/Opc.Ua.Core/Types/Utils/TraceLoggerProvider.cs
@@ -176,11 +176,13 @@ namespace Opc.Ua
                 // call short-circuit, and nothing reaches the trace file when no
                 // handler is subscribed - the usual case.
                 //
-                // The event id is not available at this point, so the mask is the
-                // one GetTraceMask derives from the level alone; a call whose
-                // event id carries its own mask is filtered exactly in Log().
-                return Tracing.IsEnabled() ||
-                    (m_provider.TraceMask & GetTraceMask(default, logLevel)) != 0;
+                // The event id is not available at this point, and a core event
+                // id carries its own category bits rather than following from
+                // the level, so deriving a mask from the level alone would
+                // report a configured category disabled and the call would never
+                // reach Log(). This therefore answers "something is configured"
+                // and leaves the exact, event-specific filtering to Log().
+                return Tracing.IsEnabled() || m_provider.TraceMask != 0;
             }
 
             public void Log<TState>(

--- a/src/Opc.Ua.Core/Types/Utils/Utils.cs
+++ b/src/Opc.Ua.Core/Types/Utils/Utils.cs
@@ -248,7 +248,7 @@ namespace Opc.Ua
         /// <param name="url">The url</param>
         public static bool IsUriHttpRelatedScheme(string url)
         {
-            return url.StartsWith(UriSchemeHttps, StringComparison.Ordinal) ||
+            return url.StartsWith(UriSchemeHttp, StringComparison.Ordinal) ||
                 IsUriHttpsScheme(url);
         }
 
@@ -1498,9 +1498,10 @@ namespace Opc.Ua
                 throw new ArgumentNullException(nameof(encoderFunc));
             }
 
+            bool remove = EqualityComparer<T>.Default.Equals(value!, default!);
             var document = new XmlDocument();
 
-            if (!EqualityComparer<T>.Default.Equals(value!, default!))
+            if (!remove)
             {
                 using IDisposable scope = AmbientMessageContext.SetScopedContext(telemetry!);
                 using var encoder = new XmlEncoder(AmbientMessageContext.CurrentContext);
@@ -1509,11 +1510,12 @@ namespace Opc.Ua
                 encoder.Pop();
                 string xml = encoder.CloseAndReturnText()!;
                 document.LoadInnerXml(xml);
-            }
 
-            if (document.DocumentElement == null)
-            {
-                return;
+                // nothing to write: the encoder produced no element.
+                if (document.DocumentElement == null)
+                {
+                    return;
+                }
             }
 
             var xmlElements = extensions.ToList();
@@ -1526,23 +1528,23 @@ namespace Opc.Ua
                         element.LocalName == elementName.Name &&
                         element.NamespaceURI == elementName.Namespace)
                     {
-                        if (EqualityComparer<T>.Default.Equals(value!, default!))
+                        if (remove)
                         {
                             xmlElements.RemoveAt(ii);
                             extensions = xmlElements.ToArrayOf();
                             return;
                         }
 
-                        xmlElements[ii] = XmlElement.From(document.DocumentElement);
+                        xmlElements[ii] = XmlElement.From(document.DocumentElement!);
                         extensions = xmlElements.ToArrayOf();
                         return;
                     }
                 }
             }
 
-            if (!EqualityComparer<T>.Default.Equals(value!, default!))
+            if (!remove)
             {
-                xmlElements.Add(XmlElement.From(document.DocumentElement));
+                xmlElements.Add(XmlElement.From(document.DocumentElement!));
                 extensions = xmlElements.ToArrayOf();
             }
         }

--- a/src/Opc.Ua.Security.Certificates/Org.BouncyCastle/PEMWriter.cs
+++ b/src/Opc.Ua.Security.Certificates/Org.BouncyCastle/PEMWriter.cs
@@ -135,11 +135,19 @@ namespace Opc.Ua.Security.Certificates
                         pemCertificateDecoded);
                     if (thumbprint.Equals(certificate.Thumbprint, StringComparison.OrdinalIgnoreCase))
                     {
+                        // Substring takes a length, not an end index. Passing
+                        // the end index removed the wrong span - and for any
+                        // block that did not start at the beginning of the file
+                        // it ran off the end and threw, which this method
+                        // reports as "not found" and the caller then treats as
+                        // a file with nothing left in it.
+                        int blockStart = beginIndex - beginlabel.Length;
+                        int blockEnd = endIndex + endlabel.Length;
+                        int blockLength = blockEnd - blockStart;
+
                         modifiedPemDataBlob = Encoding.ASCII.GetBytes(
                             pemText.Replace(
-                                pemText.Substring(
-                                    beginIndex -= beginlabel.Length,
-                                    endIndex + endlabel.Length),
+                                pemText.Substring(blockStart, blockLength),
                                 string.Empty));
                         return true;
                     }

--- a/tests/Opc.Ua.Core.Tests/Redundancy/SharedStoreLeaseElectionTests.cs
+++ b/tests/Opc.Ua.Core.Tests/Redundancy/SharedStoreLeaseElectionTests.cs
@@ -348,6 +348,131 @@ namespace Opc.Ua.Core.Tests.Redundancy
             }
         }
 
+        /// <summary>
+        /// The lease this replica wrote has to still be running for it to count
+        /// as the leader. Checked on read, because a store that hangs rather
+        /// than throws never reaches the renew failure path at all while every
+        /// other replica watches the lease expire.
+        /// </summary>
+        [Test]
+        public async Task IsLeaderReportsFalseOnceTheLocalLeaseHasExpiredAsync()
+        {
+            var time = new FakeTimeProvider();
+            using var store = new InMemorySharedKeyValueStore();
+            await using SharedStoreLeaseElection election = CreateElection(store, "A", time);
+
+            Assert.That(
+                await election.TryAcquireOrRenewAsync().ConfigureAwait(false), Is.True);
+            Assert.That(election.IsLeader, Is.True);
+
+            // still inside the lease.
+            time.Advance(s_leaseDuration - TimeSpan.FromSeconds(1));
+            Assert.That(election.IsLeader, Is.True);
+
+            // past it: another replica is free to take over, so this one is no
+            // longer the leader.
+            time.Advance(TimeSpan.FromSeconds(2));
+            Assert.That(election.IsLeader, Is.False);
+        }
+
+        /// <summary>
+        /// A renewed lease extends the local expiry, so a leader that keeps
+        /// reaching the store keeps leading.
+        /// </summary>
+        [Test]
+        public async Task RenewingTheLeaseExtendsLeadershipAsync()
+        {
+            var time = new FakeTimeProvider();
+            using var store = new InMemorySharedKeyValueStore();
+            await using SharedStoreLeaseElection election = CreateElection(store, "A", time);
+
+            Assert.That(
+                await election.TryAcquireOrRenewAsync().ConfigureAwait(false), Is.True);
+
+            time.Advance(s_leaseDuration - TimeSpan.FromSeconds(1));
+
+            Assert.That(
+                await election.TryAcquireOrRenewAsync().ConfigureAwait(false), Is.True);
+
+            time.Advance(TimeSpan.FromSeconds(2));
+            Assert.That(election.IsLeader, Is.True);
+        }
+
+        /// <summary>
+        /// A renew that never reached the store steps the replica down once the
+        /// lease it last wrote has run out, and announces it - otherwise the
+        /// standby that took over and this replica would both be leading.
+        /// </summary>
+        [Test]
+        public async Task RenewFailureStepsDownOnceTheLeaseExpiresAsync()
+        {
+            var time = new FakeTimeProvider();
+            int probes = 0;
+            var store = new Mock<ISharedKeyValueStore>();
+
+            store
+                .Setup(s => s.TryGetAsync(LeaseKey, It.IsAny<CancellationToken>()))
+                .Returns(() =>
+                {
+                    if (Interlocked.Increment(ref probes) > 1)
+                    {
+                        throw new InvalidOperationException("store offline");
+                    }
+
+                    return new ValueTask<(bool, ByteString)>((false, default));
+                });
+
+            store
+                .Setup(s => s.CompareAndSwapAsync(
+                    LeaseKey,
+                    It.IsAny<ByteString>(),
+                    It.IsAny<ByteString>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns(new ValueTask<bool>(true));
+
+            SharedStoreLeaseElection election = CreateElection(
+                store.Object, "A", time, TimeSpan.FromMilliseconds(20));
+
+            var steppedDown = new TaskCompletionSource<bool>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            var acquired = new TaskCompletionSource<bool>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+
+            election.LeadershipChanged += value =>
+            {
+                if (value)
+                {
+                    acquired.TrySetResult(true);
+                }
+                else
+                {
+                    steppedDown.TrySetResult(true);
+                }
+            };
+
+            try
+            {
+                election.Start();
+
+                await WaitWithTimeoutAsync(
+                    acquired.Task, "leadership was not acquired").ConfigureAwait(false);
+
+                // the store is unreachable from here on; once the lease it last
+                // wrote runs out the replica has to give leadership up.
+                time.Advance(s_leaseDuration + TimeSpan.FromSeconds(1));
+
+                await WaitWithTimeoutAsync(
+                    steppedDown.Task,
+                    "the replica kept leading on an expired lease").ConfigureAwait(false);
+
+                Assert.That(election.IsLeader, Is.False);
+            }
+            finally
+            {
+                await election.DisposeAsync().ConfigureAwait(false);
+            }
+        }
+
         private static SharedStoreLeaseElection CreateElection(
             ISharedKeyValueStore store,
             string nodeId,

--- a/tests/Opc.Ua.Core.Tests/Redundancy/SharedStoreLeaseElectionTests.cs
+++ b/tests/Opc.Ua.Core.Tests/Redundancy/SharedStoreLeaseElectionTests.cs
@@ -473,6 +473,126 @@ namespace Opc.Ua.Core.Tests.Redundancy
             }
         }
 
+        /// <summary>
+        /// A store that hangs rather than throws never lets the renew loop come
+        /// round to its failure path, so the step-down is driven from a watchdog
+        /// the store cannot block. Without it a replica keeps announcing itself
+        /// as leader on a lease every other replica has watched expire.
+        /// </summary>
+        [Test]
+        public async Task StoreThatHangsStillStepsTheLeaderDownAsync()
+        {
+            var time = new FakeTimeProvider();
+            var released = new SemaphoreSlim(0);
+            int probes = 0;
+            var store = new Mock<ISharedKeyValueStore>();
+
+            store
+                .Setup(s => s.TryGetAsync(LeaseKey, It.IsAny<CancellationToken>()))
+                .Returns(() =>
+                {
+                    if (Interlocked.Increment(ref probes) > 1)
+                    {
+                        // never completes until the test lets it go.
+                        return new ValueTask<(bool, ByteString)>(
+                            released.WaitAsync().ContinueWith(
+                                _ => (false, default(ByteString)),
+                                TaskScheduler.Default));
+                    }
+
+                    return new ValueTask<(bool, ByteString)>((false, default));
+                });
+
+            store
+                .Setup(s => s.CompareAndSwapAsync(
+                    LeaseKey,
+                    It.IsAny<ByteString>(),
+                    It.IsAny<ByteString>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns(new ValueTask<bool>(true));
+
+            SharedStoreLeaseElection election = CreateElection(
+                store.Object, "A", time, TimeSpan.FromMilliseconds(20));
+
+            var acquired = new TaskCompletionSource<bool>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            var steppedDown = new TaskCompletionSource<bool>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+
+            election.LeadershipChanged += value =>
+            {
+                if (value)
+                {
+                    acquired.TrySetResult(true);
+                }
+                else
+                {
+                    steppedDown.TrySetResult(true);
+                }
+            };
+
+            try
+            {
+                election.Start();
+
+                await WaitWithTimeoutAsync(
+                    acquired.Task, "leadership was not acquired").ConfigureAwait(false);
+
+                // The renew loop is now blocked in the store and will never come
+                // back on its own. Run the lease out.
+                time.Advance(s_leaseDuration + TimeSpan.FromSeconds(1));
+
+                await WaitWithTimeoutAsync(
+                    steppedDown.Task,
+                    "the replica kept leading while the store hung").ConfigureAwait(false);
+
+                Assert.That(election.IsLeader, Is.False);
+            }
+            finally
+            {
+                released.Release(int.MaxValue / 2);
+                await election.DisposeAsync().ConfigureAwait(false);
+                released.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// The lease expiry is computed before the store call. A call that took
+        /// longer than the lease duration wrote a lease that has already run
+        /// out, so it is not leadership however the swap went.
+        /// </summary>
+        [Test]
+        public async Task AcquireThatOutlastsTheLeaseIsNotLeadershipAsync()
+        {
+            var time = new FakeTimeProvider();
+            var store = new Mock<ISharedKeyValueStore>();
+
+            store
+                .Setup(s => s.TryGetAsync(LeaseKey, It.IsAny<CancellationToken>()))
+                .Returns(new ValueTask<(bool, ByteString)>((false, default)));
+
+            store
+                .Setup(s => s.CompareAndSwapAsync(
+                    LeaseKey,
+                    It.IsAny<ByteString>(),
+                    It.IsAny<ByteString>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns(() =>
+                {
+                    // the store took longer than the lease it was writing.
+                    time.Advance(s_leaseDuration + TimeSpan.FromSeconds(1));
+                    return new ValueTask<bool>(true);
+                });
+
+            await using SharedStoreLeaseElection election = CreateElection(
+                store.Object, "A", time);
+
+            bool acquired = await election.TryAcquireOrRenewAsync().ConfigureAwait(false);
+
+            Assert.That(acquired, Is.False);
+            Assert.That(election.IsLeader, Is.False);
+        }
+
         private static SharedStoreLeaseElection CreateElection(
             ISharedKeyValueStore store,
             string nodeId,

--- a/tests/Opc.Ua.Core.Tests/Security/Certificates/CertificateManager/CertificateManagerTests.cs
+++ b/tests/Opc.Ua.Core.Tests/Security/Certificates/CertificateManager/CertificateManagerTests.cs
@@ -297,6 +297,150 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
             Assert.That(result.IsValid, Is.False);
         }
 
+        /// <summary>
+        /// A validation performed before the trust list was registered caches a
+        /// core with no trust material at all. Registering the list has to evict
+        /// it, or every later validation is answered from that empty core.
+        /// </summary>
+        [Test]
+        public async Task RegisteringATrustListAfterAFailedValidationTakesEffectAsync()
+        {
+            string trustedPath = CreateTempDir();
+            using var manager = new CertificateManager(m_telemetry);
+
+            using Certificate cert = CertificateBuilder
+                .Create("CN=LateRegistration")
+                .SetRSAKeySize(2048)
+                .CreateForRSA();
+
+            using var collection = new CertificateCollection { cert };
+
+            // validated against a manager that has no trust list yet.
+            CertificateValidationResult before = await manager.ValidateAsync(
+                collection,
+                TrustListIdentifier.Peers).ConfigureAwait(false);
+            Assert.That(before.IsValid, Is.False);
+
+            manager.RegisterTrustList(TrustListIdentifier.Peers, trustedPath);
+
+            using (ICertificateStore store = manager.OpenTrustedStore(TrustListIdentifier.Peers))
+            {
+                await store.AddAsync(cert).ConfigureAwait(false);
+            }
+
+            CertificateValidationResult after = await manager.ValidateAsync(
+                collection,
+                TrustListIdentifier.Peers).ConfigureAwait(false);
+
+            Assert.That(after.IsValid, Is.True);
+        }
+
+        /// <summary>
+        /// Re-mapping the security configuration onto a different trusted store
+        /// takes effect. A cached core snapshots its trust list when it is
+        /// built, so it has to be evicted when the configuration is replaced.
+        /// </summary>
+        [Test]
+        public async Task UpdateAsyncSwitchesToTheReconfiguredTrustedStoreAsync()
+        {
+            string emptyPath = CreateTempDir();
+            string populatedPath = CreateTempDir();
+
+            using Certificate cert = CertificateBuilder
+                .Create("CN=Reconfigured")
+                .SetRSAKeySize(2048)
+                .CreateForRSA();
+
+            using (var store = new DirectoryCertificateStore(m_telemetry))
+            {
+                store.Open(populatedPath, noPrivateKeys: true);
+                await store.AddAsync(cert).ConfigureAwait(false);
+            }
+
+            using var manager = new CertificateManager(m_telemetry);
+            manager.MapFromSecurityConfiguration(SecurityConfigurationFor(emptyPath));
+
+            using var collection = new CertificateCollection { cert };
+
+            CertificateValidationResult before = await manager.ValidateAsync(
+                collection,
+                TrustListIdentifier.Peers).ConfigureAwait(false);
+            Assert.That(before.IsValid, Is.False);
+
+            await manager.UpdateAsync(SecurityConfigurationFor(populatedPath))
+                .ConfigureAwait(false);
+
+            CertificateValidationResult after = await manager.ValidateAsync(
+                collection,
+                TrustListIdentifier.Peers).ConfigureAwait(false);
+
+            Assert.That(after.IsValid, Is.True);
+        }
+
+        /// <summary>
+        /// A peer listed in the configuration's &lt;TrustedCertificates&gt;
+        /// element reaches the validator. That list was dropped on the way from
+        /// the configuration into the trust list the validator uses, so such a
+        /// peer was rejected with BadCertificateUntrusted no matter what the
+        /// configuration said.
+        /// </summary>
+        [Test]
+        public async Task ExplicitlyTrustedPeerFromConfigurationIsAcceptedAsync()
+        {
+            using Certificate cert = CertificateBuilder
+                .Create("CN=ExplicitlyTrusted")
+                .SetRSAKeySize(2048)
+                .CreateForRSA();
+
+            SecurityConfiguration configuration = SecurityConfigurationFor(CreateTempDir());
+            configuration.AddTrustedPeer(cert.RawData);
+
+            using var manager = new CertificateManager(m_telemetry);
+            manager.MapFromSecurityConfiguration(configuration);
+
+            using var collection = new CertificateCollection { cert };
+
+            CertificateValidationResult result = await manager.ValidateAsync(
+                collection,
+                TrustListIdentifier.Peers).ConfigureAwait(false);
+
+            Assert.That(result.IsValid, Is.True);
+        }
+
+        /// <summary>
+        /// A negative retention limit means the same as zero - keep no rejected
+        /// history - so the stores only ever see zero or a positive cap, no
+        /// matter which of the two ways the limit was configured.
+        /// </summary>
+        [TestCase(-1)]
+        [TestCase(-100)]
+        public void MaxRejectedCertificatesNormalisesNegativeValues(int configured)
+        {
+            using var fromSetter = new CertificateManager(m_telemetry)
+            {
+                MaxRejectedCertificates = configured
+            };
+            Assert.That(fromSetter.MaxRejectedCertificates, Is.Zero);
+
+            using var fromConstructor = new CertificateManager(
+                m_telemetry,
+                storeProviders: null,
+                maxRejectedCertificates: configured);
+            Assert.That(fromConstructor.MaxRejectedCertificates, Is.Zero);
+        }
+
+        private static SecurityConfiguration SecurityConfigurationFor(string trustedPath)
+        {
+            return new SecurityConfiguration
+            {
+                TrustedPeerCertificates = new CertificateTrustList
+                {
+                    StoreType = CertificateStoreType.Directory,
+                    StorePath = trustedPath
+                }
+            };
+        }
+
         [Test]
         public async Task ValidateTrustedCertReturnsSuccess()
         {

--- a/tests/Opc.Ua.Core.Tests/Security/Certificates/CertificateManager/CertificateManagerTests.cs
+++ b/tests/Opc.Ua.Core.Tests/Security/Certificates/CertificateManager/CertificateManagerTests.cs
@@ -408,6 +408,56 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
         }
 
         /// <summary>
+        /// A configuration that names its trusted peers inline and sets no
+        /// store path is still registered. The registration bailed out on the
+        /// empty store path, so nothing was registered at all and the validator
+        /// went on rejecting exactly the peers it was told to trust.
+        /// </summary>
+        [Test]
+        public async Task ExplicitlyTrustedPeerWithoutATrustedStorePathIsAcceptedAsync()
+        {
+            using Certificate cert = CertificateBuilder
+                .Create("CN=ExplicitlyTrustedNoStore")
+                .SetRSAKeySize(2048)
+                .CreateForRSA();
+
+            var configuration = new SecurityConfiguration
+            {
+                TrustedPeerCertificates = new CertificateTrustList()
+            };
+            configuration.AddTrustedPeer(cert.RawData);
+
+            using var manager = new CertificateManager(m_telemetry);
+            manager.MapFromSecurityConfiguration(configuration);
+
+            Assert.That(manager.TrustLists, Does.Contain(TrustListIdentifier.Peers));
+
+            using var collection = new CertificateCollection { cert };
+
+            CertificateValidationResult result = await manager.ValidateAsync(
+                collection,
+                TrustListIdentifier.Peers).ConfigureAwait(false);
+
+            Assert.That(result.IsValid, Is.True);
+        }
+
+        /// <summary>
+        /// A trust list with neither a store path nor inline certificates names
+        /// no trust material, so there is nothing to register.
+        /// </summary>
+        [Test]
+        public void EmptyTrustListIsNotRegistered()
+        {
+            using var manager = new CertificateManager(m_telemetry);
+            manager.MapFromSecurityConfiguration(new SecurityConfiguration
+            {
+                TrustedPeerCertificates = new CertificateTrustList()
+            });
+
+            Assert.That(manager.TrustLists, Does.Not.Contain(TrustListIdentifier.Peers));
+        }
+
+        /// <summary>
         /// A negative retention limit means the same as zero - keep no rejected
         /// history - so the stores only ever see zero or a positive cap, no
         /// matter which of the two ways the limit was configured.

--- a/tests/Opc.Ua.Core.Tests/Security/Certificates/CertificateManager/CertificateValidationCoreTests.cs
+++ b/tests/Opc.Ua.Core.Tests/Security/Certificates/CertificateManager/CertificateValidationCoreTests.cs
@@ -751,6 +751,83 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
             Assert.That(result.IsSuppressible, Is.True);
         }
 
+        /// <summary>
+        /// A peer named by the trust list's own TrustedCertificates element - the
+        /// &lt;TrustedCertificates&gt; configuration list, or
+        /// SecurityConfiguration.AddTrustedPeer - is trusted even though the
+        /// store behind the trust list is empty. Before the fix that list never
+        /// reached the validator and such a peer was rejected with
+        /// BadCertificateUntrusted.
+        /// </summary>
+        [Test]
+        public async Task ValidateAsyncTrustsCertificateListedOnTrustListOnlyAsync()
+        {
+            CertificateValidationCore core = NewCore();
+            core.Update(null, TrustListWith(NewTempDir(), m_selfSignedApp), null);
+            using CertificateCollection chain = Chain(m_selfSignedApp);
+
+            CertificateValidationResult result = await core.ValidateAsync(
+                chain, null, null, CancellationToken.None).ConfigureAwait(false);
+
+            Assert.That(result.IsValid, Is.True);
+        }
+
+        /// <summary>
+        /// The same for a CA: a leaf issued by an authority listed only on the
+        /// trust list chains to it.
+        /// </summary>
+        [Test]
+        public async Task ValidateAsyncTrustsLeafOfIssuerListedOnTrustListOnlyAsync()
+        {
+            CertificateValidationCore core = NewCore();
+            core.Update(null, TrustListWith(NewTempDir(), m_rootCa), null);
+            using CertificateCollection chain = Chain(m_leaf);
+
+            CertificateValidationResult result = await core.ValidateAsync(
+                chain, null, null, CancellationToken.None).ConfigureAwait(false);
+
+            Assert.That(result.IsValid, Is.True);
+        }
+
+        /// <summary>
+        /// A certificate the trust list does not name is still untrusted, so the
+        /// list is consulted rather than trusted wholesale.
+        /// </summary>
+        [Test]
+        public async Task ValidateAsyncRejectsCertificateMissingFromTrustListAsync()
+        {
+            CertificateValidationCore core = NewCore();
+            core.Update(null, TrustListWith(NewTempDir(), m_rootCa), null);
+            using CertificateCollection chain = Chain(m_selfSignedApp);
+
+            CertificateValidationResult result = await core.ValidateAsync(
+                chain, null, null, CancellationToken.None).ConfigureAwait(false);
+
+            Assert.That(result.IsValid, Is.False);
+            Assert.That(
+                ContainsStatusCode(result, StatusCodes.BadCertificateUntrusted), Is.True);
+        }
+
+        /// <summary>
+        /// A trust list whose store is empty and whose TrustedCertificates names
+        /// the given certificates, which is the shape the configuration file
+        /// produces for &lt;TrustedCertificates&gt;.
+        /// </summary>
+        private static CertificateTrustList TrustListWith(
+            string dir,
+            params Certificate[] trusted)
+        {
+            CertificateTrustList trustList = TrustList(dir);
+
+            foreach (Certificate certificate in trusted)
+            {
+                trustList.TrustedCertificates = trustList.TrustedCertificates.AddItem(
+                    new CertificateIdentifier { RawData = certificate.RawData });
+            }
+
+            return trustList;
+        }
+
         private static Certificate CreateLeaf(
             string subjectName, Certificate issuer, DateTime notBefore, DateTime notAfter)
         {

--- a/tests/Opc.Ua.Core.Tests/Security/Certificates/CertificateStoreTest.cs
+++ b/tests/Opc.Ua.Core.Tests/Security/Certificates/CertificateStoreTest.cs
@@ -504,6 +504,38 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
         }
 
         /// <summary>
+        /// A store that cannot answer the revocation question reports
+        /// Bad_NotSupported rather than throwing.
+        /// </summary>
+        /// <remarks>
+        /// The validator treats Bad_NotSupported as "this store cannot answer"
+        /// and moves on, while a thrown ServiceResultException surfaces as an
+        /// unsuppressible Bad_CertificateInvalid - which failed every CA-issued
+        /// certificate validated against an X509Store trust list on Linux and
+        /// macOS, where CRLs are not supported. Windows supports CRLs here, so
+        /// the branch is only reachable on the platforms the outage hit.
+        /// </remarks>
+        [Theory]
+        [Order(45)]
+        public async Task IsRevokedAsyncReportsNotSupportedWithoutCrlSupportAsync(string storePath)
+        {
+            ITelemetryContext telemetry = NUnitTelemetryContext.Create();
+            using var x509Store = new X509CertificateStore(telemetry);
+            x509Store.Open(storePath);
+
+            if (x509Store.SupportsCRLs)
+            {
+                Assert.Ignore("The platform's X509Store supports CRLs.");
+            }
+
+            StatusCode status = await x509Store
+                .IsRevokedAsync(GetTestCert(), GetTestCert2())
+                .ConfigureAwait(false);
+
+            Assert.That(status, Is.EqualTo((StatusCode)StatusCodes.BadNotSupported));
+        }
+
+        /// <summary>
         /// Add an new crl to the X509 store
         /// </summary>
         [Theory]

--- a/tests/Opc.Ua.Core.Tests/Security/Certificates/CertificateTrustListHandleTests.cs
+++ b/tests/Opc.Ua.Core.Tests/Security/Certificates/CertificateTrustListHandleTests.cs
@@ -1,0 +1,153 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+#nullable enable
+
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Opc.Ua.Security.Certificates;
+using Opc.Ua.Tests;
+
+namespace Opc.Ua.Core.Tests.Security.Certificates
+{
+    /// <summary>
+    /// Certificate handle ownership in
+    /// <see cref="CertificateTrustList.GetCertificatesAsync(ITelemetryContext, System.Threading.CancellationToken)"/>.
+    /// </summary>
+    /// <remarks>
+    /// The resolver hands back an owning handle and the collection takes a
+    /// reference of its own, so the resolved handle has to be released - it was
+    /// not, which cost one handle per configured trusted certificate on every
+    /// read of the list. And a list whose entries cannot all be read left the
+    /// collection, along with everything already read from the store into it,
+    /// with nothing to release it.
+    /// </remarks>
+    [TestFixture]
+    [Category("CertificateStore")]
+    [NonParallelizable]
+    public sealed class CertificateTrustListHandleTests
+    {
+        [Test]
+        public async Task GetCertificatesAsyncReleasesTheResolvedHandlesAsync()
+        {
+            ITelemetryContext telemetry = NUnitTelemetryContext.Create();
+
+            using Certificate certificate = CertificateBuilder
+                .Create("CN=TrustListHandle")
+                .SetRSAKeySize(2048)
+                .CreateForRSA();
+
+            var trustList = new CertificateTrustList
+            {
+                TrustedCertificates =
+                [
+                    new CertificateIdentifier { RawData = certificate.RawData }
+                ]
+            };
+
+            long before = Certificate.InstancesLeaked;
+
+            using (CertificateCollection certificates = await trustList
+                .GetCertificatesAsync(telemetry)
+                .ConfigureAwait(false))
+            {
+                Assert.That(certificates, Has.Count.EqualTo(1));
+            }
+
+            Assert.That(
+                Certificate.InstancesLeaked,
+                Is.LessThanOrEqualTo(before),
+                "reading the trust list left a certificate handle behind.");
+        }
+
+        /// <summary>
+        /// A read that stops part way through the list releases what it had
+        /// already collected. Cancellation is used to stop it, which is the
+        /// reachable version of "an entry could not be read".
+        /// </summary>
+        [Test]
+        public void GetCertificatesAsyncReleasesWhatItReadWhenTheReadIsStopped()
+        {
+            ITelemetryContext telemetry = NUnitTelemetryContext.Create();
+
+            using Certificate certificate = CertificateBuilder
+                .Create("CN=TrustListHandleFailure")
+                .SetRSAKeySize(2048)
+                .CreateForRSA();
+
+            string storePath = Path.Combine(
+                Path.GetTempPath(),
+                "OpcUaTrustListHandleTest_" + Guid.NewGuid().ToString("N"));
+
+            try
+            {
+                var trustList = new CertificateTrustList
+                {
+                    TrustedCertificates =
+                    [
+                        new CertificateIdentifier { RawData = certificate.RawData },
+                        // resolved from a store, so the cancellation below stops
+                        // the loop after the entry above is in the collection.
+                        new CertificateIdentifier
+                        {
+                            StoreType = CertificateStoreType.Directory,
+                            StorePath = storePath,
+                            Thumbprint = certificate.Thumbprint
+                        }
+                    ]
+                };
+
+                using var cts = new CancellationTokenSource();
+                cts.Cancel();
+
+                long before = Certificate.InstancesLeaked;
+
+                Assert.That(
+                    () => trustList.GetCertificatesAsync(telemetry, cts.Token),
+                    Throws.InstanceOf<OperationCanceledException>());
+
+                Assert.That(
+                    Certificate.InstancesLeaked,
+                    Is.LessThanOrEqualTo(before),
+                    "the partially built collection was abandoned without being released.");
+            }
+            finally
+            {
+                if (Directory.Exists(storePath))
+                {
+                    Directory.Delete(storePath, true);
+                }
+            }
+        }
+    }
+}

--- a/tests/Opc.Ua.Core.Tests/Security/Certificates/CryptoUtilsSymmetricPaddingTests.cs
+++ b/tests/Opc.Ua.Core.Tests/Security/Certificates/CryptoUtilsSymmetricPaddingTests.cs
@@ -98,9 +98,13 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
                 iv);
 
             Assert.That(decrypted, Has.Count.EqualTo(kHeaderSize + bodySize));
-            Assert.That(
-                new ArraySegment<byte>(buffer, kHeaderSize, bodySize).ToArray(),
-                Is.EqualTo(body));
+
+            // Array.Copy rather than ArraySegment.ToArray: the latter is not on
+            // .NET Framework, which this suite also builds for.
+            byte[] roundTripped = new byte[bodySize];
+            Array.Copy(buffer, kHeaderSize, roundTripped, 0, bodySize);
+
+            Assert.That(roundTripped, Is.EqualTo(body));
         }
 
         /// <summary>

--- a/tests/Opc.Ua.Core.Tests/Security/Certificates/CryptoUtilsSymmetricPaddingTests.cs
+++ b/tests/Opc.Ua.Core.Tests/Security/Certificates/CryptoUtilsSymmetricPaddingTests.cs
@@ -1,0 +1,297 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using System.Security.Cryptography;
+using NUnit.Framework;
+
+namespace Opc.Ua.Core.Tests.Security.Certificates
+{
+    /// <summary>
+    /// Regression tests for the symmetric padding handling in
+    /// <see cref="CryptoUtils"/>.
+    /// </summary>
+    /// <remarks>
+    /// Two defects are covered. The padding verification loop used to start at
+    /// <c>data.Offset</c> and stop at <c>paddingSize</c>, so for every message
+    /// with a header - which is every channel message - it ran zero times and no
+    /// filler byte was ever checked. And the padding was removed before the
+    /// signature was verified, which reports the two failures apart on a message
+    /// whose padding an attacker chose: a padding oracle.
+    ///
+    /// OPC 10000-6 6.7.2.5.1: "The value of each byte of the padding is equal to
+    /// PaddingSize", and "The signature includes the headers, all Message data,
+    /// the PaddingSize and the Padding".
+    /// </remarks>
+    [TestFixture]
+    [Category("CryptoUtils")]
+    [Parallelizable]
+    [SetCulture("en-us")]
+    public class CryptoUtilsSymmetricPaddingTests
+    {
+        /// <summary>
+        /// A UA secure conversation header is 24 bytes, so the plain text never
+        /// starts at offset zero on the real path.
+        /// </summary>
+        private const int kHeaderSize = 24;
+
+        private const int kBlockSize = 16;
+
+        private const int kHashSize = 32;
+
+        /// <summary>
+        /// Every body length produces a different padding length; all of them
+        /// have to survive the round trip.
+        /// </summary>
+        [Test]
+        public void SymmetricRoundTripPreservesBody([Range(0, 33)] int bodySize)
+        {
+            byte[] key = CreateKey(32);
+            byte[] iv = CreateKey(kBlockSize);
+            byte[] buffer = new byte[512];
+            byte[] body = CreateKey(bodySize);
+
+            Array.Copy(body, 0, buffer, kHeaderSize, bodySize);
+
+            ArraySegment<byte> encrypted = CryptoUtils.SymmetricEncryptAndSign(
+                new ArraySegment<byte>(buffer, kHeaderSize, bodySize),
+                SecurityPolicyInfo.Basic256Sha256,
+                key,
+                iv);
+
+            int encryptedLength = encrypted.Count;
+
+            Assert.That(encryptedLength, Is.GreaterThan(kHeaderSize + bodySize));
+            Assert.That((encryptedLength - kHeaderSize) % kBlockSize, Is.Zero);
+
+            ArraySegment<byte> decrypted = CryptoUtils.SymmetricDecryptAndVerify(
+                new ArraySegment<byte>(buffer, kHeaderSize, encryptedLength - kHeaderSize),
+                SecurityPolicyInfo.Basic256Sha256,
+                key,
+                iv);
+
+            Assert.That(decrypted, Has.Count.EqualTo(kHeaderSize + bodySize));
+            Assert.That(
+                new ArraySegment<byte>(buffer, kHeaderSize, bodySize).ToArray(),
+                Is.EqualTo(body));
+        }
+
+        /// <summary>
+        /// A padding whose count byte is right but whose filler bytes are not is
+        /// rejected. Before the fix the filler was never looked at, so the body
+        /// silently ended wherever the forged count byte said it did.
+        /// </summary>
+        [Test]
+        public void SymmetricDecryptRejectsForgedPaddingFiller()
+        {
+            const int bodySize = 10;
+            const int paddingSize = kBlockSize - ((bodySize + 1) % kBlockSize);
+
+            byte[] key = CreateKey(32);
+            byte[] iv = CreateKey(kBlockSize);
+            byte[] plainText = CreatePaddedPlainText(bodySize, paddingSize);
+
+            // the count byte still says five, but one filler byte no longer
+            // repeats it.
+            plainText[bodySize] = 0xAA;
+
+            byte[] buffer = BuildMessage(plainText, key, iv);
+
+            Assert.That(
+                () => CryptoUtils.SymmetricDecryptAndVerify(
+                    new ArraySegment<byte>(buffer, kHeaderSize, plainText.Length),
+                    SecurityPolicyInfo.Basic256Sha256,
+                    key,
+                    iv),
+                Throws.TypeOf<CryptographicException>());
+        }
+
+        /// <summary>
+        /// The same message with intact filler is accepted, so the rejection
+        /// above is the forged filler and not the shape of the message.
+        /// </summary>
+        [Test]
+        public void SymmetricDecryptAcceptsWellFormedPadding()
+        {
+            const int bodySize = 10;
+            const int paddingSize = kBlockSize - ((bodySize + 1) % kBlockSize);
+
+            byte[] key = CreateKey(32);
+            byte[] iv = CreateKey(kBlockSize);
+            byte[] plainText = CreatePaddedPlainText(bodySize, paddingSize);
+            byte[] buffer = BuildMessage(plainText, key, iv);
+
+            ArraySegment<byte> decrypted = CryptoUtils.SymmetricDecryptAndVerify(
+                new ArraySegment<byte>(buffer, kHeaderSize, plainText.Length),
+                SecurityPolicyInfo.Basic256Sha256,
+                key,
+                iv);
+
+            Assert.That(decrypted, Has.Count.EqualTo(kHeaderSize + bodySize));
+        }
+
+        /// <summary>
+        /// A padding count that reaches past the start of the plain text is
+        /// rejected rather than producing a negative body length.
+        /// </summary>
+        [Test]
+        public void SymmetricDecryptRejectsPaddingLongerThanTheMessage()
+        {
+            byte[] key = CreateKey(32);
+            byte[] iv = CreateKey(kBlockSize);
+            byte[] plainText = new byte[kBlockSize];
+
+            for (int ii = 0; ii < plainText.Length; ii++)
+            {
+                plainText[ii] = 0xFF;
+            }
+
+            byte[] buffer = BuildMessage(plainText, key, iv);
+
+            Assert.That(
+                () => CryptoUtils.SymmetricDecryptAndVerify(
+                    new ArraySegment<byte>(buffer, kHeaderSize, plainText.Length),
+                    SecurityPolicyInfo.Basic256Sha256,
+                    key,
+                    iv),
+                Throws.TypeOf<CryptographicException>());
+        }
+
+        /// <summary>
+        /// A tampered message fails on its signature, never on its padding. The
+        /// padding of a message that did not authenticate is attacker chosen, so
+        /// telling the two failures apart hands out a padding oracle.
+        /// </summary>
+        [Test]
+        public void SymmetricDecryptReportsSignatureFailureAheadOfPadding()
+        {
+            const int bodySize = 10;
+
+            byte[] key = CreateKey(32);
+            byte[] iv = CreateKey(kBlockSize);
+            byte[] signingKey = CreateKey(48);
+            byte[] buffer = new byte[512];
+
+            for (int ii = 0; ii < bodySize; ii++)
+            {
+                buffer[kHeaderSize + ii] = (byte)(ii + 1);
+            }
+
+            using HMAC hmac = SecurityPolicyInfo.Basic256Sha256.CreateSignatureHmac(signingKey)!;
+
+            ArraySegment<byte> encrypted = CryptoUtils.SymmetricEncryptAndSign(
+                new ArraySegment<byte>(buffer, kHeaderSize, bodySize),
+                SecurityPolicyInfo.Basic256Sha256,
+                key,
+                iv,
+                signingKey,
+                hmac);
+
+            int encryptedLength = encrypted.Count;
+
+            // flip a bit in the last cipher block, which garbles the padding the
+            // receiver sees as well as breaking the signature.
+            buffer[encryptedLength - kHashSize - 1] ^= 0x01;
+
+            Assert.That(
+                () => CryptoUtils.SymmetricDecryptAndVerify(
+                    new ArraySegment<byte>(buffer, kHeaderSize, encryptedLength - kHeaderSize),
+                    SecurityPolicyInfo.Basic256Sha256,
+                    key,
+                    iv,
+                    signingKey),
+                Throws.TypeOf<CryptographicException>()
+                    .With.Message.EqualTo("Invalid signature."));
+        }
+
+        /// <summary>
+        /// Builds a plain text of the given body length followed by a padding
+        /// laid out the way <c>AddPadding</c> lays it out.
+        /// </summary>
+        private static byte[] CreatePaddedPlainText(int bodySize, int paddingSize)
+        {
+            byte[] plainText = new byte[bodySize + paddingSize + 1];
+
+            for (int ii = 0; ii < bodySize; ii++)
+            {
+                plainText[ii] = (byte)(ii + 1);
+            }
+
+            for (int ii = 0; ii < paddingSize; ii++)
+            {
+                plainText[bodySize + ii] = (byte)paddingSize;
+            }
+
+            plainText[bodySize + paddingSize] = (byte)paddingSize;
+
+            return plainText;
+        }
+
+        /// <summary>
+        /// Lays the plain text out behind a header and encrypts it in place the
+        /// way the channel does, so the decrypt path sees exactly these bytes.
+        /// </summary>
+        private static byte[] BuildMessage(byte[] plainText, byte[] key, byte[] iv)
+        {
+            byte[] buffer = new byte[kHeaderSize + plainText.Length];
+
+            using Aes aes = Aes.Create();
+
+            aes.Mode = CipherMode.CBC;
+            aes.Padding = PaddingMode.None;
+            aes.Key = key;
+
+            // CA5401: a fixed IV is the point - this has to produce exactly the
+            // cipher text the decrypt path is handed, and the keys never leave
+            // the test.
+#pragma warning disable CA5401
+            aes.IV = iv;
+
+            using ICryptoTransform encryptor = aes.CreateEncryptor();
+#pragma warning restore CA5401
+
+            encryptor.TransformBlock(plainText, 0, plainText.Length, buffer, kHeaderSize);
+
+            return buffer;
+        }
+
+        private static byte[] CreateKey(int length)
+        {
+            byte[] key = new byte[length];
+
+            for (int ii = 0; ii < length; ii++)
+            {
+                key[ii] = (byte)((ii * 7) + 3);
+            }
+
+            return key;
+        }
+    }
+}

--- a/tests/Opc.Ua.Core.Tests/Security/Certificates/DirectoryCertificateStoreTests.cs
+++ b/tests/Opc.Ua.Core.Tests/Security/Certificates/DirectoryCertificateStoreTests.cs
@@ -397,6 +397,73 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
             }
         }
 
+        /// <summary>
+        /// Removing one certificate from a PEM file that holds several rewrites
+        /// the file to exactly what is left. The rewrite opened the file without
+        /// truncating it, and the replacement is shorter than what it replaces,
+        /// so the tail of the old content stayed behind and parsed again - the
+        /// deleted certificate came back, or a duplicate of its neighbour did.
+        /// </summary>
+        [Test]
+        public async Task DeleteFromAMultiCertificatePemFileTruncatesTheFileAsync()
+        {
+            using Certificate first = CertificateBuilder
+                .Create("CN=PemFirst")
+                .SetRSAKeySize(2048)
+                .CreateForRSA();
+            using Certificate second = CertificateBuilder
+                .Create("CN=PemSecond")
+                .SetRSAKeySize(2048)
+                .CreateForRSA();
+
+            string certificatesDir = Path.Combine(m_tempDir, "certs");
+            Directory.CreateDirectory(certificatesDir);
+
+            byte[] firstPem = PEMWriter.ExportCertificateAsPEM(first);
+            byte[] secondPem = PEMWriter.ExportCertificateAsPEM(second);
+            byte[] combined = new byte[firstPem.Length + secondPem.Length];
+            firstPem.CopyTo(combined, 0);
+            secondPem.CopyTo(combined, firstPem.Length);
+
+            string pemFile = Path.Combine(certificatesDir, "bundle.pem");
+            File.WriteAllBytes(pemFile, combined);
+
+            using (var store = new DirectoryCertificateStore(m_telemetry))
+            {
+                store.Open(m_tempDir, noPrivateKeys: true);
+
+                using (CertificateCollection before = await store.EnumerateAsync()
+                    .ConfigureAwait(false))
+                {
+                    Assert.That(before, Has.Count.EqualTo(2));
+                }
+
+                // the last certificate in the file: what is left is shorter than
+                // what was there, so anything not truncated is still readable.
+                Assert.That(
+                    await store.DeleteAsync(second.Thumbprint).ConfigureAwait(false),
+                    Is.True);
+            }
+
+            // read back from disk through a store that shares no cache with the
+            // one that performed the delete.
+            using var reopened = new DirectoryCertificateStore(m_telemetry);
+            reopened.Open(m_tempDir, noPrivateKeys: true);
+
+            using CertificateCollection after = await reopened.EnumerateAsync()
+                .ConfigureAwait(false);
+
+            Assert.That(after, Has.Count.EqualTo(1));
+            Assert.That(after[0].Thumbprint, Is.EqualTo(first.Thumbprint));
+
+            Assert.That(
+                PEMReader.ImportPublicKeysFromPEM(File.ReadAllBytes(pemFile)),
+                Has.Count.EqualTo(1));
+
+            // nothing of the removed block is left behind the rewritten content.
+            Assert.That(new FileInfo(pemFile).Length, Is.LessThan(combined.Length));
+        }
+
         [Test]
         public async Task IsRevokedAsyncReflectsCrlAddedAfterCacheWarmupAsync()
         {

--- a/tests/Opc.Ua.Core.Tests/Security/Certificates/EncryptedSecretTests.cs
+++ b/tests/Opc.Ua.Core.Tests/Security/Certificates/EncryptedSecretTests.cs
@@ -842,6 +842,84 @@ namespace Opc.Ua.Core.Tests.Security.Certificates
             return EncryptedSecret.CreateForRsa(m_context, policyUri, m_certificate);
         }
 
+        /// <summary>
+        /// The ECC secret is decrypted in place, over the buffer the caller
+        /// handed in, and only the extracted key is copied out. The plain text
+        /// left in that buffer is wiped - including on the failure path, which
+        /// is the one that matters: the decryption runs before the signature and
+        /// padding are verified, so a rejected message has the secret written
+        /// out and nothing returned.
+        /// </summary>
+        [TestCase(SecurityPolicies.ECC_nistP256)]
+        [TestCase(SecurityPolicies.ECC_nistP384)]
+        [Category("EncryptedSecretCoverage")]
+        public void EccDecryptWipesThePlainTextFromTheCallersBufferOnFailure(string policyUri)
+        {
+            RequireEccPolicy(policyUri);
+            ECCurve curve = CurveForPolicy(policyUri);
+            using Certificate senderCertificate = CreateEccCertificate(curve);
+            using Certificate receiverCertificate = CreateEccCertificate(curve);
+            using Nonce receiverEphemeralKey = CreateEphemeralKey(policyUri);
+            using Nonce senderEphemeralKey = CreateEphemeralKey(policyUri);
+            byte[] secret = SecretBytes();
+            byte[] nonce = NonceBytes();
+
+            EncryptedSecret encryptor = CreateEccEncryptor(
+                policyUri,
+                senderCertificate,
+                receiverCertificate,
+                receiverEphemeralKey,
+                senderEphemeralKey);
+            byte[] encoded = encryptor.Encrypt(secret, nonce);
+
+            int longestZeroRunBefore = LongestZeroRun(encoded);
+
+            EncryptedSecret decryptor = CreateEccDecryptor(
+                policyUri, receiverCertificate, receiverEphemeralKey);
+
+            bool accepted;
+
+            try
+            {
+                // a nonce the message was not built for: rejected after the body
+                // has already been decrypted in place.
+                accepted = decryptor.TryDecrypt(encoded, [0xAA, 0xBB, 0xCC, 0xDD], out _);
+            }
+            catch (ServiceResultException)
+            {
+                accepted = false;
+            }
+            finally
+            {
+                decryptor.SenderCertificate?.Dispose();
+            }
+
+            Assert.That(accepted, Is.False);
+
+            Assert.That(
+                LongestZeroRun(encoded),
+                Is.GreaterThan(longestZeroRunBefore + secret.Length),
+                "the decrypted secret was left behind in the caller's buffer.");
+        }
+
+        private static int LongestZeroRun(byte[] buffer)
+        {
+            int longest = 0;
+            int current = 0;
+
+            foreach (byte value in buffer)
+            {
+                current = value == 0 ? current + 1 : 0;
+
+                if (current > longest)
+                {
+                    longest = current;
+                }
+            }
+
+            return longest;
+        }
+
         private static byte[] SecretBytes()
         {
             return System.Text.Encoding.UTF8.GetBytes("opc-ua-encrypted-secret-roundtrip-value");

--- a/tests/Opc.Ua.Core.Tests/Security/Certificates/RejectedCertificateRetentionTests.cs
+++ b/tests/Opc.Ua.Core.Tests/Security/Certificates/RejectedCertificateRetentionTests.cs
@@ -1,0 +1,221 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+// CA2000: test code; many disposables are ownership-transferred to test fixtures or short-lived,
+// making CA2000 noisy without a real leak risk. Disabled file-level for the suite.
+#pragma warning disable CA2000
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Opc.Ua.Redundancy;
+using Opc.Ua.Security.Certificates;
+using Opc.Ua.Tests;
+
+namespace Opc.Ua.Core.Tests.Security.Certificates
+{
+    /// <summary>
+    /// The retention contract of <see cref="ICertificateStore.AddRejectedAsync"/>
+    /// as the two shipped store implementations have to honour it.
+    /// </summary>
+    /// <remarks>
+    /// Zero or less keeps no history at all and discards whatever is stored; a
+    /// positive value caps the history at that many, oldest discarded first.
+    /// <see cref="DirectoryCertificateStore"/> always behaved this way but did it
+    /// by writing every certificate and then deleting all of them again;
+    /// <see cref="SharedKeyValueCertificateStore"/> read zero as unlimited, so
+    /// the two store types did opposite things at the same setting and
+    /// <c>CertificateManager.MaxRejectedCertificates = 0</c> meant one thing on
+    /// a directory store and another on a key-value store.
+    /// </remarks>
+    [TestFixture]
+    [Category("CertificateStore")]
+    [NonParallelizable]
+    public class RejectedCertificateRetentionTests
+    {
+        private ITelemetryContext m_telemetry;
+        private string m_tempDir;
+
+        [SetUp]
+        public void SetUp()
+        {
+            m_telemetry = NUnitTelemetryContext.Create();
+            m_tempDir = Path.Combine(
+                Path.GetTempPath(),
+                "OpcUaRejectedStoreTest_" + Guid.NewGuid().ToString("N"));
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            (m_telemetry as IDisposable)?.Dispose();
+
+            if (Directory.Exists(m_tempDir))
+            {
+                Directory.Delete(m_tempDir, true);
+            }
+        }
+
+        [TestCase(0)]
+        [TestCase(-1)]
+        [TestCase(-5)]
+        public async Task DirectoryStoreKeepsNoHistoryAtOrBelowZeroAsync(int maxCertificates)
+        {
+            using var store = new DirectoryCertificateStore(m_telemetry);
+            store.Open(m_tempDir);
+
+            using CertificateCollection rejected = CreateCertificates(3);
+            await store.AddRejectedAsync(rejected, maxCertificates).ConfigureAwait(false);
+
+            using CertificateCollection stored = await store.EnumerateAsync()
+                .ConfigureAwait(false);
+            Assert.That(stored, Is.Empty);
+        }
+
+        [Test]
+        public async Task DirectoryStoreDiscardsHistoryWhenTheMaximumDropsToZeroAsync()
+        {
+            using var store = new DirectoryCertificateStore(m_telemetry);
+            store.Open(m_tempDir);
+
+            using CertificateCollection rejected = CreateCertificates(3);
+            await store.AddRejectedAsync(rejected, 3).ConfigureAwait(false);
+
+            using (CertificateCollection before = await store.EnumerateAsync()
+                .ConfigureAwait(false))
+            {
+                Assert.That(before, Has.Count.EqualTo(3));
+            }
+
+            using CertificateCollection more = CreateCertificates(1);
+            await store.AddRejectedAsync(more, 0).ConfigureAwait(false);
+
+            using CertificateCollection after = await store.EnumerateAsync()
+                .ConfigureAwait(false);
+            Assert.That(after, Is.Empty);
+        }
+
+        [Test]
+        public async Task DirectoryStoreCapsHistoryAtTheMaximumAsync()
+        {
+            using var store = new DirectoryCertificateStore(m_telemetry);
+            store.Open(m_tempDir);
+
+            using CertificateCollection rejected = CreateCertificates(5);
+            await store.AddRejectedAsync(rejected, 2).ConfigureAwait(false);
+
+            using CertificateCollection stored = await store.EnumerateAsync()
+                .ConfigureAwait(false);
+            Assert.That(stored, Has.Count.EqualTo(2));
+        }
+
+        [TestCase(0)]
+        [TestCase(-1)]
+        [TestCase(-5)]
+        public async Task SharedKeyValueStoreKeepsNoHistoryAtOrBelowZeroAsync(int maxCertificates)
+        {
+            using var backend = new InMemorySharedKeyValueStore();
+            using SharedKeyValueCertificateStore store = CreateKeyValueStore(backend);
+
+            using CertificateCollection rejected = CreateCertificates(3);
+            await store.AddRejectedAsync(rejected, maxCertificates).ConfigureAwait(false);
+
+            using CertificateCollection stored = await store.EnumerateAsync()
+                .ConfigureAwait(false);
+            Assert.That(stored, Is.Empty);
+        }
+
+        /// <summary>
+        /// The one behaviour that changed relative to the previous release: a
+        /// maximum of zero used to be read as unlimited here, so the history kept
+        /// growing while the directory store kept nothing.
+        /// </summary>
+        [Test]
+        public async Task SharedKeyValueStoreDiscardsHistoryWhenTheMaximumDropsToZeroAsync()
+        {
+            using var backend = new InMemorySharedKeyValueStore();
+            using SharedKeyValueCertificateStore store = CreateKeyValueStore(backend);
+
+            using CertificateCollection rejected = CreateCertificates(3);
+            await store.AddRejectedAsync(rejected, 3).ConfigureAwait(false);
+
+            using (CertificateCollection before = await store.EnumerateAsync()
+                .ConfigureAwait(false))
+            {
+                Assert.That(before, Has.Count.EqualTo(3));
+            }
+
+            using CertificateCollection more = CreateCertificates(1);
+            await store.AddRejectedAsync(more, 0).ConfigureAwait(false);
+
+            using CertificateCollection after = await store.EnumerateAsync()
+                .ConfigureAwait(false);
+            Assert.That(after, Is.Empty);
+        }
+
+        [Test]
+        public async Task SharedKeyValueStoreCapsHistoryAtTheMaximumAsync()
+        {
+            using var backend = new InMemorySharedKeyValueStore();
+            using SharedKeyValueCertificateStore store = CreateKeyValueStore(backend);
+
+            using CertificateCollection rejected = CreateCertificates(5);
+            await store.AddRejectedAsync(rejected, 2).ConfigureAwait(false);
+
+            using CertificateCollection stored = await store.EnumerateAsync()
+                .ConfigureAwait(false);
+            Assert.That(stored, Has.Count.EqualTo(2));
+        }
+
+        private SharedKeyValueCertificateStore CreateKeyValueStore(
+            ISharedKeyValueStore backend)
+        {
+            var store = new SharedKeyValueCertificateStore(backend, null, m_telemetry);
+            store.Open("kv:pki/rejected");
+            return store;
+        }
+
+        private static CertificateCollection CreateCertificates(int count)
+        {
+            var certificates = new CertificateCollection();
+
+            for (int ii = 0; ii < count; ii++)
+            {
+                using Certificate certificate = CertificateBuilder
+                    .Create($"CN=Rejected {ii} {Guid.NewGuid():N}")
+                    .SetRSAKeySize(2048)
+                    .CreateForRSA();
+                certificates.Add(certificate);
+            }
+
+            return certificates;
+        }
+    }
+}

--- a/tests/Opc.Ua.Core.Tests/Stack/Client/ClientChannelManagerCertRotationTests.cs
+++ b/tests/Opc.Ua.Core.Tests/Stack/Client/ClientChannelManagerCertRotationTests.cs
@@ -114,13 +114,7 @@ namespace Opc.Ua.Core.Tests.Stack.Client
 
                 await sut.DisposeAsync().ConfigureAwait(false);
 
-                // The production channel factory parses description.ServerCertificate
-                // into a Certificate that the real channel would own and dispose; the
-                // mock channel does not, so dispose the captured copies here.
-                while (openSettings.TryDequeue(out TransportChannelSettings? opened))
-                {
-                    opened.ServerCertificate?.Dispose();
-                }
+                DisposeOpenedCertificates(openSettings);
             }
         }
 
@@ -166,13 +160,7 @@ namespace Opc.Ua.Core.Tests.Stack.Client
 
                 await sut.DisposeAsync().ConfigureAwait(false);
 
-                // The production channel factory parses description.ServerCertificate
-                // into a Certificate that the real channel would own and dispose; the
-                // mock channel does not, so dispose the captured copies here.
-                while (openSettings.TryDequeue(out TransportChannelSettings? opened))
-                {
-                    opened.ServerCertificate?.Dispose();
-                }
+                DisposeOpenedCertificates(openSettings);
             }
         }
 
@@ -224,10 +212,7 @@ namespace Opc.Ua.Core.Tests.Stack.Client
                     await channel.CloseAsync().ConfigureAwait(false);
                 }
                 await sut.DisposeAsync().ConfigureAwait(false);
-                while (openSettings.TryDequeue(out TransportChannelSettings? opened))
-                {
-                    opened.ServerCertificate?.Dispose();
-                }
+                DisposeOpenedCertificates(openSettings);
             }
         }
 
@@ -280,7 +265,7 @@ namespace Opc.Ua.Core.Tests.Stack.Client
                     await channel.CloseAsync().ConfigureAwait(false);
                 }
                 await sut.DisposeAsync().ConfigureAwait(false);
-                DisposeOpenedServerCertificates(openSettings);
+                DisposeOpenedCertificates(openSettings);
             }
         }
 
@@ -328,7 +313,7 @@ namespace Opc.Ua.Core.Tests.Stack.Client
                     await channel.CloseAsync().ConfigureAwait(false);
                 }
                 await sut.DisposeAsync().ConfigureAwait(false);
-                DisposeOpenedServerCertificates(openSettings);
+                DisposeOpenedCertificates(openSettings);
             }
         }
 
@@ -377,7 +362,7 @@ namespace Opc.Ua.Core.Tests.Stack.Client
             finally
             {
                 await sut.DisposeAsync().ConfigureAwait(false);
-                DisposeOpenedServerCertificates(openSettings);
+                DisposeOpenedCertificates(openSettings);
             }
         }
 
@@ -430,7 +415,7 @@ namespace Opc.Ua.Core.Tests.Stack.Client
                     await secondChannel.CloseAsync().ConfigureAwait(false);
                 }
                 await sut.DisposeAsync().ConfigureAwait(false);
-                DisposeOpenedServerCertificates(openSettings);
+                DisposeOpenedCertificates(openSettings);
             }
         }
 
@@ -541,12 +526,24 @@ namespace Opc.Ua.Core.Tests.Stack.Client
             }
         }
 
-        private static void DisposeOpenedServerCertificates(
+        /// <summary>
+        /// Releases the certificate handles a real channel would own.
+        /// </summary>
+        /// <remarks>
+        /// A production channel takes over everything on the settings and
+        /// releases it when it closes: the server certificate it parses out of
+        /// the description, and the client certificate and chain the manager
+        /// hands it a reference of its own on. The mock channel captures the
+        /// settings and does neither, so the test stands in for it.
+        /// </remarks>
+        private static void DisposeOpenedCertificates(
             ConcurrentQueue<TransportChannelSettings> openSettings)
         {
             while (openSettings.TryDequeue(out TransportChannelSettings? opened))
             {
                 opened.ServerCertificate?.Dispose();
+                opened.ClientCertificate?.Dispose();
+                opened.ClientCertificateChain?.Dispose();
             }
         }
 

--- a/tests/Opc.Ua.Core.Tests/Stack/Client/ClientChannelManagerHandleTests.cs
+++ b/tests/Opc.Ua.Core.Tests/Stack/Client/ClientChannelManagerHandleTests.cs
@@ -1,0 +1,111 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+#nullable enable
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Opc.Ua.Security.Certificates;
+using Opc.Ua.Tests;
+
+namespace Opc.Ua.Core.Tests.Stack.Client
+{
+    /// <summary>
+    /// Certificate handle ownership on the channel creation path.
+    /// </summary>
+    /// <remarks>
+    /// The creation helpers take over the caller's client-certificate handles.
+    /// A channel that never opens has to release them exactly once: not at all
+    /// leaks a handle per failed connect attempt, and twice invalidates the
+    /// handle its owner is still using. The certificate was also only released
+    /// on failures raised after the channel object existed, so a failure before
+    /// that - an unsupported transport profile, for instance - left the handles
+    /// behind entirely.
+    /// </remarks>
+    [TestFixture]
+    [Category("ClientChannelManager")]
+    [SetCulture("en-us")]
+    [SetUICulture("en-us")]
+    [Parallelizable]
+    public sealed class ClientChannelManagerHandleTests
+    {
+        /// <summary>
+        /// The scheme has no transport binding, so the channel is never built
+        /// and the failure is raised before anything downstream could take the
+        /// handles over.
+        /// </summary>
+        [Test]
+        public void CreateChannelReleasesTheCertificateWhenTheSchemeIsUnsupported()
+        {
+            ITelemetryContext telemetry = NUnitTelemetryContext.Create();
+
+            Certificate owner = CertificateBuilder
+                .Create("CN=ChannelManagerHandle")
+                .SetRSAKeySize(2048)
+                .CreateForRSA();
+
+            // what the caller hands over: a reference of its own, which the
+            // creation path owns from here on.
+            Certificate handedOver = owner.AddRef();
+
+            var description = new EndpointDescription
+            {
+                EndpointUrl = "unsupported.scheme://localhost:4840",
+                TransportProfileUri = "urn:unknown:transport",
+                SecurityMode = MessageSecurityMode.None,
+                SecurityPolicyUri = SecurityPolicies.None
+            };
+
+            Assert.That(
+                async () => await ClientChannelManager.CreateUaBinaryChannelAsync(
+                    configuration: null!,
+                    description,
+                    EndpointConfiguration.Create(),
+                    handedOver,
+                    clientCertificateChain: null,
+                    ServiceMessageContext.CreateEmpty(telemetry),
+                    ct: CancellationToken.None)
+                    .ConfigureAwait(false),
+                Throws.Exception);
+
+            // Exactly one release. The caller's own reference still holds the
+            // certificate open - two releases would already have torn it down -
+            // and giving that one up is the last, so the handle is gone
+            // afterwards rather than outliving everyone who knows about it.
+            Assert.That(owner.RawData, Is.Not.Null);
+
+            owner.Dispose();
+
+            Assert.That(() => owner.AddRef(), Throws.TypeOf<ObjectDisposedException>());
+        }
+    }
+}

--- a/tests/Opc.Ua.Core.Tests/Stack/Client/ClientChannelManagerManagedTests.cs
+++ b/tests/Opc.Ua.Core.Tests/Stack/Client/ClientChannelManagerManagedTests.cs
@@ -174,6 +174,43 @@ namespace Opc.Ua.Core.Tests.Stack.Client
             Assert.That(firstKey.GetHashCode(), Is.EqualTo(secondKey.GetHashCode()));
         }
 
+        /// <summary>
+        /// The seven-argument constructor is kept alongside the profile-aware
+        /// one. Folding the new argument in as an optional parameter would be
+        /// source compatible but not binary compatible, and an application
+        /// compiled against the old signature would fail with a
+        /// MissingMethodException.
+        /// </summary>
+        [Test]
+        public void ChannelKeyKeepsTheConstructorWithoutATransportProfile()
+        {
+            ConstructorInfo? seven = typeof(ManagedChannelKey).GetConstructor(
+                [
+                    typeof(string),
+                    typeof(string),
+                    typeof(MessageSecurityMode),
+                    typeof(ByteString),
+                    typeof(int),
+                    typeof(ByteString),
+                    typeof(object)
+                ]);
+
+            Assert.That(seven, Is.Not.Null);
+
+            var key = (ManagedChannelKey)seven!.Invoke(
+                [
+                    "opc.tcp://localhost:4840",
+                    SecurityPolicies.None,
+                    MessageSecurityMode.None,
+                    default(ByteString),
+                    0,
+                    default(ByteString),
+                    null
+                ]);
+
+            Assert.That(key.TransportProfileUri, Is.Empty);
+        }
+
         [Test]
         public void ExponentialBackoffPolicyDoublesWithCap()
         {

--- a/tests/Opc.Ua.Core.Tests/Stack/Client/ClientChannelManagerManagedTests.cs
+++ b/tests/Opc.Ua.Core.Tests/Stack/Client/ClientChannelManagerManagedTests.cs
@@ -126,6 +126,54 @@ namespace Opc.Ua.Core.Tests.Stack.Client
             Assert.That(r1, Is.Not.EqualTo(r2));
         }
 
+        /// <summary>
+        /// The HTTPS binary, JSON and OpenAPI endpoints of one server share a
+        /// URL, security mode, policy and certificate but are served by
+        /// different transports. Leaving the transport profile out of the key
+        /// gave all three the single channel of whichever transport happened to
+        /// be created first.
+        /// </summary>
+        [Test]
+        public void ChannelKeyDistinguishesTransportProfiles()
+        {
+            using Certificate serverCert = s_factory.CreateCertificate("CN=server").CreateForRSA();
+
+            ConfiguredEndpoint binary = GetTestEndpoint(serverCert);
+            binary.Description.EndpointUrl = "https://localhost:4843";
+            binary.Description.TransportProfileUri = Profiles.HttpsBinaryTransport;
+
+            ConfiguredEndpoint json = GetTestEndpoint(serverCert);
+            json.Description.EndpointUrl = "https://localhost:4843";
+            json.Description.TransportProfileUri = Profiles.HttpsJsonTransport;
+
+            var binaryKey = ManagedChannelKey.FromEndpoint(binary);
+            var jsonKey = ManagedChannelKey.FromEndpoint(json);
+
+            Assert.That(binaryKey, Is.Not.EqualTo(jsonKey));
+        }
+
+        /// <summary>
+        /// Two endpoints that name the same transport profile still share a key,
+        /// so the profile was added to the identity rather than replacing it.
+        /// </summary>
+        [Test]
+        public void ChannelKeyMatchesForTheSameTransportProfile()
+        {
+            using Certificate serverCert = s_factory.CreateCertificate("CN=server").CreateForRSA();
+
+            ConfiguredEndpoint first = GetTestEndpoint(serverCert);
+            first.Description.TransportProfileUri = Profiles.UaTcpTransport;
+
+            ConfiguredEndpoint second = GetTestEndpoint(serverCert);
+            second.Description.TransportProfileUri = Profiles.UaTcpTransport;
+
+            var firstKey = ManagedChannelKey.FromEndpoint(first);
+            var secondKey = ManagedChannelKey.FromEndpoint(second);
+
+            Assert.That(firstKey, Is.EqualTo(secondKey));
+            Assert.That(firstKey.GetHashCode(), Is.EqualTo(secondKey.GetHashCode()));
+        }
+
         [Test]
         public void ExponentialBackoffPolicyDoublesWithCap()
         {

--- a/tests/Opc.Ua.Core.Tests/Stack/Client/ConfiguredEndpointTests.cs
+++ b/tests/Opc.Ua.Core.Tests/Stack/Client/ConfiguredEndpointTests.cs
@@ -531,6 +531,55 @@ namespace Opc.Ua.Core.Tests.Stack.Client
             Assert.That(endpoint.SelectedUserTokenPolicy.TokenType, Is.EqualTo(UserTokenType.Anonymous));
         }
 
+        /// <summary>
+        /// Assigning a policy selects it. The setter used to break out of its
+        /// search loop and fall through to the not-found assignment, so the
+        /// index always ended at -1 and the selection was silently discarded.
+        /// </summary>
+        [TestCase(0)]
+        [TestCase(1)]
+        [TestCase(2)]
+        public void SelectedUserTokenPolicySetterSelectsTheAssignedPolicy(int index)
+        {
+            var anonymous = new UserTokenPolicy(UserTokenType.Anonymous);
+            var userName = new UserTokenPolicy(UserTokenType.UserName);
+            var certificate = new UserTokenPolicy(UserTokenType.Certificate);
+            UserTokenPolicy[] policies = [anonymous, userName, certificate];
+
+            var endpoint = new ConfiguredEndpoint(null, new EndpointDescription
+            {
+                EndpointUrl = "opc.tcp://localhost:4840",
+                UserIdentityTokens = [.. policies]
+            })
+            {
+                SelectedUserTokenPolicy = policies[index]
+            };
+
+            Assert.That(endpoint.SelectedUserTokenPolicyIndex, Is.EqualTo(index));
+            Assert.That(
+                endpoint.SelectedUserTokenPolicy?.TokenType,
+                Is.EqualTo(policies[index].TokenType));
+        }
+
+        /// <summary>
+        /// A policy the endpoint does not offer clears the selection.
+        /// </summary>
+        [Test]
+        public void SelectedUserTokenPolicySetterClearsForAnUnknownPolicy()
+        {
+            var endpoint = new ConfiguredEndpoint(null, new EndpointDescription
+            {
+                EndpointUrl = "opc.tcp://localhost:4840",
+                UserIdentityTokens = [new UserTokenPolicy(UserTokenType.Anonymous)]
+            })
+            {
+                SelectedUserTokenPolicy = new UserTokenPolicy(UserTokenType.UserName)
+            };
+
+            Assert.That(endpoint.SelectedUserTokenPolicyIndex, Is.EqualTo(-1));
+            Assert.That(endpoint.SelectedUserTokenPolicy, Is.Null);
+        }
+
         [Test]
         public void SelectedUserTokenPolicyIndexOutOfRangeReturnsNull()
         {

--- a/tests/Opc.Ua.Core.Tests/Stack/Server/ServerBaseTransportProfileTests.cs
+++ b/tests/Opc.Ua.Core.Tests/Stack/Server/ServerBaseTransportProfileTests.cs
@@ -1,0 +1,307 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Opc.Ua.Tests;
+
+namespace Opc.Ua.Core.Tests.Stack.Server
+{
+    /// <summary>
+    /// Endpoint translation for the transport profiles that share a URL scheme.
+    /// </summary>
+    /// <remarks>
+    /// A base address carries the one profile its URL scheme implies, but an
+    /// HTTPS listener publishes binary, JSON and OpenAPI endpoints on that
+    /// scheme and a WSS listener does the same. Those endpoints used to match no
+    /// base address at all, so GetEndpoints dropped them; the ones that did match
+    /// were then collapsed onto each other because the duplicate check ignored
+    /// the transport profile.
+    ///
+    /// OPC 10000-4 5.5.4.2: the profileUris parameter is the list of transport
+    /// profiles the returned endpoints shall support.
+    /// </remarks>
+    [TestFixture]
+    [Category("Server")]
+    [SetCulture("en-us")]
+    [SetUICulture("en-us")]
+    [Parallelizable]
+    public sealed class ServerBaseTransportProfileTests : ServerBase
+    {
+        private const string kHttpsUrl = "https://localhost:51212/UA/SampleServer";
+        private const string kWssUrl = "opc.wss://localhost:51213/UA/SampleServer";
+
+        private readonly ApplicationDescription m_application;
+
+        public ServerBaseTransportProfileTests()
+            : base(NUnitTelemetryContext.Create(true))
+        {
+            m_application = new ApplicationDescription
+            {
+                ApplicationUri = "urn:localhost:TransportProfileTests",
+                ApplicationName = new LocalizedText("en-US", "TransportProfileTests"),
+                ApplicationType = ApplicationType.Server
+            };
+        }
+
+        /// <summary>
+        /// All three HTTPS profiles are published, not just the binary one whose
+        /// URI the base address happens to carry.
+        /// </summary>
+        [Test]
+        public void HttpsJsonAndOpenApiEndpointsSurviveTranslation()
+        {
+            ArrayOf<EndpointDescription> translated = TranslateEndpointDescriptions(
+                new Uri(kHttpsUrl),
+                [HttpsBaseAddress()],
+                HttpsEndpoints(),
+                m_application);
+
+            Assert.That(
+                ProfileUris(translated),
+                Is.EquivalentTo(new[]
+                {
+                    Profiles.HttpsBinaryTransport,
+                    Profiles.HttpsJsonTransport,
+                    Profiles.HttpsOpenApiTransport
+                }));
+        }
+
+        /// <summary>
+        /// The same for the WSS scheme, whose listener serves binary, JSON and
+        /// OpenAPI too.
+        /// </summary>
+        [Test]
+        public void WssJsonAndOpenApiEndpointsSurviveTranslation()
+        {
+            ArrayOf<EndpointDescription> translated = TranslateEndpointDescriptions(
+                new Uri(kWssUrl),
+                [WssBaseAddress()],
+                WssEndpoints(),
+                m_application);
+
+            Assert.That(
+                ProfileUris(translated),
+                Is.EquivalentTo(new[]
+                {
+                    Profiles.UaWssTransport,
+                    Profiles.UaWssJsonTransport,
+                    Profiles.WssOpenApiTransport
+                }));
+        }
+
+        /// <summary>
+        /// The binary endpoint is offered first. A client with no transport
+        /// filter of its own takes the first endpoint that fits its security
+        /// requirements, so the one it gets has to stay the one it can always
+        /// speak - and List.Sort is not stable, so URL alone does not settle it.
+        /// </summary>
+        [Test]
+        public void BinaryEndpointIsOfferedAheadOfJsonAndOpenApi()
+        {
+            ArrayOf<EndpointDescription> translated = TranslateEndpointDescriptions(
+                new Uri(kHttpsUrl),
+                [HttpsBaseAddress()],
+                HttpsEndpoints(),
+                m_application);
+
+            Assert.That(
+                translated[0].TransportProfileUri,
+                Is.EqualTo(Profiles.HttpsBinaryTransport));
+        }
+
+        /// <summary>
+        /// Endpoints differing only in transport profile are not treated as
+        /// duplicates of each other.
+        /// </summary>
+        [Test]
+        public void EndpointsAreNotDeduplicatedAcrossTransportProfiles()
+        {
+            ArrayOf<EndpointDescription> translated = TranslateEndpointDescriptions(
+                new Uri(kHttpsUrl),
+                [HttpsBaseAddress()],
+                HttpsEndpoints(),
+                m_application);
+
+            Assert.That(translated.Count, Is.EqualTo(3));
+
+            foreach (EndpointDescription endpoint in translated)
+            {
+                Assert.That(endpoint.EndpointUrl, Is.EqualTo(kHttpsUrl));
+                Assert.That(
+                    endpoint.SecurityMode, Is.EqualTo(MessageSecurityMode.SignAndEncrypt));
+            }
+        }
+
+        /// <summary>
+        /// Two descriptions that really are the same endpoint still collapse, so
+        /// the transport profile was added to the identity rather than replacing
+        /// it.
+        /// </summary>
+        [Test]
+        public void IdenticalEndpointsAreStillDeduplicated()
+        {
+            ArrayOf<EndpointDescription> endpoints =
+            [
+                Endpoint(kHttpsUrl, Profiles.HttpsBinaryTransport),
+                Endpoint(kHttpsUrl, Profiles.HttpsBinaryTransport)
+            ];
+
+            ArrayOf<EndpointDescription> translated = TranslateEndpointDescriptions(
+                new Uri(kHttpsUrl),
+                [HttpsBaseAddress()],
+                endpoints,
+                m_application);
+
+            Assert.That(translated.Count, Is.EqualTo(1));
+        }
+
+        /// <summary>
+        /// A client asking for the JSON or OpenAPI profile gets the HTTPS base
+        /// address back. The filter used to compare profile URIs for equality,
+        /// so such a request matched nothing and the endpoint list came back
+        /// empty.
+        /// </summary>
+        [TestCaseSource(nameof(HttpsProfileUris))]
+        public void FilterByProfileMatchesTheHttpsSchemeProfiles(string profileUri)
+        {
+            IList<BaseAddress> filtered = FilterByProfile(
+                [profileUri],
+                [HttpsBaseAddress()]);
+
+            Assert.That(filtered, Has.Count.EqualTo(1));
+        }
+
+        [TestCaseSource(nameof(WssProfileUris))]
+        public void FilterByProfileMatchesTheWssSchemeProfiles(string profileUri)
+        {
+            IList<BaseAddress> filtered = FilterByProfile(
+                [profileUri],
+                [WssBaseAddress()]);
+
+            Assert.That(filtered, Has.Count.EqualTo(1));
+        }
+
+        /// <summary>
+        /// A profile served by a different scheme still does not match, so the
+        /// filter was widened to the scheme's own profiles and no further.
+        /// </summary>
+        [Test]
+        public void FilterByProfileRejectsAProfileOfAnotherScheme()
+        {
+            IList<BaseAddress> filtered = FilterByProfile(
+                [Profiles.UaTcpTransport],
+                [HttpsBaseAddress()]);
+
+            Assert.That(filtered, Is.Empty);
+        }
+
+        public static readonly string[] HttpsProfileUris =
+        [
+            Profiles.HttpsBinaryTransport,
+            Profiles.HttpsJsonTransport,
+            Profiles.HttpsOpenApiTransport
+        ];
+
+        public static readonly string[] WssProfileUris =
+        [
+            Profiles.UaWssTransport,
+            Profiles.UaWssJsonTransport,
+            Profiles.WssOpenApiTransport
+        ];
+
+        private static List<string> ProfileUris(ArrayOf<EndpointDescription> endpoints)
+        {
+            var profileUris = new List<string>();
+
+            foreach (EndpointDescription endpoint in endpoints)
+            {
+                profileUris.Add(endpoint.TransportProfileUri);
+            }
+
+            return profileUris;
+        }
+
+        private static BaseAddress HttpsBaseAddress()
+        {
+            return new BaseAddress
+            {
+                Url = new Uri(kHttpsUrl),
+                ProfileUri = Profiles.HttpsBinaryTransport
+            };
+        }
+
+        private static BaseAddress WssBaseAddress()
+        {
+            return new BaseAddress
+            {
+                Url = new Uri(kWssUrl),
+                ProfileUri = Profiles.UaWssTransport
+            };
+        }
+
+        private static ArrayOf<EndpointDescription> HttpsEndpoints()
+        {
+            return
+            [
+                Endpoint(kHttpsUrl, Profiles.HttpsBinaryTransport),
+                Endpoint(kHttpsUrl, Profiles.HttpsJsonTransport),
+                Endpoint(kHttpsUrl, Profiles.HttpsOpenApiTransport)
+            ];
+        }
+
+        private static ArrayOf<EndpointDescription> WssEndpoints()
+        {
+            return
+            [
+                Endpoint(kWssUrl, Profiles.UaWssTransport),
+                Endpoint(kWssUrl, Profiles.UaWssJsonTransport),
+                Endpoint(kWssUrl, Profiles.WssOpenApiTransport)
+            ];
+        }
+
+        private static EndpointDescription Endpoint(string url, string transportProfileUri)
+        {
+            return new EndpointDescription
+            {
+                EndpointUrl = url,
+                TransportProfileUri = transportProfileUri,
+                SecurityMode = MessageSecurityMode.SignAndEncrypt,
+                SecurityPolicyUri = SecurityPolicies.Aes256_Sha256_RsaPss,
+                SecurityLevel = 1,
+                UserIdentityTokens =
+                [
+                    new UserTokenPolicy { TokenType = UserTokenType.Anonymous }
+                ]
+            };
+        }
+    }
+}

--- a/tests/Opc.Ua.Core.Tests/Stack/Transport/HttpsTransportChannelResponseTests.cs
+++ b/tests/Opc.Ua.Core.Tests/Stack/Transport/HttpsTransportChannelResponseTests.cs
@@ -1,0 +1,305 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+#nullable enable
+
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Net.Sockets;
+using System.Security.Authentication;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Opc.Ua.Bindings;
+using Opc.Ua.Tests;
+
+namespace Opc.Ua.Core.Tests.Stack.Transport
+{
+    /// <summary>
+    /// How <see cref="HttpsTransportChannel"/> treats the response it gets back.
+    /// </summary>
+    /// <remarks>
+    /// Two defects are covered. The whole body used to be buffered into memory
+    /// before <c>MaxMessageSize</c> was applied, so the limit only ever decided
+    /// what to do with an allocation that had already happened. And a failed
+    /// request escaped as a raw <see cref="HttpRequestException"/> on .NET,
+    /// where the inner exception is a <see cref="SocketException"/> rather than
+    /// the <see cref="WebException"/> the mapping looked for - callers that
+    /// expect a <see cref="ServiceResultException"/> saw a transport exception
+    /// instead.
+    /// </remarks>
+    [TestFixture]
+    [Category("TransportChannelDeterministic")]
+    [SetCulture("en-us")]
+    [SetUICulture("en-us")]
+    [Parallelizable]
+    public sealed class HttpsTransportChannelResponseTests
+    {
+        private const int kMaxMessageSize = 4096;
+
+        private ITelemetryContext m_telemetry = null!;
+
+        [SetUp]
+        public void SetUp()
+        {
+            m_telemetry = NUnitTelemetryContext.Create();
+        }
+
+        /// <summary>
+        /// A response that declares a length above the limit is refused on the
+        /// headers, before the body is read at all.
+        /// </summary>
+        [Test]
+        public async Task ResponseWithContentLengthAboveTheLimitIsRefusedAsync()
+        {
+            var content = new ByteArrayContent(new byte[kMaxMessageSize * 4]);
+
+            using HttpsTransportChannel channel = await CreateChannelAsync(
+                new StubHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = content
+                })).ConfigureAwait(false);
+
+            Assert.That(
+                async () => await channel
+                    .SendRequestAsync(new ReadRequest(), CancellationToken.None)
+                    .ConfigureAwait(false),
+                Throws.TypeOf<ServiceResultException>()
+                    .With.Property("StatusCode")
+                    .EqualTo((uint)StatusCodes.BadResponseTooLarge));
+        }
+
+        /// <summary>
+        /// A response that declares no length - a chunked one - is bounded as
+        /// the body arrives instead.
+        /// </summary>
+        [Test]
+        public async Task ResponseWithoutContentLengthIsBoundedWhileReadingAsync()
+        {
+            using HttpsTransportChannel channel = await CreateChannelAsync(
+                new StubHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StreamContent(
+                        new UnboundedStream(kMaxMessageSize * 4))
+                })).ConfigureAwait(false);
+
+            Assert.That(
+                async () => await channel
+                    .SendRequestAsync(new ReadRequest(), CancellationToken.None)
+                    .ConfigureAwait(false),
+                Throws.TypeOf<ServiceResultException>()
+                    .With.Property("StatusCode")
+                    .EqualTo((uint)StatusCodes.BadResponseTooLarge));
+        }
+
+        /// <summary>
+        /// A connect failure is reported as a transport problem the reconnect
+        /// policy may retry.
+        /// </summary>
+        [Test]
+        public async Task ConnectFailureIsReportedAsBadNotConnectedAsync()
+        {
+            using HttpsTransportChannel channel = await CreateChannelAsync(
+                new StubHandler(_ => throw new HttpRequestException(
+                    "refused",
+                    new SocketException((int)SocketError.ConnectionRefused))))
+                .ConfigureAwait(false);
+
+            Assert.That(
+                async () => await channel
+                    .SendRequestAsync(new ReadRequest(), CancellationToken.None)
+                    .ConfigureAwait(false),
+                Throws.TypeOf<ServiceResultException>()
+                    .With.Property("StatusCode")
+                    .EqualTo((uint)StatusCodes.BadNotConnected));
+        }
+
+        /// <summary>
+        /// A rejected TLS handshake is permanent for this endpoint, so it is not
+        /// reported as "not connected" - that would tell the reconnect policy to
+        /// retry a request that fails the same way every time.
+        /// </summary>
+        [Test]
+        public async Task TlsFailureIsReportedAsBadSecurityChecksFailedAsync()
+        {
+            using HttpsTransportChannel channel = await CreateChannelAsync(
+                new StubHandler(_ => throw new HttpRequestException(
+                    "handshake",
+                    new AuthenticationException("certificate rejected"))))
+                .ConfigureAwait(false);
+
+            Assert.That(
+                async () => await channel
+                    .SendRequestAsync(new ReadRequest(), CancellationToken.None)
+                    .ConfigureAwait(false),
+                Throws.TypeOf<ServiceResultException>()
+                    .With.Property("StatusCode")
+                    .EqualTo((uint)StatusCodes.BadSecurityChecksFailed));
+        }
+
+        /// <summary>
+        /// An HTTP error status reached the server, so it is not a connect
+        /// failure either.
+        /// </summary>
+        [Test]
+        public async Task HttpErrorStatusIsReportedAsBadUnknownResponseAsync()
+        {
+            using HttpsTransportChannel channel = await CreateChannelAsync(
+                new StubHandler(_ => new HttpResponseMessage(
+                    HttpStatusCode.InternalServerError)
+                {
+                    Content = new ByteArrayContent([])
+                })).ConfigureAwait(false);
+
+            Assert.That(
+                async () => await channel
+                    .SendRequestAsync(new ReadRequest(), CancellationToken.None)
+                    .ConfigureAwait(false),
+                Throws.TypeOf<ServiceResultException>()
+                    .With.Property("StatusCode")
+                    .EqualTo((uint)StatusCodes.BadUnknownResponse));
+        }
+
+        private async Task<HttpsTransportChannel> CreateChannelAsync(StubHandler handler)
+        {
+            var channel = new HttpsTransportChannel(
+                Utils.UriSchemeHttps,
+                m_telemetry,
+                timeProvider: null,
+                httpClientFactory: new StubClientFactory(handler));
+
+            var url = new Uri("https://localhost:4840/UA");
+            EndpointConfiguration configuration = EndpointConfiguration.Create();
+            configuration.OperationTimeout = 10000;
+            configuration.MaxMessageSize = kMaxMessageSize;
+
+            await channel.OpenAsync(
+                url,
+                new TransportChannelSettings
+                {
+                    Description = new EndpointDescription { EndpointUrl = url.ToString() },
+                    Configuration = configuration,
+                    Factory = ServiceMessageContext.CreateEmpty(m_telemetry).Factory,
+                    NamespaceUris = new NamespaceTable()
+                },
+                CancellationToken.None).ConfigureAwait(false);
+
+            return channel;
+        }
+
+        private sealed class StubClientFactory : IOpcUaHttpClientFactory
+        {
+            public StubClientFactory(StubHandler handler)
+            {
+                m_handler = handler;
+            }
+
+            public HttpClient CreateClient(string name)
+            {
+                return new HttpClient(m_handler, disposeHandler: false);
+            }
+
+            private readonly StubHandler m_handler;
+        }
+
+        private sealed class StubHandler : HttpMessageHandler
+        {
+            public StubHandler(Func<HttpRequestMessage, HttpResponseMessage> responder)
+            {
+                m_responder = responder;
+            }
+
+            protected override Task<HttpResponseMessage> SendAsync(
+                HttpRequestMessage request,
+                CancellationToken cancellationToken)
+            {
+                return Task.FromResult(m_responder(request));
+            }
+
+            private readonly Func<HttpRequestMessage, HttpResponseMessage> m_responder;
+        }
+
+        /// <summary>
+        /// A body that reports no length and keeps producing bytes, which is
+        /// what a chunked response looks like to the reader.
+        /// </summary>
+        private sealed class UnboundedStream : Stream
+        {
+            public UnboundedStream(int totalBytes)
+            {
+                m_remaining = totalBytes;
+            }
+
+            public override bool CanRead => true;
+
+            public override bool CanSeek => false;
+
+            public override bool CanWrite => false;
+
+            public override long Length => throw new NotSupportedException();
+
+            public override long Position
+            {
+                get => throw new NotSupportedException();
+                set => throw new NotSupportedException();
+            }
+
+            public override int Read(byte[] buffer, int offset, int count)
+            {
+                int read = Math.Min(count, m_remaining);
+                m_remaining -= read;
+                return read;
+            }
+
+            public override void Flush()
+            {
+            }
+
+            public override long Seek(long offset, SeekOrigin origin)
+            {
+                throw new NotSupportedException();
+            }
+
+            public override void SetLength(long value)
+            {
+                throw new NotSupportedException();
+            }
+
+            public override void Write(byte[] buffer, int offset, int count)
+            {
+                throw new NotSupportedException();
+            }
+
+            private int m_remaining;
+        }
+    }
+}

--- a/tests/Opc.Ua.Core.Tests/Stack/Transport/TcpServerChannelBufferTests.cs
+++ b/tests/Opc.Ua.Core.Tests/Stack/Transport/TcpServerChannelBufferTests.cs
@@ -337,6 +337,128 @@ namespace Opc.Ua.Core.Tests.Stack.Transport
             Assert.That(channel.CurrentState, Is.EqualTo(TcpChannelState.Faulted));
         }
 
+        /// <summary>
+        /// <c>SaveIntermediateChunk</c> takes ownership unconditionally: a chunk
+        /// it does not queue goes straight back to the pool. It used to drop
+        /// such a chunk on the floor, which leaked one receive buffer per
+        /// request on a discovery-only channel - reachable by any unauthenticated
+        /// client of a server with no None endpoint.
+        /// </summary>
+        [Test]
+        public void SaveIntermediateChunkReturnsAChunkItDoesNotQueue()
+        {
+            var pool = new TrackingArrayPool();
+            using TestServerChannel channel = CreateOpenChannel(pool);
+
+            byte[] buffer = channel.TakeBufferForTest(64);
+            Assert.That(pool.OutstandingCount, Is.EqualTo(1));
+
+            // request id zero is the "not part of a request" case, which is not
+            // queued against a partial message.
+            channel.SaveIntermediateChunkForTest(
+                requestId: 0,
+                new ArraySegment<byte>(buffer, 0, 64));
+
+            Assert.That(pool.OutstandingCount, Is.Zero);
+            Assert.That(pool.DuplicateReturnCount, Is.Zero);
+        }
+
+        /// <summary>
+        /// The chunk that trips the request chunk limit is returned along with
+        /// the ones already buffered, rather than being abandoned while the
+        /// channel is torn down.
+        /// </summary>
+        [Test]
+        public async Task IntermediateChunksBeyondTheRequestChunkLimitReturnAllBuffersAsync()
+        {
+            var pool = new TrackingArrayPool();
+            using TestServerChannel channel = CreateOpenChannel(pool);
+            channel.SetMaxRequestChunkCountForTest(1);
+
+            for (uint sequenceNumber = 1; sequenceNumber <= 3; sequenceNumber++)
+            {
+                await channel.FeedReceivedChunkAsync(
+                    channel.CreateRequestChunkForTest(
+                        TcpMessageType.Message,
+                        isFinal: false,
+                        sequenceNumber,
+                        requestId: 1))
+                    .ConfigureAwait(false);
+            }
+
+            Assert.That(pool.RentCount, Is.EqualTo(3));
+            Assert.That(pool.OutstandingCount, Is.Zero);
+            Assert.That(pool.DuplicateReturnCount, Is.Zero);
+        }
+
+        /// <summary>
+        /// An intermediate CloseSecureChannel chunk is handed to the partial
+        /// message and reported as owned. Reporting it as not owned returned the
+        /// same buffer to the pool a second time, so two callers could then be
+        /// handed the same array.
+        /// </summary>
+        [Test]
+        public async Task IntermediateCloseSecureChannelChunkIsNotReturnedTwiceAsync()
+        {
+            var pool = new TrackingArrayPool();
+            TestServerChannel channel = CreateOpenChannel(pool);
+
+            try
+            {
+                await channel.FeedReceivedChunkAsync(
+                    channel.CreateRequestChunkForTest(
+                        TcpMessageType.Close,
+                        isFinal: false,
+                        sequenceNumber: 1,
+                        requestId: 1))
+                    .ConfigureAwait(false);
+
+                Assert.That(pool.DuplicateReturnCount, Is.Zero);
+                Assert.That(pool.OutstandingCount, Is.EqualTo(1));
+            }
+            finally
+            {
+                // the channel still owns the chunk; disposing it hands the
+                // unfinished message back.
+                channel.Dispose();
+            }
+
+            Assert.That(pool.OutstandingCount, Is.Zero);
+            Assert.That(pool.DuplicateReturnCount, Is.Zero);
+        }
+
+        /// <summary>
+        /// The chunks of a message the peer never finished are released when the
+        /// channel goes away, so a client that sends one intermediate chunk and
+        /// disconnects does not cost the pool a buffer per channel.
+        /// </summary>
+        [Test]
+        public async Task DisposeReleasesTheChunksOfAnUnfinishedMessageAsync()
+        {
+            var pool = new TrackingArrayPool();
+            TestServerChannel channel = CreateOpenChannel(pool);
+
+            try
+            {
+                await channel.FeedReceivedChunkAsync(
+                    channel.CreateRequestChunkForTest(
+                        TcpMessageType.Message,
+                        isFinal: false,
+                        sequenceNumber: 1,
+                        requestId: 1))
+                    .ConfigureAwait(false);
+
+                Assert.That(pool.OutstandingCount, Is.EqualTo(1));
+            }
+            finally
+            {
+                channel.Dispose();
+            }
+
+            Assert.That(pool.OutstandingCount, Is.Zero);
+            Assert.That(pool.DuplicateReturnCount, Is.Zero);
+        }
+
         private static TestServerChannel CreateOpenChannel(
             TrackingArrayPool pool,
             int maxBufferSize = 64 * 1024)
@@ -495,6 +617,48 @@ namespace Opc.Ua.Core.Tests.Stack.Transport
             public byte[] TakeBufferForTest(int size)
             {
                 return BufferManager.TakeBuffer(size, nameof(TakeBufferForTest));
+            }
+
+            public void SetMaxRequestChunkCountForTest(int maxRequestChunkCount)
+            {
+                MaxRequestChunkCount = maxRequestChunkCount;
+            }
+
+            public void SaveIntermediateChunkForTest(uint requestId, ArraySegment<byte> chunk)
+            {
+                SaveIntermediateChunk(requestId, chunk, isServerContext: true, gateHeld: false);
+            }
+
+            /// <summary>
+            /// Builds a chunk the symmetric read path accepts: the channel runs
+            /// with <see cref="MessageSecurityMode.None"/>, so the body needs no
+            /// signature or padding.
+            /// </summary>
+            public ArraySegment<byte> CreateRequestChunkForTest(
+                uint baseMessageType,
+                bool isFinal,
+                uint sequenceNumber,
+                uint requestId,
+                int bodySize = 8)
+            {
+                int length = TcpMessageLimits.SymmetricHeaderSize +
+                    TcpMessageLimits.SequenceHeaderSize +
+                    bodySize;
+                byte[] buffer = BufferManager.TakeBuffer(
+                    length,
+                    nameof(CreateRequestChunkForTest));
+
+                uint messageType = baseMessageType |
+                    (isFinal ? TcpMessageType.Final : TcpMessageType.Intermediate);
+
+                BitConverter.GetBytes(messageType).CopyTo(buffer, 0);
+                BitConverter.GetBytes(length).CopyTo(buffer, 4);
+                BitConverter.GetBytes(ChannelId).CopyTo(buffer, 8);
+                BitConverter.GetBytes(CurrentToken!.TokenId).CopyTo(buffer, 12);
+                BitConverter.GetBytes(sequenceNumber).CopyTo(buffer, 16);
+                BitConverter.GetBytes(requestId).CopyTo(buffer, 20);
+
+                return new ArraySegment<byte>(buffer, 0, length);
             }
 
             public ValueTask FeedReceivedChunkAsync(ArraySegment<byte> chunk)

--- a/tests/Opc.Ua.Core.Tests/Stack/Transport/TcpServerChannelDeterministicTests.cs
+++ b/tests/Opc.Ua.Core.Tests/Stack/Transport/TcpServerChannelDeterministicTests.cs
@@ -312,6 +312,156 @@ namespace Opc.Ua.Core.Tests.Stack.Transport
                 Is.EqualTo((uint)StatusCodes.BadCertificateUntrusted));
         }
 
+        /// <summary>
+        /// A reconnect binds a new socket to an existing channel, and the receive
+        /// loop has to follow it. The loop used to be guarded by a plain running
+        /// flag, so the second start was a no-op and the channel kept reading
+        /// from the socket the client had already dropped - nothing sent on the
+        /// new one was ever seen.
+        /// </summary>
+        [Test]
+        public async Task StartReceiveLoopFollowsAReplacedTransportAsync()
+        {
+            Mock<ITcpChannelListener> listenerMock = CreateListenerMock();
+            using TestServerChannel channel = BuildChannel(listenerMock);
+
+            (InProcessTransport first, InProcessTransport firstPeer) =
+                InProcessTransport.CreatePair(m_buffers, 8192, m_telemetry);
+            (InProcessTransport second, InProcessTransport secondPeer) =
+                InProcessTransport.CreatePair(m_buffers, 8192, m_telemetry);
+
+            try
+            {
+                channel.SetTransport(first);
+                channel.StartReceiveLoopForTest();
+
+                // the reconnect: a new socket for the same channel.
+                channel.SetTransport(second);
+                channel.StartReceiveLoopForTest();
+
+                await secondPeer
+                    .SendChunkAsync(CreateHelloChunk(), CancellationToken.None)
+                    .ConfigureAwait(false);
+
+                Assert.That(
+                    await WaitForChunkAsync(channel, 1).ConfigureAwait(false),
+                    Is.True,
+                    "the receive loop never read from the transport that replaced the first.");
+            }
+            finally
+            {
+                firstPeer.Close();
+                secondPeer.Close();
+                first.Close();
+                second.Close();
+            }
+        }
+
+        /// <summary>
+        /// Starting the loop again on the transport it is already serving is a
+        /// no-op, so a caller cannot put two readers on one socket.
+        /// </summary>
+        [Test]
+        public async Task StartReceiveLoopIsIdempotentForTheSameTransportAsync()
+        {
+            Mock<ITcpChannelListener> listenerMock = CreateListenerMock();
+            using TestServerChannel channel = BuildChannel(listenerMock);
+
+            (InProcessTransport transport, InProcessTransport peer) =
+                InProcessTransport.CreatePair(m_buffers, 8192, m_telemetry);
+
+            try
+            {
+                channel.SetTransport(transport);
+                channel.StartReceiveLoopForTest();
+                channel.StartReceiveLoopForTest();
+                channel.StartReceiveLoopForTest();
+
+                await peer
+                    .SendChunkAsync(CreateHelloChunk(), CancellationToken.None)
+                    .ConfigureAwait(false);
+
+                Assert.That(
+                    await WaitForChunkAsync(channel, 1).ConfigureAwait(false), Is.True);
+
+                // a second reader would have consumed a chunk of its own.
+                await Task.Delay(100).ConfigureAwait(false);
+                Assert.That(channel.ChunksReceived, Is.EqualTo(1));
+            }
+            finally
+            {
+                peer.Close();
+                transport.Close();
+            }
+        }
+
+        /// <summary>
+        /// Detaching the transport retires the loop, so a later start on a
+        /// reattached transport is not mistaken for one already serving it.
+        /// </summary>
+        [Test]
+        public async Task DetachTransportRetiresTheLoopAsync()
+        {
+            Mock<ITcpChannelListener> listenerMock = CreateListenerMock();
+            using TestServerChannel channel = BuildChannel(listenerMock);
+
+            (InProcessTransport transport, InProcessTransport peer) =
+                InProcessTransport.CreatePair(m_buffers, 8192, m_telemetry);
+
+            try
+            {
+                channel.SetTransport(transport);
+                channel.StartReceiveLoopForTest();
+
+                Assert.That(channel.DetachTransportForTest(), Is.SameAs(transport));
+
+                channel.SetTransport(transport);
+                channel.StartReceiveLoopForTest();
+
+                await peer
+                    .SendChunkAsync(CreateHelloChunk(), CancellationToken.None)
+                    .ConfigureAwait(false);
+
+                Assert.That(
+                    await WaitForChunkAsync(channel, 1).ConfigureAwait(false),
+                    Is.True,
+                    "the loop did not restart on the reattached transport.");
+            }
+            finally
+            {
+                peer.Close();
+                transport.Close();
+            }
+        }
+
+        private static byte[] CreateHelloChunk()
+        {
+            byte[] chunk = new byte[32];
+            BinaryPrimitives.WriteUInt32LittleEndian(
+                chunk.AsSpan(0), TcpMessageType.Hello | TcpMessageType.Final);
+            BinaryPrimitives.WriteUInt32LittleEndian(chunk.AsSpan(4), (uint)chunk.Length);
+            return chunk;
+        }
+
+        private static async Task<bool> WaitForChunkAsync(
+            TestServerChannel channel,
+            int expected)
+        {
+            DateTime deadline = DateTime.UtcNow.AddSeconds(10);
+
+            while (DateTime.UtcNow < deadline)
+            {
+                if (channel.ChunksReceived >= expected)
+                {
+                    return true;
+                }
+
+                await Task.Delay(10).ConfigureAwait(false);
+            }
+
+            return false;
+        }
+
         private TestServerChannel BuildChannel(Mock<ITcpChannelListener> listenerMock)
         {
             return new TestServerChannel(
@@ -451,6 +601,28 @@ namespace Opc.Ua.Core.Tests.Stack.Transport
             {
                 Transport = transport;
             }
+
+            public int ChunksReceived => Volatile.Read(ref m_chunksReceived);
+
+            public void StartReceiveLoopForTest()
+            {
+                StartReceiveLoop();
+            }
+
+            public IUaSCByteTransport? DetachTransportForTest()
+            {
+                return DetachTransport();
+            }
+
+            protected override ValueTask OnChunkReceivedAsync(
+                ArraySegment<byte> message,
+                CancellationToken ct)
+            {
+                Interlocked.Increment(ref m_chunksReceived);
+                return base.OnChunkReceivedAsync(message, ct);
+            }
+
+            private int m_chunksReceived;
 
             public ValueTask<bool> FeedIncomingMessageAsync(
                 uint messageType,

--- a/tests/Opc.Ua.Core.Tests/Stack/Transport/UaSCBinaryChannelNonceTests.cs
+++ b/tests/Opc.Ua.Core.Tests/Stack/Transport/UaSCBinaryChannelNonceTests.cs
@@ -1,0 +1,156 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+#nullable enable
+
+using System.Collections.Generic;
+using NUnit.Framework;
+using Opc.Ua.Bindings;
+using Opc.Ua.Security.Certificates;
+using Opc.Ua.Tests;
+
+namespace Opc.Ua.Core.Tests.Stack.Transport
+{
+    /// <summary>
+    /// Nonce validation on the secure-channel path for the RSA Diffie-Hellman
+    /// security policies.
+    /// </summary>
+    /// <remarks>
+    /// The peer's nonce carries its Diffie-Hellman public value, and a value
+    /// outside 2 &lt;= y &lt;= p-2 is rejected. That rejection is raised as an
+    /// exception from the key-agreement code; the channel has to answer
+    /// <see langword="false"/> so the caller reports BadNonceInvalid, rather
+    /// than letting an unauthenticated peer turn a chosen nonce into an
+    /// unhandled exception on the receive path.
+    /// </remarks>
+    [TestFixture]
+    [Category("TransportChannelDeterministic")]
+    [SetCulture("en-us")]
+    [SetUICulture("en-us")]
+    [Parallelizable]
+    public sealed class UaSCBinaryChannelNonceTests
+    {
+        private ITelemetryContext m_telemetry = null!;
+        private BufferManager m_buffers = null!;
+        private ChannelQuotas m_quotas = null!;
+
+        [SetUp]
+        public void SetUp()
+        {
+            m_telemetry = NUnitTelemetryContext.Create();
+            m_buffers = new BufferManager("nonce-test", 8192, m_telemetry);
+            m_quotas = new ChannelQuotas(ServiceMessageContext.Create(m_telemetry));
+        }
+
+        /// <summary>
+        /// Zero, one and a value at or above the modulus all pin the shared
+        /// secret to something the peer already knows.
+        /// </summary>
+        [TestCase((byte)0x00, false)]
+        [TestCase((byte)0x01, false)]
+        [TestCase((byte)0xFF, true)]
+        public void ValidateNonceRejectsDegenerateDiffieHellmanValues(
+            byte lastByte,
+            bool fillAll)
+        {
+            using TestChannel channel = CreateChannel();
+
+            byte[] nonce = new byte[NonceLength];
+
+            if (fillAll)
+            {
+                for (int ii = 0; ii < nonce.Length; ii++)
+                {
+                    nonce[ii] = lastByte;
+                }
+            }
+            else
+            {
+                nonce[^1] = lastByte;
+            }
+
+            Assert.That(channel.ValidateNonceForTest(nonce), Is.False);
+        }
+
+        /// <summary>
+        /// A nonce the stack itself produces is accepted, so the range check
+        /// rejects the degenerate values and nothing else.
+        /// </summary>
+        [Test]
+        public void ValidateNonceAcceptsAWellFormedNonce()
+        {
+            using TestChannel channel = CreateChannel();
+            using Nonce nonce = Nonce.CreateNonce(SecurityPolicyInfo.RSA_DH_AesGcm);
+
+            byte[]? data = nonce.Data;
+            Assert.That(data, Is.Not.Null);
+            Assert.That(channel.ValidateNonceForTest(data!), Is.True);
+        }
+
+        [Test]
+        public void ValidateNonceRejectsAWrongLengthNonce()
+        {
+            using TestChannel channel = CreateChannel();
+
+            Assert.That(channel.ValidateNonceForTest(new byte[NonceLength - 1]), Is.False);
+        }
+
+        private const int NonceLength = 384;
+
+        private TestChannel CreateChannel()
+        {
+            return new TestChannel(m_buffers, m_quotas, m_telemetry);
+        }
+
+        private sealed class TestChannel : UaSCUaBinaryChannel
+        {
+            public TestChannel(
+                BufferManager bufferManager,
+                ChannelQuotas quotas,
+                ITelemetryContext telemetry)
+                : base(
+                    "nonce-test",
+                    bufferManager,
+                    quotas,
+                    (Certificate?)null,
+                    new List<EndpointDescription>(),
+                    MessageSecurityMode.SignAndEncrypt,
+                    SecurityPolicies.RSA_DH_AesGcm,
+                    telemetry)
+            {
+            }
+
+            public bool ValidateNonceForTest(byte[] nonce)
+            {
+                return ValidateNonce(null, nonce);
+            }
+        }
+    }
+}

--- a/tests/Opc.Ua.Core.Tests/Stack/Transport/UaSCBinaryChannelNonceTests.cs
+++ b/tests/Opc.Ua.Core.Tests/Stack/Transport/UaSCBinaryChannelNonceTests.cs
@@ -64,6 +64,16 @@ namespace Opc.Ua.Core.Tests.Stack.Transport
         [SetUp]
         public void SetUp()
         {
+            // The RSA Diffie-Hellman policies are AEAD, so a platform without
+            // AES-GCM does not offer them and the channel would have no security
+            // policy to validate against - every case below would then pass by
+            // rejecting everything, which proves nothing.
+            if (SecurityPolicies.Default.GetInfo(SecurityPolicies.RSA_DH_AesGcm) == null)
+            {
+                Assert.Ignore(
+                    "The RSA_DH_AesGcm security policy is not supported on this platform.");
+            }
+
             m_telemetry = NUnitTelemetryContext.Create();
             m_buffers = new BufferManager("nonce-test", 8192, m_telemetry);
             m_quotas = new ChannelQuotas(ServiceMessageContext.Create(m_telemetry));

--- a/tests/Opc.Ua.Core.Tests/Types/BuiltIn/SessionLessServiceMessageTests.cs
+++ b/tests/Opc.Ua.Core.Tests/Types/BuiltIn/SessionLessServiceMessageTests.cs
@@ -58,5 +58,50 @@ namespace Opc.Ua.Core.Tests.Types.BuiltIn
             Assert.That(serverUrisEncoded, Has.Length.EqualTo(1));
             Assert.Contains(expectedServerUri, serverUrisEncoded);
         }
+
+        /// <summary>
+        /// Every configured locale id is encoded. The list used to be written
+        /// only when it held more than one entry - the reserved-first-entry rule
+        /// the namespace and server tables follow, which a locale table does not
+        /// - so a client that asked for a single locale had it silently dropped.
+        /// </summary>
+        [TestCase(1)]
+        [TestCase(2)]
+        public void EncodeWritesEveryConfiguredLocaleId(int localeCount)
+        {
+            ITelemetryContext telemetry = NUnitTelemetryContext.Create();
+
+            string[] locales = localeCount == 1
+                ? ["en-US"]
+                : ["en-US", "de-DE"];
+
+            var context = new ServiceMessageContext(telemetry, EncodeableFactory.Create());
+            string result;
+
+            using (var jsonEncoder = new JsonEncoder(context, JsonEncoderOptions.Verbose))
+            {
+                var envelope = new SessionLessServiceMessage
+                {
+                    UriVersion = 1,
+                    NamespaceUris = context.NamespaceUris,
+                    ServerUris = context.ServerUris,
+                    LocaleIds = new StringTable(locales),
+                    Message = null
+                };
+
+                envelope.Encode(jsonEncoder);
+                result = jsonEncoder.CloseAndReturnText();
+            }
+
+            JsonNode jObject = JsonNode.Parse(result);
+            Assert.That(jObject, Is.Not.Null);
+
+            JsonNode localeIdsToken = jObject["LocaleIds"];
+            Assert.That(localeIdsToken, Is.Not.Null);
+
+            string[] localeIdsEncoded = JsonSerializer.Deserialize<string[]>(
+                localeIdsToken.ToJsonString());
+            Assert.That(localeIdsEncoded, Is.EqualTo(locales));
+        }
     }
 }

--- a/tests/Opc.Ua.Core.Tests/Types/ContentFilter/FilterEvaluatorCoverageTests.cs
+++ b/tests/Opc.Ua.Core.Tests/Types/ContentFilter/FilterEvaluatorCoverageTests.cs
@@ -246,15 +246,26 @@ namespace Opc.Ua.Core.Tests.Types.ContentFilter
         }
 
         [Test]
-        public void InListWithStringNonMemberYieldsFalse()
+        public void InListWithStringMemberAfterMismatchYieldsTrue()
         {
-            // For string operands InList compares against the first list entry only and
-            // returns that comparison result, so a leading mismatch yields false.
+            // A leading mismatch only rules out that operand; the remaining
+            // list entries are still compared.
             ContentFilterElement element = Element(
                 FilterOperator.InList,
                 new LiteralOperand(Variant.From("x")),
                 new LiteralOperand(Variant.From("a")),
                 new LiteralOperand(Variant.From("x")));
+            Assert.That(Filter(element).Evaluate(m_context, m_target), Is.True);
+        }
+
+        [Test]
+        public void InListWithStringNonMemberYieldsFalse()
+        {
+            ContentFilterElement element = Element(
+                FilterOperator.InList,
+                new LiteralOperand(Variant.From("x")),
+                new LiteralOperand(Variant.From("a")),
+                new LiteralOperand(Variant.From("b")));
             Assert.That(Filter(element).Evaluate(m_context, m_target), Is.False);
         }
 

--- a/tests/Opc.Ua.Core.Tests/Types/DataGeneratorTests.cs
+++ b/tests/Opc.Ua.Core.Tests/Types/DataGeneratorTests.cs
@@ -136,5 +136,115 @@ namespace Opc.Ua.Core.Tests.Types
                 "GetRandomNodeId(useBoundaryValues: true) never returned a null " +
                 "node id, so the boundary values are no longer reachable.");
         }
+
+        /// <summary>
+        /// The random bits are read back as a double. They used to be read back
+        /// as a float and widened, so the generator never produced a value
+        /// outside the float range and the whole upper exponent range of the
+        /// type went untested by everything built on it.
+        /// </summary>
+        [Test]
+        public void GetRandomDoubleCoversTheFullDoubleRange()
+        {
+            var generator = new DataGenerator(new RandomSource(42), NUnitTelemetryContext.Create());
+            bool sawBeyondSingleRange = false;
+
+            for (int ii = 0; ii < 2000 && !sawBeyondSingleRange; ii++)
+            {
+                double value = generator.GetRandomDouble();
+
+                sawBeyondSingleRange = !double.IsNaN(value) &&
+                    !double.IsInfinity(value) &&
+                    System.Math.Abs(value) > float.MaxValue;
+            }
+
+            Assert.That(sawBeyondSingleRange, Is.True,
+                "GetRandomDouble never produced a finite value outside the range " +
+                "of a float, so it is still reading the random bits as a float.");
+        }
+
+        /// <summary>
+        /// The typed array generators honour the type they picked. They used to
+        /// pick one and then fill the array from the unconstrained variant
+        /// generator, so an "integer array" could come back full of strings and
+        /// date times.
+        /// </summary>
+        [TestCaseSource(nameof(TypedArrayCases))]
+        public void TypedVariantArraysHoldOnlyTheirOwnTypes(
+            string name,
+            BuiltInType[] allowed)
+        {
+            var generator = new DataGenerator(new RandomSource(42), NUnitTelemetryContext.Create());
+
+            for (int attempt = 0; attempt < 50; attempt++)
+            {
+                Variant[] values = GenerateTypedArray(generator, name);
+
+                foreach (Variant value in values)
+                {
+                    Assert.That(
+                        value.TypeInfo.BuiltInType,
+                        Is.AnyOf(allowed),
+                        $"{name} produced a {value.TypeInfo.BuiltInType} element.");
+                }
+            }
+        }
+
+        private static Variant[] GenerateTypedArray(DataGenerator generator, string name)
+        {
+            return name switch
+            {
+                nameof(DataGenerator.GetRandomUIntegerArray) =>
+                    generator.GetRandomUIntegerArray(false, 16, true),
+                nameof(DataGenerator.GetRandomIntegerArray) =>
+                    generator.GetRandomIntegerArray(false, 16, true),
+                _ => generator.GetRandomNumberArray(false, 16, true)
+            };
+        }
+
+        public static IEnumerable<object[]> TypedArrayCases()
+        {
+            yield return
+            [
+                nameof(DataGenerator.GetRandomUIntegerArray),
+                new[]
+                {
+                    BuiltInType.Byte,
+                    BuiltInType.UInt16,
+                    BuiltInType.UInt32,
+                    BuiltInType.UInt64
+                }
+            ];
+
+            yield return
+            [
+                nameof(DataGenerator.GetRandomIntegerArray),
+                new[]
+                {
+                    BuiltInType.SByte,
+                    BuiltInType.Int16,
+                    BuiltInType.Int32,
+                    BuiltInType.Int64
+                }
+            ];
+
+            yield return
+            [
+                nameof(DataGenerator.GetRandomNumberArray),
+                new[]
+                {
+                    BuiltInType.SByte,
+                    BuiltInType.Byte,
+                    BuiltInType.Int16,
+                    BuiltInType.UInt16,
+                    BuiltInType.Int32,
+                    BuiltInType.UInt32,
+                    BuiltInType.Int64,
+                    BuiltInType.UInt64,
+                    BuiltInType.Float,
+                    BuiltInType.Double
+                }
+            ];
+        }
     }
 }

--- a/tests/Opc.Ua.Core.Tests/Types/Nonce/RsaDiffieHellmanPeerValueTests.cs
+++ b/tests/Opc.Ua.Core.Tests/Types/Nonce/RsaDiffieHellmanPeerValueTests.cs
@@ -1,0 +1,229 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using System.Globalization;
+using NUnit.Framework;
+
+namespace Opc.Ua.Core.Tests.Types.Nonce
+{
+    /// <summary>
+    /// Regression tests for the peer public value validation in
+    /// <see cref="RSADiffieHellman"/>.
+    /// </summary>
+    /// <remarks>
+    /// A finite field Diffie-Hellman peer value has to lie in
+    /// <c>2 &lt;= y &lt;= p-2</c> (RFC 7919 5.1). Without that check a peer can
+    /// send 0, 1 or p-1 and pin the shared secret to a value it already knows,
+    /// which pins every key derived from it for the channel.
+    /// </remarks>
+    [TestFixture]
+    [Category("NonceTests")]
+    [Parallelizable]
+    [SetCulture("en-us")]
+    public class RsaDiffieHellmanPeerValueTests
+    {
+        /// <summary>
+        /// The ffdhe2048 prime from RFC 7919 Appendix A.1, which is the group a
+        /// 256 byte RSA-DH nonce belongs to.
+        /// </summary>
+        private const string kFfdhe2048Hex =
+            "FFFFFFFFFFFFFFFFADF85458A2BB4A9AAFDC5620273D3CF1D8B9C583CE2D3695A9E13641146433FBCC939DCE249B3EF9" +
+            "7D2FE363630C75D8F681B202AEC4617AD3DF1ED5D5FD65612433F51F5F066ED0856365553DED1AF3B557135E7F57C935" +
+            "984F0C70E0E68B77E2A689DAF3EFE8721DF158A136ADE73530ACCA4F483A797ABC0AB182B324FB61D108A94BB2C8E3FB" +
+            "B96ADAB760D7F4681D4F42A3DE394DF4AE56EDE76372BB190B07A7C8EE0A6D709E02FCE1CDF7E2ECC03404CD28342F61" +
+            "9172FE9CE98583FF8E4F1232EEF28183C3FE3B1B4C6FAD733BB5FCBC2EC22005C58EF1837D1683B2C6F34A26C1B2EFFA" +
+            "886B423861285C97FFFFFFFFFFFFFFFF";
+
+        private const int kFfdhe2048NonceSize = 256;
+
+        /// <summary>
+        /// Zero and one are the degenerate peer values: the shared secret comes
+        /// out as zero or one no matter what private key this side holds.
+        /// </summary>
+        [TestCase(0UL)]
+        [TestCase(1UL)]
+        public void CreateRejectsPeerValueBelowTwo(ulong value)
+        {
+            byte[] nonce = new byte[kFfdhe2048NonceSize];
+            nonce[^1] = (byte)value;
+
+            Assert.That(
+                () => RSADiffieHellman.Create(nonce),
+                Throws.ArgumentException);
+        }
+
+        /// <summary>
+        /// p-1 has order two, so the shared secret is either one or p-1 and an
+        /// observer guesses it with one bit. p itself is congruent to zero.
+        /// </summary>
+        [TestCase(1)]
+        [TestCase(0)]
+        public void CreateRejectsPeerValueAtOrAboveModulusMinusOne(int subtract)
+        {
+            byte[] nonce = GetModulus();
+            nonce[^1] -= (byte)subtract;
+
+            Assert.That(
+                () => RSADiffieHellman.Create(nonce),
+                Throws.ArgumentException);
+        }
+
+        /// <summary>
+        /// A value above the modulus is outside the group altogether.
+        /// </summary>
+        [Test]
+        public void CreateRejectsPeerValueAboveTheModulus()
+        {
+            byte[] nonce = new byte[kFfdhe2048NonceSize];
+
+            for (int ii = 0; ii < nonce.Length; ii++)
+            {
+                nonce[ii] = 0xFF;
+            }
+
+            Assert.That(
+                () => RSADiffieHellman.Create(nonce),
+                Throws.ArgumentException);
+        }
+
+        /// <summary>
+        /// Both ends of the valid range are accepted, so the check rejects the
+        /// degenerate values and nothing else.
+        /// </summary>
+        [Test]
+        public void CreateAcceptsPeerValuesInsideTheGroup()
+        {
+            byte[] lowest = new byte[kFfdhe2048NonceSize];
+            lowest[^1] = 2;
+
+            byte[] highest = GetModulus();
+            highest[^1] -= 2;
+
+            Assert.That(RSADiffieHellman.Create(lowest), Is.Not.Null);
+            Assert.That(RSADiffieHellman.Create(highest), Is.Not.Null);
+        }
+
+        /// <summary>
+        /// A nonce whose length names no supported group is data the peer sent,
+        /// so it is rejected rather than resolved to some default group.
+        /// </summary>
+        [TestCase(0)]
+        [TestCase(32)]
+        [TestCase(255)]
+        [TestCase(257)]
+        public void CreateRejectsUnsupportedNonceLength(int length)
+        {
+            byte[] nonce = new byte[length];
+
+            if (length > 0)
+            {
+                nonce[^1] = 2;
+            }
+
+            Assert.That(
+                () => RSADiffieHellman.Create(nonce),
+                Throws.ArgumentException);
+        }
+
+        [Test]
+        public void CreateRejectsNullNonce()
+        {
+            Assert.That(
+                () => RSADiffieHellman.Create(null!),
+                Throws.ArgumentNullException);
+        }
+
+        /// <summary>
+        /// The nonce a locally generated key publishes is accepted by the peer
+        /// and both sides arrive at the same secret, so the range check does not
+        /// reject anything the stack itself produces.
+        /// </summary>
+        [Test]
+        public void PeersDeriveTheSameSecretAgreement()
+        {
+            RSADiffieHellman local = RSADiffieHellman.Create(RSADiffieHellmanGroup.FFDHE2048);
+            RSADiffieHellman remote = RSADiffieHellman.Create(RSADiffieHellmanGroup.FFDHE2048);
+
+            byte[] fromLocal = local.DeriveRawSecretAgreement(
+                RSADiffieHellman.Create(remote.GetNonce()));
+            byte[] fromRemote = remote.DeriveRawSecretAgreement(
+                RSADiffieHellman.Create(local.GetNonce()));
+
+            Assert.That(fromLocal, Is.EqualTo(fromRemote));
+            Assert.That(fromLocal, Is.Not.All.Zero);
+        }
+
+        /// <summary>
+        /// A remote key belonging to a different group is rejected. The check is
+        /// repeated here because a key can be built without going through
+        /// <c>Create(byte[])</c>.
+        /// </summary>
+        [Test]
+        public void DeriveRawSecretAgreementRejectsRemoteKeyFromAnotherGroup()
+        {
+            RSADiffieHellman local = RSADiffieHellman.Create(RSADiffieHellmanGroup.FFDHE2048);
+            RSADiffieHellman remote = RSADiffieHellman.Create(RSADiffieHellmanGroup.FFDHE3072);
+
+            Assert.That(
+                () => local.DeriveRawSecretAgreement(
+                    RSADiffieHellman.Create(remote.GetNonce())),
+                Throws.ArgumentException);
+        }
+
+        [Test]
+        public void DeriveRawSecretAgreementRejectsNullRemoteKey()
+        {
+            RSADiffieHellman local = RSADiffieHellman.Create(RSADiffieHellmanGroup.FFDHE2048);
+
+            Assert.That(
+                () => local.DeriveRawSecretAgreement(null!),
+                Throws.ArgumentNullException);
+        }
+
+        /// <summary>
+        /// The ffdhe2048 prime as a big endian nonce of the group's size.
+        /// </summary>
+        private static byte[] GetModulus()
+        {
+            byte[] modulus = new byte[kFfdhe2048NonceSize];
+
+            for (int ii = 0; ii < modulus.Length; ii++)
+            {
+                modulus[ii] = byte.Parse(
+                    kFfdhe2048Hex.AsSpan(ii * 2, 2),
+                    NumberStyles.HexNumber,
+                    CultureInfo.InvariantCulture);
+            }
+
+            return modulus;
+        }
+    }
+}

--- a/tests/Opc.Ua.Core.Tests/Types/Nonce/RsaDiffieHellmanPeerValueTests.cs
+++ b/tests/Opc.Ua.Core.Tests/Types/Nonce/RsaDiffieHellmanPeerValueTests.cs
@@ -29,7 +29,6 @@
  * ======================================================================*/
 
 using System;
-using System.Globalization;
 using NUnit.Framework;
 
 namespace Opc.Ua.Core.Tests.Types.Nonce
@@ -217,13 +216,27 @@ namespace Opc.Ua.Core.Tests.Types.Nonce
 
             for (int ii = 0; ii < modulus.Length; ii++)
             {
-                modulus[ii] = byte.Parse(
-                    kFfdhe2048Hex.AsSpan(ii * 2, 2),
-                    NumberStyles.HexNumber,
-                    CultureInfo.InvariantCulture);
+                modulus[ii] = (byte)(
+                    (ParseHexDigit(kFfdhe2048Hex[ii * 2]) << 4) |
+                    ParseHexDigit(kFfdhe2048Hex[(ii * 2) + 1]));
             }
 
             return modulus;
+        }
+
+        /// <summary>
+        /// Parses one hex digit. Written out rather than parsing a substring,
+        /// which allocates, or a span of the literal, which .NET Framework
+        /// cannot parse and this suite also builds for.
+        /// </summary>
+        private static int ParseHexDigit(char digit)
+        {
+            if (digit is >= '0' and <= '9')
+            {
+                return digit - '0';
+            }
+
+            return char.ToUpperInvariant(digit) - 'A' + 10;
         }
     }
 }

--- a/tests/Opc.Ua.Core.Tests/Types/Utils/TraceLoggerProviderTests.cs
+++ b/tests/Opc.Ua.Core.Tests/Types/Utils/TraceLoggerProviderTests.cs
@@ -93,6 +93,72 @@ namespace Opc.Ua.Core.Tests.Types.UtilsTests
             Assert.That(message, Does.Contain("rejected"));
         }
 
+        /// <summary>
+        /// The logger reports a level enabled when the trace mask lets it
+        /// through, with no Tracing handler subscribed. IsEnabled used to
+        /// consult only the handler, so every source-generated log call - which
+        /// checks IsEnabled before doing any work - short-circuited and nothing
+        /// reached the trace file in the usual case of no subscriber.
+        /// </summary>
+        [Test]
+        public void LoggerIsEnabledFollowsTheTraceMaskWithoutATracingHandler()
+        {
+            using var provider = new TraceLoggerProvider();
+            provider.SetTraceMask(Utils.TraceMasks.Error);
+
+            ILogger logger = provider.CreateLogger("category");
+
+            Assert.That(logger.IsEnabled(LogLevel.Error), Is.True);
+            Assert.That(logger.IsEnabled(LogLevel.Information), Is.False);
+        }
+
+        /// <summary>
+        /// A level the mask excludes stays disabled, so the mask is honoured
+        /// rather than everything being reported enabled.
+        /// </summary>
+        [Test]
+        public void LoggerIsEnabledReportsFalseWhenNothingIsMasked()
+        {
+            using var provider = new TraceLoggerProvider();
+            provider.SetTraceMask(0);
+
+            ILogger logger = provider.CreateLogger("category");
+
+            Assert.That(logger.IsEnabled(LogLevel.Error), Is.False);
+            Assert.That(logger.IsEnabled(LogLevel.Information), Is.False);
+        }
+
+        /// <summary>
+        /// A source-generated style call guarded by IsEnabled reaches the trace
+        /// file, which is the behaviour the IsEnabled fix restores.
+        /// </summary>
+        [Test]
+        public void LoggerWritesWhenTheCallIsGuardedByIsEnabled()
+        {
+            string directory = Path.Combine(
+                TestContext.CurrentContext.WorkDirectory,
+                "TraceLoggerProviderTests",
+                Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(directory);
+            string logFile = Path.Combine(directory, "trace.log");
+
+            using var provider = new TraceLoggerProvider();
+            provider.SetTraceOutput(Utils.TraceOutput.FileOnly);
+            provider.SetTraceMask(Utils.TraceMasks.Error);
+            provider.SetTraceLog(logFile, deleteExisting: true);
+
+            ILogger logger = provider.CreateLogger("category");
+
+            if (logger.IsEnabled(LogLevel.Error))
+            {
+                logger.LogError("Guarded {Value}", 23);
+            }
+
+            string text = File.ReadAllText(logFile);
+            Assert.That(text, Does.Contain("Guarded 23"));
+            Directory.Delete(directory, true);
+        }
+
         [Test]
         public void LoggerLogWritesFormattedExceptionWhenMaskIsEnabled()
         {

--- a/tests/Opc.Ua.Core.Tests/Types/Utils/TraceLoggerProviderTests.cs
+++ b/tests/Opc.Ua.Core.Tests/Types/Utils/TraceLoggerProviderTests.cs
@@ -94,22 +94,67 @@ namespace Opc.Ua.Core.Tests.Types.UtilsTests
         }
 
         /// <summary>
-        /// The logger reports a level enabled when the trace mask lets it
-        /// through, with no Tracing handler subscribed. IsEnabled used to
-        /// consult only the handler, so every source-generated log call - which
-        /// checks IsEnabled before doing any work - short-circuited and nothing
-        /// reached the trace file in the usual case of no subscriber.
+        /// The logger reports enabled when a trace mask is configured, with no
+        /// Tracing handler subscribed. IsEnabled used to consult only the
+        /// handler, so every source-generated log call - which checks IsEnabled
+        /// before doing any work - short-circuited and nothing reached the trace
+        /// file in the usual case of no subscriber.
         /// </summary>
-        [Test]
-        public void LoggerIsEnabledFollowsTheTraceMaskWithoutATracingHandler()
+        /// <remarks>
+        /// It answers for the configuration as a whole rather than for the
+        /// level: a core event id carries its own category bits, so a mask
+        /// derived from the level alone would report a configured category
+        /// disabled. Log() applies the exact, event-specific filter.
+        /// </remarks>
+        [TestCase(LogLevel.Error)]
+        [TestCase(LogLevel.Information)]
+        [TestCase(LogLevel.Trace)]
+        public void LoggerIsEnabledFollowsTheTraceMaskWithoutATracingHandler(LogLevel logLevel)
         {
             using var provider = new TraceLoggerProvider();
             provider.SetTraceMask(Utils.TraceMasks.Error);
 
             ILogger logger = provider.CreateLogger("category");
 
-            Assert.That(logger.IsEnabled(LogLevel.Error), Is.True);
-            Assert.That(logger.IsEnabled(LogLevel.Information), Is.False);
+            Assert.That(logger.IsEnabled(logLevel), Is.True);
+        }
+
+        /// <summary>
+        /// A call whose event id carries a category the mask has enabled still
+        /// reaches the trace file, even though its level maps to a different
+        /// mask bit. This is the case a level-derived IsEnabled dropped.
+        /// </summary>
+        [Test]
+        public void LoggerWritesWhenOnlyTheEventIdCategoryIsMasked()
+        {
+            string directory = Path.Combine(
+                TestContext.CurrentContext.WorkDirectory,
+                "TraceLoggerProviderTests",
+                Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(directory);
+            string logFile = Path.Combine(directory, "trace.log");
+
+            using var provider = new TraceLoggerProvider();
+            provider.SetTraceOutput(Utils.TraceOutput.FileOnly);
+            provider.SetTraceMask(Utils.TraceMasks.ServiceDetail);
+            provider.SetTraceLog(logFile, deleteExisting: true);
+
+            ILogger logger = provider.CreateLogger("category");
+            var eventId = new EventId(Utils.TraceMasks.ServiceDetail, "ServiceDetail");
+
+            if (logger.IsEnabled(LogLevel.Information))
+            {
+                logger.Log(
+                    LogLevel.Information,
+                    eventId,
+                    "Detail {Value}",
+                    null,
+                    (state, _) => "Detail 31");
+            }
+
+            string text = File.ReadAllText(logFile);
+            Assert.That(text, Does.Contain("Detail 31"));
+            Directory.Delete(directory, true);
         }
 
         /// <summary>

--- a/tests/Opc.Ua.Core.Tests/Types/Utils/UtilsAdditionalTests.cs
+++ b/tests/Opc.Ua.Core.Tests/Types/Utils/UtilsAdditionalTests.cs
@@ -624,6 +624,94 @@ namespace Opc.Ua.Core.Tests.Types.UtilsTests
             Assert.That(parsed, Is.EqualTo("decoded"));
         }
 
+        /// <summary>
+        /// Passing the default value deletes the extension. The delete never
+        /// happened: the method encoded nothing for a default value, then
+        /// returned early because the empty document had no root element, so the
+        /// removal below it was unreachable.
+        /// </summary>
+        [Test]
+        public void UpdateExtensionWithDefaultValueRemovesTheExtension()
+        {
+            var extensions = new ArrayOf<Opc.Ua.XmlElement>();
+            var elementName = new XmlQualifiedName("SampleExtension", "urn:test");
+            ITelemetryContext telemetry = NUnitTelemetryContext.Create();
+
+            Utils.UpdateExtension(
+                ref extensions,
+                elementName,
+                "alpha",
+                telemetry,
+                (encoder, value) => encoder.WriteString("Value", value));
+            Assert.That(extensions, Has.Count.EqualTo(1));
+
+            Utils.UpdateExtension<string>(
+                ref extensions,
+                elementName,
+                null,
+                telemetry,
+                (encoder, value) => encoder.WriteString("Value", value));
+
+            Assert.That(extensions, Is.Empty);
+        }
+
+        /// <summary>
+        /// Deleting an extension leaves the others alone.
+        /// </summary>
+        [Test]
+        public void UpdateExtensionWithDefaultValueKeepsOtherExtensions()
+        {
+            var extensions = new ArrayOf<Opc.Ua.XmlElement>();
+            var first = new XmlQualifiedName("FirstExtension", "urn:test");
+            var second = new XmlQualifiedName("SecondExtension", "urn:test");
+            ITelemetryContext telemetry = NUnitTelemetryContext.Create();
+
+            Utils.UpdateExtension(
+                ref extensions,
+                first,
+                "alpha",
+                telemetry,
+                (encoder, value) => encoder.WriteString("Value", value));
+            Utils.UpdateExtension(
+                ref extensions,
+                second,
+                "beta",
+                telemetry,
+                (encoder, value) => encoder.WriteString("Value", value));
+            Assert.That(extensions, Has.Count.EqualTo(2));
+
+            Utils.UpdateExtension<string>(
+                ref extensions,
+                first,
+                null,
+                telemetry,
+                (encoder, value) => encoder.WriteString("Value", value));
+
+            Assert.That(extensions, Has.Count.EqualTo(1));
+            Assert.That(extensions[0].AsXmlElement().OuterXml, Does.Contain("beta"));
+        }
+
+        /// <summary>
+        /// Deleting an extension that is not there is a no-op rather than an
+        /// empty element being added.
+        /// </summary>
+        [Test]
+        public void UpdateExtensionWithDefaultValueOnAnAbsentExtensionAddsNothing()
+        {
+            var extensions = new ArrayOf<Opc.Ua.XmlElement>();
+            var elementName = new XmlQualifiedName("SampleExtension", "urn:test");
+            ITelemetryContext telemetry = NUnitTelemetryContext.Create();
+
+            Utils.UpdateExtension<string>(
+                ref extensions,
+                elementName,
+                null,
+                telemetry,
+                (encoder, value) => encoder.WriteString("Value", value));
+
+            Assert.That(extensions, Is.Empty);
+        }
+
         [Test]
         public void UpdateEncodeableExtensionAddsReplacesAndParses()
         {

--- a/tests/Opc.Ua.Core.Tests/Types/Utils/UtilsConversionTests.cs
+++ b/tests/Opc.Ua.Core.Tests/Types/Utils/UtilsConversionTests.cs
@@ -340,13 +340,19 @@ namespace Opc.Ua.Core.Tests.Types.UtilsTests
         [Test]
         public void IsUriHttpRelatedSchemeWithHttp()
         {
-            Assert.That(Utils.IsUriHttpRelatedScheme("https://localhost:4840"), Is.True);
+            Assert.That(Utils.IsUriHttpRelatedScheme("http://localhost:4840"), Is.True);
         }
 
         [Test]
         public void IsUriHttpRelatedSchemeWithHttps()
         {
             Assert.That(Utils.IsUriHttpRelatedScheme("https://localhost:4840"), Is.True);
+        }
+
+        [Test]
+        public void IsUriHttpRelatedSchemeWithOpcHttps()
+        {
+            Assert.That(Utils.IsUriHttpRelatedScheme("opc.https://localhost:4840"), Is.True);
         }
 
         [Test]


### PR DESCRIPTION
# Description

Fixes every `src/Opc.Ua.Core` item found by a twelve-reviewer audit of `src/Opc.Ua.Server` + `src/Opc.Ua.Core` taken at 0e600c0f0, across all three tiers of that report (security/data-loss/crash, confirmed functional, and reviewer-traced). **The `src/Opc.Ua.Server` half of the audit is deliberately out of scope here** and remains open.

## Security and resource safety

- **Explicitly configured trusted certificates were ignored.** `CertificateTrustList.TrustedCertificates` (the `<TrustedCertificates>` config element, `SecurityConfiguration.AddTrustedPeer`) never reached the validator, so a peer trusted only that way was rejected with `BadCertificateUntrusted`. The list now travels from configuration through `TrustListEntry` into `TrustListState`, and is consulted both when deciding trust and when completing a chain — OPC 10000-4 6.1.3: "The list of trusted Certificates may contain a Certificate issued to another Application or it may be a Certificate belonging to a CA". The store is still consulted first, so a CA configured both ways keeps its CRL check. Cached validation cores are evicted when a trust list is re-registered, so a reconfiguration actually takes effect.
- **Unauthenticated receive-buffer leak.** `SaveIntermediateChunk` now always takes ownership of the chunk: it either stores it or returns it to the `BufferManager`. A server without a `None` endpoint gives every TCP client a discovery-only channel, and each non-discovery request leaked one `ReceiveBufferSize` buffer. Added `TakeSavedChunks` for the "body already saved" case; passing the chunk again would have queued the same buffer twice. A channel torn down while a multi-chunk message is still arriving now releases what it had buffered, which nothing did before.
- **Decrypted OpenSecureChannel buffers** are returned when verification fails, including the sibling paths where the sequence-number or certificate check rejects the message *after* the body was handed back.
- **RSA Diffie-Hellman peer values** are validated against `2 <= y <= p-2` (RFC 7919 5.1), so the shared secret can no longer be forced to a known constant by sending 0, 1 or p-1.
- **`RemovePadding` verified no padding at all** for channel messages: the loop started at `data.Offset` and stopped at `paddingSize`, so on any message with a header it ran zero times. The filler loop is corrected — OPC 10000-6 6.7.2.5.1: "The value of each byte of the padding is equal to PaddingSize" — and the signature is now checked *before* the padding is inspected so the two failures cannot be told apart.
- **Key material zeroing** on the ECC secret path: the plain text, the derived key and IV, and the ECDH shared secret, on both sides. The decrypt wipe covers the failure path too, which is the one that matters — the body is decrypted in place before the signature is verified.
- **HTTPS responses** are read with `ResponseHeadersRead` and bounded by `MaxMessageSize`, instead of the whole body being allocated before the limit was applied.
- **`X509CertificateStore.IsRevokedAsync`** reports an unanswerable revocation check as `BadCertificateRevocationUnknown` instead of throwing. The throw surfaced as an unsuppressible `BadCertificateInvalid` and failed every CA-issued certificate on Linux and macOS. See reviewer note 2.
- **Certificate handle ownership**: `ClientChannelManager` AddRefs what it hands to a transport that disposes it (and releases it again when the channel never opens), `CertificateTrustList` releases the handle `Add` took its own reference to, and `X509CertificateStore` disposes the platform handles nothing else owns.

## Transport

- The receive loop is now **one atomically swapped epoch of (transport, token)**, so a reconnect that binds a new socket to an existing channel supersedes the old loop rather than racing it. Previously the supersede path was unguarded and could start two readers on one socket, dispose an in-use `CancellationTokenSource`, and leak one per reconnect.
- A **reconnect hand-over detaches the transport before closing anything**, so the socket the adopted channel now answers on is not closed underneath it. Previously the queued `OpenSecureChannelResponse` failed with `BadConnectionClosed` and reconnect to a dropped channel could never succeed.
- A blocked or unservable **accepted socket is closed** rather than left open until process exit.
- An **invalid response sequence number reconnects the channel** instead of throwing into a handler that did nothing, which left the pending request hanging until timeout. OPC 10000-6 6.7.7 requires the receiver to close the channel, and the same section requires the error to be logged — which `HandleMessageProcessingError` now does instead of discarding it silently.
- The **abort chunk** is encoded against the room the chunk has rather than what it currently holds, so a short offending chunk can still carry the error body (OPC 10000-6 6.7.3).

## Discovery and endpoints

- `GetEndpoints` no longer drops the HTTPS and WSS JSON/OpenAPI endpoints, and no longer collapses them onto the binary one (the dedup ignored `TransportProfileUri`). `profileUris` filtering matches them too — OPC 10000-4 5.5.4.2 defines it as the "List of Transport Profile that the returned Endpoints shall support", and a client asking for the JSON profile previously got an empty list back. Results are ordered deterministically with **binary first**, so a client that takes the first endpoint that fits keeps getting the one it got before these twins were published.

## Smaller confirmed defects

`FilterEvaluator.InList` returned after the first string operand; `SelectedUserTokenPolicy` setter always ended at `-1`; `Utils.UpdateExtension` could not delete; a lease holder never stepped down while the shared store was unreachable *or hanging*; `IsUriHttpRelatedScheme` never matched `http`; `SessionLessServiceMessage` dropped a single `LocaleId`; `GetRandomDouble` used `ToSingle` and typed variant arrays ignored the requested `builtInType`; source-generated log calls never reached the trace file.

## Related Issues

- No tracking issue was opened for this work; it derives from an audit report rather than a filed issue. Happy to open one and link it if maintainers prefer.

## Notes for reviewers

1. **`MaxRejectedCertificates` semantics.** `ICertificateStore.AddRejectedAsync` documented "0 is unlimited", but `DirectoryCertificateStore` wrote every certificate and then deleted all of them at 0 (net effect: store nothing), and `CertificateManager` clamped a negative value onto 0 and *depended* on that to implement "clear the store". `SharedKeyValueCertificateStore` meanwhile treated 0 as genuinely unlimited, so the two store types did opposite things at the same setting. This PR keeps the existing observable behaviour (0 or less keeps no history and clears what is stored), removes the write-then-delete-all churn, aligns the KV store, and corrects the interface doc and `docs/DependencyInjection.md`. **The KV store is the one place whose behaviour changes** relative to master.

2. **Revocation status where X509Store has no CRLs.** `IsRevokedAsync` used to throw there, which surfaced as an unsuppressible `BadCertificateInvalid` and failed every CA-issued certificate on Linux and macOS - the outage the audit flagged. It now returns `BadCertificateRevocationUnknown`, which is what the Windows branch of the same method and a directory store without a CRL already return, and the status `RejectUnknownRevocationStatus` decides on (OPC 10000-4 6.1.3, Find Revocation List). With the default policy the certificate is accepted; an operator who opted into strict mode gets a rejection, as before on master. An earlier revision returned `BadNotSupported`, which the validator discards outright and which made revocation fail open even in strict mode; review caught it.
3. **`ManagedChannelKey` gained a `TransportProfileUri`** property and an optional trailing constructor parameter. Source-compatible, but it is public API.

## Checklist

- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf) and read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added all necessary documentation.
- [x] I have verified that my changes do not introduce (new) build or analyzer warnings.
- [ ] I ran **all** tests locally using the **UA.slnx** solution against at least .net **framework** and .net **10**, and all passed.
- [ ] I fixed **all** failing and flaky tests in the CI pipelines and **all** CodeQL warnings.
- [ ] I have addressed **all** PR feedback received.

### Regression test coverage

Each of these fails against `master`'s source and passes with the fix.

| Fix | Test |
|---|---|
| Padding filler bytes were never verified | `CryptoUtilsSymmetricPaddingTests` — forged filler rejected, plus a round trip over every padding length |
| Padding removed before the signature was checked | `CryptoUtilsSymmetricPaddingTests.SymmetricDecryptReportsSignatureFailureAheadOfPadding` |
| RSA-DH peer value not range checked | `RsaDiffieHellmanPeerValueTests` — 0, 1, p-1, p, above p, both range boundaries, group mismatch |
| A degenerate DH nonce threw instead of being rejected | `UaSCBinaryChannelNonceTests` |
| `<TrustedCertificates>` never reached the validator | `CertificateValidationCoreTests` (peer, issuer, and the negative control), `CertificateManagerTests.ExplicitlyTrustedPeerFromConfigurationIsAcceptedAsync` |
| Cached validation cores survived a trust-list change | `CertificateManagerTests` — registration after a failed validation, and `UpdateAsync` onto a different store |
| `MaxRejectedCertificates` normalisation | `CertificateManagerTests.MaxRejectedCertificatesNormalisesNegativeValues` |
| `AddRejectedAsync` retention contract | `RejectedCertificateRetentionTests` — both store types, at zero, negative and a positive cap |
| PEM rewrite left the old tail behind | `DirectoryCertificateStoreTests.DeleteFromAMultiCertificatePemFileTruncatesTheFileAsync` |
| `IsRevokedAsync` threw where CRLs are unsupported | `CertificateStoreTest.IsRevokedAsyncReportsNotSupportedWithoutCrlSupportAsync` (runs on Linux/macOS, ignored on Windows) |
| ECC secret left in the caller's buffer | `EncryptedSecretTests.EccDecryptWipesThePlainTextFromTheCallersBufferOnFailure` |
| Trust-list read leaked a handle per entry | `CertificateTrustListHandleTests` |
| A channel that never opened leaked its certificate | `ClientChannelManagerHandleTests` |
| Chunk ownership, CLO double free, chunk-limit teardown | `TcpServerChannelBufferTests` (4 new) |
| Receive loop did not follow a replaced transport | `TcpServerChannelDeterministicTests` (3 new) |
| HTTPS body unbounded, failures unmapped | `HttpsTransportChannelResponseTests` (5) |
| JSON/OpenAPI endpoints dropped, collapsed, or unordered | `ServerBaseTransportProfileTests` (12) |
| Channel key ignored the transport profile | `ClientChannelManagerManagedTests` (2 new) |
| `SelectedUserTokenPolicy` setter always ended at -1 | `ConfiguredEndpointTests` (4 new) |
| `UpdateExtension` could not delete | `UtilsAdditionalTests` (3 new) |
| A single `LocaleId` was dropped | `SessionLessServiceMessageTests` (2 new) |
| `GetRandomDouble` / typed variant arrays | `DataGeneratorTests` (4 new) |
| `TraceLoggerProvider.IsEnabled` short-circuited every log call | `TraceLoggerProviderTests` (3 new) |
| A leader never stepped down on an expired lease | `SharedStoreLeaseElectionTests` (3 new) |
| `FilterEvaluator.InList`, `IsUriHttpRelatedScheme` | existing tests corrected in the first commit |

**Not covered.** The reconnect hand-over ordering, the OpenSecureChannel decrypted-buffer returns, the client-side bad-sequence reconnect, the abort-chunk sizing and the listener closing a blocked socket all need a two-socket reconnect or a full asymmetric OpenSecureChannel exchange, which the deterministic channel harness does not model. They are exercised by the integration suites but not asserted on directly.
## Spec conformance

Where a fix has a normative basis I checked it against the published specification rather than only against the audit report:

| Change | Reference |
|---|---|
| Every padding filler byte is verified | OPC 10000-6 6.7.2.5.1 — "The value of each byte of the padding is equal to PaddingSize". The loop started at `data.Offset` and stopped at `paddingSize`, so on any message with a header it ran zero times and no filler byte was ever checked. |
| Signature verified before the padding is inspected | OPC 10000-6 6.7.2.5.1 — the signature "includes the headers, all Message data, the PaddingSize and the Padding"; 6.7.7 — the chunk "shall not be interpreted until the Message is decrypted and the signature and sequence number verified". |
| Message-processing errors are logged | OPC 10000-6 6.7.7 — "the receiver shall log a Bad_SequenceNumberInvalid error", and stacks "shall have a mechanism to log errors when invalid Messages are discarded". The handler was an empty method. |
| A bad response sequence number reconnects the channel | OPC 10000-6 6.7.7 — "the receiver shall close the communication channel". It previously threw into that empty handler and the pending request hung until timeout. |
| The trust list's own certificates are honoured as peers **and** as issuers | OPC 10000-4 6.1.3 — "The list of trusted Certificates may contain a Certificate issued to another Application or it may be a Certificate belonging to a CA". |
| The abort chunk is sized by the chunk's capacity | OPC 10000-6 6.7.3 — the abort body is `Error` plus a `Reason` string, so a chunk shorter than the error body could not carry it. |
| JSON/OpenAPI endpoints are published and match `profileUris` | OPC 10000-4 5.5.4.2 — `profileUris` is the "List of Transport Profile that the returned Endpoints shall support"; a client asking for the JSON profile previously got an empty list. |
| RSA-DH peer value restricted to `2 <= y <= p-2` | RFC 7919 5.1, which the finite-field policies are built on. I found no OPC-specific wording for this. |

One point where the spec argues against the current shape is called out in reviewer note 2 below.

### Test runs

On **net10.0**, with `Opc.Ua.Core.Tests` and `Opc.Ua.Security.Certificates.Tests` also run on **net48**. The remaining suites were not run on the .NET Framework targets locally, so that checklist box stays unchecked.

| Suite | Result |
|---|---|
| Opc.Ua.Core.Tests (net10.0) | 4630 passed, 0 failed, 88 skipped |
| Opc.Ua.Core.Tests (net48) | 4545 passed, 0 failed, 104 skipped |
| Opc.Ua.Core.Security.Tests | 556 passed, 0 failed |
| Opc.Ua.Security.Certificates.Tests (net10.0) | 355 passed, 0 failed |
| Opc.Ua.Security.Certificates.Tests (net48) | 353 passed, 0 failed |
| Opc.Ua.Configuration.Tests | 227 passed, 0 failed |
| Opc.Ua.Core.Encoders.Tests | 2929 passed, 0 failed |
| Opc.Ua.Bindings.Https.WebApi.Tests | 346 passed, 0 failed |
| Opc.Ua.Redundancy.Server.Tests | 783 passed, 0 failed |
| Opc.Ua.Client.Tests | 2217 passed, 0 failed |
| Opc.Ua.Server.Tests | 5552 passed, 0 failed |
| Opc.Ua.Sessions.Tests | 778 passed, 0 failed, 379 skipped |
| Opc.Ua.Gds.Tests | 1117 passed, 0 failed |

`Opc.Ua.Sessions.Tests` reports 379 skipped; that is identical to a `master` baseline run in a separate worktree (security policies the platform does not advertise), not a regression from this change.

`dotnet format whitespace --verify-no-changes` reports no violations in any file this PR touches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
